### PR TITLE
Include symlink targets in inputs to Android data binding actions.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java
@@ -515,17 +515,17 @@ public class AndroidCommon {
       jarsProducedForRuntime.add(resourceApk.getResourceJavaClassJar());
     }
 
-    ImmutableList<Artifact> additionalJavaInputsFromDatabinding = null;
+    NestedSet<Artifact> additionalJavaInputsFromDatabinding = null;
     if (shouldCompileJavaSrcs) {
       // Databinding metadata that the databinding annotation processor reads.
       additionalJavaInputsFromDatabinding =
           resourceApk.asDataBindingContext().processDeps(ruleContext, isBinary);
     } else {
-      ImmutableList.Builder<Artifact> outputs = ImmutableList.<Artifact>builder();
+      NestedSetBuilder<Artifact> outputs = NestedSetBuilder.stableOrder();
       DataBindingV2Provider p =
           ruleContext.getPrerequisite("application_resources", DataBindingV2Provider.PROVIDER);
-      outputs.addAll(p.getSetterStores().toList());
-      outputs.addAll(p.getTransitiveBRFiles().toList());
+      outputs.addTransitive(p.getSetterStores());
+      outputs.addTransitive(p.getTransitiveBRFiles());
       additionalJavaInputsFromDatabinding = outputs.build();
     }
 
@@ -615,7 +615,7 @@ public class AndroidCommon {
   private JavaCompilationHelper initAttributes(
       JavaTargetAttributes.Builder attributes,
       JavaSemantics semantics,
-      ImmutableList<Artifact> additionalArtifacts) {
+      NestedSet<Artifact> additionalArtifacts) {
     JavaCompilationHelper helper =
         new JavaCompilationHelper(
             ruleContext, semantics, javaCommon.getJavacOpts(), attributes, additionalArtifacts);

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLocalTestBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLocalTestBase.java
@@ -195,7 +195,7 @@ public abstract class AndroidLocalTestBase implements RuleConfiguredTargetFactor
     }
 
     // Databinding metadata that the databinding annotation processor reads.
-    ImmutableList<Artifact> additionalJavaInputsFromDatabinding =
+    NestedSet<Artifact> additionalJavaInputsFromDatabinding =
         resourceApk.asDataBindingContext().processDeps(ruleContext, /* isBinary= */ true);
 
     JavaCompilationHelper helper =
@@ -601,7 +601,7 @@ public abstract class AndroidLocalTestBase implements RuleConfiguredTargetFactor
       JavaSemantics javaSemantics,
       JavaCommon javaCommon,
       JavaTargetAttributes.Builder javaTargetAttributesBuilder,
-      ImmutableList<Artifact> additionalArtifacts)
+      NestedSet<Artifact> additionalArtifacts)
       throws RuleErrorException {
     JavaCompilationHelper javaCompilationHelper =
         new JavaCompilationHelper(

--- a/src/main/java/com/google/devtools/build/lib/rules/android/databinding/DataBindingContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/databinding/DataBindingContext.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
 import com.google.devtools.build.lib.analysis.RuleContext;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.rules.android.AndroidDataContext;
 import com.google.devtools.build.lib.rules.android.AndroidResources;
 import com.google.devtools.build.lib.rules.java.JavaPluginInfo;
@@ -79,7 +80,7 @@ public interface DataBindingContext {
    * @return the deps' metadata outputs. These need to be staged as compilation inputs to the
    *     current rule.
    */
-  ImmutableList<Artifact> processDeps(RuleContext ruleContext, boolean isBinary);
+  NestedSet<Artifact> processDeps(RuleContext ruleContext, boolean isBinary);
 
   /**
    * Creates and adds the generated Java source for data binding annotation processor to read and

--- a/src/main/java/com/google/devtools/build/lib/rules/android/databinding/DataBindingV1Context.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/databinding/DataBindingV1Context.java
@@ -19,6 +19,8 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.ActionConstructionContext;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.rules.android.AndroidCommon;
 import com.google.devtools.build.lib.rules.android.AndroidDataContext;
 import com.google.devtools.build.lib.rules.android.AndroidResources;
@@ -88,13 +90,14 @@ final class DataBindingV1Context implements DataBindingContext {
   }
 
   @Override
-  public ImmutableList<Artifact> processDeps(RuleContext ruleContext, boolean isBinary) {
+  public NestedSet<Artifact> processDeps(RuleContext ruleContext, boolean isBinary) {
 
-    ImmutableList.Builder<Artifact> dataBindingJavaInputs = ImmutableList.builder();
+    NestedSetBuilder<Artifact> dataBindingJavaInputs = NestedSetBuilder.stableOrder();
     if (AndroidResources.definesAndroidResources(ruleContext.attributes())) {
       dataBindingJavaInputs.add(DataBinding.getLayoutInfoFile(actionConstructionContext));
     }
 
+    dataBindingJavaInputs.addAll(DataBinding.getTransitiveMetadata(ruleContext, "deps"));
     for (Artifact dataBindingDepMetadata : DataBinding.getTransitiveMetadata(ruleContext, "deps")) {
       dataBindingJavaInputs.add(
           DataBinding.symlinkDepsMetadataIntoOutputTree(ruleContext, dataBindingDepMetadata));

--- a/src/main/java/com/google/devtools/build/lib/rules/android/databinding/DisabledDataBindingV1Context.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/databinding/DisabledDataBindingV1Context.java
@@ -17,6 +17,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
 import com.google.devtools.build.lib.analysis.RuleContext;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.rules.android.AndroidDataContext;
 import com.google.devtools.build.lib.rules.android.AndroidResources;
 import com.google.devtools.build.lib.rules.java.JavaPluginInfo;
@@ -35,8 +38,8 @@ class DisabledDataBindingV1Context implements DataBindingContext {
       RuleContext ruleContext, BiConsumer<JavaPluginInfo, Iterable<Artifact>> consumer) {}
 
   @Override
-  public ImmutableList<Artifact> processDeps(RuleContext ruleContext, boolean isBinary) {
-    return ImmutableList.of();
+  public NestedSet<Artifact> processDeps(RuleContext ruleContext, boolean isBinary) {
+    return NestedSetBuilder.emptySet(Order.STABLE_ORDER);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/databinding/DisabledDataBindingV2Context.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/databinding/DisabledDataBindingV2Context.java
@@ -17,7 +17,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
 import com.google.devtools.build.lib.analysis.RuleContext;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.rules.android.AndroidDataContext;
 import com.google.devtools.build.lib.rules.android.AndroidResources;
@@ -37,8 +39,8 @@ class DisabledDataBindingV2Context implements DataBindingContext {
       RuleContext ruleContext, BiConsumer<JavaPluginInfo, Iterable<Artifact>> consumer) {}
 
   @Override
-  public ImmutableList<Artifact> processDeps(RuleContext ruleContext, boolean isBinary) {
-    return ImmutableList.of();
+  public NestedSet<Artifact> processDeps(RuleContext ruleContext, boolean isBinary) {
+    return NestedSetBuilder.emptySet(Order.STABLE_ORDER);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -70,7 +70,7 @@ public final class JavaCompilationHelper {
   private final List<Artifact> translations = new ArrayList<>();
   private boolean translationsFrozen;
   private final JavaSemantics semantics;
-  private final ImmutableList<Artifact> additionalInputsForDatabinding;
+  private final NestedSet<Artifact> additionalInputsForDatabinding;
   private final StrictDepsMode strictJavaDeps;
   private final String fixDepsTool;
   private boolean enableJspecify = true;
@@ -82,7 +82,7 @@ public final class JavaCompilationHelper {
       ImmutableList<String> javacOpts,
       JavaTargetAttributes.Builder attributes,
       JavaToolchainProvider javaToolchainProvider,
-      ImmutableList<Artifact> additionalInputsForDatabinding) {
+      NestedSet<Artifact> additionalInputsForDatabinding) {
     this.ruleContext = ruleContext;
     this.javaToolchain = Preconditions.checkNotNull(javaToolchainProvider);
     this.attributes = attributes;
@@ -104,7 +104,7 @@ public final class JavaCompilationHelper {
         javacOpts,
         attributes,
         JavaToolchainProvider.from(ruleContext),
-        /* additionalInputsForDatabinding= */ ImmutableList.of());
+        /* additionalInputsForDatabinding= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER));
   }
 
   public JavaCompilationHelper(
@@ -112,7 +112,7 @@ public final class JavaCompilationHelper {
       JavaSemantics semantics,
       ImmutableList<String> javacOpts,
       JavaTargetAttributes.Builder attributes,
-      ImmutableList<Artifact> additionalInputsForDatabinding) {
+      NestedSet<Artifact> additionalInputsForDatabinding) {
     this(
         ruleContext,
         semantics,
@@ -646,8 +646,7 @@ public final class JavaCompilationHelper {
     checkNotNull(resourceJar, "resource jar output must not be null");
     JavaTargetAttributes attributes = getAttributes();
     new ResourceJarActionBuilder()
-        .setAdditionalInputs(
-            NestedSetBuilder.wrap(Order.STABLE_ORDER, additionalInputsForDatabinding))
+        .setAdditionalInputs(additionalInputsForDatabinding)
         .setJavaToolchain(javaToolchain)
         .setOutputJar(resourceJar)
         .setResources(attributes.getResources())

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -164,7 +164,7 @@ public final class JavaCompileActionBuilder {
   private NestedSet<Artifact> extraData = NestedSetBuilder.emptySet(Order.NAIVE_LINK_ORDER);
   private Label targetLabel;
   @Nullable private String injectingRuleKind;
-  private ImmutableList<Artifact> additionalInputs = ImmutableList.of();
+  private NestedSet<Artifact> additionalInputs = NestedSetBuilder.emptySet(Order.STABLE_ORDER);
   private Artifact genSourceOutput;
   private JavaCompileOutputs<Artifact> outputs;
   private JavaClasspathMode classpathMode;
@@ -220,7 +220,7 @@ public final class JavaCompileActionBuilder {
         .addTransitive(toolchain.getJavaRuntime().javaBaseInputs())
         .addTransitive(bootClassPath.bootclasspath())
         .addAll(sourcePathEntries)
-        .addAll(additionalInputs)
+        .addTransitive(additionalInputs)
         .addTransitive(bootClassPath.systemInputs());
     if (coverageArtifact != null) {
       mandatoryInputsBuilder.add(coverageArtifact);
@@ -503,7 +503,7 @@ public final class JavaCompileActionBuilder {
     return this;
   }
 
-  public JavaCompileActionBuilder setAdditionalInputs(ImmutableList<Artifact> additionalInputs) {
+  public JavaCompileActionBuilder setAdditionalInputs(NestedSet<Artifact> additionalInputs) {
     checkNotNull(additionalInputs, "additionalInputs must not be null");
     this.additionalInputs = additionalInputs;
     return this;

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
@@ -98,7 +98,7 @@ public class JavaHeaderCompileActionBuilder {
   private final ImmutableList.Builder<String> javacOptsBuilder = ImmutableList.builder();
   private JavaPluginData plugins = JavaPluginData.empty();
 
-  private ImmutableList<Artifact> additionalInputs = ImmutableList.of();
+  private NestedSet<Artifact> additionalInputs = NestedSetBuilder.emptySet(Order.STABLE_ORDER);
   private NestedSet<Artifact> toolsJars = NestedSetBuilder.emptySet(Order.NAIVE_LINK_ORDER);
 
   private boolean enableHeaderCompilerDirect = true;
@@ -228,7 +228,7 @@ public class JavaHeaderCompileActionBuilder {
 
   /** Sets additional inputs, e.g. for databinding support. */
   public JavaHeaderCompileActionBuilder setAdditionalInputs(
-      ImmutableList<Artifact> additionalInputs) {
+      NestedSet<Artifact> additionalInputs) {
     checkNotNull(additionalInputs, "additionalInputs must not be null");
     this.additionalInputs = additionalInputs;
     return this;
@@ -320,7 +320,7 @@ public class JavaHeaderCompileActionBuilder {
 
     NestedSetBuilder<Artifact> mandatoryInputsBuilder =
         NestedSetBuilder.<Artifact>stableOrder()
-            .addAll(additionalInputs)
+            .addTransitive(additionalInputs)
             .addTransitive(bootclasspathEntries)
             .addAll(sourceJars)
             .addAll(sourceFiles)

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java
@@ -350,7 +350,7 @@ final class JavaInfoBuildHelper {
             JavaInfo.streamProviders(concat(deps, exports), JavaGenJarsProvider.class)
                 .filter(not(JavaGenJarsProvider::isEmpty))
                 .collect(toImmutableList()),
-            ImmutableList.copyOf(annotationProcessorAdditionalInputs));
+            NestedSetBuilder.wrap(Order.STABLE_ORDER, annotationProcessorAdditionalInputs));
 
     JavaCompilationArgsProvider javaCompilationArgsProvider =
         helper.buildCompilationArgsProvider(artifacts, true, neverlink);

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaLibraryHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaLibraryHelper.java
@@ -24,6 +24,9 @@ import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.StrictDepsMode;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.rules.java.JavaConfiguration.JavaClasspathMode;
 import com.google.devtools.build.lib.rules.java.JavaRuleOutputJarsProvider.JavaOutput;
 import java.util.ArrayList;
@@ -218,7 +221,7 @@ public final class JavaLibraryHelper {
         true,
         /* javaInfoBuilder= */ null,
         ImmutableList.of(), // ignored when javaInfoBuilder is null
-        ImmutableList.of());
+        NestedSetBuilder.emptySet(Order.STABLE_ORDER));
   }
 
   public JavaCompilationArtifacts build(
@@ -231,7 +234,7 @@ public final class JavaLibraryHelper {
       boolean enableCompileJarAction,
       @Nullable JavaInfo.Builder javaInfoBuilder,
       List<JavaGenJarsProvider> transitiveJavaGenJars,
-      ImmutableList<Artifact> additionalInputForDatabinding)
+      NestedSet<Artifact> additionalInputForDatabinding)
       throws InterruptedException {
 
     Preconditions.checkState(output != null, "must have an output file; use setOutput()");


### PR DESCRIPTION
The intended semantics of a symlink as an action input is that only the
symlink itself is an input, not the file/directory it points to. However,
due to sandboxing limitations, such an action still executes successfully
locally, though not remotely.

Note that this change is necessary but not sufficient to make these actions
compatible with remote execution; we also need to fix #15678.