### PR TITLE
Make ManifestMergerAction worker compatible

### DIFF
--- a/src/test/java/com/google/devtools/build/android/testing/manifestmerge/BUILD
+++ b/src/test/java/com/google/devtools/build/android/testing/manifestmerge/BUILD
@@ -13,6 +13,8 @@ filegroup(
 filegroup(
     name = "test_data",
     srcs = [
+        "brokenManifest/AndroidManifest.xml",
+        "expected-merged-permissions/AndroidManifest.xml",
         "expected/AndroidManifest.xml",
         "mergeeOne/AndroidManifest.xml",
         "mergeeTwo/AndroidManifest.xml",

--- a/src/test/java/com/google/devtools/build/android/testing/manifestmerge/brokenManifest/AndroidManifest.xml
+++ b/src/test/java/com/google/devtools/build/android/testing/manifestmerge/brokenManifest/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.example.bazel"
+          android:versionCode="1"
+          android:versionName="1.0"/>
+
+    <uses-sdk
+            android:minSdkVersion="21"
+            android:targetSdkVersion="26"/>
+
+</manifest>

--- a/src/tools/android/java/com/google/devtools/build/android/ManifestMergerAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ManifestMergerAction.java
@@ -229,10 +229,15 @@ public class ManifestMergerAction {
         Files.copy(manifest, options.manifestOutput, StandardCopyOption.REPLACE_EXISTING);
       }
     } catch (AndroidManifestProcessor.ManifestProcessingException e) {
-      // We special case ManifestProcessingExceptions here to indicate that this is
-      // caused by a build error, not an Bazel-internal error.
-      logger.log(SEVERE, "Error during merging manifests", e);
-      System.exit(1); // Don't duplicate the error to the user or bubble up the exception.
+      // ManifestProcessingExceptions represent build errors that should be delivered directly to
+      // ResourceProcessorBusyBox where the exception can be delivered with a non-zero status code
+      // to the worker/process
+      // Note that this exception handler is nearly identical to the generic case, except that it
+      // does not have a log print associated with it. This is because the exception will bubble up
+      // to ResourceProcessorBusyBox, which will print an identical error message. It is preferable
+      // to slightly convolute this try/catch block, rather than pollute the user's console with
+      // extra repeated error messages.
+      throw e;
     } catch (Exception e) {
       logger.log(SEVERE, "Error during merging manifests", e);
       throw e; // This is a proper internal exception, so we bubble it up.


### PR DESCRIPTION
Calling `System#exit` kills the worker during the build. Passing the exception up to the worker should be enough for it to end up in the worker or local execution output.

Closes #14427.

PiperOrigin-RevId: 447808701