### PR TITLE
Define cc-compiler-darwin in Xcode toolchain

### DIFF
--- a/tools/osx/crosstool/BUILD.tpl
+++ b/tools/osx/crosstool/BUILD.tpl
@@ -80,6 +80,14 @@ cc_toolchain_suite(
     for arch in OSX_TOOLS_ARCHS
 ]
 
+# When xcode_locator fails and causes cc_autoconf_toolchains to fall back
+# to the non-Xcode C++ toolchain, it uses the legacy cpu value to refer to
+# the toolchain, which is "darwin" for x86_64 macOS.
+alias(
+    name = "cc-compiler-darwin",
+    actual = ":cc-compiler-darwin_x86_64",
+)
+
 [
     cc_toolchain_config(
         name = arch,


### PR DESCRIPTION
Previously, if the xcode_locator failed and cc_autoconf_toolchain used
the non-Xcode C++ toolchain as a fallback, its reference to
`@local_config_cc//:cc-compiler-darwin`, where darwin is the legacy cpu
value for x86_64 macOS, would be invalid.

Fixes #14459

Closes #14796.

PiperOrigin-RevId: 451860477
Change-Id: Iec115f600ebb7ac0786b2169276d25e3ff5d54bf