### PR TITLE
Fix additional outputs in BEP when remote_download_minimal is used

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,4 +35,4 @@ build --java_language_version=11
 build --tool_java_language_version=11
 
 # User-specific .bazelrc
-try-import user.bazelrc
+try-import %workspace%/user.bazelrc

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestResult.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestResult.java
@@ -30,6 +30,8 @@ import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.view.test.TestStatus.BlazeTestStatus;
+import com.google.devtools.build.lib.view.test.TestStatus.File;
+import com.google.devtools.build.lib.view.test.TestStatus.PathMetadata;
 import com.google.devtools.build.lib.view.test.TestStatus.TestResultData;
 import java.util.Collection;
 import java.util.List;
@@ -183,7 +185,6 @@ public class TestResult implements ExtendedEventHandler.ProgressLike {
    * (e.g., "test.log").
    */
   private Collection<Pair<String, Path>> getFiles() {
-    // TODO(ulfjack): Cache the set of generated files in the TestResultData.
-    return testAction.getTestOutputsMapping(ArtifactPathResolver.forExecRoot(execRoot), execRoot);
+    return testAction.testResultDataToMapping(execRoot, data);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/LocalFilesArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/LocalFilesArtifactUploader.java
@@ -72,5 +72,10 @@ public class LocalFilesArtifactUploader extends AbstractReferenceCounted
       }
       return FILE_URI_PATH_CONVERTER.apply(path);
     }
+
+    @Override
+    public String applyForDigest(String hash, long sizeBytes) {
+      throw new IllegalStateException("Can't formulate file:// path for a remote artifact");
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -372,9 +372,14 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
         throw new IllegalStateException(
             String.format("Illegal file reference: '%s'", path.getPathString()));
       }
+      return applyForDigest(digest.getHash(), digest.getSizeBytes());
+    }
+
+    @Override
+    public String applyForDigest(String hash, long sizeBytes) {
       return String.format(
           "bytestream://%s/blobs/%s/%d",
-          remoteServerInstanceName, digest.getHash(), digest.getSizeBytes());
+          remoteServerInstanceName, hash, sizeBytes);
     }
   }
 }

--- a/src/main/protobuf/test_status.proto
+++ b/src/main/protobuf/test_status.proto
@@ -70,6 +70,21 @@ message TestCase {
   optional bool run = 8 [default = true];
 };
 
+message PathMetadata {
+  optional string hash = 1;
+  optional int64 size_bytes = 2;
+}
+
+message File {
+  optional string name = 1;
+  optional string path = 2;
+}
+
+message TestAttempt {
+  repeated File outputs = 1;
+  map<string, PathMetadata> path_metadata = 2;
+}
+
 // TestResultData holds the outcome data for a single test action (A
 // single test rule can result in multiple actions due to sharding and
 // runs_per_test settings.)
@@ -111,4 +126,7 @@ message TestResultData {
   // Additional build info
   optional TestCase test_case = 13;
   optional FailedTestCasesStatus failed_status = 14;
+
+  // Detailed info about each attempt.
+  repeated TestAttempt attempts = 17;
 };

--- a/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
@@ -129,7 +129,16 @@ public final class BuildEventStreamerTest extends FoundationTestCase {
 
       @Override
       public PathConverter pathConverter() {
-        return Path::toString;
+        return new PathConverter() {
+          @Override
+          public String apply(Path path) {
+            return path.toString();
+          }
+          @Override
+          public String applyForDigest(String hash, long sizeBytes) {
+            throw new IllegalStateException("Can't formulate file:// path for a remote artifact");
+          }
+        };
       }
 
       @Override

--- a/src/test/java/com/google/devtools/build/lib/runtime/TestResultAggregatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/TestResultAggregatorTest.java
@@ -251,13 +251,13 @@ public final class TestResultAggregatorTest {
 
   private static TestResult testResult(TestResultData.Builder data, boolean locallyCached) {
     TestRunnerAction mockTestAction = mock(TestRunnerAction.class);
-    when(mockTestAction.getTestOutputsMapping(any(), any())).thenReturn(ImmutableList.of());
+    when(mockTestAction.getTestOutputsMapping(any(), any(), any())).thenReturn(ImmutableList.of());
     return new TestResult(mockTestAction, data.build(), locallyCached, /*systemFailure=*/ null);
   }
 
   private static TestResult shardedTestResult(TestResultData.Builder data, int shardNum) {
     TestRunnerAction mockTestAction = mock(TestRunnerAction.class);
-    when(mockTestAction.getTestOutputsMapping(any(), any())).thenReturn(ImmutableList.of());
+    when(mockTestAction.getTestOutputsMapping(any(), any(), any())).thenReturn(ImmutableList.of());
     when(mockTestAction.getShardNum()).thenReturn(shardNum);
     return new TestResult(mockTestAction, data.build(), /*cached=*/ false, /*systemFailure=*/ null);
   }


### PR DESCRIPTION
Injects optional test outputs when using --remote_download_minimal and
uses the list of injected artifacts to list them in BEP TestResult.