### PR TITLE
Docs: Include exceptions to combining selects

### DIFF
--- a/site/en/docs/configurable-attributes.md
+++ b/site/en/docs/configurable-attributes.md
@@ -364,11 +364,6 @@ Platforms are still under development. See the
 
 `select` can appear multiple times in the same attribute:
 
-Note: Some restrictions apply on what can be combined in the select's values:
- - Duplicate labels can appear in different paths of the same select.
- - Duplicate labels can *not* appear within the same path of a select.
- - Duplicate labels can *not* appear across multiple combined selects (no matter what path)
-
 ```python
 sh_binary(
     name = "my_target",
@@ -383,6 +378,11 @@ sh_binary(
            }),
 )
 ```
+
+Note: Some restrictions apply on what can be combined in the `select`s values:
+ - Duplicate labels can appear in different paths of the same `select`.
+ - Duplicate labels can *not* appear within the same path of a `select`.
+ - Duplicate labels can *not* appear across multiple combined `select`s (no matter what path)
 
 `select` cannot appear inside another `select`. If you need to nest `selects`
 and your attribute takes other targets as values, use an intermediate target:


### PR DESCRIPTION
Coming across https://github.com/bazelbuild/bazel/issues/5419 it makes sense to document these issues as exceptions to the intuitive usage of combining selects with duplicate targets

Reasoning about this is provided in https://github.com/bazelbuild/bazel/commit/497ef110c344b2a309210339f125916f355530f9 and imho it makes sense to document this behaviour