### PR TITLE
Fix alwayslink in objc_import

### DIFF
--- a/src/main/starlark/builtins_bzl/common/objc/objc_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/objc_common.bzl
@@ -183,6 +183,8 @@ def _create_context_and_provider(
             if compilation_artifacts.archive != None:
                 direct.append(compilation_artifacts.archive)
 
+        direct.extend(extra_import_libraries)
+
         objc_provider_kwargs["force_load_library"] = [
             depset(
                 direct = direct,


### PR DESCRIPTION
When `ObjcCommon` was rewritten in Starlark in 4a0cc3b3f297f8df60022ae977e170148a4c7ae4 the `archives` list from `objc_import` (passed in via `extra_import_libraries`) got dropped from the `force_load_library` list in `objc_provider`.

This fix adds them back so `-force_load` is correctly applied when `alwayslink` is set.

Here is the original Java implementation for reference:
https://github.com/bazelbuild/bazel/blob/4a0cc3b3f297f8df60022ae977e170148a4c7ae4/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommon.java#L415-L424

This `for` loop is what was omitted in the rewrite and is what is added in this PR:
```java
for (Artifact archive : extraImportLibraries) {
  objcProvider.add(FORCE_LOAD_LIBRARY, archive);
}
```

Closes #15313.

PiperOrigin-RevId: 455164591
Change-Id: Icc0a5aab26ec150475d82b57549b263418776141