### PR TITLE
Add Android integration test for large multidexing

### DIFF
--- a/src/test/shell/bazel/android/android_integration_test.sh
+++ b/src/test/shell/bazel/android/android_integration_test.sh
@@ -178,6 +178,10 @@ EOF
 }
 
 function test_native_d8_multidex_many_classfiles() {
+  # The dexer file format uses a 16-bit int in its metadata to codify how many
+  # classes exist, so projects with >2^16 classfiles need special handling. This
+  # test exercises the dex tool to make sure that >2^16 classfiles are properly
+  # handled.
   write_hello_android_files 65537
   setup_android_sdk_support
   cat > java/com/example/hello/BUILD <<'EOF'


### PR DESCRIPTION
Test for multidexing with >64k classes. Reproduces #15742. Merge after the multidexing error is fixed (currently this integration test fails with `bazel test src/test/shell/bazel/android:android_integration_test ` on baze 5.2.0).

@Bencodes @ahumesky 