### PR TITLE
Don't assume `master` as primary branch in change detection script

### DIFF
--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -46,7 +46,7 @@ set -eu
 
 MAIN_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD)
 
-COMMIT_RANGE=${COMMIT_RANGE:-$(git merge-base $MAIN_BRANCH HEAD)".."}
+COMMIT_RANGE=${COMMIT_RANGE:-$(git merge-base ${MAIN_BRANCH} HEAD)".."}
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-toplevel)"

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -44,7 +44,9 @@
 
 set -eu
 
-COMMIT_RANGE=${COMMIT_RANGE:-$(git merge-base origin/master HEAD)".."}
+MAIN_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD)
+
+COMMIT_RANGE=${COMMIT_RANGE:-$(git merge-base $MAIN_BRANCH HEAD)".."}
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
Our mainline branches are not called `master` and so this script exits with 
```bash
fatal: Not a valid object name origin/master
```

I've just modified the script to query the name of the primary branch, in `$remote_name/$branch_name` format, and pass that to `COMMIT_RANGE`.
