### PR TITLE
Add repo env test

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -262,8 +262,8 @@ public class CommandEnvironment {
         value = System.getenv(name);
       }
       if (value != null) {
-        repoEnv.put(entry.getKey(), entry.getValue());
-        repoEnvFromOptions.put(entry.getKey(), entry.getValue());
+        repoEnv.put(name, value);
+        repoEnvFromOptions.put(name, value);
       }
     }
   }


### PR DESCRIPTION
Fix and test for null value bug when using --repo_env
[Issue Link](https://github.com/bazelbuild/bazel/issues/15430)

Closes #15618.

PiperOrigin-RevId: 457728307
Change-Id: I3d57ae4ac95de09215281bec51329b7baafd53af