### PR TITLE
Optionally enable LLVM profile continuous mode

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -93,6 +93,11 @@ if [[ -z "$GCOV_PREFIX_STRIP" ]]; then
 fi
 export GCOV_PREFIX="${COVERAGE_DIR}"
 export LLVM_PROFILE_FILE="${COVERAGE_DIR}/%h-%p-%m.profraw"
+if [[ -n "$LLVM_PROFILE_CONTINUOUS_MODE" ]]; then
+  # %c enables continuous mode but expands out to nothing, so the position
+  # within LLVM_PROFILE_FILE does not matter.
+  export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE}%c"
+fi
 
 # In coverage mode for Java, we need to merge the runtime classpath before
 # running the tests. JacocoCoverageRunner uses this merged jar in order


### PR DESCRIPTION
LLVM's profile instrumentation offers a continuous mode in which
counters are continuously synced to a file rather than being dumped
once in an exit hook. This is useful for coverage runs that include
binaries that exit abnormally (e.g. in failure tests), but may require
additional compiler flags and can negatively impact runtime performance
and memory usage.

Enabling continuous mode requires adding the "%c" modifier to the value
of the LLVM_PROFILE_FILE environment variable. With this commit, the
collect_coverage.sh script adds the modifier if the test environment has
the variable LLVM_PROFILE_CONTINUOUS_MODE set. This allows both all and
individual tests to use continuous mode by setting the variable, either
via --test_env or the env attribute.

Closes #15166.

PiperOrigin-RevId: 454558752
Change-Id: Id03d00d0644742e336feab41ea479d7d8527f6c4