### PR TITLE
Fix cherrypick from e4bc370b226eb0cc536b55641640266345a214ec

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
@@ -540,6 +540,7 @@ def _cc_shared_library_impl(ctx):
         ),
         OutputGroupInfo(
             main_shared_library_output = depset(library),
+            interface_library = depset(interface_library),
             rule_impl_debug_files = depset(direct = debug_files, transitive = transitive_debug_files),
         ),
         CcSharedLibraryInfo(


### PR DESCRIPTION
Cherrypick was missing line where we add the interface library to the output group.