### PR TITLE
Replace uses of `cfg = "host"` with `cfg = "exec"`

### DIFF
--- a/site/en/docs/creating-workers.md
+++ b/site/en/docs/creating-workers.md
@@ -166,12 +166,13 @@ level of the build, this might be the attribute definition:
 "worker": attr.label(
     default = Label("//work:worker"),
     executable = True,
-    cfg = "host",
+    cfg = "exec",
 )
 ```
 
-`cfg = "host"` indicates that the worker should be built to run on your host
-platform.
+`cfg = "exec"` indicates that the worker should be built to run on your
+execution platform rather than on the target platform (i.e., the worker is used
+as tool during the build).
 
 ### Work action requirements {:#work-action-requirements}
 

--- a/site/en/rules/aspects.md
+++ b/site/en/rules/aspects.md
@@ -283,7 +283,7 @@ demonstrates how you could pass in a tool to an aspect:
         '_protoc' : attr.label(
             default = Label('//tools:protoc'),
             executable = True,
-            cfg = "host"
+            cfg = "exec"
         )
     }
 ...

--- a/src/embedded_tools.bzl
+++ b/src/embedded_tools.bzl
@@ -35,7 +35,7 @@ embedded_tools = rule(
         "out": attr.output(mandatory = True),
         "tool": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             default = Label("//src:create_embedded_tools_sh"),
         ),

--- a/src/main/res/winsdk_toolchain.bzl
+++ b/src/main/res/winsdk_toolchain.bzl
@@ -62,7 +62,7 @@ windows_resource_compiler_toolchain = rule(
         "rc_exe": attr.label(
             allow_files = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = "Label of the resource compiler (or a wrapper script)",
         ),
     },

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/function_wrap_multiple_lines_test/input.bzl
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/function_wrap_multiple_lines_test/input.bzl
@@ -47,7 +47,7 @@ dependencies here.
         "Xwatchconversion": attr.bool(default = False, doc = "Don't delete temporary lexers generated from combined grammars."),
         "_tool": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
 )

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/misc_apis_test/input.bzl
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/misc_apis_test/input.bzl
@@ -44,7 +44,7 @@ A list of dependencies.
             doc = "The location of the tool to use.",
             allow_files = True,
             default = Label("//foo/bar/baz:target"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "out": attr.output(

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -857,7 +857,7 @@ class BazelWindowsCppTest(test_base.TestBase):
         '  attrs = {',
         '    "_tool": attr.label(',
         '      executable = True,',
-        '      cfg = "host",',
+        '      cfg = "exec",',
         '      allow_files = True,',
         '      default = Label("//:genccs"),',
         '    )',

--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -177,7 +177,7 @@ class BazelWindowsTest(test_base.TestBase):
         '        "out": attr.output(mandatory = True),',
         '        "tool": attr.label(',
         '            executable = True,',
-        '            cfg = "host",',
+        '            cfg = "exec",',
         '            allow_files = True,',
         '            default = Label("//:write.bat"),',
         '        ),',

--- a/src/test/py/bazel/native_test.bzl
+++ b/src/test/py/bazel/native_test.bzl
@@ -68,7 +68,7 @@ exe_test = rule(
     attrs = {
         "src": attr.label(
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
     },

--- a/src/test/shell/bazel/apple/apple_common.sh
+++ b/src/test/shell/bazel/apple/apple_common.sh
@@ -80,7 +80,7 @@ starlark_apple_binary = rule(
             ),
         ),
         "_xcrunwrapper": attr.label(
-            cfg = "host",
+            cfg = "exec",
             default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
             executable = True,
         ),

--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -583,7 +583,7 @@ out_rule = rule(_out_rule, attrs = {
     "_hello_bin": attr.label(
         default = ":hello_bin",
         executable = True,
-        cfg = "host",
+        cfg = "exec",
     ),
 })
 EOF

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -705,11 +705,11 @@ def _tree_art_impl(ctx):
 tree_art_rule = rule(implementation = _tree_art_impl,
     attrs = {
         "_makes_tree" : attr.label(allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = "//${package}:makes_tree_artifacts.sh"),
         "_write" : attr.label(allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = "//${package}:write.sh")})
 

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -1086,7 +1086,7 @@ test_rule = rule(
     attrs = {
         "inputs": attr.label_list(allow_files = True),
         "out": attr.output(),
-        "_executable": attr.label(executable = True, cfg = "host", default = "//:exe"),
+        "_executable": attr.label(executable = True, cfg = "exec", default = "//:exe"),
     },
 )
 EOF

--- a/src/test/shell/bazel/starlark_rule_test.sh
+++ b/src/test/shell/bazel/starlark_rule_test.sh
@@ -120,7 +120,7 @@ def _impl(ctx):
 foo = rule(
     implementation = _impl,
     attrs = {
-        "tool": attr.label(allow_single_file = True, executable = True, cfg = "host"),
+        "tool": attr.label(allow_single_file = True, executable = True, cfg = "exec"),
         "out": attr.output(mandatory = True),
     },
 )

--- a/src/test/shell/integration/action_aspect_test.sh
+++ b/src/test/shell/integration/action_aspect_test.sh
@@ -110,11 +110,11 @@ def _actions_test_impl(target, ctx):
 tree_art_rule = rule(implementation = _tree_art_impl,
     attrs = {
         "_makes_tree" : attr.label(allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = "//package:makes_tree_artifacts.sh"),
         "_write" : attr.label(allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = "//package:write.sh")})
 
@@ -200,11 +200,11 @@ def _actions_test_impl(target, ctx):
 tree_art_rule = rule(implementation = _tree_art_impl,
     attrs = {
         "_makes_tree" : attr.label(allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = "//package:makes_tree_artifacts.sh"),
         "_write" : attr.label(allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = "//package:write.sh")})
 
@@ -382,7 +382,7 @@ aspect_b = aspect(
   attrs = {
     "_write": attr.label(
                 allow_single_file = True,
-                cfg = "host",
+                cfg = "exec",
                 executable = True,
                 default = "//${package}:write.sh")
   }

--- a/src/test/shell/integration/py_args_escaping_test.sh
+++ b/src/test/shell/integration/py_args_escaping_test.sh
@@ -303,7 +303,7 @@ def _impl(ctx):
 run_host_configured = rule(
     implementation = _impl,
     attrs = {
-        "tool": attr.label(executable = True, cfg = "host"),
+        "tool": attr.label(executable = True, cfg = "exec"),
         "out": attr.output(),
     },
 )

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -403,7 +403,7 @@ def _tool_impl(ctx):
     arguments = [f.path]
   )
   return DefaultInfo(files = depset([f]))
-my_tool_rule = rule(_tool_impl, attrs = { 'tool' : attr.label(executable = True, cfg = "host") })
+my_tool_rule = rule(_tool_impl, attrs = { 'tool' : attr.label(executable = True, cfg = "exec") })
 EOF
 
 cat > a/BUILD <<EOF

--- a/src/test/shell/integration/starlark_dependency_pruning_test.sh
+++ b/src/test/shell/integration/starlark_dependency_pruning_test.sh
@@ -119,7 +119,7 @@ def _impl(ctx):
 build_rule = rule(
     attrs = {
         "inputs": attr.label(),
-        "executable": attr.label(executable = True, cfg = "host"),
+        "executable": attr.label(executable = True, cfg = "exec"),
         "out": attr.output(),
     },
     implementation = _impl,

--- a/src/test/shell/integration/validation_actions_test.sh
+++ b/src/test/shell/integration/validation_actions_test.sh
@@ -88,7 +88,7 @@ rule_with_implicit_outs_and_validation = rule(
         allow_single_file = True,
         default = Label("//validation_actions:validation_tool"),
         executable = True,
-        cfg = "host"),
+        cfg = "exec"),
   }
 )
 
@@ -103,7 +103,7 @@ rule_with_implicit_and_host_deps = rule(
     "host_dep": attr.label(
         allow_single_file = True,
         default = Label("//validation_actions:some_host_dep"),
-        cfg = "host"),
+        cfg = "exec"),
   }
 )
 EOF

--- a/tools/build_defs/hash/hash.bzl
+++ b/tools/build_defs/hash/hash.bzl
@@ -33,7 +33,7 @@ def sha256(ctx, artifact, execution_requirements = None):
 tools = {
     "sha256": attr.label(
         default = Label("//tools/build_defs/hash:sha256"),
-        cfg = "host",
+        cfg = "exec",
         executable = True,
         allow_files = True,
     ),

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -110,7 +110,7 @@ _real_pkg_tar = rule(
         # Implicit dependencies.
         "build_tar": attr.label(
             default = Label("//tools/build_defs/pkg:build_tar"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             allow_files = True,
         ),

--- a/tools/ctexplain/lib_test.py
+++ b/tools/ctexplain/lib_test.py
@@ -40,7 +40,7 @@ class LibTest(test_base.TestBase):
         '    pass',
         'rule_with_host_dep = rule(',
         '    implementation = _impl,',
-        '    attrs = { "host_deps": attr.label_list(cfg = "host") })',
+        '    attrs = { "host_deps": attr.label_list(cfg = "exec") })',
     ])
     self.ScratchFile('testapp/BUILD', [
         'load("//testapp:defs.bzl", "rule_with_host_dep")',
@@ -66,7 +66,7 @@ class LibTest(test_base.TestBase):
         '    pass',
         'rule_with_host_dep = rule(',
         '    implementation = _impl,',
-        '    attrs = { "host_deps": attr.label_list(cfg = "host") })',
+        '    attrs = { "host_deps": attr.label_list(cfg = "exec") })',
     ])
     self.ScratchFile('testapp/BUILD', [
         'load("//testapp:defs.bzl", "rule_with_host_dep")',

--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -60,7 +60,7 @@ java_host_runtime_alias = rule(
                 java_common.JavaRuntimeInfo,
                 platform_common.TemplateVariableInfo,
             ],
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     provides = [


### PR DESCRIPTION
This increases the compatibility for builds where host and exec platform
are different (e.g., with remote execution).