### PR TITLE
Replace strdupa with strdup

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -146,8 +146,17 @@ static int CreateTarget(const char *path, bool is_directory) {
   }
 
   // Create the parent directory.
-  if (CreateTarget(dirname(strdupa(path)), true) < 0) {
-    DIE("CreateTarget %s", dirname(strdupa(path)));
+  {
+    char *buf, *dir;
+
+    if (!(buf = strdup(path))) DIE("strdup");
+
+    dir = dirname(buf);
+    if (CreateTarget(dir, true) < 0) {
+      DIE("CreateTarget %s", dir);
+    }
+
+    free(buf);
   }
 
   if (is_directory) {


### PR DESCRIPTION
Strdupa has potential to be unsafe thanks to the possibly unbound stack
usage. It also generates warnings when compiled on musl. This commit
therefore replaces it with properly checked heap allocation using
strdup.

Fixes #15729

Closes #15763.

PiperOrigin-RevId: 458440234
Change-Id: I8c8574f654295086f767b4fc4ca6fc1e59097beb