### PR TITLE
Bzlmod: Better canonical repo names for modules with overrides

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
@@ -62,8 +62,11 @@ public abstract class ModuleKey {
     if (WELL_KNOWN_MODULES.containsKey(getName())) {
       return WELL_KNOWN_MODULES.get(getName());
     }
+    if (ROOT.equals(this)) {
+      return "";
+    }
     if (getVersion().isEmpty()) {
-      return getName();
+      return getName() + ".override";
     }
     return getName() + "." + getVersion();
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
@@ -94,7 +94,7 @@ public class BazelModuleResolutionFunctionTest {
             "dep.1.0", createModuleKey("dep", "1.0"),
             "dep.2.0", createModuleKey("dep", "2.0"),
             "rules_cc.1.0", createModuleKey("rules_cc", "1.0"),
-            "rules_java", createModuleKey("rules_java", ""));
+            "rules_java.override", createModuleKey("rules_java", ""));
     assertThat(value.getModuleNameLookup())
         .containsExactly(
             "rules_cc", createModuleKey("rules_cc", "1.0"),

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleHelperTest.java
@@ -176,19 +176,19 @@ public final class BzlmodRepoRuleHelperTest extends FoundationTestCase {
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of(registry.getUrl()));
 
     EvaluationResult<GetRepoSpecByNameValue> result =
-        driver.evaluate(ImmutableList.of(getRepoSpecByNameKey("C")), evaluationContext);
+        driver.evaluate(ImmutableList.of(getRepoSpecByNameKey("C.override")), evaluationContext);
     if (result.hasError()) {
       fail(result.getError().toString());
     }
 
-    Optional<RepoSpec> repoSpec = result.get(getRepoSpecByNameKey("C")).rule();
+    Optional<RepoSpec> repoSpec = result.get(getRepoSpecByNameKey("C.override")).rule();
     assertThat(repoSpec)
         .hasValue(
             RepoSpec.builder()
                 .setRuleClassName("local_repository")
                 .setAttributes(
                     ImmutableMap.of(
-                        "name", "C",
+                        "name", "C.override",
                         "path", "/foo/bar/C"))
                 .build());
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -224,7 +224,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                     "",
                     0));
     assertThat(rootModuleFileValue.getNonRegistryOverrideCanonicalRepoNameLookup())
-        .containsExactly("E", "E", "G", "G");
+        .containsExactly("E.override", "E", "G.override", "G");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -116,7 +116,7 @@ public class StarlarkBazelModuleTest {
     assertThat(pomTags.get(0).getValue("pom_xmls"))
         .isEqualTo(
             StarlarkList.immutableOf(
-                Label.parseAbsoluteUnchecked("@foo//:pom.xml"),
+                Label.parseAbsoluteUnchecked("@foo.override//:pom.xml"),
                 Label.parseAbsoluteUnchecked("@bar.2.0//:pom.xml")));
   }
 


### PR DESCRIPTION
(https://github.com/bazelbuild/bazel/issues/13316)

Use "foo.override" instead of just "foo" as the canonical repo name for the module "foo" when it has a non-registry override. Context: https://groups.google.com/a/bazel.build/g/external-deps/c/GcV1cpRd-Ls/m/o446O3vGAAAJ

PiperOrigin-RevId: 423049588