### PR TITLE
Add critical path time to Build Event Protocol

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -946,6 +946,8 @@ message BuildMetrics {
     int64 wall_time_in_ms = 2;
     // The elapsed wall time in milliseconds during the analysis phase.
     int64 analysis_phase_time_in_ms = 3;
+    // The critical path time in milliseconds during this build.
+    int64 critical_path_time_in_ms = 4;
   }
   TimingMetrics timing_metrics = 5;
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
@@ -36,6 +36,7 @@ import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.skyframe.ExecutionFinishedEvent;
 import com.google.devtools.build.lib.vfs.Path;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -139,6 +140,7 @@ public class BuildSummaryStatsModule extends BlazeModule {
               .addDirectValue(
                   "critical path", criticalPath.toString().getBytes(StandardCharsets.UTF_8));
           logger.atInfo().log("%s", criticalPath);
+          eventBus.post(new CriticalPathEvent(criticalPath));
           logger.atInfo().log(
               "Slowest actions:\n  %s",
               Joiner.on("\n  ").join(criticalPathComputer.getSlowestComponents()));

--- a/src/main/java/com/google/devtools/build/lib/runtime/CriticalPathEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CriticalPathEvent.java
@@ -1,0 +1,32 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.runtime;
+
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+
+/**
+ * Event transporting information about the critical path. Emitted after the critical path has
+ * been aggregated.
+**/
+public class CriticalPathEvent implements ExtendedEventHandler.Postable {
+  private final AggregatedCriticalPath criticalPath;
+
+  public CriticalPathEvent(AggregatedCriticalPath criticalPath) {
+    this.criticalPath = criticalPath;
+  }
+
+  public AggregatedCriticalPath getCriticalPath() {
+    return criticalPath;
+  }
+}


### PR DESCRIPTION
We want to be able to look at information about the critical path time in consumers of the Build Event Protocol, and have thereby added a field for it in the TimingMetrics. This field is populated by the MetricsCollector, which subscribes to information about the critical path that is emitted by the BuildSummaryStatsModule. 

While the MetricsCollector would originally emit its metrics information upon the BuildPrecompleteEvent, it now waits until both BuildPrecompleteEvent and CriticalPathEvent have been emitted. The new CriticalPathEvent is emitted right after the critical path has been aggregated. The behavior of MetricsCollector remains the same as before upon receiving a NoBuildRequestFinishedEvent.