### PR TITLE
Allow disabling android resource merging via `android_non_transitive_r_class` configuration option

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AarImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AarImport.java
@@ -48,6 +48,7 @@ import com.google.devtools.build.lib.rules.java.ProguardLibrary;
 import com.google.devtools.build.lib.rules.java.ProguardSpecProvider;
 import com.google.devtools.build.lib.starlarkbuildapi.android.DataBindingV2ProviderApi;
 import com.google.devtools.build.lib.vfs.PathFragment;
+
 import javax.annotation.Nullable;
 
 /**
@@ -114,7 +115,8 @@ public class AarImport implements RuleConfiguredTargetFactory {
                 dataContext,
                 manifest,
                 DataBinding.contextFrom(ruleContext, dataContext.getAndroidConfig()),
-                neverlink);
+                neverlink,
+                /* nonTransitiveRClass = */ false);
 
     MergedAndroidAssets mergedAssets =
         AndroidAssets.forAarImport(assets)

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -38,7 +38,9 @@ import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
+
 import java.util.List;
+
 import javax.annotation.Nullable;
 
 /** Configuration fragment for Android rules. */
@@ -936,6 +938,16 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     public boolean useRTxtFromMergedResources;
 
     @Option(
+        name = "android_non_transitive_r_class",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.CHANGES_INPUTS},
+        help =
+            "If enabled each library only contains references to the resources it declares"
+                + " instead of declarations plus all dependency references.")
+    public boolean nonTransitiveRClass;
+
+    @Option(
         name = "legacy_main_dex_list_generator",
         // TODO(b/147692286): Update this default value to R8's GenerateMainDexList binary after
         // migrating usage.
@@ -1071,6 +1083,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final boolean alwaysFilterDuplicateClassesFromAndroidTest;
   private final boolean filterLibraryJarWithProgramJar;
   private final boolean useRTxtFromMergedResources;
+  private final boolean nonTransitiveRClass;
   private final Label legacyMainDexListGenerator;
   private final boolean disableInstrumentationManifestMerging;
   private final boolean incompatibleUseToolchainResolution;
@@ -1134,6 +1147,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
         options.alwaysFilterDuplicateClassesFromAndroidTest;
     this.filterLibraryJarWithProgramJar = options.filterLibraryJarWithProgramJar;
     this.useRTxtFromMergedResources = options.useRTxtFromMergedResources;
+    this.nonTransitiveRClass = options.nonTransitiveRClass;
     this.legacyMainDexListGenerator = options.legacyMainDexListGenerator;
     this.disableInstrumentationManifestMerging = options.disableInstrumentationManifestMerging;
     this.incompatibleUseToolchainResolution = options.incompatibleUseToolchainResolution;
@@ -1428,6 +1442,10 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
 
   public boolean includeProguardLocationReferences() {
     return includeProguardLocationReferences;
+  }
+
+  boolean nonTransitiveRClass() {
+    return nonTransitiveRClass;
   }
 
   /** Returns the label provided with --legacy_main_dex_list_generator, if any. */

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLibrary.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.rules.java.JavaSemantics;
 import com.google.devtools.build.lib.rules.java.JavaTargetAttributes;
 import com.google.devtools.build.lib.rules.java.ProguardLibrary;
 import com.google.devtools.build.lib.rules.java.ProguardSpecProvider;
+
 import javax.annotation.Nullable;
 
 /** An implementation for the "android_library" rule. */
@@ -162,7 +163,8 @@ public abstract class AndroidLibrary implements RuleConfiguredTargetFactory {
                   dataContext,
                   manifest,
                   DataBinding.contextFrom(ruleContext, dataContext.getAndroidConfig()),
-                  isNeverLink);
+                  isNeverLink,
+                  androidConfig.nonTransitiveRClass());
 
       MergedAndroidAssets assets = AndroidAssets.from(ruleContext).process(dataContext, assetDeps);
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidResourcesProcessorBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidResourcesProcessorBuilder.java
@@ -245,6 +245,8 @@ public class AndroidResourcesProcessorBuilder {
             databindingProcessedResources,
             symbols,
             /* compiledSymbols = */ null,
+            /* classJarOut = */ null,
+            /* rTxtOut = */  null,
             dataContext.getLabel(),
             processedManifest,
             dataBindingContext);

--- a/src/main/java/com/google/devtools/build/lib/rules/android/MergedAndroidResources.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/MergedAndroidResources.java
@@ -17,8 +17,10 @@ import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleErrorConsumer;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
+
 import java.util.Objects;
 import java.util.Optional;
+
 import javax.annotation.Nullable;
 
 /** Wraps merged Android resources. */

--- a/src/main/java/com/google/devtools/build/lib/rules/android/ParsedAndroidResources.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/ParsedAndroidResources.java
@@ -21,14 +21,18 @@ import com.google.devtools.build.lib.analysis.actions.ActionConstructionContext;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.rules.android.databinding.DataBindingContext;
+
 import java.util.Objects;
 import java.util.Optional;
+
 import javax.annotation.Nullable;
 
 /** Wraps parsed (and, if requested, compiled) android resources. */
 public class ParsedAndroidResources extends AndroidResources {
   @Nullable private final Artifact symbols;
   @Nullable private final Artifact compiledSymbols;
+  @Nullable private final Artifact classJarOut;
+  @Nullable private final Artifact rTxtOut;
   private final Label label;
   private final StampedAndroidManifest manifest;
   private final DataBindingContext dataBindingContext;
@@ -37,7 +41,8 @@ public class ParsedAndroidResources extends AndroidResources {
       AndroidDataContext dataContext,
       AndroidResources resources,
       StampedAndroidManifest manifest,
-      DataBindingContext dataBindingContext)
+      DataBindingContext dataBindingContext,
+      boolean nonTransitiveRClass)
       throws InterruptedException {
     AndroidResourceParsingActionBuilder builder = new AndroidResourceParsingActionBuilder();
 
@@ -46,6 +51,14 @@ public class ParsedAndroidResources extends AndroidResources {
     // In databinding v2, this strips out the databinding and generates the layout info file.
     AndroidResources databindingProcessedResources =
         dataBindingContext.processResources(dataContext, resources, manifest.getPackage());
+
+    if (nonTransitiveRClass) {
+      builder
+          .setClassJarOut(
+              dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_RESOURCES_CLASS_JAR))
+          .setRTxtOut(dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_R_TXT))
+          .setManifest(manifest.getManifest());
+    }
 
     return builder
         .setCompiledSymbolsOutput(
@@ -62,11 +75,20 @@ public class ParsedAndroidResources extends AndroidResources {
       AndroidResources resources,
       @Nullable Artifact symbols,
       @Nullable Artifact compiledSymbols,
+      @Nullable Artifact classJarOut,
+      @Nullable Artifact rTxtOut,
       Label label,
       StampedAndroidManifest manifest,
       DataBindingContext dataBindingContext) {
     return new ParsedAndroidResources(
-        resources, symbols, compiledSymbols, label, manifest, dataBindingContext);
+        resources,
+        symbols,
+        compiledSymbols,
+        classJarOut,
+        rTxtOut,
+        label,
+        manifest,
+        dataBindingContext);
   }
 
   ParsedAndroidResources(ParsedAndroidResources other, StampedAndroidManifest manifest) {
@@ -74,6 +96,8 @@ public class ParsedAndroidResources extends AndroidResources {
         other,
         other.symbols,
         other.compiledSymbols,
+        /* classJarOut= */ null,
+        /* rTxtOut= */ null,
         other.label,
         manifest,
         other.dataBindingContext);
@@ -83,12 +107,16 @@ public class ParsedAndroidResources extends AndroidResources {
       AndroidResources resources,
       Artifact symbols,
       @Nullable Artifact compiledSymbols,
+      @Nullable Artifact classJarOut,
+      @Nullable Artifact rTxtOut,
       Label label,
       StampedAndroidManifest manifest,
       DataBindingContext dataBindingContext) {
     super(resources);
     this.symbols = symbols;
     this.compiledSymbols = compiledSymbols;
+    this.classJarOut = classJarOut;
+    this.rTxtOut = rTxtOut;
     this.label = label;
     this.manifest = manifest;
     this.dataBindingContext = dataBindingContext;
@@ -102,6 +130,16 @@ public class ParsedAndroidResources extends AndroidResources {
   @Nullable
   public Artifact getCompiledSymbols() {
     return compiledSymbols;
+  }
+
+  @Nullable
+  Artifact getAapt2RTxt() {
+    return rTxtOut;
+  }
+
+  @Nullable
+  public Artifact getClassJar() {
+    return classJarOut;
   }
 
   public Iterable<Artifact> getArtifacts() {
@@ -134,6 +172,19 @@ public class ParsedAndroidResources extends AndroidResources {
     return MergedAndroidResources.mergeFrom(dataContext, this, resourceDeps);
   }
 
+  /** Skips merging this target's resources instead using artifacts produced at compilation. */
+  public MergedAndroidResources noMerge(
+      AndroidDataContext dataContext, ResourceDependencies resourceDeps) {
+    return MergedAndroidResources.of(
+        this,
+        null,
+        this.classJarOut,
+        this.rTxtOut,
+        null,
+        resourceDeps,
+        this.manifest.withProcessedManifest(this.manifest.getManifest()));
+  }
+
   @Override
   public Optional<? extends ParsedAndroidResources> maybeFilter(
       RuleErrorConsumer errorConsumer, ResourceFilter resourceFilter, boolean isDependency)
@@ -142,7 +193,14 @@ public class ParsedAndroidResources extends AndroidResources {
         .map(
             resources ->
                 ParsedAndroidResources.of(
-                    resources, symbols, compiledSymbols, label, manifest, dataBindingContext));
+                    resources,
+                    symbols,
+                    compiledSymbols,
+                    null,
+                    null,
+                    label,
+                    manifest,
+                    dataBindingContext));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/ValidatedAndroidResources.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/ValidatedAndroidResources.java
@@ -239,6 +239,8 @@ public class ValidatedAndroidResources extends MergedAndroidResources
                 new AndroidResources(getResources(), getResourceRoots()),
                 getSymbols(),
                 getCompiledSymbols(),
+                null,
+                null,
                 getLabel(),
                 getStampedManifest(),
                 // Null out databinding to avoid accidentally propagating ActionCreationContext

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidResourcesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidResourcesTest.java
@@ -30,14 +30,16 @@ import com.google.devtools.build.lib.rules.android.AndroidResourcesTest.WithoutP
 import com.google.devtools.build.lib.rules.android.databinding.DataBinding;
 import com.google.devtools.build.lib.rules.android.databinding.DataBindingContext;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import java.util.Optional;
-import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import java.util.Optional;
+import java.util.Set;
 
 /** Tests {@link AndroidResources} */
 @RunWith(Suite.class)
@@ -178,7 +180,8 @@ public abstract class AndroidResourcesTest extends ResourceTestBase {
                 dataContext,
                 getManifest(),
                 DataBinding.contextFrom(ruleContext, dataContext.getAndroidConfig()),
-                /* neverlink = */ false);
+                /* neverlink = */ false,
+                /* nonTransitiveRClass = */ dataContext.getAndroidConfig().nonTransitiveRClass());
     Optional<? extends AndroidResources> maybeFiltered =
         assertFilter(unfiltered, filteredResources, /* isDependency = */ true);
 
@@ -435,12 +438,13 @@ public abstract class AndroidResourcesTest extends ResourceTestBase {
         new AndroidResources(
             resources, AndroidResources.getResourceRoots(ruleContext, resources, "resource_files"));
     StampedAndroidManifest manifest = getManifest();
-
+    AndroidDataContext dataContext = AndroidDataContext.forNative(ruleContext);
     ParsedAndroidResources parsed =
         raw.parse(
-            AndroidDataContext.forNative(ruleContext),
+            dataContext,
             manifest,
-            dataBindingContext);
+            dataBindingContext,
+            dataContext.getAndroidConfig().nonTransitiveRClass());
 
     // Inherited values should be equal
     assertThat(raw).isEqualTo(new AndroidResources(parsed));
@@ -471,12 +475,14 @@ public abstract class AndroidResourcesTest extends ResourceTestBase {
       RuleContext ruleContext, DataBindingContext dataBindingContext)
       throws RuleErrorException, InterruptedException {
     ImmutableList<Artifact> resources = getResources("values-en/foo.xml", "drawable-hdpi/bar.png");
+    AndroidDataContext dataContext = AndroidDataContext.forNative(ruleContext);
     return new AndroidResources(
             resources, AndroidResources.getResourceRoots(ruleContext, resources, "resource_files"))
         .parse(
-            AndroidDataContext.forNative(ruleContext),
+            dataContext,
             getManifest(),
-            dataBindingContext);
+            dataBindingContext,
+            dataContext.getAndroidConfig().nonTransitiveRClass());
   }
 
   private ProcessedAndroidManifest getManifest() {

--- a/src/tools/android/java/com/google/devtools/build/android/CompileLibraryResourcesAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/CompileLibraryResourcesAction.java
@@ -14,11 +14,14 @@
 
 package com.google.devtools.build.android;
 
+import com.android.builder.core.VariantConfiguration;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.devtools.build.android.Converters.ExistingPathConverter;
 import com.google.devtools.build.android.Converters.PathConverter;
 import com.google.devtools.build.android.Converters.UnvalidatedAndroidDirectoriesConverter;
 import com.google.devtools.build.android.aapt2.Aapt2ConfigOptions;
+import com.google.devtools.build.android.aapt2.CompiledResources;
 import com.google.devtools.build.android.aapt2.ResourceCompiler;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -26,6 +29,7 @@ import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.ShellQuotedParamsFilePreProcessor;
+
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -39,63 +43,105 @@ public class CompileLibraryResourcesAction {
   public static final class Options extends OptionsBase {
 
     @Option(
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      name = "resources",
-      defaultValue = "null",
-      converter = UnvalidatedAndroidDirectoriesConverter.class,
-      category = "input",
-      help = "The resources to compile with aapt2."
-    )
+        name = "packageForR",
+        defaultValue = "null",
+        category = "config",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        help = "Custom java package to generate the R symbols files.")
+    public String packageForR;
+
+    @Option(
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        name = "resources",
+        defaultValue = "null",
+        converter = UnvalidatedAndroidDirectoriesConverter.class,
+        category = "input",
+        help = "The resources to compile with aapt2.")
     public UnvalidatedAndroidDirectories resources;
 
     @Option(
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      name = "output",
-      defaultValue = "null",
-      converter = PathConverter.class,
-      category = "output",
-      help = "Path to write the zip of compiled resources."
-    )
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        name = "output",
+        defaultValue = "null",
+        converter = PathConverter.class,
+        category = "output",
+        help = "Path to write the zip of compiled resources.")
     public Path output;
 
     @Option(
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      name = "packagePath",
-      defaultValue = "null",
-      category = "input",
-      help =
-          "The package path of the library being processed."
-              + " This value is required for processing data binding."
-    )
+        name = "targetLabel",
+        defaultValue = "null",
+        category = "input",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        help = "A label to add to the output jar's manifest as 'Target-Label'")
+    public String targetLabel;
+
+    @Option(
+        name = "injectingRuleKind",
+        defaultValue = "null",
+        category = "input",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        help = "A string to add to the output jar's manifest as 'Injecting-Rule-Kind'")
+    public String injectingRuleKind;
+
+    @Option(
+        name = "classJarOutput",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        defaultValue = "null",
+        converter = PathConverter.class,
+        category = "output",
+        help = "Path to write the jar containing the R classes.")
+    public Path classJarOut;
+
+    @Option(
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        name = "rTxtOut",
+        effectTags = {OptionEffectTag.UNKNOWN},
+        defaultValue = "null",
+        converter = PathConverter.class,
+        category = "output",
+        help = "Path to write the R.txt file.")
+    public Path rTxtOut;
+
+    @Option(
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        name = "packagePath",
+        defaultValue = "null",
+        category = "input",
+        help =
+            "The package path of the library being processed."
+                + " This value is required for processing data binding.")
     public String packagePath;
 
     @Option(
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      name = "manifest",
-      defaultValue = "null",
-      category = "input",
-      converter = ExistingPathConverter.class,
-      help =
-          "The manifest of the library being processed."
-              + " This value is required for processing data binding."
-    )
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        name = "manifest",
+        defaultValue = "null",
+        category = "input",
+        converter = ExistingPathConverter.class,
+        help =
+            "The manifest of the library being processed."
+                + " This value is required for processing data binding.")
     public Path manifest;
 
     @Option(
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      name = "dataBindingInfoOut",
-      defaultValue = "null",
-      category = "output",
-      converter = PathConverter.class,
-      help =
-          "Path for the derived data binding metadata."
-              + " This value is required for processing data binding."
-    )
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        name = "dataBindingInfoOut",
+        defaultValue = "null",
+        category = "output",
+        converter = PathConverter.class,
+        help =
+            "Path for the derived data binding metadata."
+                + " This value is required for processing data binding.")
     public Path dataBindingInfoOut;
   }
 
@@ -142,9 +188,55 @@ public class CompileLibraryResourcesAction {
               aapt2Options.useDataBindingAndroidX)
           .compile(compiler, compiledResources)
           .copyResourcesZipTo(options.output);
+
+      if (options.rTxtOut != null && options.classJarOut != null) {
+        generateRFiles(options, aapt2Options, tmp);
+      }
     } catch (IOException | ExecutionException | InterruptedException e) {
       logger.log(java.util.logging.Level.SEVERE, "Unexpected", e);
       throw e;
     }
+  }
+
+  /** Generates namespaced R.class + R.txt */
+  private static void generateRFiles(Options options, Aapt2ConfigOptions aapt2Options, Path tmp)
+      throws IOException {
+    final Path generatedSources = tmp.resolve("generated_resources");
+
+    Preconditions.checkArgument(
+        options.manifest != null || options.packageForR != null,
+        "To generate R files, either a package or manifest must be specified");
+    String packageForR = options.packageForR;
+    if (packageForR == null) {
+      packageForR =
+          Strings.nullToEmpty(VariantConfiguration.getManifestPackage(options.manifest.toFile()));
+    }
+
+    final AndroidResourceClassWriter resourceClassWriter =
+        AndroidResourceClassWriter.createWith(
+            options.targetLabel, aapt2Options.androidJar, generatedSources, packageForR);
+    resourceClassWriter.setIncludeClassFile(true);
+    resourceClassWriter.setIncludeJavaFile(false);
+
+    final PlaceholderRTxtWriter rTxtWriter = PlaceholderRTxtWriter.create(options.rTxtOut);
+
+    final SerializedAndroidData primary =
+        SerializedAndroidData.from(CompiledResources.from(options.output));
+
+    final ParsedAndroidData.Builder primaryBuilder = ParsedAndroidData.Builder.newBuilder();
+
+    final AndroidDataDeserializer deserializer =
+        AndroidCompiledDataDeserializer.create(/*includeFileContentsForValidation=*/ false);
+    primary.deserialize(
+        DependencyInfo.DependencyType.PRIMARY, deserializer, primaryBuilder.consumers());
+
+    final ParsedAndroidData primaryData = primaryBuilder.build();
+    primaryData.writeResourcesTo(resourceClassWriter);
+    primaryData.writeResourcesTo(rTxtWriter);
+    resourceClassWriter.flush();
+    rTxtWriter.flush();
+
+    AndroidResourceOutputs.createClassJar(
+        generatedSources, options.classJarOut, options.targetLabel, options.injectingRuleKind);
   }
 }


### PR DESCRIPTION
With this change each `android_library` target will generate `R` class with entries only from current local target instead of including entries from transitive closure of dependencies usually created via a separate merging action.

`R` entries from libraries should be referenced by their fully qualified name otherwise build would fail.

Reference: https://developer.android.com/studio/build/optimize-your-build#use-non-transitive-r-classes

In our large android app, we save several thousand actions and reduce cache output by 1.1 GB. 

Adapted from https://github.com/bazelbuild/bazel/pull/11385 and renamed flag to be in line with Android Gradle plugin flag.


Fixes https://github.com/bazelbuild/rules_android/issues/10