### PR TITLE
Add is_root struct field to bazel_module

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
@@ -44,6 +44,7 @@ public class StarlarkBazelModule implements StarlarkValue {
   private final String name;
   private final String version;
   private final Tags tags;
+  private final boolean isRootModule;
 
   @StarlarkBuiltin(
       name = "bazel_module_tags",
@@ -82,10 +83,11 @@ public class StarlarkBazelModule implements StarlarkValue {
     }
   }
 
-  private StarlarkBazelModule(String name, String version, Tags tags) {
+  private StarlarkBazelModule(String name, String version, Tags tags, boolean isRootModule) {
     this.name = name;
     this.version = version;
     this.tags = tags;
+    this.isRootModule = isRootModule;
   }
 
   /**
@@ -143,7 +145,8 @@ public class StarlarkBazelModule implements StarlarkValue {
     return new StarlarkBazelModule(
         module.getName(),
         module.getVersion().getOriginal(),
-        new Tags(Maps.transformValues(typeCheckedTags, StarlarkList::immutableCopyOf)));
+        new Tags(Maps.transformValues(typeCheckedTags, StarlarkList::immutableCopyOf)),
+        module.getKey().equals(ModuleKey.ROOT));
   }
 
   @Override
@@ -167,5 +170,13 @@ public class StarlarkBazelModule implements StarlarkValue {
       doc = "The tags in the module related to the module extension currently being processed.")
   public Tags getTags() {
     return tags;
+  }
+
+  @StarlarkMethod(
+      name = "is_root",
+      structField = true,
+      doc = "Whether this module is the root module.")
+  public boolean isRoot() {
+    return isRootModule;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -314,6 +314,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
   public void multipleModules() throws Exception {
     scratch.file(
         workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "module(name='root',version='1.0')",
         "bazel_dep(name='ext',version='1.0')",
         "bazel_dep(name='foo',version='1.0')",
         "bazel_dep(name='bar',version='2.0')",
@@ -363,10 +364,12 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         modulesRoot.getRelative("ext.1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
-        "  data_str = 'modules:'",
+        "  data_str = ''",
         "  for mod in ctx.modules:",
+        "    data_str += mod.name + '@' + mod.version + (' (root): ' if mod.is_root else ': ')",
         "    for tag in mod.tags.tag:",
-        "      data_str += ' ' + tag.data",
+        "      data_str += tag.data",
+        "    data_str += '\\n'",
         "  data_repo(name='ext_repo',data=data_str)",
         "tag=tag_class(attrs={'data':attr.string()})",
         "ext=module_extension(implementation=_ext_impl,tag_classes={'tag':tag})");
@@ -378,7 +381,8 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
       throw result.getError().getException();
     }
     assertThat(result.get(skyKey).getModule().getGlobal("data"))
-        .isEqualTo("modules: root foo@1.0 bar@2.0 quux@2.0");
+        .isEqualTo(
+            "root@1.0 (root): root\nfoo@1.0: foo@1.0\nbar@2.0: bar@2.0\nquux@2.0: quux@2.0\n");
   }
 
   @Test


### PR DESCRIPTION
This allows module extensions to check whether a given module is the
root module, which is necessary to implement the analogues of
--check_direct_dependencies and archive_override/git_override for
dependencies managed by extensions.

Closes #15792.

PiperOrigin-RevId: 459058350
Change-Id: I4a08ce80a636e2cb2791323476fdccddf4131de0