### PR TITLE
RemoteExecutionService: fix outputs not being uploaded

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1196,6 +1196,8 @@ public class RemoteExecutionService {
         SpawnResult.Status.SUCCESS.equals(spawnResult.status()) && spawnResult.exitCode() == 0,
         "shouldn't upload outputs of failed local action");
 
+    action.getRemoteActionExecutionContext().setStep(Step.UPLOAD_OUTPUTS);
+
     if (remoteOptions.remoteCacheAsync) {
       Single.using(
               remoteCache::retain,


### PR DESCRIPTION
In 4d900ceea12919ad62012830a95e51f9ec1a48bb we introduced validation in
DiskAndRemoteCacheClient.uploadActionResult() where context's step must
be UPLOAD_OUTPUTS to trigger the upload.

However, this value was never set in RemoteExecutionService before hand
thus led to outputs not being uploaded and cause remote cache misses.

Fix #15682

Thanks @adam-singer for doing the investigation 🙏