### PR TITLE
D8 desugarer supports persistent workers

### DIFF
--- a/src/test/shell/bazel/android/android_integration_test.sh
+++ b/src/test/shell/bazel/android/android_integration_test.sh
@@ -145,7 +145,7 @@ EOF
       //java/com/example/hello:hello || fail "build failed"
 }
 
-function test_d8_dexes_and_desugars_hello_android() {
+function test_d8_dexes_and_sandbox_desugars_hello_android() {
   write_hello_android_files
   setup_android_sdk_support
   cat > java/com/example/hello/BUILD <<'EOF'
@@ -158,11 +158,28 @@ android_binary(
 EOF
 
   bazel clean
-  # Note: D8 desugaring with persistent workers is not currently supported, so
-  # need to add --strategy=Desugar=sandboxed
   bazel build --define=android_standalone_dexing_tool=d8_compat_dx \
       --define=android_desugaring_tool=d8 \
       --strategy=Desugar=sandboxed \
+      //java/com/example/hello:hello || fail "build failed"
+}
+
+function test_d8_dexes_and_worker_desugars_hello_android() {
+  write_hello_android_files
+  setup_android_sdk_support
+  cat > java/com/example/hello/BUILD <<'EOF'
+android_binary(
+    name = 'hello',
+    manifest = "AndroidManifest.xml",
+    srcs = ['MainActivity.java'],
+    resource_files = glob(["res/**"]),
+)
+EOF
+
+  bazel clean
+  bazel build --define=android_standalone_dexing_tool=d8_compat_dx \
+      --define=android_desugaring_tool=d8 \
+      --strategy=Desugar=worker \
       //java/com/example/hello:hello || fail "build failed"
 }
 

--- a/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
@@ -47,7 +47,6 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/worker:work_request_handlers",
         "//src/main/java/com/google/devtools/common/options",
-        "//src/main/protobuf:worker_protocol_java_proto",
         "//src/tools/android/java/com/google/devtools/build/android:android_builder_lib",
         "//third_party:asm",
         "//third_party:guava",

--- a/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
@@ -47,6 +47,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/worker:work_request_handlers",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/main/protobuf:worker_protocol_java_proto",
         "//src/tools/android/java/com/google/devtools/build/android:android_builder_lib",
         "//third_party:asm",
         "//third_party:guava",

--- a/src/tools/android/java/com/google/devtools/build/android/r8/Desugar.java
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/Desugar.java
@@ -54,6 +54,8 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** Desugar compatible wrapper based on D8 desugaring engine */
 public class Desugar {
@@ -61,6 +63,7 @@ public class Desugar {
   public static final String DESUGAR_DEPS_FILENAME = "META-INF/desugar_deps";
   // We shard the compilation if we have more than this number of entries to avoid timing out.
   private static final int NUMBER_OF_ENTRIES_PER_SHARD = 100000;
+  private static final Logger logger = Logger.getLogger(Desugar.class.getName());
 
   /** Commandline options for {@link com.google.devtools.build.android.r8.Desugar}. */
   public static class DesugarOptions extends OptionsBase {
@@ -648,7 +651,7 @@ public class Desugar {
       validateOptions(options);
       new Desugar(options).desugar();
     } catch (Exception e) {
-      // There should be a logger call here.
+      logger.log(Level.SEVERE, "Error during desugaring", e);
       throw e;
     }
     return 0;
@@ -694,7 +697,7 @@ public class Desugar {
               .build();
       workerHandler.processRequests();
     } catch (IOException e) {
-      //logger.severe(e.getMessage());
+      logger.severe(e.getMessage());
       e.printStackTrace(realStdErr);
       return 1;
     } finally {


### PR DESCRIPTION
Fixes issue with the D8 desugar wrapper where persistent worker mode was not supported. Adding this capability paves the way to make D8 the default desugarer.