### PR TITLE
Shard //src/test/shell/bazel:cc_integration_test.

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -902,6 +902,7 @@ sh_test(
     size = "medium",
     srcs = ["cc_integration_test.sh"],
     data = [":test-deps"],
+    shard_count = 5,
     tags = ["no_windows"],
 )
 


### PR DESCRIPTION
Has been timing out frequently on Bazel CI recently.