### PR TITLE
Add --experimental_execution_log_explain_file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -110,7 +110,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:runtime",
-        "//src/main/java/com/google/devtools/build/lib/bazel/execlog:stable_sort",
+        "//src/main/java/com/google/devtools/build/lib/bazel/execlog",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
         "//src/main/java/com/google/devtools/build/lib/exec:executor_builder",
@@ -121,6 +121,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/protobuf:failure_details_java_proto",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.bazel;
 
+import com.google.devtools.build.lib.bazel.execlog.ExeclogExplain;
 import com.google.devtools.build.lib.bazel.execlog.StableSort;
 import com.google.devtools.build.lib.buildtool.BuildRequest;
 import com.google.devtools.build.lib.events.Event;
@@ -34,6 +35,7 @@ import com.google.devtools.build.lib.util.io.MessageOutputStreamWrapper.JsonOutp
 import com.google.devtools.build.lib.util.io.MessageOutputStreamWrapper.MessageOutputStreamCollection;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -109,7 +111,10 @@ public final class SpawnLogModule extends BlazeModule {
       outStream = new AsynchronousFileOutputStream(rawOutput);
     }
 
-    if (outStream == null) {
+    PathFragment explainFile = executionOptions.executionLogExplainFile;
+    ExeclogExplain execlogExplain = (explainFile != null)? new ExeclogExplain(env, explainFile): null;
+
+    if (outStream == null && execlogExplain == null) {
       // No logging needed
       clear();
       return;
@@ -121,7 +126,8 @@ public final class SpawnLogModule extends BlazeModule {
             outStream,
             env.getOptions().getOptions(ExecutionOptions.class),
             env.getOptions().getOptions(RemoteOptions.class),
-            env.getXattrProvider());
+            env.getXattrProvider(),
+            execlogExplain);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/execlog/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/execlog/BUILD
@@ -9,11 +9,17 @@ filegroup(
 )
 
 java_library(
-    name = "stable_sort",
+    name = "execlog",
     srcs = glob(["*.java"]),
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util/io",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/protobuf:spawn_java_proto",
         "//third_party:guava",
+        "@com_google_protobuf//java/core",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/execlog/ExeclogExplain.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/execlog/ExeclogExplain.java
@@ -1,0 +1,193 @@
+package com.google.devtools.build.lib.bazel.execlog;
+
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.runtime.CommandEnvironment;
+import com.google.devtools.build.lib.util.io.AnsiTerminal;
+import com.google.devtools.build.lib.util.io.AnsiTerminal.Color;
+import com.google.devtools.build.lib.util.io.MessageOutputStream;
+import com.google.devtools.build.lib.exec.Protos;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.protobuf.Message;
+import com.google.protobuf.Duration;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generates an explanation of the actions performed by the build by comparing
+ * the current action spawn with the one from the previous build.
+ */
+public final class ExeclogExplain implements MessageOutputStream {
+
+  private final PrintWriter writer;
+  private final ExeclogHistory history;
+
+  public ExeclogExplain(CommandEnvironment env, PathFragment explainPath) throws IOException {
+    history = new ExeclogHistory(env.getOutputBase());
+    OutputStream out = env.getWorkspace().getRelative(explainPath).getOutputStream();
+    writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8), true);
+
+    env.getReporter().handle(Event.info("Writing detail explanation of rebuilds to '" + explainPath + "'"));
+    writeHeader();
+  }
+
+  private void writeHeader() throws IOException {
+    writer.println("This file lists the build actions executed using the following format:");
+    // seconds num_inputs->num_outputs build action changed_inputs -> changed_outputs
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    AnsiTerminal terminal = new AnsiTerminal(out);
+    terminal.textGreen();
+    terminal.writeString("seconds");
+    terminal.textCyan();
+    terminal.writeString(" num_inputs");
+    terminal.textGray();
+    terminal.writeString("->");
+    terminal.textMagenta();
+    terminal.writeString("num_outputs");
+    terminal.resetTerminal();
+    terminal.writeString(" build action");
+    terminal.textCyan();
+    terminal.writeString(" changed_inputs");
+    terminal.textGray();
+    terminal.writeString(" ->");
+    terminal.textMagenta();
+    terminal.writeString(" changed_outputs\n");
+    terminal.flush();
+    terminal.resetTerminal();
+    writer.println(out);
+  }
+
+  @Override
+  public void write(Message m) throws IOException {
+    Protos.SpawnExec spawn = (Protos.SpawnExec) m;
+    Protos.SpawnExec baseSpawn = history.get(spawn);
+    Duration walltime = spawn.getWalltime();
+    double seconds = ((double) walltime.getNanos()) / 1_000_000_000 + walltime.getSeconds();
+    List<Protos.File> inputs = spawn.getInputsList();
+    List<Protos.File> outputs = spawn.getActualOutputsList();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    AnsiTerminal terminal = new AnsiTerminal(out);
+    terminal.setTextColor(seconds >= 100? Color.RED : seconds >= 10? Color.YELLOW : Color.GREEN);
+    terminal.writeString(String.format("%7.2f", seconds));
+    terminal.writeString(String.format(" %c", spawn.getRemoteCacheHit()? 'C': ' '));
+    terminal.textCyan();
+    terminal.writeString(String.format("%5d", inputs.size()));
+    terminal.textGray();
+    terminal.writeString("->");
+    terminal.textMagenta();
+    terminal.writeString(String.format("%4d ", outputs.size()));
+    terminal.resetTerminal();
+    terminal.writeString(spawn.getProgressMessage());
+
+    if (baseSpawn != null) {
+      // show changed/removed/new inputs
+      List<Protos.File> baseInputs = baseSpawn.getInputsList();
+      Map<String, Protos.File> baseInputsMap = new HashMap();
+      Map<String, Protos.File> baseInputsLeftMap = new HashMap();
+      for (Protos.File baseInput: baseInputs) {
+        baseInputsMap.put(baseInput.getPath(), baseInput);
+        baseInputsLeftMap.put(baseInput.getPath(), baseInput);
+      }
+      int numDiffInputs = 0;
+      List<Protos.File> newInputs = new ArrayList<>();
+      terminal.textCyan();
+      // changed inputs
+      for (Protos.File input: inputs) {
+        String path = input.getPath();
+        baseInputsLeftMap.remove(path);
+        Protos.File baseInput = baseInputsMap.get(path);
+        if (baseInput != null) {
+          if (!input.getDigest().equals(baseInput.getDigest())) {
+            numDiffInputs++;
+            terminal.writeString(' ' + basename(path));
+          }
+        } else {
+          newInputs.add(input);
+        }
+      }
+      // removed inputs
+      for (Protos.File input: baseInputsLeftMap.values()) {
+        numDiffInputs++;
+        terminal.writeString(" -" + basename(input.getPath()));
+      }
+      // new inputs
+      for (Protos.File input: newInputs) {
+        numDiffInputs++;
+        terminal.writeString(" +" + basename(input.getPath()));
+      }
+      if (numDiffInputs == 0) {
+        terminal.textYellow();
+        terminal.writeString(" [unchanged]");
+      }
+
+      // show changed/removed/new outputs
+      terminal.textGray();
+      terminal.writeString(" ->");
+      List<Protos.File> baseOutputs = baseSpawn.getActualOutputsList();
+      Map<String, Protos.File> baseOutputsMap = new HashMap();
+      Map<String, Protos.File> baseOutputsLeftMap = new HashMap();
+      for (Protos.File baseOutput: baseOutputs) {
+        baseOutputsMap.put(baseOutput.getPath(), baseOutput);
+        baseOutputsLeftMap.put(baseOutput.getPath(), baseOutput);
+      }
+      int numDiffOutputs = 0;
+      List<Protos.File> newOutputs = new ArrayList<>();
+      terminal.textMagenta();
+      // changed outputs
+      for (Protos.File output: outputs) {
+        String path = output.getPath();
+        baseOutputsLeftMap.remove(path);
+        Protos.File baseOutput = baseOutputsMap.get(path);
+        if (baseOutput != null) {
+          if (!output.getDigest().equals(baseOutput.getDigest())) {
+            numDiffOutputs++;
+            terminal.writeString(' ' + basename(path));
+          }
+        } else {
+          newOutputs.add(output);
+        }
+      }
+      // removed outputs
+      for (Protos.File output: baseOutputsLeftMap.values()) {
+        numDiffOutputs++;
+        terminal.writeString(" -" + basename(output.getPath()));
+      }
+      // new outputs
+      for (Protos.File output: newOutputs) {
+        numDiffOutputs++;
+        terminal.writeString(" +" + basename(output.getPath()));
+      }
+      if (numDiffOutputs == 0) {
+        terminal.textYellow();
+        terminal.writeString(" [unchanged]");
+      }
+    } else {
+      terminal.textYellow();
+      terminal.writeString(" [no history]");
+    }
+
+    terminal.flush();
+    terminal.resetTerminal();
+    writer.println(out);
+
+    history.put(spawn);
+  }
+
+  @Override
+  public void close() throws IOException {
+    writer.close();
+  }
+
+  private static String basename(String path) {
+    return path.substring(path.lastIndexOf(File.separatorChar) + 1);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/execlog/ExeclogHistory.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/execlog/ExeclogHistory.java
@@ -1,0 +1,44 @@
+package com.google.devtools.build.lib.bazel.execlog;
+
+import com.google.devtools.build.lib.exec.Protos;
+import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Stores execution log history in the file system for incremental execution log analysis
+ */
+class ExeclogHistory {
+
+  private final Path dir;
+
+  ExeclogHistory(Path outputBase) {
+    dir = outputBase.getChild("execlog_history");
+  }
+
+  void put(Protos.SpawnExec spawn) throws IOException {
+    Path path = getPath(spawn);
+    path.getParentDirectory().createDirectoryAndParents();
+    try (GZIPOutputStream out = new GZIPOutputStream(path.getOutputStream())) {
+      spawn.writeTo(out);
+    }
+  }
+
+  Protos.SpawnExec get(Protos.SpawnExec spawn) throws IOException {
+    Path path = getPath(spawn);
+    if (!path.exists()) {
+      return null;
+    }
+    try (GZIPInputStream in = new GZIPInputStream(path.getInputStream())) {
+      return Protos.SpawnExec.parseFrom(in);
+    }
+  }
+
+  private Path getPath(Protos.SpawnExec spawn) {
+    String key = spawn.getTargetLabel() + '|' + spawn.getProgressMessage(); // should be unique
+    String digest = Fingerprint.getHexDigest(key);
+    return dir.getChild(digest.substring(0, 2)).getChild(digest);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -263,6 +263,7 @@ java_library(
         "//third_party:jsr305",
         "//third_party/protobuf:protobuf_java",
         "//third_party/protobuf:protobuf_java_util",
+        "@com_google_protobuf//java/core",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -456,6 +456,17 @@ public class ExecutionOptions extends OptionsBase {
   public PathFragment executionLogJsonFile;
 
   @Option(
+      name = "experimental_execution_log_explain_file",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      converter = OptionsUtils.PathFragmentConverter.class,
+      help =
+          "Causes the build system to explain each action executed by the "
+              + "build in detail. The explanation is written to the specified log file.")
+  public PathFragment executionLogExplainFile;
+
+  @Option(
       name = "experimental_split_xml_generation",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,

--- a/src/main/java/com/google/devtools/build/lib/util/io/AnsiTerminal.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/AnsiTerminal.java
@@ -153,6 +153,20 @@ public class AnsiTerminal {
   }
 
   /**
+   * Makes text print on the terminal in cyan.
+   */
+  public void textCyan() throws IOException {
+    setTextColor(Color.CYAN);
+  }
+
+  /**
+   * Makes text print on the terminal in gray.
+   */
+  public void textGray() throws IOException {
+    setTextColor(Color.GRAY);
+  }
+
+  /**
    * Set the terminal title.
    */
   public void setTitle(String title) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/bazel/execlog/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/execlog/BUILD
@@ -16,7 +16,7 @@ java_library(
     name = "StableSortTest_lib",
     srcs = ["StableSortTest.java"],
     deps = [
-        "//src/main/java/com/google/devtools/build/lib/bazel/execlog:stable_sort",
+        "//src/main/java/com/google/devtools/build/lib/bazel/execlog",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/protobuf:spawn_java_proto",
         "//third_party:guava",

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -524,7 +524,7 @@ public class AbstractSpawnStrategyTest {
     when(actionExecutionContext.getContext(eq(SpawnLogContext.class)))
         .thenReturn(
             new SpawnLogContext(
-                execRoot, messageOutput, executionOptions, remoteOptions, SyscallCache.NO_CACHE));
+                execRoot, messageOutput, executionOptions, remoteOptions, SyscallCache.NO_CACHE, null));
     when(spawnRunner.execAsync(any(Spawn.class), any(SpawnExecutionContext.class)))
         .thenReturn(
             FutureSpawn.immediate(


### PR DESCRIPTION
This option is similar to --explain but uses the information in the execution log to show which inputs and outputs changed. It is implemented by keeping a history of the previous execution logs spawns keyed by the target + action progress message and comparing the digests of the new inputs/outputs to the old ones.

Sample explain file generated:
<img width="1173" alt="Screen Shot 2022-07-07 at 5 10 38 PM" src="https://user-images.githubusercontent.com/1301827/177808242-d735cdb2-59db-4c73-b9d6-d9696f58c7eb.png">

