### PR TITLE
Expand and clarify XML_OUTPUT_FILE description in test encyclopedia

### DIFF
--- a/site/en/reference/test-encyclopedia.md
+++ b/site/en/reference/test-encyclopedia.md
@@ -447,9 +447,12 @@ The initial environment block shall be composed as follows:
   </tr>
   <tr>
     <td><code>XML_OUTPUT_FILE</code></td>
-    <td>Location of the test result XML output file. The XML schema is based on
-      the <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
-             class="external">JUnit test result schema</a>.</td>
+    <td>
+      Location to which test actions should write a test result XML output file.
+      Otherwise, Bazel generates a default XML output file wrapping the test log
+      as part of the test action. The XML schema is based on the 
+      <a href="https://windyroad.com.au/dl/Open%20Source/JUnit.xsd"
+        class="external">JUnit test result schema</a>.</td>
     <td>optional</td>
   </tr>
   <tr>


### PR DESCRIPTION
This change adds a couple sentences to documentation based on my reading of https://github.com/bazelbuild/bazel/blob/master/tools/test/test-setup.sh#L178-L215

### Motivation
To clarify the usage and default behavior of Bazel regarding test result XML output files. 

This doc update might have saved me a few hours of pain — I'm hoping to save the next developer this time.