### PR TITLE
Accept tildes in --override_repository

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -254,10 +254,14 @@ public class RepositoryOptions extends OptionsBase {
         throw new OptionsParsingException(
             "Repository overrides must be of the form 'repository-name=path'", input);
       }
-      PathFragment path = PathFragment.create(pieces[1]);
-      if (!path.isAbsolute()) {
+      OptionsUtils.AbsolutePathFragmentConverter absolutePathFragmentConverter =
+          new OptionsUtils.AbsolutePathFragmentConverter();
+      PathFragment path;
+      try {
+        path = absolutePathFragmentConverter.convert(pieces[1]);
+      } catch (OptionsParsingException e) {
         throw new OptionsParsingException(
-            "Repository override directory must be an absolute path", input);
+            "Repository override directory must be an absolute path", input, e);
       }
       try {
         return RepositoryOverride.create(RepositoryName.create("@" + pieces[0]), path);

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.bazel.repository;
 
+import static com.google.common.base.StandardSystemProperty.USER_HOME;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.RepositoryOverride;
@@ -52,6 +53,13 @@ public class RepositoryOptionsTest {
     assertThat(actual.repositoryName())
         .isEqualTo(RepositoryName.createFromValidStrippedName("foo"));
     assertThat(actual.path()).isEqualTo(PathFragment.create("/bar=/baz"));
+  }
+
+  @Test
+  public void testOverridePathWithTilde() throws Exception {
+    RepositoryOverride actual = converter.convert("foo=~/bar");
+    assertThat(actual.repositoryName()).isEqualTo(RepositoryName.createUnvalidated("foo"));
+    assertThat(actual.path()).isEqualTo(PathFragment.create(USER_HOME.value() + "/bar"));
   }
 
   @Test


### PR DESCRIPTION
This is useful for adding this in your global ~/.bazelrc file for easy
rules debugging.

Closes #15417.

PiperOrigin-RevId: 460689663
Change-Id: I12206d24002e606f3769bb3faed0b73701ed5aad