### PR TITLE
Change py_binary's main attribute type to STRING

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyRuleClasses.java
@@ -143,7 +143,7 @@ public final class BazelPyRuleClasses {
           <code>name</code> is used instead (see above). If <code>name</code> does not
           match any filename in <code>srcs</code>, <code>main</code> must be specified.
           <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
-          .add(attr("main", LABEL).allowedFileTypes(PyRuleClasses.PYTHON_SOURCE))
+          .add(attr("main", STRING))
           /* <!-- #BLAZE_RULE($base_py_binary).ATTRIBUTE(python_version) -->
           Whether to build this target (and its transitive <code>deps</code>) for Python 2 or Python
           3. Valid values are <code>"PY2"</code> and <code>"PY3"</code> (the default).

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PyCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PyCommon.java
@@ -877,7 +877,14 @@ public final class PyCommon {
     Rule target = ruleContext.getRule();
     boolean explicitMain = target.isAttributeValueExplicitlySpecified("main");
     if (explicitMain) {
-      mainSourceName = ruleContext.attributes().get("main", BuildType.LABEL).getName();
+      // The "main" attribute used to be of type BuildType.LABEL, but this logic only used the name
+      // part. For backwards compatibility, only take the part after the last label delimiter - if
+      // the string is a valid label, this will give its name.
+      String maybeLabel = ruleContext.attributes().get("main", Type.STRING);
+      int lastLabelDelimiter = Math.max(
+          Math.max(maybeLabel.lastIndexOf('@'), maybeLabel.lastIndexOf('/')),
+          maybeLabel.lastIndexOf(':'));
+      mainSourceName = maybeLabel.substring(lastLabelDelimiter + 1);
       if (!mainSourceName.endsWith(".py")) {
         ruleContext.attributeError("main", "main must end in '.py'");
       }


### PR DESCRIPTION
py_binary's `main` attribute being a label results in a somewhat
unexpected dependency on the file target provided in the attribute.
In the case where the main file happens to be an implicit output file,
mentioning it in a label causes it to be reported as a "source file"
dependency, which is misleading.

This is fixed by changing the type of the `main` attribute to `STRING`.
In order to preserve backwards compatibility, only the portion of the
attribute after the last occurrence of `:` (if any) is used,
corresponding to the previous logic that only considered the name of the
label.

Fixes #15850