### PR TITLE
Fix analyze-profile phase summary format

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/output/PhaseText.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/output/PhaseText.java
@@ -58,7 +58,7 @@ public final class PhaseText extends TextPrinter {
           prettyPercentage(relativeDuration));
     }
 
-    lnPrintf("------------------------------------------------");
+    lnPrintf("---------------------------------------------------------------------");
     long totalDurationInMs = Duration.ofNanos(phaseSummaryStats.getTotalDuration()).toMillis();
     lnPrintf(
         THREE_COLUMN_FORMAT,

--- a/src/main/java/com/google/devtools/build/lib/profiler/output/TextPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/output/TextPrinter.java
@@ -20,7 +20,7 @@ import java.io.PrintStream;
  */
 public abstract class TextPrinter {
 
-  protected static final String THREE_COLUMN_FORMAT = "%-28s %10s %8s";
+  protected static final String THREE_COLUMN_FORMAT = "%-49s %10s %8s";
 
   protected final PrintStream out;
 


### PR DESCRIPTION
The current output of `bazel analyze-profile ...` is not properly formatted and looks like:
```
=== PHASE SUMMARY INFORMATION ===

Total launch phase time         1.486 s    0.51%
Total init phase time           0.422 s    0.15%
Total target pattern evaluation phase time    6.203 s    2.15%
Total interleaved loading-and-analysis phase time  100.341 s   34.71%
Total preparation phase time    0.376 s    0.13%
Total execution phase time    180.205 s   62.33%
Total finish phase time         0.086 s    0.03%
------------------------------------------------
Total run time                289.121 s  100.00%
```

this fixes it to:
```
=== PHASE SUMMARY INFORMATION ===

Total launch phase time                              1.486 s    0.51%
Total init phase time                                0.422 s    0.15%
Total target pattern evaluation phase time           6.203 s    2.15%
Total interleaved loading-and-analysis phase time  100.341 s   34.71%
Total preparation phase time                         0.376 s    0.13%
Total execution phase time                         180.205 s   62.33%
Total finish phase time                              0.086 s    0.03%
---------------------------------------------------------------------
Total run time                                     289.121 s  100.00%
```

Fixes #15888