### PR TITLE
Remote: Fix performance regression in "upload missing inputs".

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -13,8 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.devtools.build.lib.remote.util.RxFutures.toCompletable;
 import static com.google.devtools.build.lib.remote.util.RxFutures.toSingle;
@@ -25,9 +24,12 @@ import static java.lang.String.format;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.profiler.Profiler;
+import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
@@ -36,16 +38,21 @@ import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.RxUtils.TransferResult;
 import com.google.protobuf.Message;
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.CompletableObserver;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.SingleEmitter;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.subjects.AsyncSubject;
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.concurrent.GuardedBy;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /** A {@link RemoteCache} with additional functionality needed for remote execution. */
 public class RemoteExecutionCache extends RemoteCache {
@@ -85,13 +92,10 @@ public class RemoteExecutionCache extends RemoteCache {
       return;
     }
 
-    MissingDigestFinder missingDigestFinder = new MissingDigestFinder(context, allDigests.size());
     Flowable<TransferResult> uploads =
-        Flowable.fromIterable(allDigests)
-            .flatMapSingle(
-                digest ->
-                    uploadBlobIfMissing(
-                        context, merkleTree, additionalInputs, force, missingDigestFinder, digest));
+        createUploadTasks(context, merkleTree, additionalInputs, allDigests, force)
+            .flatMap(uploadTasks -> findMissingBlobs(context, uploadTasks))
+            .flatMapPublisher(this::waitForUploadTasks);
 
     try {
       mergeBulkTransfer(uploads).blockingAwait();
@@ -103,36 +107,6 @@ public class RemoteExecutionCache extends RemoteCache {
       }
       throw e;
     }
-  }
-
-  private Single<TransferResult> uploadBlobIfMissing(
-      RemoteActionExecutionContext context,
-      MerkleTree merkleTree,
-      Map<Digest, Message> additionalInputs,
-      boolean force,
-      MissingDigestFinder missingDigestFinder,
-      Digest digest) {
-    Completable upload =
-        casUploadCache.execute(
-            digest,
-            Completable.defer(
-                () ->
-                    // Only reach here if the digest is missing and is not being uploaded.
-                    missingDigestFinder
-                        .registerAndCount(digest)
-                        .flatMapCompletable(
-                            missingDigests -> {
-                              if (missingDigests.contains(digest)) {
-                                return toCompletable(
-                                    () -> uploadBlob(context, digest, merkleTree, additionalInputs),
-                                    directExecutor());
-                              } else {
-                                return Completable.complete();
-                              }
-                            })),
-            /* onIgnored= */ missingDigestFinder::count,
-            force);
-    return toTransferResult(upload);
   }
 
   private ListenableFuture<Void> uploadBlob(
@@ -165,92 +139,150 @@ public class RemoteExecutionCache extends RemoteCache {
                 digest)));
   }
 
-  /**
-   * A missing digest finder that initiates the request when the internal counter reaches an
-   * expected count.
-   */
-  class MissingDigestFinder {
-    private final int expectedCount;
+  static class UploadTask {
+    Digest digest;
+    AtomicReference<Disposable> disposable;
+    SingleEmitter<Boolean> continuation;
+    Completable completion;
+  }
 
-    private final AsyncSubject<ImmutableSet<Digest>> digestsSubject;
-    private final Single<ImmutableSet<Digest>> resultSingle;
+  private Single<List<UploadTask>> createUploadTasks(
+      RemoteActionExecutionContext context,
+      MerkleTree merkleTree,
+      Map<Digest, Message> additionalInputs,
+      Iterable<Digest> allDigests,
+      boolean force) {
+    return Single.using(
+        () -> Profiler.instance().profile("collect digests"),
+        ignored ->
+            Flowable.fromIterable(allDigests)
+                .flatMapMaybe(
+                    digest ->
+                        maybeCreateUploadTask(context, merkleTree, additionalInputs, digest, force))
+                .collect(Collectors.toList()),
+        SilentCloseable::close);
+  }
 
-    @GuardedBy("this")
-    private final Set<Digest> digests;
+  private Maybe<UploadTask> maybeCreateUploadTask(
+      RemoteActionExecutionContext context,
+      MerkleTree merkleTree,
+      Map<Digest, Message> additionalInputs,
+      Digest digest,
+      boolean force) {
+    return Maybe.create(
+        emitter -> {
+          AsyncSubject<Void> completion = AsyncSubject.create();
+          UploadTask uploadTask = new UploadTask();
+          uploadTask.digest = digest;
+          uploadTask.disposable = new AtomicReference<>();
+          uploadTask.completion =
+              Completable.fromObservable(
+                  completion.doOnDispose(
+                      () -> {
+                        Disposable d = uploadTask.disposable.getAndSet(null);
+                        if (d != null) {
+                          d.dispose();
+                        }
+                      }));
+          Completable upload =
+              casUploadCache.execute(
+                  digest,
+                  Single.<Boolean>create(
+                          continuation -> {
+                            uploadTask.continuation = continuation;
+                            emitter.onSuccess(uploadTask);
+                          })
+                      .flatMapCompletable(
+                          shouldUpload -> {
+                            if (!shouldUpload) {
+                              return Completable.complete();
+                            }
 
-    @GuardedBy("this")
-    private int currentCount = 0;
+                            return toCompletable(
+                                () ->
+                                    uploadBlob(
+                                        context, uploadTask.digest, merkleTree, additionalInputs),
+                                directExecutor());
+                          }),
+                  /* onAlreadyRunning= */ () -> emitter.onSuccess(uploadTask),
+                  /* onAlreadyFinished= */ emitter::onComplete,
+                  force);
+          upload.subscribe(
+              new CompletableObserver() {
+                @Override
+                public void onSubscribe(@NonNull Disposable d) {
+                  uploadTask.disposable.set(d);
+                }
 
-    MissingDigestFinder(RemoteActionExecutionContext context, int expectedCount) {
-      checkArgument(expectedCount > 0, "expectedCount should be greater than 0");
-      this.expectedCount = expectedCount;
-      this.digestsSubject = AsyncSubject.create();
-      this.digests = new HashSet<>();
+                @Override
+                public void onComplete() {
+                  completion.onComplete();
+                }
 
-      AtomicBoolean findMissingDigestsCalled = new AtomicBoolean(false);
-      this.resultSingle =
-          Single.fromObservable(
-              digestsSubject
-                  .flatMapSingle(
-                      digests -> {
-                        boolean wasCalled = findMissingDigestsCalled.getAndSet(true);
-                        // Make sure we don't have re-subscription caused by refCount() below.
-                        checkState(!wasCalled, "FindMissingDigests is called more than once");
-                        return toSingle(
-                            () -> findMissingDigests(context, digests), directExecutor());
-                      })
-                  // Use replay here because we could have a race condition that downstream hasn't
-                  // been added to the subscription list (to receive the upstream result) while
-                  // upstream is completed.
-                  .replay(1)
-                  .refCount());
-    }
+                @Override
+                public void onError(@NonNull Throwable e) {
+                  Disposable d = uploadTask.disposable.get();
+                  if (d != null && d.isDisposed()) {
+                    return;
+                  }
 
-    /**
-     * Register the {@code digest} and increase the counter.
-     *
-     * <p>Returned Single cannot be subscribed more than once.
-     *
-     * @return Single that emits the result of the {@code FindMissingDigest} request.
-     */
-    Single<ImmutableSet<Digest>> registerAndCount(Digest digest) {
-      AtomicBoolean subscribed = new AtomicBoolean(false);
-      // count() will potentially trigger the findMissingDigests call. Adding and counting before
-      // returning the Single could introduce a race that the result of findMissingDigests is
-      // available but the consumer doesn't get it because it hasn't subscribed the returned
-      // Single. In this case, it subscribes after upstream is completed resulting a re-run of
-      // findMissingDigests (due to refCount()).
-      //
-      // Calling count() inside doOnSubscribe to ensure the consumer already subscribed to the
-      // returned Single to avoid a re-execution of findMissingDigests.
-      return resultSingle.doOnSubscribe(
-          d -> {
-            boolean wasSubscribed = subscribed.getAndSet(true);
-            checkState(!wasSubscribed, "Single is subscribed more than once");
-            synchronized (this) {
-              digests.add(digest);
-            }
-            count();
-          });
-    }
+                  completion.onError(e);
+                }
+              });
+        });
+  }
 
-    /** Increase the counter. */
-    void count() {
-      ImmutableSet<Digest> digestsResult = null;
+  private Single<List<UploadTask>> findMissingBlobs(
+      RemoteActionExecutionContext context, List<UploadTask> uploadTasks) {
+    return Single.using(
+        () -> Profiler.instance().profile("findMissingDigests"),
+        ignored ->
+            Single.fromObservable(
+                Observable.fromSingle(
+                        toSingle(
+                                () -> {
+                                  ImmutableList<Digest> digestsToQuery =
+                                      uploadTasks.stream()
+                                          .filter(uploadTask -> uploadTask.continuation != null)
+                                          .map(uploadTask -> uploadTask.digest)
+                                          .collect(ImmutableList.toImmutableList());
+                                  if (digestsToQuery.isEmpty()) {
+                                    return immediateFuture(ImmutableSet.of());
+                                  }
+                                  return findMissingDigests(context, digestsToQuery);
+                                },
+                                directExecutor())
+                            .map(
+                                missingDigests -> {
+                                  for (UploadTask uploadTask : uploadTasks) {
+                                    if (uploadTask.continuation != null) {
+                                      uploadTask.continuation.onSuccess(
+                                          missingDigests.contains(uploadTask.digest));
+                                    }
+                                  }
+                                  return uploadTasks;
+                                }))
+                    // Use AsyncSubject so that if downstream is disposed, the
+                    // findMissingDigests call is not cancelled (because it may be needed by other
+                    // threads).
+                    .subscribeWith(AsyncSubject.create()))
+                .doOnDispose(() -> {
+                  for (UploadTask uploadTask : uploadTasks) {
+                    Disposable d = uploadTask.disposable.getAndSet(null);
+                    if (d != null) {
+                      d.dispose();
+                    }
+                  }
+                }),
+        SilentCloseable::close);
+  }
 
-      synchronized (this) {
-        if (currentCount < expectedCount) {
-          currentCount++;
-          if (currentCount == expectedCount) {
-            digestsResult = ImmutableSet.copyOf(digests);
-          }
-        }
-      }
-
-      if (digestsResult != null) {
-        digestsSubject.onNext(digestsResult);
-        digestsSubject.onComplete();
-      }
-    }
+  private Flowable<TransferResult> waitForUploadTasks(List<UploadTask> uploadTasks) {
+    return Flowable.using(
+        () -> Profiler.instance().profile("upload"),
+        ignored ->
+            Flowable.fromIterable(uploadTasks)
+                .flatMapSingle(uploadTask -> toTransferResult(uploadTask.completion)),
+        SilentCloseable::close);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/AsyncTaskCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/AsyncTaskCache.java
@@ -257,10 +257,10 @@ public final class AsyncTaskCache<KeyT, ValueT> {
   /**
    * Executes a task.
    *
-   * @see #execute(Object, Single, Action, boolean).
+   * @see #execute(Object, Single, Action, Action, boolean).
    */
   public Single<ValueT> execute(KeyT key, Single<ValueT> task, boolean force) {
-    return execute(key, task, () -> {}, force);
+    return execute(key, task, () -> {}, () -> {}, force);
   }
 
   /**
@@ -270,12 +270,17 @@ public final class AsyncTaskCache<KeyT, ValueT> {
    * <p>If the cache is already shutdown, a {@link CancellationException} will be emitted.
    *
    * @param key identifies the task.
-   * @param onIgnored callback called when provided task is ignored.
+   * @param onAlreadyFinished callback called when provided task is already finished.
    * @param force re-execute a finished task if set to {@code true}.
    * @return a {@link Single} which turns to completed once the task is finished or propagates the
    *     error if any.
    */
-  public Single<ValueT> execute(KeyT key, Single<ValueT> task, Action onIgnored, boolean force) {
+  public Single<ValueT> execute(
+      KeyT key,
+      Single<ValueT> task,
+      Action onAlreadyRunning,
+      Action onAlreadyFinished,
+      boolean force) {
     return Single.create(
         emitter -> {
           synchronized (lock) {
@@ -285,7 +290,7 @@ public final class AsyncTaskCache<KeyT, ValueT> {
             }
 
             if (!force && finished.containsKey(key)) {
-              onIgnored.run();
+              onAlreadyFinished.run();
               emitter.onSuccess(finished.get(key));
               return;
             }
@@ -294,7 +299,7 @@ public final class AsyncTaskCache<KeyT, ValueT> {
 
             Execution execution = inProgress.get(key);
             if (execution != null) {
-              onIgnored.run();
+              onAlreadyRunning.run();
             } else {
               execution = new Execution(key, task);
               inProgress.put(key, execution);
@@ -445,13 +450,23 @@ public final class AsyncTaskCache<KeyT, ValueT> {
 
     /** Same as {@link AsyncTaskCache#execute} but operates on {@link Completable}. */
     public Completable execute(KeyT key, Completable task, boolean force) {
-      return execute(key, task, () -> {}, force);
+      return execute(key, task, () -> {}, () -> {}, force);
     }
 
     /** Same as {@link AsyncTaskCache#execute} but operates on {@link Completable}. */
-    public Completable execute(KeyT key, Completable task, Action onIgnored, boolean force) {
+    public Completable execute(
+        KeyT key,
+        Completable task,
+        Action onAlreadyRunning,
+        Action onAlreadyFinished,
+        boolean force) {
       return Completable.fromSingle(
-          cache.execute(key, task.toSingleDefault(Optional.empty()), onIgnored, force));
+          cache.execute(
+              key,
+              task.toSingleDefault(Optional.empty()),
+              onAlreadyRunning,
+              onAlreadyFinished,
+              force));
     }
 
     /** Returns a set of keys for tasks which is finished. */

--- a/src/test/java/com/google/devtools/build/lib/remote/InMemoryRemoteCache.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/InMemoryRemoteCache.java
@@ -17,6 +17,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import build.bazel.remote.execution.v2.Digest;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.InMemoryCacheClient;
@@ -37,6 +38,10 @@ class InMemoryRemoteCache extends RemoteExecutionCache {
 
   InMemoryRemoteCache(RemoteOptions options, DigestUtil digestUtil) {
     super(new InMemoryCacheClient(), options, digestUtil);
+  }
+
+  InMemoryRemoteCache(RemoteCacheClient cacheProtocol, RemoteOptions options, DigestUtil digestUtil) {
+    super(cacheProtocol, options, digestUtil);
   }
 
   Digest addContents(RemoteActionExecutionContext context, String txt)

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
 import static org.mockito.ArgumentMatchers.any;
@@ -48,6 +49,7 @@ import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.InMemoryCacheClient;
+import com.google.devtools.build.lib.remote.util.RxNoGlobalErrorsRule;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.util.io.FileOutErr;
@@ -63,9 +65,13 @@ import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -74,6 +80,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -82,6 +89,9 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link RemoteCache}. */
 @RunWith(JUnit4.class)
 public class RemoteCacheTest {
+  @Rule
+  public final RxNoGlobalErrorsRule rxNoGlobalErrorsRule = new RxNoGlobalErrorsRule();
+
   private RemoteActionExecutionContext context;
   private FileSystem fs;
   private Path execRoot;
@@ -294,18 +304,32 @@ public class RemoteCacheTest {
   }
 
   @Test
-  public void ensureInputsPresent_interrupted_cancelInProgressUploadTasks() throws Exception {
+  public void ensureInputsPresent_interruptedDuringUploadBlobs_cancelInProgressUploadTasks()
+      throws Exception {
     // arrange
-    InMemoryRemoteCache remoteCache = spy(newRemoteCache());
+    RemoteCacheClient cacheProtocol = spy(new InMemoryCacheClient());
+    RemoteExecutionCache remoteCache = spy(newRemoteExecutionCache(cacheProtocol));
 
-    CountDownLatch findMissingDigestsCalled = new CountDownLatch(1);
+    List<SettableFuture<Void>> futures = new ArrayList<>();
+    CountDownLatch uploadBlobCalls = new CountDownLatch(2);
     doAnswer(
             invocationOnMock -> {
-              findMissingDigestsCalled.countDown();
-              return SettableFuture.create();
+              uploadBlobCalls.countDown();
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              return future;
             })
-        .when(remoteCache)
-        .findMissingDigests(any(), any());
+        .when(cacheProtocol)
+        .uploadBlob(any(), any(), any());
+    doAnswer(
+            invocationOnMock -> {
+              uploadBlobCalls.countDown();
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              return future;
+            })
+        .when(cacheProtocol)
+        .uploadFile(any(), any(), any());
 
     Path path = fs.getPath("/execroot/foo");
     FileSystemUtils.writeContentAsLatin1(path, "bar");
@@ -328,7 +352,8 @@ public class RemoteCacheTest {
 
     // act
     thread.start();
-    findMissingDigestsCalled.await();
+    uploadBlobCalls.await();
+    assertThat(futures.size()).isEqualTo(2);
     assertThat(remoteCache.casUploadCache.getInProgressTasks()).isNotEmpty();
 
     thread.interrupt();
@@ -336,6 +361,172 @@ public class RemoteCacheTest {
 
     // assert
     assertThat(remoteCache.casUploadCache.getInProgressTasks()).isEmpty();
+    assertThat(remoteCache.casUploadCache.getFinishedTasks()).isEmpty();
+    for (SettableFuture<Void> future : futures) {
+      assertThat(future.isCancelled()).isTrue();
+    }
+  }
+
+  @Test
+  public void ensureInputsPresent_multipleConsumers_interruptedOneDuringFindMissingBlobs_keepAndFinishInProgressUploadTasks()
+      throws Exception {
+    // arrange
+    RemoteCacheClient cacheProtocol = spy(new InMemoryCacheClient());
+    RemoteExecutionCache remoteCache = spy(newRemoteExecutionCache(cacheProtocol));
+
+    SettableFuture<ImmutableSet<Digest>> findMissingDigestsFuture = SettableFuture.create();
+    CountDownLatch findMissingDigestsCalled = new CountDownLatch(1);
+    doAnswer(
+        invocationOnMock -> {
+          findMissingDigestsCalled.countDown();
+          return findMissingDigestsFuture;
+        })
+        .when(remoteCache)
+        .findMissingDigests(any(), any());
+    Deque<SettableFuture<Void>> futures = new ConcurrentLinkedDeque<>();
+    CountDownLatch uploadBlobCalls = new CountDownLatch(2);
+    doAnswer(
+        invocationOnMock -> {
+          uploadBlobCalls.countDown();
+          SettableFuture<Void> future = SettableFuture.create();
+          futures.add(future);
+          return future;
+        })
+        .when(cacheProtocol)
+        .uploadBlob(any(), any(), any());
+    doAnswer(
+        invocationOnMock -> {
+          uploadBlobCalls.countDown();
+          SettableFuture<Void> future = SettableFuture.create();
+          futures.add(future);
+          return future;
+        })
+        .when(cacheProtocol)
+        .uploadFile(any(), any(), any());
+
+    Path path = fs.getPath("/execroot/foo");
+    FileSystemUtils.writeContentAsLatin1(path, "bar");
+    SortedMap<PathFragment, Path> inputs = new TreeMap<>();
+    inputs.put(PathFragment.create("foo"), path);
+    MerkleTree merkleTree = MerkleTree.build(inputs, digestUtil);
+
+    CountDownLatch ensureInputsPresentReturned = new CountDownLatch(2);
+    CountDownLatch ensureInterrupted = new CountDownLatch(1);
+    Runnable work =
+        () -> {
+          try {
+            remoteCache.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), false);
+          } catch (IOException ignored) {
+            // ignored
+          } catch (InterruptedException e) {
+            ensureInterrupted.countDown();
+          } finally {
+            ensureInputsPresentReturned.countDown();
+          }
+        };
+    Thread thread1 = new Thread(work);
+    Thread thread2 = new Thread(work);
+    thread1.start();
+    thread2.start();
+    findMissingDigestsCalled.await();
+
+    // act
+    thread1.interrupt();
+    ensureInterrupted.await();
+    findMissingDigestsFuture.set(ImmutableSet.copyOf(merkleTree.getAllDigests()));
+
+    uploadBlobCalls.await();
+    assertThat(futures.size()).isEqualTo(2);
+
+    // assert
+    assertThat(remoteCache.casUploadCache.getInProgressTasks().size()).isEqualTo(2);
+    assertThat(remoteCache.casUploadCache.getFinishedTasks()).isEmpty();
+    for (SettableFuture<Void> future : futures) {
+      assertThat(future.isCancelled()).isFalse();
+    }
+
+    for (SettableFuture<Void> future : futures) {
+      future.set(null);
+    }
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).isEmpty();
+    assertThat(remoteCache.casUploadCache.getFinishedTasks().size()).isEqualTo(2);
+    ensureInputsPresentReturned.await();
+  }
+
+  @Test
+  public void ensureInputsPresent_multipleConsumers_interruptedOneDuringUploadBlobs_keepInProgressUploadTasks()
+      throws Exception {
+    // arrange
+    RemoteCacheClient cacheProtocol = spy(new InMemoryCacheClient());
+    RemoteExecutionCache remoteCache = spy(newRemoteExecutionCache(cacheProtocol));
+
+    List<SettableFuture<Void>> futures = new ArrayList<>();
+    CountDownLatch uploadBlobCalls = new CountDownLatch(2);
+    doAnswer(
+            invocationOnMock -> {
+              uploadBlobCalls.countDown();
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              return future;
+            })
+        .when(cacheProtocol)
+        .uploadBlob(any(), any(), any());
+    doAnswer(
+            invocationOnMock -> {
+              uploadBlobCalls.countDown();
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              return future;
+            })
+        .when(cacheProtocol)
+        .uploadFile(any(), any(), any());
+
+    Path path = fs.getPath("/execroot/foo");
+    FileSystemUtils.writeContentAsLatin1(path, "bar");
+    SortedMap<PathFragment, Path> inputs = new TreeMap<>();
+    inputs.put(PathFragment.create("foo"), path);
+    MerkleTree merkleTree = MerkleTree.build(inputs, digestUtil);
+
+    CountDownLatch ensureInputsPresentReturned = new CountDownLatch(2);
+    CountDownLatch ensureInterrupted = new CountDownLatch(1);
+    Runnable work =
+        () -> {
+          try {
+            remoteCache.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), false);
+          } catch (IOException ignored) {
+            // ignored
+          } catch (InterruptedException e) {
+            ensureInterrupted.countDown();
+          } finally {
+            ensureInputsPresentReturned.countDown();
+          }
+        };
+    Thread thread1 = new Thread(work);
+    Thread thread2 = new Thread(work);
+
+    // act
+    thread1.start();
+    thread2.start();
+    uploadBlobCalls.await();
+    assertThat(futures.size()).isEqualTo(2);
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).isNotEmpty();
+
+    thread1.interrupt();
+    ensureInterrupted.await();
+
+    // assert
+    assertThat(remoteCache.casUploadCache.getInProgressTasks().size()).isEqualTo(2);
+    assertThat(remoteCache.casUploadCache.getFinishedTasks()).isEmpty();
+    for (SettableFuture<Void> future : futures) {
+      assertThat(future.isCancelled()).isFalse();
+    }
+
+    for (SettableFuture<Void> future : futures) {
+      future.set(null);
+    }
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).isEmpty();
+    assertThat(remoteCache.casUploadCache.getFinishedTasks().size()).isEqualTo(2);
+    ensureInputsPresentReturned.await();
   }
 
   @Test
@@ -363,5 +554,10 @@ public class RemoteCacheTest {
 
   private RemoteCache newRemoteCache(RemoteCacheClient remoteCacheClient) {
     return new RemoteCache(remoteCacheClient, Options.getDefaults(RemoteOptions.class), digestUtil);
+  }
+
+  private RemoteExecutionCache newRemoteExecutionCache(RemoteCacheClient remoteCacheClient) {
+    return new RemoteExecutionCache(
+        remoteCacheClient, Options.getDefaults(RemoteOptions.class), digestUtil);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /** A {@link RemoteCacheClient} that stores its contents in memory. */
-public final class InMemoryCacheClient implements RemoteCacheClient {
+public class InMemoryCacheClient implements RemoteCacheClient {
 
   private final ListeningExecutorService executorService =
       MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(100));


### PR DESCRIPTION
The regression was introduced in 702df847cf32789ffe6c0a7c7679e92a7ccccb8d where we essentially create a subscriber for each digest to subscribe the result of `findMissingBlobs`.

This change update the code to not create so many subscribers but maintain the same functionalities.

Fixes #15872.