### PR TITLE
Move link to make document a bit easier to follow.

### DIFF
--- a/site/en/rules/config.md
+++ b/site/en/rules/config.md
@@ -512,9 +512,6 @@ multi_arch_transition = transition(
 )
 ```
 
-See [Accessing attributes with transitions](#accessing-attributes-with-transitions)
-for how to read these keys.
-
 ### Attaching transitions {:#attaching-transitions}
 
 [End to end example](https://github.com/bazelbuild/examples/tree/HEAD/configurations/attaching_transitions_to_rules){: .external}
@@ -559,6 +556,9 @@ drink_rule = rule(
     ...
 ```
 Outgoing edge transitions can be 1:1 or 1:2+.
+
+See [Accessing attributes with transitions](#accessing-attributes-with-transitions)
+for how to read these keys.
 
 ### Transitions on native options {:#transitions-native-options}
 


### PR DESCRIPTION
Move the link to `#accessing-attributes-with-transitions`
from the section about how to define 1:2 transitions into the section
on how to attach an outgoing transition to an attribute, since that's
the section people are most likely to be reading when they need to
see that link.

This got me, leading to me opening https://github.com/bazelbuild/bazel/issues/15892, because I wasn't implementing a 1:2+ transition and hadn't kept reading to the end of the document.