### PR TITLE
Removed documentation for `-extra_checks` which has been gone since v3.5

### DIFF
--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -401,15 +401,6 @@ of all affected classes. Also note that javacopts parameters listed in
 specific java_library or java_binary build rules will be placed on the javac
 command line _after_ these options.
 
-##### `-extra_checks[:(off|on)]` {:#extra-checks}
-
-This javac option enables extra correctness checks. Any problems found will
-be presented as errors.
-Either `-extra_checks` or `-extra_checks:on` may be used
-to force the checks to be turned on. `-extra_checks:off` completely
-disables the analysis.
-When this option is not specified, the default behavior is used.
-
 #### `--strict_java_deps (default|strict|off|warn|error)` {:#strict-java-deps}
 
 This option controls whether javac checks for missing direct dependencies.


### PR DESCRIPTION
Support for flag removed in 1819f6ecf5b7f28fadcff54dd9454a91d9d2d8a6
Closest analogue is `-XepDisableAllChecks`, an Error Prone flag documented at https://errorprone.info/docs/flags

Note that `-XepDisableAllChecks` will not necessarily disable all Error Prone checks. For example, [UnicodeDirectionalityCharacters](https://github.com/google/error-prone/blob/0da434efc8adca8682bea159c97f7fab65745c83/core/src/main/java/com/google/errorprone/bugpatterns/UnicodeDirectionalityCharacters.java) cannot be disabled.