### PR TITLE
[remote] Improve .netrc test in RemoteModuleTest

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -566,6 +566,8 @@ public final class RemoteModuleTest {
             clientEnv, fileSystem, reporter, authAndTLSOptions, remoteOptions);
 
     assertThat(credentials).isNotNull();
+    assertThat(credentials.getRequestMetadata(URI.create("https://foo.example.org"))).isNotEmpty();
+    assertThat(credentials.getRequestMetadata(URI.create("https://bar.example.org"))).isEmpty();
   }
 
   private static void assertRequestMetadata(


### PR DESCRIPTION
The return value being non-null doesn't assert that we actually parsed the (expected) `.netrc`.