### PR TITLE
target pattern file: allow comments

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/TargetPatternsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/TargetPatternsHelper.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.runtime.commands;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Preconditions;
@@ -29,6 +30,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.common.options.OptionsParsingResult;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Predicate;
 
 /** Provides support for reading target patterns from a file or the command-line. */
 final class TargetPatternsHelper {
@@ -54,7 +56,12 @@ final class TargetPatternsHelper {
       Path residuePath =
           env.getWorkingDirectory().getRelative(buildRequestOptions.targetPatternFile);
       try {
-        targets = FileSystemUtils.readLines(residuePath, UTF_8);
+        targets =
+            FileSystemUtils.readLines(residuePath, UTF_8).stream()
+                .map(s -> s.split("#")[0])
+                .map(String::trim)
+                .filter(Predicate.not(String::isEmpty))
+                .collect(toImmutableList());
       } catch (IOException e) {
         throw new TargetPatternsHelperException(
             "I/O error reading from " + residuePath.getPathString() + ": " + e.getMessage(),

--- a/src/test/shell/integration/target_pattern_file_test.sh
+++ b/src/test/shell/integration/target_pattern_file_test.sh
@@ -73,7 +73,8 @@ sh_test(name = "y", srcs = ["x.out"])
 EOF
 
   cat >build.params <<'EOF'
-//:x
+# Test comment
+//:x # Trailing comment
 //:y
 EOF
 }


### PR DESCRIPTION
`--target_pattern_file` could be a great tool assisting migration of a
code base from one Bazel config to another.  User could define a list of
targets that can be built with the new configs and incrementally expand
that list with each change that was introduced.  Multiple users / teams
could collaborate on such migration by adding / removing their targets
into / from the pattern file.

Having the ability to provide comments to annotate the targets in the
pattern file with extra information during the migration process added a
great value and context for build maintainers to track migration
progress.

Add support for Bash-style comments to the target-pattern file.

Closes #15903.

PiperOrigin-RevId: 461861131
Change-Id: I401f71fcf1e343c8689424979e4f48fb723fba9f