### PR TITLE
Fail the build on repository rule errors in a module extension

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -332,6 +332,35 @@ class BazelModuleTest(test_base.TestBase):
         'ERROR: For repository \'B\', the root module requires module version B@1.0, but got B@1.1 in the resolved dependency graph.',
         stderr)
 
+  def testRepositoryRuleErrorInModuleExtensionFailsTheBuild(self):
+    self.ScratchFile('MODULE.bazel', [
+        'module_ext = use_extension("//pkg:extension.bzl", "module_ext")',
+        'use_repo(module_ext, "foo")',
+    ])
+    self.ScratchFile('pkg/BUILD.bazel')
+    self.ScratchFile('pkg/rules.bzl', [
+        'def _repo_rule_impl(ctx):',
+        '    ctx.file("WORKSPACE")',
+        'repo_rule = repository_rule(implementation = _repo_rule_impl)',
+    ])
+    self.ScratchFile('pkg/extension.bzl', [
+        'load(":rules.bzl", "repo_rule")',
+        'def _module_ext_impl(ctx):',
+        '    repo_rule(name = "foo", invalid_attr = "value")',
+        'module_ext = module_extension(implementation = _module_ext_impl)',
+    ])
+    exit_code, _, stderr = self.RunBazel(['run', '@foo//...'],
+                                         allow_failure=True)
+    self.AssertExitCode(exit_code, 48, stderr)
+    self.assertIn(
+        "ERROR: <builtin>: //pkg:@.module_ext.foo: no such attribute 'invalid_attr' in 'repo_rule' rule",
+        stderr)
+    self.assertTrue(
+        any([
+            '/pkg/extension.bzl", line 3, column 14, in _module_ext_impl'
+            in line for line in stderr
+        ]))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Fail the build on repository rule errors in a module extension

Also emit a Starlark stack trace pointing to the particular call site
of the repository rule.

Previously, the root cause error would be printed, but the build would
continue.

Fixes https://github.com/bazelbuild/bazel/issues/14526#issuecomment-1149683214

Closes #15796.

PiperOrigin-RevId: 459065865
Change-Id: I2444378c7857b1031fabfacd00f8246583bb2146

Closes #15802