### PR TITLE
Increase osx_cc_configure timeouts

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -71,7 +71,7 @@ def _compile_cc_file_single_arch(repository_ctx, src_name, out_name):
         "-o",
         out_name,
         src_name,
-    ], 30)
+    ], 60)
     if (xcrun_result.return_code != 0):
         error_msg = (
             "return code {code}, stderr: {err}, stdout: {out}"
@@ -107,7 +107,7 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
         "-o",
         out_name,
         src_name,
-    ], 30)
+    ], 60)
 
     if xcrun_result.return_code == 0:
         xcrun_result = repository_ctx.execute([
@@ -120,7 +120,7 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
             "--sign",
             "-",
             out_name,
-        ], 30)
+        ], 60)
         if xcrun_result.return_code != 0:
             error_msg = (
                 "codesign return code {code}, stderr: {err}, stdout: {out}"


### PR DESCRIPTION
People see a lot of timeouts on these calls, especially when using
github actions. Bumping them a bit shouldn't hurt the common case but
might help this issue.

Related: https://github.com/bazelbuild/bazel/issues/14113

Closes #15877.

PiperOrigin-RevId: 462325991
Change-Id: I61819f558eed7964ac9fee1d9ff5171689e01aa5