### PR TITLE
Introduce persistent_multiplex_android_resource_processor expansion flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -861,8 +861,40 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
           "--strategy=AndroidManifestMerger=worker",
           "--strategy=Aapt2Optimize=worker",
           "--strategy=AARGenerator=worker",
+          "--strategy=Desugar=worker",
+          "--strategy=DexBuilder=worker",
         })
     public Void persistentResourceProcessor;
+
+    @Option(
+        name = "persistent_multiplex_android_resource_processor",
+        defaultValue = "null",
+        documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+        effectTags = {
+          OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS,
+          OptionEffectTag.EXECUTION,
+        },
+        help = "Enable the persistent Android resource processor by using workers.",
+        expansion = {
+          "--persistent_android_resource_processor",
+          "--modify_execution_info=AaptPackage=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidResourceParser=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidResourceValidator=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidResourceCompiler=+supports-multiplex-workers",
+          "--modify_execution_info=RClassGenerator=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidResourceLink=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidAapt2=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidAssetMerger=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidResourceMerger=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidCompiledResourceMerger=+supports-multiplex-workers",
+          "--modify_execution_info=ManifestMerger=+supports-multiplex-workers",
+          "--modify_execution_info=AndroidManifestMerger=+supports-multiplex-workers",
+          "--modify_execution_info=Aapt2Optimize=+supports-multiplex-workers",
+          "--modify_execution_info=AARGenerator=+supports-multiplex-workers",
+          "--modify_execution_info=Desugar=+supports-multiplex-workers",
+          "--modify_execution_info=DexBuilder=+supports-multiplex-workers",
+        })
+    public Void persistentMultiplexAndroidResourceProcessor;
 
     /**
      * We use this option to decide when to enable workers for busybox tools. This flag is also a
@@ -882,17 +914,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
         defaultValue = "false",
         help = "Tracking flag for when busybox workers are enabled.")
     public boolean persistentBusyboxTools;
-
-    @Option(
-        name = "experimental_persistent_multiplex_busybox_tools",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {
-          OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS,
-          OptionEffectTag.EXECUTION,
-        },
-        defaultValue = "false",
-        help = "Tracking flag for when multiplex busybox workers are enabled.")
-    public boolean experimentalPersistentMultiplexBusyboxTools;
 
     @Option(
         name = "experimental_remove_r_classes_from_instrumentation_test_jar",
@@ -1019,8 +1040,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
       host.oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest =
           oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest;
       host.persistentBusyboxTools = persistentBusyboxTools;
-      host.experimentalPersistentMultiplexBusyboxTools =
-          experimentalPersistentMultiplexBusyboxTools;
 
       // Unless the build was started from an Android device, host means MAIN.
       host.configurationDistinguisher = ConfigurationDistinguisher.MAIN;
@@ -1066,7 +1085,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final boolean dataBindingUpdatedArgs;
   private final boolean dataBindingAndroidX;
   private final boolean persistentBusyboxTools;
-  private final boolean experimentalPersistentMultiplexBusyboxTools;
   private final boolean filterRJarsFromAndroidTest;
   private final boolean removeRClassesFromInstrumentationTestJar;
   private final boolean alwaysFilterDuplicateClassesFromAndroidTest;
@@ -1126,8 +1144,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     this.dataBindingUpdatedArgs = options.dataBindingUpdatedArgs;
     this.dataBindingAndroidX = options.dataBindingAndroidX;
     this.persistentBusyboxTools = options.persistentBusyboxTools;
-    this.experimentalPersistentMultiplexBusyboxTools =
-        options.experimentalPersistentMultiplexBusyboxTools;
     this.filterRJarsFromAndroidTest = options.filterRJarsFromAndroidTest;
     this.removeRClassesFromInstrumentationTestJar =
         options.removeRClassesFromInstrumentationTestJar;
@@ -1377,11 +1393,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   @Override
   public boolean persistentBusyboxTools() {
     return persistentBusyboxTools;
-  }
-
-  @Override
-  public boolean persistentMultiplexBusyboxTools() {
-    return experimentalPersistentMultiplexBusyboxTools;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDataContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDataContext.java
@@ -64,7 +64,6 @@ public class AndroidDataContext implements AndroidDataContextApi {
   private final FilesToRunProvider busybox;
   private final AndroidSdkProvider sdk;
   private final boolean persistentBusyboxToolsEnabled;
-  private final boolean persistentMultiplexBusyboxTools;
   private final boolean optOutOfResourcePathShortening;
   private final boolean optOutOfResourceNameObfuscation;
   private final boolean throwOnShrinkResources;
@@ -91,7 +90,6 @@ public class AndroidDataContext implements AndroidDataContextApi {
         ruleContext,
         ruleContext.getExecutablePrerequisite("$android_resources_busybox"),
         androidConfig.persistentBusyboxTools(),
-        androidConfig.persistentMultiplexBusyboxTools(),
         AndroidSdkProvider.fromRuleContext(ruleContext),
         hasExemption(ruleContext, "allow_raw_access_to_resource_paths", false),
         hasExemption(ruleContext, "allow_resource_name_obfuscation_opt_out", false),
@@ -116,7 +114,6 @@ public class AndroidDataContext implements AndroidDataContextApi {
       RuleContext ruleContext,
       FilesToRunProvider busybox,
       boolean persistentBusyboxToolsEnabled,
-      boolean persistentMultiplexBusyboxTools,
       AndroidSdkProvider sdk,
       boolean optOutOfResourcePathShortening,
       boolean optOutOfResourceNameObfuscation,
@@ -129,7 +126,6 @@ public class AndroidDataContext implements AndroidDataContextApi {
       boolean includeProguardLocationReferences,
       ImmutableMap<String, String> executionInfo) {
     this.persistentBusyboxToolsEnabled = persistentBusyboxToolsEnabled;
-    this.persistentMultiplexBusyboxTools = persistentMultiplexBusyboxTools;
     this.ruleContext = ruleContext;
     this.busybox = busybox;
     this.sdk = sdk;
@@ -224,10 +220,6 @@ public class AndroidDataContext implements AndroidDataContextApi {
 
   public boolean isPersistentBusyboxToolsEnabled() {
     return persistentBusyboxToolsEnabled;
-  }
-
-  public boolean isPersistentMultiplexBusyboxTools() {
-    return persistentMultiplexBusyboxTools;
   }
 
   public boolean optOutOfResourcePathShortening() {

--- a/src/main/java/com/google/devtools/build/lib/rules/android/BusyBoxActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/BusyBoxActionBuilder.java
@@ -369,10 +369,6 @@ public final class BusyBoxActionBuilder {
       commandLine.add("--logWarnings=false");
       spawnActionBuilder.addCommandLine(commandLine.build(), WORKERS_FORCED_PARAM_FILE_INFO);
       executionInfo.putAll(ExecutionRequirements.WORKER_MODE_ENABLED);
-
-      if (dataContext.isPersistentMultiplexBusyboxTools()) {
-        executionInfo.putAll(ExecutionRequirements.WORKER_MULTIPLEX_MODE_ENABLED);
-      }
     } else {
       spawnActionBuilder.addCommandLine(commandLine.build(), FORCED_PARAM_FILE_INFO);
     }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
@@ -232,13 +232,6 @@ public interface AndroidConfigurationApi extends StarlarkValue {
   boolean persistentBusyboxTools();
 
   @StarlarkMethod(
-      name = "experimental_persistent_multiplex_busybox_tools",
-      structField = true,
-      doc = "",
-      documented = false)
-  boolean persistentMultiplexBusyboxTools();
-
-  @StarlarkMethod(
       name = "get_output_directory_name",
       structField = true,
       doc = "",

--- a/src/test/shell/bazel/android/resource_processing_integration_test.sh
+++ b/src/test/shell/bazel/android/resource_processing_integration_test.sh
@@ -123,7 +123,7 @@ function test_persistent_multiplex_resource_processor() {
   setup_font_resources
 
   assert_build //java/bazel:bin --persistent_android_resource_processor \
-    --experimental_persistent_multiplex_busybox_tools
+    --persistent_multiplex_android_resource_processor
 }
 
 run_suite "Resource processing integration tests"

--- a/src/test/shell/bazel/android/resource_processing_integration_test.sh
+++ b/src/test/shell/bazel/android/resource_processing_integration_test.sh
@@ -122,7 +122,8 @@ function test_persistent_multiplex_resource_processor() {
   create_android_binary
   setup_font_resources
 
-  assert_build //java/bazel:bin --persistent_android_resource_processor \
+  assert_build //java/bazel:bin --experimental_worker_multiplex \
+    --persistent_android_resource_processor \
     --persistent_multiplex_android_resource_processor
 }
 


### PR DESCRIPTION
Alternative approach to https://github.com/bazelbuild/bazel/pull/15321#issuecomment-1192772584 that leverages an expansion CLI flag instead of proliferating unique experimental multiplex flags.