### PR TITLE
Add worker assertions resource_processing_integration_test

### DIFF
--- a/src/test/shell/bazel/android/resource_processing_integration_test.sh
+++ b/src/test/shell/bazel/android/resource_processing_integration_test.sh
@@ -127,7 +127,7 @@ function test_persistent_multiplex_resource_processor() {
   setup_font_resources
 
   assert_build //java/bazel:bin --experimental_worker_multiplex \
-    --persistent_multiplex_android_tools \
+    --persistent_multiplex_android_resource_processor \
     --worker_verbose &> $TEST_log
   expect_log "Created new non-sandboxed AndroidResourceParser multiplex-worker (id [0-9]\+)"
   expect_log "Created new non-sandboxed AndroidResourceCompiler multiplex-worker (id [0-9]\+)"

--- a/src/test/shell/bazel/android/resource_processing_integration_test.sh
+++ b/src/test/shell/bazel/android/resource_processing_integration_test.sh
@@ -111,7 +111,13 @@ function test_persistent_resource_processor() {
   create_android_binary
   setup_font_resources
 
-  assert_build //java/bazel:bin --persistent_android_resource_processor
+  assert_build //java/bazel:bin --persistent_android_resource_processor \
+    --worker_verbose &> $TEST_log
+  expect_log "Created new non-sandboxed AndroidResourceParser worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed AndroidResourceCompiler worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed AndroidCompiledResourceMerger worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed AndroidAapt2 worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed ManifestMerger worker (id [0-9]\+)"
 }
 
 function test_persistent_multiplex_resource_processor() {
@@ -121,7 +127,13 @@ function test_persistent_multiplex_resource_processor() {
   setup_font_resources
 
   assert_build //java/bazel:bin --experimental_worker_multiplex \
-    --persistent_multiplex_android_tools
+    --persistent_multiplex_android_tools \
+    --worker_verbose &> $TEST_log
+  expect_log "Created new non-sandboxed AndroidResourceParser multiplex-worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed AndroidResourceCompiler multiplex-worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed AndroidCompiledResourceMerger multiplex-worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed AndroidAapt2 multiplex-worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed ManifestMerger multiplex-worker (id [0-9]\+)"
 }
 
 run_suite "Resource processing integration tests"

--- a/src/test/shell/bazel/android/resource_processing_integration_test.sh
+++ b/src/test/shell/bazel/android/resource_processing_integration_test.sh
@@ -127,7 +127,7 @@ function test_persistent_multiplex_resource_processor() {
   setup_font_resources
 
   assert_build //java/bazel:bin --experimental_worker_multiplex \
-    --persistent_multiplex_android_resource_processor \
+    --persistent_multiplex_android_tools \
     --worker_verbose &> $TEST_log
   expect_log "Created new non-sandboxed AndroidResourceParser multiplex-worker (id [0-9]\+)"
   expect_log "Created new non-sandboxed AndroidResourceCompiler multiplex-worker (id [0-9]\+)"


### PR DESCRIPTION
Adding a few assertions to the worker and multiplex worker tests to ensure that the expected workers are in fact coming up.