### PR TITLE
Update supported Ubuntu versions

### DIFF
--- a/site/en/install/ubuntu.md
+++ b/site/en/install/ubuntu.md
@@ -9,8 +9,8 @@ if needed as a backup option (for example, if you don't have admin access).
 
 Supported Ubuntu Linux platforms:
 
+*   20.04 (LTS)
 *   18.04 (LTS)
-*   16.04 (LTS)
 
 Bazel should be compatible with other Ubuntu releases and Debian
 "stretch" and above, but is untested and not guaranteed to work.


### PR DESCRIPTION
Ubuntu 16.04 is no longer tested in the CI, but 20.04 is
https://github.com/bazelbuild/bazel/blob/master/.bazelci/presubmit.yml