### PR TITLE
Minor fixes to support OpenBSD

### DIFF
--- a/src/main/tools/BUILD
+++ b/src/main/tools/BUILD
@@ -15,6 +15,7 @@ cc_library(
     name = "process-tools",
     srcs = ["process-tools.cc"] + select({
         "//src/conditions:darwin": ["process-tools-darwin.cc"],
+        "//src/conditions:openbsd": ["process-tools-darwin.cc"],
         "//conditions:default": ["process-tools-linux.cc"],
     }),
     hdrs = ["process-tools.h"],

--- a/src/main/tools/process-tools-darwin.cc
+++ b/src/main/tools/process-tools-darwin.cc
@@ -93,7 +93,11 @@ int WaitForProcessGroupToTerminate(pid_t pgid) {
     if (nprocs == 1) {
       // Found only one process, which must be the leader because we have
       // purposely expect it as a zombie with WaitForProcess.
+#if defined(__OpenBSD__)
+      if (procs->p_pid != pgid) {
+#else
       if (procs->kp_proc.p_pid != pgid) {
+#endif
         DIE("Process group leader must be the only process left");
       }
       free(procs);

--- a/src/zip_builtins.sh
+++ b/src/zip_builtins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
Allow Bazel to build and run on openbsd.
* Darwin and OpenBSD both support kevent and the relevant sysctl, so use the darwin process-tools for both.
* They just differ in the internal structure of `struct kinfo_proc`, so account for that.
* Use the `env` trick to locate `bash`, for portability.
 
`process-tools-darwin.cc` should probably be renamed to `process-tools-kevent.cc`, but that can come later.