### PR TITLE
Pass `--host_jvmopt` to host options attribute

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -622,6 +622,7 @@ public class JavaOptions extends FragmentOptions {
       host.jvmOpts = ImmutableList.of("-XX:ErrorFile=/dev/stderr");
     } else {
       host.jvmOpts = hostJvmOpts;
+      host.hostJvmOpts = hostJvmOpts;
     }
 
 


### PR DESCRIPTION
**Background**
We hit a similar issue with https://github.com/bazelbuild/bazel/issues/12403 when trying to add `--host_jvmopt` in our build. The error message looks like this:
```
ERROR: file 'external/remote_java_tools/proguard' is generated by these conflicting actions:
Label: @remote_java_tools//:proguard
RuleClass: java_binary rule
Configuration: a46bb511e54d3417610f91a9e0438015d7a78d7ac4f86f7c2440dea289d49498, 88e50b932f2f46570420b692a53eb24e621234bce56b60adfcb78e0fc18f0b30
Mnemonic: TemplateExpand
Action key: 8f032555b33813e37fe81cc562b797ada9bb13f67fa7f56de2561b90dea164f6, 38d3af6a15195200b199160dca175890cd7d2b77f291e8ec0cd4330ebe825fee
Progress message: Expanding template external/remote_java_tools/proguard
PrimaryInput: (null)
PrimaryOutput: File:[[<execution_root>]bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin]external/remote_java_tools/proguard
Owner information: ConfiguredTargetKey{label=@remote_java_tools//:proguard, config=BuildConfigurationValue.Key[a46bb511e54d3417610f91a9e0438015d7a78d7ac4f86f7c2440dea289d49498]}, ConfiguredTargetKey{label=@remote_java_tools//:proguard, config=BuildConfigurationValue.Key[88e50b932f2f46570420b692a53eb24e621234bce56b60adfcb78e0fc18f0b30]}
MandatoryInputs: are equal
Outputs: are equal 
```

**Change**
Follow the idea of this fix (https://github.com/bazelbuild/bazel/commit/e6670825b1e183f81f5c864aafd425d512fa9ff5), we tried adding `hostJvmOpts` to the host options attribute and we verified it fixed the issue.