### PR TITLE
Add `--output=files` mode to cquery

### DIFF
--- a/site/docs/cquery.html
+++ b/site/docs/cquery.html
@@ -452,6 +452,26 @@ There are other options for exposing the results as well. </p>
 
 </p>
 
+<h3>Files output</h3>
+
+<pre>
+--output=files
+</pre>
+
+<p>
+  This option prints a list of the output files produced by each target matched
+  by the query similar to the list printed at the end of a <code>bazel build</code>
+  invocation. The output contains only the files advertised in the requested
+  output groups as determined by the
+  <a href="https://docs.bazel.build/version/main/reference/command-line-reference#flag--output_groups"><code>--output_groups</code></a>
+  flag and never contains source files.
+
+  Note: The output of <code>bazel cquery --output=files //pkg:foo</code> contains the output
+  files of <code>//pkg:foo</code> in <i>all</i> configurations that occur in the build (also
+  see the <a href="#target-pattern-evaluation">section on target pattern evaluation</a>. If that
+  is not desired, wrap you query in <a href="#config"><code>config(..., target)</code></a>.
+</p>
+
 <h3>Defining the output format using Starlark</h3>
 
 <pre>

--- a/src/main/java/com/google/devtools/build/lib/analysis/TopLevelArtifactHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/TopLevelArtifactHelper.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.configuredtargets.InputFileConfiguredTarget;
+import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet.Node;
@@ -234,6 +236,36 @@ public final class TopLevelArtifactHelper {
 
     return new ArtifactsToBuild(
         allOutputGroups.build(), /*allOutputGroupsImportant=*/ allOutputGroupsImportant);
+  }
+
+  /**
+   * Returns false if the build outputs provided by the target should never be shown to users.
+   *
+   * <p>Always returns false for hidden rules and source file targets.
+   */
+  public static boolean shouldConsiderForDisplay(ConfiguredTarget configuredTarget) {
+    // TODO(bazel-team): this is quite ugly. Add a marker provider for this check.
+    if (configuredTarget instanceof InputFileConfiguredTarget) {
+      // Suppress display of source files (because we do no work to build them).
+      return false;
+    }
+    if (configuredTarget instanceof RuleConfiguredTarget) {
+      RuleConfiguredTarget ruleCt = (RuleConfiguredTarget) configuredTarget;
+      if (ruleCt.getRuleClassString().contains("$")) {
+        // Suppress display of hidden rules
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if the given artifact should be shown to users as a build output.
+   *
+   * <p>Always returns false for middleman and source artifacts.
+   */
+  public static boolean shouldDisplay(Artifact artifact) {
+    return !artifact.isSourceArtifact() && !artifact.isMiddlemanArtifact();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/buildtool/CqueryBuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/CqueryBuildTool.java
@@ -57,6 +57,7 @@ public final class CqueryBuildTool extends PostAnalysisQueryBuildTool<KeyedConfi
         env.getRelativeWorkingDirectory(),
         env.getPackageManager().getPackagePath(),
         () -> walkableGraph,
-        cqueryOptions);
+        cqueryOptions,
+        request.getTopLevelArtifactContext());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/BUILD
@@ -49,6 +49,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:target_and_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:toolchain_collection",
         "//src/main/java/com/google/devtools/build/lib/analysis:toolchain_context",
+        "//src/main/java/com/google/devtools/build/lib/analysis:top_level_artifact_context",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/causes",

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallback.java
@@ -37,7 +37,7 @@ class BuildOutputFormatterCallback extends CqueryThreadsafeCallback {
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTarget> accessor) {
-    super(eventHandler, options, out, skyframeExecutor, accessor);
+    super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ false);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.ConfiguredTargetValue;
+import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
@@ -81,6 +82,8 @@ public class ConfiguredTargetQueryEnvironment
 
   private CqueryOptions cqueryOptions;
 
+  private final TopLevelArtifactContext topLevelArtifactContext;
+
   private final KeyExtractor<KeyedConfiguredTarget, ConfiguredTargetKey>
       configuredTargetKeyExtractor;
 
@@ -119,7 +122,8 @@ public class ConfiguredTargetQueryEnvironment
       PathFragment parserPrefix,
       PathPackageLocator pkgPath,
       Supplier<WalkableGraph> walkableGraphSupplier,
-      Set<Setting> settings)
+      Set<Setting> settings,
+      TopLevelArtifactContext topLevelArtifactContext)
       throws InterruptedException {
     super(
         keepGoing,
@@ -135,6 +139,7 @@ public class ConfiguredTargetQueryEnvironment
     this.configuredTargetKeyExtractor = KeyedConfiguredTarget::getConfiguredTargetKey;
     this.transitiveConfigurations =
         getTransitiveConfigurations(transitiveConfigurationKeys, walkableGraphSupplier.get());
+    this.topLevelArtifactContext = topLevelArtifactContext;
   }
 
   public ConfiguredTargetQueryEnvironment(
@@ -147,7 +152,8 @@ public class ConfiguredTargetQueryEnvironment
       PathFragment parserPrefix,
       PathPackageLocator pkgPath,
       Supplier<WalkableGraph> walkableGraphSupplier,
-      CqueryOptions cqueryOptions)
+      CqueryOptions cqueryOptions,
+      TopLevelArtifactContext topLevelArtifactContext)
       throws InterruptedException {
     this(
         keepGoing,
@@ -159,7 +165,8 @@ public class ConfiguredTargetQueryEnvironment
         parserPrefix,
         pkgPath,
         walkableGraphSupplier,
-        cqueryOptions.toSettings());
+        cqueryOptions.toSettings(),
+        topLevelArtifactContext);
     this.cqueryOptions = cqueryOptions;
   }
 
@@ -270,7 +277,9 @@ public class ConfiguredTargetQueryEnvironment
             accessor,
             kct -> getFwdDeps(ImmutableList.of(kct))),
         new StarlarkOutputFormatterCallback(
-            eventHandler, cqueryOptions, out, skyframeExecutor, accessor));
+            eventHandler, cqueryOptions, out, skyframeExecutor, accessor),
+        new FilesOutputFormatterCallback(
+            eventHandler, cqueryOptions, out, skyframeExecutor, accessor, topLevelArtifactContext));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.query2.cquery;
 
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.query2.NamedThreadSafeOutputFormatterCallback;
@@ -55,6 +56,7 @@ public abstract class CqueryThreadsafeCallback
   protected final ConfiguredTargetAccessor accessor;
 
   private final List<String> result = new ArrayList<>();
+  private final boolean uniquifyResults;
 
   @SuppressWarnings("DefaultCharset")
   CqueryThreadsafeCallback(
@@ -62,7 +64,8 @@ public abstract class CqueryThreadsafeCallback
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<KeyedConfiguredTarget> accessor) {
+      TargetAccessor<KeyedConfiguredTarget> accessor,
+      boolean uniquifyResults) {
     this.eventHandler = eventHandler;
     this.options = options;
     if (out != null) {
@@ -72,6 +75,7 @@ public abstract class CqueryThreadsafeCallback
     }
     this.skyframeExecutor = skyframeExecutor;
     this.accessor = (ConfiguredTargetAccessor) accessor;
+    this.uniquifyResults = uniquifyResults;
   }
 
   public void addResult(String string) {
@@ -86,7 +90,8 @@ public abstract class CqueryThreadsafeCallback
   @Override
   public void close(boolean failFast) throws InterruptedException, IOException {
     if (!failFast && printStream != null) {
-      for (String s : result) {
+      List<String> resultsToPrint = uniquifyResults ? ImmutableSet.copyOf(result).asList() : result;
+      for (String s : resultsToPrint) {
         // TODO(ulfjack): We should use queryOptions.getLineTerminator() instead.
         printStream.append(s).append("\n");
       }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallback.java
@@ -1,0 +1,68 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.query2.cquery;
+
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
+import com.google.devtools.build.lib.analysis.TopLevelArtifactHelper;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
+import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Cquery output formatter that prints the set of output files advertised by the matched targets.
+ */
+public class FilesOutputFormatterCallback extends CqueryThreadsafeCallback {
+
+  private final TopLevelArtifactContext topLevelArtifactContext;
+
+  FilesOutputFormatterCallback(
+      ExtendedEventHandler eventHandler,
+      CqueryOptions options,
+      OutputStream out,
+      SkyframeExecutor skyframeExecutor,
+      TargetAccessor<KeyedConfiguredTarget> accessor,
+      TopLevelArtifactContext topLevelArtifactContext) {
+    // Different targets may provide the same artifact, so we deduplicate the collection of all
+    // results at the end.
+    super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ true);
+    this.topLevelArtifactContext = topLevelArtifactContext;
+  }
+
+  @Override
+  public String getName() {
+    return "files";
+  }
+
+  @Override
+  public void processOutput(Iterable<KeyedConfiguredTarget> partialResult)
+      throws IOException, InterruptedException {
+    for (KeyedConfiguredTarget keyedTarget : partialResult) {
+      ConfiguredTarget target = keyedTarget.getConfiguredTarget();
+      if (!TopLevelArtifactHelper.shouldConsiderForDisplay(target)) {
+        continue;
+      }
+      TopLevelArtifactHelper.getAllArtifactsToBuild(target, topLevelArtifactContext)
+          .getImportantArtifacts()
+          .toList()
+          .stream()
+          .filter(TopLevelArtifactHelper::shouldDisplay)
+          .map(Artifact::getExecPathString)
+          .forEach(this::addResult);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
@@ -86,7 +86,7 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTarget> accessor,
       DepsRetriever depsRetriever) {
-    super(eventHandler, options, out, skyframeExecutor, accessor);
+    super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ false);
     this.depsRetriever = depsRetriever;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
@@ -36,7 +36,7 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTarget> accessor,
       boolean showKind) {
-    super(eventHandler, options, out, skyframeExecutor, accessor);
+    super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ false);
     this.showKind = showKind;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
@@ -75,7 +75,7 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
       TargetAccessor<KeyedConfiguredTarget> accessor,
       AspectResolver resolver,
       OutputType outputType) {
-    super(eventHandler, options, out, skyframeExecutor, accessor);
+    super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ false);
     this.outputType = outputType;
     this.skyframeExecutor = skyframeExecutor;
     this.resolver = resolver;

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -142,7 +142,7 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTarget> accessor)
       throws QueryException, InterruptedException {
-    super(eventHandler, options, out, skyframeExecutor, accessor);
+    super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ false);
 
     ParserInput input = null;
     String exceptionMessagePrefix;

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
@@ -83,7 +83,7 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
       TargetAccessor<KeyedConfiguredTarget> accessor,
       BuildConfiguration hostConfiguration,
       @Nullable TransitionFactory<RuleTransitionData> trimmingTransitionFactory) {
-    super(eventHandler, options, out, skyframeExecutor, accessor);
+    super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ false);
     this.hostConfiguration = hostConfiguration;
     this.trimmingTransitionFactory = trimmingTransitionFactory;
     this.partialResultMap = Maps.newHashMap();

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
@@ -165,3 +165,21 @@ java_test(
         "//third_party:truth",
     ],
 )
+
+java_test(
+    name = "FilesOutputFormatterCallbackTest",
+    srcs = ["FilesOutputFormatterCallbackTest.java"],
+    shard_count = 4,
+    deps = [
+        ":configured_target_query_helper",
+        ":configured_target_query_test",
+        "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/analysis:top_level_artifact_context",
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/query2",
+        "//src/main/java/com/google/devtools/build/lib/query2/engine",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
@@ -49,7 +49,8 @@ public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<KeyedCo
         parserPrefix,
         analysisHelper.getPackageManager().getPackagePath(),
         () -> walkableGraph,
-        this.settings);
+        this.settings,
+        null);
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallbackTest.java
@@ -1,0 +1,172 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.query2.cquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.eventbus.EventBus;
+import com.google.devtools.build.lib.analysis.OutputGroupInfo;
+import com.google.devtools.build.lib.analysis.OutputGroupInfo.ValidationMode;
+import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
+import com.google.devtools.build.lib.query2.engine.QueryExpression;
+import com.google.devtools.build.lib.query2.engine.QueryParser;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests cquery's {@link --output=files} format. */
+public class FilesOutputFormatterCallbackTest extends ConfiguredTargetQueryTest {
+
+  private CqueryOptions options;
+  private Reporter reporter;
+  private final List<Event> events = new ArrayList<>();
+
+  @Before
+  public final void defineSimpleRule() throws Exception {
+    writeFile(
+        "defs/rules.bzl",
+        "def _r_impl(ctx):",
+        "    default_file = ctx.actions.declare_file(ctx.attr.name + '_default_file')",
+        "    output_group_only = ctx.actions.declare_file(ctx.attr.name + '_output_group_only')",
+        "    runfile = ctx.actions.declare_file(ctx.attr.name + '_runfile')",
+        "    executable_only = ctx.actions.declare_file(ctx.attr.name + '_executable')",
+        "    files = [default_file, output_group_only, runfile, executable_only]",
+        "    ctx.actions.run_shell(",
+        "        outputs = files,",
+        "        command = '\\n'.join(['touch %s' % file.path for file in files]),",
+        "    )",
+        "    return [",
+        "        DefaultInfo(",
+        "            executable = executable_only,",
+        "            files = depset(",
+        "                direct = [",
+        "                    default_file,",
+        "                    ctx.file._implicit_source_dep,",
+        "                    ctx.file.explicit_source_dep,",
+        "                ],",
+        "                transitive = [info[DefaultInfo].files for info in ctx.attr.deps]",
+        "            ),",
+        "            runfiles = ctx.runfiles([runfile]),",
+        "        ),",
+        "        OutputGroupInfo(",
+        "            foobar = [output_group_only],",
+        "        ),",
+        "    ]",
+        "r = rule(",
+        "    implementation = _r_impl,",
+        "    executable = True,",
+        "    attrs = {",
+        "        'deps': attr.label_list(),",
+        "        '_implicit_source_dep': attr.label(default = 'rules.bzl', allow_single_file ="
+            + " True),",
+        "        'explicit_source_dep': attr.label(allow_single_file = True),",
+        "    },",
+        ")");
+    writeFile("defs/BUILD", "exports_files(['rules.bzl'])");
+    writeFile(
+        "pkg/BUILD",
+        "load('//defs:rules.bzl', 'r')",
+        "r(",
+        "    name = 'main',",
+        "    explicit_source_dep = 'BUILD',",
+        ")",
+        "r(",
+        "    name = 'other',",
+        "    deps = [':main'],",
+        "    explicit_source_dep = 'BUILD',",
+        ")");
+  }
+
+  @Before
+  public final void setUpCqueryOptions() {
+    this.options = new CqueryOptions();
+    this.reporter = new Reporter(new EventBus(), events::add);
+  }
+
+  private List<String> getOutput(String queryExpression, List<String> outputGroups)
+      throws Exception {
+    QueryExpression expression = QueryParser.parse(queryExpression, getDefaultFunctions());
+    Set<String> targetPatternSet = new LinkedHashSet<>();
+    expression.collectTargetPatterns(targetPatternSet);
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
+        ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    FilesOutputFormatterCallback callback =
+        new FilesOutputFormatterCallback(
+            reporter,
+            options,
+            new PrintStream(output),
+            getHelper().getSkyframeExecutor(),
+            env.getAccessor(),
+            // Based on BuildRequest#getTopLevelArtifactContext.
+            new TopLevelArtifactContext(
+                false,
+                false,
+                false,
+                OutputGroupInfo.determineOutputGroups(outputGroups, ValidationMode.OFF, false)));
+    env.evaluateQuery(expression, callback);
+    return Arrays.asList(output.toString(UTF_8).split(System.lineSeparator()));
+  }
+
+  @Test
+  public void basicQuery_defaultOutputGroup() throws Exception {
+    List<String> output = getOutput("//pkg:all", ImmutableList.of());
+    assertContainsExactlyWithBinDirPrefix(
+        output, "pkg/main_default_file", "pkg/other_default_file");
+  }
+
+  @Test
+  public void basicQuery_defaultAndCustomOutputGroup() throws Exception {
+    List<String> output = getOutput("//pkg:main", ImmutableList.of("+foobar"));
+    assertContainsExactlyWithBinDirPrefix(
+        output, "pkg/main_default_file", "pkg/main_output_group_only");
+  }
+
+  @Test
+  public void basicQuery_customOutputGroupOnly() throws Exception {
+    List<String> output = getOutput("//pkg:other", ImmutableList.of("foobar"));
+    assertContainsExactlyWithBinDirPrefix(output, "pkg/other_output_group_only");
+  }
+
+  private void assertContainsExactlyWithBinDirPrefix(
+      List<String> output, String... binDirRelativePaths) {
+    if (binDirRelativePaths.length == 0) {
+      assertThat(output).isEmpty();
+      return;
+    }
+
+    // Extract the configuration-dependent bin dir from the first output.
+    assertThat(output).isNotEmpty();
+    String firstPath = output.get(0);
+    String binDir = firstPath.substring(0, firstPath.indexOf("bin/") + "bin/".length());
+
+    assertThat(output)
+        .containsExactly(
+            Arrays.stream(binDirRelativePaths)
+                .map(binDirRelativePath -> binDir + binDirRelativePath)
+                .toArray());
+  }
+}


### PR DESCRIPTION
With the new output mode `--output=files`, cquery lists all files advertised by the matched targets in the currently requested output groups.

This new mode has the following advantages over `--output=starlark` combined with an appropriate handcrafted `--starlark:expr`:
* provides a canonical answer to the very common "Where are my build outputs?" question
* is more friendly to new users as it doesn't require knowing about providers and non-BUILD dialect Starlark
* takes the value of `--output_groups` into account
* stays as close to the logic for build summaries printed by `bazel build` as possible

Fixes #8739

RELNOTES: `cquery`'s new output mode [`--output=files`](https://bazel.build/docs/cquery#files-output) lists the output files of the targets matching the query. It takes the current value of `--output_groups` into account.

Closes #15552.

PiperOrigin-RevId: 462630629
Change-Id: Ic648f22aa160ee57b476180561b444f08799ebb6

Fixes #15927