### PR TITLE
Retry IOException "Operation timed out"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -58,15 +58,16 @@ public final class RemoteCacheClientFactory {
       @Nullable Credentials creds,
       AuthAndTLSOptions authAndTlsOptions,
       Path workingDirectory,
-      DigestUtil digestUtil)
+      DigestUtil digestUtil,
+      RemoteRetrier retrier)
       throws IOException {
     Preconditions.checkNotNull(workingDirectory, "workingDirectory");
     if (isHttpCache(options) && isDiskCache(options)) {
       return createDiskAndHttpCache(
-          workingDirectory, options.diskCache, options, creds, authAndTlsOptions, digestUtil);
+          workingDirectory, options.diskCache, options, creds, authAndTlsOptions, digestUtil, retrier);
     }
     if (isHttpCache(options)) {
-      return createHttp(options, creds, authAndTlsOptions, digestUtil);
+      return createHttp(options, creds, authAndTlsOptions, digestUtil, retrier);
     }
     if (isDiskCache(options)) {
       return createDiskCache(
@@ -85,7 +86,8 @@ public final class RemoteCacheClientFactory {
       RemoteOptions options,
       Credentials creds,
       AuthAndTLSOptions authAndTlsOptions,
-      DigestUtil digestUtil) {
+      DigestUtil digestUtil,
+      RemoteRetrier retrier) {
     Preconditions.checkNotNull(options.remoteCache, "remoteCache");
 
     try {
@@ -104,6 +106,7 @@ public final class RemoteCacheClientFactory {
               options.remoteVerifyDownloads,
               ImmutableList.copyOf(options.remoteHeaders),
               digestUtil,
+              retrier,
               creds,
               authAndTlsOptions);
         } else {
@@ -117,6 +120,7 @@ public final class RemoteCacheClientFactory {
             options.remoteVerifyDownloads,
             ImmutableList.copyOf(options.remoteHeaders),
             digestUtil,
+            retrier,
             creds,
             authAndTlsOptions);
       }
@@ -145,7 +149,8 @@ public final class RemoteCacheClientFactory {
       RemoteOptions options,
       Credentials cred,
       AuthAndTLSOptions authAndTlsOptions,
-      DigestUtil digestUtil)
+      DigestUtil digestUtil,
+      RemoteRetrier retrier)
       throws IOException {
     Path cacheDir =
         workingDirectory.getRelative(Preconditions.checkNotNull(diskCachePath, "diskCachePath"));
@@ -153,7 +158,7 @@ public final class RemoteCacheClientFactory {
       cacheDir.createDirectoryAndParents();
     }
 
-    RemoteCacheClient httpCache = createHttp(options, cred, authAndTlsOptions, digestUtil);
+    RemoteCacheClient httpCache = createHttp(options, cred, authAndTlsOptions, digestUtil, retrier);
     return createDiskAndRemoteClient(
         workingDirectory,
         diskCachePath,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -249,6 +249,8 @@ public final class RemoteModule extends BlazeModule {
                      String msg = e.getMessage().toLowerCase();
                      if (msg.contains("connection reset by peer")) {
                        retry = true;
+                     } else if (msg.contains("operation timed out")) {
+                       retry = true;
                      }
                    }
                    return retry;

--- a/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -21,6 +21,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_version_info",
         "//src/main/java/com/google/devtools/build/lib/authandtls",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote:Retrier",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:auth",

--- a/src/main/java/com/google/devtools/build/lib/remote/http/DownloadCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/DownloadCommand.java
@@ -25,12 +25,18 @@ final class DownloadCommand {
   private final boolean casDownload;
   private final Digest digest;
   private final OutputStream out;
+  private final long offset;
 
-  DownloadCommand(URI uri, boolean casDownload, Digest digest, OutputStream out) {
+  DownloadCommand(URI uri, boolean casDownload, Digest digest, OutputStream out, long offset) {
     this.uri = Preconditions.checkNotNull(uri);
     this.casDownload = casDownload;
     this.digest = Preconditions.checkNotNull(digest);
     this.out = Preconditions.checkNotNull(out);
+    this.offset = offset;
+  }
+
+  DownloadCommand(URI uri, boolean casDownload, Digest digest, OutputStream out) {
+    this(uri, casDownload, digest, out, 0);
   }
 
   public URI uri() {
@@ -48,4 +54,6 @@ final class DownloadCommand {
   public OutputStream out() {
     return out;
   }
+
+  public long offset() { return offset; }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpException.java
@@ -18,7 +18,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import java.io.IOException;
 
 /** An exception that propagates the http status. */
-final class HttpException extends IOException {
+public final class HttpException extends IOException {
   private final HttpResponse response;
 
   HttpException(HttpResponse response, String message, Throwable cause) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactoryTest.java
@@ -18,6 +18,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.disk.DiskAndRemoteCacheClient;
@@ -32,6 +34,8 @@ import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import java.io.IOException;
+import java.util.concurrent.Executors;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +51,13 @@ public class RemoteCacheClientFactoryTest {
   private final AuthAndTLSOptions authAndTlsOptions = Options.getDefaults(AuthAndTLSOptions.class);
   private Path workingDirectory;
   private InMemoryFileSystem fs;
+  private ListeningScheduledExecutorService retryScheduler =
+          MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
+  private RemoteRetrier retrier = new RemoteRetrier(
+          () -> RemoteRetrier.RETRIES_DISABLED,
+          (e) -> false,
+          retryScheduler,
+          Retrier.ALLOW_ALL_CALLS);
 
   @Before
   public final void setUp() {
@@ -63,7 +74,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(DiskAndRemoteCacheClient.class);
   }
@@ -76,7 +87,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(DiskAndRemoteCacheClient.class);
     assertThat(workingDirectory.exists()).isTrue();
@@ -96,7 +107,8 @@ public class RemoteCacheClientFactoryTest {
                 /* creds= */ null,
                 authAndTlsOptions,
                 /* workingDirectory= */ null,
-                digestUtil));
+                digestUtil,
+                retrier));
   }
 
   @Test
@@ -106,7 +118,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(HttpCacheClient.class);
   }
@@ -125,7 +137,8 @@ public class RemoteCacheClientFactoryTest {
                         /* creds= */ null,
                         authAndTlsOptions,
                         workingDirectory,
-                        digestUtil)))
+                        digestUtil,
+                        retrier)))
         .hasMessageThat()
         .contains("Remote cache proxy unsupported: bad-proxy");
   }
@@ -136,7 +149,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(HttpCacheClient.class);
   }
@@ -147,7 +160,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(DiskCacheClient.class);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -23,6 +23,7 @@ java_test(
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
         "//src/main/java/com/google/devtools/build/lib/authandtls",
+        "//src/main/java/com/google/devtools/build/lib/remote:Retrier",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/http",
         "//src/main/java/com/google/devtools/build/lib/remote/util",


### PR DESCRIPTION
- Retry on HTTP remote cache fetch failure
- Fix test build
- Retry cache operation for `IOException` "Operation timed out"
