### PR TITLE
Do not force unresolved symlinks to be absolute

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -335,8 +335,9 @@ if [ "${PLATFORM}" = "windows" ]; then
   # We don't rely on runfiles trees on Windows
   cat <<'EOF' >${ARCHIVE_DIR}/build-runfiles${EXE_EXT}
 #!/bin/sh
-mkdir -p $2
-cp $1 $2/MANIFEST
+# Skip over --allow_relative.
+mkdir -p $3
+cp $2 $3/MANIFEST
 EOF
 else
   cat <<'EOF' >${ARCHIVE_DIR}/build-runfiles${EXE_EXT}
@@ -350,8 +351,9 @@ else
 # bootstrap version of Bazel, but we'd still need a shell wrapper around it, so
 # it's not clear whether that would be a win over a few lines of Lovecraftian
 # code)
-MANIFEST="$1"
-TREE="$2"
+# Skip over --allow_relative.
+MANIFEST="$2"
+TREE="$3"
 
 rm -fr "$TREE"
 mkdir -p "$TREE"

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -249,6 +249,7 @@ java_library(
         "starlark/StarlarkRuleContext.java",
         "starlark/StarlarkRuleTransitionProvider.java",
         "starlark/StarlarkTransition.java",
+        "starlark/UnresolvedSymlinkAction.java",
         "test/AnalysisTestActionBuilder.java",
         "test/BaselineCoverageAction.java",
         "test/CoverageCommon.java",

--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -23,8 +23,6 @@ import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.actions.AbstractFileWriteAction;
 import com.google.devtools.build.lib.analysis.actions.DeterministicWriter;
-import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
-import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.util.Fingerprint;
@@ -129,7 +127,7 @@ public final class SourceManifestAction extends AbstractFileWriteAction {
       Artifact primaryOutput,
       Runfiles runfiles,
       boolean remotableSourceManifestActions) {
-    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), primaryOutput, false);
+    super(owner, runfiles.getSymlinkArtifacts(), primaryOutput, false);
     this.manifestWriter = manifestWriter;
     this.runfiles = runfiles;
     this.remotableSourceManifestActions = remotableSourceManifestActions;
@@ -227,7 +225,11 @@ public final class SourceManifestAction extends AbstractFileWriteAction {
         // This trailing whitespace is REQUIRED to process the single entry line correctly.
         manifestWriter.append(' ');
         if (symlink != null) {
-          manifestWriter.append(symlink.getPath().getPathString());
+          if (symlink.isSymlink()) {
+            manifestWriter.append(symlink.getPath().readSymbolicLink().getPathString());
+          } else {
+            manifestWriter.append(symlink.getPath().getPathString());
+          }
         }
         manifestWriter.append('\n');
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java
@@ -36,7 +36,10 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import javax.annotation.Nullable;
 
-/** Action to create a symbolic link. */
+/**
+ * Action to create a symlink to a known-to-exist target with alias semantics similar to a true copy
+ * of the input (if any).
+ */
 public final class SymlinkAction extends AbstractAction {
   private static final String GUID = "7f4fab4d-d0a7-4f0f-8649-1d0337a21fee";
 
@@ -150,13 +153,6 @@ public final class SymlinkAction extends AbstractAction {
     Preconditions.checkState(!execPath.isAbsolute());
     return new SymlinkAction(
         owner, execPath, primaryInput, primaryOutput, progressMessage, TargetType.FILESET);
-  }
-
-  public static SymlinkAction createUnresolved(
-      ActionOwner owner, Artifact primaryOutput, PathFragment targetPath, String progressMessage) {
-    Preconditions.checkArgument(primaryOutput.isSymlink());
-    return new SymlinkAction(
-        owner, targetPath, null, primaryOutput, progressMessage, TargetType.OTHER);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -273,7 +273,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
             ? (String) progressMessageUnchecked
             : "Creating symlink " + outputArtifact.getExecPathString();
 
-    SymlinkAction action;
+    Action action;
     if (targetFile != Starlark.NONE) {
       Artifact inputArtifact = (Artifact) targetFile;
       if (outputArtifact.isSymlink()) {
@@ -324,10 +324,10 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       }
 
       action =
-          SymlinkAction.createUnresolved(
+          new UnresolvedSymlinkAction(
               ruleContext.getActionOwner(),
               outputArtifact,
-              PathFragment.create((String) targetPath),
+              (String) targetPath,
               progressMessage);
     }
     registerAction(action);

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkAction.java
@@ -1,0 +1,112 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.analysis.starlark;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.actions.AbstractAction;
+import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionExecutionException;
+import com.google.devtools.build.lib.actions.ActionKeyContext;
+import com.google.devtools.build.lib.actions.ActionOwner;
+import com.google.devtools.build.lib.actions.ActionResult;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
+import com.google.devtools.build.lib.server.FailureDetails;
+import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
+import com.google.devtools.build.lib.server.FailureDetails.SymlinkAction.Code;
+import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Action to create a possibly unresolved symbolic link to a raw path.
+ *
+ * To create a symlink to a known-to-exist target with alias semantics similar to a true copy of the
+ * input, use {@link SymlinkAction} instead.
+ */
+public final class UnresolvedSymlinkAction extends AbstractAction {
+  private static final String GUID = "0f302651-602c-404b-881c-58913193cfe7";
+
+  private final String target;
+  private final String progressMessage;
+
+  public UnresolvedSymlinkAction(
+      ActionOwner owner,
+      Artifact primaryOutput,
+      String target,
+      String progressMessage) {
+    super(
+        owner,
+        NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+        ImmutableSet.of(primaryOutput));
+    this.target = target;
+    this.progressMessage = progressMessage;
+  }
+
+  @Override
+  public ActionResult execute(ActionExecutionContext actionExecutionContext)
+      throws ActionExecutionException {
+
+    Path outputPath = actionExecutionContext.getInputPath(getPrimaryOutput());
+    try {
+      // TODO: PathFragment#create normalizes the symlink target, which may change how it resolves
+      //  when combined with directory symlinks. Ideally, Bazel's file system abstraction would
+      //  offer a way to create symlinks without any preprocessing of the target.
+      outputPath.createSymbolicLink(PathFragment.create(target));
+    } catch (IOException e) {
+      String message =
+          String.format(
+              "failed to create symbolic link '%s' to '%s' due to I/O error: %s",
+              getPrimaryOutput().getExecPathString(), target, e.getMessage());
+      DetailedExitCode code = createDetailedExitCode(message, Code.LINK_CREATION_IO_EXCEPTION);
+      throw new ActionExecutionException(message, e, this, false, code);
+    }
+
+    return ActionResult.EMPTY;
+  }
+
+  @Override
+  protected void computeKey(
+      ActionKeyContext actionKeyContext,
+      @Nullable ArtifactExpander artifactExpander,
+      Fingerprint fp) {
+    fp.addString(GUID);
+    fp.addString(target);
+  }
+
+  @Override
+  public String getMnemonic() {
+    return "UnresolvedSymlink";
+  }
+
+  @Override
+  protected String getRawProgressMessage() {
+    return progressMessage;
+  }
+
+  private static DetailedExitCode createDetailedExitCode(String message, Code detailedCode) {
+    return DetailedExitCode.of(
+        FailureDetail.newBuilder()
+            .setMessage(message)
+            .setSymlinkAction(FailureDetails.SymlinkAction.newBuilder().setCode(detailedCode))
+            .build());
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
@@ -180,8 +180,8 @@ public final class SymlinkTreeHelper {
     Preconditions.checkNotNull(shellEnvironment);
     List<String> args = Lists.newArrayList();
     args.add(binTools.getEmbeddedPath(BUILD_RUNFILES).asFragment().getPathString());
+    args.add("--allow_relative");
     if (filesetTree) {
-      args.add("--allow_relative");
       args.add("--use_metadata");
     }
     args.add(inputManifest.relativeTo(execRoot).getPathString());

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/RunfilesApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/RunfilesApi.java
@@ -41,6 +41,9 @@ public interface RunfilesApi extends StarlarkValue {
   @StarlarkMethod(name = "files", doc = "Returns the set of runfiles as files.", structField = true)
   Depset /*<? extends FileApi>*/ getArtifactsForStarlark();
 
+  @StarlarkMethod(name = "declared_symlinks", doc = "Returns the set of declared symlinks as files.", structField = true)
+  Depset /*<? extends FileApi>*/ getSymlinkArtifactsForStarlark();
+
   @StarlarkMethod(name = "symlinks", doc = "Returns the set of symlinks.", structField = true)
   Depset /*<? extends SymlinkEntryApi>*/ getSymlinksForStarlark();
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
@@ -544,6 +544,17 @@ public interface StarlarkRuleContextApi<ConstraintValueT extends ConstraintValue
                     + "use the <code>default</code> order (which, as the name implies, is the "
                     + "default)."),
         @Param(
+            name = "declared_symlinks",
+            allowedTypes = {@ParamType(type = Sequence.class, generic1 = FileApi.class)},
+            named = true,
+            defaultValue = "[]",
+            doc = "<p><b>Experimental</b>. This parameter is experimental and may change at any "
+                + "time. Please do not depend on it. It may be enabled on an experimental basis by "
+                + "setting <code>--experimental_allow_unresolved_symlinks</code>.</p>"
+                + "<p>The list of symlinks declared with ctx.actions.declare_symlink() to be added "
+                + "to the runfiles. The symlinks will be staged as they are without any processing "
+                + "applied to their targets or intermediate symlinks."),
+        @Param(
             name = "collect_data",
             defaultValue = "False",
             named = true,
@@ -590,6 +601,7 @@ public interface StarlarkRuleContextApi<ConstraintValueT extends ConstraintValue
   RunfilesApi runfiles(
       Sequence<?> files,
       Object transitiveFiles,
+      Sequence<?> declaredSymlinks,
       Boolean collectData,
       Boolean collectDefault,
       Object symlinks,

--- a/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeHelperTest.java
@@ -48,10 +48,11 @@ public final class SymlinkTreeHelperTest {
     assertThat(command.getEnvironment()).isEmpty();
     assertThat(command.getWorkingDirectory()).isEqualTo(execRoot.getPathFile());
     ImmutableList<String> commandLine = command.getArguments();
-    assertThat(commandLine).hasSize(3);
+    assertThat(commandLine).hasSize(4);
     assertThat(commandLine.get(0)).endsWith(SymlinkTreeHelper.BUILD_RUNFILES);
-    assertThat(commandLine.get(1)).isEqualTo("input_manifest");
-    assertThat(commandLine.get(2)).isEqualTo("output/MANIFEST");
+    assertThat(commandLine.get(1)).isEqualTo("--allow_relative");
+    assertThat(commandLine.get(2)).isEqualTo("input_manifest");
+    assertThat(commandLine.get(3)).isEqualTo("output/MANIFEST");
   }
 
   @Test

--- a/src/test/shell/bazel/bazel_symlink_test.sh
+++ b/src/test/shell/bazel/bazel_symlink_test.sh
@@ -411,11 +411,11 @@ EOF
   cat > a/BUILD <<'EOF'
 load(":a.bzl", "a")
 
-a(name="a", link_target="/somewhere/in/my/heart")
+a(name="a", link_target="../somewhere/in/my/heart")
 EOF
 
   bazel build --experimental_allow_unresolved_symlinks //a:a || fail "build failed"
-  assert_contains "input link is /somewhere/in/my/heart" bazel-bin/a/a.file
+  assert_contains "input link is ../somewhere/in/my/heart" bazel-bin/a/a.file
 }
 
 function test_symlink_file_to_file_created_from_symlink_action() {
@@ -729,6 +729,142 @@ genrule(
 EOF
 
   bazel --windows_enable_symlinks build --experimental_allow_unresolved_symlinks //a:exec || fail "build failed"
+}
+
+function test_unresolved_symlink_hermetic_in_sandbox() {
+  if "$is_windows"; then
+    # TODO(#10298): Support unresolved symlinks on Windows.
+    return 0
+  fi
+
+  mkdir -p pkg
+  cat > pkg/def.bzl <<'EOF'
+def _r(ctx):
+  symlink = ctx.actions.declare_symlink(ctx.label.name + "_s")
+  ctx.actions.symlink(output=symlink, target_path=ctx.file.file.basename)
+
+  output = ctx.actions.declare_file(ctx.label.name)
+  ctx.actions.run_shell(
+    command = "{ cat %s || true; } >  %s" % (symlink.path, output.path),
+    inputs = [symlink] + ([ctx.file.file] if ctx.attr.stage_target else []),
+    outputs = [output],
+  )
+  return DefaultInfo(files=depset([output]))
+
+r = rule(
+    implementation=_r,
+    attrs = {
+        "file": attr.label(allow_single_file=True),
+        "stage_target": attr.bool(),
+    }
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":def.bzl", "r")
+
+genrule(name = "a", outs = ["file"], cmd = "echo hello >$@")
+r(name="b", file="file")
+r(name="c", file="file", stage_target=True)
+EOF
+
+  bazel build //pkg:b --experimental_allow_unresolved_symlinks --spawn_strategy=local
+  [ -s bazel-bin/pkg/b ] && fail "symlink should not resolve"
+
+  bazel clean
+  bazel build //pkg:a --spawn_strategy=sandboxed
+  bazel build //pkg:b --experimental_allow_unresolved_symlinks --spawn_strategy=local
+  [ -s bazel-bin/pkg/b ] || fail "symlink should resolve"
+
+  bazel clean
+  bazel build //pkg:c --experimental_allow_unresolved_symlinks --spawn_strategy=local
+  [ -s bazel-bin/pkg/c ] || fail "symlink should resolve"
+
+  bazel clean
+  bazel build //pkg:b --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed
+  [ -s bazel-bin/pkg/b ] && fail "sandboxed build is not hermetic"
+
+  bazel clean
+  bazel build //pkg:a --spawn_strategy=sandboxed
+  bazel build //pkg:b --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed
+  [ -s bazel-bin/pkg/b ] && fail "sandboxed build is not hermetic"
+
+  bazel clean
+  bazel build //pkg:c --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed
+  [ -s bazel-bin/pkg/c ] || fail "symlink should resolve"
+}
+
+function test_unresolved_symlink_in_runfiles() {
+  if "$is_windows"; then
+    # TODO(#10298): Support unresolved symlinks on Windows.
+    return 0
+  fi
+
+  mkdir -p pkg
+  cat > pkg/def.bzl <<'EOF'
+def _r(ctx):
+  symlink = ctx.actions.declare_symlink(ctx.label.name + "_s")
+  target = ctx.file.file.basename
+  ctx.actions.symlink(output=symlink, target_path=target)
+
+  script = ctx.actions.declare_file(ctx.label.name)
+  content = """
+#!/usr/bin/env bash
+cd $0.runfiles/{workspace_name}
+[ -L {symlink} ] || {{ echo "runfile is not a symlink"; exit 1; }}
+[ $(readlink {symlink}) == "{target}" ] || {{ echo "runfile symlink does not have the expected target, got: $(readlink {symlink})"; exit 1; }}
+[ -s {symlink} ] || {{ echo "runfile not resolved"; exit 1; }}
+""".format(
+    symlink = symlink.short_path,
+    target = target,
+    workspace_name = ctx.workspace_name,
+  )
+  ctx.actions.write(script, content, is_executable=True)
+
+  runfiles = ctx.runfiles(
+      files = [ctx.file.file] if ctx.attr.stage_file else [],
+      declared_symlinks = [symlink],
+  )
+  return DefaultInfo(executable=script, runfiles=runfiles)
+
+r = rule(
+    implementation = _r,
+    attrs = {
+        "file": attr.label(allow_single_file = True),
+        "stage_file": attr.bool(),
+    },
+    executable = True,
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":def.bzl", "r")
+
+genrule(name="a", outs=["file"], cmd="echo hello >$@")
+r(name="tool", file="file", stage_file=True)
+r(name="non_hermetic_tool", file="file", stage_file=False)
+genrule(
+    name = "use_tool",
+    outs = ["out"],
+    cmd = "$(location :tool) && touch $@",
+    tools = [":tool"],
+)
+genrule(
+    name = "use_tool_non_hermetically",
+    outs = ["out_non_hermetic"],
+    cmd = "$(location :non_hermetic_tool) && touch $@",
+    # Stage file outside the runfiles tree.
+    tools = [":non_hermetic_tool", "file"],
+)
+EOF
+
+  bazel build --experimental_allow_unresolved_symlinks --spawn_strategy=local //pkg:use_tool_non_hermetically && fail "symlink in runfiles resolved outside the runfiles tree"
+
+  bazel clean
+  bazel build --experimental_allow_unresolved_symlinks --spawn_strategy=local //pkg:use_tool || fail "local build failed"
+
+  bazel clean
+  bazel build --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed //pkg:use_tool || fail "sandboxed build failed"
+  # Keep the implicitly built //pkg:a around to make the symlink resolve outside the sandbox.
+  bazel build --experimental_allow_unresolved_symlinks --spawn_strategy=sandboxed //pkg:use_tool_non_hermetically && fail "sandboxed symlink in runfiles resolved outside the runfiles tree" || true
 }
 
 run_suite "Tests for symlink artifacts"


### PR DESCRIPTION
The documentation of `ctx.actions.symlink(target_path = ...)` states
that the given path is used as the symlink target without any changes,
but in reality this path has so far always been converted into an
absolute path by prepending the exec root. This is changed by this
commit, which gets very close to the documented behavior by preserving
the target path as is except for the standard normalization applied by
`PathFragment`. Improving the situation even further would require
modifying or adding to Bazel's core file system API, which may be done
in a follow-up PR.

Since relative symlinks only resolve correctly at the location they were
originally created, they have to be handled specially when staged as
runfiles. This commit adds a new `declared_symlinks` parameter to the
rule context's `runfiles` method that takes in symlink artifacts
declared via `ctx.actions.declare_symlink`. These symlinks are staged at
their runfiles path directly, with no further processing of their target
and without any intermediate runfiles pointing back to the artifact's
location under the exec root. This has to main benefits:
* With local execution, symlinks are resolved within the runfiles tree,
  which is more hermetic than following the runfiles symlink back into
  the exec root and resolving the symlink artifact there.
* Actions can expect symlink artifacts to be stages as is without
  intermediate symlinks with local and sandboxed execution, both inside
  and outside the runfiles tree. This is important for packaging actions
  as well as rulesets sensitive to symlinks (e.g. rules_js).

As a side-effect of the switch to relative symlinks, this commit
resolves a non-hermeticity issue observed in
https://github.com/bazelbuild/bazel/issues/10298#issuecomment-1192939423
Integration tests are added to verify that symlinks staged in the
sandbox are no longer resolved non-hermetically.

Fixes #14224