### PR TITLE
Let labels in --aspect go through repo mapping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -641,6 +641,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/skyframe:target_pattern_phase_value",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/skyframe",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:flogger",

--- a/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
@@ -54,6 +54,8 @@ import com.google.devtools.build.lib.analysis.test.InstrumentedFilesInfo;
 import com.google.devtools.build.lib.bugreport.BugReporter;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
@@ -88,6 +90,7 @@ import com.google.devtools.build.lib.skyframe.SkyframeAnalysisResult;
 import com.google.devtools.build.lib.skyframe.SkyframeBuildView;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
 import com.google.devtools.build.lib.skyframe.TargetPatternPhaseValue;
+import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.devtools.build.skyframe.WalkableGraph;
@@ -274,6 +277,17 @@ public class BuildView {
             .map(BuildView::getConfiguredTargetKey)
             .collect(Collectors.toList());
 
+    RepositoryMapping mainRepoMapping;
+    try {
+      mainRepoMapping = skyframeExecutor.getMainRepoMapping(eventHandler);
+    } catch (AbruptExitException e) {
+      String errorMessage = String.format(
+          "Failed to get main repo mapping for aspect label canonicalization: %s", e.getMessage());
+      throw new ViewCreationFailedException(
+          errorMessage,
+          createFailureDetail(errorMessage, Analysis.Code.UNEXPECTED_ANALYSIS_EXCEPTION),
+          e);
+    }
     ImmutableList.Builder<AspectClass> aspectClassesBuilder = ImmutableList.builder();
     for (String aspect : aspects) {
       // Syntax: label%aspect
@@ -304,9 +318,8 @@ public class BuildView {
         }
         Label starlarkFileLabel;
         try {
-          starlarkFileLabel =
-              Label.parseAbsolute(
-                  bzlFileLoadLikeString, /* repositoryMapping= */ ImmutableMap.of());
+          starlarkFileLabel = Label.parseWithRepoContext(bzlFileLoadLikeString,
+              Label.RepoContext.of(RepositoryName.MAIN, mainRepoMapping));
         } catch (LabelSyntaxException e) {
           String errorMessage = String.format("Invalid aspect '%s': %s", aspect, e.getMessage());
           throw new ViewCreationFailedException(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
@@ -8418,6 +8418,32 @@ public class StarlarkDefinedAspectsTest extends AnalysisTestCase {
     assertThat(aspectAResult).isEqualTo("aspect_a on target //test:dep_target, p = p_v1");
   }
 
+  @Test
+  public void testAspectLabelIsRepoMapped() throws Exception {
+    scratch.appendFile("WORKSPACE", "workspace(name = 'my_repo')");
+    scratch.file(
+        "test/aspect.bzl",
+        "load(':rule.bzl', 'MyInfo')",
+        "def _impl(target, ctx):",
+        "   if MyInfo not in target:",
+        "       fail('Provider identity mismatch')",
+        "   return struct()",
+        "MyAspect = aspect(implementation=_impl)");
+    scratch.file(
+        "test/rule.bzl",
+        "MyInfo = provider()",
+        "def _impl(ctx):",
+        "    return [MyInfo()]",
+        "my_rule = rule(implementation=_impl)");
+    scratch.file("test/BUILD",
+        "load(':rule.bzl', 'my_rule')",
+        "my_rule(name = 'target')");
+
+    AnalysisResult result = update(ImmutableList.of("@my_repo//test:aspect.bzl%MyAspect"),
+        "//test:target");
+    assertThat(result.hasError()).isFalse();
+  }
+
   private ConfiguredAspect getConfiguredAspect(
       Map<AspectKey, ConfiguredAspect> aspectsMap, String aspectName) {
     for (Map.Entry<AspectKey, ConfiguredAspect> entry : aspectsMap.entrySet()) {


### PR DESCRIPTION
The labels passed in via `--aspect` now go through the main repository's
repository mapping, which ensures that Starlark provider identity is
established correctly even when e.g. the main workspace is referred to
via it's name rather.

Fixes #15989