### PR TITLE
[5.3.0] Remote: Fix performance regression in "upload missing inputs".

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/InMemoryRemoteCache.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/InMemoryRemoteCache.java
@@ -17,6 +17,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import build.bazel.remote.execution.v2.Digest;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.InMemoryCacheClient;
@@ -37,6 +38,11 @@ class InMemoryRemoteCache extends RemoteExecutionCache {
 
   InMemoryRemoteCache(RemoteOptions options, DigestUtil digestUtil) {
     super(new InMemoryCacheClient(), options, digestUtil);
+  }
+
+  InMemoryRemoteCache(
+      RemoteCacheClient cacheProtocol, RemoteOptions options, DigestUtil digestUtil) {
+    super(cacheProtocol, options, digestUtil);
   }
 
   Digest addContents(RemoteActionExecutionContext context, String txt)

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
@@ -39,9 +39,12 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.remote.util.InMemoryCacheClient;
+import com.google.devtools.build.lib.remote.util.RxNoGlobalErrorsRule;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.util.io.FileOutErr;
@@ -56,15 +59,20 @@ import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -73,6 +81,7 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link RemoteCache}. */
 @RunWith(JUnit4.class)
 public class RemoteCacheTest {
+  @Rule public final RxNoGlobalErrorsRule rxNoGlobalErrorsRule = new RxNoGlobalErrorsRule();
 
   private RemoteActionExecutionContext context;
   private FileSystem fs;
@@ -199,18 +208,32 @@ public class RemoteCacheTest {
   }
 
   @Test
-  public void ensureInputsPresent_interrupted_cancelInProgressUploadTasks() throws Exception {
+  public void ensureInputsPresent_interruptedDuringUploadBlobs_cancelInProgressUploadTasks()
+      throws Exception {
     // arrange
-    InMemoryRemoteCache remoteCache = spy(newRemoteCache());
+    RemoteCacheClient cacheProtocol = spy(new InMemoryCacheClient());
+    RemoteExecutionCache remoteCache = spy(newRemoteExecutionCache(cacheProtocol));
 
-    CountDownLatch findMissingDigestsCalled = new CountDownLatch(1);
+    List<SettableFuture<Void>> futures = new ArrayList<>();
+    CountDownLatch uploadBlobCalls = new CountDownLatch(2);
     doAnswer(
             invocationOnMock -> {
-              findMissingDigestsCalled.countDown();
-              return SettableFuture.create();
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              uploadBlobCalls.countDown();
+              return future;
             })
-        .when(remoteCache)
-        .findMissingDigests(any(), any());
+        .when(cacheProtocol)
+        .uploadBlob(any(), any(), any());
+    doAnswer(
+            invocationOnMock -> {
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              uploadBlobCalls.countDown();
+              return future;
+            })
+        .when(cacheProtocol)
+        .uploadFile(any(), any(), any());
 
     Path path = fs.getPath("/execroot/foo");
     FileSystemUtils.writeContentAsLatin1(path, "bar");
@@ -233,7 +256,8 @@ public class RemoteCacheTest {
 
     // act
     thread.start();
-    findMissingDigestsCalled.await();
+    uploadBlobCalls.await();
+    assertThat(futures).hasSize(2);
     assertThat(remoteCache.casUploadCache.getInProgressTasks()).isNotEmpty();
 
     thread.interrupt();
@@ -241,10 +265,183 @@ public class RemoteCacheTest {
 
     // assert
     assertThat(remoteCache.casUploadCache.getInProgressTasks()).isEmpty();
+    assertThat(remoteCache.casUploadCache.getFinishedTasks()).isEmpty();
+    for (SettableFuture<Void> future : futures) {
+      assertThat(future.isCancelled()).isTrue();
+    }
+  }
+
+  @Test
+  public void
+      ensureInputsPresent_multipleConsumers_interruptedOneDuringFindMissingBlobs_keepAndFinishInProgressUploadTasks()
+          throws Exception {
+    // arrange
+    RemoteCacheClient cacheProtocol = spy(new InMemoryCacheClient());
+    RemoteExecutionCache remoteCache = spy(newRemoteExecutionCache(cacheProtocol));
+
+    SettableFuture<ImmutableSet<Digest>> findMissingDigestsFuture = SettableFuture.create();
+    CountDownLatch findMissingDigestsCalled = new CountDownLatch(1);
+    doAnswer(
+            invocationOnMock -> {
+              findMissingDigestsCalled.countDown();
+              return findMissingDigestsFuture;
+            })
+        .when(remoteCache)
+        .findMissingDigests(any(), any());
+    Deque<SettableFuture<Void>> futures = new ConcurrentLinkedDeque<>();
+    CountDownLatch uploadBlobCalls = new CountDownLatch(2);
+    doAnswer(
+            invocationOnMock -> {
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              uploadBlobCalls.countDown();
+              return future;
+            })
+        .when(cacheProtocol)
+        .uploadBlob(any(), any(), any());
+    doAnswer(
+            invocationOnMock -> {
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              uploadBlobCalls.countDown();
+              return future;
+            })
+        .when(cacheProtocol)
+        .uploadFile(any(), any(), any());
+
+    Path path = fs.getPath("/execroot/foo");
+    FileSystemUtils.writeContentAsLatin1(path, "bar");
+    SortedMap<PathFragment, Path> inputs = new TreeMap<>();
+    inputs.put(PathFragment.create("foo"), path);
+    MerkleTree merkleTree = MerkleTree.build(inputs, digestUtil);
+
+    CountDownLatch ensureInputsPresentReturned = new CountDownLatch(2);
+    CountDownLatch ensureInterrupted = new CountDownLatch(1);
+    Runnable work =
+        () -> {
+          try {
+            remoteCache.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), false);
+          } catch (IOException ignored) {
+            // ignored
+          } catch (InterruptedException e) {
+            ensureInterrupted.countDown();
+          } finally {
+            ensureInputsPresentReturned.countDown();
+          }
+        };
+    Thread thread1 = new Thread(work);
+    Thread thread2 = new Thread(work);
+    thread1.start();
+    thread2.start();
+    findMissingDigestsCalled.await();
+
+    // act
+    thread1.interrupt();
+    ensureInterrupted.await();
+    findMissingDigestsFuture.set(ImmutableSet.copyOf(merkleTree.getAllDigests()));
+
+    uploadBlobCalls.await();
+    assertThat(futures).hasSize(2);
+
+    // assert
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).hasSize(2);
+    assertThat(remoteCache.casUploadCache.getFinishedTasks()).isEmpty();
+    for (SettableFuture<Void> future : futures) {
+      assertThat(future.isCancelled()).isFalse();
+    }
+
+    for (SettableFuture<Void> future : futures) {
+      future.set(null);
+    }
+    ensureInputsPresentReturned.await();
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).isEmpty();
+    assertThat(remoteCache.casUploadCache.getFinishedTasks()).hasSize(2);
+  }
+
+  @Test
+  public void
+      ensureInputsPresent_multipleConsumers_interruptedOneDuringUploadBlobs_keepInProgressUploadTasks()
+          throws Exception {
+    // arrange
+    RemoteCacheClient cacheProtocol = spy(new InMemoryCacheClient());
+    RemoteExecutionCache remoteCache = spy(newRemoteExecutionCache(cacheProtocol));
+
+    List<SettableFuture<Void>> futures = new ArrayList<>();
+    CountDownLatch uploadBlobCalls = new CountDownLatch(2);
+    doAnswer(
+            invocationOnMock -> {
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              uploadBlobCalls.countDown();
+              return future;
+            })
+        .when(cacheProtocol)
+        .uploadBlob(any(), any(), any());
+    doAnswer(
+            invocationOnMock -> {
+              SettableFuture<Void> future = SettableFuture.create();
+              futures.add(future);
+              uploadBlobCalls.countDown();
+              return future;
+            })
+        .when(cacheProtocol)
+        .uploadFile(any(), any(), any());
+
+    Path path = fs.getPath("/execroot/foo");
+    FileSystemUtils.writeContentAsLatin1(path, "bar");
+    SortedMap<PathFragment, Path> inputs = new TreeMap<>();
+    inputs.put(PathFragment.create("foo"), path);
+    MerkleTree merkleTree = MerkleTree.build(inputs, digestUtil);
+
+    CountDownLatch ensureInputsPresentReturned = new CountDownLatch(2);
+    CountDownLatch ensureInterrupted = new CountDownLatch(1);
+    Runnable work =
+        () -> {
+          try {
+            remoteCache.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), false);
+          } catch (IOException ignored) {
+            // ignored
+          } catch (InterruptedException e) {
+            ensureInterrupted.countDown();
+          } finally {
+            ensureInputsPresentReturned.countDown();
+          }
+        };
+    Thread thread1 = new Thread(work);
+    Thread thread2 = new Thread(work);
+
+    // act
+    thread1.start();
+    thread2.start();
+    uploadBlobCalls.await();
+    assertThat(futures).hasSize(2);
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).hasSize(2);
+
+    thread1.interrupt();
+    ensureInterrupted.await();
+
+    // assert
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).hasSize(2);
+    assertThat(remoteCache.casUploadCache.getFinishedTasks()).isEmpty();
+    for (SettableFuture<Void> future : futures) {
+      assertThat(future.isCancelled()).isFalse();
+    }
+
+    for (SettableFuture<Void> future : futures) {
+      future.set(null);
+    }
+    ensureInputsPresentReturned.await();
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).isEmpty();
+    assertThat(remoteCache.casUploadCache.getFinishedTasks()).hasSize(2);
   }
 
   private InMemoryRemoteCache newRemoteCache() {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
     return new InMemoryRemoteCache(options, digestUtil);
+  }
+
+  private RemoteExecutionCache newRemoteExecutionCache(RemoteCacheClient remoteCacheClient) {
+    return new RemoteExecutionCache(
+        remoteCacheClient, Options.getDefaults(RemoteOptions.class), digestUtil);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -92,6 +93,7 @@ import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.FakeSpawnExecutionContext;
+import com.google.devtools.build.lib.remote.util.InMemoryCacheClient;
 import com.google.devtools.build.lib.remote.util.RxNoGlobalErrorsRule;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
@@ -110,6 +112,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -160,7 +163,7 @@ public class RemoteExecutionServiceTest {
     checkNotNull(stderr.getParentDirectory()).createDirectoryAndParents();
     outErr = new FileOutErr(stdout, stderr);
 
-    cache = spy(new InMemoryRemoteCache(remoteOptions, digestUtil));
+    cache = spy(new InMemoryRemoteCache(spy(new InMemoryCacheClient()), remoteOptions, digestUtil));
     executor = mock(RemoteExecutionClient.class);
 
     RequestMetadata metadata =
@@ -1544,8 +1547,16 @@ public class RemoteExecutionServiceTest {
 
   @Test
   public void uploadInputsIfNotPresent_interrupted_requestCancelled() throws Exception {
+    CountDownLatch uploadBlobCalled = new CountDownLatch(1);
+    CountDownLatch interrupted = new CountDownLatch(1);
     SettableFuture<ImmutableSet<Digest>> future = SettableFuture.create();
-    doReturn(future).when(cache).findMissingDigests(any(), any());
+    doAnswer(
+            invocationOnMock -> {
+              uploadBlobCalled.countDown();
+              return future;
+            })
+        .when(cache.cacheProtocol)
+        .uploadBlob(any(), any(), any());
     ActionInput input = ActionInputHelper.fromPath("inputs/foo");
     fakeFileCache.createScratchInput(input, "input-foo");
     RemoteExecutionService service = newRemoteExecutionService();
@@ -1556,13 +1567,22 @@ public class RemoteExecutionServiceTest {
             NestedSetBuilder.create(Order.STABLE_ORDER, input));
     FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
     RemoteAction action = service.buildRemoteAction(spawn, context);
+    Thread thread =
+        new Thread(
+            () -> {
+              try {
+                service.uploadInputsIfNotPresent(action, /*force=*/ false);
+              } catch (InterruptedException ignored) {
+                interrupted.countDown();
+              } catch (IOException ignored) {
+                // intentionally ignored
+              }
+            });
 
-    try {
-      Thread.currentThread().interrupt();
-      service.uploadInputsIfNotPresent(action, /*force=*/ false);
-    } catch (InterruptedException ignored) {
-      // Intentionally left empty
-    }
+    thread.start();
+    uploadBlobCalled.await();
+    thread.interrupt();
+    interrupted.await();
 
     assertThat(future.isCancelled()).isTrue();
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /** A {@link RemoteCacheClient} that stores its contents in memory. */
-public final class InMemoryCacheClient implements RemoteCacheClient {
+public class InMemoryCacheClient implements RemoteCacheClient {
 
   private final ListeningExecutorService executorService =
       MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(100));


### PR DESCRIPTION
The regression was introduced in 702df847cf32789ffe6c0a7c7679e92a7ccccb8d where we essentially create a subscriber for each digest to subscribe the result of `findMissingBlobs`.

This change update the code to not create so many subscribers but maintain the same functionalities.

Fixes #15872.

Closes #15890.

PiperOrigin-RevId: 463826260
Change-Id: Id0b1c7c309fc9653a47c5df95c609b34e6510cde

Closes #15912.