### PR TITLE
Warn about source directory being unsound

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
@@ -278,6 +278,13 @@ public final class ArtifactFunction implements SkyFunction {
 
     if (fileValue.isDirectory()) {
       env.getListener().post(SourceDirectoryEvent.create(artifact.getExecPath()));
+      if (!TrackSourceDirectoriesFlag.trackSourceDirectories()) {
+        env.getListener().handle(Event.warn(String.format(
+            "input '%s' is a directory; dependency checking of source directories is unsound. "
+                + "Either use an archive instead or enable highly experimental source directory "
+                + "tracking via --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1.",
+            artifact.prettyPrint())));
+      }
     }
 
     if (!fileValue.isDirectory() || !TrackSourceDirectoriesFlag.trackSourceDirectories()) {

--- a/src/test/shell/integration/execution_phase_tests.sh
+++ b/src/test/shell/integration/execution_phase_tests.sh
@@ -393,6 +393,21 @@ function test_track_directory_crossing_package() {
   expect_log "WARNING: Directory artifact foo/dir crosses package boundary into"
 }
 
+function test_source_directory_no_warning_with_directory_tracking() {
+  mkdir -p foo/dir
+  echo "filegroup(name = 'foo', srcs = ['dir'])" > foo/BUILD
+  bazel --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1 build //foo \
+      >& "$TEST_log" || fail "Expected success"
+  expect_not_log "WARNING: input 'foo/dir'"
+}
+
+function test_source_directory_warning_without_directory_tracking() {
+  mkdir -p foo/dir
+  echo "filegroup(name = 'foo', srcs = ['dir'])" > foo/BUILD
+  bazel build //foo >& "$TEST_log" || fail "Expected success"
+  expect_log "WARNING: input 'foo/dir' is a directory; dependency checking of source directories is unsound."
+}
+
 # Regression test for b/174837755.
 # TODO(b/172462551) Clean this up after the experiment
 function test_skyframe_eval_with_ordered_list_incremental_with_error() {


### PR DESCRIPTION
When a source artifact is a directory and source directory tracking is
not enabled, a warning is printed that instructs the user to either use
an archive instead or enable the (experimental) source directory
tracking functionality.

See #15774 for additional context.