### PR TITLE
Add rules_license to deps of shell/bazel tests. Use in java_tools_test.

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -15,6 +15,14 @@ filegroup(
 )
 
 gen_workspace_stanza(
+    name = "rules_license_stanza",
+    out = "rules_license_stanza.txt",
+    repos = [
+        "rules_license",
+    ],
+)
+
+gen_workspace_stanza(
     name = "rules_proto_stanza",
     out = "rules_proto_stanza.txt",
     repos = [
@@ -26,6 +34,7 @@ filegroup(
     name = "test-deps",
     testonly = 1,
     srcs = [
+        ":rules_license_stanza.txt",
         ":test-deps-wo-bazel",
         "//src:bazel",
         "//src/test/shell:bin/bazel",

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -76,6 +76,9 @@ function set_up() {
   fi
   cat > WORKSPACE <<EOF
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+EOF
+  cat $(rlocation io_bazel/src/tests/shell/bazel/rules_license_stanza.txt) >> WORKSPACE
+  cat >> WORKSPACE <<EOF
 http_archive(
     name = "local_java_tools",
     urls = ["${java_tools_zip_file_url}"]
@@ -85,6 +88,7 @@ http_archive(
     urls = ["${java_tools_prebuilt_zip_file_url}"]
 )
 EOF
+  cat $(rlocation io_bazel/src/tests/shell/bazel/rules_license_stanza.txt) >> WORKSPACE
 }
 
 function expect_path_in_java_tools() {


### PR DESCRIPTION
rules_license is needed for almost all test WORKSPACEs.
This unblocks. #16035.