### PR TITLE
repository_ctx: Allow renaming archive entries during extraction.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -110,17 +110,25 @@ public final class WorkspaceRuleEvent implements Postable {
 
   /** Creates a new WorkspaceRuleEvent for an extract event. */
   public static WorkspaceRuleEvent newExtractEvent(
-      String archive, String output, String stripPrefix, String ruleLabel, Location location) {
-    ExtractEvent e =
+      String archive,
+      String output,
+      String stripPrefix,
+      Map<String, String> renameFiles,
+      String ruleLabel,
+      Location location) {
+
+    WorkspaceLogProtos.ExtractEvent.Builder e =
         WorkspaceLogProtos.ExtractEvent.newBuilder()
             .setArchive(archive)
             .setOutput(output)
-            .setStripPrefix(stripPrefix)
-            .build();
+            .setStripPrefix(stripPrefix);
+    if (renameFiles != null) {
+      e = e.putAllRenameFiles(renameFiles);
+    }
 
     WorkspaceLogProtos.WorkspaceEvent.Builder result =
         WorkspaceLogProtos.WorkspaceEvent.newBuilder();
-    result = result.setExtractEvent(e);
+    result = result.setExtractEvent(e.build());
     if (location != null) {
       result = result.setLocation(location.toString());
     }
@@ -138,6 +146,7 @@ public final class WorkspaceRuleEvent implements Postable {
       String integrity,
       String type,
       String stripPrefix,
+      Map<String, String> renameFiles,
       String ruleLabel,
       Location location) {
     WorkspaceLogProtos.DownloadAndExtractEvent.Builder e =
@@ -149,6 +158,9 @@ public final class WorkspaceRuleEvent implements Postable {
             .setStripPrefix(stripPrefix);
     for (URL u : urls) {
       e.addUrl(u.toString());
+    }
+    if (renameFiles != null) {
+      e = e.putAllRenameFiles(renameFiles);
     }
 
     WorkspaceLogProtos.WorkspaceEvent.Builder result =

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -117,18 +117,17 @@ public final class WorkspaceRuleEvent implements Postable {
       String ruleLabel,
       Location location) {
 
-    WorkspaceLogProtos.ExtractEvent.Builder e =
+    ExtractEvent e =
         WorkspaceLogProtos.ExtractEvent.newBuilder()
             .setArchive(archive)
             .setOutput(output)
-            .setStripPrefix(stripPrefix);
-    if (renameFiles != null) {
-      e = e.putAllRenameFiles(renameFiles);
-    }
+            .setStripPrefix(stripPrefix)
+            .putAllRenameFiles(renameFiles)
+            .build();
 
     WorkspaceLogProtos.WorkspaceEvent.Builder result =
         WorkspaceLogProtos.WorkspaceEvent.newBuilder();
-    result = result.setExtractEvent(e.build());
+    result = result.setExtractEvent(e);
     if (location != null) {
       result = result.setLocation(location.toString());
     }
@@ -155,12 +154,10 @@ public final class WorkspaceRuleEvent implements Postable {
             .setSha256(sha256)
             .setIntegrity(integrity)
             .setType(type)
-            .setStripPrefix(stripPrefix);
+            .setStripPrefix(stripPrefix)
+            .putAllRenameFiles(renameFiles);
     for (URL u : urls) {
       e.addUrl(u.toString());
-    }
-    if (renameFiles != null) {
-      e = e.putAllRenameFiles(renameFiles);
     }
 
     WorkspaceLogProtos.WorkspaceEvent.Builder result =

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -59,6 +59,8 @@ message ExtractEvent {
   string output = 2;
   // A directory prefix to strip from extracted files.
   string strip_prefix = 3;
+  // Files to rename during extraction.
+  map<string, string> rename_files = 4;
 }
 
 message DownloadAndExtractEvent {
@@ -74,6 +76,8 @@ message DownloadAndExtractEvent {
   string strip_prefix = 5;
   // checksum in Subresource Integrity format, if specified
   string integrity = 6;
+  // Files to rename during extraction.
+  map<string, string> rename_files = 7;
 }
 
 // Information on "file" event in repository_ctx.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/ArFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/ArFunction.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Map;
 import org.apache.commons.compress.archivers.ar.ArArchiveEntry;
 import org.apache.commons.compress.archivers.ar.ArArchiveInputStream;
 
@@ -49,11 +50,17 @@ public class ArFunction implements Decompressor {
       throw new InterruptedException();
     }
 
+    Map<String, String> renameFiles = descriptor.renameFiles();
+
     try (InputStream decompressorStream = getDecompressorStream(descriptor)) {
       ArArchiveInputStream arStream = new ArArchiveInputStream(decompressorStream);
       ArArchiveEntry entry;
       while ((entry = arStream.getNextArEntry()) != null) {
-        Path filePath = descriptor.repositoryPath().getRelative(entry.getName());
+        String entryName = entry.getName();
+        if (renameFiles != null) {
+          entryName = renameFiles.getOrDefault(entryName, entryName);
+        }
+        Path filePath = descriptor.repositoryPath().getRelative(entryName);
         filePath.getParentDirectory().createDirectoryAndParents();
         if (entry.isDirectory()) {
           // ar archives don't contain any directory information, so this should never

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/ArFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/ArFunction.java
@@ -57,9 +57,7 @@ public class ArFunction implements Decompressor {
       ArArchiveEntry entry;
       while ((entry = arStream.getNextArEntry()) != null) {
         String entryName = entry.getName();
-        if (renameFiles != null) {
-          entryName = renameFiles.getOrDefault(entryName, entryName);
-        }
+        entryName = renameFiles.getOrDefault(entryName, entryName);
         Path filePath = descriptor.repositoryPath().getRelative(entryName);
         filePath.getParentDirectory().createDirectoryAndParents();
         if (entry.isDirectory()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
@@ -47,6 +47,7 @@ public abstract class CompressedTarFunction implements Decompressor {
       throw new InterruptedException();
     }
     Optional<String> prefix = descriptor.prefix();
+    Map<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
     Set<String> availablePrefixes = new HashSet<>();
     // Store link, target info of symlinks, we create them after regular files are extracted.
@@ -56,7 +57,11 @@ public abstract class CompressedTarFunction implements Decompressor {
       TarArchiveInputStream tarStream = new TarArchiveInputStream(decompressorStream);
       TarArchiveEntry entry;
       while ((entry = tarStream.getNextTarEntry()) != null) {
-        StripPrefixedPath entryPath = StripPrefixedPath.maybeDeprefix(entry.getName(), prefix);
+        String entryName = entry.getName();
+        if (renameFiles != null) {
+          entryName = renameFiles.getOrDefault(entryName, entryName);
+        }
+        StripPrefixedPath entryPath = StripPrefixedPath.maybeDeprefix(entryName, prefix);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
 
         if (prefix.isPresent() && !foundPrefix) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
@@ -58,9 +58,7 @@ public abstract class CompressedTarFunction implements Decompressor {
       TarArchiveEntry entry;
       while ((entry = tarStream.getNextTarEntry()) != null) {
         String entryName = entry.getName();
-        if (renameFiles != null) {
-          entryName = renameFiles.getOrDefault(entryName, entryName);
-        }
+        entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath = StripPrefixedPath.maybeDeprefix(entryName, prefix);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompre
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -33,17 +34,21 @@ public class DecompressorDescriptor {
   private final Path repositoryPath;
   private final Optional<String> prefix;
   private final boolean executable;
+  private final Map<String, String> renameFiles;
   private final Decompressor decompressor;
 
   private DecompressorDescriptor(
       String targetKind, String targetName, Path archivePath, Path repositoryPath,
-      @Nullable String prefix, boolean executable, Decompressor decompressor) {
+      @Nullable String prefix, boolean executable,
+      @Nullable Map<String, String> renameFiles,
+      Decompressor decompressor) {
     this.targetKind = targetKind;
     this.targetName = targetName;
     this.archivePath = archivePath;
     this.repositoryPath = repositoryPath;
     this.prefix = Optional.fromNullable(prefix);
     this.executable = executable;
+    this.renameFiles = renameFiles;
     this.decompressor = decompressor;
   }
 
@@ -71,6 +76,10 @@ public class DecompressorDescriptor {
     return executable;
   }
 
+  public Map<String, String> renameFiles() {
+    return renameFiles;
+  }
+
   public Decompressor getDecompressor() {
     return decompressor;
   }
@@ -92,12 +101,13 @@ public class DecompressorDescriptor {
         && Objects.equals(repositoryPath, descriptor.repositoryPath)
         && Objects.equals(prefix, descriptor.prefix)
         && Objects.equals(executable, descriptor.executable)
+        && Objects.equals(renameFiles, descriptor.renameFiles)
         && decompressor == descriptor.decompressor;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(targetKind, targetName, archivePath, repositoryPath, prefix);
+    return Objects.hash(targetKind, targetName, archivePath, repositoryPath, prefix, renameFiles);
   }
 
   public static Builder builder() {
@@ -115,6 +125,7 @@ public class DecompressorDescriptor {
     private Path repositoryPath;
     private String prefix;
     private boolean executable;
+    private Map<String, String> renameFiles;
     private Decompressor decompressor;
 
     private Builder() {
@@ -125,7 +136,7 @@ public class DecompressorDescriptor {
         decompressor = DecompressorValue.getDecompressor(archivePath);
       }
       return new DecompressorDescriptor(
-          targetKind, targetName, archivePath, repositoryPath, prefix, executable, decompressor);
+          targetKind, targetName, archivePath, repositoryPath, prefix, executable, renameFiles, decompressor);
     }
 
     @CanIgnoreReturnValue
@@ -161,6 +172,12 @@ public class DecompressorDescriptor {
     @CanIgnoreReturnValue
     public Builder setExecutable(boolean executable) {
       this.executable = executable;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder setRenameFiles(Map<String, String> renameFiles) {
+      this.renameFiles = renameFiles;
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
@@ -15,10 +15,12 @@
 package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -40,7 +42,7 @@ public class DecompressorDescriptor {
   private DecompressorDescriptor(
       String targetKind, String targetName, Path archivePath, Path repositoryPath,
       @Nullable String prefix, boolean executable,
-      @Nullable Map<String, String> renameFiles,
+      Map<String, String> renameFiles,
       Decompressor decompressor) {
     this.targetKind = targetKind;
     this.targetName = targetName;
@@ -135,8 +137,12 @@ public class DecompressorDescriptor {
       if (decompressor == null) {
         decompressor = DecompressorValue.getDecompressor(archivePath);
       }
+      if (renameFiles == null) {
+        renameFiles = Collections.emptyMap();
+      }
       return new DecompressorDescriptor(
-          targetKind, targetName, archivePath, repositoryPath, prefix, executable, renameFiles, decompressor);
+          targetKind, targetName, archivePath, repositoryPath, prefix, executable,
+          renameFiles, decompressor);
     }
 
     @CanIgnoreReturnValue
@@ -177,7 +183,7 @@ public class DecompressorDescriptor {
 
     @CanIgnoreReturnValue
     public Builder setRenameFiles(Map<String, String> renameFiles) {
-      this.renameFiles = renameFiles;
+      this.renameFiles = ImmutableMap.copyOf(renameFiles);
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressor.java
@@ -88,9 +88,7 @@ public class ZipDecompressor implements Decompressor {
       Collection<ZipFileEntry> entries = reader.entries();
       for (ZipFileEntry entry : entries) {
         String entryName = entry.getName();
-        if (renameFiles != null) {
-          entryName = renameFiles.getOrDefault(entryName, entryName);
-        }
+        entryName = renameFiles.getOrDefault(entryName, entryName);
         StripPrefixedPath entryPath = StripPrefixedPath.maybeDeprefix(entryName, prefix);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressor.java
@@ -79,6 +79,7 @@ public class ZipDecompressor implements Decompressor {
       throws IOException, InterruptedException {
     Path destinationDirectory = descriptor.repositoryPath();
     Optional<String> prefix = descriptor.prefix();
+    Map<String, String> renameFiles = descriptor.renameFiles();
     boolean foundPrefix = false;
     // Store link, target info of symlinks, we create them after regular files are extracted.
     Map<Path, PathFragment> symlinks = new HashMap<>();
@@ -86,7 +87,11 @@ public class ZipDecompressor implements Decompressor {
     try (ZipReader reader = new ZipReader(descriptor.archivePath().getPathFile())) {
       Collection<ZipFileEntry> entries = reader.entries();
       for (ZipFileEntry entry : entries) {
-        StripPrefixedPath entryPath = StripPrefixedPath.maybeDeprefix(entry.getName(), prefix);
+        String entryName = entry.getName();
+        if (renameFiles != null) {
+          entryName = renameFiles.getOrDefault(entryName, entryName);
+        }
+        StripPrefixedPath entryPath = StripPrefixedPath.maybeDeprefix(entryName, prefix);
         foundPrefix = foundPrefix || entryPath.foundPrefix();
         if (entryPath.skip()) {
           continue;

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -749,8 +749,22 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
                     + " archive. Instead of needing to specify this prefix over and over in the"
                     + " <code>build_file</code>, this field can be used to strip it from extracted"
                     + " files."),
+        @Param(
+            name = "renameFiles",
+            defaultValue = "{}",
+            named = true,
+            positional = false,
+            doc =
+                "An optional dict specifying files to rename during the extraction. Archive entries"
+                    + " with names exactly matching a key will be renamed to the value, prior to"
+                    + " any directory prefix adjustment."),
       })
-  public void extract(Object archive, Object output, String stripPrefix, StarlarkThread thread)
+  public void extract(
+      Object archive,
+      Object output,
+      String stripPrefix,
+      Dict<?, ?> renameFiles, // <String, String> expected
+      StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     StarlarkPath archivePath = getPath("extract()", archive);
 
@@ -762,11 +776,15 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     StarlarkPath outputPath = getPath("extract()", output);
     checkInOutputDirectory("write", outputPath);
 
+    Map<String, String> renameFilesMap =
+        Dict.cast(renameFiles, String.class, String.class, "renameFiles");
+
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newExtractEvent(
             archive.toString(),
             output.toString(),
             stripPrefix,
+            renameFilesMap,
             rule.getLabel().toString(),
             thread.getCallerLocation());
     env.getListener().post(w);
@@ -782,6 +800,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
             .setArchivePath(archivePath.getPath())
             .setRepositoryPath(outputPath.getPath())
             .setPrefix(stripPrefix)
+            .setRenameFiles(renameFilesMap)
             .build());
     env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));
   }
@@ -881,6 +900,15 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
                     + " risk to omit the checksum as remote files can change. At best omitting this"
                     + " field will make your build non-hermetic. It is optional to make development"
                     + " easier but should be set before shipping."),
+        @Param(
+            name = "renameFiles",
+            defaultValue = "{}",
+            named = true,
+            positional = false,
+            doc =
+                "An optional dict specifying files to rename during the extraction. Archive entries"
+                    + " with names exactly matching a key will be renamed to the value, prior to"
+                    + " any directory prefix adjustment."),
       })
   public StructImpl downloadAndExtract(
       Object url,
@@ -892,6 +920,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       String canonicalId,
       Dict<?, ?> auth, // <String, Dict> expected
       String integrity,
+      Dict<?, ?> renameFiles, // <String, String> expected
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     Map<URI, Map<String, String>> authHeaders = getAuthHeaders(getAuthContents(auth, "auth"));
@@ -911,6 +940,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       checksumValidation = e;
     }
 
+    Map<String, String> renameFilesMap =
+        Dict.cast(renameFiles, String.class, String.class, "renameFiles");
+
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newDownloadAndExtractEvent(
             urls,
@@ -919,6 +951,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
             integrity,
             type,
             stripPrefix,
+            renameFilesMap,
             rule.getLabel().toString(),
             thread.getCallerLocation());
 
@@ -977,6 +1010,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
               .setArchivePath(downloadedPath)
               .setRepositoryPath(outputPath.getPath())
               .setPrefix(stripPrefix)
+              .setRenameFiles(renameFilesMap)
               .build());
       env.getListener().post(new ExtractProgress(outputPath.getPath().toString()));
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -757,7 +757,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
             doc =
                 "An optional dict specifying files to rename during the extraction. Archive entries"
                     + " with names exactly matching a key will be renamed to the value, prior to"
-                    + " any directory prefix adjustment."),
+                    + " any directory prefix adjustment. This can be used to extract archives that"
+                    + " contain non-Unicode filenames, or which have files that would extract to"
+                    + " the same path on case-insensitive filesystems."),
       })
   public void extract(
       Object archive,
@@ -908,7 +910,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
             doc =
                 "An optional dict specifying files to rename during the extraction. Archive entries"
                     + " with names exactly matching a key will be renamed to the value, prior to"
-                    + " any directory prefix adjustment."),
+                    + " any directory prefix adjustment. This can be used to extract archives that"
+                    + " contain non-Unicode filenames, or which have files that would extract to"
+                    + " the same path on case-insensitive filesystems."),
       })
   public StructImpl downloadAndExtract(
       Object url,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -750,7 +750,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
                     + " <code>build_file</code>, this field can be used to strip it from extracted"
                     + " files."),
         @Param(
-            name = "renameFiles",
+            name = "rename_files",
             defaultValue = "{}",
             named = true,
             positional = false,
@@ -777,7 +777,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     checkInOutputDirectory("write", outputPath);
 
     Map<String, String> renameFilesMap =
-        Dict.cast(renameFiles, String.class, String.class, "renameFiles");
+        Dict.cast(renameFiles, String.class, String.class, "rename_files");
 
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newExtractEvent(
@@ -901,7 +901,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
                     + " field will make your build non-hermetic. It is optional to make development"
                     + " easier but should be set before shipping."),
         @Param(
-            name = "renameFiles",
+            name = "rename_files",
             defaultValue = "{}",
             named = true,
             positional = false,
@@ -941,7 +941,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     }
 
     Map<String, String> renameFilesMap =
-        Dict.cast(renameFiles, String.class, String.class, "renameFiles");
+        Dict.cast(renameFiles, String.class, String.class, "rename_files");
 
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newDownloadAndExtractEvent(

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/ArFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/ArFunctionTest.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.runfiles.Runfiles;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -60,6 +61,23 @@ public class ArFunctionTest {
     // There are 20 bytes in the content "this is the second test file"
     assertThat(secondFile.getFileSize()).isEqualTo(29);
     assertThat(secondFile.isSymbolicLink()).isFalse();
+  }
+
+  /**
+   * Test decompressing an ar file, with some entries being renamed during the
+   * extraction process.
+   */
+  @Test
+  public void testDecompressWithRenamedFiles() throws Exception {
+    HashMap<String, String> renameFiles = new HashMap<>();
+    renameFiles.put("archived_first.txt", "renamed_file.txt");
+    DecompressorDescriptor.Builder descriptorBuilder =
+        createDescriptorBuilder().setRenameFiles(renameFiles);
+    Path outputDir = decompress(descriptorBuilder);
+
+    assertThat(outputDir.exists()).isTrue();
+    Path renamedFile = outputDir.getRelative("renamed_file.txt");
+    assertThat(renamedFile.exists()).isTrue();
   }
 
   private Path decompress(DecompressorDescriptor.Builder descriptorBuilder) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
@@ -86,6 +86,27 @@ public class CompressedTarFunctionTest {
     assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
   }
 
+  /**
+   * Test that entry renaming is applied prior to prefix stripping.
+   */
+  @Test
+  public void testDecompressWithRenamedFilesAndPrefix() throws Exception {
+    String innerDirName = ROOT_FOLDER_NAME + "/" + INNER_FOLDER_NAME;
+
+    HashMap<String, String> renameFiles = new HashMap<>();
+    renameFiles.put(
+      innerDirName + "/hardLinkFile",
+      innerDirName + "/renamedFile");
+    DecompressorDescriptor.Builder descriptorBuilder =
+        archiveDescriptor.createDescriptorBuilder()
+            .setPrefix(ROOT_FOLDER_NAME)
+            .setRenameFiles(renameFiles);
+    Path outputDir = decompress(descriptorBuilder);
+
+    Path innerDir = outputDir.getRelative(INNER_FOLDER_NAME);
+    assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
+  }
+
   private Path decompress(DecompressorDescriptor.Builder descriptorBuilder) throws Exception {
     descriptorBuilder.setDecompressor(TarGzFunction.INSTANCE);
     return new CompressedTarFunction() {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.bazel.repository;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescriptor.INNER_FOLDER_NAME;
 import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 
@@ -21,6 +22,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.zip.GZIPInputStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,6 +64,26 @@ public class CompressedTarFunctionTest {
     Path outputDir = decompress(descriptorBuilder);
 
     archiveDescriptor.assertOutputFiles(outputDir, INNER_FOLDER_NAME);
+  }
+
+  /**
+   * Test decompressing a tar.gz file, with some entries being renamed during the
+   * extraction process.
+   */
+  @Test
+  public void testDecompressWithRenamedFiles() throws Exception {
+    String innerDirName = ROOT_FOLDER_NAME + "/" + INNER_FOLDER_NAME;
+
+    HashMap<String, String> renameFiles = new HashMap<>();
+    renameFiles.put(
+      innerDirName + "/hardLinkFile",
+      innerDirName + "/renamedFile");
+    DecompressorDescriptor.Builder descriptorBuilder =
+        archiveDescriptor.createDescriptorBuilder().setRenameFiles(renameFiles);
+    Path outputDir = decompress(descriptorBuilder);
+
+    Path innerDir = outputDir.getRelative(ROOT_FOLDER_NAME).getRelative(INNER_FOLDER_NAME);
+    assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
   }
 
   private Path decompress(DecompressorDescriptor.Builder descriptorBuilder) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressorTest.java
@@ -19,6 +19,7 @@ import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescript
 import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 
 import com.google.devtools.build.lib.vfs.Path;
+import java.util.HashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -66,6 +67,27 @@ public class ZipDecompressorTest {
     Path outputDir = decompress(descriptorBuilder);
 
     archiveDescriptor.assertOutputFiles(outputDir, INNER_FOLDER_NAME);
+  }
+
+  /**
+   * Test decompressing a zip file, with some entries being renamed during the
+   * extraction process.
+   */
+  @Test
+  public void testDecompressWithRenamedFiles() throws Exception {
+    TestArchiveDescriptor archiveDescriptor = new TestArchiveDescriptor(ARCHIVE_NAME, "out", false);
+    String innerDirName = ROOT_FOLDER_NAME + "/" + INNER_FOLDER_NAME;
+
+    HashMap<String, String> renameFiles = new HashMap<>();
+    renameFiles.put(
+      innerDirName + "/hardLinkFile",
+      innerDirName + "/renamedFile");
+    DecompressorDescriptor.Builder descriptorBuilder =
+        archiveDescriptor.createDescriptorBuilder().setRenameFiles(renameFiles);
+    Path outputDir = decompress(descriptorBuilder);
+
+    Path innerDir = outputDir.getRelative(ROOT_FOLDER_NAME).getRelative(INNER_FOLDER_NAME);
+    assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
   }
 
   private Path decompress(DecompressorDescriptor.Builder descriptorBuilder) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/ZipDecompressorTest.java
@@ -90,6 +90,28 @@ public class ZipDecompressorTest {
     assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
   }
 
+  /**
+   * Test that entry renaming is applied prior to prefix stripping.
+   */
+  @Test
+  public void testDecompressWithRenamedFilesAndPrefix() throws Exception {
+    TestArchiveDescriptor archiveDescriptor = new TestArchiveDescriptor(ARCHIVE_NAME, "out", false);
+    String innerDirName = ROOT_FOLDER_NAME + "/" + INNER_FOLDER_NAME;
+
+    HashMap<String, String> renameFiles = new HashMap<>();
+    renameFiles.put(
+      innerDirName + "/hardLinkFile",
+      innerDirName + "/renamedFile");
+    DecompressorDescriptor.Builder descriptorBuilder =
+        archiveDescriptor.createDescriptorBuilder()
+            .setPrefix(ROOT_FOLDER_NAME)
+            .setRenameFiles(renameFiles);
+    Path outputDir = decompress(descriptorBuilder);
+
+    Path innerDir = outputDir.getRelative(INNER_FOLDER_NAME);
+    assertThat(innerDir.getRelative("renamedFile").exists()).isTrue();
+  }
+
   private Path decompress(DecompressorDescriptor.Builder descriptorBuilder) throws Exception {
     descriptorBuilder.setDecompressor(ZipDecompressor.INSTANCE);
     return ZipDecompressor.INSTANCE.decompress(descriptorBuilder.build());

--- a/src/test/shell/bazel/bazel_workspaces_test.sh
+++ b/src/test/shell/bazel/bazel_workspaces_test.sh
@@ -417,6 +417,38 @@ function test_download_and_extract() {
   ensure_output_contains_exactly_once "external/repo/out_dir/download_and_extract.txt" "This is one file"
 }
 
+function test_extract_rename_files() {
+  local archive_tar="${TEST_TMPDIR}/archive.tar"
+
+  # Create a tar archive with two entries, which would have conflicting
+  # paths if extracted to a case-insensitive filesystem.
+  pushd "${TEST_TMPDIR}"
+  mkdir prefix
+  echo "First file: a" > prefix/a.txt
+  tar -cvf archive.tar prefix
+  rm prefix/a.txt
+  echo "Second file: A" > prefix/A.txt
+  tar -rvf archive.tar prefix
+  popd
+
+  set_workspace_command "
+  repository_ctx.extract('${archive_tar}', 'out_dir', 'prefix/', renameFiles={
+    'prefix/A.txt': 'prefix/renamed-A.txt',
+  })"
+
+  build_and_process_log --exclude_rule "//external:local_config_cc"
+
+  ensure_contains_exactly 'location: .*repos.bzl:3:25' 1
+  ensure_contains_atleast 'rule: "//external:repo"' 2
+  ensure_contains_exactly 'extract_event' 1
+  ensure_contains_exactly 'rename_files' 1
+  ensure_contains_exactly 'key: "prefix/A.txt"' 1
+  ensure_contains_exactly 'value: "prefix/renamed.A.txt"' 1
+
+  ensure_output_contains_exactly_once "external/repo/out_dir/a.txt" "First file: a"
+  ensure_output_contains_exactly_once "external/repo/out_dir/renamed-A.txt" "Second file: A"
+}
+
 function test_file() {
   set_workspace_command 'repository_ctx.file("filefile.sh", "echo filefile", True)'
 

--- a/src/test/shell/bazel/bazel_workspaces_test.sh
+++ b/src/test/shell/bazel/bazel_workspaces_test.sh
@@ -432,7 +432,7 @@ function test_extract_rename_files() {
   popd
 
   set_workspace_command "
-  repository_ctx.extract('${archive_tar}', 'out_dir', 'prefix/', renameFiles={
+  repository_ctx.extract('${archive_tar}', 'out_dir', 'prefix/', rename_files={
     'prefix/A.txt': 'prefix/renamed-A.txt',
   })"
 


### PR DESCRIPTION
Adds a `rename_files=` parameter to the `extract()` and `download_and_extract()` methods of `repository_ctx`. This new parameter takes a dict of archive entries to rename, and is applied prior to any prefix adjustment.