### PR TITLE
Use env trick for these test scripts.

### DIFF
--- a/tools/test/generate-xml.sh
+++ b/tools/test/generate-xml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
Attempting to run tests on projects will fail when bash is not in /bin,
so use the env trick again here.