### PR TITLE
Display human readable bytes in download progress

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -22,6 +22,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadProgressEvent.java
@@ -16,8 +16,8 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import java.net.URL;
-import java.text.NumberFormat;
 import java.util.Locale;
+import com.google.devtools.build.lib.remote.util.Utils;
 
 /**
  * Postable event reporting on progress made downloading an URL. It can be used to report the URL
@@ -73,9 +73,7 @@ public class DownloadProgressEvent implements ExtendedEventHandler.FetchProgress
   @Override
   public String getProgress() {
     if (bytesRead > 0) {
-      NumberFormat formatter = NumberFormat.getIntegerInstance(Locale.ENGLISH);
-      formatter.setGroupingUsed(true);
-      return formatter.format(bytesRead) + "B";
+      return String.format("%s (%,dB)", Utils.bytesCountToDisplayString(bytesRead), bytesRead);
     } else {
       return "";
     }


### PR DESCRIPTION
Before:

```
Fetching https://mirror.bazel.build/..._x64.tar.gz; 28,324,614B 9s
```

After:

```
Fetching https://mirror.bazel.build/..._x64.tar.gz; 27 MB (28,324,614B) 9s
```