### PR TITLE
Buildfix Netty filter on this select default case.

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -668,8 +668,14 @@ distrib_java_import(
     enable_distributions = ["debian"],
     jars = [
         "netty_tcnative/netty-tcnative-classes-2.0.51.Final.jar",
-        ":netty_tcnative/netty-tcnative-filtered.jar",
-    ],
+    ] + select({
+        "//src/conditions:darwin_arm64": [":netty_tcnative/netty-tcnative-filtered.jar"],
+        "//src/conditions:darwin_x86_64": [":netty_tcnative/netty-tcnative-filtered.jar"],
+        "//src/conditions:linux_aarch64": [":netty_tcnative/netty-tcnative-filtered.jar"],
+        "//src/conditions:linux_x86_64": [":netty_tcnative/netty-tcnative-filtered.jar"],
+        "//src/conditions:windows": [":netty_tcnative/netty-tcnative-filtered.jar"],
+        "//conditions:default": [],
+    }),
 )
 
 distrib_java_import(


### PR DESCRIPTION
The `filter_netty_dynamic_libs` genrule has no srcs when not Darwin,
Linux, or Windows. In this case, attempting to invoke the genrule breaks
the build because the `cp` command has no input. Instead, only depend on
this genrule output when the platform is Darwin, Linux, or Windows.

There might be a nicer way of doing this, but this works.