### PR TITLE
Include exception message for "Source forest creation failed" error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -595,10 +595,11 @@ public class ExecutionTool {
                 request.getOptions(BuildLanguageOptions.class).experimentalSiblingRepositoryLayout);
         symlinkForest.plantSymlinkForest();
       } catch (IOException e) {
+        String message = String.format("Source forest creation failed: %s", e.getMessage());
         throw new AbruptExitException(
             DetailedExitCode.of(
                 FailureDetail.newBuilder()
-                    .setMessage("Source forest creation failed")
+                    .setMessage(message)
                     .setSymlinkForest(
                         FailureDetails.SymlinkForest.newBuilder()
                             .setCode(FailureDetails.SymlinkForest.Code.CREATION_FAILED))


### PR DESCRIPTION
We experienced this error from integration tests which failed to clean up after themselves and left write-protected files behind. This is just a small messaging improvement which would have made finding the root cause easier.

The change here is analogous to this error: https://github.com/bazelbuild/bazel/blob/d1820a75ea3eb182ef2c2319bb77be19c4113a47/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java#L875