### PR TITLE
Verify gRPC cache downloads after flushing the output.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -418,19 +418,21 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
                       @Override
                       public void onCompleted() {
                         try {
+                          try {
+                            out.flush();
+                          } finally {
+                            releaseOut();
+                          }
                           if (digestSupplier != null) {
                             Utils.verifyBlobContents(digest, digestSupplier.get());
                           }
-                          out.flush();
-                          future.set(rawOut.getCount());
                         } catch (IOException e) {
                           future.setException(e);
                         } catch (RuntimeException e) {
                           logger.atWarning().withCause(e).log("Unexpected exception");
                           future.setException(e);
-                        } finally {
-                          releaseOut();
                         }
+                        future.set(rawOut.getCount());
                       }
 
                       private void releaseOut() {


### PR DESCRIPTION
Make sure any internal buffers (especially compression) are flushed before attempting verify the digest of the downloaded file.