### PR TITLE
Add RunfilesLibraryInfo provider

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -87,6 +87,7 @@ filegroup(
         "//tools/jdk:bzl_srcs",
         "//tools/osx:bzl_srcs",
         "//tools/python:bzl_srcs",
+        "//tools/runfiles:bzl_srcs",
         "//tools/sh:bzl_srcs",
         "//tools/test:bzl_srcs",
         "//tools/windows:bzl_srcs",

--- a/tools/runfiles/BUILD
+++ b/tools/runfiles/BUILD
@@ -11,6 +11,9 @@ filegroup(
 
 filegroup(
     name = "embedded_tools",
-    srcs = ["BUILD.tools"],
+    srcs = [
+        "BUILD.tools",
+        "runfiles.bzl",
+    ],
     visibility = ["//tools:__pkg__"],
 )

--- a/tools/runfiles/BUILD.tools
+++ b/tools/runfiles/BUILD.tools
@@ -1,6 +1,12 @@
+package(default_visibility = ["//visibility:private"])
+
 java_library(
     name = "java-runfiles",
     deprecation = "Depend on @bazel_tools//tools/java/runfiles instead. This target will be deleted in Bazel 0.19.0",
-    visibility = ["//visibility:public"],
     exports = ["//tools/java/runfiles"],
+)
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = ["runfiles.bzl"],
 )

--- a/tools/runfiles/runfiles.bzl
+++ b/tools/runfiles/runfiles.bzl
@@ -1,0 +1,9 @@
+RunfilesLibraryInfo = provider(
+    doc = """
+A marker for targets providing runfiles lookup functionality.
+
+Rules may choose to emit additional information required to locate runfiles at runtime if this provider is present on a direct dependency.
+
+Note: At this point, neither Bazel nor native rules check for the presence of this provider.
+""",
+)


### PR DESCRIPTION
The new Starlark-defined RunfilesLibraryInfo provider may be used in the
future to decide whether additional information has to be emitted by a
rule for a target to find its runfiles at runtime. This may include
serializing repository mapping information to a runfile and/or
generating code that provides the canonical name of the current
repository.

The provider is added now rather than later so that third-party runfiles
libraries can rely on it being present earlier - they have to wait for
their minimum supported Bazel version to offer it. If it should turn out
not to be needed, it can safely be removed before any ruleset would have
a reason to depend on it.

Work towards https://github.com/bazelbuild/proposals/pull/269