### PR TITLE
Allow malloc attribute of cc_* rules to accept any targets

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary_attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary_attrs.bzl
@@ -62,7 +62,7 @@ cc_binary_attrs_with_aspects = {
     "malloc": attr.label(
         default = Label("@" + semantics.get_repo() + "//tools/cpp:malloc"),
         allow_files = False,
-        allow_rules = ["cc_library"],
+        providers = [CcInfo],
         aspects = [graph_structure_aspect],
     ),
     "_default_malloc": attr.label(


### PR DESCRIPTION
Close https://github.com/bazelbuild/bazel/issues/8252