### PR TITLE
Show a better error when MODULE.bazel is missing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -293,7 +293,7 @@ public class ModuleFileFunction implements SkyFunction {
     try {
       return FileSystemUtils.readWithKnownFileSize(path, path.getFileSize());
     } catch (IOException e) {
-      throw new ModuleFileFunctionException(e);
+      throw errorf(Code.MODULE_NOT_FOUND, "MODULE.bazel expected but not found at %s", path);
     }
   }
 


### PR DESCRIPTION
Previously, Bazel would error out with this message if it couldn't find
a MODULE.bazel (e.g. in the root module):

```
ERROR: unknown error during computation of main repo mapping
```