### PR TITLE
Include stack trace in all gRPC errors when --verbose_failures is set.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -507,7 +507,8 @@ public final class RemoteModule extends BlazeModule {
       }
     } catch (IOException e) {
       String errorMessage =
-          "Failed to query remote execution capabilities: " + Utils.grpcAwareErrorMessage(e);
+          "Failed to query remote execution capabilities: "
+              + Utils.grpcAwareErrorMessage(e, verboseFailures);
       if (remoteOptions.remoteLocalFallback) {
         if (verboseFailures) {
           errorMessage += System.lineSeparator() + Throwables.getStackTraceAsString(e);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -141,13 +141,7 @@ final class RemoteSpawnCache implements SpawnCache {
         if (BulkTransferException.isOnlyCausedByCacheNotFoundException(e)) {
           // Intentionally left blank
         } else {
-          String errorMessage;
-          if (!verboseFailures) {
-            errorMessage = Utils.grpcAwareErrorMessage(e);
-          } else {
-            // On --verbose_failures print the whole stack trace
-            errorMessage = "\n" + Throwables.getStackTraceAsString(e);
-          }
+          String errorMessage = Utils.grpcAwareErrorMessage(e, verboseFailures);
           if (isNullOrEmpty(errorMessage)) {
             errorMessage = e.getClass().getSimpleName();
           }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -566,11 +566,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
       catastrophe = false;
     }
 
-    String errorMessage = Utils.grpcAwareErrorMessage(exception);
-    if (verboseFailures) {
-      // On --verbose_failures print the whole stack trace
-      errorMessage += "\n" + Throwables.getStackTraceAsString(exception);
-    }
+    String errorMessage = Utils.grpcAwareErrorMessage(exception, verboseFailures);
 
     if (exception.getCause() instanceof ExecutionStatusException) {
       ExecutionStatusException e = (ExecutionStatusException) exception.getCause();

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -384,7 +384,7 @@ public final class Utils {
         + errorDetailsMessage(status.getDetailsList());
   }
 
-  public static String grpcAwareErrorMessage(IOException e) {
+  private static String grpcAwareErrorMessage(IOException e) {
     io.grpc.Status errStatus = io.grpc.Status.fromThrowable(e);
     if (e.getCause() instanceof ExecutionStatusException) {
       // Display error message returned by the remote service.

--- a/src/test/java/com/google/devtools/build/lib/remote/UtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/UtilsTest.java
@@ -36,14 +36,35 @@ import org.junit.runners.JUnit4;
 public class UtilsTest {
 
   @Test
-  public void testGrpcAwareErrorMessages() {
+  public void testGrpcAwareErrorMessage() {
     IOException ioError = new IOException("io error");
     IOException wrappedGrpcError =
         new IOException(
             "wrapped error", Status.ABORTED.withDescription("grpc error").asRuntimeException());
 
-    assertThat(Utils.grpcAwareErrorMessage(ioError)).isEqualTo("io error");
-    assertThat(Utils.grpcAwareErrorMessage(wrappedGrpcError)).isEqualTo("ABORTED: grpc error");
+    assertThat(Utils.grpcAwareErrorMessage(ioError, /* verboseFailures= */ false))
+        .isEqualTo("io error");
+    assertThat(Utils.grpcAwareErrorMessage(wrappedGrpcError, /* verboseFailures= */ false))
+        .isEqualTo("ABORTED: grpc error");
+  }
+
+  @Test
+  public void testGrpcAwareErrorMessage_verboseFailures() {
+    IOException ioError = new IOException("io error");
+    IOException wrappedGrpcError =
+        new IOException(
+            "wrapped error", Status.ABORTED.withDescription("grpc error").asRuntimeException());
+
+    assertThat(Utils.grpcAwareErrorMessage(ioError, /* verboseFailures= */ true))
+        .startsWith(
+            "io error\n"
+                + "java.io.IOException: io error\n"
+                + "\tat com.google.devtools.build.lib.remote.UtilsTest.testGrpcAwareErrorMessage_verboseFailures");
+    assertThat(Utils.grpcAwareErrorMessage(wrappedGrpcError, /* verboseFailures= */ true))
+        .startsWith(
+            "ABORTED: grpc error\n"
+                + "java.io.IOException: wrapped error\n"
+                + "\tat com.google.devtools.build.lib.remote.UtilsTest.testGrpcAwareErrorMessage_verboseFailures");
   }
 
   @Test


### PR DESCRIPTION
Also refactor a couple places where the stack trace was included in an ad-hoc
manner, and force Utils.grpcAwareErrorMessage callers to be explicit to avoid
future instances.