### PR TITLE
Add .wasm cc artifact executable extension

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ArtifactCategory.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ArtifactCategory.java
@@ -23,7 +23,7 @@ public enum ArtifactCategory {
   STATIC_LIBRARY("lib", ".a", ".lib"),
   ALWAYSLINK_STATIC_LIBRARY("lib", ".lo", ".lo.lib"),
   DYNAMIC_LIBRARY("lib", ".so", ".dylib", ".dll"),
-  EXECUTABLE("", "", ".exe"),
+  EXECUTABLE("", "", ".exe", ".wasm"),
   INTERFACE_LIBRARY("lib", ".ifso", ".tbd", ".if.lib", ".lib"),
   PIC_FILE("", ".pic"),
   INCLUDED_FILE_LIST("", ".d"),


### PR DESCRIPTION
This allows creating a custom cc_toolchain that compiles to WebAssembly that outputs a wasm file with the standard extension, without needing to have a genrule that renames the file