### PR TITLE
Keep usePlatformsRepoForConstraints value in host cfg

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -960,6 +960,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     host.enableAspectHints = enableAspectHints;
     host.allowUnresolvedSymlinks = allowUnresolvedSymlinks;
 
+    host.usePlatformsRepoForConstraints = usePlatformsRepoForConstraints;
     return host;
   }
 


### PR DESCRIPTION
The value gets reset to the default (true) so setting `--noincompatible_use_platforms_repo_for_constraints` has no effect if the target using the constraint is build for the host config.

Related issue: https://github.com/bazelbuild/bazel/issues/8622