### PR TITLE
Add support for remotejdk17 for linux-aarch64 (arm64)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.tmpl
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.tmpl
@@ -301,6 +301,21 @@ maybe(
     version = "17",
 )
 
+maybe(
+    remote_java_repository,
+    name = "remotejdk17_linux_aarch64",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+    sha256 = "e92a9676c8f6939fd4f2a0e8d55f93e787b1296793a1808d76afec8ba32e9344",
+    strip_prefix = "zulu17.28.13-ca-jdk17.0.0-linux_aarch64",
+    urls = [
+        "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux_aarch64.tar.gz",
+    ],
+    version = "17",
+)
+
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
     remote_java_repository,

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -463,6 +463,7 @@ _JDKS = [
     "remotejdk17_macos_aarch64",
     "remotejdk17_win",
     "remotejdk17_win_arm64",
+    "remotejdk17_linux_aarch64",
     "remotejdk17_linux",
 ]
 


### PR DESCRIPTION
This closes https://github.com/bazelbuild/bazel/issues/14937 (support java language level 17 on linux-aarch64)