### PR TITLE
Add versioned soname support to interface_library

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImportRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImportRule.java
@@ -68,7 +68,9 @@ public final class CcImportRule implements RuleDefinition {
         .add(
             attr("interface_library", LABEL)
                 .allowedFileTypes(
-                    CppFileTypes.INTERFACE_SHARED_LIBRARY, CppFileTypes.UNIX_SHARED_LIBRARY))
+                    CppFileTypes.INTERFACE_SHARED_LIBRARY,
+                    CppFileTypes.UNIX_SHARED_LIBRARY,
+                    CppFileTypes.VERSIONED_SHARED_LIBRARY))
         /*<!-- #BLAZE_RULE($cc_import).ATTRIBUTE(hdrs) -->
           The list of header files published by
           this precompiled library to be directly included by sources in dependent rules.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -633,7 +633,9 @@ public abstract class CcModule
     }
     if (interfaceLibrary != null) {
       String filename = interfaceLibrary.getFilename();
-      if (!FileTypeSet.of(CppFileTypes.INTERFACE_SHARED_LIBRARY, CppFileTypes.UNIX_SHARED_LIBRARY)
+      if (!FileTypeSet.of(CppFileTypes.INTERFACE_SHARED_LIBRARY,
+                  CppFileTypes.UNIX_SHARED_LIBRARY,
+                  CppFileTypes.VERSIONED_SHARED_LIBRARY)
           .matches(filename)) {
         extensionErrorsBuilder.append(
             String.format(

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/Link.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/Link.java
@@ -50,7 +50,9 @@ public abstract class Link {
           FileType.NO_EXTENSION);
 
   public static final FileTypeSet ONLY_INTERFACE_LIBRARY_FILETYPES =
-      FileTypeSet.of(CppFileTypes.INTERFACE_SHARED_LIBRARY);
+      FileTypeSet.of(CppFileTypes.INTERFACE_SHARED_LIBRARY,
+              CppFileTypes.UNIX_SHARED_LIBRARY,
+              CppFileTypes.VERSIONED_SHARED_LIBRARY);
 
   public static final FileTypeSet ARCHIVE_LIBRARY_FILETYPES =
       FileTypeSet.of(

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -88,7 +88,7 @@ def _grep_includes_executable(grep_includes):
 
 def _check_file_extension(file, allowed_extensions, allow_versioned_shared_libraries):
     extension = "." + file.extension
-    if _matches_extension(extension, allowed_extensions) or (allow_versioned_shared_libraries and _is_versioned_shared_library_extension_valid(file.path)):
+    if _matches_extension(extension, allowed_extensions) or (allow_versioned_shared_libraries and _is_versioned_library_extension_valid(file.path)):
         return True
     return False
 

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -558,7 +558,7 @@ def _build_precompiled_files(ctx):
         shared_libraries,
     )
 
-def _is_versioned_shared_library_extension_valid(shared_library_name):
+def _is_versioned_library_extension_valid(shared_library_name):
     # validate agains the regex "^.+\\.((so)|(dylib))(\\.\\d\\w*)+$",
     # must match VERSIONED_SHARED_LIBRARY.
     for ext in (".so.", ".dylib."):
@@ -583,7 +583,7 @@ def _is_valid_shared_library_name(shared_library_name):
         shared_library_name.endswith(".dylib")):
         return True
 
-    return _is_versioned_shared_library_extension_valid(shared_library_name)
+    return _is_versioned_library_extension_valid(shared_library_name)
 
 _SHARED_LIBRARY_EXTENSIONS = ["so", "dll", "dylib"]
 
@@ -591,7 +591,7 @@ def _is_valid_shared_library_artifact(shared_library):
     if (shared_library.extension in _SHARED_LIBRARY_EXTENSIONS):
         return True
 
-    return _is_versioned_shared_library_extension_valid(shared_library.basename)
+    return _is_versioned_library_extension_valid(shared_library.basename)
 
 def _get_providers(deps, provider):
     providers = []

--- a/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
@@ -57,6 +57,10 @@ def _perform_error_checks(
         not cc_helper.is_valid_shared_library_artifact(shared_library_artifact)):
         fail("'shared_library' does not produce any cc_import shared_library files (expected .so, .dylib or .dll)")
 
+    if (interface_library_artifact != None and
+        not cc_helper.is_interface_library_extension_valid(interface_library_artifact.basename)):
+        fail("'interface_library' does not produce any cc_import interface_library files (expected .ifso, .tbd, .dll.a, .dylib, .so, or .lib)")
+
 def _create_archive_action(
         ctx,
         feature_configuration,
@@ -194,9 +198,7 @@ cc_import = rule(
         "static_library": attr.label(allow_single_file = [".a", ".lib"]),
         "pic_static_library": attr.label(allow_single_file = [".pic.a", ".pic.lib"]),
         "shared_library": attr.label(allow_single_file = True),
-        "interface_library": attr.label(
-            allow_single_file = [".ifso", ".tbd", ".lib", ".so", ".dylib"],
-        ),
+        "interface_library": attr.label(allow_single_file = True),
         "pic_objects": attr.label_list(
             allow_files = [".o", ".pic.o"],
         ),

--- a/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
@@ -59,7 +59,7 @@ def _perform_error_checks(
 
     if (interface_library_artifact != None and
         not cc_helper.is_interface_library_extension_valid(interface_library_artifact.basename)):
-        fail("'interface_library' does not produce any cc_import interface_library files (expected .ifso, .tbd, .dll.a, .dylib, .so, or .lib)")
+        fail("'interface_library' does not produce any cc_import interface_library files (expected .ifso, .tbd, .dll.a, .dylib, .so or .lib)")
 
 def _create_archive_action(
         ctx,

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
@@ -301,6 +301,31 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
   }
 
   @Test
+  public void testCcImportWithVersionedInterfaceSharedLibrary() throws Exception {
+    useConfiguration("--cpu=k8");
+    ConfiguredTarget target =
+        scratchConfiguredTarget(
+            "a",
+            "foo",
+            starlarkImplementationLoadStatement,
+            "cc_import(name = 'foo', interface_library = 'libfoo.so.1ab2.1_a2', system_provided = 1)");
+    Artifact library =
+        target
+            .get(CcInfo.PROVIDER)
+            .getCcLinkingContext()
+            .getLibraries()
+            .getSingleton()
+            .getResolvedSymlinkInterfaceLibrary();
+    assertThat(artifactsToStrings(ImmutableList.of(library))).containsExactly("src a/libfoo.so.1ab2.1_a2");
+    Iterable<Artifact> dynamicLibrariesForRuntime =
+        target
+            .get(CcInfo.PROVIDER)
+            .getCcLinkingContext()
+            .getDynamicLibrariesForRuntime(/* linkingStatically= */ false);
+    assertThat(artifactsToStrings(dynamicLibrariesForRuntime)).isEmpty();
+  }
+
+  @Test
   public void testCcImportWithBothStaticAndSharedLibraries() throws Exception {
     useConfiguration("--cpu=k8", "--noincompatible_enable_cc_toolchain_resolution");
     ConfiguredTarget target =

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -5303,7 +5303,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(e)
         .hasMessageThat()
         .contains(
-            "'a.dll' does not have any of the allowed extensions .ifso, .tbd, .lib or .dll.a");
+            "'a.dll' does not have any of the allowed extensions .ifso, .tbd, .lib, .dll.a, .so or .dylib");
   }
 
   @Test


### PR DESCRIPTION
There doesn't seem to be a compelling reason to not support this, and there's no other way (it seems) to allow one to provide a shim (with a versioned filename) that won't end up in the runfiles tree.

This mostly consists of adding the `VERSIONED_SHARED_LIBRARY` support through to the `interface_library` and has the practical effect of allowing `.dylib.VERSION` and `.so.VERSION` for that field. I don't know enough about `soname`/versioning/Windows to claim confidently that these are the only two extensions one would put versions on but it's all I've ever seen and matches `shared_library`.

Probably fixes #7059