### PR TITLE
Remove Desugar tests from postsubmit

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -243,12 +243,6 @@ tasks:
       - "//tools/test/..."
       # Re-enable the following tests on Windows:
       # https://github.com/bazelbuild/bazel/issues/4292
-      - "-//src/test/java/com/google/devtools/build/android/desugar/nest/..."
-      - "-//src/test/java/com/google/devtools/build/android/desugar/stringconcat/..."
-      - "-//src/test/java/com/google/devtools/build/android/desugar/testing/junit/..."
-      - "-//src/test/java/com/google/devtools/build/android/desugar/covariantreturn/..."
-      - "-//src/test/java/com/google/devtools/build/android/desugar/scan/..."
-      - "-//src/test/java/com/google/devtools/build/android/desugar/typeannotation/..."
       - "-//src/test/java/com/google/devtools/build/android/r8/..."
       - "-//src/test/java/com/google/devtools/build/lib/query2/cquery/..."
       - "-//src/test/java/com/google/devtools/build/lib/query2/engine/..."


### PR DESCRIPTION
because they are already removed by 5767cba4044c2bfd8a4c9596c44d2363630b489d.

Fixes our postsubmit pipeline.