### PR TITLE
Fix links to persistent workers and multiple-workers

### DIFF
--- a/site/en/docs/sandboxing.md
+++ b/site/en/docs/sandboxing.md
@@ -97,7 +97,7 @@ strategies that Bazel tries to use (for example, `bazel build
 
 Dynamic execution usually requires sandboxing for local execution. To opt out,
 pass the `--experimental_local_lockfree_output` flag. Dynamic execution silently
-sandboxes [persistent workers](/persistent-workers.html).
+sandboxes [persistent workers](persistent-workers.md).
 
 ## Downsides to sandboxing {:#sandboxing_downsides}
 
@@ -108,10 +108,10 @@ sandboxes [persistent workers](/persistent-workers.html).
     mitigate the setup and teardown cost.
 
 -   Sandboxing effectively disables any cache the tool may have. You can
-    mitigate this by using [persistent workers](/persistent-workers.html), at
+    mitigate this by using [persistent workers](persistent-workers.md), at
     the cost of weaker sandbox guarantees.
 
--   [Multiplex workers](/multiplex-worker.html) require explicit worker support
+-   [Multiplex workers](multiplex-worker.md) require explicit worker support
     to be sandboxed. Workers that do not support multiplex sandboxing run as
     singleplex workers under dynamic execution, which can cost extra memory.
 


### PR DESCRIPTION
This PR fixes links to persistent workers and multiple-workers on documentation of sandboxing. Currently, these links cause 404 errors in https://bazel.build/docs/sandboxing.