### PR TITLE
Preserve relative order of explicit and expanded Starlark flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -25,8 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.devtools.build.lib.cmdline.LabelValidator;
-import com.google.devtools.build.lib.cmdline.LabelValidator.BadLabelException;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -131,24 +129,18 @@ public class StarlarkOptionsParser {
   // require multiple rounds of parsing to fit starlark-defined options into native option format.
   @VisibleForTesting
   public void parse(ExtendedEventHandler eventHandler) throws OptionsParsingException {
-    ImmutableList.Builder<String> residue = new ImmutableList.Builder<>();
+    parseGivenArgs(eventHandler, nativeOptionsParser.getSkippedArgs());
+  }
+
+  @VisibleForTesting
+  public void parseGivenArgs(ExtendedEventHandler eventHandler, List<String> args)
+      throws OptionsParsingException {
     // Map of <option name (label), <unparsed option value, loaded option>>.
     Multimap<String, Pair<String, Target>> unparsedOptions = LinkedListMultimap.create();
 
-    // sort the old residue into starlark flags and legitimate residue
-    for (String arg : nativeOptionsParser.getPreDoubleDashResidue()) {
-      // TODO(bazel-team): support single dash options?
-      if (!arg.startsWith("--")) {
-        residue.add(arg);
-        continue;
-      }
-
+    for (String arg : args) {
       parseArg(arg, unparsedOptions, eventHandler);
     }
-
-    List<String> postDoubleDashResidue = nativeOptionsParser.getPostDoubleDashResidue();
-    residue.addAll(postDoubleDashResidue);
-    nativeOptionsParser.setResidue(residue.build(), postDoubleDashResidue);
 
     if (unparsedOptions.isEmpty()) {
       return;
@@ -236,6 +228,9 @@ public class StarlarkOptionsParser {
       Multimap<String, Pair<String, Target>> unparsedOptions,
       ExtendedEventHandler eventHandler)
       throws OptionsParsingException {
+    if (!arg.startsWith("--")) {
+      throw new OptionsParsingException("Invalid options syntax: " + arg, arg);
+    }
     int equalsAt = arg.indexOf('=');
     String name = equalsAt == -1 ? arg.substring(2) : arg.substring(2, equalsAt);
     if (name.trim().isEmpty()) {
@@ -308,51 +303,6 @@ public class StarlarkOptionsParser {
     return buildSetting;
   }
 
-  /**
-   * Separates out any Starlark options from the given list
-   *
-   * <p>This method doesn't go through the trouble to actually load build setting targets and verify
-   * they are build settings, it just assumes all strings that look like they could be build
-   * settings, aka are formatted like a flag and can parse out to a proper label, are build
-   * settings. Use actual parsing functions above to do full build setting verification.
-   *
-   * @param list List of strings from which to parse out starlark options
-   * @return Returns a pair of string lists. The first item contains the list of starlark options
-   *     that were removed; the second contains the remaining string from the original list.
-   */
-  public static Pair<ImmutableList<String>, ImmutableList<String>> removeStarlarkOptions(
-      List<String> list) {
-    ImmutableList.Builder<String> keep = ImmutableList.builder();
-    ImmutableList.Builder<String> remove = ImmutableList.builder();
-    for (String name : list) {
-      // Check if the string is a flag and trim off "--" if so.
-      if (!name.startsWith("--")) {
-        keep.add(name);
-        continue;
-      }
-      String potentialStarlarkFlag = name.substring(2);
-      // Check if the string uses the "no" prefix for setting boolean flags to false, trim
-      // off "no" if so.
-      if (name.startsWith("no")) {
-        potentialStarlarkFlag = potentialStarlarkFlag.substring(2);
-      }
-      // Check if the string contains a value, trim off the value if so.
-      int equalsIdx = potentialStarlarkFlag.indexOf('=');
-      if (equalsIdx > 0) {
-        potentialStarlarkFlag = potentialStarlarkFlag.substring(0, equalsIdx);
-      }
-      // Check if we can properly parse the (potentially trimmed) string as a label. If so, count
-      // as starlark flag, else count as regular residue.
-      try {
-        LabelValidator.validateAbsoluteLabel(potentialStarlarkFlag);
-        remove.add(name);
-      } catch (BadLabelException e) {
-        keep.add(name);
-      }
-    }
-    return Pair.of(remove.build(), keep.build());
-  }
-
   @VisibleForTesting
   public static StarlarkOptionsParser newStarlarkOptionsParserForTesting(
       SkyframeExecutor skyframeExecutor,
@@ -361,11 +311,6 @@ public class StarlarkOptionsParser {
       OptionsParser nativeOptionsParser) {
     return new StarlarkOptionsParser(
         skyframeExecutor, relativeWorkingDirectory, reporter, nativeOptionsParser);
-  }
-
-  @VisibleForTesting
-  public void setResidueForTesting(List<String> residue) {
-    nativeOptionsParser.setResidue(residue, ImmutableList.of());
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
@@ -30,7 +30,6 @@ import com.google.devtools.build.lib.runtime.BlazeRuntime;
 import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.InfoItem;
-import com.google.devtools.build.lib.runtime.StarlarkOptionsParser;
 import com.google.devtools.build.lib.runtime.commands.info.BlazeBinInfoItem;
 import com.google.devtools.build.lib.runtime.commands.info.BlazeGenfilesInfoItem;
 import com.google.devtools.build.lib.runtime.commands.info.BlazeTestlogsInfoItem;
@@ -65,7 +64,6 @@ import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.InterruptedFailureDetails;
-import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.io.OutErr;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -189,16 +187,14 @@ public class InfoCommand implements BlazeCommand {
         }
       }
 
-      Pair<ImmutableList<String>, ImmutableList<String>> starlarkOptionsAndResidue =
-          StarlarkOptionsParser.removeStarlarkOptions(optionsParsingResult.getResidue());
-      ImmutableList<String> removedStarlarkOptions = starlarkOptionsAndResidue.getFirst();
-      ImmutableList<String> residue = starlarkOptionsAndResidue.getSecond();
-      if (!removedStarlarkOptions.isEmpty()) {
+      List<String> starlarkOptions = optionsParsingResult.getSkippedArgs();
+      List<String> residue = optionsParsingResult.getResidue();
+      if (!starlarkOptions.isEmpty()) {
         env.getReporter()
             .handle(
                 Event.warn(
                     "info command does not support starlark options. Ignoring options: "
-                        + removedStarlarkOptions));
+                        + starlarkOptions));
       }
 
       env.getEventBus().post(new NoBuildEvent());

--- a/src/main/java/com/google/devtools/common/options/OptionsParser.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParser.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MoreCollectors;
 import com.google.common.escape.Escaper;
@@ -669,12 +670,7 @@ public class OptionsParser implements OptionsParsingResult {
     Preconditions.checkNotNull(priority);
     Preconditions.checkArgument(priority != OptionPriority.PriorityCategory.DEFAULT);
     OptionsParserImplResult optionsParserImplResult = impl.parse(priority, sourceFunction, args);
-    residue.addAll(optionsParserImplResult.getResidue());
-    postDoubleDashResidue.addAll(optionsParserImplResult.postDoubleDashResidue);
-    if (!allowResidue && !residue.isEmpty()) {
-      String errorMsg = "Unrecognized arguments: " + Joiner.on(' ').join(residue);
-      throw new OptionsParsingException(errorMsg);
-    }
+    addResidueFromResult(optionsParserImplResult);
     aliases.putAll(optionsParserImplResult.aliases);
   }
 
@@ -700,10 +696,16 @@ public class OptionsParser implements OptionsParsingResult {
         args);
     OptionsParserImplResult optionsParserImplResult =
         impl.parseArgsAsExpansionOfOption(optionToExpand, o -> source, args);
-    residue.addAll(optionsParserImplResult.getResidue());
-    postDoubleDashResidue.addAll(optionsParserImplResult.postDoubleDashResidue);
-    if (!allowResidue && !residue.isEmpty()) {
-      String errorMsg = "Unrecognized arguments: " + Joiner.on(' ').join(residue);
+    addResidueFromResult(optionsParserImplResult);
+  }
+
+  private void addResidueFromResult(OptionsParserImplResult result) throws OptionsParsingException {
+    residue.addAll(result.getResidue());
+    postDoubleDashResidue.addAll(result.postDoubleDashResidue);
+    if (!allowResidue && (!getSkippedArgs().isEmpty() || !residue.isEmpty())) {
+      String errorMsg =
+          "Unrecognized arguments: "
+              + Joiner.on(' ').join(Iterables.concat(getSkippedArgs(), residue));
       throw new OptionsParsingException(errorMsg);
     }
   }
@@ -745,7 +747,12 @@ public class OptionsParser implements OptionsParsingResult {
   }
 
   @Override
-  public List<String> getResidue() {
+  public ImmutableList<String> getSkippedArgs() {
+    return ImmutableList.copyOf(impl.getSkippedArgs());
+  }
+
+  @Override
+  public ImmutableList<String> getResidue() {
     return ImmutableList.copyOf(residue);
   }
 

--- a/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -162,6 +163,32 @@ class OptionsParserImpl {
   private final boolean ignoreInternalOptions;
   @Nullable private final String aliasFlag;
 
+  /**
+   * This option is used to collect skipped arguments while preserving the relative ordering between
+   * those given explicitly on the command line and those expanded by {@code ConfigExpander}. The
+   * field itself is not used for any purpose other than retrieving its {@link Option} annotation.
+   */
+  @Option(
+      name = "skipped args",
+      allowMultiple = true,
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.NO_OP},
+      help = "Only used internally by OptionsParserImpl")
+  private final List<String> skippedArgs = new ArrayList<>();
+
+  private static final OptionDefinition skippedArgsDefinition;
+
+  static {
+    try {
+      skippedArgsDefinition =
+          OptionDefinition.extractOptionDefinition(
+              OptionsParserImpl.class.getDeclaredField("skippedArgs"));
+    } catch (NoSuchFieldException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   OptionsParserImpl(
       OptionsData optionsData,
       ArgsPreProcessor argsPreProcessor,
@@ -220,6 +247,7 @@ class OptionsParserImpl {
   /** Implements {@link OptionsParser#canonicalize}. */
   List<ParsedOptionDescription> asCanonicalizedListOfParsedOptions() {
     return optionValues.keySet().stream()
+        .filter(k -> !Objects.equals(k, skippedArgsDefinition))
         .map(optionDefinition -> optionValues.get(optionDefinition).getCanonicalInstances())
         .flatMap(Collection::stream)
         // Return the effective (canonical) options in the order they were applied.
@@ -356,6 +384,15 @@ class OptionsParserImpl {
     return optionValues.get(optionDefinition) != null;
   }
 
+  @SuppressWarnings("unchecked")
+  List<String> getSkippedArgs() {
+    OptionValueDescription value = optionValues.get(skippedArgsDefinition);
+    if (value == null) {
+      return ImmutableList.of();
+    }
+    return (List<String>) value.getValue();
+  }
+
   /**
    * Parses the args, and returns what it doesn't parse. May be called multiple times, and may be
    * called recursively. The option's definition dictates how it reacts to multiple settings. By
@@ -403,19 +440,32 @@ class OptionsParserImpl {
 
       arg = swapShorthandAlias(arg);
 
-      if (containsSkippedPrefix(arg)) {
-        unparsedArgs.add(arg);
-        continue;
-      }
-
       if (arg.equals("--")) { // "--" means all remaining args aren't options
         Iterators.addAll(unparsedPostDoubleDashArgs, argsIterator);
         break;
       }
 
-      ParsedOptionDescription parsedOption =
-          identifyOptionAndPossibleArgument(
-              arg, argsIterator, priority, sourceFunction, implicitDependent, expandedFrom);
+      ParsedOptionDescription parsedOption;
+      if (containsSkippedPrefix(arg)) {
+        // Parse the skipped arg into a synthetic allowMultiple option to preserve its order
+        // relative to skipped args coming from expansions. Simply adding it to the residue would
+        // end up placing expanded skipped args after all explicitly given skipped args, which isn't
+        // correct.
+        parsedOption =
+            ParsedOptionDescription.newParsedOptionDescription(
+                skippedArgsDefinition,
+                arg,
+                arg,
+                new OptionInstanceOrigin(
+                    priority,
+                    sourceFunction.apply(skippedArgsDefinition),
+                    implicitDependent,
+                    expandedFrom));
+      } else {
+        parsedOption =
+            identifyOptionAndPossibleArgument(
+                arg, argsIterator, priority, sourceFunction, implicitDependent, expandedFrom);
+      }
       handleNewParsedOption(parsedOption);
       priority = OptionPriority.nextOptionPriority(priority);
     }
@@ -560,7 +610,11 @@ class OptionsParserImpl {
     // As much as possible, we want the behaviors of these different types of flags to be
     // identical, as this minimizes the number of edge cases, but we do not yet track these values
     // in the same way.
-    if (parsedOption.getImplicitDependent() == null) {
+
+    // Do not list the internal "skipped args" option that is only used to accumulate skipped
+    // arguments.
+    if (parsedOption.getImplicitDependent() == null
+        && !Objects.equals(parsedOption.getOptionDefinition(), skippedArgsDefinition)) {
       // Log explicit options and expanded options in the order they are parsed (can be sorted
       // later). This information is needed to correctly canonicalize flags.
       parsedOptions.add(parsedOption);
@@ -603,7 +657,7 @@ class OptionsParserImpl {
     } else if (arg.startsWith("--")) { // --long_option
 
       int equalsAt = arg.indexOf('=');
-      int nameStartsAt = arg.startsWith("--") ? 2 : 1;
+      int nameStartsAt = 2;
       String name =
           equalsAt == -1 ? arg.substring(nameStartsAt) : arg.substring(nameStartsAt, equalsAt);
       if (name.trim().isEmpty()) {

--- a/src/main/java/com/google/devtools/common/options/OptionsParsingResult.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParsingResult.java
@@ -32,9 +32,12 @@ public interface OptionsParsingResult extends OptionsProvider {
   OptionValueDescription getOptionValueDescription(String name);
 
   /**
-   * Returns an immutable copy of the residue, that is, the arguments that
-   * have not been parsed.
+   * Returns an immutable copy of all arguments that were skipped because they matched a skipped
+   * prefix.
    */
+  List<String> getSkippedArgs();
+
+  /** Returns an immutable copy of the residue, that is, the arguments that have not been parsed. */
   List<String> getResidue();
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/runtime/FlagAliasTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/FlagAliasTest.java
@@ -116,7 +116,7 @@ public final class FlagAliasTest {
         ImmutableList.of(
             "c0", "--rc_source=/somewhere/.blazerc", "--flag_alias=foo=//bar", "--foo");
     optionHandler.parseOptions(args, eventHandler);
-    assertThat(parser.getResidue()).contains("--//bar");
+    assertThat(parser.getSkippedArgs()).contains("--//bar");
   }
 
   @Test
@@ -142,9 +142,9 @@ public final class FlagAliasTest {
             "--foo",
             "--flag_alias=foo=//baz",
             "--foo");
-    ImmutableList<String> expectedResidue = ImmutableList.of("--//bar", "--//baz");
+    ImmutableList<String> expectedSkippedArgs = ImmutableList.of("--//bar", "--//baz");
     optionHandler.parseOptions(args, eventHandler);
-    assertThat(parser.getResidue()).isEqualTo(expectedResidue);
+    assertThat(parser.getSkippedArgs()).isEqualTo(expectedSkippedArgs);
   }
 
   @Test
@@ -155,9 +155,9 @@ public final class FlagAliasTest {
             "--default_override=0:c0=--flag_alias=foo=//bar",
             "--default_override=0:c0=--foo",
             "--rc_source=/somewhere/.blazerc");
-    ImmutableList<String> expectedResidue = ImmutableList.of("--//bar");
+    ImmutableList<String> expectedSkippedArgs = ImmutableList.of("--//bar");
     optionHandler.parseOptions(args, eventHandler);
-    assertThat(parser.getResidue()).isEqualTo(expectedResidue);
+    assertThat(parser.getSkippedArgs()).isEqualTo(expectedSkippedArgs);
   }
 
   @Test
@@ -168,9 +168,9 @@ public final class FlagAliasTest {
             "--default_override=0:c0=--flag_alias=foo=//bar",
             "--rc_source=/somewhere/.blazerc",
             "--foo");
-    ImmutableList<String> expectedResidue = ImmutableList.of("--//bar");
+    ImmutableList<String> expectedSkippedArgs = ImmutableList.of("--//bar");
     optionHandler.parseOptions(args, eventHandler);
-    assertThat(parser.getResidue()).isEqualTo(expectedResidue);
+    assertThat(parser.getSkippedArgs()).isEqualTo(expectedSkippedArgs);
   }
 
   @Test
@@ -178,9 +178,9 @@ public final class FlagAliasTest {
     ImmutableList<String> args =
         ImmutableList.of(
             "c0", "--rc_source=/somewhere/.blazerc", "--flag_alias=foo=//bar", "--foo=7");
-    ImmutableList<String> expectedResidue = ImmutableList.of("--//bar=7");
+    ImmutableList<String> expectedSkippedArgs = ImmutableList.of("--//bar=7");
     optionHandler.parseOptions(args, eventHandler);
-    assertThat(parser.getResidue()).isEqualTo(expectedResidue);
+    assertThat(parser.getSkippedArgs()).isEqualTo(expectedSkippedArgs);
   }
 
   // Regression test for b/172453517

--- a/src/test/java/com/google/devtools/build/lib/starlark/util/StarlarkOptionsTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/util/StarlarkOptionsTestCase.java
@@ -63,8 +63,8 @@ public class StarlarkOptionsTestCase extends BuildViewTestCase {
   }
 
   protected OptionsParsingResult parseStarlarkOptions(String options) throws Exception {
-    starlarkOptionsParser.setResidueForTesting(Arrays.asList(options.split(" ")));
-    starlarkOptionsParser.parse(new StoredEventHandler());
+    starlarkOptionsParser.parseGivenArgs(
+        new StoredEventHandler(), Arrays.asList(options.split(" ")));
     return starlarkOptionsParser.getNativeOptionsParserFortesting();
   }
 

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -266,3 +266,9 @@ py_test(
         ":test_base",
     ],
 )
+
+py_test(
+    name = "starlark_options_test",
+    srcs = ["starlark_options_test.py"],
+    deps = [":test_base"],
+)

--- a/src/test/py/bazel/starlark_options_test.py
+++ b/src/test/py/bazel/starlark_options_test.py
@@ -1,0 +1,82 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from src.test.py.bazel import test_base
+
+
+class StarlarkOptionsTest(test_base.TestBase):
+
+  def testCanOverrideStarlarkFlagInBazelrcConfigStanza(self):
+    self.ScratchFile("WORKSPACE.bazel")
+    self.ScratchFile("bazelrc", [
+        "build:red --//f:color=red",
+    ])
+    self.ScratchFile("f/BUILD.bazel", [
+        'load(":f.bzl", "color", "r")',
+        "color(",
+        '    name = "color",',
+        '    build_setting_default = "white",',
+        ")",
+        'r(name = "r")',
+    ])
+    self.ScratchFile("f/f.bzl", [
+        'ColorValue = provider("color")',
+        "def _color_impl(ctx):",
+        "    return [ColorValue(color = ctx.build_setting_value)]",
+        "color = rule(",
+        "    implementation = _color_impl,",
+        "build_setting = config.string(flag = True),",
+        ")",
+        "def _r_impl(ctx):",
+        "    print(ctx.attr._color[ColorValue].color)",
+        "    return [DefaultInfo()]",
+        "r = rule(",
+        "    implementation = _r_impl,",
+        '    attrs = {"_color": attr.label(default = "//f:color")},',
+        ")",
+    ])
+
+    exit_code, _, stderr = self.RunBazel([
+        "--bazelrc=bazelrc",
+        "build",
+        "--nobuild",
+        "//f:r",
+        "--config=red",
+        "--//f:color=green",
+    ])
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertTrue(
+        any("/f/f.bzl:9:10: green" in line for line in stderr),
+        "\n".join(stderr),
+    )
+
+    exit_code, _, stderr = self.RunBazel([
+        "--bazelrc=bazelrc",
+        "build",
+        "--nobuild",
+        "//f:r",
+        "--//f:color=green",
+        "--config=red",
+    ])
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertTrue(
+        any("/f/f.bzl:9:10: red" in line for line in stderr),
+        "\n".join(stderr),
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Previously, Starlark flags expanded from a --config stanze would always
be added to the end of the residue containing the explicitly given
Starlark flags. As a result, Starlark flags expanded from --config could
not be overridden.

With this commit, Starlark flags are parsed with the same semantics as
a regular allowMultiple option, thus preserving their order through
expansions.

This is implemented by introducing a synthetic allowMultiple option of
type List<String> in OptionsParserImpl that skipped args are parsed
into.

As a result, Starlark options are now available from the new
getSkippedArgs() method on OptionsParser rather than as part of the
residue, with the latter now only containing build targets.

Fixes #13231
Fixes #15679

Closes #15807.

PiperOrigin-RevId: 467931815
Change-Id: Ic64c6e075c08d898e5e7b8bf4c777827134d89fa