### PR TITLE
WIP: Track runfiles library users in RunfilesProvider

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTargetFactory.java
@@ -405,7 +405,8 @@ public final class ConfiguredTargetFactory {
       throws ActionConflictException, InterruptedException, AnalysisFailurePropagationException {
     RuleConfiguredTargetBuilder builder = new RuleConfiguredTargetBuilder(ruleContext);
     builder.addNativeDeclaredProvider(AnalysisFailureInfo.forAnalysisFailureSets(analysisFailures));
-    builder.addProvider(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY));
+    builder.addProvider(RunfilesProvider.class,
+        RunfilesProvider.simple(ruleContext, Runfiles.EMPTY));
     ConfiguredTarget configuredTarget = builder.build();
     if (configuredTarget == null) {
       // A failure here is a failure in analysis failure testing machinery, not a "normal" analysis
@@ -437,7 +438,8 @@ public final class ConfiguredTargetFactory {
       RuleConfiguredTargetBuilder builder = new RuleConfiguredTargetBuilder(ruleContext);
       builder.addNativeDeclaredProvider(
           AnalysisFailureInfo.forAnalysisFailures(analysisFailures.build()));
-      builder.addProvider(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY));
+      builder.addProvider(RunfilesProvider.class,
+          RunfilesProvider.simple(ruleContext, Runfiles.EMPTY));
       ConfiguredTarget configuredTarget = builder.build();
       if (configuredTarget == null) {
         // See comment in erroredConfiguredTargetWithFailures.
@@ -692,7 +694,8 @@ public final class ConfiguredTargetFactory {
               "Missing fragment class: " + missingFragmentClass.getName(),
               Code.FRAGMENT_CLASS_MISSING));
     }
-    builder.addProvider(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY));
+    builder.addProvider(RunfilesProvider.class,
+        RunfilesProvider.simple(ruleContext, Runfiles.EMPTY));
     try {
       return builder.build();
     } catch (ActionConflictException e) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
@@ -229,7 +229,7 @@ public class IncompatibleTargetChecker {
     TransitiveInfoProviderMapBuilder providerBuilder =
         new TransitiveInfoProviderMapBuilder()
             .put(incompatiblePlatformProvider)
-            .add(RunfilesProvider.simple(Runfiles.EMPTY))
+            .add(RunfilesProvider.EMPTY)
             .add(fileProvider)
             .add(filesToRunProvider);
     if (configuration.hasFragment(TestConfiguration.class)) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtil.java
@@ -625,11 +625,12 @@ public final class StarlarkRuleConfiguredTargetUtil {
 
     RunfilesProvider runfilesProvider =
         statelessRunfiles != null
-            ? RunfilesProvider.simple(mergeFiles(statelessRunfiles, executable, ruleContext))
+            ? RunfilesProvider.simple(ruleContext,
+            mergeFiles(statelessRunfiles, executable, ruleContext))
             : RunfilesProvider.withData(
                 // The executable doesn't get into the default runfiles if we have runfiles states.
                 // This is to keep Starlark genrule consistent with the original genrule.
-                defaultRunfiles != null ? defaultRunfiles : Runfiles.EMPTY,
+                ruleContext, defaultRunfiles != null ? defaultRunfiles : Runfiles.EMPTY,
                 dataRunfiles != null ? dataRunfiles : Runfiles.EMPTY);
     builder.addProvider(RunfilesProvider.class, runfilesProvider);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShBinary.java
@@ -90,7 +90,7 @@ public class ShBinary implements RuleConfiguredTargetFactory {
     return new RuleConfiguredTargetBuilder(ruleContext)
         .setFilesToBuild(filesToBuild)
         .setRunfilesSupport(runfilesSupport, mainExecutable)
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, runfiles))
         .addNativeDeclaredProvider(
             InstrumentedFilesCollector.collect(ruleContext, ShCoverage.INSTRUMENTATION_SPEC))
         .build();

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShLibrary.java
@@ -50,7 +50,7 @@ public class ShLibrary implements RuleConfiguredTargetFactory {
             .build();
     return new RuleConfiguredTargetBuilder(ruleContext)
         .setFilesToBuild(filesToBuild)
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, runfiles))
         .addNativeDeclaredProvider(
             InstrumentedFilesCollector.collect(ruleContext, ShCoverage.INSTRUMENTATION_SPEC))
         .build();

--- a/src/main/java/com/google/devtools/build/lib/rules/LateBoundAlias.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/LateBoundAlias.java
@@ -74,7 +74,7 @@ public final class LateBoundAlias implements RuleConfiguredTargetFactory {
   private static ConfiguredTarget createEmptyConfiguredTarget(RuleContext ruleContext)
       throws ActionConflictException, InterruptedException {
     return new RuleConfiguredTargetBuilder(ruleContext)
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/ToolchainType.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/ToolchainType.java
@@ -42,7 +42,7 @@ public class ToolchainType implements RuleConfiguredTargetFactory {
     ToolchainTypeInfo toolchainTypeInfo = ToolchainTypeInfo.create(ruleContext.getLabel());
 
     return new RuleConfiguredTargetBuilder(ruleContext)
-        .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
+        .addProvider(RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
         .addNativeDeclaredProvider(toolchainTypeInfo)
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
@@ -854,9 +854,9 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
         .addProvider(
             RunfilesProvider.class,
             RunfilesProvider.simple(
-                new Runfiles.Builder(
-                        ruleContext.getWorkspaceName(),
-                        ruleContext.getConfiguration().legacyExternalRunfiles())
+                ruleContext, new Runfiles.Builder(
+                    ruleContext.getWorkspaceName(),
+                    ruleContext.getConfiguration().legacyExternalRunfiles())
                     .addRunfiles(ruleContext, RunfilesProvider.DEFAULT_RUNFILES)
                     .addTransitiveArtifacts(filesToBuild)
                     .build()))

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java
@@ -786,7 +786,7 @@ public class AndroidCommon {
     return builder
         .setFilesToBuild(filesToBuild)
         .addNativeDeclaredProvider(javaInfo)
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(getRunfiles()))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, getRunfiles()))
         .addNativeDeclaredProvider(
             createAndroidIdeInfoProvider(
                 ruleContext,

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDevice.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDevice.java
@@ -141,7 +141,7 @@ public class AndroidDevice implements RuleConfiguredTargetFactory {
         ruleContext.attributes().get("pregenerate_oat_files_for_tests", Type.BOOLEAN);
     return new RuleConfiguredTargetBuilder(ruleContext)
         .setFilesToBuild(filesToBuild)
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, runfiles))
         .setRunfilesSupport(runfilesSupport, executable)
         .addFilesToRun(extraFilesToRun)
         .addNativeDeclaredProvider(new ExecutionInfo(executionInfo))

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDeviceScriptFixture.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDeviceScriptFixture.java
@@ -48,7 +48,7 @@ public class AndroidDeviceScriptFixture implements RuleConfiguredTargetFactory {
         .addProvider(
             RunfilesProvider.class,
             RunfilesProvider.simple(
-                new Runfiles.Builder(ruleContext.getWorkspaceName())
+                ruleContext, new Runfiles.Builder(ruleContext.getWorkspaceName())
                     .addArtifact(fixtureScript)
                     .build()))
         .addNativeDeclaredProvider(

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidHostServiceFixture.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidHostServiceFixture.java
@@ -57,7 +57,7 @@ public class AndroidHostServiceFixture implements RuleConfiguredTargetFactory {
             .build();
     return ruleBuilder
         .setFilesToBuild(filesToBuild)
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, runfiles))
         .addNativeDeclaredProvider(
             new AndroidHostServiceFixtureInfoProvider(
                 executable.getExecutable(),

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidInstrumentationTestBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidInstrumentationTestBase.java
@@ -98,7 +98,7 @@ public class AndroidInstrumentationTestBase implements RuleConfiguredTargetFacto
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .setFilesToBuild(NestedSetBuilder.<Artifact>stableOrder().add(testExecutable).build())
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, runfiles))
         .setRunfilesSupport(
             RunfilesSupport.withExecutable(ruleContext, runfiles, testExecutable), testExecutable)
         .addNativeDeclaredProvider(getExecutionInfoProvider(ruleContext))

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLocalTestBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLocalTestBase.java
@@ -396,7 +396,7 @@ public abstract class AndroidLocalTestBase implements RuleConfiguredTargetFactor
         .addProvider(
             RunfilesProvider.class,
             RunfilesProvider.withData(
-                defaultRunfiles,
+                ruleContext, defaultRunfiles,
                 new Runfiles.Builder(ruleContext.getWorkspaceName())
                     .merge(runfilesSupport)
                     .build()))

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -749,7 +749,8 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
 
     CcStarlarkApiProvider.maybeAdd(ruleContext, ruleBuilder);
     ruleBuilder
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runtimeFiles.runfiles()))
+        .addProvider(RunfilesProvider.class,
+            RunfilesProvider.simple(ruleContext, runtimeFiles.runfiles()))
         .addNativeDeclaredProvider(
             new DebugPackageProvider(ruleContext.getLabel(), strippedFile, binary, explicitDwpFile))
         .setRunfilesSupport(runfilesSupport, binary)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcHostToolchainAliasRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcHostToolchainAliasRule.java
@@ -74,7 +74,7 @@ public class CcHostToolchainAliasRule implements RuleDefinition {
       ToolchainInfo toolchain = ccToolchainAlias.get(ToolchainInfo.PROVIDER);
 
       return new RuleConfiguredTargetBuilder(ruleContext)
-          .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
+          .addProvider(RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
           .addNativeDeclaredProvider(ccToolchainProvider)
           .addNativeDeclaredProvider(toolchain)
           .addNativeDeclaredProvider(templateVariableInfo)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -500,7 +500,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
             CcCommon.mergeOutputGroups(
                 ImmutableList.of(currentOutputGroups, outputGroups.buildOrThrow())))
         .addNativeDeclaredProvider(instrumentedFilesProvider)
-        .addProvider(RunfilesProvider.withData(defaultRunfiles.build(), dataRunfiles.build()));
+        .addProvider(RunfilesProvider.withData(ruleContext, defaultRunfiles.build(), dataRunfiles.build()));
   }
 
   private static void warnAboutEmptyLibraries(RuleContext ruleContext,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchain.java
@@ -71,7 +71,7 @@ public class CcToolchain implements RuleConfiguredTargetFactory {
     RuleConfiguredTargetBuilder ruleConfiguredTargetBuilder =
         new RuleConfiguredTargetBuilder(ruleContext)
             .addNativeDeclaredProvider(attributes)
-            .addProvider(RunfilesProvider.simple(Runfiles.EMPTY));
+            .addProvider(RunfilesProvider.simple(ruleContext, Runfiles.EMPTY));
 
     if (attributes.getLicensesProvider() != null) {
       ruleConfiguredTargetBuilder.add(LicensesProvider.class, attributes.getLicensesProvider());

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainAliasRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainAliasRule.java
@@ -88,7 +88,7 @@ public class CcToolchainAliasRule implements RuleDefinition {
                   .build());
 
       return new RuleConfiguredTargetBuilder(ruleContext)
-          .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
+          .addProvider(RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
           .addNativeDeclaredProvider(ccToolchainProvider)
           .addNativeDeclaredProvider(toolchain)
           .addNativeDeclaredProvider(templateVariableInfo)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainSuite.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainSuite.java
@@ -95,7 +95,7 @@ public class CcToolchainSuite implements RuleConfiguredTargetFactory {
             .addNativeDeclaredProvider(ccToolchainProvider)
             .addNativeDeclaredProvider(templateVariableInfo)
             .setFilesToBuild(ccToolchainProvider.getAllFilesIncludingLibc())
-            .addProvider(RunfilesProvider.simple(Runfiles.EMPTY));
+            .addProvider(RunfilesProvider.simple(ruleContext, Runfiles.EMPTY));
 
     if (ccToolchainProvider.getLicensesProvider() != null) {
       builder.add(LicensesProvider.class, ccToolchainProvider.getLicensesProvider());

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoPrefetchHints.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoPrefetchHints.java
@@ -37,7 +37,7 @@ public final class FdoPrefetchHints implements RuleConfiguredTargetFactory {
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addNativeDeclaredProvider(new FdoPrefetchHintsProvider(inputFile))
-        .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
+        .addProvider(RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
         .build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoProfile.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoProfile.java
@@ -43,7 +43,7 @@ public final class FdoProfile implements RuleConfiguredTargetFactory {
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addNativeDeclaredProvider(new FdoProfileProvider(inputFile, protoProfileArtifact))
-        .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
+        .addProvider(RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
         .build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/PropellerOptimize.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/PropellerOptimize.java
@@ -37,7 +37,7 @@ public final class PropellerOptimize implements RuleConfiguredTargetFactory {
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addNativeDeclaredProvider(new PropellerOptimizeProvider(inputFile))
-        .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
+        .addProvider(RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
         .build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoLibrary.java
@@ -50,7 +50,7 @@ public class CcProtoLibrary implements RuleConfiguredTargetFactory {
         ruleContext)
         .setFilesToBuild(depProviders.filesBuilder)
         .addProvider(
-            RunfilesProvider.class, RunfilesProvider.withData(Runfiles.EMPTY, Runfiles.EMPTY))
+            RunfilesProvider.class, RunfilesProvider.withData(ruleContext, Runfiles.EMPTY, Runfiles.EMPTY))
         .addProviders(depProviders.providerMap);
 
     for (String groupName : depProviders.outputGroupInfo) {

--- a/src/main/java/com/google/devtools/build/lib/rules/extra/ActionListener.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/extra/ActionListener.java
@@ -58,7 +58,7 @@ public final class ActionListener implements RuleConfiguredTargetFactory {
     }
     extraActionMap = extraActionMapBuilder.build();
     return new RuleConfiguredTargetBuilder(ruleContext)
-        .add(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+        .add(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
         .add(ExtraActionMapProvider.class, new ExtraActionMapProvider(extraActionMap))
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/extra/ExtraActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/extra/ExtraActionFactory.java
@@ -92,7 +92,7 @@ public final class ExtraActionFactory implements RuleConfiguredTargetFactory {
             requiresActionOutput);
     return new RuleConfiguredTargetBuilder(context)
         .addProvider(ExtraActionSpec.class, spec)
-        .add(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+        .add(RunfilesProvider.class, RunfilesProvider.simple(context, Runfiles.EMPTY))
         .build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/filegroup/Filegroup.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/filegroup/Filegroup.java
@@ -87,7 +87,7 @@ public class Filegroup implements RuleConfiguredTargetFactory {
 
     RunfilesProvider runfilesProvider =
         RunfilesProvider.withData(
-            new Runfiles.Builder(
+            ruleContext, new Runfiles.Builder(
                     ruleContext.getWorkspaceName(), configuration.legacyExternalRunfiles())
                 .addRunfiles(ruleContext, RunfilesProvider.DEFAULT_RUNFILES)
                 .build(),

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
@@ -200,9 +200,9 @@ public class GenQuery implements RuleConfiguredTargetFactory {
         .addProvider(
             RunfilesProvider.class,
             RunfilesProvider.simple(
-                new Runfiles.Builder(
-                        ruleContext.getWorkspaceName(),
-                        ruleContext.getConfiguration().legacyExternalRunfiles())
+                ruleContext, new Runfiles.Builder(
+                    ruleContext.getWorkspaceName(),
+                    ruleContext.getConfiguration().legacyExternalRunfiles())
                     .addTransitiveArtifacts(filesToBuild)
                     .build()))
         .addOutputGroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
@@ -257,7 +257,7 @@ public abstract class GenRuleBase implements RuleConfiguredTargetFactory {
 
     RunfilesProvider runfilesProvider = RunfilesProvider.withData(
         // No runfiles provided if not a data dependency.
-        Runfiles.EMPTY,
+        ruleContext, Runfiles.EMPTY,
         // We only need to consider the outputs of a genrule
         // No need to visit the dependencies of a genrule. They cross from the target into the host
         // configuration, because the dependencies of a genrule are always built for the host

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaBinary.java
@@ -405,7 +405,7 @@ public class JavaBinary implements RuleConfiguredTargetFactory {
 
     RunfilesProvider runfilesProvider =
         RunfilesProvider.withData(
-            defaultRunfiles,
+            ruleContext, defaultRunfiles,
             new Runfiles.Builder(
                     ruleContext.getWorkspaceName(),
                     ruleContext.getConfiguration().legacyExternalRunfiles())

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaImport.java
@@ -182,7 +182,7 @@ public class JavaImport implements RuleConfiguredTargetFactory {
     return ruleBuilder
         .setFilesToBuild(filesToBuild)
         .addNativeDeclaredProvider(javaInfo)
-        .add(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
+        .add(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, runfiles))
         .addNativeDeclaredProvider(new ProguardSpecProvider(proguardSpecs))
         .addOutputGroup(JavaSemantics.SOURCE_JARS_OUTPUT_GROUP, transitiveJavaSourceJars)
         .addOutputGroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaPackageConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaPackageConfiguration.java
@@ -49,7 +49,7 @@ public class JavaPackageConfiguration implements RuleConfiguredTargetFactory {
     ImmutableList<String> javacopts =
         ImmutableList.copyOf(ruleContext.getExpander().withDataLocations().tokenized("javacopts"));
     return new RuleConfiguredTargetBuilder(ruleContext)
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
         .setFilesToBuild(NestedSetBuilder.emptySet(Order.STABLE_ORDER))
         .addProvider(JavaPackageConfigurationProvider.create(packages, javacopts, data))
         .build();

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntime.java
@@ -129,7 +129,7 @@ public class JavaRuntime implements RuleConfiguredTargetFactory {
         new ToolchainInfo(
             ImmutableMap.<String, Object>builder().put("java_runtime", javaRuntime).buildOrThrow());
     return new RuleConfiguredTargetBuilder(ruleContext)
-        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
+        .addProvider(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, runfiles))
         .setFilesToBuild(filesToBuild)
         .addNativeDeclaredProvider(javaRuntime)
         .addNativeDeclaredProvider(templateVariableInfo)

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchain.java
@@ -203,7 +203,8 @@ public class JavaToolchain implements RuleConfiguredTargetFactory {
             .addStarlarkTransitiveInfo(JavaToolchainProvider.LEGACY_NAME, provider)
             .addNativeDeclaredProvider(provider)
             .addNativeDeclaredProvider(toolchainInfo)
-            .addProvider(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+            .addProvider(RunfilesProvider.class,
+                RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
             .setFilesToBuild(new NestedSetBuilder<Artifact>(Order.STABLE_ORDER).build());
 
     return builder.build();

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
@@ -153,7 +153,7 @@ public class ObjcRuleClasses {
   static RuleConfiguredTargetBuilder ruleConfiguredTarget(RuleContext ruleContext,
       NestedSet<Artifact> filesToBuild) {
     RunfilesProvider runfilesProvider = RunfilesProvider.withData(
-        new Runfiles.Builder(
+        ruleContext, new Runfiles.Builder(
             ruleContext.getWorkspaceName(),
             ruleContext.getConfiguration().legacyExternalRunfiles())
             .addRunfiles(ruleContext, RunfilesProvider.DEFAULT_RUNFILES).build(),

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PyExecutable.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PyExecutable.java
@@ -109,7 +109,7 @@ public abstract class PyExecutable implements RuleConfiguredTargetFactory {
       dataRunfiles = commonRunfiles;
     }
 
-    RunfilesProvider runfilesProvider = RunfilesProvider.withData(defaultRunfiles, dataRunfiles);
+    RunfilesProvider runfilesProvider = RunfilesProvider.withData(ruleContext, defaultRunfiles, dataRunfiles);
 
     RuleConfiguredTargetBuilder builder = new RuleConfiguredTargetBuilder(ruleContext);
     common.addCommonTransitiveInfoProviders(builder, common.getFilesToBuild());

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PyLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PyLibrary.java
@@ -71,7 +71,7 @@ public abstract class PyLibrary implements RuleConfiguredTargetFactory {
         .addNativeDeclaredProvider(
             new PyCcLinkParamsProvider(
                 semantics.buildCcInfoProvider(ruleContext, ruleContext.getPrerequisites("deps"))))
-        .add(RunfilesProvider.class, RunfilesProvider.simple(runfilesBuilder.build()))
+        .add(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, runfilesBuilder.build()))
         .build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/test/TestSuite.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/TestSuite.java
@@ -86,7 +86,7 @@ public class TestSuite implements RuleConfiguredTargetFactory {
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .add(RunfilesProvider.class,
-            RunfilesProvider.withData(Runfiles.EMPTY, runfiles))
+            RunfilesProvider.withData(ruleContext, Runfiles.EMPTY, runfiles))
         .add(TransitiveTestsProvider.class, new TransitiveTestsProvider())
         .build();
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -405,6 +405,30 @@ java_test(
     ],
 )
 
+java_test(
+    name = "RunfilesLibraryUsersTest",
+    srcs = ["RunfilesLibraryUsersTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution_impl",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:precomputed_value",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:repository_mapping_value",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/skyframe",
+        "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/bazel/bzlmod:util",
+        "//src/test/java/com/google/devtools/build/lib/skyframe:testutil",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
 test_suite(
     name = "AllAnalysisTests",
     tests = [

--- a/src/test/java/com/google/devtools/build/lib/analysis/RunfilesLibraryUsersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/RunfilesLibraryUsersTest.java
@@ -1,0 +1,309 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.analysis;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createModuleKey;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.RunfilesProvider.RepositoryNameAndMapping;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
+import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.skyframe.PrecomputedValue;
+import com.google.devtools.build.lib.skyframe.PrecomputedValue.Injected;
+import com.google.devtools.build.lib.skyframe.RepositoryMappingValue;
+import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.skyframe.EvaluationResult;
+import com.google.devtools.build.skyframe.SkyKey;
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class RunfilesLibraryUsersTest extends BuildViewTestCase {
+
+  private Path moduleRoot;
+  private FakeRegistry registry;
+
+  @Override
+  protected ImmutableList<Injected> extraPrecomputedValues() {
+    try {
+      moduleRoot = scratch.dir("modules");
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    registry = FakeRegistry.DEFAULT_FACTORY.newFakeRegistry(moduleRoot.getPathString());
+    return ImmutableList.of(
+        PrecomputedValue.injected(
+            ModuleFileFunction.REGISTRIES, ImmutableList.of(registry.getUrl())),
+        PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
+        PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
+        PrecomputedValue.injected(
+            BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING));
+  }
+
+  @Test
+  public void testRunfilesLibraryUsersCollectedInRunfilesProvider() throws Exception {
+    setBuildLanguageOptions("--enable_bzlmod");
+    scratch.file("MODULE.bazel",
+        "module()",
+        "bazel_dep(name='starlark_non_user',version='1.0')");
+    registry
+        .addModule(
+            createModuleKey("utils", "1.0"),
+            "module(name='utils',version='1.0')",
+            "bazel_dep(name='bar_user',version='1.0')")
+        .addModule(
+            createModuleKey("cc_user", "1.0"),
+            "module(name='cc_user',version='1.0')",
+            "bazel_dep(name='utils',version='1.0')")
+        .addModule(
+            createModuleKey("cc_non_user", "1.0"),
+            "module(name='cc_non_user',version='1.0')",
+            "bazel_dep(name='cc_user',version='1.0')")
+        .addModule(
+            createModuleKey("java_user", "1.0"),
+            "module(name='java_user',version='1.0')",
+            "bazel_dep(name='utils',version='1.0')")
+        .addModule(
+            createModuleKey("java_non_user", "1.0"),
+            "module(name='java_non_user',version='1.0')",
+            "bazel_dep(name='java_user',version='1.0')")
+        .addModule(
+            createModuleKey("bar_user", "1.0"),
+            "module(name='bar_user',version='1.0')",
+            "bazel_dep(name='utils',version='1.0')",
+            "register_toolchains('//:bar_toolchain')")
+        .addModule(
+            createModuleKey("starlark_user", "1.0"),
+            "module(name='starlark_user',version='1.0')",
+            "bazel_dep(name='utils',version='1.0')")
+        .addModule(
+            createModuleKey("starlark_tool_user", "1.0"),
+            "module(name='starlark_tool_user',version='1.0')",
+            "bazel_dep(name='utils',version='1.0')")
+        .addModule(
+            createModuleKey("starlark_non_user", "1.0"),
+            "module(name='starlark_non_user',version='1.0')",
+            "bazel_dep(name='utils',version='1.0')",
+            "bazel_dep(name='starlark_user',version='1.0')",
+            "bazel_dep(name='starlark_tool_user',version='1.0')",
+            "bazel_dep(name='java_non_user',version='1.0')",
+            "bazel_dep(name='cc_non_user',version='1.0')",
+            "bazel_dep(name='bar_user',version='1.0')");
+
+    scratch.file(moduleRoot.getRelative("utils~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(moduleRoot.getRelative("utils~1.0").getRelative("BUILD").getPathString(),
+        "load(':utils.bzl', 'runfiles_lib')",
+        "runfiles_lib(name='runfiles_lib',visibility=['//visibility:public'])");
+    scratch.file(
+        moduleRoot.getRelative("utils~1.0").getRelative("utils.bzl").getPathString(),
+        "def _runfiles_lib_impl(ctx):",
+        "  return [",
+        "    CcInfo(),",
+        "    RunfilesLibraryInfo(),",
+        "  ]",
+        "runfiles_lib = rule(_runfiles_lib_impl)",
+        "",
+        "def _starlark_rule_impl(ctx):",
+        // Explicitly do not merge in runfiles, just create a new runfiles object.
+        "  return [DefaultInfo(runfiles = ctx.runfiles())]",
+        "starlark_rule = rule(",
+        "  implementation = _starlark_rule_impl,",
+        "  attrs = {",
+        "    'deps': attr.label_list(),",
+        "    'tool_deps': attr.label_list(cfg = 'exec'),",
+        "  },",
+        "  toolchains = ['@bar_user//:toolchain_type'],",
+        ")");
+
+    scratch.file(moduleRoot.getRelative("cc_user~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(
+        moduleRoot.getRelative("cc_user~1.0").getRelative("BUILD").getPathString(),
+        "cc_library(",
+        "  name = 'cc_user',",
+        "  deps = ['@utils//:runfiles_lib'],",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    scratch.file(
+        moduleRoot.getRelative("cc_non_user~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(
+        moduleRoot.getRelative("cc_non_user~1.0").getRelative("BUILD").getPathString(),
+        "cc_library(",
+        "  name = 'cc_non_user',",
+        "  deps = ['@cc_user//:cc_user'],",
+        ")");
+
+    scratch.file(moduleRoot.getRelative("java_user~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(
+        moduleRoot.getRelative("java_user~1.0").getRelative("BUILD").getPathString(),
+        "java_library(",
+        "  name = 'java_user',",
+        "  runtime_deps = ['@utils//:runfiles_lib'],",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    scratch.file(
+        moduleRoot.getRelative("java_non_user~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(
+        moduleRoot.getRelative("java_non_user~1.0").getRelative("BUILD").getPathString(),
+        "java_library(",
+        "  name = 'java_non_user',",
+        "  srcs = ['Lib.java'],",
+        "  deps = ['@java_user//:java_user'],",
+        ")");
+
+    scratch.file(
+        moduleRoot.getRelative("bar_user~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(
+        moduleRoot.getRelative("bar_user~1.0").getRelative("BUILD").getPathString(),
+        "load(':toolchain.bzl', 'bar_toolchain')",
+        "java_library(",
+        "  name = 'bar_user',",
+        "  srcs = ['Runtime.java'],",
+        "  deps = ['@utils//:runfiles_lib'],",
+        ")",
+        "bar_toolchain(",
+        "  name = 'bar',",
+        "  runtime = ':bar_user',",
+        ")",
+        "toolchain_type(name = 'toolchain_type')",
+        "toolchain(",
+        "  name = 'bar_toolchain',",
+        "  toolchain = ':bar',",
+        "  toolchain_type = ':toolchain_type',",
+        ")");
+    scratch.file(
+        moduleRoot.getRelative("bar_user~1.0").getRelative("toolchain.bzl").getPathString(),
+        "def _bar_toolchain_impl(ctx):",
+        "  return [platform_common.ToolchainInfo(type = 'bar')]",
+        "bar_toolchain = rule(",
+        "  implementation = _bar_toolchain_impl,",
+        "  attrs = {'runtime': attr.label()},",
+        ")");
+
+    scratch.file(
+        moduleRoot.getRelative("starlark_user~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(
+        moduleRoot.getRelative("starlark_user~1.0").getRelative("BUILD").getPathString(),
+        "load('@utils//:utils.bzl', 'starlark_rule')",
+        "starlark_rule(",
+        "  name = 'starlark_user',",
+        "  deps = ['@utils//:runfiles_lib'],",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    scratch.file(
+        moduleRoot.getRelative("starlark_tool_user~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(
+        moduleRoot.getRelative("starlark_tool_user~1.0").getRelative("BUILD").getPathString(),
+        "load('@utils//:utils.bzl', 'starlark_rule')",
+        "starlark_rule(",
+        "  name = 'starlark_tool_user',",
+        "  deps = ['@utils//:runfiles_lib'],",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    scratch.file(
+        moduleRoot.getRelative("starlark_non_user~1.0").getRelative("WORKSPACE").getPathString());
+    scratch.file(
+        moduleRoot.getRelative("starlark_non_user~1.0").getRelative("BUILD").getPathString(),
+        "load('@utils//:utils.bzl', 'starlark_rule')",
+        "starlark_rule(",
+        "  name = 'starlark_non_user',",
+        "  deps = [",
+        "    '@starlark_user//:starlark_user',",
+        "    '@java_non_user//:java_non_user',",
+        "    '@cc_non_user//:cc_non_user',",
+        "  ],",
+        "  tool_deps = [",
+        "    '@starlark_tool_user//:starlark_tool_user',",
+        "    '@utils//:runfiles_lib',",
+        "  ],",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    assertThat(getRunfilesLibraryUsers("@@utils~1.0//:runfiles_lib")).isEmpty();
+
+    RepositoryName ccUser = RepositoryName.createUnvalidated("cc_user~1.0");
+    Map<RepositoryName, RepositoryMapping> ccUserRunfilesLibraryUsers = getRunfilesLibraryUsers(
+        "@@cc_user~1.0//:cc_user");
+    RepositoryMapping ccUserMapping = getRepositoryMapping(ccUser);
+    assertThat(ccUserRunfilesLibraryUsers).containsExactly(ccUser, ccUserMapping);
+
+    Map<RepositoryName, RepositoryMapping> ccNonUserRunfilesLibraryUsers = getRunfilesLibraryUsers(
+        "@@cc_non_user~1.0//:cc_non_user");
+    assertThat(ccNonUserRunfilesLibraryUsers).containsExactly(ccUser, ccUserMapping);
+
+    RepositoryName javaUser = RepositoryName.createUnvalidated("java_user~1.0");
+    Map<RepositoryName, RepositoryMapping> javaUserRunfilesLibraryUsers = getRunfilesLibraryUsers(
+        "@@java_user~1.0//:java_user");
+    RepositoryMapping javaUserMapping = getRepositoryMapping(javaUser);
+    assertThat(javaUserRunfilesLibraryUsers).containsExactly(javaUser, javaUserMapping);
+
+    Map<RepositoryName, RepositoryMapping> javaNonUserRunfilesLibraryUsers = getRunfilesLibraryUsers(
+        "@@java_non_user~1.0//:java_non_user");
+    assertThat(javaNonUserRunfilesLibraryUsers).containsExactly(javaUser, javaUserMapping);
+
+    RepositoryName barUser = RepositoryName.createUnvalidated("bar_user~1.0");
+    Map<RepositoryName, RepositoryMapping> barUserRunfilesLibraryUsers = getRunfilesLibraryUsers(
+        "@@bar_user~1.0//:bar_user");
+    RepositoryMapping barUserMapping = getRepositoryMapping(barUser);
+    assertThat(barUserRunfilesLibraryUsers).containsExactly(barUser, barUserMapping);
+
+    RepositoryName starlarkUser = RepositoryName.createUnvalidated("starlark_user~1.0");
+    Map<RepositoryName, RepositoryMapping> starlarkUserRunfilesLibraryUsers = getRunfilesLibraryUsers(
+        "@@starlark_user~1.0//:starlark_user");
+    RepositoryMapping starlarkUserMapping = getRepositoryMapping(starlarkUser);
+    assertThat(starlarkUserRunfilesLibraryUsers).containsExactly(starlarkUser, starlarkUserMapping);
+
+    Map<RepositoryName, RepositoryMapping> starlarkNonUserRunfilesLibraryUsers = getRunfilesLibraryUsers(
+        "@@starlark_non_user~1.0//:starlark_non_user");
+    assertThat(starlarkNonUserRunfilesLibraryUsers).containsExactly(
+        javaUser, javaUserMapping, ccUser, ccUserMapping, starlarkUser, starlarkUserMapping,
+        barUser, barUserMapping);
+  }
+
+  private RepositoryMapping getRepositoryMapping(RepositoryName ccUser)
+      throws InterruptedException {
+    SkyKey key = RepositoryMappingValue.key(ccUser);
+    EvaluationResult<RepositoryMappingValue> result = SkyframeExecutorTestUtils.evaluate(
+        getSkyframeExecutor(), key, /*keepGoing=*/ false, reporter);
+    return result.get(key).getRepositoryMapping();
+  }
+
+  private Map<RepositoryName, RepositoryMapping> getRunfilesLibraryUsers(String label)
+      throws Exception {
+    ConfiguredTarget target = getConfiguredTarget(Label.parseCanonical(label), targetConfig);
+    RunfilesProvider runfilesProvider = target.getProvider(RunfilesProvider.class);
+
+    assertThat(runfilesProvider).isNotNull();
+    assertThat(runfilesProvider.getRunfilesLibraryUsers()).isNotNull();
+    return runfilesProvider.getRunfilesLibraryUsers().toList().stream().collect(
+        Collectors.toMap(RepositoryNameAndMapping::getRepositoryName,
+            RepositoryNameAndMapping::getRepositoryMapping));
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TrimTestConfigurationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TrimTestConfigurationTest.java
@@ -71,7 +71,7 @@ public final class TrimTestConfigurationTest extends AnalysisTestCase {
           new Runfiles.Builder(context.getWorkspaceName()).addArtifact(executable).build();
       return new RuleConfiguredTargetBuilder(context)
           .setFilesToBuild(NestedSetBuilder.create(Order.STABLE_ORDER, executable))
-          .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
+          .addProvider(RunfilesProvider.class, RunfilesProvider.simple(context, runfiles))
           .setRunfilesSupport(
               RunfilesSupport.withExecutable(context, runfiles, executable), executable)
           .build();

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/MockRuleDefaults.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/MockRuleDefaults.java
@@ -97,7 +97,7 @@ public class MockRuleDefaults {
       return new RuleConfiguredTargetBuilder(ruleContext)
           .setFilesToBuild(filesToBuild)
           .setRunfilesSupport(null, null)
-          .add(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+          .add(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
           .build();
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/TestAspects.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/TestAspects.java
@@ -171,7 +171,7 @@ public class TestAspects {
                   new RuleInfo(collectAspectData("rule " + ruleContext.getLabel(), ruleContext)))
               .setFilesToBuild(NestedSetBuilder.<Artifact>create(Order.STABLE_ORDER))
               .setRunfilesSupport(null, null)
-              .add(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY));
+              .add(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, Runfiles.EMPTY));
 
       if (ruleContext.getRule().getRuleClassObject().getName().equals("honest")) {
         builder.addProvider(new RequiredProvider());
@@ -189,11 +189,11 @@ public class TestAspects {
     public ConfiguredTarget create(RuleContext ruleContext)
         throws InterruptedException, RuleErrorException, ActionConflictException {
       return new RuleConfiguredTargetBuilder(ruleContext)
-              .addProvider(
-                  new RuleInfo(collectAspectData("rule " + ruleContext.getLabel(), ruleContext)))
-              .setFilesToBuild(NestedSetBuilder.<Artifact>create(Order.STABLE_ORDER))
-              .setRunfilesSupport(null, null)
-              .add(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+          .addProvider(
+              new RuleInfo(collectAspectData("rule " + ruleContext.getLabel(), ruleContext)))
+          .setFilesToBuild(NestedSetBuilder.<Artifact>create(Order.STABLE_ORDER))
+          .setRunfilesSupport(null, null)
+          .add(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
               .addProvider(new RequiredProvider())
               .addProvider(new RequiredProvider2())
               .build();
@@ -226,7 +226,7 @@ public class TestAspects {
                   new RuleInfo(infoBuilder.build()))
               .setFilesToBuild(NestedSetBuilder.<Artifact>create(Order.STABLE_ORDER))
               .setRunfilesSupport(null, null)
-              .add(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY));
+              .add(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, Runfiles.EMPTY));
 
       return builder.build();
     }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BuiltinsInjectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BuiltinsInjectionTest.java
@@ -155,7 +155,7 @@ public class BuiltinsInjectionTest extends BuildViewTestCase {
           .setFilesToBuild(
               NestedSetBuilder.wrap(Order.STABLE_ORDER, ruleContext.getOutputArtifacts()))
           .setRunfilesSupport(null, null)
-          .add(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+          .add(RunfilesProvider.class, RunfilesProvider.simple(ruleContext, Runfiles.EMPTY))
           .build();
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/testutil/UnknownRuleConfiguredTarget.java
+++ b/src/test/java/com/google/devtools/build/lib/testutil/UnknownRuleConfiguredTarget.java
@@ -62,7 +62,7 @@ public class UnknownRuleConfiguredTarget implements RuleConfiguredTargetFactory 
             Code.FAIL_ACTION_UNKNOWN));
     return new RuleConfiguredTargetBuilder(context)
         .setFilesToBuild(filesToBuild)
-        .add(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
+        .add(RunfilesProvider.class, RunfilesProvider.simple(context, Runfiles.EMPTY))
         .build();
   }
 }


### PR DESCRIPTION
RunfilesProvider now tracks the repository names and mappings of
runfiles library users among the transitive non-tool dependencies of
each rule, as marked by the RunfilesLibraryInfo provider.

The list of runfiles library users for an executable target will be used
in a follow-up commit to create a repository mapping manifest containing
only the mappings of those repositories that contain targets that
actually perform runfiles lookups.

Work towards #16124
