### PR TITLE
Throw explicit exception if experimental_split_coverage_postprocessing is used without experimental_fetch_all_coverage_outputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -102,14 +102,10 @@ public class StandaloneTestStrategy extends TestStrategy {
       TestRunnerAction action, ActionExecutionContext actionExecutionContext)
       throws ExecException, InterruptedException {
     if (action.getExecutionSettings().getInputManifest() == null) {
-      String errorMessage = "cannot run local tests with --nobuild_runfile_manifests";
-      throw new TestExecException(
-          errorMessage,
-          FailureDetail.newBuilder()
-              .setTestAction(
-                  TestAction.newBuilder().setCode(TestAction.Code.LOCAL_TEST_PREREQ_UNMET))
-              .setMessage(errorMessage)
-              .build());
+      throw createTestExecException(
+          TestAction.Code.LOCAL_TEST_PREREQ_UNMET,
+          "cannot run local tests with --nobuild_runfile_manifests"
+      );
     }
     Map<String, String> testEnvironment =
         createEnvironment(
@@ -641,6 +637,16 @@ public class StandaloneTestStrategy extends TestStrategy {
     }
   }
 
+  private static TestExecException createTestExecException(TestAction.Code errorCode, String errorMessage) {
+    return new TestExecException(
+        errorMessage,
+        FailureDetail.newBuilder()
+            .setTestAction(TestAction.newBuilder().setCode(errorCode))
+            .setMessage(errorMessage)
+            .build()
+    );
+  }
+
   private final class BazelTestAttemptContinuation extends TestAttemptContinuation {
     private final TestRunnerAction testAction;
     private final ActionExecutionContext actionExecutionContext;
@@ -760,6 +766,16 @@ public class StandaloneTestStrategy extends TestStrategy {
             .setHasCoverage(testAction.isCoverageMode());
 
         if (testAction.isCoverageMode() && testAction.getSplitCoveragePostProcessing()) {
+          if (testAction.getCoverageDirectoryTreeArtifact() == null) {
+            // Otherwise we'll get a NPE https://github.com/bazelbuild/bazel/issues/13185
+            TestExecException e = createTestExecException(
+                TestAction.Code.LOCAL_TEST_PREREQ_UNMET,
+                "coverageDirectoryTreeArtifact is null: --experimental_split_coverage_postprocessing depends on --experimental_fetch_all_coverage_outputs being enabled"
+            );
+            closeSuppressed(e, streamed);
+            closeSuppressed(e, fileOutErr);
+            throw e;
+          }
           actionExecutionContext
               .getMetadataHandler()
               .getMetadata(testAction.getCoverageDirectoryTreeArtifact());

--- a/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
@@ -875,6 +875,32 @@ EOF
   assert_contains 'name: "test.lcov"' bep.txt
 }
 
+function test_coverage_with_experimental_split_coverage_postprocessing_only() {
+  local -r LCOV=$(which lcov)
+  if [[ ! -x ${LCOV:-/usr/bin/lcov} ]]; then
+    echo "lcov not installed. Skipping test."
+    return
+  fi
+
+  cat << EOF > BUILD
+cc_test(
+  name = "hello-test",
+  srcs = ["hello-test.cc"],
+)
+EOF
+
+
+  cat << EOF > hello-test.cc
+int main() {
+  return 0;
+}
+EOF
+  bazel coverage --test_output=all --experimental_split_coverage_postprocessing //:hello-test \
+                &>$TEST_log && fail "Expected test failure" || :
+
+  assert_contains '--experimental_split_coverage_postprocessing depends on --experimental_fetch_all_coverage_outputs being enabled' $TEST_log
+}
+
 function test_coverage_doesnt_fail_on_empty_output() {
     if is_gcov_missing_or_wrong_version; then
         echo "Skipping test." && return


### PR DESCRIPTION
This closes https://github.com/bazelbuild/bazel/issues/13185
According to https://github.com/bazelbuild/bazel/commit/e411fa74176cdc54f84d62c189d042e9fb6d5c79,
The flag --experimental_split_coverage_postprocessing depends on the flag
--experimental_fetch_all_coverage_outputs being enabled, but if the former one
is set without the latter one, Bazel throws a quite confusing NullPointerException.
Now we throw an explicit exception with proper error message.