### PR TITLE
Forward `strict_proto_deps` in `java_proto_library`.

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/proto/java_proto_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/proto/java_proto_library.bzl
@@ -114,6 +114,7 @@ def java_compile_for_protos(ctx, output_jar_suffix, source_jar = None, deps = []
             exports = exports,
             output = output_jar,
             output_source_jar = source_jar,
+            strict_deps = ctx.fragments.proto.strict_proto_deps(),
             injecting_rule_kind = injecting_rule_kind,
             javac_opts = java_toolchain.compatible_javacopts("proto"),
             enable_jspecify = False,
@@ -140,7 +141,7 @@ bazel_java_proto_aspect = aspect(
     attr_aspects = ["deps", "exports"],
     required_providers = [ProtoInfo],
     provides = [JavaInfo, JavaProtoAspectInfo],
-    fragments = ["java"],
+    fragments = ["java", "proto"],
 )
 
 def bazel_java_proto_library_rule(ctx):


### PR DESCRIPTION
`strict_proto_deps` is not forwarded to `java_proto_library` rule, which causes `//src/tools/execlog:parser` to fail to build, regardless of the values of `experimental_strict_java_deps` and `strict_proto_deps`.

```
ERROR: /private/var/tmp/_bazel__nixbld1/d87cd14b08eca34b82f3fdf08fc103d4/external/com_google_protobuf/BUILD:387:15: Building external/com_google_protobuf/libduration_proto-speed.jar (1 source jar) failed: (Exit 1): java failed: error executing command (from target @com_google_protobuf//:duration_proto)
  (cd /private/var/tmp/_bazel__nixbld1/d87cd14b08eca34b82f3fdf08fc103d4/execroot/io_bazel && \
  exec env - \
    LC_CTYPE=en_US.UTF-8 \
    PATH=/nix/store/rs23kn5r3qm96cq26b6bzy2w7rs5r39d-python3-3.10.5/bin:/nix/store/v4fybh0lri7qdq9bplq2hdp24a7lygd1-unzip-6.0/bin:/nix/store/0gd8gqrmdxh2rdkhzwbv7n5f2v3ad82d-which-2.21/bin:/nix/store/cfqal1x0y7chc6zglahf0wk3ban508rr-zip-3.0/bin:/nix/store/0svfqkj8vjvq49yk5fij9z053x9i6l4j-cctools-port-949.0.1/bin:/nix/store/qba0zdib24nhdjdw6vk90hqz3il48xkg-clang-wrapper-11.1.0/bin:/nix/store/lpysf2qn09j9nyd4l7s3xjww6qhmqa1i-clang-11.1.0/bin:/nix/store/3mfkgajns47hfv0diihzi2scwl4hm2fl-coreutils-9.1/bin:/nix/store/xl4xqz4hsr58ws1z7n7g47y4smyw62ip-cctools-binutils-darwin-wrapper-949.0.1/bin:/nix/store/nq7dispfy6jj8m56963b5w990djs431y-cctools-binutils-darwin-949.0.1/bin:/nix/store/6f6amv380wrw9kz2rbk5h7c6ykpnhp94-zulu11.48.21-ca-jdk-11.0.11/bin:/nix/store/db7n4xkfng8y4c3klp6bjppaws3rphq6-bash-5.1-p16/bin:/nix/store/mvzlxhs0gphkgmrf90jyvp5zwidw567v-file-5.42/bin:/nix/store/8d0wgshdr8qa81ylani8kyld6ap317cl-findutils-4.9.0/bin:/nix/store/1rkr80jzyilhw7mcasqfs9i8hcz3wpc0-gawk-5.1.1/bin:/nix/store/jdvpk1v5a1bbzfjm510b97p0bh7vnc5q-gnugrep-3.7/bin:/nix/store/vb661ycg7yvg7mvfy27z78j2dv29760w-gnused-4.8/bin:/nix/store/x7mvjq5gdqqhdlv7y1x0idanwwak69pr-gnutar-1.34/bin:/nix/store/rjk7n53h36yzk55vy218nw32y3h51rkz-gzip-1.12/bin:/nix/store/rsm0lr4r4i936zbk1a37bc223pgxwgja-python-2.7.18/bin:/nix/store/3mfkgajns47hfv0diihzi2scwl4hm2fl-coreutils-9.1/bin:/nix/store/8d0wgshdr8qa81ylani8kyld6ap317cl-findutils-4.9.0/bin:/nix/store/4d236ml1h032wr2vglnldbjkapcrhw2d-diffutils-3.8/bin:/nix/store/vb661ycg7yvg7mvfy27z78j2dv29760w-gnused-4.8/bin:/nix/store/jdvpk1v5a1bbzfjm510b97p0bh7vnc5q-gnugrep-3.7/bin:/nix/store/1rkr80jzyilhw7mcasqfs9i8hcz3wpc0-gawk-5.1.1/bin:/nix/store/bi4ffmv3hxzpdy4jqcm15n36plmv6k7g-gnutar-1.34/bin:/nix/store/rjk7n53h36yzk55vy218nw32y3h51rkz-gzip-1.12/bin:/nix/store/mcj3cypgv0pramf11a3pwazlyg1iyfg8-bzip2-1.0.8-bin/bin:/nix/store/yflpngzrwq9imh90wy6p7r8jysg6x5w4-gnumake-4.3/bin:/nix/store/db7n4xkfng8y4c3klp6bjppaws3rphq6-bash-5.1-p16/bin:/nix/store/lmkwb03xcz7z4np5kanq56svm8k95kz2-patch-2.7.6/bin:/nix/store/dvvvwv9m34sylq63nnx0d4rjsbps773v-xz-5.2.5-bin/bin:/nix/store/q7nqswqxq8fjp2qd9yi9jw0qnw2vpc3g-file-5.42/bin \
  external/local_jdk/bin/java -XX:-CompactStrings '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.resources=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED' '--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED' '--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED' '--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED' '--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED' '--add-opens=java.base/java.nio=ALL-UNNAMED' '--add-opens=java.base/java.lang=ALL-UNNAMED' '-Dsun.io.useCanonCaches=false' -jar external/remote_java_tools/java_tools/JavaBuilder_deploy.jar @bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/libduration_proto-speed.jar-0.params @bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/libduration_proto-speed.jar-1.params)
# Configuration: aa62b104728333160c03f68b4c57ca48ee8593677daa2bf808f485ebec8af3a8
# Execution platform: //:default_host_platform
bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/_javac/duration_proto/libduration_proto-speed_tmp/com/google/protobuf/Duration.java:58: error: [strict] Using type com.google.protobuf.GeneratedMessageV3 from an indirect dependency (TOOL_INFO: "@com_google_protobuf//java/core"). See command below **
    com.google.protobuf.GeneratedMessageV3 implements
                       ^
bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/_javac/duration_proto/libduration_proto-speed_tmp/com/google/protobuf/Duration.java:82: error: [strict] Using type com.google.protobuf.CodedInputStream from an indirect dependency (TOOL_INFO: "@com_google_protobuf//java/core:lite_runtime_only"). See command below **
      com.google.protobuf.CodedInputStream input,
                         ^
 ** Please add the following dependencies:
  @com_google_protobuf//java/core @com_google_protobuf//java/core:lite_runtime_only to @com_google_protobuf//:duration_proto
 ** You can use the following buildozer command:
buildozer 'add deps @com_google_protobuf//java/core @com_google_protobuf//java/core:lite_runtime_only' @com_google_protobuf//:duration_proto

Target //src/tools/execlog:parser_deploy.jar failed to build
```