### PR TITLE
Add tool name for objcopy

### DIFF
--- a/tools/build_defs/cc/action_names.bzl
+++ b/tools/build_defs/cc/action_names.bzl
@@ -94,6 +94,9 @@ OBJC_FULLY_LINK_ACTION_NAME = "objc-fully-link"
 # A string constant for the clif actions.
 CLIF_MATCH_ACTION_NAME = "clif-match"
 
+# A string constant for the obj copy actions.
+OBJ_COPY_ACTION_NAME = "objcopy_embed_data"
+
 ACTION_NAMES = struct(
     c_compile = C_COMPILE_ACTION_NAME,
     cpp_compile = CPP_COMPILE_ACTION_NAME,
@@ -122,4 +125,5 @@ ACTION_NAMES = struct(
     objcpp_compile = OBJCPP_COMPILE_ACTION_NAME,
     objcpp_executable = OBJCPP_EXECUTABLE_ACTION_NAME,
     clif_match = CLIF_MATCH_ACTION_NAME,
+    objcopy_embed_data = OBJ_COPY_ACTION_NAME,
 )

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -159,7 +159,18 @@ def _impl(ctx):
         ],
     )
 
+    objcopy_action = action_config(
+        action_name = ACTION_NAMES.objcopy_embed_data,
+        tools = [ 
+            tool(
+                path = ctx.attr.tool_paths["objcopy"]
+            ),
+        ],
+    )
+
+
     action_configs.append(llvm_cov_action)
+    action_configs.append(objcopy_action)
 
     supports_pic_feature = feature(
         name = "supports_pic",


### PR DESCRIPTION
It is not clear to me why this constant is in [src/main/starlark/builtins_bzl/common/cc/action_names.bzl](https://github.com/bazelbuild/bazel/blob/master/src/main/starlark/builtins_bzl/common/cc/action_names.bzl) but not in [tools/build_defs/cc/action_names.bzl](https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/cc/action_names.bzl), but it makes `get_tool_for_action` really annoying.

Furthermore, it seems that if we are willing to define `llvm-cov` for everyone we should do the same for `objcopy`.