### PR TITLE
Use True instead of 1 in the documentation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
@@ -246,7 +246,7 @@ public class GenRuleBaseRule implements RuleDefinition {
 
         /* <!-- #BLAZE_RULE(genrule).ATTRIBUTE(output_to_bindir) -->
         <p>
-          If set to 1, this option causes output files to be written into the <code>bin</code>
+          If set to True, this option causes output files to be written into the <code>bin</code>
           directory instead of the <code>genfiles</code> directory.
         </p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
@@ -259,7 +259,7 @@ public class GenRuleBaseRule implements RuleDefinition {
 
         /* <!-- #BLAZE_RULE(genrule).ATTRIBUTE(local) -->
         <p>
-          If set to 1, this option forces this <code>genrule</code> to run using the "local"
+          If set to True, this option forces this <code>genrule</code> to run using the "local"
           strategy, which means no remote execution, no sandboxing, no persistent workers.
         </p>
         <p>


### PR DESCRIPTION
The parameter is a boolean and because of that True can also be used.
From readibility point of view, it is better to use True to know that
this is a boolean value and cannot be any arbitrary integer.
Having 1 in the documentation makes the users also to use 1 instead
of True, that is why the proposal to change it here.