### PR TITLE
Linux sandbox: ignore ENODEV when making the filesystem read-only.

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -382,13 +382,15 @@ static void MakeFilesystemMostlyReadOnly() {
       // /proc/sys/fs/binfmt_misc, because it is hidden. If we get ESTALE, the
       // mount is a broken NFS mount. In the ideal case, the user would either
       // fix or remove that mount, but in cases where that's not possible, we
-      // should just ignore it.
+      // should just ignore it. Similarly, one can get ENODEV in case of
+      // autofs/automount failure.
       switch (errno) {
         case EACCES:
         case EPERM:
         case EINVAL:
         case ENOENT:
         case ESTALE:
+        case ENODEV:
           PRINT_DEBUG(
               "remount(nullptr, %s, nullptr, %d, nullptr) failure (%m) ignored",
               ent->mnt_dir, mountFlags);


### PR DESCRIPTION
The code remounting existing mounts as read-only already ignores various
errors, such as `EINVAL`, `ESTALE` etc.

Unfortunately, it doesn't ignore `ENODEV`, which can occur in case of
`autofs`/`automount` failure.
Currently, having a single broken automount on the host can cause all
sandboxes to fail with the following error:

```
src/main/tools/linux-sandbox-pid1.cc:281: "remount(nullptr,
/data/foo, nullptr, 2101281, nullptr)": No such device
```

So simply also add `ENODEV` to the list of errors ignored.