### PR TITLE
Use True instead of 1 in the documentation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcBinaryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcBinaryRule.java
@@ -62,7 +62,7 @@ public final class BazelCcBinaryRule implements RuleDefinition {
         <p>
           If you specify both <code>linkopts=['-static']</code> and <code>linkshared=True</code>,
           you get a single completely self-contained unit. If you specify both
-          <code>linkstatic=1</code> and <code>linkshared=True</code>, you get a single, mostly
+          <code>linkstatic=True</code> and <code>linkshared=True</code>, you get a single, mostly
           self-contained unit.
         </p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -253,7 +253,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
 
     if (common.getLinkopts().contains("-static")) {
       ruleContext.attributeWarning("linkopts", "Using '-static' here won't work. "
-                                   + "Did you mean to use 'linkstatic=1' instead?");
+                                   + "Did you mean to use 'linkstatic=True' instead?");
     }
 
     linkingHelper.setShouldCreateDynamicLibrary(createDynamicLibrary);
@@ -509,7 +509,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
         && ccCompilationOutputs.getObjectFiles(true).isEmpty()) {
       if (!linkstaticAttribute && appearsToHaveObjectFiles(ruleContext.attributes())) {
         ruleContext.attributeWarning("linkstatic",
-            "setting 'linkstatic=1' is recommended if there are no object files");
+            "setting 'linkstatic=True' is recommended if there are no object files");
       }
     } else {
       if (!linkstaticAttribute && !appearsToHaveObjectFiles(ruleContext.attributes())) {
@@ -522,9 +522,9 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
              + element.prettyPrint() + ". "
              + "(You may have used some very confusing rule names in srcs? "
              + "Or the library consists entirely of a linker script?) "
-             + "Bazel assumed linkstatic=1, but this may be inappropriate. "
+             + "Bazel assumed linkstatic=True, but this may be inappropriate. "
              + "You may need to add an explicit '.cc' file to 'srcs'. "
-             + "Alternatively, add 'linkstatic=1' to suppress this warning");
+             + "Alternatively, add 'linkstatic=True' to suppress this warning");
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -354,7 +354,7 @@ public class CppOptions extends FragmentOptions {
           "Deprecated, superseded by --incompatible_remove_legacy_whole_archive "
               + "(see https://github.com/bazelbuild/bazel/issues/7362 for details). "
               + "When on, use --whole-archive for cc_binary rules that have "
-              + "linkshared=1 and either linkstatic=1 or '-static' in linkopts. "
+              + "linkshared=True and either linkstatic=True or '-static' in linkopts. "
               + "This is for backwards compatibility only. "
               + "A better alternative is to use alwayslink=1 where required.")
   public boolean legacyWholeArchive;

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
@@ -288,7 +288,7 @@ public class GenRuleBaseRule implements RuleDefinition {
         /* <!-- #BLAZE_RULE(genrule).ATTRIBUTE(executable) -->
         Declare output to be executable.
         <p>
-          Setting this flag to 1 means the output is an executable file and can be run using the
+          Setting this flag to True means the output is an executable file and can be run using the
           <code>run</code> command. The genrule must produce exactly one output in this case.
           If this attribute is set, <code>run</code> will try executing the file regardless of
           its content.

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcStarlarkApiProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcStarlarkApiProviderApi.java
@@ -37,7 +37,7 @@ public interface CcStarlarkApiProviderApi<FileT extends FileApi> {
       doc =
           "Returns the <a href=\"depset.html\">depset</a> of libraries for either "
               + "<code>FULLY STATIC</code> mode (<code>linkopts=[\"-static\"]</code>) or "
-              + "<code>MOSTLY STATIC</code> mode (<code>linkstatic=1</code>) "
+              + "<code>MOSTLY STATIC</code> mode (<code>linkstatic=True</code>) "
               + "(possibly empty but never <code>None</code>)")
   public Depset /*<FileT>*/ getLibrariesForStarlark();
 
@@ -47,7 +47,7 @@ public interface CcStarlarkApiProviderApi<FileT extends FileApi> {
       doc =
           "Returns the list of flags given to the C++ linker command for either "
               + "<code>FULLY STATIC</code> mode (<code>linkopts=[\"-static\"]</code>) or "
-              + "<code>MOSTLY STATIC</code> mode (<code>linkstatic=1</code>) "
+              + "<code>MOSTLY STATIC</code> mode (<code>linkstatic=True</code>) "
               + "(possibly empty but never <code>None</code>)")
   public ImmutableList<String> getLinkopts();
 


### PR DESCRIPTION
The parameter is a boolean and because of that True can also be used.
From readibility point of view, it is better to use True to know that
this is a boolean value and cannot be any arbitrary integer.
Having 1 in the documentation makes the users also to use 1 instead
of True, that is why the proposal to change it here.