### PR TITLE
Only try to create groups of test actions in the ui.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -525,7 +525,7 @@ class UiStateTracker {
 
     getActionState(action, actionId, event.getNanoTimeStart());
 
-    if (action.getOwner() != null) {
+    if (action.getOwner() != null && "TestRunner".equals(action.getOwner().getMnemonic())) {
       Label owner = action.getOwner().getLabel();
       if (owner != null) {
         Set<Artifact> testActionsForOwner = testActions.get(owner);
@@ -599,7 +599,7 @@ class UiStateTracker {
 
     checkNotNull(activeActions.remove(actionId), "%s not active after %s", actionId, event);
 
-    if (action.getOwner() != null) {
+    if (action.getOwner() != null && "TestRunner".equals(action.getOwner().getMnemonic())) {
       Label owner = action.getOwner().getLabel();
       if (owner != null) {
         Set<Artifact> testActionsForOwner = testActions.get(owner);
@@ -745,7 +745,7 @@ class UiStateTracker {
   protected String describeAction(
       ActionState actionState, long nanoTime, int desiredWidth, Set<Artifact> toSkip) {
     ActionExecutionMetadata action = actionState.action;
-    if (action.getOwner() != null) {
+    if (action.getOwner() != null && "TestRunner".equals(action.getOwner().getMnemonic())) {
       Label owner = action.getOwner().getLabel();
       if (owner != null) {
         Set<Artifact> allRelatedActions = testActions.get(owner);


### PR DESCRIPTION
A target with test actions may have other actions registered that should not be reported in the UI as tests themselves.

Fixes https://github.com/bazelbuild/bazel/issues/16174.