### PR TITLE
Fix duplicated error on explicit incompatible target

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ViewCreationFailedException.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ViewCreationFailedException.java
@@ -37,7 +37,7 @@ public class ViewCreationFailedException extends Exception {
   }
 
   public ViewCreationFailedException(FailureDetail failureDetail, Throwable cause) {
-    super(cause);
+    super(cause.getMessage(), cause);
     this.failureDetail = checkNotNull(failureDetail);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
@@ -274,7 +274,7 @@ public class TopLevelConstraintSemantics {
         }
       }
     } catch (TargetCompatibilityCheckException e) {
-      throw new ViewCreationFailedException(e.getMessage(), e.failureDetail, e);
+      throw new ViewCreationFailedException(e.getMessage(), e.failureDetail);
     }
 
     return PlatformRestrictionsResult.builder()

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
@@ -274,7 +274,7 @@ public class TopLevelConstraintSemantics {
         }
       }
     } catch (TargetCompatibilityCheckException e) {
-      throw new ViewCreationFailedException(e.getMessage(), e.failureDetail);
+      throw new ViewCreationFailedException(e.getFailureDetail(), /*cause=*/ e);
     }
 
     return PlatformRestrictionsResult.builder()

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -1299,8 +1299,8 @@ function test_aquery_incompatible_target() {
     --platforms=@//target_skipping:foo3_platform \
     '//target_skipping:sh_foo1' &> "${TEST_log}" \
     && fail "Bazel aquery passed unexpectedly."
-  expect_log 'Target //target_skipping:sh_foo1 is incompatible and cannot be built, but was explicitly requested'
-  expect_log "target platform (//target_skipping:foo3_platform) didn't satisfy constraint //target_skipping:foo1"
+  expect_log_once 'Target //target_skipping:sh_foo1 is incompatible and cannot be built, but was explicitly requested'
+  expect_log_once "target platform (//target_skipping:foo3_platform) didn't satisfy constraint //target_skipping:foo1"
 }
 
 # Use aspects to interact with incompatible targets and validate the behaviour.
@@ -1445,16 +1445,15 @@ EOF
     --platforms=@//target_skipping:foo1_bar1_platform \
     //target_skipping:twice_inspected_foo3_target &> "${TEST_log}" \
     && fail "Bazel passed unexpectedly."
-  # TODO(#15427): Should use expect_log_once here when the issue is fixed.
-  expect_log 'ERROR: Target //target_skipping:twice_inspected_foo3_target is incompatible and cannot be built, but was explicitly requested.'
-  expect_log '^Dependency chain:$'
-  expect_log '^    //target_skipping:twice_inspected_foo3_target '
-  expect_log '^    //target_skipping:previously_inspected_basic_target '
-  expect_log '^    //target_skipping:inspected_foo3_target '
-  expect_log '^    //target_skipping:aliased_other_basic_target '
-  expect_log '^    //target_skipping:other_basic_target '
-  expect_log "    //target_skipping:basic_foo3_target .*  <-- target platform (//target_skipping:foo1_bar1_platform) didn't satisfy constraint //target_skipping:foo3:"
-  expect_log 'FAILED: Build did NOT complete successfully'
+  expect_log_once 'ERROR: Target //target_skipping:twice_inspected_foo3_target is incompatible and cannot be built, but was explicitly requested.'
+  expect_log_once '^Dependency chain:$'
+  expect_log_once '^    //target_skipping:twice_inspected_foo3_target '
+  expect_log_once '^    //target_skipping:previously_inspected_basic_target '
+  expect_log_once '^    //target_skipping:inspected_foo3_target '
+  expect_log_once '^    //target_skipping:aliased_other_basic_target '
+  expect_log_once '^    //target_skipping:other_basic_target '
+  expect_log_once "    //target_skipping:basic_foo3_target .*  <-- target platform (//target_skipping:foo1_bar1_platform) didn't satisfy constraint //target_skipping:foo3:"
+  expect_log_once 'FAILED: Build did NOT complete successfully'
   expect_not_log "${debug_message1}"
   expect_not_log "${debug_message2}"
   expect_not_log "${debug_message3}"

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -1452,8 +1452,8 @@ EOF
   expect_log_once '^    //target_skipping:inspected_foo3_target '
   expect_log_once '^    //target_skipping:aliased_other_basic_target '
   expect_log_once '^    //target_skipping:other_basic_target '
-  expect_log_once "    //target_skipping:basic_foo3_target .*  <-- target platform (//target_skipping:foo1_bar1_platform) didn't satisfy constraint //target_skipping:foo3:"
-  expect_log_once 'FAILED: Build did NOT complete successfully'
+  expect_log_once "    //target_skipping:basic_foo3_target .*  <-- target platform (//target_skipping:foo1_bar1_platform) didn't satisfy constraint //target_skipping:foo3$"
+  expect_log 'FAILED: Build did NOT complete successfully'
   expect_not_log "${debug_message1}"
   expect_not_log "${debug_message2}"
   expect_not_log "${debug_message3}"


### PR DESCRIPTION
Currently the "cannot be built, but was explicitly requested" error
message gets printed twice. This can be seen when running the
integration tests:

    $ bazel test -c opt //src/test/shell/integration:target_compatible_with_test --test_output=streamed --test_filter=test_aquery_incompatible_target
    ** test_aquery_incompatible_target *********************************************
    -- Test log: -----------------------------------------------------------
    $TEST_TMPDIR defined: output root default is '/bazel-cache/phil/bazel/_bazel_phil/9ea7728127d38e06511786263f870905/sandbox/linux-sandbox/3035/execroot/io_bazel/_tmp/c749fd38ac9a4ad6bd41e9653bbceab5' and max_idle_secs default is '15'.
    WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:
    /etc/bazel.bazelrc
    Extracting Bazel installation...
    Starting local Bazel server and connecting to it...
    Loading:
    Loading: 0 packages loaded
    Analyzing: target //target_skipping:sh_foo1 (1 packages loaded, 0 targets configured)
    Analyzing: target //target_skipping:sh_foo1 (33 packages loaded, 134 targets configured)
    ERROR: Target //target_skipping:sh_foo1 is incompatible and cannot be built, but was explicitly requested.
    Dependency chain:
        //target_skipping:sh_foo1 (e1f684)
        //target_skipping:foo1.sh (e1f684)
        //target_skipping:genrule_foo1 (e1f684)   <-- target platform (//target_skipping:foo3_platform) didn't satisfy constraint //target_skipping:foo1: Target //target_skipping:sh_foo1 is incompatible and cannot be built, but was explicitly requested.
    Dependency chain:
        //target_skipping:sh_foo1 (e1f684)
        //target_skipping:foo1.sh (e1f684)
        //target_skipping:genrule_foo1 (e1f684)   <-- target platform (//target_skipping:foo3_platform) didn't satisfy constraint //target_skipping:foo1
    INFO: Elapsed time: 5.525s
    INFO: 0 processes.
    FAILED: Build did NOT complete successfully (36 packages loaded, 159 targets configured)
    FAILED: Build did NOT complete successfully (36 packages loaded, 159 targets configured)

This patch fixes the issue by using the `ViewCreationFailedException`
overload that doesn't let us specify a custom message. The message
is already contained in the `cause`. This way the message doesn't
get duplicated. This did require changing the
`ViewCreationFailedException` code slightly.  But the functionality
should be the desired one.

Fixes #15427