### PR TITLE
Reenable the UDS proxy tests.

### DIFF
--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -157,8 +157,7 @@ EOF
       || fail "Failed to build //a:foo with remote cache"
 }
 
-# TODO(b/211478955): Deflake and re-enable.
-function DISABLED_test_remote_grpc_via_unix_socket_proxy() {
+function test_remote_grpc_via_unix_socket_proxy() {
   case "$PLATFORM" in
   darwin|freebsd|linux|openbsd)
     ;;
@@ -182,12 +181,12 @@ EOF
   # small maximum length limits for UNIX domain sockets.
   socket_dir=$(mktemp -d -t "remote_executor.XXXXXXXX")
   PROXY="$(rlocation io_bazel/src/test/shell/bazel/remote/uds_proxy.py)"
-  python "${PROXY}" "${socket_dir}/executor-socket" "localhost:${worker_port}" &
+  python3 "${PROXY}" "${socket_dir}/executor-socket" "localhost:${worker_port}" &
   proxy_pid=$!
 
   bazel build \
       --remote_executor=grpc://noexist.invalid \
-      --remote_proxy="unix:${socket_dir}/executor-socket" \
+      --remote_proxy="unix://${socket_dir}/executor-socket" \
       //a:foo \
       || fail "Failed to build //a:foo with remote cache"
 
@@ -196,8 +195,7 @@ EOF
   rmdir "${socket_dir}"
 }
 
-# TODO(b/211478955): Deflake and re-enable.
-function DISABLED_test_remote_grpc_via_unix_socket_direct() {
+function test_remote_grpc_via_unix_socket_direct() {
   case "$PLATFORM" in
   darwin|freebsd|linux|openbsd)
     ;;
@@ -221,11 +219,11 @@ EOF
   # small maximum length limits for UNIX domain sockets.
   socket_dir=$(mktemp -d -t "remote_executor.XXXXXXXX")
   PROXY="$(rlocation io_bazel/src/test/shell/bazel/remote/uds_proxy.py)"
-  python "${PROXY}" "${socket_dir}/executor-socket" "localhost:${worker_port}" &
+  python3 "${PROXY}" "${socket_dir}/executor-socket" "localhost:${worker_port}" &
   proxy_pid=$!
 
   bazel build \
-      --remote_executor="unix:${socket_dir}/executor-socket" \
+      --remote_executor="unix://${socket_dir}/executor-socket" \
       //a:foo \
       || fail "Failed to build //a:foo with remote cache"
 


### PR DESCRIPTION
These tests were disabled due to flakiness in 8e3c0df. As a consequence, we
introduced an undetected regression in 5.3 (#16171).

I've rerun the tests multiple times, both locally and remotely, and I've seen
no evidence of flakiness. Therefore, I'm declaring that this issue has
mysteriously fixed itself.

Notes:

* Use `python3` instead of `python` to run the UDS proxy, as the latter is no
  longer available in some of the environments where the tests run.
* The correct URI syntax for a Unix domain socket URI is unix:///path/to/socket
  rather than unix:/path/to/socket, as the URI technically has no host
  component. The latter form still works due to lenient parsing in the gRPC
  gRPC library, but this may change in the future, so the tests should exercise
  the correct form.

Fixes #16185.