### PR TITLE
Do not crash on URIs without a host component.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperProvider.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.authandtls.credentialhelper;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.errorprone.annotations.Immutable;
@@ -66,7 +67,12 @@ public final class CredentialHelperProvider {
   public Optional<CredentialHelper> findCredentialHelper(URI uri) {
     Preconditions.checkNotNull(uri);
 
-    String host = Preconditions.checkNotNull(uri.getHost());
+    String host = uri.getHost();
+    if (Strings.isNullOrEmpty(host)) {
+      // Some URIs (e.g. unix://) legitimately have no host component.
+      return Optional.empty();
+    }
+
     Optional<Path> credentialHelper =
         findHostCredentialHelper(host)
             .or(() -> findWildcardCredentialHelper(host))

--- a/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelperProviderTest.java
@@ -105,6 +105,15 @@ public class CredentialHelperProviderTest {
   }
 
   @Test
+  public void uriWithoutHostComponent() throws Exception {
+    Path helper = fileSystem.getPath(EXAMPLE_COM_HELPER_PATH);
+    CredentialHelperProvider provider =
+        CredentialHelperProvider.builder().add("example.com", helper).build();
+
+    assertThat(provider.findCredentialHelper(URI.create("unix:///path/to/socket"))).isEmpty();
+  }
+
+  @Test
   public void addNonExecutableDefaultHelper() throws Exception {
     Path helper = fileSystem.getPath("/path/to/non/executable");
     setUpHelper(helper);


### PR DESCRIPTION
URIs such as `unix://...` (Unix domain socket) may legitimately be missing a
host component. We should gracefully handle them when looking for a credential
helper (no such helper can exist for them since the lookup is host-based, but
this could change in the future).

Fixes #16171 which is a regression in 5.3. We had some tests for this in
remote_execution_test.sh, but they were disabled due to flakiness in 8e3c0df.
I've filed #16185 to reenable them.

Closes #16184.

PiperOrigin-RevId: 470724658
Change-Id: Ibd7203546f00fe2335c14e7a5fa6d5bf64868bac