### PR TITLE
Fix wrong nested testsuite tags 

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/model/AntXmlResultWriter.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/model/AntXmlResultWriter.java
@@ -91,13 +91,13 @@ public final class AntXmlResultWriter implements XmlResultWriter {
     writeTestCases(writer, result, parentFailures);
     writeTestSuiteOutput(writer);
 
-    writer.endElement();
-
     for (TestResult child : result.getChildResults()) {
       if (!child.getChildResults().isEmpty()) {
         writeTestSuite(writer, child, parentFailures);
       }
     }
+
+    writer.endElement();
   }
 
   private void writeTestSuiteProperties(XmlWriter writer, TestResult result) throws IOException {

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/XmlOutputExercises.ant.xml
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/XmlOutputExercises.ant.xml
@@ -3,7 +3,7 @@
     <testsuite name='com.google.testing.junit.runner.testbed.XmlOutputExercises' timestamp='' hostname='localhost' tests='7' failures='1' errors='0' time='' package='' id='0'>
         <properties />
         <system-out />
-        <system-err /></testsuite>
+    <system-err />
     <testsuite name='com.google.testing.junit.runner.testbed.XmlOutputExercises$FailureTest' timestamp='' hostname='localhost' tests='1' failures='1' errors='0' time='' package='' id='1'>
       <properties />
       <testcase name='testFail' classname='com.google.testing.junit.runner.testbed.XmlOutputExercises$FailureTest' time=''>
@@ -28,4 +28,4 @@
         <testcase name='compareToGreaterInstance' classname='com.google.testing.junit.runner.testbed.XmlOutputExercises$ComparabilityTest' time='' />
         <testcase name='compareToLessInstance' classname='com.google.testing.junit.runner.testbed.XmlOutputExercises$ComparabilityTest' time='' />
         <system-out />
-    <system-err /></testsuite></testsuites>
+      <system-err /></testsuite></testsuite></testsuites>


### PR DESCRIPTION
This fixes https://github.com/bazelbuild/bazel/issues/16191

Previously, there was an obvious error in the case of nested test suites.
For example, in the following example:

```
public class Enclosed {
    public static class Inner1 { ... }
}
```

The xml generated by previous `AntXmlResultWriter` was:

```
<testsuite name="Enclosed">
  ...
</testsuite>
<testsuite name="Enclosed$Inner1">
  ...
</testsuite>
```

This is obviously wrong. The correct xml should be:

```
<testsuite name="Enclosed">
  ...
  <testsuite name="Enclosed$Inner1">
    ...
  </testsuite>
</testsuite>
```

I'm a bit surprised it has existed for 6 years unnoticed.

RELNOTES[INC]: xml test results have been changed how nested test classes are displayed. This might either fix or break external integrations.