### PR TITLE
errors: noBuildFile suggests BUILD.bazel too

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -1431,8 +1431,9 @@ public class BzlLoadFunction implements SkyFunction {
       return new BzlLoadFailedException(
           String.format(
               "Every .bzl file must have a corresponding package, but '%s' does not have one."
-                  + " Please create a BUILD file in the same or any parent directory. Note that"
-                  + " this BUILD file does not need to do anything except exist.",
+                  + " Please create a BUILD or BUILD.bazel file in the same or any parent"
+                  + " directory. Note that this BUILD file does not need to do anything except"
+                  + " exist.",
               file),
           Code.PACKAGE_NOT_FOUND);
     }


### PR DESCRIPTION
Hi 👋🏼 apologies for the unsolicited submission, this just seemed like a simple QOL improvement for bazel errors so I figured I'd give it a shot (not sure how much of this code is shared with blaze if any at all so I understand if this can't make it in because of google3).

Because there are three kinds of files bazel really cares about (BUILD, BUILD.bazel, and *.bzl) for people unfamiliar with the system it can be confusing that BUILD.bzl, for example, wouldn't work (we've seen this happen). If the noBuildFile error message suggests either BUILD or BUILD.bazel, it becomes more obvious that those are the only two options.