### PR TITLE
Fix dynamic library lookup with remotely executed tools

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -549,18 +549,25 @@ public class CppActionConfigs {
                         "      flag_group {",
                         "        expand_if_true: 'is_cc_test'",
                         // TODO(b/27153401): This should probably be @loader_path on osx.
-                        "        flag: ",
-                        "          '-Wl,-rpath,$EXEC_ORIGIN/%{runtime_library_search_directories}'",
+                        "        flag: '-Xlinker'",
+                        "        flag: '-rpath'",
+                        "        flag: '-Xlinker'",
+                        "        flag: '$EXEC_ORIGIN/%{runtime_library_search_directories}'",
                         "      }",
                         "      flag_group {",
                         "        expand_if_false: 'is_cc_test'",
                         ifLinux(
                             platform,
-                            "        flag: '-Wl,-rpath,$ORIGIN/"
-                                + "%{runtime_library_search_directories}'"),
+                            "        flag: '-Xlinker'",
+                            "        flag: '-rpath'",
+                            "        flag: '-Xlinker'",
+                            "        flag: '$ORIGIN/" + "%{runtime_library_search_directories}'"),
                         ifMac(
                             platform,
-                            "        flag: '-Wl,-rpath,@loader_path/"
+                            "        flag: '-Xlinker'",
+                            "        flag: '-rpath'",
+                            "        flag: '-Xlinker'",
+                            "        flag: '@loader_path/"
                                 + "%{runtime_library_search_directories}'"),
                         "      }",
                         "    }",
@@ -579,11 +586,16 @@ public class CppActionConfigs {
                         "      flag_group {",
                         ifLinux(
                             platform,
-                            "        flag: '-Wl,-rpath,$ORIGIN/"
-                                + "%{runtime_library_search_directories}'"),
+                            "        flag: '-Xlinker'",
+                            "        flag: '-rpath'",
+                            "        flag: '-Xlinker'",
+                            "        flag: '$ORIGIN/" + "%{runtime_library_search_directories}'"),
                         ifMac(
                             platform,
-                            "        flag: '-Wl,-rpath,@loader_path/"
+                            "        flag: '-Xlinker'",
+                            "        flag: '-rpath'",
+                            "        flag: '-Xlinker'",
+                            "        flag: '@loader_path/"
                                 + "%{runtime_library_search_directories}'"),
                         "    }",
                         "  }",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -831,6 +831,10 @@ public final class CppConfiguration extends Fragment
     return cppOptions.objcEnableBinaryStripping;
   }
 
+  public boolean incompatibleRunfilesDirectoryRpath() {
+    return cppOptions.incompatibleRunfilesDirectoryRpath;
+  }
+
   @StarlarkMethod(
       name = "experimental_cc_implementation_deps",
       documented = false,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -855,6 +855,18 @@ public class CppOptions extends FragmentOptions {
   public boolean disableExpandIfAllAvailableInFlagSet;
 
   @Option(
+      name = "incompatible_runfiles_directory_rpath",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "If true, the main repository directory under the runfiles directory is added to the "
+              + "collection of RPATHs on cc_binary targets. This ensures that remotely executed "
+              + "cc_binary tools can find their dynamic dependencies.")
+  public boolean incompatibleRunfilesDirectoryRpath;
+
+  @Option(
       name = "experimental_includes_attribute_subpackage_traversal",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
@@ -1227,6 +1239,7 @@ public class CppOptions extends FragmentOptions {
     host.strictSystemIncludes = strictSystemIncludes;
     host.useArgsParamsFile = useArgsParamsFile;
     host.experimentalIncludeScanning = experimentalIncludeScanning;
+    host.incompatibleRunfilesDirectoryRpath = incompatibleRunfilesDirectoryRpath;
 
     // Save host options for further use.
     host.hostCoptList = hostCoptList;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
@@ -170,16 +170,18 @@ public class LibrariesToLinkCollector {
       ImmutableList.Builder<String> execRoots = ImmutableList.builder();
       // Handles cases 1, 3, 4, 5, and 7.
       execRoots.add("../".repeat(output.getRootRelativePath().segmentCount() - 1));
-      // Handle cases 2 and 6.
-      String solibRepositoryName;
-      if (isExternal && !usesLegacyRepositoryLayout) {
-        // Case 6b
-        solibRepositoryName = output.getRunfilesPath().getSegment(1);
-      } else {
-        // Cases 2 and 6a
-        solibRepositoryName = workspaceName;
+      if (cppConfiguration.incompatibleRunfilesDirectoryRpath()) {
+        // Handle cases 2 and 6.
+        String solibRepositoryName;
+        if (isExternal && !usesLegacyRepositoryLayout) {
+          // Case 6b
+          solibRepositoryName = output.getRunfilesPath().getSegment(1);
+        } else {
+          // Cases 2 and 6a
+          solibRepositoryName = workspaceName;
+        }
+        execRoots.add(output.getFilename() + ".runfiles/" + solibRepositoryName + "/");
       }
-      execRoots.add(output.getFilename() + ".runfiles/" + solibRepositoryName + "/");
       if (isExternal && usesLegacyRepositoryLayout) {
         // Handles case 8a. The runfiles path is of the form ../some_repo/pkg/file and we need to
         // walk up some_repo/pkg and then down into main_repo.

--- a/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
@@ -7922,7 +7922,10 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = [
-                            "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}",
+                            "-Xlinker",
+                            "-rpath",
+                            "-Xlinker",
+                            "@loader_path/%{runtime_library_search_directories}",
                         ],
                         iterate_over = "runtime_library_search_directories",
                         expand_if_available = "runtime_library_search_directories",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
@@ -444,7 +444,9 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
     Artifact mainBin = getBinArtifact("bin", main);
     CppLinkAction action = (CppLinkAction) getGeneratingAction(mainBin);
     List<String> linkArgv = action.getLinkCommandLine().arguments();
-    assertThat(linkArgv).contains("-Wl,-rpath,$ORIGIN/../_solib_k8/_U_S_Sa_Cfoo___Ua");
+    assertThat(linkArgv)
+        .containsAtLeast("-Xlinker", "-rpath", "-Xlinker", "$ORIGIN/../_solib_k8/_U_S_Sa_Cfoo___Ua")
+        .inOrder();
   }
 
   @Test
@@ -525,6 +527,8 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
     Artifact mainBin = getBinArtifact("bin", main);
     CppLinkAction action = (CppLinkAction) getGeneratingAction(mainBin);
     List<String> linkArgv = action.getLinkCommandLine().arguments();
-    assertThat(linkArgv).contains("-Wl,-rpath,$ORIGIN/../_solib_k8/_U_S_Sa_Cfoo___Ua");
+    assertThat(linkArgv)
+        .containsAtLeast("-Xlinker", "-rpath", "-Xlinker", "$ORIGIN/../_solib_k8/_U_S_Sa_Cfoo___Ua")
+        .inOrder();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2123,7 +2123,7 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     Artifact mainBin = getBinArtifact("main", main);
     CppLinkAction action = (CppLinkAction) getGeneratingAction(mainBin);
     assertThat(Joiner.on(" ").join(action.getLinkCommandLine().arguments()))
-        .doesNotContain("-Wl,-rpath");
+        .doesNotContain("-Xlinker -rpath");
   }
 
   @Test
@@ -2156,12 +2156,21 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     Artifact mainBin = getBinArtifact("main", main);
     CppLinkAction action = (CppLinkAction) getGeneratingAction(mainBin);
     List<String> linkArgv = action.getLinkCommandLine().arguments();
-    assertThat(linkArgv).contains("-Wl,-rpath,$ORIGIN/../_solib_k8/");
+    assertThat(linkArgv)
+        .containsAtLeast("-Xlinker", "-rpath", "-Xlinker", "$ORIGIN/../_solib_k8/")
+        .inOrder();
+    assertThat(linkArgv)
+        .containsAtLeast(
+            "-Xlinker",
+            "-rpath",
+            "-Xlinker",
+            "$ORIGIN/main.runfiles/" + TestConstants.WORKSPACE_NAME + "/_solib_k8/")
+        .inOrder();
     assertThat(linkArgv)
         .contains("-L" + TestConstants.PRODUCT_NAME + "-out/k8-fastbuild/bin/_solib_k8");
     assertThat(linkArgv).contains("-lno-transition_Slibdep1");
     assertThat(Joiner.on(" ").join(linkArgv))
-        .doesNotContain("-Wl,-rpath,$ORIGIN/../_solib_k8/../../../k8-fastbuild-ST-");
+        .doesNotContain("-Xlinker -rpath -Xlinker $ORIGIN/../_solib_k8/../../../k8-fastbuild-ST-");
     assertThat(Joiner.on(" ").join(linkArgv))
         .doesNotContain("-L" + TestConstants.PRODUCT_NAME + "-out/k8-fastbuild-ST-");
     assertThat(Joiner.on(" ").join(linkArgv)).doesNotContain("-lST-");
@@ -2216,9 +2225,18 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     Artifact mainBin = getBinArtifact("main", main);
     CppLinkAction action = (CppLinkAction) getGeneratingAction(mainBin);
     List<String> linkArgv = action.getLinkCommandLine().arguments();
-    assertThat(linkArgv).contains("-Wl,-rpath,$ORIGIN/../_solib_k8/");
+    assertThat(linkArgv)
+        .containsAtLeast("-Xlinker", "-rpath", "-Xlinker", "$ORIGIN/../_solib_k8/")
+        .inOrder();
+    assertThat(linkArgv)
+        .containsAtLeast(
+            "-Xlinker",
+            "-rpath",
+            "-Xlinker",
+            "$ORIGIN/main.runfiles/" + TestConstants.WORKSPACE_NAME + "/_solib_k8/")
+        .inOrder();
     assertThat(Joiner.on(" ").join(linkArgv))
-        .contains("-Wl,-rpath,$ORIGIN/../../../k8-fastbuild-ST-");
+        .contains("-Xlinker -rpath -Xlinker $ORIGIN/../../../k8-fastbuild-ST-");
     assertThat(Joiner.on(" ").join(linkArgv))
         .contains("-L" + TestConstants.PRODUCT_NAME + "-out/k8-fastbuild-ST-");
     assertThat(Joiner.on(" ").join(linkArgv)).containsMatch("-lST-[0-9a-f]+_transition_Slibdep2");

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -260,7 +260,9 @@ public class CppLinkActionTest extends BuildViewTestCase {
             ".* -L[^ ]*some-dir(?= ).* -L[^ ]*some-other-dir(?= ).* "
                 + "-lbar -l:qux.so(?= ).* -ldl -lutil .*");
     assertThat(Joiner.on(" ").join(arguments))
-        .matches(".* -Wl,-rpath[^ ]*some-dir(?= ).* -Wl,-rpath[^ ]*some-other-dir .*");
+        .matches(
+            ".* -Xlinker -rpath -Xlinker [^ ]*some-dir(?= ).* -Xlinker -rpath -Xlinker [^"
+                + " ]*some-other-dir .*");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
@@ -521,7 +521,8 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
         "    if binary_type == 'dylib':",
         "        linkopts.append('-dynamiclib')",
         "    elif binary_type == 'loadable_bundle':",
-        "        linkopts.extend(['-bundle', '-Wl,-rpath,@loader_path/Frameworks'])",
+        "        linkopts.extend(['-bundle', '-Xlinker', '-rpath', '-Xlinker',"
+            + " '@loader_path/Frameworks'])",
         "    if ctx.attr.bundle_loader:",
         "        bundle_loader = ctx.attr.bundle_loader",
         "        bundle_loader_file = bundle_loader[apple_common.AppleExecutableBinary].binary",
@@ -782,7 +783,7 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
     assertThat(Joiner.on(" ").join(linkAction.getArguments()))
         .contains("-bundle_loader " + getBinArtifact("bin_lipobin", binTarget).getExecPath());
     assertThat(Joiner.on(" ").join(linkAction.getArguments()))
-        .contains("-Wl,-rpath,@loader_path/Frameworks");
+        .contains("-Xlinker -rpath -Xlinker @loader_path/Frameworks");
   }
 
   protected Action lipoLibAction(String libLabel) throws Exception {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3062,4 +3062,130 @@ function test_unresolved_symlink_spawn_absolute() {
   do_test_unresolved_symlink spawn /non/existent
 }
 
+function setup_cc_binary_tool_with_dynamic_deps() {
+  local repo=$1
+
+  cat >> WORKSPACE <<'EOF'
+local_repository(
+  name = "other_repo",
+  path = "other_repo",
+)
+EOF
+
+  mkdir -p $repo
+  touch $repo/WORKSPACE
+
+  mkdir -p $repo/lib
+  # Use a comma in the target name as that is known to be problematic whith -Wl,
+  # which is commonly used to pass rpaths to the linker.
+  cat > $repo/lib/BUILD <<'EOF'
+cc_binary(
+  name = "l,ib",
+  srcs = ["lib.cpp"],
+  linkshared = True,
+  linkstatic = True,
+)
+
+cc_import(
+  name = "dynamic_l,ib",
+  shared_library = ":l,ib",
+  hdrs = ["lib.h"],
+  visibility = ["//visibility:public"],
+)
+EOF
+  cat > $repo/lib/lib.h <<'EOF'
+void print_greeting();
+EOF
+  cat > $repo/lib/lib.cpp <<'EOF'
+#include <cstdio>
+void print_greeting() {
+  printf("Hello, world!\n");
+}
+EOF
+
+  mkdir -p $repo/pkg
+  cat > $repo/pkg/BUILD <<'EOF'
+cc_binary(
+  name = "tool",
+  srcs = ["tool.cpp"],
+  deps = ["//lib:dynamic_l,ib"],
+)
+
+genrule(
+  name = "rule",
+  outs = ["out"],
+  cmd = "$(location :tool) > $@",
+  tools = [":tool"],
+)
+EOF
+  cat > $repo/pkg/tool.cpp <<'EOF'
+#include "lib/lib.h"
+int main() {
+  print_greeting();
+}
+EOF
+}
+
+function test_cc_binary_tool_with_dynamic_deps() {
+  if [[ "$PLATFORM" == "darwin" ]]; then
+    # TODO(b/37355380): This test is disabled due to RemoteWorker not supporting
+    # setting SDKROOT and DEVELOPER_DIR appropriately, as is required of
+    # action executors in order to select the appropriate Xcode toolchain.
+    return 0
+  fi
+
+  setup_cc_binary_tool_with_dynamic_deps .
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      //pkg:rule >& $TEST_log || fail "Build should succeed"
+}
+
+function test_cc_binary_tool_with_dynamic_deps_sibling_repository_layout() {
+  if [[ "$PLATFORM" == "darwin" ]]; then
+    # TODO(b/37355380): This test is disabled due to RemoteWorker not supporting
+    # setting SDKROOT and DEVELOPER_DIR appropriately, as is required of
+    # action executors in order to select the appropriate Xcode toolchain.
+    return 0
+  fi
+
+  setup_cc_binary_tool_with_dynamic_deps .
+
+  bazel build \
+      --experimental_sibling_repository_layout \
+      --remote_executor=grpc://localhost:${worker_port} \
+      //pkg:rule >& $TEST_log || fail "Build should succeed"
+}
+
+function test_external_cc_binary_tool_with_dynamic_deps() {
+  if [[ "$PLATFORM" == "darwin" ]]; then
+    # TODO(b/37355380): This test is disabled due to RemoteWorker not supporting
+    # setting SDKROOT and DEVELOPER_DIR appropriately, as is required of
+    # action executors in order to select the appropriate Xcode toolchain.
+    return 0
+  fi
+
+  setup_cc_binary_tool_with_dynamic_deps other_repo
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      @other_repo//pkg:rule >& $TEST_log || fail "Build should succeed"
+}
+
+function test_external_cc_binary_tool_with_dynamic_deps_sibling_repository_layout() {
+  if [[ "$PLATFORM" == "darwin" ]]; then
+    # TODO(b/37355380): This test is disabled due to RemoteWorker not supporting
+    # setting SDKROOT and DEVELOPER_DIR appropriately, as is required of
+    # action executors in order to select the appropriate Xcode toolchain.
+    return 0
+  fi
+
+  setup_cc_binary_tool_with_dynamic_deps other_repo
+
+  bazel build \
+      --experimental_sibling_repository_layout \
+      --remote_executor=grpc://localhost:${worker_port} \
+      @other_repo//pkg:rule >& $TEST_log || fail "Build should succeed"
+}
+
 run_suite "Remote execution and remote cache tests"

--- a/tools/cpp/osx_cc_wrapper.sh.tpl
+++ b/tools/cpp/osx_cc_wrapper.sh.tpl
@@ -42,7 +42,7 @@ function parse_option() {
         LIBS="${BASH_REMATCH[1]} $LIBS"
     elif [[ "$opt" =~ ^-L(.*)$ ]]; then
         LIB_DIRS="${BASH_REMATCH[1]} $LIB_DIRS"
-    elif [[ "$opt" =~ ^-Wl,-rpath,\@loader_path/(.*)$ ]]; then
+    elif [[ "$opt" =~ ^\@loader_path/(.*)$ ]]; then
         RPATHS="${BASH_REMATCH[1]} ${RPATHS}"
     elif [[ "$opt" = "-o" ]]; then
         # output is coming

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -486,13 +486,19 @@ def _impl(ctx):
                         flag_groups = [
                             flag_group(
                                 flags = [
-                                    "-Wl,-rpath,$EXEC_ORIGIN/%{runtime_library_search_directories}",
+                                    "-Xlinker",
+                                    "-rpath",
+                                    "-Xlinker",
+                                    "$EXEC_ORIGIN/%{runtime_library_search_directories}",
                                 ],
                                 expand_if_true = "is_cc_test",
                             ),
                             flag_group(
                                 flags = [
-                                    "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}",
+                                    "-Xlinker",
+                                    "-rpath",
+                                    "-Xlinker",
+                                    "$ORIGIN/%{runtime_library_search_directories}",
                                 ],
                                 expand_if_false = "is_cc_test",
                             ),
@@ -513,7 +519,10 @@ def _impl(ctx):
                         flag_groups = [
                             flag_group(
                                 flags = [
-                                    "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}",
+                                    "-Xlinker",
+                                    "-rpath",
+                                    "-Xlinker",
+                                    "$ORIGIN/%{runtime_library_search_directories}",
                                 ],
                             ),
                         ],

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -777,7 +777,10 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = [
-                            "-Wl,-rpath,@loader_path/%{runtime_library_search_directories}",
+                            "-Xlinker",
+                            "-rpath",
+                            "-Xlinker",
+                            "@loader_path/%{runtime_library_search_directories}",
                         ],
                         iterate_over = "runtime_library_search_directories",
                         expand_if_available = "runtime_library_search_directories",


### PR DESCRIPTION
When a cc_binary tool is executed directly (e.g. in a genrule) with
remote execution, its dynamic dependencies are only available from the
solib directory in the runfiles directory. This commit adds an
additional rpath entry for this directory.

Since target names may contain commas and the newly added rpaths contain
target names, the `-Xlinker` compiler is now used everywhere instead of
the `-Wl` flag, which doesn't support commas in linker arguments.