### PR TITLE
Provide BAZEL_CURRENT_REPOSITORY local define in cc_* rules 

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -690,7 +690,7 @@ def cc_binary_impl(ctx, additional_linkopts):
         cc_toolchain = cc_toolchain,
         user_compile_flags = cc_helper.get_copts(ctx, common, feature_configuration, additional_make_variable_substitutions),
         defines = common.defines,
-        local_defines = common.local_defines,
+        local_defines = common.local_defines + cc_helper.get_local_defines_for_runfiles_lookup(ctx),
         loose_includes = common.loose_include_dirs,
         system_includes = common.system_include_dirs,
         private_hdrs = common.private_hdrs,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -927,6 +927,9 @@ def _is_stamping_enabled_for_aspect(ctx):
         stamp = ctx.rule.attr.stamp
     return stamp
 
+def _get_local_defines_for_runfiles_lookup(ctx):
+    return ["BAZEL_CURRENT_REPOSITORY=\"{}\"".format(ctx.label.workspace_name)]
+
 cc_helper = struct(
     merge_cc_debug_contexts = _merge_cc_debug_contexts,
     is_code_coverage_enabled = _is_code_coverage_enabled,
@@ -972,4 +975,5 @@ cc_helper = struct(
     build_linking_context_from_libraries = _build_linking_context_from_libraries,
     is_stamping_enabled = _is_stamping_enabled,
     is_stamping_enabled_for_aspect = _is_stamping_enabled_for_aspect,
+    get_local_defines_for_runfiles_lookup = _get_local_defines_for_runfiles_lookup,
 )

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -58,7 +58,7 @@ def _cc_library_impl(ctx):
         feature_configuration = feature_configuration,
         user_compile_flags = cc_helper.get_copts(ctx, common, feature_configuration, additional_make_variable_substitutions),
         defines = common.defines,
-        local_defines = common.local_defines,
+        local_defines = common.local_defines + cc_helper.get_local_defines_for_runfiles_lookup(ctx),
         loose_includes = common.loose_include_dirs,
         system_includes = common.system_include_dirs,
         copts_filter = common.copts_filter,


### PR DESCRIPTION
`BAZEL_CURRENT_REPOSITORY` contains the canonical name of the repository
containing the current target and is required to look up runfiles using
apparent repository names when repository mappings are used, e.g. with
Bzlmod.

Work towards https://github.com/bazelbuild/bazel/issues/16124