### PR TITLE
Make bazel_cc_code_coverage_test more robust against GCC version diff…

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -150,8 +150,6 @@ tasks:
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/import_deps_checker/..."
-      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/16229
-      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -143,8 +143,6 @@ tasks:
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/import_deps_checker/..."
-      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/16229
-      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
   macos:
     xcode_version: "13.0"
     shards: 5


### PR DESCRIPTION
…erences

* -fprofile-dir shouldn't be used because on the g++ command line because it has different behaviour with different versions (w.r.t. where the output gcda file ends up).
* The gcda and gcno files may end up in the same directory as the object file or in the current working directory.
* The output of the gcov call in collect_cc_coverage may be "*.gcda.gcov.json.gz" or "*.gcov.json.gz" (as well as the original text file for much older GCC versions).

Also re-enable the test for Ubuntu 20.04 pre and postsubmits.

Fixes #16229