### PR TITLE
PatchUtil.java: don't sliently ignore patch chunk without prelude lines

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -395,6 +395,13 @@ public class PatchUtil {
       throws PatchFailedException {
     // If the patchContent is not empty, it should have correct format.
     if (!patchContent.isEmpty()) {
+      if (patchContent.size() < 2
+          || !patchContent.get(0).startsWith("---")
+          || !patchContent.get(1).startsWith("+++")) {
+        throw new PatchFailedException(
+            String.format(
+                "The patch content must start with ---/+++ prelude lines at line %d.", loc));
+      }
       if (header == null) {
         throw new PatchFailedException(
             String.format(


### PR DESCRIPTION
Previously, patch content without ---/+++ prelude lines was silently ignored, which may cause patch file to be incorrectly applied. For example, https://github.com/bazelbuild/bazel/pull/16233

This PR makes sure PatchUtil correctly reports the error to users.