### PR TITLE
Add `experimental_remote_cache_key_ignore_stamping` to skip volatile stamping files on compute shared cache key

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -128,6 +128,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.core.SingleObserver;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
+
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -340,7 +341,8 @@ public class RemoteExecutionService {
   public boolean mayBeExecutedRemotely(Spawn spawn) {
     return remoteCache instanceof RemoteExecutionCache
         && remoteExecutor != null
-        && Spawns.mayBeExecutedRemotely(spawn);
+        && Spawns.mayBeExecutedRemotely(spawn)
+        && !(remoteOptions.remoteCacheKeyIgnoreStamping && hasVolatileArtifacts(spawn));
   }
 
   private SortedMap<PathFragment, ActionInput> buildOutputDirMap(Spawn spawn) {
@@ -398,7 +400,7 @@ public class RemoteExecutionService {
         inputMap = newInputMap;
       }
       return MerkleTree.build(
-          inputMap,
+          filterInputs(inputMap),
           toolSignature == null ? ImmutableSet.of() : toolSignature.toolInputs,
           context.getMetadataProvider(),
           execRoot,
@@ -430,7 +432,7 @@ public class RemoteExecutionService {
     ConcurrentLinkedQueue<MerkleTree> subMerkleTrees = new ConcurrentLinkedQueue<>();
     subMerkleTrees.add(
         MerkleTree.build(
-            walker.getLeavesInputMapping(),
+            filterInputs(walker.getLeavesInputMapping()),
             metadataProvider,
             execRoot,
             artifactPathResolver,
@@ -442,6 +444,20 @@ public class RemoteExecutionService {
                   subNodeKey, subWalker, metadataProvider, artifactPathResolver));
         });
     return MerkleTree.merge(subMerkleTrees, digestUtil);
+  }
+
+  private SortedMap<PathFragment, ActionInput> filterInputs(SortedMap<PathFragment, ActionInput> inputs) {
+    if (!remoteOptions.remoteCacheKeyIgnoreStamping) {
+      return inputs;
+    }
+    SortedMap<PathFragment, ActionInput> result = new TreeMap<>();
+    for (Entry<PathFragment, ActionInput> entry : inputs.entrySet()) {
+      ActionInput input = entry.getValue();
+      if (!isConstantMetadata(input)) {
+        result.put(entry.getKey(), input);
+      }
+    }
+    return result;
   }
 
   @Nullable
@@ -1583,6 +1599,23 @@ public class RemoteExecutionService {
       reportedErrors.add(evt.getMessage());
       reporter.handle(evt);
     }
+  }
+
+  private static boolean hasVolatileArtifacts(Spawn spawn) {
+    var inputFiles = spawn.getInputFiles();
+    for (ActionInput inputFile : inputFiles.getLeaves()) {
+      if (isConstantMetadata(inputFile)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isConstantMetadata(ActionInput input) {
+    if (input instanceof Artifact) {
+      return ((Artifact) input).isConstantMetadata();
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -81,6 +81,14 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public String remoteExecutor;
 
   @Option(
+    name = "experimental_remote_cache_key_ignore_stamping",
+    defaultValue = "false",
+    documentationCategory = OptionDocumentationCategory.REMOTE,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help = "Don't use volatile stamping data in shared cache key. Also disable remote execution for stamping actions.")
+  public boolean remoteCacheKeyIgnoreStamping;
+
+  @Option(
       name = "experimental_remote_execution_keepalive",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,


### PR DESCRIPTION
Changes (enabled by `--experimental_remote_cache_key_ignore_stamping` flag):
 - added the --experimental_remote_cache_key_ignore_stamping flag, which removes volatile files from the cache key;
 - since without volatile files it is impossible to execute Action on build farm, Swap with volatile files is executes only locally.

As result, stamping spaws would execute locally, but with correct remote caching.

Related issues:
 - https://github.com/bazelbuild/bazel/issues/16231
 - https://github.com/bazelbuild/bazel/issues/10075