### PR TITLE
[5.3.1] add change to allow blaze info to skip Starlark build settings that start with --no prefix

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -333,7 +333,7 @@ public class StarlarkOptionsParser {
       String potentialStarlarkFlag = name.substring(2);
       // Check if the string uses the "no" prefix for setting boolean flags to false, trim
       // off "no" if so.
-      if (name.startsWith("no")) {
+      if (potentialStarlarkFlag.startsWith("no")) {
         potentialStarlarkFlag = potentialStarlarkFlag.substring(2);
       }
       // Check if the string contains a value, trim off the value if so.


### PR DESCRIPTION
Resolves #16257 .