### PR TITLE
Remove no-op options already no-op in Bazel 5

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
@@ -29,18 +29,6 @@ import com.google.devtools.common.options.OptionsBase;
  */
 public class AnalysisOptions extends OptionsBase {
   @Option(
-    name = "analysis_warnings_as_errors",
-    deprecationWarning =
-        "analysis_warnings_as_errors is now a no-op and will be removed in"
-            + " an upcoming Blaze release",
-    defaultValue = "false",
-    documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-    effectTags = {OptionEffectTag.NO_OP},
-    help = "Treat visible analysis warnings as errors."
-  )
-  public boolean analysisWarningsAsErrors;
-
-  @Option(
     name = "discard_analysis_cache",
     defaultValue = "false",
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -54,33 +54,6 @@ public final class BazelRulesModule extends BlazeModule {
   public static class BuildGraveyardOptions extends OptionsBase {
 
     @Option(
-        name = "incompatible_disable_legacy_proto_provider",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-        help = "Deprecated no-op.")
-    public boolean disableLegacyProtoProvider;
-
-    @Option(
-        name = "incompatible_disable_proto_source_root",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-        help = "Deprecated no-op.")
-    public boolean disableProtoSourceRoot;
-
-    @Option(
-        name = "incompatible_do_not_emit_buggy_external_repo_import",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED, OptionMetadataTag.INCOMPATIBLE_CHANGE},
-        help = "Deprecated no-op.")
-    public boolean doNotUseBuggyImportPath;
-
-    @Option(
         name = "incompatible_disable_crosstool_file",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
@@ -153,15 +126,6 @@ public final class BazelRulesModule extends BlazeModule {
         metadataTags = {OptionMetadataTag.DEPRECATED, OptionMetadataTag.INCOMPATIBLE_CHANGE},
         help = "Deprecated no-op.")
     public boolean incompatibleDisableInMemoryToolsDefaultsPackage;
-
-    @Option(
-        name = "experimental_enable_cc_toolchain_config_info",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED},
-        help = "No-op")
-    public boolean enableCcToolchainConfigInfoFromStarlark;
 
     @Option(
         name = "output_symbol_counts",
@@ -241,25 +205,6 @@ public final class BazelRulesModule extends BlazeModule {
     public boolean disableLegacyToolchainStarlarkApi;
 
     @Option(
-        name = "incompatible_disable_late_bound_option_defaults",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED, OptionMetadataTag.INCOMPATIBLE_CHANGE},
-        help = "This option is deprecated and has no effect.")
-    public boolean incompatibleDisableLateBoundOptionDefaults;
-
-    @Deprecated
-    @Option(
-        name = "ui",
-        oldName = "experimental_ui",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.UNKNOWN},
-        help = "No-op.")
-    public boolean experimentalUi;
-
-    @Option(
         name = "incompatible_enable_profile_by_default",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
@@ -267,15 +212,6 @@ public final class BazelRulesModule extends BlazeModule {
         metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
         help = "No-op.")
     public boolean enableProfileByDefault;
-
-    @Option(
-        name = "experimental_skyframe_eval_with_ordered_list",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        metadataTags = OptionMetadataTag.EXPERIMENTAL,
-        effectTags = {OptionEffectTag.NO_OP},
-        help = "No-op")
-    public boolean skyframeEvalWithOrderedList;
 
     @Option(
         name = "legacy_spawn_scheduler",
@@ -425,15 +361,6 @@ public final class BazelRulesModule extends BlazeModule {
     public boolean forceIgnoreDashStatic;
 
     @Option(
-        name = "incompatible_use_native_patch",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED, OptionMetadataTag.INCOMPATIBLE_CHANGE},
-        help = "This option is deprecated and has no effect.")
-    public boolean useNativePatch;
-
-    @Option(
         name = "experimental_profile_action_counts",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
@@ -491,43 +418,6 @@ public final class BazelRulesModule extends BlazeModule {
         effectTags = {OptionEffectTag.NO_OP},
         help = "No-op")
     public boolean experimentalAllowTopLevelAspectsParameters;
-
-    @Option(
-        name = "experimental_required_aspects",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED, OptionMetadataTag.EXPERIMENTAL},
-        help = "No-op")
-    public boolean experimentalRequiredAspects;
-
-    @Option(
-        name = "experimental_shadowed_action",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED, OptionMetadataTag.EXPERIMENTAL},
-        help = "No-op")
-    public boolean shadowedAction;
-
-    @Option(
-        name = "json_trace_compression",
-        oldName = "experimental_json_trace_compression",
-        defaultValue = "auto",
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED, OptionMetadataTag.EXPERIMENTAL},
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        help = "No-op")
-    public TriState enableTracerCompression;
-
-    @Option(
-        name = "experimental_profile_cpu_usage",
-        defaultValue = "true",
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED, OptionMetadataTag.EXPERIMENTAL},
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        help = "No-op")
-    public boolean enableCpuUsageProfiling;
 
     @Option(
         name = "bes_best_effort",

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -40,19 +40,6 @@ import javax.annotation.Nullable;
 /** Options common to all commands. */
 public class CommonCommandOptions extends OptionsBase {
 
-  /**
-   * To create a new incompatible change, see the javadoc for {@link
-   * AllIncompatibleChangesExpansion}.
-   */
-  @Option(
-      name = "all_incompatible_changes",
-      defaultValue = "null",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.NO_OP},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help = "No-op, being removed. See https://github.com/bazelbuild/bazel/issues/13892")
-  public Void allIncompatibleChanges;
-
   // It's by design that this field is unused: this command line option takes effect by reading its
   // value during options parsing based on its (string) name.
   @Option(

--- a/src/test/shell/integration/execution_phase_tests.sh
+++ b/src/test/shell/integration/execution_phase_tests.sh
@@ -392,43 +392,4 @@ function test_track_directory_crossing_package() {
       >& "$TEST_log" || fail "Expected success"
   expect_log "WARNING: Directory artifact foo/dir crosses package boundary into"
 }
-
-# Regression test for b/174837755.
-# TODO(b/172462551) Clean this up after the experiment
-function test_skyframe_eval_with_ordered_list_incremental_with_error() {
-  export DONT_SANITY_CHECK_SERIALIZATION=1
-  mkdir -p foo
-  cat > foo/BUILD <<EOF
-cc_binary(
-    name = "main",
-    srcs = [
-        "main.cc",
-    ],
-    deps = [":lib"],
-)
-
-cc_library(
-    name = "lib",
-    srcs = [
-        "lib.cc",
-        "lib.h",
-    ],
-)
-EOF
-  touch foo/lib.h
-  touch foo/main.cc
-  echo "abc" > foo/lib.cc
-
-  bazel build --experimental_skyframe_eval_with_ordered_list //foo:main \
-    &> "$TEST_log" && fail "Expected failure"
-
-  bazel build --experimental_skyframe_eval_with_ordered_list //foo:main \
-    &> "$TEST_log" && fail "Expected failure"
-
-  # The incremental run shouldn't crash bazel.
-  exit_code="$?"
-  [[ "$exit_code" -eq 1 ]] || fail "Unexpected exit code: $exit_code"
-
-  true  # reset the last exit code so the test won't be considered failed
-}
 run_suite "Integration tests of ${PRODUCT_NAME} using the execution phase."


### PR DESCRIPTION
These no-op options were already no-op in Bazel 5 LTS.