### PR TITLE
[repository/downloader] Add support for multiple header values

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
@@ -47,7 +47,7 @@ public class DelegatingDownloader implements Downloader {
   @Override
   public void download(
       List<URL> urls,
-      Map<URI, Map<String, String>> authHeaders,
+      Map<URI, Map<String, List<String>>> authHeaders,
       Optional<Checksum> checksum,
       String canonicalId,
       Path destination,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -111,7 +111,7 @@ public class DownloadManager {
    */
   public Path download(
       List<URL> originalUrls,
-      Map<URI, Map<String, String>> authHeaders,
+      Map<URI, Map<String, List<String>>> authHeaders,
       Optional<Checksum> checksum,
       String canonicalId,
       Optional<String> type,
@@ -133,7 +133,7 @@ public class DownloadManager {
     //  ctx.download{,_and_extract}, this not the case. Should be refactored to handle all .netrc
     //  parsing in one place, in Java code (similarly to #downloadAndReadOneUrl).
     ImmutableList<URL> rewrittenUrls = ImmutableList.copyOf(originalUrls);
-    Map<URI, Map<String, String>> rewrittenAuthHeaders = authHeaders;
+    Map<URI, Map<String, List<String>>> rewrittenAuthHeaders = authHeaders;
 
     if (rewriter != null) {
       ImmutableList<UrlRewriter.RewrittenURL> rewrittenUrlMappings = rewriter.amend(originalUrls);
@@ -303,7 +303,7 @@ public class DownloadManager {
     if (Thread.interrupted()) {
       throw new InterruptedException();
     }
-    Map<URI, Map<String, String>> authHeaders = ImmutableMap.of();
+    Map<URI, Map<String, List<String>>> authHeaders = ImmutableMap.of();
     ImmutableList<URL> rewrittenUrls = ImmutableList.of(originalUrl);
 
     if (netrcCreds != null) {
@@ -314,7 +314,7 @@ public class DownloadManager {
           authHeaders =
               ImmutableMap.of(
                   originalUrl.toURI(),
-                  ImmutableMap.of(headers.getKey(), headers.getValue().get(0)));
+                  ImmutableMap.of(headers.getKey(), ImmutableList.of(headers.getValue().get(0))));
         }
       } catch (URISyntaxException e) {
         // If the credentials extraction failed, we're letting bazel try without credentials.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
@@ -42,7 +42,7 @@ public interface Downloader {
    */
   void download(
       List<URL> urls,
-      Map<URI, Map<String, String>> authHeaders,
+      Map<URI, Map<String, List<String>>> authHeaders,
       Optional<Checksum> checksum,
       String canonicalId,
       Path output,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -91,7 +91,7 @@ class HttpConnector {
     return Math.round(unscaled * timeoutScaling);
   }
 
-  URLConnection connect(URL originalUrl, Function<URL, ImmutableMap<String, String>> requestHeaders)
+  URLConnection connect(URL originalUrl, Function<URL, ImmutableMap<String, List<String>>> requestHeaders)
       throws IOException {
 
     if (Thread.interrupted()) {
@@ -116,13 +116,16 @@ class HttpConnector {
             COMPRESSED_EXTENSIONS.contains(HttpUtils.getExtension(url.getPath()))
                 || COMPRESSED_EXTENSIONS.contains(HttpUtils.getExtension(originalUrl.getPath()));
         connection.setInstanceFollowRedirects(false);
-        for (Map.Entry<String, String> entry : requestHeaders.apply(url).entrySet()) {
+        for (Map.Entry<String, List<String>> entry : requestHeaders.apply(url).entrySet()) {
           if (isAlreadyCompressed && Ascii.equalsIgnoreCase(entry.getKey(), "Accept-Encoding")) {
             // We're not going to ask for compression if we're downloading a file that already
             // appears to be compressed.
             continue;
           }
-          connection.addRequestProperty(entry.getKey(), entry.getValue());
+          String key = entry.getKey();
+          for (String value : entry.getValue()) {
+            connection.addRequestProperty(key, value);
+          }
         }
         if (connection.getRequestProperty("User-Agent") == null) {
           connection.setRequestProperty("User-Agent", USER_AGENT_VALUE);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -14,9 +14,11 @@
 
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
@@ -30,6 +32,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -47,12 +50,12 @@ import java.util.Map;
 @ThreadSafe
 final class HttpConnectorMultiplexer {
 
-  private static final ImmutableMap<String, String> REQUEST_HEADERS =
+  private static final ImmutableMap<String, List<String>> REQUEST_HEADERS =
       ImmutableMap.of(
           "Accept-Encoding",
-          "gzip",
+              ImmutableList.of("gzip"),
           "User-Agent",
-          "Bazel/" + BlazeVersionInfo.instance().getReleaseName());
+          ImmutableList.of("Bazel/" + BlazeVersionInfo.instance().getReleaseName()));
 
   private final EventHandler eventHandler;
   private final HttpConnector connector;
@@ -84,8 +87,9 @@ final class HttpConnectorMultiplexer {
    *
    * @param url the URL to conenct to. can be: file, http, or https
    * @param checksum checksum lazily checked on entire payload, or empty to disable
-   * @return an {@link InputStream} of response payload
+   * @param authHeaders
    * @param type extension, e.g. "tar.gz" to force on downloaded filename, or empty to not do this
+   * @return an {@link InputStream} of response payload
    * @throws IOException if all mirrors are down and contains suppressed exception of each attempt
    * @throws InterruptedIOException if current thread is being cast into oblivion
    * @throws IllegalArgumentException if {@code urls} is empty or has an unsupported protocol
@@ -93,27 +97,27 @@ final class HttpConnectorMultiplexer {
   public HttpStream connect(
       URL url,
       Optional<Checksum> checksum,
-      Map<URI, Map<String, String>> authHeaders,
+      Map<URI, Map<String, List<String>>> authHeaders,
       Optional<String> type)
       throws IOException {
     Preconditions.checkArgument(HttpUtils.isUrlSupportedByDownloader(url));
     if (Thread.interrupted()) {
       throw new InterruptedIOException();
     }
-    Function<URL, ImmutableMap<String, String>> headerFunction =
+    Function<URL, ImmutableMap<String, List<String>>> headerFunction =
         getHeaderFunction(REQUEST_HEADERS, authHeaders);
     URLConnection connection = connector.connect(url, headerFunction);
     return httpStreamFactory.create(
         connection,
         url,
         checksum,
-        (Throwable cause, ImmutableMap<String, String> extraHeaders) -> {
+        (Throwable cause, ImmutableMap<String, List<String>> extraHeaders) -> {
           eventHandler.handle(
               Event.progress(String.format("Lost connection for %s due to %s", url, cause)));
           return connector.connect(
               connection.getURL(),
               newUrl ->
-                  new ImmutableMap.Builder<String, String>()
+                  new ImmutableMap.Builder<String, List<String>>()
                       .putAll(headerFunction.apply(newUrl))
                       .putAll(extraHeaders)
                       .buildOrThrow());
@@ -121,13 +125,14 @@ final class HttpConnectorMultiplexer {
         type);
   }
 
-  public static Function<URL, ImmutableMap<String, String>> getHeaderFunction(
-      Map<String, String> baseHeaders, Map<URI, Map<String, String>> additionalHeaders) {
+  @VisibleForTesting
+  static Function<URL, ImmutableMap<String, List<String>>> getHeaderFunction(
+      Map<String, List<String>> baseHeaders, Map<URI, Map<String, List<String>>> additionalHeaders) {
     return url -> {
-      ImmutableMap<String, String> headers = ImmutableMap.copyOf(baseHeaders);
+      ImmutableMap<String, List<String>> headers = ImmutableMap.copyOf(baseHeaders);
       try {
         if (additionalHeaders.containsKey(url.toURI())) {
-          Map<String, String> newHeaders = new HashMap<>(headers);
+          Map<String, List<String>> newHeaders = new HashMap<>(headers);
           newHeaders.putAll(additionalHeaders.get(url.toURI()));
           headers = ImmutableMap.copyOf(newHeaders);
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -63,7 +63,7 @@ public class HttpDownloader implements Downloader {
   @Override
   public void download(
       List<URL> urls,
-      Map<URI, Map<String, String>> authHeaders,
+      Map<URI, Map<String, List<String>>> authHeaders,
       Optional<Checksum> checksum,
       String canonicalId,
       Path destination,
@@ -132,7 +132,7 @@ public class HttpDownloader implements Downloader {
   /** Downloads the contents of one URL and reads it into a byte array. */
   public byte[] downloadAndReadOneUrl(
       URL url,
-      Map<URI, Map<String, String>> authHeaders,
+      Map<URI, Map<String, List<String>>> authHeaders,
       ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv)
       throws IOException, InterruptedException {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/RetryingInputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/RetryingInputStream.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
 import java.io.IOException;
@@ -22,6 +23,7 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.net.SocketTimeoutException;
 import java.net.URLConnection;
+import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -38,10 +40,9 @@ class RetryingInputStream extends InputStream {
 
   /** Lambda for establishing a connection. */
   interface Reconnector {
-
     /** Establishes a connection with the same parameters as what was passed to us initially. */
     URLConnection connect(
-        Throwable cause, ImmutableMap<String, String> extraHeaders)
+        Throwable cause, ImmutableMap<String, List<String>> extraHeaders)
             throws IOException;
   }
 
@@ -117,11 +118,11 @@ class RetryingInputStream extends InputStream {
       URLConnection connection;
       long amountRead = toto.get();
       if (amountRead == 0) {
-        connection = reconnector.connect(cause, ImmutableMap.<String, String>of());
+        connection = reconnector.connect(cause, ImmutableMap.of());
       } else {
         connection =
             reconnector.connect(
-                cause, ImmutableMap.of("Range", String.format("bytes=%d-", amountRead)));
+                cause, ImmutableMap.of("Range", ImmutableList.of(String.format("bytes=%d-", amountRead))));
         if (!Strings.nullToEmpty(connection.getHeaderField("Content-Range"))
                 .startsWith(String.format("bytes %d-", amountRead))) {
           throw new IOException(String.format(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -126,9 +126,9 @@ public class UrlRewriter {
    * @param authHeaders A map of the URLs and their corresponding auth tokens.
    * @return A map of the updated authentication headers.
    */
-  public Map<URI, Map<String, String>> updateAuthHeaders(
-      List<RewrittenURL> urls, Map<URI, Map<String, String>> authHeaders, Credentials netrcCreds) {
-    Map<URI, Map<String, String>> updatedAuthHeaders = new HashMap<>(authHeaders);
+  public Map<URI, Map<String, List<String>>> updateAuthHeaders(
+      List<RewrittenURL> urls, Map<URI, Map<String, List<String>>> authHeaders, Credentials netrcCreds) {
+    Map<URI, Map<String, List<String>>> updatedAuthHeaders = new HashMap<>(authHeaders);
 
     for (RewrittenURL url : urls) {
       // if URL was not re-written by UrlRewriter in first place, we should not attach auth headers
@@ -142,7 +142,7 @@ public class UrlRewriter {
         try {
           String token =
               "Basic " + Base64.getEncoder().encodeToString(userInfo.getBytes(ISO_8859_1));
-          updatedAuthHeaders.put(url.url().toURI(), ImmutableMap.of("Authorization", token));
+          updatedAuthHeaders.put(url.url().toURI(), ImmutableMap.of("Authorization", ImmutableList.of(token)));
         } catch (URISyntaxException e) {
           // If the credentials extraction failed, we're letting bazel try without credentials.
         }
@@ -159,7 +159,7 @@ public class UrlRewriter {
           if (firstAuthHeader.getValue() != null && !firstAuthHeader.getValue().isEmpty()) {
             updatedAuthHeaders.put(
                 url.url().toURI(),
-                ImmutableMap.of(firstAuthHeader.getKey(), firstAuthHeader.getValue().get(0)));
+                ImmutableMap.of(firstAuthHeader.getKey(), ImmutableList.of(firstAuthHeader.getValue().get(0))));
           }
         } catch (URISyntaxException | IOException e) {
           // If the credentials extraction failed, we're letting bazel try without credentials.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -154,9 +154,9 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
    * authentication, adding those headers is enough; for other forms of authentication other
    * measures might be necessary.
    */
-  private static ImmutableMap<URI, Map<String, String>> getAuthHeaders(Map<String, Dict<?, ?>> auth)
+  private static ImmutableMap<URI, Map<String, List<String>>> getAuthHeaders(Map<String, Dict<?, ?>> auth)
       throws RepositoryFunctionException, EvalException {
-    ImmutableMap.Builder<URI, Map<String, String>> headers = new ImmutableMap.Builder<>();
+    ImmutableMap.Builder<URI, Map<String, List<String>>> headers = new ImmutableMap.Builder<>();
     for (Map.Entry<String, Dict<?, ?>> entry : auth.entrySet()) {
       try {
         URL url = new URL(entry.getKey());
@@ -174,7 +174,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
                 url.toURI(),
                 ImmutableMap.of(
                     "Authorization",
-                    "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(UTF_8))));
+                    ImmutableList.of("Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(UTF_8)))));
           } else if ("pattern".equals(authMap.get("type"))) {
             if (!authMap.containsKey("pattern")) {
               throw Starlark.errorf(
@@ -201,7 +201,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
               result = result.replaceAll(demarcatedComponent, (String) authMap.get(component));
             }
 
-            headers.put(url.toURI(), ImmutableMap.of("Authorization", result));
+            headers.put(url.toURI(), ImmutableMap.of("Authorization", ImmutableList.of(result)));
           }
         }
       } catch (MalformedURLException e) {
@@ -445,7 +445,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
       String integrity,
       StarlarkThread thread)
       throws RepositoryFunctionException, EvalException, InterruptedException {
-    ImmutableMap<URI, Map<String, String>> authHeaders =
+    ImmutableMap<URI, Map<String, List<String>>> authHeaders =
         getAuthHeaders(getAuthContents(authUnchecked, "auth"));
 
     ImmutableList<URL> urls =
@@ -634,7 +634,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
       Dict<?, ?> renameFiles, // <String, String> expected
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
-    ImmutableMap<URI, Map<String, String>> authHeaders =
+    ImmutableMap<URI, Map<String, List<String>>> authHeaders =
         getAuthHeaders(getAuthContents(auth, "auth"));
 
     ImmutableList<URL> urls =

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -23,6 +23,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
 import com.google.devtools.build.lib.bazel.repository.downloader.HashOutputStream;
@@ -105,14 +106,14 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
 
   @Override
   public void download(
-      List<URL> urls,
-      Map<URI, Map<String, String>> authHeaders,
-      com.google.common.base.Optional<Checksum> checksum,
-      String canonicalId,
-      Path destination,
-      ExtendedEventHandler eventHandler,
-      Map<String, String> clientEnv,
-      com.google.common.base.Optional<String> type)
+          List<URL> urls,
+          Map<URI, Map<String, List<String>>> authHeaders,
+          com.google.common.base.Optional<Checksum> checksum,
+          String canonicalId,
+          Path destination,
+          ExtendedEventHandler eventHandler,
+          Map<String, String> clientEnv,
+          com.google.common.base.Optional<String> type)
       throws IOException, InterruptedException {
     RequestMetadata metadata =
         TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "remote_downloader", null);
@@ -148,7 +149,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
   static FetchBlobRequest newFetchBlobRequest(
       String instanceName,
       List<URL> urls,
-      Map<URI, Map<String, String>> authHeaders,
+      Map<URI, Map<String, List<String>>> authHeaders,
       com.google.common.base.Optional<Checksum> checksum,
       String canonicalId) {
     FetchBlobRequest.Builder requestBuilder =
@@ -197,13 +198,17 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     return out;
   }
 
-  private static String authHeadersJson(Map<URI, Map<String, String>> authHeaders) {
+  private static String authHeadersJson(Map<URI, Map<String, List<String>>> authHeaders) {
     Map<String, JsonObject> subObjects = new TreeMap<>();
-    for (Map.Entry<URI, Map<String, String>> entry : authHeaders.entrySet()) {
+    for (Map.Entry<URI, Map<String, List<String>>> entry : authHeaders.entrySet()) {
       JsonObject subObject = new JsonObject();
-      Map<String, String> orderedHeaders = new TreeMap<>(entry.getValue());
-      for (Map.Entry<String, String> subEntry : orderedHeaders.entrySet()) {
-        subObject.addProperty(subEntry.getKey(), subEntry.getValue());
+      Map<String, List<String>> orderedHeaders = new TreeMap<>(entry.getValue());
+      for (Map.Entry<String, List<String>> subEntry : orderedHeaders.entrySet()) {
+        // TODO(yannic): Introduce incompatible flag for including all headers, not just the first.
+        String value = Iterables.getFirst(subEntry.getValue(), null);
+        if (value != null) {
+          subObject.addProperty(subEntry.getKey(), value);
+        }
       }
       subObjects.put(entry.getKey().toString(), subObject);
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
 import com.google.devtools.build.lib.bazel.repository.downloader.RetryingInputStream.Reconnector;
@@ -40,6 +41,7 @@ import java.io.InterruptedIOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
@@ -149,50 +151,47 @@ public class HttpConnectorMultiplexerTest {
 
   @Test
   public void testHeaderComputationFunction() throws Exception {
-    Map<String, String> baseHeaders =
-        ImmutableMap.of("Accept-Encoding", "gzip", "User-Agent", "Bazel/testing");
-    Map<URI, Map<String, String>> additionalHeaders =
+    Map<String, List<String>> baseHeaders =
+        ImmutableMap.of("Accept-Encoding", ImmutableList.of("gzip"), "User-Agent", ImmutableList.of("Bazel/testing"));
+    Map<URI, Map<String, List<String>>> additionalHeaders =
         ImmutableMap.of(
             new URI("http://hosting.example.com/user/foo/file.txt"),
-            ImmutableMap.of("Authentication", "Zm9vOmZvb3NlY3JldA=="));
+            ImmutableMap.of("Authentication", ImmutableList.of("Zm9vOmZvb3NlY3JldA==")));
 
-    Function<URL, ImmutableMap<String, String>> headerFunction =
+    Function<URL, ImmutableMap<String, List<String>>> headerFunction =
         HttpConnectorMultiplexer.getHeaderFunction(baseHeaders, additionalHeaders);
 
     // Unreleated URL
     assertThat(headerFunction.apply(new URL("http://example.org/some/path/file.txt")))
-        .containsExactly("Accept-Encoding", "gzip", "User-Agent", "Bazel/testing");
+        .containsExactly("Accept-Encoding", ImmutableList.of("gzip"), "User-Agent", ImmutableList.of("Bazel/testing"));
 
     // With auth headers
     assertThat(headerFunction.apply(new URL("http://hosting.example.com/user/foo/file.txt")))
         .containsExactly(
-            "Accept-Encoding",
-            "gzip",
-            "User-Agent",
-            "Bazel/testing",
+                "Accept-Encoding", ImmutableList.of("gzip"), "User-Agent", ImmutableList.of("Bazel/testing"),
             "Authentication",
-            "Zm9vOmZvb3NlY3JldA==");
+            ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
 
     // Other hosts
     assertThat(headerFunction.apply(new URL("http://hosting2.example.com/user/foo/file.txt")))
-        .containsExactly("Accept-Encoding", "gzip", "User-Agent", "Bazel/testing");
+        .containsExactly("Accept-Encoding", ImmutableList.of("gzip"), "User-Agent", ImmutableList.of("Bazel/testing"));
     assertThat(headerFunction.apply(new URL("http://sub.hosting.example.com/user/foo/file.txt")))
-        .containsExactly("Accept-Encoding", "gzip", "User-Agent", "Bazel/testing");
+        .containsExactly("Accept-Encoding", ImmutableList.of("gzip"), "User-Agent", ImmutableList.of("Bazel/testing"));
     assertThat(headerFunction.apply(new URL("http://example.com/user/foo/file.txt")))
-        .containsExactly("Accept-Encoding", "gzip", "User-Agent", "Bazel/testing");
+        .containsExactly("Accept-Encoding", ImmutableList.of("gzip"), "User-Agent", ImmutableList.of("Bazel/testing"));
     assertThat(
             headerFunction.apply(
                 new URL("http://hosting.example.com.evil.example/user/foo/file.txt")))
-        .containsExactly("Accept-Encoding", "gzip", "User-Agent", "Bazel/testing");
+        .containsExactly("Accept-Encoding", ImmutableList.of("gzip"), "User-Agent", ImmutableList.of("Bazel/testing"));
 
     // Verify that URL-specific headers overwrite
-    Map<String, String> annonAuth =
-        ImmutableMap.of("Authentication", "YW5vbnltb3VzOmZvb0BleGFtcGxlLm9yZw==");
-    Function<URL, ImmutableMap<String, String>> combinedHeaders =
+    Map<String, List<String>> annonAuth =
+        ImmutableMap.of("Authentication", ImmutableList.of("YW5vbnltb3VzOmZvb0BleGFtcGxlLm9yZw=="));
+    Function<URL, ImmutableMap<String, List<String>>> combinedHeaders =
         HttpConnectorMultiplexer.getHeaderFunction(annonAuth, additionalHeaders);
     assertThat(combinedHeaders.apply(new URL("http://hosting.example.com/user/foo/file.txt")))
-        .containsExactly("Authentication", "Zm9vOmZvb3NlY3JldA==");
+        .containsExactly("Authentication", ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
     assertThat(combinedHeaders.apply(new URL("http://unreleated.example.org/user/foo/file.txt")))
-        .containsExactly("Authentication", "YW5vbnltb3VzOmZvb0BleGFtcGxlLm9yZw==");
+        .containsExactly("Authentication", ImmutableList.of("YW5vbnltb3VzOmZvb0BleGFtcGxlLm9yZw=="));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
@@ -46,6 +47,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -110,7 +112,7 @@ public class HttpConnectorTest {
                 connector
                     .connect(
                         createTempFile(fileContents).toURI().toURL(),
-                        url -> ImmutableMap.<String, String>of())
+                        url -> ImmutableMap.of())
                     .getInputStream()))
         .isEqualTo(fileContents);
   }
@@ -119,12 +121,12 @@ public class HttpConnectorTest {
   public void badHost_throwsIOException() throws Exception {
     thrown.expect(IOException.class);
     thrown.expectMessage("Unknown host: bad.example");
-    connector.connect(new URL("http://bad.example"), url -> ImmutableMap.<String, String>of());
+    connector.connect(new URL("http://bad.example"), url -> ImmutableMap.of());
   }
 
   @Test
   public void normalRequest() throws Exception {
-    final Map<String, String> headers = new ConcurrentHashMap<>();
+    final Map<String, List<String>> headers = new ConcurrentHashMap<>();
     try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       @SuppressWarnings("unused") 
       Future<?> possiblyIgnoredError =
@@ -152,15 +154,15 @@ public class HttpConnectorTest {
               connector
                   .connect(
                       new URL(String.format("http://localhost:%d/boo", server.getLocalPort())),
-                      url -> ImmutableMap.of("Content-Encoding", "gzip"))
+                      url -> ImmutableMap.of("Content-Encoding", ImmutableList.of("gzip")))
                   .getInputStream(),
               ISO_8859_1)) {
         assertThat(CharStreams.toString(payload)).isEqualTo("hello");
       }
     }
-    assertThat(headers).containsEntry("x-method", "GET");
-    assertThat(headers).containsEntry("x-request-uri", "/boo");
-    assertThat(headers).containsEntry("content-encoding", "gzip");
+    assertThat(headers).containsEntry("x-method", ImmutableList.of("GET"));
+    assertThat(headers).containsEntry("x-request-uri", ImmutableList.of("/boo"));
+    assertThat(headers).containsEntry("content-encoding", ImmutableList.of("gzip"));
   }
 
   @Test
@@ -204,7 +206,7 @@ public class HttpConnectorTest {
               connector
                   .connect(
                       new URL(String.format("http://localhost:%d", server.getLocalPort())),
-                      url -> ImmutableMap.<String, String>of())
+                      url -> ImmutableMap.of())
                   .getInputStream(),
               ISO_8859_1)) {
         assertThat(CharStreams.toString(payload)).isEqualTo("hello");
@@ -263,7 +265,7 @@ public class HttpConnectorTest {
               connector
                   .connect(
                       new URL(String.format("http://localhost:%d", port)),
-                      url -> ImmutableMap.<String, String>of())
+                      url -> ImmutableMap.of())
                   .getInputStream(),
               ISO_8859_1)) {
         assertThat(CharStreams.toString(payload)).isEqualTo("hello");
@@ -323,7 +325,7 @@ public class HttpConnectorTest {
               connector
                   .connect(
                       new URL(String.format("http://localhost:%d", server.getLocalPort())),
-                      url -> ImmutableMap.<String, String>of())
+                      url -> ImmutableMap.of())
                   .getInputStream(),
               ISO_8859_1)) {
         assertThat(CharStreams.toString(payload)).isEqualTo("hello");
@@ -356,7 +358,7 @@ public class HttpConnectorTest {
               connector
                   .connect(
                       new URL(String.format("http://localhost:%d", server.getLocalPort())),
-                      url -> ImmutableMap.<String, String>of())
+                      url -> ImmutableMap.of())
                   .getInputStream(),
               ISO_8859_1)) {
         fail("Should have thrown");
@@ -395,7 +397,7 @@ public class HttpConnectorTest {
       thrown.expectMessage("401 Unauthorized");
       connector.connect(
           new URL(String.format("http://localhost:%d", server.getLocalPort())),
-          url -> ImmutableMap.<String, String>of());
+          url -> ImmutableMap.of());
     }
   }
 
@@ -427,7 +429,7 @@ public class HttpConnectorTest {
       thrown.expectMessage("404 Not Found");
       connector.connect(
           new URL(String.format("http://localhost:%d", server.getLocalPort())),
-          url -> ImmutableMap.<String, String>of());
+          url -> ImmutableMap.of());
     }
   }
 
@@ -462,7 +464,7 @@ public class HttpConnectorTest {
               });
       connector.connect(
           new URL(String.format("http://localhost:%d", server.getLocalPort())),
-          url -> ImmutableMap.<String, String>of());
+          url -> ImmutableMap.of());
       fail();
     } catch (IOException ignored) {
       // ignored
@@ -505,7 +507,7 @@ public class HttpConnectorTest {
       try {
         connector.connect(
             new URL(String.format("http://localhost:%d", server.getLocalPort())),
-            url -> ImmutableMap.<String, String>of());
+            url -> ImmutableMap.of());
       } finally {
         assertThat(tries.get()).isGreaterThan(2);
       }
@@ -544,7 +546,7 @@ public class HttpConnectorTest {
       try {
         connector.connect(
             new URL(String.format("http://localhost:%d", server.getLocalPort())),
-            url -> ImmutableMap.<String, String>of());
+            url -> ImmutableMap.of());
       } finally {
         assertThat(tries.get()).isGreaterThan(2);
       }
@@ -576,8 +578,8 @@ public class HttpConnectorTest {
 
   public void redirectToDifferentPath_works(String code) throws Exception {
     String redirectCode = "HTTP/1.1 " + code + " Redirect";
-    final Map<String, String> headers1 = new ConcurrentHashMap<>();
-    final Map<String, String> headers2 = new ConcurrentHashMap<>();
+    final Map<String, List<String>> headers1 = new ConcurrentHashMap<>();
+    final Map<String, List<String>> headers2 = new ConcurrentHashMap<>();
     try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       @SuppressWarnings("unused")
       Future<?> possiblyIgnoredError =
@@ -615,23 +617,23 @@ public class HttpConnectorTest {
       URLConnection connection =
           connector.connect(
               new URL(String.format("http://localhost:%d", server.getLocalPort())),
-              url -> ImmutableMap.<String, String>of());
+              url -> ImmutableMap.of());
       assertThat(connection.getURL()).isEqualTo(
           new URL(String.format("http://localhost:%d/doodle.tar.gz", server.getLocalPort())));
       try (InputStream input = connection.getInputStream()) {
         assertThat(ByteStreams.toByteArray(input)).isEmpty();
       }
     }
-    assertThat(headers1).containsEntry("x-request-uri", "/");
-    assertThat(headers2).containsEntry("x-request-uri", "/doodle.tar.gz");
+    assertThat(headers1).containsEntry("x-request-uri", ImmutableList.of("/"));
+    assertThat(headers2).containsEntry("x-request-uri", ImmutableList.of("/doodle.tar.gz"));
   }
 
   public void redirectToDifferentServer_works(String code) throws Exception {
     String redirectCode = "HTTP/1.1 " + code + " Redirect";
     final String basic1 = "Basic b25lOmZpcnN0c2VjcmV0";
     final String basic2 = "Basic dHdvOnNlY29uZHNlY3JldA==";
-    final Map<String, String> headers1 = new ConcurrentHashMap<>();
-    final Map<String, String> headers2 = new ConcurrentHashMap<>();
+    final Map<String, List<String>> headers1 = new ConcurrentHashMap<>();
+    final Map<String, List<String>> headers2 = new ConcurrentHashMap<>();
     try (ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
         ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       @SuppressWarnings("unused")
@@ -679,16 +681,16 @@ public class HttpConnectorTest {
               });
       // Header function that provides different auth headers for
       // the two servers.
-      Function<URL, ImmutableMap<String, String>> authHeaders =
-          new Function<URL, ImmutableMap<String, String>>() {
+      Function<URL, ImmutableMap<String, List<String>>> authHeaders =
+          new Function<>() {
             @Override
-            public ImmutableMap<String, String> apply(URL url) {
+            public ImmutableMap<String, List<String>> apply(URL url) {
               if (url.getPort() == server1.getLocalPort()) {
-                return ImmutableMap.of("Authentication", basic1);
+                return ImmutableMap.of("Authentication", ImmutableList.of(basic1));
               } else if (url.getPort() == server2.getLocalPort()) {
-                return ImmutableMap.of("Authentication", basic2);
+                return ImmutableMap.of("Authentication", ImmutableList.of(basic2));
               } else {
-                return ImmutableMap.<String, String>of();
+                return ImmutableMap.of();
               }
             }
           };
@@ -701,8 +703,8 @@ public class HttpConnectorTest {
         assertThat(ByteStreams.toByteArray(input)).isEqualTo("hello".getBytes(US_ASCII));
       }
       // Verify that the correct form of authentication is used for each server.
-      assertThat(headers1).containsEntry("authentication", basic1);
-      assertThat(headers2).containsEntry("authentication", basic2);
+      assertThat(headers1).containsEntry("authentication", ImmutableList.of(basic1));
+      assertThat(headers2).containsEntry("authentication", ImmutableList.of(basic2));
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpParser.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpParser.java
@@ -15,9 +15,12 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.common.base.Ascii;
+import com.google.common.collect.ImmutableList;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /** Utility class for parsing HTTP messages. */
@@ -25,7 +28,7 @@ final class HttpParser {
 
   /** Exhausts request line and headers of HTTP request. */
   static void readHttpRequest(InputStream stream) throws IOException {
-    readHttpRequest(stream, new HashMap<String, String>());
+    readHttpRequest(stream, new HashMap<>());
   }
 
   /**
@@ -37,7 +40,7 @@ final class HttpParser {
    * @throws IOException if reading failed or premature end of stream encountered
    * @throws HttpParserError if 400 error should be sent to client and connection must be closed
    */
-  static void readHttpRequest(InputStream stream, Map<String, String> output) throws IOException {
+  static void readHttpRequest(InputStream stream, Map<String, List<String>> output) throws IOException {
     StringBuilder builder = new StringBuilder(256);
     State state = State.METHOD;
     String key = "";
@@ -56,7 +59,7 @@ final class HttpParser {
             if (builder.length() == 0) {
               throw new HttpParserError();
             }
-            output.put("x-method", builder.toString());
+            output.put("x-method", ImmutableList.of(builder.toString()));
             builder.setLength(0);
             state = State.URI;
           } else if (c == '\r' || c == '\n') {
@@ -70,7 +73,7 @@ final class HttpParser {
             if (builder.length() == 0) {
               throw new HttpParserError();
             }
-            output.put("x-request-uri", builder.toString());
+            output.put("x-request-uri", ImmutableList.of(builder.toString()));
             builder.setLength(0);
             state = State.VERSION;
           } else {
@@ -79,7 +82,7 @@ final class HttpParser {
           break;
         case VERSION:
           if (c == '\r' || c == '\n') {
-            output.put("x-version", builder.toString());
+            output.put("x-version", ImmutableList.of(builder.toString()));
             builder.setLength(0);
             state = c == '\r' ? State.CR1 : State.LF1;
           } else {
@@ -120,7 +123,7 @@ final class HttpParser {
           // fall through
         case HVAL:
           if (c == '\r' || c == '\n') {
-            output.put(key, builder.toString());
+            output.put(key, ImmutableList.of(builder.toString()));
             builder.setLength(0);
             state = c == '\r' ? State.CR1 : State.LF1;
           } else {

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/RetryingInputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/RetryingInputStreamTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.repository.downloader.RetryingInputStream.Reconnector;
 import java.io.IOException;
@@ -94,7 +95,7 @@ public class RetryingInputStreamTest {
     when(connection.getHeaderField("Content-Range")).thenReturn("bytes 1-42/42");
     assertThat(stream.read()).isEqualTo(1);
     assertThat(stream.read()).isEqualTo(2);
-    verify(reconnector).connect(any(Throwable.class), eq(ImmutableMap.of("Range", "bytes=1-")));
+    verify(reconnector).connect(any(Throwable.class), eq(ImmutableMap.of("Range", ImmutableList.of("bytes=1-"))));
     verify(delegate, times(2)).read();
     verify(delegate).close();
     verify(newDelegate).read();
@@ -108,7 +109,7 @@ public class RetryingInputStreamTest {
     when(reconnector.connect(any(Throwable.class), any(ImmutableMap.class))).thenReturn(connection);
     when(connection.getInputStream()).thenReturn(newDelegate);
     assertThat(stream.read()).isEqualTo(1);
-    verify(reconnector).connect(any(Throwable.class), eq(ImmutableMap.<String, String>of()));
+    verify(reconnector).connect(any(Throwable.class), eq(ImmutableMap.of()));
     verify(delegate).read();
     verify(delegate).close();
     verify(newDelegate).read();
@@ -142,7 +143,7 @@ public class RetryingInputStreamTest {
     SocketTimeoutException e = assertThrows(SocketTimeoutException.class, () -> stream.read());
     assertThat(e.getSuppressed()).hasLength(3);
       verify(reconnector, times(3))
-          .connect(any(Throwable.class), eq(ImmutableMap.of("Range", "bytes=1-")));
+          .connect(any(Throwable.class), eq(ImmutableMap.of("Range", ImmutableList.of("bytes=1-"))));
       verify(delegate, times(5)).read();
     verify(delegate, times(3)).close();
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -317,7 +317,7 @@ public class UrlRewriterTest {
                 new URL("https://my.example.com/from_other_netrc_entry/bar"),
                 new URL("https://my.example.com/no_creds/bar"),
                 new URL("https://should-not-be-overridden.com/")));
-    Map<URI, Map<String, String>> updatedAuthHeaders =
+    Map<URI, Map<String, List<String>>> updatedAuthHeaders =
         munger.updateAuthHeaders(amended, ImmutableMap.of(), netrc);
 
     String expectedToken =
@@ -330,11 +330,11 @@ public class UrlRewriterTest {
     assertThat(updatedAuthHeaders)
         .containsExactly(
             new URI("https://user:password@mycorp.com/foo/bar"),
-            ImmutableMap.of("Authorization", expectedToken),
+            ImmutableMap.of("Authorization", ImmutableList.of(expectedToken)),
             new URI("https://mycorp.com/from_netrc/bar"),
-            ImmutableMap.of("Authorization", expectedFirstNetrcToken),
+            ImmutableMap.of("Authorization", ImmutableList.of(expectedFirstNetrcToken)),
             new URI("https://myothercorp.com/from_netrc/bar"),
-            ImmutableMap.of("Authorization", expectedSecondNetrcToken));
+            ImmutableMap.of("Authorization", ImmutableList.of(expectedSecondNetrcToken)));
     // yet all four urls should be present
     assertThat(amended)
         .containsExactly(

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -160,7 +160,7 @@ public class GrpcRemoteDownloaderTest {
       guavaChecksum = com.google.common.base.Optional.<Checksum>of(checksum.get());
     }
 
-    final Map<URI, Map<String, String>> authHeaders = ImmutableMap.of();
+    final Map<URI, Map<String, List<String>>> authHeaders = ImmutableMap.of();
     final String canonicalId = "";
     final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
     final Map<String, String> clientEnv = ImmutableMap.of();
@@ -308,10 +308,10 @@ public class GrpcRemoteDownloaderTest {
             ImmutableMap.of(
                 new URI("http://example.com"),
                 ImmutableMap.of(
-                    "Some-Header", "some header content",
-                    "Another-Header", "another header content"),
+                    "Some-Header", ImmutableList.of("some header content"),
+                    "Another-Header", ImmutableList.of("another header content")),
                 new URI("http://example.org"),
-                ImmutableMap.of("Org-Header", "org header content")),
+                ImmutableMap.of("Org-Header", ImmutableList.of("org header content"))),
             com.google.common.base.Optional.<Checksum>of(
                 Checksum.fromSubresourceIntegrity(
                     "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),


### PR DESCRIPTION
Headers can generally be specified multiple times, not just once.

This refactoring is prerequisite for adding support for getting credentials from the credential helper.

Note that this does not change the Starlark API or the qualifier for the gRPC remote downloader (both of which need to go through the process for incompatible changes - which should hopefully be pretty straight forward to do as this feature doesn't seem to be used that much AFAICT).

Progress on #15856