### PR TITLE
Allow C/C++ coverage collection for external targets

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -109,17 +109,22 @@ function test_cc_test_llvm_coverage_doesnt_fail() {
 }
 
 function test_cc_test_llvm_coverage_produces_lcov_report() {
-  local -r llvm_profdata="/usr/bin/llvm-profdata-9"
+  local -r clang="/usr/bin/clang"
+  if [[ ! -x ${clang} ]]; then
+    return
+  fi
+  local -r clang_version=$(clang --version | grep -o "clang version [0-9]*" | cut -d " " -f 3)
+  if [ "$clang_version" -lt 9 ] || [ "$clang_version" -eq 10 ] || [ "$clang_version" -eq 11 ]; then
+    # No lcov produced with <9.0, no branch coverage with 10.0 and 11.0.
+    echo "clang versions <9.0 as well as 10.0 and 11.0 are not supported." && return
+  fi
+
+  local -r llvm_profdata="/usr/bin/llvm-profdata"
   if [[ ! -x ${llvm_profdata} ]]; then
     return
   fi
 
-  local -r clang="/usr/bin/clang-9"
-  if [[ ! -x ${clang} ]]; then
-    return
-  fi
-
-  local -r llvm_cov="/usr/bin/llvm-cov-9"
+  local -r llvm_cov="/usr/bin/llvm-cov"
   if [[ ! -x ${llvm_cov} ]]; then
     return
   fi
@@ -150,17 +155,22 @@ end_of_record"
 }
 
 function test_cc_test_with_runtime_objects_not_in_runfiles() {
-  local -r llvm_profdata="/usr/bin/llvm-profdata-9"
+  local -r clang="/usr/bin/clang"
+  if [[ ! -x ${clang} ]]; then
+    return
+  fi
+  local -r clang_version=$(clang --version | grep -o "clang version [0-9]*" | cut -d " " -f 3)
+  if [ "$clang_version" -lt 9 ] || [ "$clang_version" -eq 10 ] || [ "$clang_version" -eq 11 ]; then
+    # No lcov produced with <9.0, no branch coverage with 10.0 and 11.0.
+    echo "clang versions <9.0 as well as 10.0 and 11.0 are not supported." && return
+  fi
+
+  local -r llvm_profdata="/usr/bin/llvm-profdata"
   if [[ ! -x ${llvm_profdata} ]]; then
     return
   fi
 
-  local -r clang="/usr/bin/clang-9"
-  if [[ ! -x ${clang} ]]; then
-    return
-  fi
-
-  local -r llvm_cov="/usr/bin/llvm-cov-9"
+  local -r llvm_cov="/usr/bin/llvm-cov"
   if [[ ! -x ${llvm_cov} ]]; then
     return
   fi
@@ -296,17 +306,22 @@ EOF
 }
 
 function test_external_cc_target_can_collect_coverage() {
-  local -r llvm_profdata="/usr/bin/llvm-profdata-9"
+  local -r clang="/usr/bin/clang"
+  if [[ ! -x ${clang} ]]; then
+    return
+  fi
+  local -r clang_version=$(clang --version | grep -o "clang version [0-9]*" | cut -d " " -f 3)
+  if [ "$clang_version" -lt 9 ] || [ "$clang_version" -eq 10 ] || [ "$clang_version" -eq 11 ]; then
+    # No lcov produced with <9.0, no branch coverage with 10.0 and 11.0.
+    echo "clang versions <9.0 as well as 10.0 and 11.0 are not supported." && return
+  fi
+
+  local -r llvm_profdata="/usr/bin/llvm-profdata"
   if [[ ! -x ${llvm_profdata} ]]; then
     return
   fi
 
-  local -r clang="/usr/bin/clang-9"
-  if [[ ! -x ${clang} ]]; then
-    return
-  fi
-
-  local -r llvm_cov="/usr/bin/llvm-cov-9"
+  local -r llvm_cov="/usr/bin/llvm-cov"
   if [[ ! -x ${llvm_cov} ]]; then
     return
   fi
@@ -362,17 +377,22 @@ end_of_record'
 }
 
 function test_external_cc_target_coverage_not_collected_by_default() {
-  local -r llvm_profdata="/usr/bin/llvm-profdata-9"
+  local -r clang="/usr/bin/clang"
+  if [[ ! -x ${clang} ]]; then
+    return
+  fi
+  local -r clang_version=$(clang --version | grep -o "clang version [0-9]*" | cut -d " " -f 3)
+  if [ "$clang_version" -lt 9 ] || [ "$clang_version" -eq 10 ] || [ "$clang_version" -eq 11 ]; then
+    # No lcov produced with <9.0, no branch coverage with 10.0 and 11.0.
+    echo "clang versions <9.0 as well as 10.0 and 11.0 are not supported." && return
+  fi
+
+  local -r llvm_profdata="/usr/bin/llvm-profdata"
   if [[ ! -x ${llvm_profdata} ]]; then
     return
   fi
 
-  local -r clang="/usr/bin/clang-9"
-  if [[ ! -x ${clang} ]]; then
-    return
-  fi
-
-  local -r llvm_cov="/usr/bin/llvm-cov-9"
+  local -r llvm_cov="/usr/bin/llvm-cov"
   if [[ ! -x ${llvm_cov} ]]; then
     return
   fi

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -93,7 +93,6 @@ function llvm_coverage_lcov() {
   done < "${COVERAGE_MANIFEST}"
 
   "${LLVM_COV}" export -instr-profile "${output_file}.data" -format=lcov \
-      -ignore-filename-regex='.*external/.+' \
       -ignore-filename-regex='/tmp/.+' \
       ${object_param} | sed 's#/proc/self/cwd/##' > "${output_file}"
 }

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -235,7 +235,6 @@ LCOV_MERGER_CMD="${LCOV_MERGER} --coverage_dir=${COVERAGE_DIR} \
   --filter_sources=/usr/lib/.+ \
   --filter_sources=/usr/include.+ \
   --filter_sources=/Applications/.+ \
-  --filter_sources=.*external/.+ \
   --source_file_manifest=${COVERAGE_MANIFEST}"
 
 if [[ $COVERAGE_REPORTED_TO_ACTUAL_SOURCES_FILE ]]; then


### PR DESCRIPTION
Removes hardcoded filters that result in no coverage being reported for `cc_*` targets in external repositories even when matched by the `--instrumentation_filter`.

Work towards #16228
Work towards #16208