### PR TITLE
Make --modify_execution_info additive

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1660,6 +1660,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:build_configuration_event",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_limits",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/execution_info_modifier",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/cmdline",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -894,7 +894,7 @@ public class BuildConfigurationValue
    */
   public ImmutableMap<String, String> modifiedExecutionInfo(
       ImmutableMap<String, String> executionInfo, String mnemonic) {
-    if (!options.executionInfoModifier.matches(mnemonic)) {
+    if (!ExecutionInfoModifier.collapse(options.executionInfoModifier, options.additiveModifyExecutionInfo).matches(mnemonic)) {
       return executionInfo;
     }
     Map<String, String> mutableCopy = new HashMap<>(executionInfo);
@@ -904,7 +904,7 @@ public class BuildConfigurationValue
 
   /** Applies {@code executionInfoModifiers} to the given {@code executionInfo}. */
   public void modifyExecutionInfo(Map<String, String> executionInfo, String mnemonic) {
-    options.executionInfoModifier.apply(mnemonic, executionInfo);
+    ExecutionInfoModifier.collapse(options.executionInfoModifier, options.additiveModifyExecutionInfo).apply(mnemonic, executionInfo);
   }
 
   /** Returns the list of default features used for all packages. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -807,14 +807,15 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
   @Option(
       name = "modify_execution_info",
+      allowMultiple = true,
       converter = ExecutionInfoModifier.Converter.class,
+      defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {
         OptionEffectTag.EXECUTION,
         OptionEffectTag.AFFECTS_OUTPUTS,
         OptionEffectTag.LOADING_AND_ANALYSIS,
       },
-      defaultValue = "",
       help =
           "Add or remove keys from an action's execution info based on action mnemonic.  "
               + "Applies only to actions which support execution info. Many common actions "
@@ -829,7 +830,25 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
               + "all Genrule actions.\n"
               + "  '(?!Genrule).*=-requires-x' removes 'requires-x' from the execution info for "
               + "all non-Genrule actions.\n")
-  public ExecutionInfoModifier executionInfoModifier;
+  public List<ExecutionInfoModifier> executionInfoModifier;
+
+  @Option(
+      name = "incompatible_modify_execution_info_additive_flag",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {
+        OptionEffectTag.EXECUTION,
+        OptionEffectTag.AFFECTS_OUTPUTS,
+        OptionEffectTag.LOADING_AND_ANALYSIS,
+      },
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "When enabled, passing multiple --modify_execution_info flags is additive."
+              + " When disabled, only the last flag is taken into account."
+
+      )
+  public boolean additiveModifyExecutionInfo;
+
 
   @Option(
       name = "include_config_fragments_provider",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionInfoModifier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionInfoModifier.java
@@ -113,20 +113,24 @@ public abstract class ExecutionInfoModifier {
    */
   public static ExecutionInfoModifier collapse(List<ExecutionInfoModifier> executionInfoList, boolean isAdditive) {
     ImmutableList.Builder<Expression> allExpressionsBuilder = ImmutableList.builder();
+    ImmutableList.Builder<String> allExpressionsInputs = ImmutableList.builder();
 
     if (executionInfoList != null && executionInfoList.size() > 0) {
       if (isAdditive) {
         for (ExecutionInfoModifier eim : executionInfoList) {
           allExpressionsBuilder.addAll(eim.expressions());
+          allExpressionsInputs.add(eim.option());
         }
       } else {
         // When not treating execution info as additive, only the last passed option wins.
-        allExpressionsBuilder.addAll(executionInfoList.get(executionInfoList.size() - 1).expressions());
+        final ExecutionInfoModifier eim = executionInfoList.get(executionInfoList.size() - 1);
+        allExpressionsBuilder.addAll(eim.expressions());
+        allExpressionsInputs.add(eim.option());
       }
 
     }
 
-    return create("", allExpressionsBuilder.build());
+    return create(String.join(",", allExpressionsInputs.build()), allExpressionsBuilder.build());
   }
 
   /** Modifies the given map of {@code executionInfo} to add or remove the keys for this option. */

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -227,6 +227,7 @@ bazel_fragments["CoreOptions"] = fragment(
         "//command_line_option:incompatible_merge_genfiles_directory",
         "//command_line_option:experimental_platform_in_output_dir",
         "//command_line_option:host_cpu",
+        "//command_line_option:incompatible_modify_execution_info_additive_flag",
         "//command_line_option:include_config_fragments_provider",
         "//command_line_option:experimental_debug_selects_always_succeed",
         "//command_line_option:incompatible_check_testonly_for_output_files",

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/ExecutionInfoModifierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/ExecutionInfoModifierTest.java
@@ -82,6 +82,8 @@ public class ExecutionInfoModifierTest {
     assertModifierMatchesAndResults(mergedModifier, "GenericAction", ImmutableSet.of("z"));
     assertModifierMatchesAndResults(mergedModifier, "MergeLayers", ImmutableSet.of("u"));
     assertModifierMatchesAndResults(mergedModifier, "OtherAction", ImmutableSet.of("o"));
+    assertThat(mergedModifier.option()).isEqualTo("Genrule=+x,CppCompile=-y1,GenericAction=+z,MergeLayers=+t,OtherAction=+o" +
+            ",Genrule=-x,CppCompile=+y1,CppCompile=+y2,GenericAction=+z,MergeLayers=+u,.*=-t");
   }
 
   @Test
@@ -97,6 +99,7 @@ public class ExecutionInfoModifierTest {
     assertModifierMatchesAndResults(mergedModifier1, "GenericAction", ImmutableSet.of("z"));
     assertModifierMatchesAndResults(mergedModifier1, "MergeLayers", ImmutableSet.of("u"));
     assertThat(mergedModifier1.matches("OtherAction")).isFalse();
+    assertThat(mergedModifier1.option()).isEqualTo("Genrule=-x,CppCompile=+y1,CppCompile=+y2,GenericAction=+z,MergeLayers=+u");
 
     ExecutionInfoModifier mergedModifier2 = ExecutionInfoModifier.collapse(List.of(modifier1, modifier2, modifier3), false);
 
@@ -105,6 +108,7 @@ public class ExecutionInfoModifierTest {
     assertModifierMatchesAndResults(mergedModifier2, "GenericAction", ImmutableSet.of());
     assertModifierMatchesAndResults(mergedModifier2, "MergeLayers", ImmutableSet.of());
     assertModifierMatchesAndResults(mergedModifier2, "OtherAction", ImmutableSet.of());
+    assertThat(mergedModifier2.option()).isEqualTo(".*=-t");
   }
 
   @Test


### PR DESCRIPTION
Calling --modify_execution_info multiple times used to result in the last version being used. With this change, options are amended additively.

Fixes #13342