### PR TITLE
BES: make uploader retry attempts configurable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploader.java
@@ -93,12 +93,6 @@ import javax.annotation.concurrent.GuardedBy;
 public final class BuildEventServiceUploader implements Runnable {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
-  /** Configuration knobs related to RPC retries. Values chosen by good judgement. */
-  private static final int MAX_NUM_RETRIES =
-      Integer.parseInt(System.getProperty("BAZEL_BES_NUM_RETRIES_ON_RPC_FAILURE", "4"));
-
-  private static final int DELAY_MILLIS = 1000;
-
   private final BuildEventServiceClient besClient;
   private final BuildEventArtifactUploader buildEventUploader;
   private final BuildEventServiceProtoUtil besProtoUtil;
@@ -544,7 +538,7 @@ public final class BuildEventServiceUploader implements Runnable {
                     BuildProgress.Code.BES_STREAM_NOT_RETRYING_FAILURE,
                     message);
               }
-              if (retryAttempt == MAX_NUM_RETRIES) {
+              if (retryAttempt == this.buildEventProtocolOptions.buildEventUploadAttempt) {
                 String message =
                     String.format(
                         "Not retrying publishBuildEvents, no more attempts left: status='%s'",
@@ -629,7 +623,7 @@ public final class BuildEventServiceUploader implements Runnable {
       throws DetailedStatusException, InterruptedException {
     int retryAttempt = 0;
     StatusException cause = null;
-    while (retryAttempt <= MAX_NUM_RETRIES) {
+    while (retryAttempt <= this.buildEventProtocolOptions.buildEventUploadAttempt) {
       try {
         besClient.publish(request);
         return;
@@ -656,7 +650,7 @@ public final class BuildEventServiceUploader implements Runnable {
     throw withFailureDetail(
         cause,
         BuildProgress.Code.BES_UPLOAD_RETRY_LIMIT_EXCEEDED_FAILURE,
-        "All retry attempts failed.");
+        String.format("All %d retry attempts failed.", retryAttempt-1));
   }
 
   private void ensureUploadThreadStarted() {
@@ -723,9 +717,9 @@ public final class BuildEventServiceUploader implements Runnable {
         && !status.getCode().equals(Code.FAILED_PRECONDITION);
   }
 
-  private static long retrySleepMillis(int attempt) {
+  private long retrySleepMillis(int attempt) {
     // This somewhat matches the backoff used for gRPC connection backoffs.
-    return (long) (DELAY_MILLIS * Math.pow(1.6, attempt));
+    return (long) (this.buildEventProtocolOptions.buildEventUploadAttemptDelay * Math.pow(1.6, attempt));
   }
 
   private DetailedStatusException withFailureDetail(

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventProtocolOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventProtocolOptions.java
@@ -43,6 +43,25 @@ public class BuildEventProtocolOptions extends OptionsBase {
   public String buildEventUploadStrategy;
 
   @Option(
+    name = "experimental_build_event_upload_retry_attempt",
+    defaultValue = "4",
+    documentationCategory = OptionDocumentationCategory.LOGGING,
+    effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+    help = "The number of times Bazel would attempt to retry uploading a build event."
+  )
+  public int buildEventUploadAttempt;
+
+  @Option(
+    name = "experimental_build_event_upload_retry_attempt_delay",
+    defaultValue = "1000",
+    documentationCategory = OptionDocumentationCategory.LOGGING,
+    effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+    help = 
+		"Between each retry upload attempt, Bazel would sleep "
+			  + "for 'delay_duration * (1.6 ^ attempt)' milliseconds")
+  public int buildEventUploadAttemptDelay;
+
+  @Option(
       name = "experimental_stream_log_file_uploads",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.LOGGING,

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
@@ -228,6 +228,17 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
   }
 
   @Test
+  public void testRetryCount() throws Exception {
+    runBuildWithOptions(
+		"--bes_backend=does.not.exist:1234",
+		"--experimental_build_event_upload_retry_attempt=3"
+	);
+    afterBuildCommand();
+
+    events.assertContainsError("The Build Event Protocol upload failed: All 3 retry attempts failed");
+  }
+
+  @Test
   public void testConnectivityFailureDisablesBesStreaming() throws Exception {
     class FailingConnectivityStatusProvider extends BlazeModule
         implements ConnectivityStatusProvider {


### PR DESCRIPTION
Depends on different Build Event Service setup, there could be different failure modes that may tolerate less or more failures for Build Events uploading.

Allow users to tweak the number without having to use a custom JVM args or shipping a fork of Bazel with these number tweaked.