### PR TITLE
Delete download temp directory after the build.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -222,6 +222,10 @@ final class RemoteActionContextProvider {
     this.tempPathGenerator = tempPathGenerator;
   }
 
+  TempPathGenerator getTempPathGenerator() {
+    return tempPathGenerator;
+  }
+
   public void afterCommand() {
     BlockWaitingModule blockWaitingModule =
         checkNotNull(env.getRuntime().getBlazeModule(BlockWaitingModule.class));

--- a/src/main/java/com/google/devtools/build/lib/remote/util/TempPathGenerator.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/TempPathGenerator.java
@@ -19,7 +19,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** A generator that generate temporary path under a given directory. */
 @ThreadSafe
-public class TempPathGenerator {
+public final class TempPathGenerator {
   private final Path tempDir;
   private final AtomicInteger index = new AtomicInteger();
 


### PR DESCRIPTION
I have observed that since https://github.com/bazelbuild/bazel/commit/bce7db055dd702e8a101f975f8585e0dfeb18a67, `WARNING: Found stale downloads from previous build, deleting...` is printed after every non-clean build. The reason appeared to be that the `remote` staging directory was not deleted after a build.