### PR TITLE
Update Autocomplete for Source Code in IDE Docs

### DIFF
--- a/site/en/install/ide.md
+++ b/site/en/install/ide.md
@@ -96,8 +96,11 @@ Eclipse projects.
 
 ### C Language Family (C++, C, Objective-C, and Objective-C++)
 
-[`hedronvision/bazel-compile-commands-extractor`](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete in a wide variety of editors. It lets language servers, like clangd and other tooling, draw upon Bazel's understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
+[`hedronvision/bazel-compile-commands-extractor`](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete in a wide variety of extensible editors, including VSCode, Vim, Emacs, Sublime, etc.. It lets language servers, like clangd, ccls, and other tooling, draw upon Bazel's understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
 
+### Java
+
+[`georgewfraser/java-language-server`](https://github.com/georgewfraser/java-language-server) - Java Language Server (LSP) with support for Bazel-built projects
 
 ## Automatically run build and test on file change {:#bazel-watcher}
 

--- a/site/en/install/ide.md
+++ b/site/en/install/ide.md
@@ -96,7 +96,7 @@ Eclipse projects.
 
 ### C Language Family (C++, C, Objective-C, and Objective-C++)
 
-[`hedronvision/bazel-compile-commands-extractor`](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete in a wide variety of extensible editors, including VSCode, Vim, Emacs, Sublime, etc.. It lets language servers, like clangd, ccls, and other tooling, draw upon Bazel's understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
+[`hedronvision/bazel-compile-commands-extractor`](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete in a wide variety of extensible editors, including VSCode, Vim, Emacs, Sublime, etc. It lets language servers, like clangd, ccls, and other tooling, draw upon Bazel's understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
 
 ### Java
 

--- a/site/en/install/ide.md
+++ b/site/en/install/ide.md
@@ -96,7 +96,7 @@ Eclipse projects.
 
 ### C Language Family (C++, C, Objective-C, and Objective-C++)
 
-[`hedronvision/bazel-compile-commands-extractor`](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete in a wide variety of extensible editors, including VSCode, Vim, Emacs, Sublime, etc. It lets language servers, like clangd, ccls, and other tooling, draw upon Bazel's understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
+[`hedronvision/bazel-compile-commands-extractor`](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete in a wide variety of extensible editors, including VSCode, Vim, Emacs, and Sublime. It lets language servers, like clangd and ccls, and other types of tooling, draw upon Bazel's understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
 
 ### Java
 


### PR DESCRIPTION
Hello wonderful Bazelers,

This PR updates the Autocomplete for Source Code section of the IDE docs in two ways:
1. Following on from #14448 (merged), it more precisely describes the scope of Hedron Compile Commands extractor, as it has gained users across editors and LSPs since the original entry.
2. It also adds the Java language server I saw on Awesome Bazel, which has lots of stars.

Thanks for your consideration!
Chris
(ex-Googler)