### PR TITLE
WIP: Match `alias` targets with `register_toolchain` `:all` patterns

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -285,6 +285,7 @@ EOF
   mkdir -p ${BAZEL_TOOLS_REPO}/tools/jdk
   link_file "${PWD}/tools/jdk/BUILD.tools" "${BAZEL_TOOLS_REPO}/tools/jdk/BUILD"
   link_children "${PWD}" tools/jdk "${BAZEL_TOOLS_REPO}"
+  mv -f "${BAZEL_TOOLS_REPO}/tools/jdk/toolchains/BUILD.tools" "${BAZEL_TOOLS_REPO}/tools/jdk/toolchains/BUILD"
 
   # Create @bazel_tools//tools/java/runfiles
   mkdir -p ${BAZEL_TOOLS_REPO}/tools/java/runfiles

--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -30,6 +30,7 @@ from src.create_embedded_tools_lib import is_executable
 output_paths = [
     ('*MODULE.tools', lambda x: 'MODULE.bazel'),
     ('*tools/jdk/BUILD.tools', lambda x: 'tools/jdk/BUILD'),
+    ('*tools/jdk/toolchains/BUILD.tools', lambda x: 'tools/jdk/toolchains/BUILD'),
     ('*tools/build_defs/repo/BUILD.repo',
      lambda x: 'tools/build_defs/repo/BUILD'),
     ('*tools/j2objc/BUILD.tools', lambda x: 'tools/j2objc/BUILD'),

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.tmpl
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.tmpl
@@ -273,4 +273,4 @@ maybe(
 {rules_proto}
 )
 
-register_toolchains("@bazel_tools//tools/jdk:all")
+register_toolchains("@bazel_tools//tools/jdk/toolchains:all")

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -74,7 +74,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "register_toolchains('@rules_java//java/toolchains/runtime:all')",
         "register_toolchains('@rules_java//java/toolchains/javac:all')",
         "bind(name = 'android/sdk', actual='@bazel_tools//tools/android:sdk')",
-        "register_toolchains('@bazel_tools//tools/cpp:all')",
+        "register_toolchains('@bazel_tools//tools/cpp:toolchain')",
         "register_toolchains('@bazel_tools//tools/jdk:all')",
         "register_toolchains('@bazel_tools//tools/android:all')",
         // Note this path is created inside the test infrastructure in
@@ -132,6 +132,8 @@ public final class BazelAnalysisMock extends AnalysisMock {
       }
       config.create("embedded_tools/" + filename, MoreFiles.asCharSource(path, UTF_8).read());
     }
+    // Referenced by jdk.WORKSPACE.
+    config.create("embedded_tools/tools/jdk/toolchains/BUILD");
     config.create(
         "embedded_tools/tools/jdk/BUILD",
         "load(",

--- a/src/test/java/com/google/devtools/build/lib/starlark/BindTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/BindTest.java
@@ -73,7 +73,7 @@ public class BindTest extends BuildViewTestCase {
 
     scratch.appendFile(
         "WORKSPACE",
-        "register_toolchains('" + TestConstants.TOOLS_REPOSITORY + "//tools/jdk:all')",
+        "register_toolchains('" + TestConstants.TOOLS_REPOSITORY + "//tools/jdk/toolchains:all')",
         "bind(",
         "    name = 'long-horse',",
         "    actual = '//test:giraffe',",

--- a/src/test/shell/integration/java_integration_test.sh
+++ b/src/test/shell/integration/java_integration_test.sh
@@ -267,7 +267,7 @@ EOF
   # Set javabase to an absolute path.
   bazel build //$pkg/java/hello:hello //$pkg/java/hello:hello_deploy.jar \
       "$stamp_arg" \
-      --extra_toolchains="//$pkg/jvm:all,//tools/jdk:all" \
+      --extra_toolchains="//$pkg/jvm:all,//tools/jdk/toolchains:all" \
       --platforms="//$pkg/jvm:platform" \
       "$embed_label" >&"$TEST_log" \
       || fail "Build failed"

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -24,6 +24,7 @@ filegroup(
         "proguard_whitelister_test_input.pgcfg",
         "remote_java_repository.bzl",
         "toolchain_utils.bzl",
+        "//tools/jdk/toolchains:srcs",
     ],
 )
 

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -324,58 +324,41 @@ alias(
 RELEASES = (8, 9, 10, 11)
 
 [
-    default_java_toolchain(
+    alias(
         name = "toolchain_java%d" % release,
-        configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
-        source_version = "%s" % release,
-        target_version = "%s" % release,
+        actual = "//tools/jdk/toolchains:toolchain_java%d" % release,
     )
     for release in RELEASES
 ]
 
 # A toolchain that targets java 14.
-default_java_toolchain(
+alias(
     name = "toolchain_jdk_14",
-    configuration = dict(),
-    java_runtime = "@bazel_tools//tools/jdk:remotejdk_14",
-    source_version = "14",
-    target_version = "14",
+    actual = "//tools/jdk/toolchains:toolchain_jdk_14",
 )
 
 # A toolchain that targets java 15.
-default_java_toolchain(
+alias(
     name = "toolchain_jdk_15",
-    configuration = dict(),
-    java_runtime = "@bazel_tools//tools/jdk:remotejdk_15",
-    source_version = "15",
-    target_version = "15",
+    actual = "//tools/jdk/toolchains:toolchain_jdk_15",
 )
 
 # A toolchain that targets java 16.
-default_java_toolchain(
+alias(
     name = "toolchain_jdk_16",
-    configuration = dict(),
-    java_runtime = "@bazel_tools//tools/jdk:remotejdk_16",
-    source_version = "16",
-    target_version = "16",
+    actual = "//tools/jdk/toolchains:toolchain_jdk_16",
 )
 
 # A toolchain that targets java 17.
-default_java_toolchain(
+alias(
     name = "toolchain_jdk_17",
-    configuration = dict(),
-    java_runtime = "@bazel_tools//tools/jdk:remotejdk_17",
-    source_version = "17",
-    target_version = "17",
+    actual = "//tools/jdk/toolchains:toolchain_jdk_17",
 )
 
 # A toolchain that targets java 18.
-default_java_toolchain(
+alias(
     name = "toolchain_jdk_18",
-    configuration = dict(),
-    java_runtime = "@bazel_tools//tools/jdk:remotejdk_18",
-    source_version = "18",
-    target_version = "18",
+    actual = "//tools/jdk/toolchains:toolchain_jdk_18",
 )
 
 default_java_toolchain(

--- a/tools/jdk/toolchains/BUILD
+++ b/tools/jdk/toolchains/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "srcs",
+    srcs = [
+        "BUILD",
+        "BUILD.tools",
+    ],
+)

--- a/tools/jdk/toolchains/BUILD.tools
+++ b/tools/jdk/toolchains/BUILD.tools
@@ -1,0 +1,68 @@
+load(
+    "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
+    "DEFAULT_TOOLCHAIN_CONFIGURATION",
+    "PREBUILT_TOOLCHAIN_CONFIGURATION",
+    "VANILLA_TOOLCHAIN_CONFIGURATION",
+    "bootclasspath",
+    "default_java_toolchain",
+    "java_runtime_files",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+RELEASES = (8, 9, 10, 11)
+
+[
+    default_java_toolchain(
+        name = "toolchain_java%d" % release,
+        configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
+        source_version = "%s" % release,
+        target_version = "%s" % release,
+    )
+    for release in RELEASES
+]
+
+# A toolchain that targets java 14.
+default_java_toolchain(
+    name = "toolchain_jdk_14",
+    configuration = dict(),
+    java_runtime = "@bazel_tools//tools/jdk:remotejdk_14",
+    source_version = "14",
+    target_version = "14",
+)
+
+# A toolchain that targets java 15.
+default_java_toolchain(
+    name = "toolchain_jdk_15",
+    configuration = dict(),
+    java_runtime = "@bazel_tools//tools/jdk:remotejdk_15",
+    source_version = "15",
+    target_version = "15",
+)
+
+# A toolchain that targets java 16.
+default_java_toolchain(
+    name = "toolchain_jdk_16",
+    configuration = dict(),
+    java_runtime = "@bazel_tools//tools/jdk:remotejdk_16",
+    source_version = "16",
+    target_version = "16",
+)
+
+# A toolchain that targets java 17.
+default_java_toolchain(
+    name = "toolchain_jdk_17",
+    configuration = dict(),
+    java_runtime = "@bazel_tools//tools/jdk:remotejdk_17",
+    source_version = "17",
+    target_version = "17",
+)
+
+# A toolchain that targets java 18.
+default_java_toolchain(
+    name = "toolchain_jdk_18",
+    configuration = dict(),
+    java_runtime = "@bazel_tools//tools/jdk:remotejdk_18",
+    source_version = "18",
+    target_version = "18",
+)


### PR DESCRIPTION
`register_toolchains("//pkg:all")` now follows `alias` targets defined in `pkg` and register any toolchains they point to.

Also moves the `toolchain` targets defined in `@bazel_tools//tools/jdk` to a separate package to realize the recommendation given in the release notes below and thus prevent eager fetches of JDKs for unused toolchains.

RELNOTES: `:all` target patterns provided in `register_toolchains` calls now also match `alias` in addition to `toolchain` targets. To avoid unnecessary fetches, `toolchain` targets should not be declared in packages with `alias` targets referencing repositories that aren't meant to be fetched unconditionally.

Fixes #16298