### PR TITLE
remote: Remove warning about deleting temp downloads directory.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -918,8 +918,6 @@ public final class RemoteModule extends BlazeModule {
       throws AbruptExitException {
     Path tempDir = env.getActionTempsDirectory().getChild("remote");
     if (tempDir.exists()) {
-      env.getReporter()
-          .handle(Event.warn("Found stale downloads from previous build, deleting..."));
       try {
         tempDir.deleteTree();
       } catch (IOException e) {


### PR DESCRIPTION
The remote download directory is not deleted at the end of a build, so it is normal to hit this codepath.