### PR TITLE
Add --incompatible_sandbox_hermetic_tmp 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -30,6 +30,8 @@ import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.exec.TreeDeleter;
 import com.google.devtools.build.lib.exec.local.LocalEnvProvider;
 import com.google.devtools.build.lib.exec.local.PosixLocalEnvProvider;
@@ -52,7 +54,9 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 /** Spawn runner that uses linux sandboxing APIs to execute a local subprocess. */
@@ -60,6 +64,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
   // Since checking if sandbox is supported is expensive, we remember what we've checked.
   private static final Map<Path, Boolean> isSupportedMap = new HashMap<>();
+  private static final AtomicBoolean warnedAboutNonHermeticTmp = new AtomicBoolean();
 
   /**
    * Returns whether the linux sandbox is supported on the local machine by running a small command
@@ -119,6 +124,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   @Nullable private final SandboxfsProcess sandboxfsProcess;
   private final boolean sandboxfsMapSymlinkTargets;
   private final TreeDeleter treeDeleter;
+  private final Reporter reporter;
 
   /**
    * Creates a sandboxed spawn runner that uses the {@code linux-sandbox} tool.
@@ -158,6 +164,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     this.sandboxfsMapSymlinkTargets = sandboxfsMapSymlinkTargets;
     this.localEnvProvider = new PosixLocalEnvProvider(cmdEnv.getClientEnv());
     this.treeDeleter = treeDeleter;
+    this.reporter = cmdEnv.getReporter();
   }
 
   @Override
@@ -178,6 +185,26 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     sandboxExecRoot.getParentDirectory().createDirectory();
     sandboxExecRoot.createDirectory();
 
+    Path sandboxTmp = null;
+    if (getSandboxOptions().sandboxHermeticTmp) {
+      PathFragment tmpRoot = PathFragment.create("/tmp");
+      // With a tmpfs on /tmp, mounting a disk-based hermetic /tmp isn't necessary.
+      if (!getSandboxOptions().sandboxTmpfsPath.contains(tmpRoot)) {
+        // Mounting a tmpfs strictly below the hermetic /tmp isn't supported. We fall back to
+        // non-hermetic /tmp in that case, but print a warning mentioning the problematic mount.
+        Optional<PathFragment> tmpfsPathUnderTmp = getSandboxOptions().sandboxTmpfsPath.stream()
+          .filter(path -> path.startsWith(tmpRoot))
+          .findFirst();
+        if (tmpfsPathUnderTmp.isEmpty()) {
+          sandboxTmp = sandboxPath.getRelative("_tmp");
+          sandboxTmp.createDirectoryAndParents();
+        } else if (warnedAboutNonHermeticTmp.compareAndSet(false, true)) {
+          reporter.handle(Event.warn(String.format(
+            "Falling back to non-hermetic /tmp in sandbox due to '%s' being a tmpfs path", tmpfsPathUnderTmp.get())));
+        }
+      }
+    }
+
     ImmutableMap<String, String> environment =
         localEnvProvider.rewriteLocalEnv(spawn.getEnvironment(), binTools, "/tmp");
 
@@ -196,7 +223,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
             .addExecutionInfo(spawn.getExecutionInfo())
             .setWritableFilesAndDirectories(writableDirs)
             .setTmpfsDirectories(ImmutableSet.copyOf(getSandboxOptions().sandboxTmpfsPath))
-            .setBindMounts(getReadOnlyBindMounts(blazeDirs, sandboxExecRoot))
+            .setBindMounts(getBindMounts(blazeDirs, sandboxExecRoot, sandboxTmp))
             .setUseFakeHostname(getSandboxOptions().sandboxFakeHostname)
             .setCreateNetworkNamespace(
                 !(allowNetwork
@@ -282,15 +309,31 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     return writableDirs.build();
   }
 
-  private SortedMap<Path, Path> getReadOnlyBindMounts(
-      BlazeDirectories blazeDirs, Path sandboxExecRoot) throws UserExecException {
+  private SortedMap<Path, Path> getBindMounts(
+      BlazeDirectories blazeDirs, Path sandboxExecRoot, @Nullable Path sandboxTmp) throws UserExecException {
     Path tmpPath = fileSystem.getPath("/tmp");
     final SortedMap<Path, Path> bindMounts = Maps.newTreeMap();
+    boolean buildUnderTmp = false;
     if (blazeDirs.getWorkspace().startsWith(tmpPath)) {
       bindMounts.put(blazeDirs.getWorkspace(), blazeDirs.getWorkspace());
+      buildUnderTmp = true;
     }
     if (blazeDirs.getOutputBase().startsWith(tmpPath)) {
       bindMounts.put(blazeDirs.getOutputBase(), blazeDirs.getOutputBase());
+      buildUnderTmp = true;
+    }
+    if (sandboxTmp != null) {
+      if (buildUnderTmp) {
+        if (warnedAboutNonHermeticTmp.compareAndSet(false, true)) {
+          reporter.handle(Event.warn("Falling back to non-hermetic /tmp in sandbox since workspace or output base " +
+            "lie under /tmp"));
+        }
+      } else {
+        // Mount a fresh, empty temporary directory as /tmp for each sandbox rather than reusing the
+        // host filesystem's /tmp. User-specified bind mounts can override this and use the host's
+        // /tmp instead by mounting /tmp to /tmp, if desired.
+        bindMounts.put(tmpPath, sandboxTmp);
+      }
     }
     for (ImmutableMap.Entry<String, String> additionalMountPath :
         getSandboxOptions().sandboxAdditionalMounts) {

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -370,6 +370,17 @@ public class SandboxOptions extends OptionsBase {
               + "then the input files will be copied instead.")
   public boolean useHermetic;
 
+  @Option(
+      name = "incompatible_sandbox_hermetic_tmp",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+        "If set to true, each Linux sandbox will have its own dedicated empty directory mounted as /tmp rather than"
+            + "sharing /tmp with the host filesystem. Use --sandbox_add_mount_pair=/tmp to keep seeing the host's /tmp "
+            + "in all sandboxes.")
+  public boolean sandboxHermeticTmp;
+
   /** Converter for the number of threads used for asynchronous tree deletion. */
   public static final class AsyncTreeDeletesConverter extends ResourceConverter {
     public AsyncTreeDeletesConverter() {

--- a/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunnerTest.java
@@ -202,6 +202,62 @@ public final class LinuxSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTes
     assertThat(spawnResult.getNumInvoluntaryContextSwitches()).isEmpty();
   }
 
+  @Test
+  public void hermeticTmp_tmpCreatedAndMounted() throws Exception {
+    runtimeWrapper.addOptions("--incompatible_sandbox_hermetic_tmp");
+    CommandEnvironment commandEnvironment = createCommandEnvironment();
+    LinuxSandboxedSpawnRunner runner = setupSandboxAndCreateRunner(commandEnvironment);
+    Spawn spawn = new SpawnBuilder().build();
+    SandboxedSpawn sandboxedSpawn = runner.prepareSpawn(spawn, createSpawnExecutionContext(spawn));
+
+    Path sandboxPath = sandboxedSpawn.getSandboxExecRoot().getParentDirectory().getParentDirectory();
+    Path hermeticTmpPath = sandboxPath.getRelative("_tmp");
+    assertThat(hermeticTmpPath.isDirectory()).isTrue();
+
+    assertThat(sandboxedSpawn).isInstanceOf(SymlinkedSandboxedSpawn.class);
+    String args = String.join(" ", sandboxedSpawn.getArguments());
+    assertThat(args).contains("-w /tmp");
+    assertThat(args).contains("-M " + hermeticTmpPath + " -m /tmp");
+  }
+
+  @Test
+  public void hermeticTmp_sandboxTmpfsOnTmp_tmpNotCreatedOrMounted() throws Exception {
+    runtimeWrapper.addOptions("--incompatible_sandbox_hermetic_tmp", "--sandbox_tmpfs_path=/tmp");
+    CommandEnvironment commandEnvironment = createCommandEnvironment();
+    LinuxSandboxedSpawnRunner runner = setupSandboxAndCreateRunner(commandEnvironment);
+    Spawn spawn = new SpawnBuilder().build();
+    SandboxedSpawn sandboxedSpawn = runner.prepareSpawn(spawn, createSpawnExecutionContext(spawn));
+
+    Path sandboxPath = sandboxedSpawn.getSandboxExecRoot().getParentDirectory().getParentDirectory();
+    Path hermeticTmpPath = sandboxPath.getRelative("_tmp");
+    assertThat(hermeticTmpPath.isDirectory()).isFalse();
+
+    assertThat(sandboxedSpawn).isInstanceOf(SymlinkedSandboxedSpawn.class);
+    String args = String.join(" ", sandboxedSpawn.getArguments());
+    assertThat(args).contains("-w /tmp");
+    assertThat(args).contains("-e /tmp");
+    assertThat(args).doesNotContain("-m /tmp");
+  }
+
+  @Test
+  public void hermeticTmp_sandboxTmpfsUnderTmp_tmpNotCreatedOrMounted() throws Exception {
+    runtimeWrapper.addOptions("--incompatible_sandbox_hermetic_tmp", "--sandbox_tmpfs_path=/tmp/subdir");
+    CommandEnvironment commandEnvironment = createCommandEnvironment();
+    LinuxSandboxedSpawnRunner runner = setupSandboxAndCreateRunner(commandEnvironment);
+    Spawn spawn = new SpawnBuilder().build();
+    SandboxedSpawn sandboxedSpawn = runner.prepareSpawn(spawn, createSpawnExecutionContext(spawn));
+
+    Path sandboxPath = sandboxedSpawn.getSandboxExecRoot().getParentDirectory().getParentDirectory();
+    Path hermeticTmpPath = sandboxPath.getRelative("_tmp");
+    assertThat(hermeticTmpPath.isDirectory()).isFalse();
+
+    assertThat(sandboxedSpawn).isInstanceOf(SymlinkedSandboxedSpawn.class);
+    String args = String.join(" ", sandboxedSpawn.getArguments());
+    assertThat(args).contains("-w /tmp");
+    assertThat(args).contains("-e /tmp");
+    assertThat(args).doesNotContain("-m /tmp");
+  }
+
   private static LinuxSandboxedSpawnRunner setupSandboxAndCreateRunner(
       CommandEnvironment commandEnvironment) throws IOException {
     Path execRoot = commandEnvironment.getExecRoot();


### PR DESCRIPTION
With the new flag, each Linux sandbox will have its own dedicated empty
directory mounted as `/tmp` rather than sharing `/tmp` with the host
filesystem.

This is necessary since the Linux sandbox uses a PID namespace, but many
tools (e.g. the JVM) create files at well-known locations such as
`/tmp/.javapid${PID}`, which leads to collisions between different
sandboxes and the host. These collisions can result in crashes or
surprising situations such as Java agents being attached to a JVM in a
different sandbox.

With the flag enabled, `--sandbox_add_mount_pair=/tmp` can be used to
restore the old behavior of a non-hermetic `/tmp` directory.

This is made possible by a small change to linux-sandbox which allows
mount pair source directories to also be marked as writable directories.

Work towards #3236