### PR TITLE
Add exec platform and properties to verbose_explanation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -220,12 +220,18 @@ public class ActionCacheChecker {
     if (handler != null) {
       if (cacheConfig.verboseExplanations()) {
         String keyDescription = action.describeKey();
+        String execPlatform = action.getExecutionPlatform() == null ? "<null>" :
+                              action.getExecutionPlatform().toString();
+        String execProps = action.getExecProperties().toString();
         reportRebuild(
             handler,
             action,
             keyDescription == null
                 ? "action command has changed"
-                : "action command has changed.\nNew action: " + keyDescription);
+                : "action command has changed.\n" +
+                    "New action: " + keyDescription + // keyDescription ends with newline already.
+                    "    Platform: " + execPlatform + "\n" +
+                    "    Exec Properties: " + execProps + "\n");
       } else {
         reportRebuild(
             handler,


### PR DESCRIPTION
I was puzzled why a certain build was being rebuilt from scratch when I targeted a remote build system, even though the build had been completed in the local cache. Running

     bazel build //path/to/my/build --explain=explain.txt --verbose_explanations

showed the exact same output for remote and local.

Turns out, the [execution platform and properties](https://github.com/bazelbuild/bazel/blob/f28209df2b0ebeff1de0b8b7f6b9e215d890e753/src/main/java/com/google/devtools/build/lib/actions/ActionKeyCacher.java#L67-L73) contribute to the action cache key. However, if these are not shown in the verbose explain output, this is not clear.

By printing this out, it should be more apparent why the action cache key miss occurs. 