### PR TITLE
Move macOS framework name linking into framework feature

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -258,14 +258,6 @@ def _impl(ctx):
                         ],
                     ),
                     flag_group(
-                        flags = ["-framework", "%{framework_names}"],
-                        iterate_over = "framework_names",
-                    ),
-                    flag_group(
-                        flags = ["-weak_framework", "%{weak_framework_names}"],
-                        iterate_over = "weak_framework_names",
-                    ),
-                    flag_group(
                         flags = ["-l%{library_names}"],
                         iterate_over = "library_names",
                     ),
@@ -526,14 +518,6 @@ def _impl(ctx):
             flag_set(
                 flag_groups = [
                     flag_group(flags = ["-target", target_system_name]),
-                    flag_group(
-                        flags = ["-framework", "%{framework_names}"],
-                        iterate_over = "framework_names",
-                    ),
-                    flag_group(
-                        flags = ["-weak_framework", "%{weak_framework_names}"],
-                        iterate_over = "weak_framework_names",
-                    ),
                     flag_group(
                         flags = ["-l%{library_names}"],
                         iterate_over = "library_names",
@@ -1247,6 +1231,14 @@ def _impl(ctx):
                     flag_group(
                         flags = ["-F%{framework_paths}"],
                         iterate_over = "framework_paths",
+                    ),
+                    flag_group(
+                        flags = ["-framework", "%{framework_names}"],
+                        iterate_over = "framework_names",
+                    ),
+                    flag_group(
+                        flags = ["-weak_framework", "%{weak_framework_names}"],
+                        iterate_over = "weak_framework_names",
                     ),
                 ],
             ),


### PR DESCRIPTION
This is a subtle change that moves the `-framework Foo` arguments to the linker after the `-filelist` argument. This matters in the case you have multiple symbols, one that is in your code, where the objects / archives are in the filelist, and one is in one of your pre-compiled framework dependencies. Previously the framework definition would have been preferred. This is inline with the order Xcode uses for this. The difference has cause real issues with prebuilt Swift https://github.com/apple/swift/issues/61287