### PR TITLE
Improve error message when DumpPlatformClassPath fails

### DIFF
--- a/tools/jdk/DumpPlatformClassPath.java
+++ b/tools/jdk/DumpPlatformClassPath.java
@@ -102,15 +102,21 @@ public class DumpPlatformClassPath {
     // initialized bootclasspath data back out.
 
     Context context = new Context();
-    JavacTool.create()
+    try {
+      JavacTool.create()
         .getTask(
-            /* out = */ null,
-            /* fileManager = */ null,
-            /* diagnosticListener = */ null,
-            /* options = */ Arrays.asList("--system", String.valueOf(targetJavabase)),
-            /* classes = */ null,
-            /* compilationUnits = */ null,
-            context);
+          /* out = */ null,
+          /* fileManager = */ null,
+          /* diagnosticListener = */ null,
+          /* options = */ Arrays.asList("--system", String.valueOf(targetJavabase)),
+          /* classes = */ null,
+          /* compilationUnits = */ null,
+          context);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(String.format("Failed to collect system class path. Please ensure that the " +
+        "configured Java runtime ('%s') is a complete JDK. There are known issues with Homebrew versions of the " +
+        "Java runtime.", targetJavabase.toRealPath()), e);
+    }
     StandardJavaFileManager fileManager =
         (StandardJavaFileManager) context.get(JavaFileManager.class);
 


### PR DESCRIPTION
When JavacTools#create throws IllegalArgumentException, the likely cause is that the configured Java runtime is not a JDK or missing files, as is known to be the case with Homebrew installations. Rather than fail with a cryptic stack trace that only mentions `external/local_jdk`, print a descriptive error with the resolved path of the configured runtime's home directory.

Fixes #15452