### PR TITLE
Fix `//third_party:netty_tcnative` target on OpenBSD & FreeBSD.

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -665,8 +665,13 @@ distrib_java_import(
     enable_distributions = ["debian"],
     jars = [
         "netty_tcnative/netty-tcnative-classes-2.0.51.Final.jar",
-        ":netty_tcnative/netty-tcnative-filtered.jar",
-    ],
+    ] + select({
+        # No tcnative dynamic library is available for these platforms.
+        "//src/conditions:freebsd": [],
+        "//src/conditions:openbsd": [],
+        # For other platforms, a tcnative dynamic library is available.
+        "//conditions:default": [":netty_tcnative/netty-tcnative-filtered.jar"],
+    }),
 )
 
 distrib_java_import(


### PR DESCRIPTION
On these platforms, no tcnative shared library is available. Without this change, the build fails with the following error.

```
ERROR: /home/ad/tree/third_party/BUILD:612:8: in cmd attribute of genrule rule //third_party:filter_netty_dynamic_libs: variable '$<' : no input file

ERROR: /home/ad/tree/third_party/BUILD:612:8: Analysis of target '//third_party:filter_netty_dynamic_libs' failed
```

(The root cause was that the `:filter_netty_dynamic_libs` target [assumed it could copy the shared library](https://github.com/bazelbuild/bazel/blob/c418e9e2635a0afdcbb36f7c14b41fec8417a356/third_party/BUILD#L623) even when [there was no shared library](https://github.com/bazelbuild/bazel/blob/c418e9e2635a0afdcbb36f7c14b41fec8417a356/third_party/BUILD#L620).