### PR TITLE
Upload dangling symlinks found in the outputs of local actions.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -115,6 +115,7 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
@@ -1257,8 +1258,10 @@ public class RemoteExecutionService {
           ImmutableList.Builder<Path> outputFiles = ImmutableList.builder();
           // Check that all mandatory outputs are created.
           for (ActionInput outputFile : action.getSpawn().getOutputFiles()) {
+            Symlinks followSymlinks = outputFile.isSymlink() ? Symlinks.NOFOLLOW : Symlinks.FOLLOW;
             Path localPath = execRoot.getRelative(outputFile.getExecPath());
-            if (action.getSpawn().isMandatoryOutput(outputFile) && !localPath.exists()) {
+            if (action.getSpawn().isMandatoryOutput(outputFile)
+                && !localPath.exists(followSymlinks)) {
               throw new IOException(
                   "Expected output " + prettyPrint(outputFile) + " was not created locally.");
             }

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -413,6 +413,18 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public boolean incompatibleRemoteSymlinks;
 
   @Option(
+      name = "incompatible_remote_dangling_symlinks",
+      defaultValue = "true",
+      category = "remote",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "If set to true and --incompatible_remote_symlinks is also true, symlinks in action"
+              + " outputs are allowed to dangle.")
+  public boolean incompatibleRemoteDanglingSymlinks;
+
+  @Option(
       name = "experimental_remote_cache_compression",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,

--- a/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
@@ -267,6 +267,12 @@ public final class ActionsTestUtil {
     return treeArtifact;
   }
 
+  public static SpecialArtifact createUnresolvedSymlinkArtifactWithExecPath(
+      ArtifactRoot root, PathFragment execPath) {
+    return SpecialArtifact.create(
+        root, execPath, NULL_ARTIFACT_OWNER, SpecialArtifactType.UNRESOLVED_SYMLINK);
+  }
+
   public static void assertNoArtifactEndingWith(RuleConfiguredTarget target, String path) {
     Pattern endPattern = Pattern.compile(path + "$");
     for (ActionAnalysisMetadata action : target.getActions()) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -1368,6 +1368,40 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void uploadOutputs_uploadRelativeDanglingSymlink_works() throws Exception {
+    // arrange
+    Path linkPath = execRoot.getRelative("outputs/link");
+    linkPath.createSymbolicLink(PathFragment.create("some/path"));
+    Artifact outputSymlink =
+        ActionsTestUtil.createUnresolvedSymlinkArtifactWithExecPath(
+            artifactRoot, linkPath.relativeTo(execRoot));
+    RemoteExecutionService service = newRemoteExecutionService();
+    Spawn spawn = newSpawn(ImmutableMap.of(), ImmutableSet.of(outputSymlink));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+    SpawnResult spawnResult =
+        new SpawnResult.Builder()
+            .setExitCode(0)
+            .setStatus(SpawnResult.Status.SUCCESS)
+            .setRunnerName("test")
+            .build();
+
+    // act
+    UploadManifest manifest = service.buildUploadManifest(action, spawnResult);
+    service.uploadOutputs(action, spawnResult);
+
+    // assert
+    ActionResult.Builder expectedResult = ActionResult.newBuilder();
+    expectedResult.addOutputFileSymlinksBuilder().setPath("outputs/link").setTarget("some/path");
+    assertThat(manifest.getActionResult()).isEqualTo(expectedResult.build());
+    // assertThat(
+    //         getFromFuture(
+    //             cache.findMissingDigests(
+    //                 remoteActionExecutionContext, ImmutableList.of(barDigest))))
+    //     .isEmpty();
+  }
+
+  @Test
   public void uploadOutputs_emptyOutputs_doNotPerformUpload() throws Exception {
     // Test that uploading an empty output does not try to perform an upload.
 

--- a/src/test/java/com/google/devtools/build/lib/remote/UploadManifestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/UploadManifestTest.java
@@ -202,7 +202,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(target);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(link));
     Digest digest = digestUtil.compute(target);
     assertThat(um.getDigestToFile()).containsExactly(digest, link);
@@ -223,7 +228,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(dir);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(link));
     Digest digest = digestUtil.compute(foo);
     assertThat(um.getDigestToFile()).containsExactly(digest, execRoot.getRelative("link/foo"));
@@ -250,7 +260,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(target);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(link));
     Digest digest = digestUtil.compute(target);
     assertThat(um.getDigestToFile()).containsExactly(digest, link);
@@ -271,7 +286,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(dir);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(link));
     Digest digest = digestUtil.compute(foo);
     assertThat(um.getDigestToFile()).containsExactly(digest, execRoot.getRelative("link/foo"));
@@ -298,7 +318,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(target.relativeTo(execRoot));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(link));
     Digest digest = digestUtil.compute(target);
     assertThat(um.getDigestToFile()).containsExactly(digest, link);
@@ -319,7 +344,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(dir.relativeTo(execRoot));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(link));
     Digest digest = digestUtil.compute(foo);
     assertThat(um.getDigestToFile()).containsExactly(digest, execRoot.getRelative("link/foo"));
@@ -346,7 +376,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(target.relativeTo(execRoot));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(link));
     assertThat(um.getDigestToFile()).isEmpty();
 
@@ -366,7 +401,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(dir.relativeTo(execRoot));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(link));
     assertThat(um.getDigestToFile()).isEmpty();
 
@@ -376,14 +416,20 @@ public class UploadManifestTest {
   }
 
   @Test
-  public void actionResult_noFollowSymlinks_absoluteDanglingSymlinkError() throws Exception {
+  public void actionResult_noFollowSymlinks_noAllowDanglingSymlinks_absoluteDanglingSymlinkError()
+      throws Exception {
     ActionResult.Builder result = ActionResult.newBuilder();
     Path link = execRoot.getRelative("link");
     Path target = execRoot.getRelative("target");
     link.createSymbolicLink(target);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     IOException e = assertThrows(IOException.class, () -> um.addFiles(ImmutableList.of(link)));
     assertThat(e).hasMessageThat().contains("dangling");
     assertThat(e).hasMessageThat().contains("/execroot/link");
@@ -391,18 +437,70 @@ public class UploadManifestTest {
   }
 
   @Test
-  public void actionResult_noFollowSymlinks_relativeDanglingSymlinkError() throws Exception {
+  public void actionResult_noFollowSymlinks_allowDanglingSymlinks_absoluteDanglingSymlinkAsSymlink()
+      throws Exception {
+    ActionResult.Builder result = ActionResult.newBuilder();
+    Path link = execRoot.getRelative("link");
+    Path target = execRoot.getRelative("target");
+    link.createSymbolicLink(target);
+
+    UploadManifest um =
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ true);
+    um.addFiles(ImmutableList.of(link));
+    assertThat(um.getDigestToFile()).isEmpty();
+
+    ActionResult.Builder expectedResult = ActionResult.newBuilder();
+    expectedResult.addOutputFileSymlinksBuilder().setPath("link").setTarget("/execroot/target");
+    assertThat(result.build()).isEqualTo(expectedResult.build());
+  }
+
+  @Test
+  public void actionResult_noFollowSymlinks_noAllowDanglingSymlinks_relativeDanglingSymlinkError()
+      throws Exception {
     ActionResult.Builder result = ActionResult.newBuilder();
     Path link = execRoot.getRelative("link");
     Path target = execRoot.getRelative("target");
     link.createSymbolicLink(target.relativeTo(link.getParentDirectory()));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     IOException e = assertThrows(IOException.class, () -> um.addFiles(ImmutableList.of(link)));
     assertThat(e).hasMessageThat().contains("dangling");
     assertThat(e).hasMessageThat().contains("/execroot/link");
     assertThat(e).hasMessageThat().contains("target");
+  }
+
+  @Test
+  public void actionResult_noFollowSymlinks_allowDanglingSymlinks_relativeDanglingSymlinkAsSymlink()
+      throws Exception {
+    ActionResult.Builder result = ActionResult.newBuilder();
+    Path link = execRoot.getRelative("link");
+    Path target = execRoot.getRelative("target");
+    link.createSymbolicLink(target.relativeTo(link.getParentDirectory()));
+
+    UploadManifest um =
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ true);
+    um.addFiles(ImmutableList.of(link));
+    assertThat(um.getDigestToFile()).isEmpty();
+
+    ActionResult.Builder expectedResult = ActionResult.newBuilder();
+    expectedResult.addOutputFileSymlinksBuilder().setPath("link").setTarget("target");
+    assertThat(result.build()).isEqualTo(expectedResult.build());
   }
 
   @Test
@@ -416,7 +514,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(target);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(dir));
     Digest digest = digestUtil.compute(target);
     assertThat(um.getDigestToFile()).containsExactly(digest, link);
@@ -448,7 +551,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(bardir);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(dir));
     Digest digest = digestUtil.compute(foo);
     assertThat(um.getDigestToFile()).containsExactly(digest, execRoot.getRelative("dir/link/foo"));
@@ -485,7 +593,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(target);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(dir));
     Digest digest = digestUtil.compute(target);
     assertThat(um.getDigestToFile()).containsExactly(digest, link);
@@ -517,7 +630,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(bardir);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(dir));
     Digest digest = digestUtil.compute(foo);
     assertThat(um.getDigestToFile()).containsExactly(digest, execRoot.getRelative("dir/link/foo"));
@@ -553,7 +671,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(PathFragment.create("../target"));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(dir));
     Digest digest = digestUtil.compute(target);
     assertThat(um.getDigestToFile()).containsExactly(digest, link);
@@ -585,7 +708,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(PathFragment.create("../bardir"));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(dir));
     Digest digest = digestUtil.compute(foo);
     assertThat(um.getDigestToFile()).containsExactly(digest, execRoot.getRelative("dir/link/foo"));
@@ -622,7 +750,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(PathFragment.create("../target"));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(dir));
     assertThat(um.getDigestToFile()).isEmpty();
 
@@ -653,7 +786,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(PathFragment.create("../bardir"));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     um.addFiles(ImmutableList.of(dir));
     assertThat(um.getDigestToFile()).isEmpty();
 
@@ -671,7 +809,9 @@ public class UploadManifestTest {
   }
 
   @Test
-  public void actionResult_noFollowSymlinks_absoluteDanglingSymlinkInDirectory() throws Exception {
+  public void
+      actionResult_noFollowSymlinks_noAllowDanglingSymlinks_absoluteDanglingSymlinkInDirectory()
+          throws Exception {
     ActionResult.Builder result = ActionResult.newBuilder();
     Path dir = execRoot.getRelative("dir");
     dir.createDirectory();
@@ -680,7 +820,12 @@ public class UploadManifestTest {
     link.createSymbolicLink(target);
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     IOException e = assertThrows(IOException.class, () -> um.addFiles(ImmutableList.of(dir)));
     assertThat(e).hasMessageThat().contains("dangling");
     assertThat(e).hasMessageThat().contains("/execroot/dir/link");
@@ -688,8 +833,33 @@ public class UploadManifestTest {
   }
 
   @Test
-  public void actionResult_noFollowSymlinks_relativeDanglingSymlinkInDirectoryAsSymlink()
-      throws Exception {
+  public void
+      actionResult_noFollowSymlinks_allowDanglingSymlinks_absoluteDanglingSymlinkInDirectory()
+          throws Exception {
+    ActionResult.Builder result = ActionResult.newBuilder();
+    Path dir = execRoot.getRelative("dir");
+    dir.createDirectory();
+    Path target = execRoot.getRelative("target");
+    Path link = execRoot.getRelative("dir/link");
+    link.createSymbolicLink(target);
+
+    UploadManifest um =
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ true);
+    IOException e = assertThrows(IOException.class, () -> um.addFiles(ImmutableList.of(dir)));
+    assertThat(e).hasMessageThat().contains("dangling");
+    assertThat(e).hasMessageThat().contains("/execroot/dir/link");
+    assertThat(e).hasMessageThat().contains("/execroot/target");
+  }
+
+  @Test
+  public void
+      actionResult_noFollowSymlinks_noAllowDanglingSymlinks_relativeDanglingSymlinkInDirectoryAsSymlink()
+          throws Exception {
     ActionResult.Builder result = ActionResult.newBuilder();
     Path dir = execRoot.getRelative("dir");
     dir.createDirectory();
@@ -698,7 +868,46 @@ public class UploadManifestTest {
     link.createSymbolicLink(target.relativeTo(link.getParentDirectory()));
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
+    um.addFiles(ImmutableList.of(dir));
+    assertThat(um.getDigestToFile()).isEmpty();
+
+    Tree tree =
+        Tree.newBuilder()
+            .setRoot(
+                Directory.newBuilder()
+                    .addSymlinks(SymlinkNode.newBuilder().setName("link").setTarget("target")))
+            .build();
+    Digest treeDigest = digestUtil.compute(tree);
+
+    ActionResult.Builder expectedResult = ActionResult.newBuilder();
+    expectedResult.addOutputDirectoriesBuilder().setPath("dir").setTreeDigest(treeDigest);
+    assertThat(result.build()).isEqualTo(expectedResult.build());
+  }
+
+  @Test
+  public void
+      actionResult_noFollowSymlinks_allowDanglingSymlinks_relativeDanglingSymlinkInDirectoryAsSymlink()
+          throws Exception {
+    ActionResult.Builder result = ActionResult.newBuilder();
+    Path dir = execRoot.getRelative("dir");
+    dir.createDirectory();
+    Path target = execRoot.getRelative("dir/target");
+    Path link = execRoot.getRelative("dir/link");
+    link.createSymbolicLink(target.relativeTo(link.getParentDirectory()));
+
+    UploadManifest um =
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ true);
     um.addFiles(ImmutableList.of(dir));
     assertThat(um.getDigestToFile()).isEmpty();
 
@@ -725,7 +934,12 @@ public class UploadManifestTest {
     Path special = dir.getRelative("special");
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     UserExecException e =
         assertThrows(UserExecException.class, () -> um.addFiles(ImmutableList.of(special)));
     assertThat(e).hasMessageThat().contains("special file");
@@ -739,7 +953,12 @@ public class UploadManifestTest {
     Path link = dir.getRelative("link");
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     UserExecException e =
         assertThrows(UserExecException.class, () -> um.addFiles(ImmutableList.of(link)));
     assertThat(e).hasMessageThat().contains("special file");
@@ -752,7 +971,12 @@ public class UploadManifestTest {
     Path dir = createDirectoryWithSpecialFile("dir", "special");
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ false);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ false,
+            /*allowDanglingSymlinks=*/ false);
     UserExecException e =
         assertThrows(UserExecException.class, () -> um.addFiles(ImmutableList.of(dir)));
     assertThat(e).hasMessageThat().contains("special file");
@@ -765,7 +989,12 @@ public class UploadManifestTest {
     Path dir = createDirectoryWithSymlinkToSpecialFile("dir", "link", "special");
 
     UploadManifest um =
-        new UploadManifest(digestUtil, remotePathResolver, result, /*followSymlinks=*/ true);
+        new UploadManifest(
+            digestUtil,
+            remotePathResolver,
+            result,
+            /*followSymlinks=*/ true,
+            /*allowDanglingSymlinks=*/ false);
     UserExecException e =
         assertThrows(UserExecException.class, () -> um.addFiles(ImmutableList.of(dir)));
     assertThat(e).hasMessageThat().contains("special file");


### PR DESCRIPTION
Since we don't know whether a dangling symlink is supposed to point to a file or a directory, we always report it as a symlink to a file. The distinction only matters in V2 of the protocol, with V2.1 reporting them uniformly, so it doesn't seem to be worth the effort to match up the input and output types.

Dangling symlinks to absolute paths are unconditionally uploaded. A followup PR will gate their upload on the presence of the respective server capability (SymlinkAbsolutePathStrategy.ALLOW).

The change is behind a new `--incompatible_remote_dangling_symlinks` flag, which will be introduced in the flipped state. See #16353.

Progress towards #16289.