### PR TITLE
Flip --incompatible_remote_downloader_send_all_headers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -622,7 +622,7 @@ public final class RemoteOptions extends CommonRemoteOptions {
 
   @Option(
       name = "incompatible_remote_downloader_send_all_headers",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/16356

RELNOTES[INC]: --incompatible_remote_downloader_send_all_headers is flipped to true. See #16356 for details.