### PR TITLE
[bes] Attach `RequestMetadata` to RPC calls

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BUILD
@@ -16,6 +16,7 @@ java_library(
         "//third_party:netty_tcnative",
     ],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/grpc-java:grpc-jar",

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceGrpcClient.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceGrpcClient.java
@@ -102,7 +102,10 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
           .withInterceptors(
               TracingMetadataUtils.attachMetadataInterceptor(
                   TracingMetadataUtils.buildMetadata(
-                      buildRequestId, commandId.toString(), "publish_lifecycle_event", null)))
+                      buildRequestId,
+                      commandId.toString(),
+                      "publish_lifecycle_event",
+                      /* actionMetadata= */ null)))
           .publishLifecycleEvent(lifecycleEvent);
     } catch (StatusRuntimeException e) {
       Throwables.throwIfInstanceOf(Throwables.getRootCause(e), InterruptedException.class);
@@ -128,7 +131,7 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
                           buildRequestId,
                           commandId.toString(),
                           "publish_build_tool_event_stream",
-                          null)))
+                          /* actionMetadata= */ null)))
               .publishBuildToolEventStream(
               new StreamObserver<PublishBuildToolEventStreamResponse>() {
                 @Override

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceGrpcClient.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BuildEventServiceGrpcClient.java
@@ -17,10 +17,12 @@ package com.google.devtools.build.lib.buildeventservice.client;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.v1.PublishBuildEventGrpc;
 import com.google.devtools.build.v1.PublishBuildEventGrpc.PublishBuildEventBlockingStub;
 import com.google.devtools.build.v1.PublishBuildEventGrpc.PublishBuildEventStub;
@@ -28,14 +30,19 @@ import com.google.devtools.build.v1.PublishBuildToolEventStreamRequest;
 import com.google.devtools.build.v1.PublishBuildToolEventStreamResponse;
 import com.google.devtools.build.v1.PublishLifecycleEventRequest;
 import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
+import java.util.UUID;
 import javax.annotation.Nullable;
 
 /** Implementation of BuildEventServiceClient that uploads data using gRPC. */
@@ -48,15 +55,22 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
   private final PublishBuildEventStub besAsync;
   private final PublishBuildEventBlockingStub besBlocking;
 
+  private final String buildRequestId;
+  private final UUID commandId;
+
   public BuildEventServiceGrpcClient(
       ManagedChannel channel,
       @Nullable CallCredentials callCredentials,
-      ClientInterceptor interceptor) {
+      ClientInterceptor interceptor,
+      String buildRequestId,
+      UUID commandId) {
     this.besAsync =
         configureStub(PublishBuildEventGrpc.newStub(channel), callCredentials, interceptor);
     this.besBlocking =
         configureStub(PublishBuildEventGrpc.newBlockingStub(channel), callCredentials, interceptor);
     this.channel = channel;
+    this.buildRequestId = Preconditions.checkNotNull(buildRequestId);
+    this.commandId = Preconditions.checkNotNull(commandId);
   }
 
   @VisibleForTesting
@@ -67,6 +81,8 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
     this.besAsync = besAsync;
     this.besBlocking = besBlocking;
     this.channel = channel;
+    this.buildRequestId = "testing/" + UUID.randomUUID();
+    this.commandId = UUID.randomUUID();
   }
 
   private static <T extends AbstractStub<T>> T configureStub(
@@ -83,6 +99,10 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
     try {
       besBlocking
           .withDeadlineAfter(RPC_TIMEOUT.toMillis(), MILLISECONDS)
+          .withInterceptors(
+              TracingMetadataUtils.attachMetadataInterceptor(
+                  TracingMetadataUtils.buildMetadata(
+                      buildRequestId, commandId.toString(), "publish_lifecycle_event", null)))
           .publishLifecycleEvent(lifecycleEvent);
     } catch (StatusRuntimeException e) {
       Throwables.throwIfInstanceOf(Throwables.getRootCause(e), InterruptedException.class);
@@ -94,10 +114,22 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
     private final StreamObserver<PublishBuildToolEventStreamRequest> stream;
     private final SettableFuture<Status> streamStatus;
 
-    public BESGrpcStreamContext(PublishBuildEventStub besAsync, AckCallback ackCallback) {
+    public BESGrpcStreamContext(
+        PublishBuildEventStub besAsync,
+        AckCallback ackCallback,
+        String buildRequestId,
+        UUID commandId) {
       this.streamStatus = SettableFuture.create();
       this.stream =
-          besAsync.publishBuildToolEventStream(
+          besAsync
+              .withInterceptors(
+                  TracingMetadataUtils.attachMetadataInterceptor(
+                      TracingMetadataUtils.buildMetadata(
+                          buildRequestId,
+                          commandId.toString(),
+                          "publish_build_tool_event_stream",
+                          null)))
+              .publishBuildToolEventStream(
               new StreamObserver<PublishBuildToolEventStreamResponse>() {
                 @Override
                 public void onNext(PublishBuildToolEventStreamResponse response) {
@@ -157,7 +189,7 @@ public class BuildEventServiceGrpcClient implements BuildEventServiceClient {
   @Override
   public StreamContext openStream(AckCallback ackCallback) throws InterruptedException {
     try {
-      return new BESGrpcStreamContext(besAsync, ackCallback);
+      return new BESGrpcStreamContext(besAsync, ackCallback, buildRequestId, commandId);
     } catch (StatusRuntimeException e) {
       Throwables.throwIfInstanceOf(Throwables.getRootCause(e), InterruptedException.class);
       ListenableFuture<Status> status = Futures.immediateFuture(Status.fromThrowable(e));

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -56,6 +56,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/transports",
         "//src/main/java/com/google/devtools/build/lib/network:connectivity_status",
         "//src/main/java/com/google/devtools/build/lib/network:noop_connectivity",
+        "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
@@ -71,5 +72,6 @@ java_test(
         "@googleapis//:google_devtools_build_v1_build_events_java_proto",
         "@googleapis//:google_devtools_build_v1_publish_build_event_java_grpc",
         "@googleapis//:google_devtools_build_v1_publish_build_event_java_proto",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceGrpcClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceGrpcClientTest.java
@@ -120,7 +120,7 @@ public class BuildEventServiceGrpcClientTest {
       extraHeaders.put(Metadata.Key.of("metadata-foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
       ClientInterceptor interceptor = MetadataUtils.newAttachHeadersInterceptor(extraHeaders);
       BuildEventServiceGrpcClient grpcClient =
-          new BuildEventServiceGrpcClient(server.getChannel(), null, interceptor);
+          new BuildEventServiceGrpcClient(server.getChannel(), null, interceptor, "testing/" + UUID.randomUUID(), UUID.randomUUID());
       assertThat(grpcClient.openStream(ack -> {}).getStatus().get()).isEqualTo(Status.OK);
       assertThat(seenHeaders).hasSize(1);
       Metadata headers = seenHeaders.get(0);
@@ -133,7 +133,7 @@ public class BuildEventServiceGrpcClientTest {
   public void immediateSuccess() throws Exception {
     try (TestServer server = startTestServer(NOOP_SERVER.bindService())) {
       assertThat(
-              new BuildEventServiceGrpcClient(server.getChannel(), null, null)
+              new BuildEventServiceGrpcClient(server.getChannel(), null, null, "testing/" + UUID.randomUUID(), UUID.randomUUID())
                   .openStream(ack -> {})
                   .getStatus()
                   .get())
@@ -154,7 +154,7 @@ public class BuildEventServiceGrpcClientTest {
               }
             }.bindService())) {
       assertThat(
-              new BuildEventServiceGrpcClient(server.getChannel(), null, null)
+              new BuildEventServiceGrpcClient(server.getChannel(), null, null, "testing/" + UUID.randomUUID(), UUID.randomUUID())
                   .openStream(ack -> {})
                   .getStatus()
                   .get())


### PR DESCRIPTION
This allows servers to trace the requests similarly to other RPCs.