### PR TITLE
Only show the base name of archives being extracted.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -715,7 +715,8 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
         Profiler.instance().profile("extracting: " + getIdentifyingStringForLogging())) {
       env.getListener()
           .post(
-              new ExtractProgress(outputPath.getPath().toString(), "Extracting " + downloadedPath));
+              new ExtractProgress(
+                  outputPath.getPath().toString(), "Extracting " + downloadedPath.getBaseName()));
       DecompressorValue.decompress(
           DecompressorDescriptor.builder()
               .setContext(getIdentifyingStringForLogging())

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -489,7 +489,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     env.getListener()
         .post(
             new ExtractProgress(
-                outputPath.getPath().toString(), "Extracting " + archivePath.getPath()));
+                outputPath.getPath().toString(), "Extracting " + archivePath.getBasename()));
     DecompressorValue.decompress(
         DecompressorDescriptor.builder()
             .setContext(getIdentifyingStringForLogging())


### PR DESCRIPTION
Most of the archive path is a long absolute path into Bazel internal directories, which is not interesting to look at.