### PR TITLE
Add Objc.static_framework_file to fully link arguments

### DIFF
--- a/src/main/starlark/builtins_bzl/common/objc/compilation_support.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/compilation_support.bzl
@@ -51,6 +51,8 @@ def _build_variable_extensions(
         import_paths = []
         for import_lib in objc_provider.imported_library.to_list():
             import_paths.append(import_lib.path)
+        for static_framework_file in objc_provider.static_framework_file.to_list():
+            import_paths.append(static_framework_file.path)
 
         extensions["objc_library_exec_paths"] = exclusively_objc_libs
         extensions["cc_library_exec_paths"] = cc_libs.keys()
@@ -578,6 +580,7 @@ def _register_fully_link_action(common_variables, objc_provider, name):
     linker_inputs.extend(objc_provider.flattened_objc_libraries())
     linker_inputs.extend(objc_provider.flattened_cc_libraries())
     linker_inputs.extend(objc_provider.imported_library.to_list())
+    linker_inputs.extend(objc_provider.static_framework_file.to_list())
 
     return cc_common.link(
         name = name,


### PR DESCRIPTION
When you are creating a fully linked static library that directly depends on static frameworks, you ideally want this framework to be linked, just as if it was an imported static library. Previously it would be silently ignored and you would have to distribute the static framework with the fully linked library. If users need the previous behavior they should use `avoid_deps` when creating the fully linked library.