### PR TITLE
Guarantee classes are packed with their inner synthetic lambdas during sharding

### DIFF
--- a/src/test/java/com/google/devtools/build/android/dexer/BUILD
+++ b/src/test/java/com/google/devtools/build/android/dexer/BUILD
@@ -97,7 +97,7 @@ java_library(
     srcs = [":mixed_srcjar_gen"],
 )
 
-android_library(
+java_library(
     name = "innerclasses_testinput",
     srcs = glob(["testdata/innerclasses/*.java"]),
 )

--- a/src/test/java/com/google/devtools/build/android/dexer/BUILD
+++ b/src/test/java/com/google/devtools/build/android/dexer/BUILD
@@ -34,6 +34,7 @@ java_library(
         "//src/test/java/com/google/devtools/build/lib/testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestSuite",
         "//src/tools/android/java/com/google/devtools/build/android/dexer",
+        "//src/tools/android/java/com/google/devtools/build/android/r8",
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:mockito",
@@ -47,7 +48,10 @@ java_library(
 
 java_library(
     name = "testdata",
-    srcs = glob(["testdata/**/*.java"]),
+    srcs = glob(
+            ["testdata/**/*.java"],
+            exclude = ["testdata/innerclasses/*"],
+    ),
 )
 
 java_test(
@@ -56,6 +60,7 @@ java_test(
     data = [
         "test_main_dex_list.txt",
         ":mixed_testinput",
+        ":innerclasses_testinput",
         ":testdata",
         ":tests",
     ],
@@ -64,6 +69,7 @@ java_test(
         "-Dtestinputjar=io_bazel/$(location :tests)",
         "-Dtestinputjar2=io_bazel/$(location :testdata)",
         "-Dmixedinputjar=io_bazel/$(location :mixed_testinput)",
+        "-Dinnerclassesinputjar=io_bazel/$(location :innerclasses_testinput)"
     ],
     runtime_deps = [
         ":tests",
@@ -89,4 +95,9 @@ genrule(
 java_library(
     name = "mixed_testinput",
     srcs = [":mixed_srcjar_gen"],
+)
+
+android_library(
+    name = "innerclasses_testinput",
+    srcs = glob(["testdata/innerclasses/*.java"]),
 )

--- a/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/AnotherClass.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/AnotherClass.java
@@ -1,0 +1,27 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.android.dexer.testdata.innerclasses;
+
+public class AnotherClass {
+  public void M1() {
+  }
+  public void M2() {
+  }
+  public void M3() {
+  }
+  public void M4() {
+  }
+  public void M5() {
+  }
+}

--- a/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/OuterClass.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/OuterClass.java
@@ -1,0 +1,36 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.android.dexer.testdata.innerclasses;
+
+interface Inner {
+    public void bar();
+}
+
+public class OuterClass {
+  public void foo() {
+
+    Inner in1 = () -> {
+    };
+    Inner in2 = () -> {
+    };
+    Inner in3 = () -> {
+    };
+    Inner in4 = () -> {
+    };
+    Inner in5 = () -> {
+    };
+    Inner in6 = () -> {
+    };
+  }
+}

--- a/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/OuterClass.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/OuterClass.java
@@ -20,6 +20,7 @@ interface Inner {
 public class OuterClass {
   public void foo() {
 
+    // Syntethic lambdas should be packed together.
     Inner in1 = () -> {
     };
     Inner in2 = () -> {
@@ -32,5 +33,19 @@ public class OuterClass {
     };
     Inner in6 = () -> {
     };
+  }
+
+  // Plain inner classes may be packed in a different shard.
+  private static class InnerClass0 {
+  }
+  private static class InnerClass1 {
+  }
+  private static class InnerClass2 {
+  }
+  private static class InnerClass3 {
+  }
+  private static class InnerClass4 {
+  }
+  private static class InnerClass5 {
   }
 }

--- a/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/OuterClass_WithUnderscore.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/OuterClass_WithUnderscore.java
@@ -1,0 +1,19 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.android.dexer.testdata.innerclasses;
+
+public class OuterClass_WithUnderscore {
+    public void baz() {
+    }
+}

--- a/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/SomeClass.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/testdata/innerclasses/SomeClass.java
@@ -1,0 +1,20 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.android.dexer.testdata.innerclasses;
+
+public class SomeClass {
+  public int foo() {
+    return 0;
+  }
+}

--- a/src/tools/android/java/com/google/devtools/build/android/dexer/DexFileSplitter.java
+++ b/src/tools/android/java/com/google/devtools/build/android/dexer/DexFileSplitter.java
@@ -280,7 +280,7 @@ class DexFileSplitter implements Closeable {
       ImmutableList<Map.Entry<String, ZipFile>> filesToProcess, Predicate<String> filter)
       throws IOException {
 
-    // Collect a class and its inner classes as a unit so that they can be placed in
+    // Collect a class and its inner synthetic lambda classes as a unit so that they can be placed in
     // in a single shard in the next step.
     // Here we assume filesToProcess is sorted in lexicographical order and outer classes
     // appear before than the inner classes. 
@@ -346,13 +346,13 @@ class DexFileSplitter implements Closeable {
           .map(e -> e.getDexFile())
           .collect(ImmutableList.toImmutableList());
 
-      // Track all dex files for a class and its inner classes as a unit.
-      // Placing inner classes in a different shard than its outer class
+      // Track all dex files for a class and its lambda classes as a unit.
+      // Placing lambda classes in a different shard than its outer class
       // can lead to D8 failing during dex merge.
       if (tracker.track(dexFiles)) {
           nextShard();
           checkState(!tracker.track(dexFiles),
-                  "Impossible to fit %s and all of its inner classes in a single shard",
+                  "Impossible to fit %s and all of its synthetic lambda classes in a single shard",
                   dexEntries.get(0).getEntry().getName());
       }
 

--- a/src/tools/android/java/com/google/devtools/build/android/dexer/DexFileSplitter.java
+++ b/src/tools/android/java/com/google/devtools/build/android/dexer/DexFileSplitter.java
@@ -271,9 +271,9 @@ class DexFileSplitter implements Closeable {
     closer.close();
   }
 
-  private boolean isOuterClass(String classFile) {
+  private boolean isLambda(String classFile) {
     String components[] = classFile.split("/");
-    return !components[components.length-1].contains("$");
+    return components[components.length-1].contains("ExternalSyntheticLambda");
   }
 
   private void processDexFiles(
@@ -288,10 +288,10 @@ class DexFileSplitter implements Closeable {
     for (Map.Entry<String, ZipFile> entry : filesToProcess) {
       String filename = entry.getKey();
       if (filter.test(filename)) {
-        boolean isOuter = isOuterClass(filename);
+        boolean isLambda = isLambda(filename);
 
-	    // TODO: optimize- this currently creates a list of size one for most cases
-	 if (isOuter) {
+	 // TODO: optimize- this currently creates a list of size one for most cases
+	 if (!isLambda) {
 	    if (!zipEntries.isEmpty()) {
 		processDexEntries(zipEntries);
 	    }

--- a/src/tools/android/java/com/google/devtools/build/android/dexer/DexFileSplitter.java
+++ b/src/tools/android/java/com/google/devtools/build/android/dexer/DexFileSplitter.java
@@ -291,12 +291,12 @@ class DexFileSplitter implements Closeable {
         boolean isOuter = isOuterClass(filename);
 
 	    // TODO: optimize- this currently creates a list of size one for most cases
-        if (!zipEntries.isEmpty() && isOuter) { 
-            processDexEntries(zipEntries);
-        }
-        if (isOuter) {
-            zipEntries.clear();
-        }
+	 if (isOuter) {
+	    if (!zipEntries.isEmpty()) {
+		processDexEntries(zipEntries);
+	    }
+	    zipEntries.clear();
+	}
         zipEntries.add(entry);
       }
     }

--- a/src/tools/android/java/com/google/devtools/build/android/dexer/DexLimitTracker.java
+++ b/src/tools/android/java/com/google/devtools/build/android/dexer/DexLimitTracker.java
@@ -22,6 +22,7 @@ import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.ImmutableList;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 /**
  * Helper to track how many unique field and method references we've seen in a given set of .dex
@@ -35,6 +36,22 @@ class DexLimitTracker {
 
   public DexLimitTracker(int maxNumberOfIdxPerDex) {
     this.maxNumberOfIdxPerDex = maxNumberOfIdxPerDex;
+  }
+
+  /**
+   * Tracks the field and method references in the given files and returns whether we're within
+   * limits.
+   *
+   * @return {@code true} if method or field references are outside limits, {@code false} both
+   *     are within limits.
+   */
+  public boolean track(List<Dex> dexFiles) {
+    for (Dex dexFile : dexFiles) {
+        if (track(dexFile)) {
+            return true;
+        }
+    }
+    return false;
   }
 
   /**

--- a/src/tools/android/java/com/google/devtools/build/android/dexer/ZipEntryComparator.java
+++ b/src/tools/android/java/com/google/devtools/build/android/dexer/ZipEntryComparator.java
@@ -27,6 +27,8 @@ enum ZipEntryComparator implements Comparator<ZipEntry> {
    */
   LIKE_DX;
 
+  private static String LAMBDA_NAME = "ExternalSyntheticLambda";
+
   @Override
   // Copied from com.android.dx.cf.direct.ClassPathOpener
   public int compare(ZipEntry a, ZipEntry b) {
@@ -47,6 +49,10 @@ enum ZipEntryComparator implements Comparator<ZipEntry> {
     // Ensure inner classes sort second
     a = a.replace('$', '0');
     b = b.replace('$', '0');
+
+    // Make sure lambdas come before any other inner class.
+    a = a.replace(LAMBDA_NAME, "0");
+    b = b.replace(LAMBDA_NAME, "0");
 
     /*
      * Assuming "package-info" only occurs at the end, ensures package-info

--- a/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
@@ -40,6 +40,7 @@ java_library(
         ),
         "//conditions:default": ["NoAndroidSdkStub.java"],
     }),
+    testonly = 1,
     visibility = [
             "//src/test/java/com/google/devtools/build/android/r8:__pkg__",
             # needed to test DexFileSplitter with desugared jars
@@ -57,7 +58,7 @@ java_library(
         "//third_party:guava",
         "//third_party:jsr305",
     ] + select({
-        "//external:has_androidsdk": ["//external:android/d8_jar_import"],
+        "//external:has_androidsdk": ["@android_gmaven_r8_for_testing//jar"],
         "//conditions:default": [],
     }),
 )

--- a/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
@@ -40,7 +40,11 @@ java_library(
         ),
         "//conditions:default": ["NoAndroidSdkStub.java"],
     }),
-    visibility = ["//src/test/java/com/google/devtools/build/android/r8:__pkg__"],
+    visibility = [
+            "//src/test/java/com/google/devtools/build/android/r8:__pkg__",
+            # needed to test DexFileSplitter with desugared jars
+            "//src/test/java/com/google/devtools/build/android/dexer:__pkg__",
+     ],
     runtime_deps = [
         "//src/tools/android/java/com/google/devtools/build/android/desugar/dependencies",
     ],

--- a/src/tools/android/java/com/google/devtools/build/android/r8/Desugar.java
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/Desugar.java
@@ -28,6 +28,7 @@ import com.android.tools.r8.Diagnostic;
 import com.android.tools.r8.DiagnosticsHandler;
 import com.android.tools.r8.errors.InterfaceDesugarMissingTypeDiagnostic;
 import com.android.tools.r8.utils.StringDiagnostic;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.android.Converters.ExistingPathConverter;
 import com.google.devtools.build.android.Converters.PathConverter;
@@ -370,7 +371,8 @@ public class Desugar {
 
   private final DesugarOptions options;
 
-  private Desugar(DesugarOptions options) {
+  @VisibleForTesting  
+  public Desugar(DesugarOptions options) {
     this.options = options;
   }
 
@@ -497,7 +499,8 @@ public class Desugar {
     }
   }
 
-  private void desugar() throws CompilationFailedException, IOException {
+  @VisibleForTesting
+  public void desugar() throws CompilationFailedException, IOException {
     // Prepare bootclasspath and classpath. Some jars on the classpath are considered to be
     // bootclasspath, and are moved there.
     ImmutableList.Builder<ClassFileResourceProvider> bootclasspathProvidersBuilder =


### PR DESCRIPTION
If a desugared lambda is packed in a different shard than the one from its original class D8 will fail with the following message:

Attempt at compiling intermediate artifact without its context

Changed sharding code so that it treats a class and synthetic lambda classes as a single unit.

Fixes https://github.com/bazelbuild/bazel/issues/16368