### PR TITLE
Add link to Further Rule Documentation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/RuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleFunction.java
@@ -25,7 +25,8 @@ import net.starlark.java.eval.StarlarkCallable;
     doc =
         "A callable value representing the type of a native or Starlark rule. Calling the value"
             + " during evaluation of a package's BUILD file creates an instance of the rule and"
-            + " adds it to the package's target set.")
+            + " adds it to the package's target set. For more information, visit this page about"
+            + "<a href ='https://bazel.build/extending/rules'>Rules</a>."
 public interface RuleFunction extends StarlarkCallable {
   RuleClass getRuleClass();
 }


### PR DESCRIPTION
Update https://bazel.build/rules/lib/rule to point to https://bazel.build/extending/rules for more information about `rule(...)`