### PR TITLE
fix: expand_location binary target inputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -1133,7 +1133,11 @@ public final class StarlarkRuleContext implements StarlarkRuleContextApi<Constra
   }
 
   /**
-   * Builds a map: Label -> List of runfiles from the given labels.
+   * Builds a map: Label -> List of files from the given labels.
+   * It first looks into the runfiles and then into files. If the label being iterated is an
+   * executable, then it will have the same behaviour as native rules special attributes (data,
+   * tools) in which only the executable file is mapped to the label. This allows executable targets
+   * to have the location expansion work with the singular form of location/execpath/rootpath.
    *
    * @param knownLabels List of known labels
    * @return Immutable map with immutable collections as values

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -1133,7 +1133,7 @@ public final class StarlarkRuleContext implements StarlarkRuleContextApi<Constra
   }
 
   /**
-   * Builds a map: Label -> List of files from the given labels
+   * Builds a map: Label -> List of runfiles from the given labels.
    *
    * @param knownLabels List of known labels
    * @return Immutable map with immutable collections as values
@@ -1143,9 +1143,14 @@ public final class StarlarkRuleContext implements StarlarkRuleContextApi<Constra
     ImmutableMap.Builder<Label, ImmutableCollection<Artifact>> builder = ImmutableMap.builder();
 
     for (TransitiveInfoCollection current : knownLabels) {
+      Label label = AliasProvider.getDependencyLabel(current);
+      FilesToRunProvider filesToRun = current.getProvider(FilesToRunProvider.class);
+      Artifact executableArtifact = filesToRun.getExecutable();
       builder.put(
-          AliasProvider.getDependencyLabel(current),
-          current.getProvider(FileProvider.class).getFilesToBuild().toList());
+          label,
+          executableArtifact != null
+            ? ImmutableList.of(executableArtifact)
+            : filesToRun.getFilesToRun().toList());
     }
 
     return builder.buildOrThrow();

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -1134,7 +1134,7 @@ public final class StarlarkRuleContext implements StarlarkRuleContextApi<Constra
 
   /**
    * Builds a map: Label -> List of files from the given labels.
-   * It first looks into the runfiles and then into files. If the label being iterated is an
+   * It first looks into the files-to-run and then into files. If the label being iterated is an
    * executable, then it will have the same behaviour as native rules special attributes (data,
    * tools) in which only the executable file is mapped to the label. This allows executable targets
    * to have the location expansion work with the singular form of location/execpath/rootpath.

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -658,6 +658,41 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
     assertThat(loc).isEqualTo("foo/libjl.jar");
   }
 
+  /** Asserts that a custom rule has the same behaviour as native rules when 
+   * expanding executable target locations.
+  */
+  @Test
+  public void testExpandLocationExecutableTargets() throws Exception {
+    scratch.file(
+        "test/defs.bzl",
+        "def _impl(ctx):",
+        "  env = {}",
+        "  for k, v in ctx.attr.env.items():",
+        "    env[k] = ctx.expand_location(v, targets = ctx.attr.data)",
+        "  return [DefaultInfo()]",
+        "expand_location_env_rule = rule(",
+        "    implementation = _impl,",
+        "    attrs = {",
+        "       'data': attr.label_list(allow_files=True),",
+        "       'env': attr.string_dict(),",
+        "    }",
+        ")");
+
+    scratch.file("test/main.py", "");
+
+    scratch.file(
+        "test/BUILD",
+        "load('//test:defs.bzl', 'expand_location_env_rule')",
+        "py_binary(name = 'main', srcs = ['main.py'])",
+        "expand_location_env_rule(",
+        "  name = 'expand_location_env',",
+        "  data = [':main'],",
+        "  env = {'MAIN_EXECPATH': '$(execpath :main)'},",
+        ")");
+
+    assertThat(getConfiguredTarget("//test:expand_location_env")).isNotNull();
+  }
+
   /** Regression test to check that expand_location allows ${var} and $$. */
   @Test
   public void testExpandLocationWithDollarSignsAndCurlys() throws Exception {


### PR DESCRIPTION
The previous behaviour was that location expansion on native rules would accept binary targets as inputs and resolve to a single location. This was not an option on custom rules. This patch aligns the behaviour of Starlark's ctx.expand_location to the native rules. E.g. a py_binary can be expanded using location/execpath/rootpath instead of previously only locations/execpaths/rootpaths.

For more context, see https://github.com/bazelbuild/rules_python/pull/846. To be able to add the multi-toolchain feature to rules_python, I had to trick `ctx.expand_location` using the `tools` attribute while this is not fixed.