### PR TITLE
starlark cpu profiler: fix compilation warning on MacOS

### DIFF
--- a/src/main/java/net/starlark/java/eval/cpu_profiler_posix.cc
+++ b/src/main/java/net/starlark/java/eval/cpu_profiler_posix.cc
@@ -21,10 +21,15 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#else  // darwin
+#include <pthread.h>
+#endif
 
 namespace cpu_profiler {
 
@@ -40,7 +45,9 @@ pid_t gettid(void) {
 #ifdef __linux__
   return (pid_t)syscall(SYS_gettid);
 #else  // darwin
-  return (pid_t)syscall(SYS_thread_selfid);
+  uint64_t tid64;
+  pthread_threadid_np(NULL, &tid64);
+  return (pid_t)tid64;
 #endif
 }
 


### PR DESCRIPTION
On MacOS 10.12 and above, we get the warning as follow

```
src/main/java/net/starlark/java/eval/cpu_profiler_posix.cc:43:17: warning: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Wdeprecated-declarations]
  return (pid_t)syscall(SYS_thread_selfid);
                ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:746:6: note: 'syscall' has been explicitly marked deprecated here
int      syscall(int, ...);
         ^
1 warning generated.
```

Switch to use pthread_threadid_np to get ID instead.