### PR TITLE
Remove --[no]use_action_cache from user manual because it is misleading

### DIFF
--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -1403,12 +1403,6 @@ for comparisons.
 Temporary flag for testing bazel default visibility changes. Not intended for general use
 but documented for completeness' sake.
 
-#### `--[no]use_action_cache` {:#use-action-cache}
-
-This option is enabled by default. If disabled, Bazel will not use its local action cache.
-Disabling the local action cache saves memory and disk space for clean builds, but will make
-incremental builds slower.
-
 #### `--starlark_cpu_profile=_file_` {:#starlark-cpu-profile}
 
 This flag, whose value is the name of a file, causes Bazel to gather


### PR DESCRIPTION
Per discussion in https://bazelbuild.slack.com/archives/CA31HN1T3/p1664993836113209

> Son Luong Ngoc
I think the doc should remove that flag, it's misleading. It does not completely disable usage of AC but only the local PAC (stored in 2 files)
