### PR TITLE
zstd-jni: upgrade to v1.5.2-3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "grpc", version = "1.47.0", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "rules_pkg", version = "0.7.0")
 bazel_dep(name = "stardoc", version = "0.5.0", repo_name = "io_bazel_skydoc")
-bazel_dep(name = "zstd-jni", version = "1.5.0-4")
+bazel_dep(name = "zstd-jni", version = "1.5.2-3")
 
 # The following are required when building without WORKSPACE SUFFIX
 bazel_dep(name = "rules_cc", version = "0.0.2")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -289,7 +289,7 @@ dist_http_archive(
     build_file = "//third_party:zstd-jni/zstd-jni.BUILD",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE_WIN,
-    strip_prefix = "zstd-jni-1.5.0-4",
+    strip_prefix = "zstd-jni-1.5.2-3",
 )
 
 http_archive(

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -235,15 +235,15 @@ DIST_DEPS = {
         "strip_prefix": "abseil-cpp-20211102.0",
     },
     "zstd-jni": {
-        "archive": "v1.5.0-4.zip",
+        "archive": "v1.5.2-3.zip",
         "patch_args": ["-p1"],
         "patches": [
             "//third_party:zstd-jni/Native.java.patch",
         ],
-        "sha256": "d320d59b89a163c5efccbe4915ae6a49883ce653cdc670643dfa21c6063108e4",
+        "sha256": "366009a43cfada35015e4cc40a7efc4b7f017c6b8df5cac3f87d2478027b2056",
         "urls": [
-            "https://mirror.bazel.build/github.com/luben/zstd-jni/archive/v1.5.0-4.zip",
-            "https://github.com/luben/zstd-jni/archive/v1.5.0-4.zip",
+            "https://mirror.bazel.build/github.com/luben/zstd-jni/archive/refs/tags/v1.5.2-3.zip",
+            "https://github.com/luben/zstd-jni/archive/refs/tags/v1.5.2-3.zip",
         ],
         "used_in": [
             "additional_distfiles",

--- a/third_party/zstd-jni/zstd-jni.BUILD
+++ b/third_party/zstd-jni/zstd-jni.BUILD
@@ -24,9 +24,12 @@ cc_binary(
         "src/main/native/**/*.c",
         "src/main/native/**/*.h",
     ]) + [
-            ":jni_md.h",
-            ":jni.h",
-        ],
+        ":jni_md.h",
+        ":jni.h",
+    ] + select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": glob(["src/main/native/**/*.S"]),
+    }),
     copts = select({
         "@bazel_tools//src/conditions:windows": [],
         "@bazel_tools//src/conditions:darwin": [


### PR DESCRIPTION
This fixes these warning messages found when compiling Bazel with an older version of the library.

```
INFO: From Building external/zstd-jni/libzstd-jni-class.jar (20 source files):
external/zstd-jni/src/main/java/com/github/luben/zstd/ZstdInputStream.java:46: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    public void setFinalize(boolean finalize) {
                ^
external/zstd-jni/src/main/java/com/github/luben/zstd/ZstdOutputStream.java:21: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush, boolean useChecksums) throws IOException {
           ^
external/zstd-jni/src/main/java/com/github/luben/zstd/ZstdOutputStream.java:32: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush) throws IOException {
           ^
external/zstd-jni/src/main/java/com/github/luben/zstd/ZstdOutputStream.java:86: warning: [dep-ann] deprecated item is not annotated with @Deprecated
    public void setFinalize(boolean finalize) {
                ^
```

and

```
INFO: From Compiling src/main/native/compress/zstd_compress_superblock.c:
external/zstd-jni/src/main/native/compress/zstd_compress_superblock.c:134:12: warning: variable 'litLengthSum' set but not used [-Wunused-but-set-variable]
    size_t litLengthSum = 0;
           ^
1 warning generated.
```

Minor changes needed for the BUILD files so that assembly file(s) are included during compilation on non-windows platforms.