### PR TITLE
Remove unused symbol_counts feature

### DIFF
--- a/site/en/docs/cc-toolchain-config-reference.md
+++ b/site/en/docs/cc-toolchain-config-reference.md
@@ -926,13 +926,6 @@ Note: The **Action** column indicates the relevant action type, if applicable.
    </td>
   </tr>
   <tr>
-   <td><strong><code>symbol_counts_output</code></strong>
-   </td>
-   <td>link</td>
-   <td>Path to which to write symbol counts.
-   </td>
-  </tr>
-  <tr>
    <td><strong><code>linkstamp_paths</code></strong>
    </td>
    <td>link</td>
@@ -1123,7 +1116,6 @@ conditions.
     <li>Adds <code>autofdo</code> (if not present) feature to the top of the toolchain</li>
     <li>Adds <code>build_interface_libraries</code> (if not present) feature to the top of the toolchain</li>
     <li>Adds <code>dynamic_library_linker_tool</code> (if not present) feature to the top of the toolchain</li>
-    <li>Adds <code>symbol_counts</code> (if not present) feature to the top of the toolchain</li>
     <li>Adds <code>shared_flag</code> (if not present) feature to the top of the toolchain</li>
     <li>Adds <code>linkstamps</code> (if not present) feature to the top of the toolchain</li>
     <li>Adds <code>output_execpath_flags</code> (if not present) feature to the top of the toolchain</li>

--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -312,18 +312,6 @@ extension.
 
 The options `--fdo_instrument` and `--fdo_optimize` cannot be used at the same time.
 
-#### `--[no]output_symbol_counts` {:#output-symbol-counts}
-
-If enabled, each gold-invoked link of a C++ executable binary will output
-a _symbol counts_ file (via the `--print-symbol-counts` gold
-option). For each linker input, the file logs the number of symbols that were
-defined and the number of symbols that were used in the binary.
-This information can be used to track unnecessary link dependencies.
-The symbol counts file is written to the binary's output path with the name
-`[targetname].sc`.
-
-This option is disabled by default.
-
 #### `--java_language_version={{ "<var>" }}version{{ "</var>" }}` {:#java-language-version}
 
 This option specifies the version of Java sources. For example:

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -127,15 +127,6 @@ public final class BazelRulesModule extends BlazeModule {
     public boolean incompatibleDisableInMemoryToolsDefaultsPackage;
 
     @Option(
-        name = "output_symbol_counts",
-        defaultValue = "false",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.ACTION_COMMAND_LINES, OptionEffectTag.AFFECTS_OUTPUTS},
-        metadataTags = {OptionMetadataTag.HIDDEN, OptionMetadataTag.DEPRECATED},
-        help = "Deprecated no-op.")
-    public boolean symbolCounts;
-
-    @Option(
         name = "incompatible_disable_sysroot_from_configuration",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -453,26 +453,6 @@ public class CppActionConfigs {
                         "    }",
                         "  }")));
       }
-
-      if (!existingFeatureNames.contains("symbol_counts")) {
-        featureBuilder.add(
-            getFeature(
-                Joiner.on("\n")
-                    .join(
-                        "  name: 'symbol_counts'",
-                        "  flag_set {",
-                        "    action: 'c++-link-executable'",
-                        "    action: 'c++-link-dynamic-library'",
-                        "    action: 'c++-link-nodeps-dynamic-library'",
-                        "    action: 'lto-index-for-dynamic-library'",
-                        "    action: 'lto-index-for-nodeps-dynamic-library'",
-                        "    action: 'lto-index-for-executable'",
-                        "    flag_group {",
-                        "      expand_if_all_available: 'symbol_counts_output'",
-                        "      flag: '-Wl,--print-symbol-counts=%{symbol_counts_output}'",
-                        "    }",
-                        "  }")));
-      }
       if (!existingFeatureNames.contains("shared_flag")) {
         featureBuilder.add(
             getFeature(
@@ -1188,7 +1168,6 @@ public class CppActionConfigs {
                         "  tool {",
                         "    tool_path: '" + gccToolPath + "'",
                         "  }",
-                        "  implies: 'symbol_counts'",
                         "  implies: 'strip_debug_symbols'",
                         "  implies: 'linkstamps'",
                         "  implies: 'output_execpath_flags'",
@@ -1212,7 +1191,6 @@ public class CppActionConfigs {
                         "  tool {",
                         "    tool_path: '" + gccToolPath + "'",
                         "  }",
-                        "  implies: 'symbol_counts'",
                         "  implies: 'strip_debug_symbols'",
                         "  implies: 'linkstamps'",
                         "  implies: 'output_execpath_flags'",
@@ -1238,7 +1216,6 @@ public class CppActionConfigs {
                         "  }",
                         "  implies: 'build_interface_libraries'",
                         "  implies: 'dynamic_library_linker_tool'",
-                        "  implies: 'symbol_counts'",
                         "  implies: 'strip_debug_symbols'",
                         "  implies: 'shared_flag'",
                         "  implies: 'linkstamps'",
@@ -1264,7 +1241,6 @@ public class CppActionConfigs {
                         "  }",
                         "  implies: 'build_interface_libraries'",
                         "  implies: 'dynamic_library_linker_tool'",
-                        "  implies: 'symbol_counts'",
                         "  implies: 'strip_debug_symbols'",
                         "  implies: 'shared_flag'",
                         "  implies: 'linkstamps'",
@@ -1290,7 +1266,6 @@ public class CppActionConfigs {
                         "  }",
                         "  implies: 'build_interface_libraries'",
                         "  implies: 'dynamic_library_linker_tool'",
-                        "  implies: 'symbol_counts'",
                         "  implies: 'strip_debug_symbols'",
                         "  implies: 'shared_flag'",
                         "  implies: 'linkstamps'",
@@ -1316,7 +1291,6 @@ public class CppActionConfigs {
                         "  }",
                         "  implies: 'build_interface_libraries'",
                         "  implies: 'dynamic_library_linker_tool'",
-                        "  implies: 'symbol_counts'",
                         "  implies: 'strip_debug_symbols'",
                         "  implies: 'shared_flag'",
                         "  implies: 'linkstamps'",

--- a/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
@@ -1773,7 +1773,6 @@ def _impl(ctx):
         cpp_link_executable_action = action_config(
             action_name = ACTION_NAMES.cpp_link_executable,
             implies = [
-                "symbol_counts",
                 "linkstamps",
                 "output_execpath_flags",
                 "runtime_root_flags",
@@ -1798,7 +1797,6 @@ def _impl(ctx):
         cpp_link_executable_action = action_config(
             action_name = ACTION_NAMES.cpp_link_executable,
             implies = [
-                "symbol_counts",
                 "linkstamps",
                 "output_execpath_flags",
                 "runtime_root_flags",
@@ -1823,7 +1821,6 @@ def _impl(ctx):
         cpp_link_executable_action = action_config(
             action_name = ACTION_NAMES.cpp_link_executable,
             implies = [
-                "symbol_counts",
                 "linkstamps",
                 "output_execpath_flags",
                 "runtime_root_flags",
@@ -1847,7 +1844,6 @@ def _impl(ctx):
         cpp_link_executable_action = action_config(
             action_name = ACTION_NAMES.cpp_link_executable,
             implies = [
-                "symbol_counts",
                 "linkstamps",
                 "output_execpath_flags",
                 "runtime_root_flags",
@@ -1871,7 +1867,6 @@ def _impl(ctx):
         cpp_link_executable_action = action_config(
             action_name = ACTION_NAMES.cpp_link_executable,
             implies = [
-                "symbol_counts",
                 "linkstamps",
                 "output_execpath_flags",
                 "runtime_root_flags",
@@ -1895,7 +1890,6 @@ def _impl(ctx):
         cpp_link_executable_action = action_config(
             action_name = ACTION_NAMES.cpp_link_executable,
             implies = [
-                "symbol_counts",
                 "linkstamps",
                 "output_execpath_flags",
                 "runtime_root_flags",
@@ -1920,7 +1914,6 @@ def _impl(ctx):
         cpp_link_executable_action = action_config(
             action_name = ACTION_NAMES.cpp_link_executable,
             implies = [
-                "symbol_counts",
                 "linkstamps",
                 "output_execpath_flags",
                 "runtime_root_flags",
@@ -1945,7 +1938,6 @@ def _impl(ctx):
         cpp_link_executable_action = action_config(
             action_name = ACTION_NAMES.cpp_link_executable,
             implies = [
-                "symbol_counts",
                 "linkstamps",
                 "output_execpath_flags",
                 "runtime_root_flags",
@@ -3526,7 +3518,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -3552,7 +3543,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -3578,7 +3568,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -3603,7 +3592,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -3628,7 +3616,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -3653,7 +3640,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -3679,7 +3665,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -3705,7 +3690,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -4959,7 +4943,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -4985,7 +4968,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -5011,7 +4993,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -5036,7 +5017,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -5061,7 +5041,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -5086,7 +5065,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -5112,7 +5090,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -5138,7 +5115,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
             implies = [
                 "has_configured_linker_path",
-                "symbol_counts",
                 "shared_flag",
                 "linkstamps",
                 "output_execpath_flags",
@@ -8435,21 +8411,6 @@ def _impl(ctx):
         ],
     )
 
-    symbol_counts_feature = feature(
-        name = "symbol_counts",
-        flag_sets = [
-            flag_set(
-                actions = _NON_OBJC_LINK_ACTIONS,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-Wl,--print-symbol-counts=%{symbol_counts_output}"],
-                        expand_if_available = "symbol_counts_output",
-                    ),
-                ],
-            ),
-        ],
-    )
-
     gcc_coverage_map_format_feature = feature(
         name = "gcc_coverage_map_format",
         flag_sets = [
@@ -8640,7 +8601,6 @@ def _impl(ctx):
         generate_linkmap_feature,
         objc_actions_feature,
         strip_debug_symbols_feature,
-        symbol_counts_feature,
         shared_flag_feature,
         linkstamps_feature,
         output_execpath_flags_feature,

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -712,23 +712,6 @@ def _impl(ctx):
         ],
     )
 
-    symbol_counts_feature = feature(
-        name = "symbol_counts",
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions + lto_index_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-Wl,--print-symbol-counts=%{symbol_counts_output}",
-                        ],
-                        expand_if_available = "symbol_counts_output",
-                    ),
-                ],
-            ),
-        ],
-    )
-
     strip_debug_symbols_feature = feature(
         name = "strip_debug_symbols",
         flag_sets = [
@@ -1243,7 +1226,6 @@ def _impl(ctx):
             autofdo_feature,
             build_interface_libraries_feature,
             dynamic_library_linker_tool_feature,
-            symbol_counts_feature,
             shared_flag_feature,
             linkstamps_feature,
             output_execpath_flags_feature,

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -306,7 +306,6 @@ def _impl(ctx):
         implies = [
             "contains_objc_source",
             "has_configured_linker_path",
-            "symbol_counts",
             "shared_flag",
             "linkstamps",
             "output_execpath_flags",
@@ -574,7 +573,6 @@ def _impl(ctx):
         action_name = ACTION_NAMES.cpp_link_executable,
         implies = [
             "contains_objc_source",
-            "symbol_counts",
             "linkstamps",
             "output_execpath_flags",
             "runtime_root_flags",
@@ -644,7 +642,6 @@ def _impl(ctx):
         implies = [
             "contains_objc_source",
             "has_configured_linker_path",
-            "symbol_counts",
             "shared_flag",
             "linkstamps",
             "output_execpath_flags",
@@ -957,21 +954,6 @@ def _impl(ctx):
     fastbuild_feature = feature(name = "fastbuild")
 
     no_legacy_features_feature = feature(name = "no_legacy_features")
-
-    symbol_counts_feature = feature(
-        name = "symbol_counts",
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-Wl,--print-symbol-counts=%{symbol_counts_output}"],
-                        expand_if_available = "symbol_counts_output",
-                    ),
-                ],
-            ),
-        ],
-    )
 
     user_link_flags_feature = feature(
         name = "user_link_flags",
@@ -2730,7 +2712,6 @@ def _impl(ctx):
             contains_objc_source_feature,
             objc_actions_feature,
             strip_debug_symbols_feature,
-            symbol_counts_feature,
             shared_flag_feature,
             kernel_extension_feature,
             linkstamps_feature,
@@ -2812,7 +2793,6 @@ def _impl(ctx):
             contains_objc_source_feature,
             objc_actions_feature,
             strip_debug_symbols_feature,
-            symbol_counts_feature,
             shared_flag_feature,
             kernel_extension_feature,
             linkstamps_feature,


### PR DESCRIPTION
This feature only applied if `symbol_counts_output` was set, which doesn't appear to be possible.