### PR TITLE
Fix bazel hanging when outputs got evicted from remote execution cache with --remote_download_toplevel enabled

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -229,11 +229,6 @@ public class RemoteExecutionCache extends RemoteCache {
 
                 @Override
                 public void onError(@NonNull Throwable e) {
-                  Disposable d = uploadTask.disposable.get();
-                  if (d != null && d.isDisposed()) {
-                    return;
-                  }
-
                   completion.onError(e);
                 }
               });


### PR DESCRIPTION
#16422 This PR removes ignoring exception from upload task which leads to Bazel hanging in scenario represented in this issue