### PR TITLE
Fix strict deps violation in singlejar build

### DIFF
--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -192,8 +192,26 @@ function test_java_tools_singlejar_builds() {
   bazel build @local_java_tools//:singlejar_cc_bin || fail "singlejar failed to build"
 }
 
+function test_java_tools_singlejar_builds_with_layering_check() {
+  if [[ ! $(type -P clang) ]]; then
+    return
+  fi
+
+  bazel build --repo_env=CC=clang --features=layering_check \
+    @local_java_tools//:singlejar_cc_bin || fail "singlejar failed to build with layering check"
+}
+
 function test_java_tools_ijar_builds() {
   bazel build @local_java_tools//:ijar_cc_binary || fail "ijar failed to build"
+}
+
+function test_java_tools_ijar_builds_with_layering_check() {
+  if [[ ! $(type -P clang) ]]; then
+    return
+  fi
+
+  bazel build --repo_env=CC=clang --features=layering_check \
+    @local_java_tools//:ijar_cc_binary || fail "ijar failed to build with layering check"
 }
 
 run_suite "Java tools archive tests"

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -381,6 +381,8 @@ cc_binary(
     malloc = ":malloc",
     visibility = ["//visibility:public"],
     deps = [
+        ":combiners",
+        ":diag",
         ":options",
         ":output_jar",
         "//java_tools/zlib",


### PR DESCRIPTION
singlejar and hence the `NONPREBUILT_TOOLCHAIN_CONFIGURATION` did not build with `--features=layering_check` due to includes being used from indirect dependencies.

Work towards https://github.com/bazelbuild/bazel/issues/13944#issuecomment-1271745466