### PR TITLE
Enables compiling against direct dependencies only

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -777,7 +777,9 @@ public final class JavaCompilationHelper {
       attributes.addDirectJars(directJars);
     }
 
-    attributes.merge(args);
+    boolean pruneTransitiveDeps = ruleContext.getFragment(JavaConfiguration.class)
+        .experimentalPruneTransitiveDeps();
+    attributes.merge(args, pruneTransitiveDeps);
   }
 
   private void addLibrariesToAttributesInternal(Iterable<? extends TransitiveInfoCollection> deps) {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -113,6 +113,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   private final boolean multiReleaseDeployJars;
   private final boolean disallowJavaImportExports;
   private final boolean disallowJavaImportEmptyJars;
+  private final boolean experimentalPruneTransitiveDeps;
 
   // TODO(dmarting): remove once we have a proper solution for #2539
   private final boolean useLegacyBazelJavaTest;
@@ -156,6 +157,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     this.multiReleaseDeployJars = javaOptions.multiReleaseDeployJars;
     this.disallowJavaImportExports = javaOptions.disallowJavaImportExports;
     this.disallowJavaImportEmptyJars = javaOptions.disallowJavaImportEmptyJars;
+    this.experimentalPruneTransitiveDeps = javaOptions.experimentalPruneTransitiveDeps;
 
     Map<String, Label> optimizers = javaOptions.bytecodeOptimizers;
     if (optimizers.size() > 1) {
@@ -465,5 +467,9 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
 
   public boolean requireJavaPluginInfo() {
     return requireJavaPluginInfo;
+  }
+
+  public boolean experimentalPruneTransitiveDeps() {
+    return experimentalPruneTransitiveDeps;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaImport.java
@@ -113,9 +113,11 @@ public class JavaImport implements RuleConfiguredTargetFactory {
           ruleContext.getUniqueDirectoryArtifact(
               "_java_import", "jdeps.proto", ruleContext.getBinOrGenfilesDirectory());
       JavaCompilationArgsProvider provider = JavaCompilationArgsProvider.legacyFromTargets(targets);
+      boolean pruneTransitiveDeps = ruleContext.getFragment(JavaConfiguration.class)
+          .experimentalPruneTransitiveDeps();
       JavaTargetAttributes attributes =
           new JavaTargetAttributes.Builder(semantics)
-              .merge(provider)
+              .merge(provider, pruneTransitiveDeps)
               .addDirectJars(provider.getDirectCompileTimeJars())
               .build();
       ImportDepsCheckActionBuilder.newBuilder()

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaLibraryHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaLibraryHelper.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.StrictDepsMode;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.rules.java.JavaConfiguration.JavaClasspathMode;
@@ -404,7 +405,14 @@ public final class JavaLibraryHelper {
       attributes.addDirectJars(mergedDeps.getDirectCompileTimeJars());
     }
 
-    attributes.addCompileTimeClassPathEntries(mergedDeps.getTransitiveCompileTimeJars());
+    boolean pruneTransitiveDeps = ruleContext.getFragment(JavaConfiguration.class)
+        .experimentalPruneTransitiveDeps();
+
+    NestedSet<Artifact> localCompileTimeDeps = pruneTransitiveDeps
+        ? mergedDeps.getDirectCompileTimeJars()
+        : mergedDeps.getTransitiveCompileTimeJars();
+
+    attributes.addCompileTimeClassPathEntries(localCompileTimeDeps);
     attributes.addRuntimeClassPathEntries(mergedRuntimeDeps.getRuntimeJars());
     attributes.addRuntimeClassPathEntries(mergedDeps.getRuntimeJars());
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -621,6 +621,21 @@ public class JavaOptions extends FragmentOptions {
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "Enable experimental jspecify integration.")
   public boolean experimentalEnableJspecify;
+
+  @Option(
+      name = "experimental_prune_transitive_deps",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
+      effectTags = {
+          OptionEffectTag.LOADING_AND_ANALYSIS,
+          OptionEffectTag.EXECUTION,
+          OptionEffectTag.AFFECTS_OUTPUTS},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "If enabled, compilation is performed against only direct dependencies. Transitive deps "
+              + "required for compilation must be explicitly added")
+  public boolean experimentalPruneTransitiveDeps;
+
   @Override
   public FragmentOptions getHost() {
     // Note validation actions don't run in host config, so no need copying flags related to that.

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
@@ -130,7 +130,6 @@ public class JavaTargetAttributes {
 
     @CanIgnoreReturnValue
     public Builder merge(JavaCompilationArgsProvider context, boolean pruneTransitiveDeps) {
-      addCompileTimeClassPathEntries(context.getTransitiveCompileTimeJars());
       addCompileTimeClassPathEntries(
           pruneTransitiveDeps ? context.getDirectCompileTimeJars()
               : context.getTransitiveCompileTimeJars());

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
@@ -129,9 +129,11 @@ public class JavaTargetAttributes {
     }
 
     @CanIgnoreReturnValue
-    public Builder merge(JavaCompilationArgsProvider context) {
-      Preconditions.checkArgument(!built);
+    public Builder merge(JavaCompilationArgsProvider context, boolean pruneTransitiveDeps) {
       addCompileTimeClassPathEntries(context.getTransitiveCompileTimeJars());
+      addCompileTimeClassPathEntries(
+          pruneTransitiveDeps ? context.getDirectCompileTimeJars()
+              : context.getTransitiveCompileTimeJars());
       addRuntimeClassPathEntries(context.getRuntimeJars());
       return this;
     }


### PR DESCRIPTION
Defines `--experimental_prune_transitive_deps` that will allow you to make java and android to only use direct dependancies when compiling a given target. This significantly speeds up incremental compilations at the cost of adding explicit deps to all targets. 

relates to https://github.com/bazelbuild/rules_kotlin/pull/842 