### PR TITLE
Fix index in `Sequence#cast` error message always being 0

### DIFF
--- a/src/main/java/net/starlark/java/eval/Sequence.java
+++ b/src/main/java/net/starlark/java/eval/Sequence.java
@@ -120,6 +120,7 @@ public interface Sequence<E>
             "at index %d of %s, got element of type %s, want %s",
             i, what, Starlark.type(elem), Starlark.classType(elemType));
       }
+      i++;
     }
     @SuppressWarnings("unchecked") // safe
     Sequence<T> result = (Sequence) x;

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -3362,7 +3362,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
             () -> CcModule.flagSetFromStarlark(flagSetStruct, /* actionName= */ null));
     assertThat(e)
         .hasMessageThat()
-        .contains("at index 0 of actions, got element of type struct, want string");
+        .contains("at index 1 of actions, got element of type struct, want string");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
@@ -967,7 +967,7 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
 
     reporter.removeHandler(failFastHandler);
     checkFailingLookup("//a:foo.bzl", "initialization of module 'a/foo.bzl' failed");
-    assertContainsEvent("at index 0 of visibility list, got element of type int, want string");
+    assertContainsEvent("at index 1 of visibility list, got element of type int, want string");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -422,7 +422,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
   @Test
   public void testLabelListWithAspectsError() throws Exception {
     ev.checkEvalErrorContains(
-        "at index 0 of aspects, got element of type int, want Aspect",
+        "at index 1 of aspects, got element of type int, want Aspect",
         "def _impl(target, ctx):",
         "   pass",
         "my_aspect = aspect(implementation = _impl)",

--- a/src/test/java/net/starlark/java/eval/testdata/string_misc.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_misc.star
@@ -95,7 +95,7 @@ assert_eq("a".endswith(()), False)
 assert_eq("".endswith(()), False)
 assert_fails(lambda: "a".endswith(["a"]), "got .* 'list', want 'string or tuple'")
 assert_fails(lambda: "1".endswith((1,)), "at index 0 of sub, got element of type int, want string")
-assert_fails(lambda: "a".endswith(("1", 1)), "at index 0 of sub, got element of type int, want string")
+assert_fails(lambda: "a".endswith(("1", 1)), "at index 1 of sub, got element of type int, want string")
 
 # startswith
 assert_eq("Apricot".startswith("Apr"), True)
@@ -119,7 +119,7 @@ assert_eq("a".startswith(()), False)
 assert_eq("".startswith(()), False)
 assert_fails(lambda: "a".startswith(["a"]), "got .* 'list', want 'string or tuple'")
 assert_fails(lambda: "1".startswith((1,)), "at index 0 of sub, got element of type int, want string")
-assert_fails(lambda: "a".startswith(("1", 1)), "at index 0 of sub, got element of type int, want string")
+assert_fails(lambda: "a".startswith(("1", 1)), "at index 1 of sub, got element of type int, want string")
 
 # substring
 assert_eq("012345678"[0:-1], "01234567")


### PR DESCRIPTION
The index into the list wasn't incremented, resulting in a confusing error message.