### PR TITLE
Remove default visibility to public

### DIFF
--- a/examples/cpp/BUILD
+++ b/examples/cpp/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 cc_library(
     name = "hello-lib",
     srcs = ["hello-lib.cc"],
@@ -27,4 +25,5 @@ cc_test(
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
+    visibility = ["//examples:__pkg__"],
 )

--- a/examples/py/BUILD
+++ b/examples/py/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 py_library(
     name = "lib",
     srcs = ["lib.py"],
@@ -14,4 +12,5 @@ py_binary(
 filegroup(
     name = "srcs",
     srcs = ["BUILD"] + glob(["**/*.py"]),
+    visibility = ["//examples:__pkg__"],
 )


### PR DESCRIPTION
Adhere to best practices https://bazel.build/concepts/visibility#best-practices
An example should follow the best practices