### PR TITLE
Fix 'bazel sync' crash after interrupt with Ctrl-C

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/SyncCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/SyncCommand.java
@@ -218,11 +218,13 @@ public final class SyncCommand implements BlazeCommand {
             "Repository fetch failure.");
       }
     } catch (InterruptedException e) {
+      String errorMessage = "Sync interrupted: " + e.getMessage();
+      env.getReporter().handle(Event.error(errorMessage));
       reportNoBuildRequestFinished(env, ExitCode.INTERRUPTED);
-      BlazeCommandResult.detailedExitCode(
-          InterruptedFailureDetails.detailedExitCode(e.getMessage()));
+      return BlazeCommandResult.detailedExitCode(
+          InterruptedFailureDetails.detailedExitCode(errorMessage));
     } catch (AbruptExitException e) {
-      env.getReporter().handle(Event.error(e.getMessage()));
+      env.getReporter().handle(Event.error("Unknown error: " + e.getMessage()));
       reportNoBuildRequestFinished(env, ExitCode.LOCAL_ENVIRONMENTAL_ERROR);
       return BlazeCommandResult.detailedExitCode(e.getDetailedExitCode());
     }


### PR DESCRIPTION
Bazel sync command handles InterruptedException, but uses 'getMessage' method which may return 'null' and in this case 'detailedExitCode' raises 'NullPointerException'.

Constructing separate non-empty string together with getMessage's result fixes this problem. This changes similar to what currently used in Fetch and Modquery commands

Fixes: #16339