### PR TITLE
Cherry-pick[5.3.2]: Update GrpcRemoteDownloader to only include relevant headers.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -23,6 +23,8 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
 import com.google.devtools.build.lib.bazel.repository.downloader.HashOutputStream;
@@ -171,7 +173,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       requestBuilder.addQualifiers(
           Qualifier.newBuilder()
               .setName(QUALIFIER_AUTH_HEADERS)
-              .setValue(authHeadersJson(authHeaders))
+              .setValue(authHeadersJson(urls, authHeaders, includeAllHeaders))
               .build());
     }
 
@@ -197,15 +199,25 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     return out;
   }
 
-  private static String authHeadersJson(Map<URI, Map<String, String>> authHeaders) {
+	
+  private static String authHeadersJson(
+      List<URL> urls, Map<URI, Map<String, List<String>>> authHeaders, boolean includeAllHeaders) {
+    ImmutableSet<String> hostSet =
+        urls.stream().map(URL::getHost).collect(ImmutableSet.toImmutableSet());
     Map<String, JsonObject> subObjects = new TreeMap<>();
-    for (Map.Entry<URI, Map<String, String>> entry : authHeaders.entrySet()) {
+    for (Map.Entry<URI, Map<String, List<String>>> entry : authHeaders.entrySet()) {
+      URI uri = entry.getKey();
+      // Only add headers that are relevant to the hosts.
+      if (!hostSet.contains(uri.getHost())) {
+        continue;
+      }
+
       JsonObject subObject = new JsonObject();
       Map<String, String> orderedHeaders = new TreeMap<>(entry.getValue());
       for (Map.Entry<String, String> subEntry : orderedHeaders.entrySet()) {
         subObject.addProperty(subEntry.getKey(), subEntry.getValue());
       }
-      subObjects.put(entry.getKey().toString(), subObject);
+      subObjects.put(uri.toString(), subObject);
     }
 
     JsonObject authHeadersJson = new JsonObject();

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -320,9 +320,6 @@ public class GrpcRemoteDownloaderTest {
             + "\"http://example.com\":{"
             + "\"Another-Header\":\"another header content\","
             + "\"Some-Header\":\"some header content\""
-            + "},"
-            + "\"http://example.org\":{"
-            + "\"Org-Header\":\"org header content\""
             + "}"
             + "}";
 
@@ -345,4 +342,58 @@ public class GrpcRemoteDownloaderTest {
                         .setValue(expectedAuthHeadersJson))
                 .build());
   }
+
+  @Test
+  public void testFetchBlobRequestWithAllHeaders() throws Exception {
+    FetchBlobRequest request =
+        GrpcRemoteDownloader.newFetchBlobRequest(
+            "instance name",
+            ImmutableList.of(
+                new URL("http://example.com/a"),
+                new URL("http://example.com/b"),
+                new URL("file:/not/limited/to/http")),
+            ImmutableMap.of(
+                new URI("http://example.com"),
+                ImmutableMap.of(
+                    "Some-Header", ImmutableList.of("some header content"),
+                    "Another-Header",
+                        ImmutableList.of("another header content", "even more header content")),
+                new URI("http://example.org"),
+                ImmutableMap.of(
+                    "Org-Header",
+                    ImmutableList.of("org header content", "and a second one", "and a third one"))),
+            com.google.common.base.Optional.<Checksum>of(
+                Checksum.fromSubresourceIntegrity(
+                    "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),
+            "canonical ID",
+            /* includeAllHeaders= */ true);
+
+    final String expectedAuthHeadersJson =
+        "{"
+            + "\"http://example.com\":{"
+            + "\"Another-Header\":[\"another header content\",\"even more header content\"],"
+            + "\"Some-Header\":[\"some header content\"]"
+            + "}"
+            + "}";
+
+    assertThat(request)
+        .isEqualTo(
+            FetchBlobRequest.newBuilder()
+                .setInstanceName("instance name")
+                .addUris("http://example.com/a")
+                .addUris("http://example.com/b")
+                .addUris("file:/not/limited/to/http")
+                .addQualifiers(
+                    Qualifier.newBuilder()
+                        .setName("checksum.sri")
+                        .setValue("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
+                .addQualifiers(
+                    Qualifier.newBuilder().setName("bazel.canonical_id").setValue("canonical ID"))
+                .addQualifiers(
+                    Qualifier.newBuilder()
+                        .setName("bazel.auth_headers")
+                        .setValue(expectedAuthHeadersJson))
+                .build());
+  }
+
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/security/advisories/GHSA-mxr8-q875-rhwq.

RELNOTES[INC]: GrpcRemoteDownloader only includes relevant headers instead of sending all credentials.

Closes #16439.

PiperOrigin-RevId: 480069164
Change-Id: I49950311c04d1997d26832431d531a9036efdb18