### PR TITLE
Add patch files for protobuf 3.19.6

### DIFF
--- a/third_party/protobuf/3.19.6.bzlmod.patch
+++ b/third_party/protobuf/3.19.6.bzlmod.patch
@@ -1,0 +1,21 @@
+diff --git a/java/util/BUILD b/java/util/BUILD
+index ee6ddeaf1..54e20ea24 100644
+--- a/java/util/BUILD
++++ b/java/util/BUILD
+@@ -13,11 +13,11 @@ java_library(
+     deps = [
+         "//java/core",
+         "//java/lite",
+-        "@maven//:com_google_code_findbugs_jsr305",
+-        "@maven//:com_google_code_gson_gson",
+-        "@maven//:com_google_errorprone_error_prone_annotations",
+-        "@maven//:com_google_guava_guava",
+-        "@maven//:com_google_j2objc_j2objc_annotations",
++        "//external:jsr305",
++        "//external:gson",
++        "//external:error_prone_annotations",
++        "//external:guava",
++        "//external:j2objc_annotations",
+     ],
+ )
+ 

--- a/third_party/protobuf/3.19.6.patch
+++ b/third_party/protobuf/3.19.6.patch
@@ -1,0 +1,99 @@
+diff --git a/BUILD b/BUILD
+index 1690d4219..24206b7fc 100644
+--- a/BUILD
++++ b/BUILD
+@@ -19,7 +19,7 @@ exports_files(["LICENSE"])
+ # ZLIB configuration
+ ################################################################################
+ 
+-ZLIB_DEPS = ["@zlib//:zlib"]
++ZLIB_DEPS = ["@io_bazel//third_party/zlib"]
+ 
+ ################################################################################
+ # Protobuf Runtime Library
+diff --git a/java/core/BUILD b/java/core/BUILD
+index 419eafb58..42f02efc2 100644
+--- a/java/core/BUILD
++++ b/java/core/BUILD
+@@ -1,6 +1,5 @@
+ load("@bazel_skylib//rules:build_test.bzl", "build_test")
+ load("@rules_java//java:defs.bzl", "java_library", "java_lite_proto_library", "java_proto_library")
+-load("@rules_jvm_external//:defs.bzl", "java_export")
+ load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
+ load("//:internal.bzl", "conformance_test")
+ load("//:protobuf_version.bzl", "PROTOBUF_VERSION")
+@@ -110,17 +109,6 @@ java_library(
+     ],
+ )
+ 
+-# Bazel users, don't depend on this target, use //java/lite.
+-java_export(
+-    name = "lite_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-javalite:%s" % PROTOBUF_VERSION,
+-    pom_template = "//java/lite:pom_template.xml",
+-    resources = [
+-        "//:lite_well_known_protos",
+-    ],
+-    runtime_deps = [":lite"],
+-)
+-
+ java_library(
+     name = "lite_runtime_only",
+     srcs = LITE_SRCS,
+@@ -145,17 +133,6 @@ java_library(
+     ],
+ )
+ 
+-# Bazel users, don't depend on this target, use :core.
+-java_export(
+-    name = "core_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_VERSION,
+-    pom_template = "pom_template.xml",
+-    resources = [
+-        "//:well_known_protos",
+-    ],
+-    runtime_deps = [":core"],
+-)
+-
+ filegroup(
+     name = "release",
+     srcs = [
+diff --git a/java/util/BUILD b/java/util/BUILD
+index ee6ddeaf1..de2caf8df 100644
+--- a/java/util/BUILD
++++ b/java/util/BUILD
+@@ -1,5 +1,4 @@
+ load("@rules_java//java:defs.bzl", "java_proto_library")
+-load("@rules_jvm_external//:defs.bzl", "java_export")
+ load("@rules_proto//proto:defs.bzl", "proto_library")
+ load("//:protobuf_version.bzl", "PROTOBUF_VERSION")
+ load("//java/internal:testing.bzl", "junit_tests")
+@@ -13,23 +12,14 @@ java_library(
+     deps = [
+         "//java/core",
+         "//java/lite",
+-        "@maven//:com_google_code_findbugs_jsr305",
+-        "@maven//:com_google_code_gson_gson",
+-        "@maven//:com_google_errorprone_error_prone_annotations",
+-        "@maven//:com_google_guava_guava",
+-        "@maven//:com_google_j2objc_j2objc_annotations",
++        "@io_bazel//third_party:jsr305",
++        "@io_bazel//third_party:gson",
++        "@io_bazel//third_party:error_prone_annotations",
++        "@io_bazel//third_party:guava",
++        "@io_bazel//third_party/java/j2objc-annotations",
+     ],
+ )
+ 
+-# Bazel users, don't depend on this target, use :util.
+-java_export(
+-    name = "util_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-java-util:%s" % PROTOBUF_VERSION,
+-    pom_template = "pom_template.xml",
+-    visibility = ["//java:__pkg__"],
+-    runtime_deps = [":util"],
+-)
+-
+ filegroup(
+     name = "release",
+     srcs = [


### PR DESCRIPTION
We are upgrading protobuf version to address https://github.com/protocolbuffers/protobuf/archive/v3.19.6.tar.gz