### PR TITLE
[4.2.3] Update GrpcRemoteDownloader to only include relevant headers. (#16450)

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -1,6 +1,8 @@
 ---
 platforms:
   centos7_java11_devtoolset10:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
@@ -8,6 +10,8 @@ platforms:
       - "-c"
       - "opt"
   ubuntu1604:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
@@ -15,6 +19,8 @@ platforms:
       - "-c"
       - "opt"
   ubuntu1804:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
@@ -22,6 +28,8 @@ platforms:
       - "-c"
       - "opt"
   ubuntu2004:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
@@ -29,6 +37,8 @@ platforms:
       - "-c"
       - "opt"
   macos:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
@@ -36,6 +46,8 @@ platforms:
       - "-c"
       - "opt"
   windows:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     build_flags:
       - "--copt=-w"
       - "--host_copt=-w"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -1,6 +1,8 @@
 ---
 tasks:
   centos7_java11_devtoolset10:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
@@ -45,6 +47,8 @@ tasks:
       - build
       - test
   ubuntu1604:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
@@ -81,6 +85,8 @@ tasks:
       - build
       - test
   ubuntu1804:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
@@ -121,6 +127,7 @@ tasks:
   ubuntu1804_clang:
     platform: ubuntu1804
     environment:
+      USE_BAZEL_VERSION: 4.2.2
       CC: clang
       CC_CONFIGURE_DEBUG: 1
     name: "Clang"
@@ -148,6 +155,8 @@ tasks:
       - build
       - test
   ubuntu2004:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
@@ -194,6 +203,8 @@ tasks:
       - build
       - test
   macos:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
@@ -232,6 +243,8 @@ tasks:
       - build
       - test
   windows:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     batch_commands:
       - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
     build_flags:
@@ -256,6 +269,8 @@ tasks:
       - build
       - test
   rbe_ubuntu1604:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'
         -e 's/^# android_ndk_repository/android_ndk_repository/'
@@ -268,6 +283,8 @@ tasks:
     include_json_profile:
       - build
   kythe_ubuntu2004:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'
       -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,8 @@
 ---
 tasks:
   centos7_java11_devtoolset10:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shards: 4
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -43,6 +45,8 @@ tasks:
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_sh_test"
   ubuntu1604:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shards: 4
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -77,6 +81,8 @@ tasks:
       - "-//src/java_tools/buildjar/..."
       - "-//src/java_tools/import_deps_checker/..."
   ubuntu1804:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shards: 4
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -115,6 +121,7 @@ tasks:
   ubuntu1804_clang:
     platform: ubuntu1804
     environment:
+      USE_BAZEL_VERSION: 4.2.2
       CC: clang
       CC_CONFIGURE_DEBUG: 1
     name: "Clang"
@@ -139,6 +146,8 @@ tasks:
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
   ubuntu2004:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shards: 4
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -183,6 +192,8 @@ tasks:
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel/android:android_ndk_integration_test_with_head_android_tools"
   macos:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shards: 5
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -222,6 +233,8 @@ tasks:
       # C++ coverage is not supported on macOS yet.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
   windows:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shards: 4
     batch_commands:
       - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
@@ -244,6 +257,8 @@ tasks:
     test_targets:
       - "//src:all_windows_tests"
   rbe_ubuntu1604:
+    environment:
+      USE_BAZEL_VERSION: 4.2.2
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -23,6 +23,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
 import com.google.devtools.build.lib.bazel.repository.downloader.HashOutputStream;
@@ -165,7 +166,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       requestBuilder.addQualifiers(
           Qualifier.newBuilder()
               .setName(QUALIFIER_AUTH_HEADERS)
-              .setValue(authHeadersJson(authHeaders))
+              .setValue(authHeadersJson(urls, authHeaders))
               .build());
     }
 
@@ -190,15 +191,24 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     return out;
   }
 
-  private static String authHeadersJson(Map<URI, Map<String, String>> authHeaders) {
+  private static String authHeadersJson(
+      List<URL> urls, Map<URI, Map<String, String>> authHeaders) {
+    ImmutableSet<String> hostSet =
+        urls.stream().map(URL::getHost).collect(ImmutableSet.toImmutableSet());
     Map<String, JsonObject> subObjects = new TreeMap<>();
     for (Map.Entry<URI, Map<String, String>> entry : authHeaders.entrySet()) {
+      URI uri = entry.getKey();
+      // Only add headers that are relevant to the hosts.
+      if (!hostSet.contains(uri.getHost())) {
+        continue;
+      }
+
       JsonObject subObject = new JsonObject();
       Map<String, String> orderedHeaders = new TreeMap<>(entry.getValue());
       for (Map.Entry<String, String> subEntry : orderedHeaders.entrySet()) {
         subObject.addProperty(subEntry.getKey(), subEntry.getValue());
       }
-      subObjects.put(entry.getKey().toString(), subObject);
+      subObjects.put(uri.toString(), subObject);
     }
 
     JsonObject authHeadersJson = new JsonObject();

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -321,9 +321,6 @@ public class GrpcRemoteDownloaderTest {
             + "\"http://example.com\":{"
             + "\"Another-Header\":\"another header content\","
             + "\"Some-Header\":\"some header content\""
-            + "},"
-            + "\"http://example.org\":{"
-            + "\"Org-Header\":\"org header content\""
             + "}"
             + "}";
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/security/advisories/GHSA-mxr8-q875-rhwq.

RELNOTES[INC]: GrpcRemoteDownloader only includes relevant headers instead of sending all credentials.

Closes #16439.

PiperOrigin-RevId: 480069164
Change-Id: I49950311c04d1997d26832431d531a9036efdb18

Co-authored-by: kshyanashree <109167932+kshyanashree@users.noreply.github.com>