### PR TITLE
Inject all metadata at once after the action is executed.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -107,7 +107,7 @@ public class RemoteActionFileSystem extends DelegateFileSystem {
   }
 
   void flush() {
-    checkNotNull(metadataInjector, "metadataInject is null");
+    checkNotNull(metadataInjector, "metadataInjector is null");
 
     for (Map.Entry<PathFragment, Artifact> entry : outputMapping.entrySet()) {
       PathFragment execPath = entry.getKey();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
@@ -70,6 +70,7 @@ public class RemoteOutputService implements OutputService {
         execRootFragment,
         relativeOutputPath,
         inputArtifactData,
+        outputArtifacts,
         actionInputFetcher);
   }
 
@@ -96,6 +97,11 @@ public class RemoteOutputService implements OutputService {
   @Override
   public void finalizeBuild(boolean buildSuccessful) {
     // Intentionally left empty.
+  }
+
+  @Override
+  public void flushActionFileSystem(FileSystem actionFileSystem) {
+    ((RemoteActionFileSystem) actionFileSystem).flush();
   }
 
   @Override
@@ -142,7 +148,8 @@ public class RemoteOutputService implements OutputService {
       Map<Artifact, ImmutableList<FilesetOutputSymlink>> filesets) {
     FileSystem remoteFileSystem =
         new RemoteActionFileSystem(
-            fileSystem, execRoot, relativeOutputPath, actionInputMap, actionInputFetcher);
+            fileSystem, execRoot, relativeOutputPath, actionInputMap, ImmutableList.of(),
+            actionInputFetcher);
     return ArtifactPathResolver.createPathResolver(remoteFileSystem, fileSystem.getPath(execRoot));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -1200,6 +1200,8 @@ public final class SkyframeActionExecutor {
         Preconditions.checkState(action.inputsDiscovered(),
             "Action %s successfully executed, but inputs still not known", action);
 
+        flushActionFileSystem(actionExecutionContext.getActionFileSystem(), outputService);
+
         if (!checkOutputs(
             action,
             metadataHandler,
@@ -1509,6 +1511,13 @@ public final class SkyframeActionExecutor {
     return actionFileSystem == null
         ? LostInputsCheck.NONE
         : () -> outputService.checkActionFileSystemForLostInputs(actionFileSystem, action);
+  }
+
+  private static void flushActionFileSystem(@Nullable FileSystem actionFileSystem,
+      @Nullable OutputService outputService) {
+    if (outputService != null && actionFileSystem != null) {
+      outputService.flushActionFileSystem(actionFileSystem);
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/OutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OutputService.java
@@ -192,14 +192,23 @@ public interface OutputService {
       FileSystem actionFileSystem,
       Environment env,
       MetadataInjector injector,
-      ImmutableMap<Artifact, ImmutableList<FilesetOutputSymlink>> filesets) {}
+      ImmutableMap<Artifact, ImmutableList<FilesetOutputSymlink>> filesets) {
+  }
 
   /**
    * Checks the filesystem returned by {@link #createActionFileSystem} for errors attributable to
    * lost inputs.
    */
   default void checkActionFileSystemForLostInputs(FileSystem actionFileSystem, Action action)
-      throws LostInputsActionExecutionException {}
+      throws LostInputsActionExecutionException {
+  }
+
+  /**
+   * Flush the internal state of filesystem returned by {@link #createActionFileSystem} after action
+   * execution, before skyframe checking the action outputs.
+   */
+  default void flushActionFileSystem(FileSystem actionFileSystem) {
+  }
 
   default boolean supportsPathResolverForArtifactValues() {
     return false;

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -26,6 +26,7 @@ import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
@@ -363,6 +364,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
             execRoot.asFragment(),
             outputRoot.getRoot().asPath().relativeTo(execRoot).getPathString(),
             outputs,
+            ImmutableList.of(artifact),
             actionInputFetcher);
     Path remotePath = remoteFs.getPath(artifact.getPath().getPathString());
     assertThat(remotePath.getFileSystem()).isEqualTo(remoteFs);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashCode;
 import com.google.common.util.concurrent.Futures;
 import com.google.devtools.build.lib.actions.ActionInputMap;
@@ -153,15 +154,23 @@ public final class RemoteActionFileSystemTest {
   }
 
   private RemoteActionFileSystem newRemoteActionFileSystem(ActionInputMap inputs) {
+    return newRemoteActionFileSystem(inputs, ImmutableList.of());
+  }
+
+  private RemoteActionFileSystem newRemoteActionFileSystem(ActionInputMap inputs,
+      Iterable<Artifact> outputs) {
     return new RemoteActionFileSystem(
         fs,
         execRoot.asFragment(),
         outputRoot.getRoot().asPath().relativeTo(execRoot).getPathString(),
         inputs,
+        outputs,
         inputFetcher);
   }
 
-  /** Returns a remote artifact and puts its metadata into the action input map. */
+  /**
+   * Returns a remote artifact and puts its metadata into the action input map.
+   */
   private Artifact createRemoteArtifact(
       String pathFragment, String contents, ActionInputMap inputs) {
     Path p = outputRoot.getRoot().asPath().getRelative(pathFragment);


### PR DESCRIPTION
So that spawns within one action will be able to change the injected metadata using e.g. renameTo.

Also only allows metadata injection for declared action outputs instead of declared spawn outputs.

Related #16351.