### PR TITLE
Be explicit about alowing empty globs (fourth part)

### DIFF
--- a/tools/build_defs/pkg/BUILD
+++ b/tools/build_defs/pkg/BUILD
@@ -30,7 +30,10 @@ py_library(
 
 filegroup(
     name = "archive_testdata",
-    srcs = glob(["testdata/**"]),
+    srcs = glob(
+        ["testdata/**"],
+        allow_empty = True,
+    ),
 )
 
 py_test(

--- a/tools/jdk/jdk.BUILD
+++ b/tools/jdk/jdk.BUILD
@@ -183,6 +183,7 @@ filegroup(
     name = "jdk-lib",
     srcs = glob(
         ["lib/**"],
+        allow_empty = True,
         exclude = [
             "lib/missioncontrol/**",
             "lib/visualvm/**",


### PR DESCRIPTION
There are several globs that are empty and this prevents building with the incompatible flag #8195.
This commit just makes it explicit that empty is allowed.