### PR TITLE
Remotely upload the undeclared test outputs directory as a directory, not a file.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionInput.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionInput.java
@@ -41,6 +41,9 @@ public interface ActionInput {
    */
   PathFragment getExecPath();
 
+  /** The input is a directory. */
+  boolean isDirectory();
+
   /** The input is a symlink that is supposed to stay un-dereferenced. */
   boolean isSymlink();
 

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionInputHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionInputHelper.java
@@ -41,6 +41,11 @@ public final class ActionInputHelper {
     }
 
     @Override
+    public boolean isDirectory() {
+      return false;
+    }
+
+    @Override
     public int hashCode() {
       return getExecPathString().hashCode();
     }
@@ -98,6 +103,32 @@ public final class ActionInputHelper {
       @Override
       public PathFragment getExecPath() {
         return path;
+      }
+    };
+  }
+
+  /**
+   * Creates an ActionInput with just the given relative path (which must point to a directory) and
+   * no digest.
+   *
+   * @param path the relative path of the input.
+   * @return a ActionInput.
+   */
+  public static ActionInput fromPathToDirectory(PathFragment path) {
+    return new BasicActionInput() {
+      @Override
+      public String getExecPathString() {
+        return path.getPathString();
+      }
+
+      @Override
+      public PathFragment getExecPath() {
+        return path;
+      }
+
+      @Override
+      public boolean isDirectory() {
+        return true;
       }
     };
   }

--- a/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
@@ -305,6 +305,11 @@ public class CommandLines {
     }
 
     @Override
+    public boolean isDirectory() {
+      return false;
+    }
+
+    @Override
     public boolean isSymlink() {
       return false;
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/VirtualActionInput.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/VirtualActionInput.java
@@ -55,6 +55,11 @@ public interface VirtualActionInput extends ActionInput, StreamWriter {
     private EmptyActionInput() {}
 
     @Override
+    public boolean isDirectory() {
+      return false;
+    }
+
+    @Override
     public boolean isSymlink() {
       return false;
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -350,7 +350,7 @@ public class TestRunnerAction extends AbstractAction
     if (testConfiguration.getZipUndeclaredTestOutputs()) {
       outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsZipPath()));
     } else {
-      outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsDir()));
+      outputs.add(ActionInputHelper.fromPathToDirectory(getUndeclaredOutputsDir()));
     }
     outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsManifestPath()));
     outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsAnnotationsPath()));

--- a/src/main/java/com/google/devtools/build/lib/exec/BinTools.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/BinTools.java
@@ -189,6 +189,11 @@ public final class BinTools {
     }
 
     @Override
+    public boolean isDirectory() {
+      return false;
+    }
+
+    @Override
     public ByteString getBytes() throws IOException {
       ByteString.Output out = ByteString.newOutput();
       writeTo(out);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -225,7 +225,7 @@ public class RemoteExecutionService {
     ArrayList<String> outputDirectories = new ArrayList<>();
     for (ActionInput output : outputs) {
       String pathString = decodeBytestringUtf8(remotePathResolver.localPathToOutputPath(output));
-      if (output instanceof Artifact && ((Artifact) output).isTreeArtifact()) {
+      if (output.isDirectory()) {
         outputDirectories.add(pathString);
       } else {
         outputFiles.add(pathString);

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionInputMapTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionInputMapTest.java
@@ -506,6 +506,11 @@ public final class ActionInputMapTest {
     }
 
     @Override
+    public boolean isDirectory() {
+      return false;
+    }
+
+    @Override
     public boolean isSymlink() {
       return false;
     }

--- a/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
@@ -314,6 +314,11 @@ public final class ActionsTestUtil {
       }
 
       @Override
+      public boolean isDirectory() {
+        return false;
+      }
+
+      @Override
       public boolean isSymlink() {
         return false;
       }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -177,6 +177,86 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void buildRemoteAction_withRegularFileAsOutput() throws Exception {
+    PathFragment execPath = execRoot.getRelative("path/to/tree").asFragment();
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(ActionsTestUtil.createArtifactWithExecPath(artifactRoot, execPath))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).containsExactly(execPath.toString());
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+  }
+
+  @Test
+  public void buildRemoteAction_withTreeArtifactAsOutput() throws Exception {
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(
+                ActionsTestUtil.createTreeArtifactWithGeneratingAction(
+                    artifactRoot, PathFragment.create("path/to/dir")))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).containsExactly("path/to/dir");
+  }
+
+  @Test
+  public void buildRemoteAction_withUnresolvedSymlinkAsOutput() throws Exception {
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(
+                ActionsTestUtil.createUnresolvedSymlinkArtifactWithExecPath(
+                    artifactRoot, PathFragment.create("path/to/link")))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).containsExactly("path/to/link");
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+  }
+
+  @Test
+  public void buildRemoteAction_withActionInputFileAsOutput() throws Exception {
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(ActionInputHelper.fromPath(PathFragment.create("path/to/file")))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).containsExactly("path/to/file");
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+  }
+
+  @Test
+  public void buildRemoteAction_withActionInputDirectoryAsOutput() throws Exception {
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(ActionInputHelper.fromPathToDirectory(PathFragment.create("path/to/dir")))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).containsExactly("path/to/dir");
+  }
+
+  @Test
   public void buildRemoteAction_differentiateWorkspace_generateActionSalt() throws Exception {
     Spawn spawn =
         new SpawnBuilder("dummy")

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -212,6 +212,11 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
                   }
 
                   @Override
+                  public boolean isDirectory() {
+                    return false;
+                  }
+
+                  @Override
                   public boolean isSymlink() {
                     return false;
                   }
@@ -225,6 +230,11 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
                   @Override
                   public String getExecPathString() {
                     return "bar";
+                  }
+
+                  @Override
+                  public boolean isDirectory() {
+                    return false;
                   }
 
                   @Override


### PR DESCRIPTION
Fixes #16315.