### PR TITLE
Match execroot relative path with --experimental_remote_download_regex

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1228,7 +1228,8 @@ public class RemoteExecutionService {
     ImmutableList.Builder<ListenableFuture<FileMetadata>> builder = new ImmutableList.Builder<>();
 
     for (FileMetadata file : metadata.files()) {
-      if (!realToTmpPath.containsKey(file.path) && predicate.test(file.path.toString())) {
+      if (!realToTmpPath.containsKey(file.path) && predicate.test(
+          file.path.relativeTo(execRoot).toString())) {
         Path tmpPath = tempPathGenerator.generateTempPath();
         realToTmpPath.put(file.path, tmpPath);
         builder.add(downloadFile(context, progressStatusListener, file, tmpPath));
@@ -1237,7 +1238,8 @@ public class RemoteExecutionService {
 
     for (Map.Entry<Path, DirectoryMetadata> entry : metadata.directories()) {
       for (FileMetadata file : entry.getValue().files()) {
-        if (!realToTmpPath.containsKey(file.path) && predicate.test(file.path.toString())) {
+        if (!realToTmpPath.containsKey(file.path) && predicate.test(
+            file.path.relativeTo(execRoot).toString())) {
           Path tmpPath = tempPathGenerator.generateTempPath();
           realToTmpPath.put(file.path, tmpPath);
           builder.add(downloadFile(context, progressStatusListener, file, tmpPath));

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -1228,6 +1228,18 @@ EOF
   [[ ! -e "bazel-bin/a/liblib.jar" ]] || fail "bazel-bin/a/liblib.jar shouldn't exist"
   [[ ! -e "bazel-bin/a/liblib.jdeps" ]] || fail "bazel-bin/a/liblib.jdeps shouldn't exist"
 
+  # io_bazel is the name of the Bazel workspace and thus contained in the full
+  # path of any output artifact, but not in the exec root relative part that we
+  # want the regex to match against.
+  bazel clean && bazel test \
+        --remote_executor=grpc://localhost:${worker_port} \
+        --remote_download_minimal \
+        --experimental_remote_download_regex="/io_bazel/" \
+        //a:test >& $TEST_log || fail "Failed to build"
+
+  [[ ! -e "bazel-bin/a/liblib.jar" ]] || fail "bazel-bin/a/liblib.jar file shouldn't exist!"
+  [[ ! -e "bazel-bin/a/liblib.jdeps" ]] || fail "bazel-bin/a/liblib.jdeps file shouldn't exist!"
+
   bazel clean && bazel test \
         --remote_executor=grpc://localhost:${worker_port} \
         --remote_download_minimal \


### PR DESCRIPTION
Previously, the regex was applied to the full on-disk path of an output, which can lead to non-hermetic matching behavior.