### PR TITLE
Revert to using `matches` instead of `find` with `remote_download_regex`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -234,7 +234,7 @@ public class RemoteExecutionService {
     this.shouldForceDownloadPredicate =
         path -> {
           for (Pattern pattern : patterns) {
-            if (pattern.matcher(path).find()) {
+            if (pattern.matcher(path).matches()) {
               return true;
             }
           }


### PR DESCRIPTION
Reverts a change made in https://github.com/bazelbuild/bazel/commit/e8278edbec1c6be14f01b2ecb078042ee9e753e9 alongside enabling `allowMultiple` for `--experimental_remote_download_regex`.

It is much easier to accidentally write regexes with pathological performance with `find` than with `matches`. If needed, the `find` functionality can always be obtained with `matches` by prepending and appending `.*` as needed.

In addition, common usage scenarios such as matching by file extension are easier to get right: With `matches`, `jar` will visibly fail to have an effect and is easily corrected to `.*jar` (or even `.*\.jar`), whereas with `find` it will silently fetch entire directories that contain the substring `jar`, potentially causing performance regressions.