### PR TITLE
Update flag `--experimental_remote_download_regex` to accept multiple regular expressions.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -142,7 +142,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
@@ -215,18 +214,25 @@ public class RemoteExecutionService {
 
     this.scheduler = Schedulers.from(executor, /*interruptibleWorker=*/ true);
 
-    String regex = remoteOptions.remoteDownloadRegex;
     // TODO(bazel-team): Consider adding a warning or more validation if the remoteDownloadRegex is
-    // used without RemoteOutputsMode.MINIMAL.
-    this.shouldForceDownloads =
-        !regex.isEmpty()
-            && (remoteOptions.remoteOutputsMode == RemoteOutputsMode.MINIMAL
-                || remoteOptions.remoteOutputsMode == RemoteOutputsMode.TOPLEVEL);
-    Pattern pattern = Pattern.compile(regex);
+    // used without Build without the Bytes.
+    ImmutableList.Builder<Pattern> builder = ImmutableList.builder();
+    if (remoteOptions.remoteOutputsMode == RemoteOutputsMode.MINIMAL
+        || remoteOptions.remoteOutputsMode == RemoteOutputsMode.TOPLEVEL) {
+      for (String regex : remoteOptions.remoteDownloadRegex) {
+        builder.add(Pattern.compile(regex));
+      }
+    }
+    ImmutableList<Pattern> patterns = builder.build();
+    this.shouldForceDownloads = !patterns.isEmpty();
     this.shouldForceDownloadPredicate =
         path -> {
-          Matcher m = pattern.matcher(path);
-          return m.matches();
+          for (Pattern pattern : patterns) {
+            if (pattern.matcher(path).matches()) {
+              return true;
+            }
+          }
+          return false;
         };
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -581,15 +581,16 @@ public final class RemoteOptions extends OptionsBase {
 
   @Option(
       name = "experimental_remote_download_regex",
-      defaultValue = "",
+      defaultValue = "null",
+      allowMultiple = true,
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
           "Force Bazel to download the artifacts that match the given regexp. To be used in"
-              + " conjunction with --remote_download_minimal or --remote_download_toplevel to allow"
+              + " conjunction with Build without the Bytes (or the internal equivalent) to allow"
               + " the client to request certain artifacts that might be needed locally (e.g. IDE"
               + " support)")
-  public String remoteDownloadRegex;
+  public List<String> remoteDownloadRegex;
 
   // The below options are not configurable by users, only tests.
   // This is part of the effort to reduce the overall number of flags.


### PR DESCRIPTION
PiperOrigin-RevId: 470707773
Change-Id: I9cec072e32b641fc4cc068d53d83d95a5fe9c55d

(cherry picked from commit e8278edbec1c6be14f01b2ecb078042ee9e753e9)

Also includes the change in #16476.