### PR TITLE
Clarify repo visibility error message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -194,9 +194,14 @@ public final class RepositoryName {
     return ownerRepoIfNotVisible == null;
   }
 
-  @Nullable
-  public RepositoryName getOwnerRepoIfNotVisible() {
-    return ownerRepoIfNotVisible;
+  // Must only be called if isVisible() returns true.
+  public String getOwnerRepoDisplayString() {
+    Preconditions.checkNotNull(ownerRepoIfNotVisible);
+    if (ownerRepoIfNotVisible.isMain()) {
+      return "main repository";
+    } else {
+      return String.format("repository '%s'", ownerRepoIfNotVisible.getNameWithAt());
+    }
   }
 
   /** Returns if this is the main repository. */

--- a/src/main/java/com/google/devtools/build/lib/cmdline/TargetPattern.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/TargetPattern.java
@@ -924,10 +924,8 @@ public abstract class TargetPattern {
           repository = repoMapping.get(repoPart);
           if (!repository.isVisible()) {
             throw new TargetParsingException(
-                String.format(
-                    "Repository '@%s' is not visible from repository '@%s'",
-                    repository.getName(), repository.getOwnerRepoIfNotVisible()),
-                Code.PACKAGE_NOT_FOUND);
+                String.format("No repository visible as '@%s' from %s", repository.getName(),
+                    repository.getOwnerRepoDisplayString()), Code.PACKAGE_NOT_FOUND);
           }
         }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -245,8 +245,8 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
     if (!repositoryName.isVisible()) {
       return new NoRepositoryDirectoryValue(
           String.format(
-              "Repository '@%s' is not visible from repository '%s'",
-              repositoryName.getName(), repositoryName.getOwnerRepoIfNotVisible().getNameWithAt()));
+              "No repository visible as '@%s' from %s",
+              repositoryName.getName(), repositoryName.getOwnerRepoDisplayString()));
     }
 
     Map<RepositoryName, PathFragment> overrides = REPOSITORY_OVERRIDES.get(env);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
@@ -102,8 +102,8 @@ public class PackageLookupFunction implements SkyFunction {
       return new PackageLookupValue.NoRepositoryPackageLookupValue(
           repoName.getNameWithAt(),
           String.format(
-              "Repository '@%s' is not visible from repository '%s'",
-              repoName.getName(), repoName.getOwnerRepoIfNotVisible().getNameWithAt()));
+              "No repository visible as '@%s' from %s",
+              repoName.getName(), repoName.getOwnerRepoDisplayString()));
     }
 
     if (deletedPackages.get().contains(packageKey)) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -1034,7 +1034,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     assertThat(result.hasError()).isTrue();
     assertThat(result.getError().getException())
         .hasMessageThat()
-        .contains("Repository '@foo' is not visible from repository '@~ext~ext'");
+        .contains("No repository visible as '@foo' from repository '@~ext~ext'");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -452,7 +452,31 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     RepositoryDirectoryValue repositoryDirectoryValue = (RepositoryDirectoryValue) result.get(key);
     assertThat(repositoryDirectoryValue.repositoryExists()).isFalse();
     assertThat(repositoryDirectoryValue.getErrorMsg())
-        .contains("Repository '@foo' is not visible from repository '@fake_owner_repo'");
+        .contains("No repository visible as '@foo' from repository '@fake_owner_repo'");
+  }
+
+  @Test
+  public void loadInvisibleRepositoryFromMain() throws Exception {
+
+    StoredEventHandler eventHandler = new StoredEventHandler();
+    SkyKey key =
+        RepositoryDirectoryValue.key(
+            RepositoryName.createUnvalidated("foo")
+                .toNonVisible(RepositoryName.MAIN));
+    EvaluationContext evaluationContext =
+        EvaluationContext.newBuilder()
+            .setKeepGoing(false)
+            .setNumThreads(8)
+            .setEventHandler(eventHandler)
+            .build();
+    EvaluationResult<SkyValue> result =
+        evaluator.evaluate(ImmutableList.of(key), evaluationContext);
+
+    assertThat(result.hasError()).isFalse();
+    RepositoryDirectoryValue repositoryDirectoryValue = (RepositoryDirectoryValue) result.get(key);
+    assertThat(repositoryDirectoryValue.repositoryExists()).isFalse();
+    assertThat(repositoryDirectoryValue.getErrorMsg())
+        .contains("No repository visible as '@foo' from main repository");
   }
 
   private void loadRepo(String strippedRepoName) throws InterruptedException {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageLookupFunctionTest.java
@@ -352,7 +352,7 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
                 PathFragment.EMPTY_FRAGMENT));
     assertThat(packageLookupValue.packageExists()).isFalse();
     assertThat(packageLookupValue.getErrorReason()).isEqualTo(ErrorReason.REPOSITORY_NOT_FOUND);
-    assertThat(packageLookupValue.getErrorMsg()).contains("not visible from repository");
+    assertThat(packageLookupValue.getErrorMsg()).contains("No repository visible as");
   }
 
   @Test
@@ -368,7 +368,7 @@ public abstract class PackageLookupFunctionTest extends FoundationTestCase {
                 PathFragment.EMPTY_FRAGMENT));
     assertThat(packageLookupValue.packageExists()).isFalse();
     assertThat(packageLookupValue.getErrorReason()).isEqualTo(ErrorReason.REPOSITORY_NOT_FOUND);
-    assertThat(packageLookupValue.getErrorMsg()).contains("not visible from repository");
+    assertThat(packageLookupValue.getErrorMsg()).contains("No repository visible as");
   }
 
   @Test


### PR DESCRIPTION
Instead of saying `Repository '@foo' is not visible from repository '@bar'`, the message now says `No repository visible as '@foo' from '@bar'`.

The previous message made it sound as if there was a repo known as `@foo` that just happens not to be visible from `@bar` (similar to Java strict deps or the visibility attribute on rules), when in fact `@foo` is just a string made up by `@bar` that has no meaning until it is mentioned in some `use_repo` call.

Also replaces `repository '@@'` with the less cryptic term `main repository`.