### PR TITLE
Honour `NETRC` env var in HTTP repository rules

### DIFF
--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -110,6 +110,8 @@ def _get_auth(ctx, urls):
     """Given the list of URLs obtain the correct auth dict."""
     if ctx.attr.netrc:
         netrc = read_netrc(ctx, ctx.attr.netrc)
+    elif "NETRC" in ctx.os.environ:
+        netrc = read_netrc(ctx, ctx.os.environ["NETRC"])
     else:
         netrc = read_user_netrc(ctx)
     return use_netrc(netrc, urls, ctx.attr.auth_patterns)


### PR DESCRIPTION
## Intent
To make `http_*` rules respect the `NETRC` environment variable when defined instead of directly failing to `$HOME/.netrc`.

## Notes
I am not sure if the current implementation of ignoring the `NETRC` environment variable was deliberate. However, I have a use case where we would like to inject an auto-generated `.netrc` file through subprocess substitution (see example below), and, therefore, having support for the `NETRC` environment variable would be greatly appreciated.

```
NETRC=<(/bin/netrc-generator) bazel build //...
```