### PR TITLE
Decanonicalize labels emitted by {a,c,}query if possible

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -419,9 +419,19 @@ public final class Label implements Comparable<Label>, StarlarkValue, SkyKey, Co
    * Label.parse*(x.getUnambiguousCanonicalForm(), ...).equals(x)}).
    */
   public String getUnambiguousCanonicalForm() {
-    return String.format(
-        "@@%s//%s:%s",
-        packageIdentifier.getRepository().getName(), packageIdentifier.getPackageFragment(), name);
+    return packageIdentifier.getUnambiguousCanonicalForm() + ":" + name;
+  }
+
+  /**
+   * Returns a label string that is suitable for display, i.e., it resolves to this label when
+   * parsed in the context of the main repository and has a repository part that is as simple as
+   * possible.
+   *
+   * @param mainRepositoryMapping the {@link RepositoryMapping} of the main repository
+   * @return analogous to {@link PackageIdentifier#getDisplayForm(RepositoryMapping)}
+   */
+  public String getDisplayForm(RepositoryMapping mainRepositoryMapping) {
+    return packageIdentifier.getDisplayForm(mainRepositoryMapping) + ":" + name;
   }
 
   /** Return the name of the repository label refers to without the leading `at` symbol. */

--- a/src/main/java/com/google/devtools/build/lib/cmdline/TargetPattern.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/TargetPattern.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;

--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
@@ -249,6 +250,11 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
 
   protected TargetPattern getPattern(String pattern) throws TargetParsingException {
     return mainRepoTargetParser.parse(pattern);
+  }
+
+  @Override
+  public RepositoryMapping getMainRepoMapping() {
+    return mainRepoTargetParser.getRepoMapping();
   }
 
   public ThreadSafeMutableSet<T> getFwdDeps(Iterable<T> targets) throws InterruptedException {

--- a/src/main/java/com/google/devtools/build/lib/query2/SkyQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/SkyQueryEnvironment.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.lib.bugreport.BugReport;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.ParallelVisitor.VisitTaskStatusCallback;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.SignedTargetPattern;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
@@ -956,6 +957,12 @@ public class SkyQueryEnvironment extends AbstractBlazeQueryEnvironment<Target>
   @Override
   public TargetAccessor<Target> getAccessor() {
     return accessor;
+  }
+
+  @Override
+  @ThreadSafe
+  public RepositoryMapping getMainRepoMapping() {
+    return mainRepoTargetParser.getRepoMapping();
   }
 
   @ThreadSafe

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
@@ -170,7 +170,8 @@ public class ActionGraphQueryEnvironment
             StreamedOutputHandler.OutputType.JSON,
             actionFilters),
         new ActionGraphTextOutputFormatterCallback(
-            eventHandler, aqueryOptions, out, skyframeExecutor, accessor, actionFilters),
+            eventHandler, aqueryOptions, out, skyframeExecutor, accessor, actionFilters,
+            getMainRepoMapping()),
         new ActionGraphSummaryOutputFormatterCallback(
             eventHandler, aqueryOptions, out, skyframeExecutor, accessor, actionFilters));
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.analysis.actions.Substitution;
 import com.google.devtools.build.lib.analysis.actions.TemplateExpansionAction;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.AspectDescriptor;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
@@ -62,6 +63,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
 
   private final ActionKeyContext actionKeyContext = new ActionKeyContext();
   private final AqueryActionFilter actionFilters;
+  private final RepositoryMapping mainRepoMapping;
   private Map<String, String> paramFileNameToContentMap;
 
   ActionGraphTextOutputFormatterCallback(
@@ -70,9 +72,11 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTargetValue> accessor,
-      AqueryActionFilter actionFilters) {
+      AqueryActionFilter actionFilters,
+      RepositoryMapping mainRepoMapping) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
     this.actionFilters = actionFilters;
+    this.mainRepoMapping = mainRepoMapping;
   }
 
   @Override
@@ -145,7 +149,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
 
       stringBuilder
           .append("  Target: ")
-          .append(actionOwner.getLabel())
+          .append(actionOwner.getLabel().getDisplayForm(mainRepoMapping))
           .append('\n')
           .append("  Configuration: ")
           .append(configProto.getMnemonic())
@@ -153,7 +157,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
       if (actionOwner.getExecutionPlatform() != null) {
         stringBuilder
             .append("  Execution platform: ")
-            .append(actionOwner.getExecutionPlatform().label().toString())
+            .append(actionOwner.getExecutionPlatform().label().getDisplayForm(mainRepoMapping))
             .append("\n");
       }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -205,9 +206,11 @@ public class ConfiguredTargetQueryEnvironment
         cqueryOptions.aspectDeps.createResolver(packageManager, eventHandler);
     return ImmutableList.of(
         new LabelAndConfigurationOutputFormatterCallback(
-            eventHandler, cqueryOptions, out, skyframeExecutor, accessor, true),
+            eventHandler, cqueryOptions, out, skyframeExecutor, accessor, true,
+            getMainRepoMapping()),
         new LabelAndConfigurationOutputFormatterCallback(
-            eventHandler, cqueryOptions, out, skyframeExecutor, accessor, false),
+            eventHandler, cqueryOptions, out, skyframeExecutor, accessor, false,
+            getMainRepoMapping()),
         new TransitionsOutputFormatterCallback(
             eventHandler,
             cqueryOptions,
@@ -215,7 +218,8 @@ public class ConfiguredTargetQueryEnvironment
             skyframeExecutor,
             accessor,
             hostConfiguration,
-            trimmingTransitionFactory),
+            trimmingTransitionFactory,
+            getMainRepoMapping()),
         new ProtoOutputFormatterCallback(
             eventHandler,
             cqueryOptions,
@@ -251,7 +255,8 @@ public class ConfiguredTargetQueryEnvironment
             out,
             skyframeExecutor,
             accessor,
-            kct -> getFwdDeps(ImmutableList.of(kct))),
+            kct -> getFwdDeps(ImmutableList.of(kct)),
+            getMainRepoMapping()),
         new StarlarkOutputFormatterCallback(
             eventHandler, cqueryOptions, out, skyframeExecutor, accessor),
         new FilesOutputFormatterCallback(

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
 import com.google.devtools.build.lib.graph.Node;
@@ -65,12 +66,14 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
             };
 
         @Override
-        public String getLabel(Node<KeyedConfiguredTarget> node) {
+        public String getLabel(Node<KeyedConfiguredTarget> node,
+            RepositoryMapping mainRepositoryMapping) {
           // Node payloads are ConfiguredTargets. Output node labels are target labels + config
           // hashes.
           KeyedConfiguredTarget kct = node.getLabel();
           return String.format(
-              "%s (%s)", kct.getLabel(), shortId(getConfiguration(kct.getConfigurationKey())));
+              "%s (%s)", kct.getLabel().getDisplayForm(mainRepositoryMapping),
+              shortId(getConfiguration(kct.getConfigurationKey())));
         }
 
         @Override
@@ -79,15 +82,19 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
         }
       };
 
+  private final RepositoryMapping mainRepoMapping;
+
   GraphOutputFormatterCallback(
       ExtendedEventHandler eventHandler,
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTarget> accessor,
-      DepsRetriever depsRetriever) {
+      DepsRetriever depsRetriever,
+      RepositoryMapping mainRepoMapping) {
     super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ false);
     this.depsRetriever = depsRetriever;
+    this.mainRepoMapping = mainRepoMapping;
   }
 
   @Override
@@ -117,7 +124,8 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
             // select() conditions don't matter for cquery because cquery operates post-analysis
             // phase, when select()s have been resolved and removed from the graph.
             /*maxConditionalEdges=*/ 0,
-            options.graphFactored);
+            options.graphFactored,
+            mainRepoMapping);
     graphWriter.write(graph, /*conditionalEdges=*/ null, outputStream);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.analysis.RequiredConfigFragmentsProvider;
 import com.google.devtools.build.lib.analysis.config.CoreOptions.IncludeConfigFragmentsEnum;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
@@ -28,6 +29,7 @@ import java.io.OutputStream;
 /** Default Output callback for cquery. Prints a label and configuration pair per result. */
 public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsafeCallback {
   private final boolean showKind;
+  private final RepositoryMapping mainRepoMapping;
 
   LabelAndConfigurationOutputFormatterCallback(
       ExtendedEventHandler eventHandler,
@@ -35,9 +37,11 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTarget> accessor,
-      boolean showKind) {
+      boolean showKind,
+      RepositoryMapping mainRepoMapping) {
     super(eventHandler, options, out, skyframeExecutor, accessor, /*uniquifyResults=*/ false);
     this.showKind = showKind;
+    this.mainRepoMapping = mainRepoMapping;
   }
 
   @Override
@@ -55,7 +59,7 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
       }
       output =
           output
-              .append(keyedConfiguredTarget.getLabel())
+              .append(keyedConfiguredTarget.getLabel().getDisplayForm(mainRepoMapping))
               .append(" (")
               .append(shortId(getConfiguration(keyedConfiguredTarget.getConfigurationKey())))
               .append(")");

--- a/src/main/java/com/google/devtools/build/lib/query2/engine/QueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/engine/QueryEnvironment.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.util.DetailedExitCode;
@@ -535,6 +536,13 @@ public interface QueryEnvironment<T> {
    * returns {@code this}.
    */
   TargetAccessor<T> getAccessor();
+
+  /**
+   * Returns the {@link RepositoryMapping} of the main repository so that output formatters can
+   * resolve canonical repository names in labels back to the more readable local names used by the
+   * main repository.
+   */
+  RepositoryMapping getMainRepoMapping();
 
   /**
    * Whether the given setting is enabled. The code should default to return {@code false} for all

--- a/src/main/java/com/google/devtools/build/lib/query2/query/BlazeQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/BlazeQueryEnvironment.java
@@ -20,6 +20,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.cmdline.TargetPattern.Parser;
@@ -498,6 +499,11 @@ public class BlazeQueryEnvironment extends AbstractBlazeQueryEnvironment<Target>
   @Override
   public TargetAccessor<Target> getAccessor() {
     return accessor;
+  }
+
+  @Override
+  public RepositoryMapping getMainRepoMapping() {
+    return mainRepoTargetParser.getRepoMapping();
   }
 
   /** Given a set of target nodes, returns the targets. */

--- a/src/main/java/com/google/devtools/build/lib/query2/query/GraphlessBlazeQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/GraphlessBlazeQueryEnvironment.java
@@ -17,6 +17,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.cmdline.TargetPattern.Parser;
@@ -506,5 +507,10 @@ public class GraphlessBlazeQueryEnvironment extends AbstractBlazeQueryEnvironmen
   @Override
   public TargetAccessor<Target> getAccessor() {
     return accessor;
+  }
+
+  @Override
+  public RepositoryMapping getMainRepoMapping() {
+    return mainRepoTargetParser.getRepoMapping();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/AbstractUnorderedFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/AbstractUnorderedFormatter.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.common.collect.Iterables;
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
 import com.google.devtools.build.lib.graph.Node;
@@ -45,12 +46,14 @@ abstract class AbstractUnorderedFormatter extends OutputFormatter implements Str
       OutputStream out,
       AspectResolver aspectResolver,
       @Nullable EventHandler eventHandler,
-      HashFunction hashFunction)
+      HashFunction hashFunction,
+      RepositoryMapping mainRepoMapping)
       throws IOException, InterruptedException {
     setOptions(options, aspectResolver, hashFunction);
     setEventHandler(eventHandler);
     OutputFormatterCallback.processAllTargets(
-        createPostFactoStreamCallback(out, options), getOrderedTargets(result, options));
+        createPostFactoStreamCallback(out, options, mainRepoMapping),
+        getOrderedTargets(result, options));
   }
 
   protected Iterable<Target> getOrderedTargets(Digraph<Target> result, QueryOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/BuildOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/BuildOutputFormatter.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.query2.query.output;
 import com.google.common.base.Ascii;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.BuildType;
@@ -221,7 +222,7 @@ public class BuildOutputFormatter extends AbstractUnorderedFormatter {
   /** Query's implementation. */
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
-      OutputStream out, final QueryOptions options) {
+      OutputStream out, final QueryOptions options, RepositoryMapping mainRepoMapping) {
     return new BuildOutputFormatterCallback(out, options.getLineTerminator());
   }
 
@@ -229,7 +230,7 @@ public class BuildOutputFormatter extends AbstractUnorderedFormatter {
   public ThreadSafeOutputFormatterCallback<Target> createStreamCallback(
       OutputStream out, QueryOptions options, QueryEnvironment<?> env) {
     return new SynchronizedDelegatingOutputFormatterCallback<>(
-        createPostFactoStreamCallback(out, options));
+        createPostFactoStreamCallback(out, options, env.getMainRepoMapping()));
   }
 
   private static class BuildOutputFormatterCallback extends TextOutputFormatterCallback<Target> {

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/GraphOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/GraphOutputFormatter.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
 import com.google.devtools.build.lib.graph.Node;
@@ -40,9 +41,9 @@ class GraphOutputFormatter extends OutputFormatter {
         private final TargetOrdering targetOrdering = new FormatUtils.TargetOrdering();
 
         @Override
-        public String getLabel(Node<Target> node) {
+        public String getLabel(Node<Target> node, RepositoryMapping mainRepositoryMapping) {
           // Node payloads are Targets. Output node labels are target labels.
-          return node.getLabel().getLabel().toString();
+          return node.getLabel().getLabel().getDisplayForm(mainRepositoryMapping);
         }
 
         @Override
@@ -58,7 +59,8 @@ class GraphOutputFormatter extends OutputFormatter {
       OutputStream out,
       AspectResolver aspectProvider,
       EventHandler eventHandler,
-      HashFunction hashFunction) {
+      HashFunction hashFunction,
+      RepositoryMapping mainRepoMapping) {
     boolean sortLabels = options.orderOutput == OrderOutput.FULL;
     GraphOutputWriter<Target> graphWriter =
         new GraphOutputWriter<>(
@@ -67,7 +69,8 @@ class GraphOutputFormatter extends OutputFormatter {
             sortLabels,
             options.graphNodeStringLimit,
             options.graphConditionalEdgesLimit,
-            options.graphFactored);
+            options.graphFactored,
+            mainRepoMapping);
     graphWriter.write(result, new ConditionalEdges(result), out);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/GraphOutputWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/GraphOutputWriter.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.collect.CollectionUtils;
 import com.google.devtools.build.lib.collect.EquivalenceRelation;
 import com.google.devtools.build.lib.graph.Digraph;
@@ -54,7 +55,7 @@ public final class GraphOutputWriter<T> {
      * <p>This is not the same as a build {@link Label}. This is just the text associated with a
      * node in a GraphViz graph.
      */
-    String getLabel(Node<T> node);
+    String getLabel(Node<T> node, RepositoryMapping mainRepositoryMapping);
 
     /** Returns a comparator for the build graph nodes that form the payloads of GraphViz nodes. */
     Comparator<T> comparator();
@@ -67,6 +68,7 @@ public final class GraphOutputWriter<T> {
   private final int maxConditionalEdges;
   private final boolean mergeEquivalentNodes;
   private final Ordering<Node<T>> nodeComparator;
+  private final RepositoryMapping mainRepoMapping;
 
   private static final int RESERVED_LABEL_CHARS = "\\n...and 9999999 more items".length();
 
@@ -90,13 +92,15 @@ public final class GraphOutputWriter<T> {
       boolean sortLabels,
       int maxLabelSize,
       int maxConditionalEdges,
-      boolean mergeEquivalentNodes) {
+      boolean mergeEquivalentNodes,
+      RepositoryMapping mainRepoMapping) {
     this.nodeReader = nodeReader;
     this.lineTerminator = lineTerminator;
     this.sortLabels = sortLabels;
     this.maxLabelSize = maxLabelSize;
     this.maxConditionalEdges = maxConditionalEdges;
     this.mergeEquivalentNodes = mergeEquivalentNodes;
+    this.mainRepoMapping = mainRepoMapping;
     nodeComparator = Ordering.from(nodeReader.comparator()).onResultOf(Node::getLabel);
   }
 
@@ -120,7 +124,7 @@ public final class GraphOutputWriter<T> {
   private void outputUnfactored(
       Digraph<T> graph, @Nullable ConditionalEdges conditionalEdges, PrintWriter out) {
     graph.visitNodesBeforeEdges(
-        new DotOutputVisitor<T>(out, nodeReader::getLabel) {
+        new DotOutputVisitor<T>(out, node -> nodeReader.getLabel(node, mainRepoMapping)) {
           @Override
           public void beginVisit() {
             super.beginVisit();
@@ -180,7 +184,7 @@ public final class GraphOutputWriter<T> {
           StringBuilder buf = new StringBuilder();
           int count = 0;
           for (Node<T> eqNode : node.getLabel()) {
-            String labelString = nodeReader.getLabel(eqNode);
+            String labelString = nodeReader.getLabel(eqNode, mainRepoMapping);
             if (!firstItem) {
               buf.append("\\n");
 

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/LabelOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/LabelOutputFormatter.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.engine.OutputFormatterCallback;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment;
@@ -42,7 +43,7 @@ class LabelOutputFormatter extends AbstractUnorderedFormatter {
 
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
-      OutputStream out, final QueryOptions options) {
+      OutputStream out, final QueryOptions options, RepositoryMapping mainRepoMapping) {
     return new TextOutputFormatterCallback<Target>(out) {
       @Override
       public void processOutput(Iterable<Target> partialResult) throws IOException {
@@ -53,7 +54,7 @@ class LabelOutputFormatter extends AbstractUnorderedFormatter {
             writer.append(' ');
           }
           Label label = target.getLabel();
-          writer.append(label.getCanonicalForm()).append(lineTerm);
+          writer.append(label.getDisplayForm(mainRepoMapping)).append(lineTerm);
         }
       }
     };
@@ -63,6 +64,6 @@ class LabelOutputFormatter extends AbstractUnorderedFormatter {
   public ThreadSafeOutputFormatterCallback<Target> createStreamCallback(
       OutputStream out, QueryOptions options, QueryEnvironment<?> env) {
     return new SynchronizedDelegatingOutputFormatterCallback<>(
-        createPostFactoStreamCallback(out, options));
+        createPostFactoStreamCallback(out, options, env.getMainRepoMapping()));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/LocationOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/LocationOutputFormatter.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.common.AbstractBlazeQueryEnvironment;
 import com.google.devtools.build.lib.query2.common.CommonQueryOptions;
@@ -75,7 +76,7 @@ class LocationOutputFormatter extends AbstractUnorderedFormatter {
 
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
-      OutputStream out, final QueryOptions options) {
+      OutputStream out, final QueryOptions options, RepositoryMapping mainRepoMapping) {
     return new TextOutputFormatterCallback<Target>(out) {
 
       @Override
@@ -87,7 +88,7 @@ class LocationOutputFormatter extends AbstractUnorderedFormatter {
               .append(": ")
               .append(target.getTargetKind())
               .append(" ")
-              .append(target.getLabel().getCanonicalForm())
+              .append(target.getLabel().getDisplayForm(mainRepoMapping))
               .append(lineTerm);
         }
       }
@@ -98,6 +99,6 @@ class LocationOutputFormatter extends AbstractUnorderedFormatter {
   public ThreadSafeOutputFormatterCallback<Target> createStreamCallback(
       OutputStream out, QueryOptions options, QueryEnvironment<?> env) {
     return new SynchronizedDelegatingOutputFormatterCallback<>(
-        createPostFactoStreamCallback(out, options));
+        createPostFactoStreamCallback(out, options, env.getMainRepoMapping()));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/MaxrankOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/MaxrankOutputFormatter.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.query2.query.output;
 import static java.util.Comparator.comparingInt;
 
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
 import com.google.devtools.build.lib.graph.Node;
@@ -58,7 +59,8 @@ class MaxrankOutputFormatter extends OutputFormatter {
       OutputStream out,
       AspectResolver aspectResolver,
       EventHandler eventHandler,
-      HashFunction hashFunction)
+      HashFunction hashFunction,
+      RepositoryMapping mainRepoMapping)
       throws IOException {
     // In order to handle cycles correctly, we need work on the strong
     // component graph, as cycles should be treated a "clump" of nodes all on
@@ -102,7 +104,7 @@ class MaxrankOutputFormatter extends OutputFormatter {
     final String lineTerm = options.getLineTerminator();
     PrintStream printStream = new PrintStream(out);
     for (RankAndLabel item : output) {
-      printStream.print(item + lineTerm);
+      printStream.print(item.toDisplayString(mainRepoMapping) + lineTerm);
     }
     flushAndCheckError(printStream);
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/MinrankOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/MinrankOutputFormatter.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.common.hash.HashFunction;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
 import com.google.devtools.build.lib.graph.Node;
@@ -70,7 +71,8 @@ class MinrankOutputFormatter extends OutputFormatter {
       OutputStream out,
       AspectResolver aspectResolver,
       EventHandler eventHandler,
-      HashFunction hashFunction)
+      HashFunction hashFunction,
+      RepositoryMapping mainRepoMapping)
       throws IOException {
     PrintStream printStream = new PrintStream(out);
     // getRoots() isn't defined for cyclic graphs, so in order to handle
@@ -108,7 +110,7 @@ class MinrankOutputFormatter extends OutputFormatter {
     if (outputToOrder != null) {
       Collections.sort(outputToOrder);
       for (RankAndLabel item : outputToOrder) {
-        printStream.print(item + lineTerm);
+        printStream.print(item.toDisplayString(mainRepoMapping) + lineTerm);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/OutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/OutputFormatter.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
 import com.google.devtools.build.lib.packages.Target;
@@ -58,6 +59,7 @@ public abstract class OutputFormatter {
       OutputStream out,
       AspectResolver aspectProvider,
       @Nullable EventHandler eventHandler,
-      HashFunction hashFunction)
+      HashFunction hashFunction,
+      RepositoryMapping mainRepoMapping)
       throws IOException, InterruptedException;
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/PackageOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/PackageOutputFormatter.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.common.collect.Sets;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.engine.OutputFormatterCallback;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment;
@@ -25,8 +26,8 @@ import java.io.OutputStream;
 import java.util.Set;
 
 /**
- * An output formatter that prints the names of the packages of the target
- * set, in lexicographical order without duplicates.
+ * An output formatter that prints the names of the packages of the target set, in lexicographical
+ * order without duplicates.
  */
 class PackageOutputFormatter extends AbstractUnorderedFormatter {
 
@@ -37,7 +38,7 @@ class PackageOutputFormatter extends AbstractUnorderedFormatter {
 
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
-      OutputStream out, final QueryOptions options) {
+      OutputStream out, final QueryOptions options, RepositoryMapping mainRepoMapping) {
     return new TextOutputFormatterCallback<Target>(out) {
       private final Set<String> packageNames = Sets.newTreeSet();
 
@@ -45,7 +46,8 @@ class PackageOutputFormatter extends AbstractUnorderedFormatter {
       public void processOutput(Iterable<Target> partialResult) {
 
         for (Target target : partialResult) {
-          packageNames.add(target.getLabel().getPackageIdentifier().toString());
+          packageNames.add(
+              target.getLabel().getPackageIdentifier().getDisplayForm(mainRepoMapping));
         }
       }
 
@@ -66,6 +68,6 @@ class PackageOutputFormatter extends AbstractUnorderedFormatter {
   public ThreadSafeOutputFormatterCallback<Target> createStreamCallback(
       OutputStream out, QueryOptions options, QueryEnvironment<?> env) {
     return new SynchronizedDelegatingOutputFormatterCallback<>(
-        createPostFactoStreamCallback(out, options));
+        createPostFactoStreamCallback(out, options, env.getMainRepoMapping()));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/PackageOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/PackageOutputFormatter.java
@@ -46,8 +46,13 @@ class PackageOutputFormatter extends AbstractUnorderedFormatter {
       public void processOutput(Iterable<Target> partialResult) {
 
         for (Target target : partialResult) {
-          packageNames.add(
-              target.getLabel().getPackageIdentifier().getDisplayForm(mainRepoMapping));
+          String packageLabel = target.getLabel().getPackageIdentifier()
+              .getDisplayForm(mainRepoMapping);
+          // For backwards compatibility, emit main repo packages as "a/b" rather than "//a/b".
+          if (packageLabel.startsWith("//")) {
+            packageLabel = packageLabel.substring(2);
+          }
+          packageNames.add(packageLabel);
         }
       }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
@@ -19,7 +19,6 @@ import static com.google.devtools.build.lib.query2.proto.proto2api.Build.Target.
 import static com.google.devtools.build.lib.query2.proto.proto2api.Build.Target.Discriminator.RULE;
 import static com.google.devtools.build.lib.query2.proto.proto2api.Build.Target.Discriminator.SOURCE_FILE;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -32,6 +31,7 @@ import com.google.common.collect.Maps;
 import com.google.common.hash.HashFunction;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
@@ -158,21 +158,15 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
 
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
-      OutputStream out, QueryOptions options) {
+      OutputStream out, QueryOptions options, RepositoryMapping mainRepoMapping) {
     return new StreamedQueryResultFormatter(out);
   }
 
   @Override
   public ThreadSafeOutputFormatterCallback<Target> createStreamCallback(
       OutputStream out, QueryOptions options, QueryEnvironment<?> env) {
-    return createStreamCallback(out, options);
-  }
-
-  @VisibleForTesting
-  public ThreadSafeOutputFormatterCallback<Target> createStreamCallback(
-      OutputStream out, QueryOptions options) {
     return new SynchronizedDelegatingOutputFormatterCallback<>(
-        createPostFactoStreamCallback(out, options));
+        createPostFactoStreamCallback(out, options, env.getMainRepoMapping()));
   }
 
   private static Iterable<Target> getSortedLabels(Digraph<Target> result) {

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOutputUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOutputUtils.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
 import com.google.devtools.build.lib.packages.Target;
@@ -59,7 +60,8 @@ public class QueryOutputUtils {
       OutputStream outputStream,
       AspectResolver aspectResolver,
       @Nullable EventHandler eventHandler,
-      HashFunction hashFunction)
+      HashFunction hashFunction,
+      RepositoryMapping mainRepoMapping)
       throws IOException, InterruptedException {
     /*
      * This is not really streaming, but we are using the streaming interface for writing into the
@@ -71,7 +73,8 @@ public class QueryOutputUtils {
       streamedFormatter.setOptions(queryOptions, aspectResolver, hashFunction);
       streamedFormatter.setEventHandler(eventHandler);
       OutputFormatterCallback.processAllTargets(
-          streamedFormatter.createPostFactoStreamCallback(outputStream, queryOptions),
+          streamedFormatter.createPostFactoStreamCallback(outputStream, queryOptions,
+              mainRepoMapping),
           targetsResult);
     } else {
       @SuppressWarnings("unchecked")
@@ -85,7 +88,8 @@ public class QueryOutputUtils {
 
       try (SilentCloseable closeable = Profiler.instance().profile("formatter.output")) {
         formatter.output(
-            queryOptions, subgraph, outputStream, aspectResolver, eventHandler, hashFunction);
+            queryOptions, subgraph, outputStream, aspectResolver, eventHandler, hashFunction,
+            mainRepoMapping);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/RankAndLabel.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/RankAndLabel.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 
 class RankAndLabel implements Comparable<RankAndLabel> {
   private final int rank;
@@ -39,6 +40,10 @@ class RankAndLabel implements Comparable<RankAndLabel> {
 
   @Override
   public String toString() {
-    return rank + " " + label.getCanonicalForm();
+    return toDisplayString(RepositoryMapping.ALWAYS_FALLBACK);
+  }
+
+  public String toDisplayString(RepositoryMapping mainRepoMapping) {
+    return rank + " " + label.getDisplayForm(mainRepoMapping);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedFormatter.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.query2.query.output;
 
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.common.CommonQueryOptions;
@@ -62,5 +63,5 @@ public interface StreamedFormatter {
    * already-computed result of a query.
    */
   OutputFormatterCallback<Target> createPostFactoStreamCallback(
-      OutputStream out, QueryOptions options);
+      OutputStream out, QueryOptions options, RepositoryMapping mainRepoMapping);
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.query2.query.output;
 
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.query2.engine.OutputFormatterCallback;
 import java.io.IOException;
@@ -31,7 +32,7 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
 
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
-      final OutputStream out, final QueryOptions options) {
+      final OutputStream out, final QueryOptions options, RepositoryMapping mainRepoMapping) {
     return new OutputFormatterCallback<Target>() {
       @Override
       public void processOutput(Iterable<Target> partialResult)

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/XmlOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/XmlOutputFormatter.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.hash.HashFunction;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.DependencyFilter;
@@ -75,7 +76,7 @@ class XmlOutputFormatter extends AbstractUnorderedFormatter {
   public ThreadSafeOutputFormatterCallback<Target> createStreamCallback(
       OutputStream out, QueryOptions options, QueryEnvironment<?> env) {
     return new SynchronizedDelegatingOutputFormatterCallback<>(
-        createPostFactoStreamCallback(out, options));
+        createPostFactoStreamCallback(out, options, env.getMainRepoMapping()));
   }
 
   @Override
@@ -94,7 +95,7 @@ class XmlOutputFormatter extends AbstractUnorderedFormatter {
 
   @Override
   public OutputFormatterCallback<Target> createPostFactoStreamCallback(
-      OutputStream out, QueryOptions options) {
+      OutputStream out, QueryOptions options, RepositoryMapping mainRepoMapping) {
     return new OutputFormatterCallback<Target>() {
 
       private Document doc;

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
@@ -268,6 +268,7 @@ public class GenQuery implements RuleConfiguredTargetFactory {
     OutputFormatter formatter;
     AggregateAllOutputFormatterCallback<Target, ?> targets;
     boolean graphlessQuery;
+    AbstractBlazeQueryEnvironment<Target> queryEnvironment;
     try {
       Set<Setting> settings = queryOptions.toSettings();
 
@@ -303,7 +304,7 @@ public class GenQuery implements RuleConfiguredTargetFactory {
                       RepositoryMappingResolutionException.class);
       Preconditions.checkNotNull(repositoryMappingValue);
 
-      AbstractBlazeQueryEnvironment<Target> queryEnvironment =
+      queryEnvironment =
           QUERY_ENVIRONMENT_FACTORY.create(
               /* queryTransitivePackagePreloader= */ null,
               /* graphFactory= */ null,
@@ -367,7 +368,8 @@ public class GenQuery implements RuleConfiguredTargetFactory {
           outputStream,
           queryOptions.aspectDeps.createResolver(packageProvider, getEventHandler(ruleContext)),
           getEventHandler(ruleContext),
-          hashFunction);
+          hashFunction,
+          queryEnvironment.getMainRepoMapping());
       outputStream.close();
     } catch (ClosedByInterruptException e) {
       throw new InterruptedException(e.getMessage());

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
@@ -185,7 +185,8 @@ public final class QueryCommand extends QueryEnvironmentBasedCommand {
               out,
               queryOptions.aspectDeps.createResolver(env.getPackageManager(), env.getReporter()),
               env.getReporter(),
-              hashFunction);
+              hashFunction,
+              queryEnv.getMainRepoMapping());
         } catch (ClosedByInterruptException | InterruptedException e) {
           return reportAndCreateInterruptedResult(env);
         } catch (IOException e) {

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
@@ -39,6 +39,7 @@ java_test(
     deps = [
         ":configured_target_query_helper",
         ":configured_target_query_test",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/query2",
         "//src/main/java/com/google/devtools/build/lib/query2/engine",
@@ -150,6 +151,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transition_factories",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/no_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/transition_factory",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/query2",

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallbackTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.EventBus;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
@@ -80,7 +81,8 @@ public class GraphOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
             new PrintStream(output),
             getHelper().getSkyframeExecutor(),
             env.getAccessor(),
-            ct -> env.getFwdDeps(ImmutableList.of(ct)));
+            ct -> env.getFwdDeps(ImmutableList.of(ct)),
+            RepositoryMapping.ALWAYS_FALLBACK);
     env.evaluateQuery(expression, callback);
     return Arrays.asList(output.toString().split(System.lineSeparator()));
   }

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterTest.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.analysis.config.TransitionFactories;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.analysis.util.MockRule;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.packages.RuleTransitionData;
@@ -245,7 +246,8 @@ public class TransitionsOutputFormatterTest extends ConfiguredTargetQueryTest {
             getHelper().getSkyframeExecutor(),
             env.getAccessor(),
             env.getHostConfiguration(),
-            trimmingTransitionFactory);
+            trimmingTransitionFactory,
+            RepositoryMapping.ALWAYS_FALLBACK);
     env.evaluateQuery(env.transformParsedQuery(QueryParser.parse(queryExpression, env)), callback);
     return callback.getResult();
   }

--- a/src/test/py/bazel/bzlmod/bzlmod_query_test.py
+++ b/src/test/py/bazel/bzlmod/bzlmod_query_test.py
@@ -30,9 +30,11 @@ class BzlmodQueryTest(test_base.TestBase):
     self.registries_work_dir = tempfile.mkdtemp(dir=self._test_cwd)
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main'))
-    self.main_registry.createCcModule('aaa', '1.0') \
+    self.main_registry.createCcModule('aaa', '1.0', {'ccc': '1.2'}) \
       .createCcModule('aaa', '1.1') \
-      .createCcModule('bbb', '1.0', {'aaa': '1.0'}, {'aaa': 'com_foo_bar_aaa'})
+      .createCcModule('bbb', '1.0', {'aaa': '1.0'}, {'aaa': 'com_foo_bar_aaa'}) \
+      .createCcModule('ccc', '1.2')
+
     self.ScratchFile(
         '.bazelrc',
         [
@@ -58,7 +60,29 @@ class BzlmodQueryTest(test_base.TestBase):
     ])
     _, stdout, _ = self.RunBazel(['query', '@my_repo//...'],
                                  allow_failure=False)
-    self.assertListEqual(['@aaa~1.0//:lib_aaa'], stdout)
+    self.assertListEqual(['@my_repo//:lib_aaa'], stdout)
+
+  def testQueryModuleRepoTransitiveDeps(self):
+    self.ScratchFile('MODULE.bazel', [
+      'bazel_dep(name = "aaa", version = "1.0", repo_name = "my_repo")',
+    ])
+    self.ScratchFile('BUILD', [
+      'cc_binary(',
+      '  name = "main",',
+      '  srcs = ["main.cc"],',
+      '  deps = ["@my_repo//:lib_aaa"],',
+      ')',
+    ])
+    _, stdout, _ = self.RunBazel(
+        [
+          'query',
+          'kind("cc_.* rule", deps(//:main))',
+          '--noimplicit_deps',
+          '--notool_deps',
+        ],
+        allow_failure=False)
+    self.assertListEqual(
+        ['//:main', '@my_repo//:lib_aaa', '@@ccc~1.2//:lib_ccc'], stdout)
 
   def testAqueryModuleRepoTargetsBelow(self):
     self.ScratchFile('MODULE.bazel', [
@@ -67,7 +91,33 @@ class BzlmodQueryTest(test_base.TestBase):
     ])
     _, stdout, _ = self.RunBazel(['aquery', '@my_repo//...'],
                                  allow_failure=False)
+    # This label is stringified into a "purpose" in some action before it
+    # reaches aquery code, so can't decanonicalize it.
     self.assertEqual(stdout[0], 'cc_library-compile for @aaa~1.0//:lib_aaa')
+    self.assertIn('Target: @my_repo//:lib_aaa', stdout)
+
+  def testAqueryModuleRepoTransitiveDeps(self):
+    self.ScratchFile('MODULE.bazel', [
+      'bazel_dep(name = "aaa", version = "1.0", repo_name = "my_repo")',
+    ])
+    self.ScratchFile('BUILD', [
+      'cc_binary(',
+      '  name = "main",',
+      '  srcs = ["main.cc"],',
+      '  deps = ["@my_repo//:lib_aaa"],',
+      ')',
+    ])
+    _, stdout, _ = self.RunBazel(
+        [
+          'aquery',
+          'kind("cc_.* rule", deps(//:main))',
+          '--noimplicit_deps',
+          '--notool_deps',
+        ],
+        allow_failure=False)
+    self.assertIn('Target: //:main', stdout)
+    self.assertIn('Target: @my_repo//:lib_aaa', stdout)
+    self.assertIn('Target: @@ccc~1.2//:lib_ccc', stdout)
 
   def testCqueryModuleRepoTargetsBelow(self):
     self.ScratchFile('MODULE.bazel', [
@@ -76,7 +126,31 @@ class BzlmodQueryTest(test_base.TestBase):
     ])
     _, stdout, _ = self.RunBazel(['cquery', '@my_repo//...'],
                                  allow_failure=False)
-    self.assertRegex(stdout[0], r'@aaa~1.0//:lib_aaa \([\w\d]+\)')
+    self.assertRegex(stdout[0], r'@my_repo//:lib_aaa \([\w\d]+\)')
+
+  def testCqueryModuleRepoTransitiveDeps(self):
+    self.ScratchFile('MODULE.bazel', [
+      'bazel_dep(name = "aaa", version = "1.0", repo_name = "my_repo")',
+    ])
+    self.ScratchFile('BUILD', [
+      'cc_binary(',
+      '  name = "main",',
+      '  srcs = ["main.cc"],',
+      '  deps = ["@my_repo//:lib_aaa"],',
+      ')',
+    ])
+    _, stdout, _ = self.RunBazel(
+        [
+          'cquery',
+          'kind("cc_.* rule", deps(//:main))',
+          '--noimplicit_deps',
+          '--notool_deps',
+        ],
+        allow_failure=False)
+    self.assertRegex(stdout[0], r'^//:main \([\w\d]+\)$')
+    self.assertRegex(stdout[1], r'^@my_repo//:lib_aaa \([\w\d]+\)$')
+    self.assertRegex(stdout[2], r'^@@ccc~1.2//:lib_ccc \([\w\d]+\)$')
+    self.assertEqual(len(stdout), 3)
 
   def testFetchModuleRepoTargetsBelow(self):
     self.ScratchFile('MODULE.bazel', [
@@ -101,7 +175,7 @@ class BzlmodQueryTest(test_base.TestBase):
     self.assertIsNotNone(output_file)
     output = output_file.readlines()
     output_file.close()
-    self.assertListEqual(['@aaa~1.0//:lib_aaa\n'], output)
+    self.assertListEqual(['@my_repo//:lib_aaa\n'], output)
 
   def testQueryCannotResolveRepoMapping_malformedModuleFile(self):
     self.ScratchFile('MODULE.bazel', [


### PR DESCRIPTION
Uses the newly added `PackageIdentifier#getDisplayForm` to turn labels
in the output of query, aquery, and cquery into the most concise
representation that allows them to be resolved from the context of the
main repository.