### PR TITLE
Use the execution time instead of the worker time for the wall time

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -129,8 +129,8 @@ final class RemoteSpawnCache implements SpawnCache {
                   /*cacheHit=*/ true,
                   result.cacheName(),
                   inMemoryOutput,
-                  result.getExecutionMetadata().getWorkerStartTimestamp(),
-                  result.getExecutionMetadata().getWorkerCompletedTimestamp(),
+                  result.getExecutionMetadata().getExecutionStartTimestamp(),
+                  result.getExecutionMetadata().getExecutionCompletedTimestamp(),
                   spawnMetrics.build(),
                   spawn.getMnemonic());
           return SpawnCache.success(spawnResult);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -424,8 +424,8 @@ public class RemoteSpawnRunner implements SpawnRunner {
         cacheHit,
         cacheName,
         inMemoryOutput,
-        result.getExecutionMetadata().getWorkerStartTimestamp(),
-        result.getExecutionMetadata().getWorkerCompletedTimestamp(),
+        result.getExecutionMetadata().getExecutionStartTimestamp(),
+        result.getExecutionMetadata().getExecutionCompletedTimestamp(),
         spawnMetrics
             .setFetchTime(fetchTime.elapsed().minus(networkTimeEnd.minus(networkTimeStart)))
             .setTotalTime(totalTime.elapsed())

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -124,10 +124,14 @@ public class UploadManifest {
     }
 
     if (startTime.isPresent() && wallTime.isPresent()) {
+      Timestamp startTimestamp = instantToTimestamp(startTime.get());
+      Timestamp completedTimestamp = instantToTimestamp(startTime.get().plus(wallTime.get()));
       result
           .getExecutionMetadataBuilder()
-          .setWorkerStartTimestamp(instantToTimestamp(startTime.get()))
-          .setWorkerCompletedTimestamp(instantToTimestamp(startTime.get().plus(wallTime.get())));
+          .setWorkerStartTimestamp(startTimestamp)
+          .setExecutionStartTimestamp(startTimestamp)
+          .setExecutionCompletedTimestamp(completedTimestamp)
+          .setWorkerCompletedTimestamp(completedTimestamp);
     }
 
     return manifest;


### PR DESCRIPTION
SpawnResult.getWallTime() is documented as follows:

    Returns the wall time taken by the {@link Spawn}'s execution.

With the math performed as is, we also end up including time spent downloading inputs and uploading outputs. I don't think that this is in the spirit of this method. There are also getUserTime() and getSystemTime(), meaning this was likely modeled after the time(1) utility.

Cc @tjgq, as this logic was added in 93029d8f1f01be440d8e06cce9585ad912f9169b.