### PR TITLE
Optionally let `print` emit a stack trace

### DIFF
--- a/src/main/java/net/starlark/java/eval/EvalException.java
+++ b/src/main/java/net/starlark/java/eval/EvalException.java
@@ -108,7 +108,7 @@ public class EvalException extends Exception {
    */
   public final String getMessageWithStack(SourceReader src) {
     if (callstack != null) {
-      return formatCallStack(callstack, getMessage(), src);
+      return formatCallStack(callstack, getMessage(), src, /*isPrint=*/false);
     }
     return getMessage();
   }
@@ -152,12 +152,16 @@ public class EvalException extends Exception {
       };
 
   /**
-   * Formats the given call stack and error message. Provided as a separate function from {@link
-   * #getMessageWithStack} so that clients may modify the stack and/or error before formatting it.
-   * The source line for each stack frame is obtained from the provided SourceReader.
+   * Formats the given call stack and error or print message. Provided as a separate function from
+   * {@link #getMessageWithStack} so that clients may modify the stack and/or error before
+   * formatting it. The source line for each stack frame is obtained from the provided
+   * SourceReader.
+   *
+   * @param isPrint True if invoked from the built-in 'print' function rather than an error.
    */
   public static String formatCallStack(
-      List<StarlarkThread.CallStackEntry> callstack, String message, SourceReader src) {
+      List<StarlarkThread.CallStackEntry> callstack, String message, SourceReader src,
+      boolean isPrint) {
     StringBuilder buf = new StringBuilder();
     int n = callstack.size(); // n > 0
     String prefix = "Error: ";
@@ -165,7 +169,12 @@ public class EvalException extends Exception {
     // Instead just prefix the name of the built-in onto the error message.
     StarlarkThread.CallStackEntry leaf = callstack.get(n - 1);
     if (leaf.location.equals(Location.BUILTIN)) {
-      prefix = "Error in " + leaf.name + ": ";
+      if (isPrint) {
+        // This is reached when using print(..., with_trace=True).
+        prefix = "print: ";
+      } else {
+        prefix = "Error in " + leaf.name + ": ";
+      }
       n--;
     }
     if (n > 0) {

--- a/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
+++ b/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
@@ -1954,6 +1954,35 @@ public final class StarlarkEvaluationTest {
   }
 
   @Test
+  public void testPrintWithTrace() throws Exception {
+    ParserInput input = ParserInput.fromLines(
+        "def foo(value):",
+        "    if value:",
+        "        print(value, with_trace = True)",
+        "def bar(value):",
+        "    foo(value)",
+        "def baz(value):",
+        "    bar(value)",
+        "baz(42)"
+    );
+    List<String> prints = new ArrayList<>();
+    try (Mutability mu = Mutability.create("test")) {
+      StarlarkThread thread = new StarlarkThread(mu, StarlarkSemantics.DEFAULT);
+      thread.setPrintHandler((unused, msg) -> prints.add(msg));
+      Starlark.execFile(input, FileOptions.DEFAULT, Module.create(), thread);
+    }
+    assertThat(prints).hasSize(1);
+    assertThat(prints.get(0).split("\n")).asList().containsExactly(
+        "Traceback (most recent call last):",
+        "\tFile \"\", line 8, column 4, in <toplevel>",
+        "\tFile \"\", line 7, column 8, in baz",
+        "\tFile \"\", line 5, column 8, in bar",
+        "\tFile \"\", line 3, column 14, in foo",
+        "print: 42"
+    ).inOrder();
+  }
+
+  @Test
   public void testPrintBadKwargs() throws Exception {
     ev.new Scenario()
         .testIfErrorContains(


### PR DESCRIPTION
RELNOTES: The new `with_trace` keyword parameter of the `print` function can be used to emit a stack trace for the location of the call, similar to that of the `fail` function.

Fixes https://github.com/bazelbuild/bazel/issues/13275
Work towards https://github.com/bazelbuild/bazel-skylib/issues/290
