### PR TITLE
Don't overwrite errors during `bazel run`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -652,7 +652,7 @@ public final class UiEventHandler implements EventHandler {
   @Subscribe
   public void afterCommand(AfterCommandEvent event) {
     synchronized (this) {
-      buildRunning = true;
+      buildRunning = false;
     }
     completeBuild();
     try {

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -695,4 +695,22 @@ EOF
   expect_log_n "^"$'\e'"\[31m"$'\e'"\[1mFAILED:"$'\e'"\[0m Build did NOT complete successfully" 4
 }
 
+function test_bazel_run_error_visible() {
+  mkdir -p foo
+  cat > foo/BUILD <<'EOF'
+sh_test(
+  name = 'foo',
+  srcs = ['foo.sh'],
+  shard_count = 2,
+)
+EOF
+  touch foo/foo.sh
+  chmod +x foo/foo.sh
+  bazel run --curses=yes //foo &> "$TEST_log" && "Expected failure"
+  expect_log "ERROR: 'run' only works with tests with one shard"
+  # If we would print this again after the run failed, we would overwrite the
+  # error message above.
+  expect_log_n "INFO: Build completed successfully, [45] total actions" 1
+}
+
 run_suite "Integration tests for ${PRODUCT_NAME}'s UI"


### PR DESCRIPTION
We output the "Build completed successfully" message via the progress bar (IMHO, as a more long term fix we should fix that). The progress bar clears previous progress bar contents. Previously, we did miss to mark the build as no longer running when it was actually complete. Both at this point of the invocation, and later when the whole invocation was complete we did output the "Build completed successfully" message, deleting what we thought would be the contents of the progress bar, not aware that there was an ERROR message in between.

The new test illustrates this behavior.

In 7c074b5a5f03a05a108fdfed1910fe75a538a323, `buildComplete` was changed into `buildRunning` and the boolean value was reversed. But we missed changing the value on `AfterCommandEvent`.