### PR TITLE
Expose compatibility arguments on java toolchains

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -139,7 +139,7 @@ NONPREBUILT_TOOLCHAIN_CONFIGURATION = dict(
     java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
 )
 
-def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION, toolchain_definition = True, **kwargs):
+def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION, toolchain_definition = True, exec_compatible_with = [], target_compatible_with = [], **kwargs):
     """Defines a remote java_toolchain with appropriate defaults for Bazel."""
 
     toolchain_args = dict(_BASE_TOOLCHAIN_CONFIGURATION)
@@ -160,6 +160,8 @@ def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION
             toolchain_type = "@bazel_tools//tools/jdk:toolchain_type",
             target_settings = [name + "_version_setting"],
             toolchain = name,
+            exec_compatible_with = exec_compatible_with,
+            target_compatible_with = target_compatible_with,
         )
 
 def java_runtime_files(name, srcs):

--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -38,7 +38,7 @@ def _detect_java_version(repository_ctx, java_bin):
         return minor
     return major
 
-def local_java_runtime(name, java_home, version, runtime_name = None, visibility = ["//visibility:public"]):
+def local_java_runtime(name, java_home, version, runtime_name = None, visibility = ["//visibility:public"], exec_compatible_with = [], target_compatible_with = []):
     """Defines a java_runtime target together with Java runtime and compile toolchain definitions.
 
     Java runtime toolchain is constrained by flag --java_runtime_version having
@@ -102,6 +102,8 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
                 source_version = str(version),
                 target_version = str(version),
                 java_runtime = runtime_name,
+                exec_compatible_with = exec_compatible_with,
+                target_compatible_with = target_compatible_with,
             )
 
     # else version is not recognized and no compilation toolchains are predefined


### PR DESCRIPTION
This change allows providing the `exec_compatibility_with` and `target_compatibility_with` arguments to native.toolchain from invocations of the local_java_runtime and default_java_toolchain.

This is useful for setting constraints on javatoolchains. With the default arguments provided, this does not break the API of these functions.

Closes #16497