### PR TITLE
Improve AbruptExitException error messages

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -980,11 +980,11 @@ public class ExecutionTool {
   }
 
   private static AbruptExitException createExitException(
-      String message, Code detailedCode, IOException e) {
+      String messagePrefix, Code detailedCode, IOException e) {
     return new AbruptExitException(
         DetailedExitCode.of(
             FailureDetail.newBuilder()
-                .setMessage(message)
+                .setMessage(String.format("%s: %s", messagePrefix, e.getMessage()))
                 .setExecution(Execution.newBuilder().setCode(detailedCode))
                 .build()),
         e);


### PR DESCRIPTION
When misconfiguring the Remote Output Service (#12823), Bazel may sometimes throw error messages that look like this:

    ERROR: Couldn't create action output directory

No details about the actual reason for it failing are included. This change adds some string formatting, so that the error message becomes as follows:

    ERROR: Couldn't create action output directory: /private/var/tmp/_bazel_ed/.../execroot/.../bazel-out/_tmp/actions (No such file or directory)

This makes it a lot easier to understand what's wrong.