### PR TITLE
[bazel clean] [pr] Enable async options for darwin/bsd clients

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
@@ -179,8 +179,8 @@ public final class CleanCommand implements BlazeCommand {
   public static boolean canUseAsync(boolean async, boolean expunge, OS os, Reporter reporter) {
     // TODO(bazel-team): Deactivate expunge_async on Windows or Unknown platforms as support for
     // daemonizing is done in daemonize.c and does not support those platforms.
-    boolean asyncSupportUnsupported = os == OS.WINDOWS || os == OS.UNKNOWN;
-    if (async && asyncSupportUnsupported) {
+    boolean asyncSupportMissing = os == OS.WINDOWS || os == OS.UNKNOWN;
+    if (async && asyncSupportMissing) {
       String fallbackName = expunge ? "--expunge" : "synchronous clean";
       reporter.handle(
           Event.info(
@@ -190,7 +190,7 @@ public final class CleanCommand implements BlazeCommand {
     }
 
     String cleanBanner =
-        (async || asyncSupportUnsupported)
+        (async || asyncSupportMissing)
             ? "Starting clean."
             : "Starting clean (this may take a while). "
                 + "Consider using --async if the clean takes more than several minutes.";

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
@@ -177,13 +177,10 @@ public final class CleanCommand implements BlazeCommand {
 
   @VisibleForTesting
   public static boolean canUseAsync(boolean async, boolean expunge, OS os, Reporter reporter) {
-    // TODO(dmarting): Deactivate expunge_async on non-Linux platform until we completely fix it
-    // for non-Linux platforms (https://github.com/bazelbuild/bazel/issues/1906).
-    // MacOS and FreeBSD support setsid(2) but don't have /usr/bin/setsid, so if we wanted to
-    // support --expunge_async on these platforms, we'd have to write a wrapper that calls setsid(2)
-    // and exec(2).
-    boolean asyncSupport = os == OS.LINUX;
-    if (async && !asyncSupport) {
+    // TODO(bazel-team): Deactivate expunge_async on Windows or Unknown platforms as support for
+    // daemonizing is done in daemonize.c and does not support those platforms.
+    boolean asyncSupportUnsupported = os == OS.WINDOWS || os == OS.UNKNOWN;
+    if (async && asyncSupportUnsupported) {
       String fallbackName = expunge ? "--expunge" : "synchronous clean";
       reporter.handle(
           Event.info(
@@ -193,7 +190,7 @@ public final class CleanCommand implements BlazeCommand {
     }
 
     String cleanBanner =
-        (async || !asyncSupport)
+        (async || asyncSupportUnsupported)
             ? "Starting clean."
             : "Starting clean (this may take a while). "
                 + "Consider using --async if the clean takes more than several minutes.";

--- a/src/test/java/com/google/devtools/build/lib/runtime/commands/CleanCommandRecommendsAsyncTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/commands/CleanCommandRecommendsAsyncTest.java
@@ -50,11 +50,17 @@ public class CleanCommandRecommendsAsyncTest {
           {/* asyncOnCommandLine= */ true, OS.LINUX, false},
           {/* asyncOnCommandLine= */ true, OS.WINDOWS, false},
           {/* asyncOnCommandLine= */ true, OS.DARWIN, false},
+          {/* asyncOnCommandLine= */ true, OS.FREEBSD, false},
+          {/* asyncOnCommandLine= */ true, OS.OPENBSD, false},
+          {/* asyncOnCommandLine= */ true, OS.UNKNOWN, false},
 
           // When --async is not provided, expect the suggestion on platforms that support it.
           {/* asyncOnCommandLine= */ false, OS.LINUX, true},
           {/* asyncOnCommandLine= */ false, OS.WINDOWS, false},
-          {/* asyncOnCommandLine= */ false, OS.DARWIN, false},
+          {/* asyncOnCommandLine= */ false, OS.DARWIN, true},
+          {/* asyncOnCommandLine= */ false, OS.FREEBSD, true},
+          {/* asyncOnCommandLine= */ false, OS.OPENBSD, true},
+          {/* asyncOnCommandLine= */ false, OS.UNKNOWN, false},
         });
   }
 
@@ -66,7 +72,7 @@ public class CleanCommandRecommendsAsyncTest {
 
     boolean async =
         CleanCommand.canUseAsync(this.asyncOnCommandLine, /* expunge= */ false, os, reporter);
-    if (os != OS.LINUX) {
+    if (os == OS.WINDOWS || os == OS.UNKNOWN) {
       assertThat(async).isFalse();
     }
 


### PR DESCRIPTION
Enable `bazel clean --async` on Darwin and BSD clients. Issue tracked at https://github.com/bazelbuild/bazel/issues/16505