### PR TITLE
Check type of `lines` parameter in `ScratchFile` Python test helper

### DIFF
--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -124,7 +124,7 @@ class TestInitPyFiles(test_base.TestBase):
         '  main = "bin.py",',
         ')',
     ])
-    self.ScratchFile('bin.py', 'print("Hello, world")')
+    self.ScratchFile('bin.py', ['print("Hello, world")'])
     exit_code, _, stderr = self.RunBazel(
         ['build', '--build_python_zip', '//:bin.v1'])
     self.AssertExitCode(exit_code, 0, stderr)

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -285,6 +285,8 @@ class TestBase(unittest.TestCase):
     """
     if not path:
       return
+    if lines is not None and not type(lines) is list:
+      raise ValueError('expected lines to be a list, got ' + str(type(lines)))
     abspath = self.Path(path)
     if os.path.exists(abspath) and not os.path.isfile(abspath):
       raise IOError('"%s" (%s) exists and is not a file' % (path, abspath))


### PR DESCRIPTION
Since strings are iterable in Python, accidentally passing a string to the `ScratchFile` test helper ends up writing one character per line, which leads to very confusing error messages.