### PR TITLE
Bazel profile: improve reporting of critical path components

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -1000,6 +1000,11 @@ public final class Profiler {
         writer.beginObject();
         writer.name("mnemonic").value(data.mnemonic.getValueForJson());
         writer.endObject();
+      } else if (data.type == ProfilerTask.CRITICAL_PATH_COMPONENT) {
+        writer.name("args");
+        writer.beginObject();
+        writer.name("tid").value(data.threadId);
+        writer.endObject();
       }
       long threadId =
           data.type == ProfilerTask.CRITICAL_PATH_COMPONENT


### PR DESCRIPTION
The Bazel profile reports the critical path. To enable it to be stored in a separate thread, the `tid` is set to 0 throughout. However, this makes it hard to match critical path events to events in the skyframe-evaluator threads.

This change adds the `tid` of the event in the `args` of the `critical path component` event. Like this, the critical path components continue to be listed in the critical path thread, as well as allowing the unique identification of which actual event in the evaluator threads it corresponds to.