### PR TITLE
Add --regex_features option

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1709,6 +1709,9 @@ java_library(
 java_library(
     name = "config/core_option_converters",
     srcs = ["config/CoreOptionConverters.java"],
+    exports = [
+        "//src/main/java/com/google/devtools/build/lib/exec:regex_filter_assignment_converter",
+    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -837,6 +837,11 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
     return options.defaultFeatures;
   }
 
+  /** @return the list of regex features used for all packages. */
+  public List<Map.Entry<RegexFilter, List<String>>> getRegexFeatures() {
+    return options.regexFeatures;
+  }
+
   /**
    * Returns the "top-level" environment space, i.e. the set of environments all top-level targets
    * must be compatible with. An empty value implies no restrictions.

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.EmptyToNullLabelConverter;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.LabelListConverter;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.exec.RegexFilterAssignmentConverter;
 import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters;
@@ -625,6 +626,21 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public List<String> defaultFeatures;
 
   @Option(
+      name = "regex_features",
+      allowMultiple = true,
+      defaultValue = "null",
+      converter = RegexFilterAssignmentConverter.class,
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.CHANGES_INPUTS, OptionEffectTag.AFFECTS_OUTPUTS},
+      help =
+          "The given features will be enabled or disabled by default for all targets matching the regex. "
+              + "Specifying -<feature> will disable the feature globally. "
+              + "Negative features always override positive ones. "
+              + "This flag is used to enable rolling out default feature changes without a "
+              + "Bazel release.")
+  public List<Map.Entry<RegexFilter, List<String>>> regexFeatures;
+
+  @Option(
       name = "target_environment",
       converter = LabelListConverter.class,
       allowMultiple = true,
@@ -948,6 +964,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
     // === Pass on C++ compiler features.
     host.defaultFeatures = ImmutableList.copyOf(defaultFeatures);
+    host.regexFeatures = ImmutableList.copyOf(regexFeatures);
 
     // Save host options in case of a further exec->host transition.
     host.hostCpu = hostCpu;


### PR DESCRIPTION
The `--features` flag is very useful to experiment but has a very large blast radius. As features often change compilation flags, this causes full rebuilds. The alternative at the moment is to add the feature to the `features` attribute of the individiual targets or packages which seems suboptimal. `--regex_features` would allow adding and removing features for specific targets directly on command line.