### PR TITLE
Added `run_under_env` argument to `RunEnvironmentInfo`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
@@ -474,6 +474,7 @@ public final class RuleConfiguredTargetBuilder {
     if (environmentProvider != null) {
       testActionBuilder.addExtraEnv(environmentProvider.getEnvironment());
       testActionBuilder.addExtraInheritedEnv(environmentProvider.getInheritedEnvironment());
+      testActionBuilder.setRunUnderEnv(environmentProvider.getRunUnderEnv());
     }
 
     TestParams testParams =

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -98,12 +98,14 @@ public final class TestActionBuilder {
   private int explicitShardCount;
   private final Map<String, String> extraEnv;
   private final Set<String> extraInheritedEnv;
+  private @Nullable String runUnderEnv;
 
   public TestActionBuilder(RuleContext ruleContext) {
     this.ruleContext = ruleContext;
     this.extraEnv = new TreeMap<>();
     this.extraInheritedEnv = new TreeSet<>();
     this.additionalTools = new ImmutableList.Builder<>();
+    this.runUnderEnv = null;
   }
 
   /**
@@ -177,6 +179,12 @@ public final class TestActionBuilder {
   @CanIgnoreReturnValue
   public TestActionBuilder addExtraInheritedEnv(List<String> extraInheritedEnv) {
     this.extraInheritedEnv.addAll(extraInheritedEnv);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public TestActionBuilder setRunUnderEnv(@Nullable String runUnderEnv) {
+    this.runUnderEnv = runUnderEnv;
     return this;
   }
 
@@ -339,6 +347,7 @@ public final class TestActionBuilder {
               ruleContext,
               runfilesSupport,
               executable,
+              runUnderEnv,
               instrumentedFileManifest,
               shards,
               runsPerTest);
@@ -351,7 +360,7 @@ public final class TestActionBuilder {
     } else {
       executionSettings =
           new TestTargetExecutionSettings(
-              ruleContext, runfilesSupport, executable, null, shards, runsPerTest);
+              ruleContext, runfilesSupport, executable, runUnderEnv, null, shards, runsPerTest);
     }
 
     extraTestEnv.putAll(extraEnv);

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetExecutionSettings.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetExecutionSettings.java
@@ -41,6 +41,7 @@ public final class TestTargetExecutionSettings {
   private final int totalRuns;
   private final RunUnder runUnder;
   private final Artifact runUnderExecutable;
+  private final @Nullable String runUnderEnv;
   private final Artifact executable;
   private final boolean runfilesSymlinksCreated;
   @Nullable private final Path runfilesDir;
@@ -53,6 +54,7 @@ public final class TestTargetExecutionSettings {
       RuleContext ruleContext,
       RunfilesSupport runfilesSupport,
       Artifact executable,
+      @Nullable String runUnderEnv,
       Artifact instrumentedFileManifest,
       int shards,
       int runs)
@@ -74,6 +76,7 @@ public final class TestTargetExecutionSettings {
     this.testFilter = testConfig.getTestFilter();
     this.testRunnerFailFast = testConfig.getTestRunnerFailFast();
     this.executable = executable;
+    this.runUnderEnv = runUnderEnv;
     this.runfilesSymlinksCreated = runfilesSupport.isBuildRunfileLinks();
     this.runfilesDir = runfilesSupport.getRunfilesDirectory();
     this.runfiles = runfilesSupport.getRunfiles();
@@ -115,6 +118,10 @@ public final class TestTargetExecutionSettings {
 
   public RunUnder getRunUnder() {
     return runUnder;
+  }
+
+  public @Nullable String getRunUnderEnv() {
+    return runUnderEnv;
   }
 
   public Artifact getExecutable() {

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -439,8 +439,10 @@ java_library(
     name = "test_policy",
     srcs = ["TestPolicy.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:shell_escaper",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/exec/TestPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestPolicy.java
@@ -15,6 +15,8 @@ package com.google.devtools.build.lib.exec;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.test.TestRunnerAction;
+import com.google.devtools.build.lib.analysis.test.TestStrategy;
+import com.google.devtools.build.lib.util.ShellEscaper;
 import com.google.devtools.build.lib.util.UserUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.time.Duration;
@@ -89,6 +91,13 @@ public class TestPolicy {
 
     // Rule-specified test env.
     testAction.getExtraTestEnv().resolve(env, clientEnv);
+
+    // Add the --run_under environment variable if set.
+    String runUnderEnv = testAction.getExecutionSettings().getRunUnderEnv();
+    if (runUnderEnv != null) {
+      env.put(
+          runUnderEnv, ShellEscaper.escapeJoinAll(TestStrategy.computeRunUnderArgs(testAction)));
+    }
 
     // Overwrite with the environment common to all actions, see --action_env.
     testAction.getConfiguration().getActionEnvironment().resolve(env, clientEnv);

--- a/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
@@ -49,6 +49,7 @@ public class StarlarkTestingModule implements TestingModuleApi {
         Dict.cast(environment, String.class, String.class, "environment"),
         StarlarkList.immutableCopyOf(
             Sequence.cast(inheritedEnvironment, String.class, "inherited_environment")),
+        /* runUnderEnv= */ null,
         /* shouldErrorOnNonExecutableRule= */ false);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/RunEnvironmentInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/RunEnvironmentInfoApi.java
@@ -20,12 +20,14 @@ import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.NoneType;
 import net.starlark.java.eval.Sequence;
 
 /**
@@ -91,13 +93,25 @@ public interface RunEnvironmentInfoApi extends StructApi {
                       + " when the target that returns this provider is executed, either as a"
                       + " test or via the run command. If a variable is contained in both <code>"
                       + "environment</code> and <code>inherited_environment</code>, the value"
-                      + " inherited from the shell environment will take precedence if set.")
+                      + " inherited from the shell environment will take precedence if set."),
+          @Param(
+              name = "run_under_env",
+              allowedTypes = {@ParamType(type = String.class), @ParamType(type = NoneType.class)},
+              defaultValue = "None",
+              named = true,
+              positional = false,
+              doc =
+                  "The name of an environment variable to represent the value of the"
+                      + " <code>--run_under<code> command line argument. By setting this, the \"run"
+                      + " under\" functionality will not be executed. Instead, it will be up to the"
+                      + " built executable to handle this functionality.")
         },
         selfCall = true)
     @StarlarkConstructor
     RunEnvironmentInfoApi constructor(
         Dict<?, ?> environment, // <String, String> expected
-        Sequence<?> inheritedEnvironment /* <String> expected */)
+        Sequence<?> inheritedEnvironment, /* <String> expected */
+        Object run_under_env /* String or NoneType expected */)
         throws EvalException;
   }
 }


### PR DESCRIPTION
Executable Starlark rules can use the `run_under_env` parameter of `RunEnvironmentInfo` to define an environment variable with the value of `--run_under` when it's set. This is useful in cases where executable targets execute some sort of process-wrapper which either sub-processes or execs into the expected process. Before, `--run_under` would happen on the process wrapper which made debuggers and profiling tools harder to use as the process they were attached to was not the process users cared about. 

After this change, by having an executable Starlark rule return `RunEnvironmentInfo(run_under_env = "RUN_UNDER_VALUE")`, `run` or `test` invocations which pass `--run_under='strace -c'` will cause the executable to have `RUN_UNDER_VALUE='strace -c'` set in it's environment.

RELNOTES: Executable Starlark rules can use the `run_under_env` parameter of `RunEnvironmentInfo` to define an environment variable with the value of `--run_under` when it's set. This allows Starlark rule authors to control how this value is used.

closes https://github.com/bazelbuild/bazel/issues/16232