### PR TITLE
Remove references to io_bazel repository

### DIFF
--- a/third_party/grpc/build_defs.bzl
+++ b/third_party/grpc/build_defs.bzl
@@ -67,7 +67,7 @@ _java_grpc_gensource = rule(
             allow_single_file = True,
         ),
         "_java_plugin": attr.label(
-            default = Label("@io_bazel//third_party/grpc-java:grpc-java-plugin"),
+            default = Label("//third_party/grpc-java:grpc-java-plugin"),
             executable = True,
             cfg = "host",
         ),
@@ -111,10 +111,10 @@ def java_grpc_library(name, srcs, deps, enable_deprecated = None, visibility = N
         srcs = [gensource_name],
         visibility = visibility,
         deps = [
-            "@io_bazel//third_party:javax_annotations",
-            "@io_bazel//third_party:jsr305",
-            "@io_bazel//third_party/grpc-java:grpc-jar",
-            "@io_bazel//third_party:guava",
+            Label("//third_party:javax_annotations"),
+            Label("//third_party:jsr305"),
+            Label("//third_party/grpc-java:grpc-jar"),
+            Label("//third_party:guava"),
             "@com_google_protobuf//:protobuf_java",
         ] + deps,
         **kwargs


### PR DESCRIPTION
Users of @bazel_tools and bzlmod are broken when referring to the package that uses io_bazel.