### PR TITLE
Improve error on invalid `-//foo` and `-@repo//foo` options

### DIFF
--- a/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
@@ -476,6 +476,16 @@ class OptionsParserImpl {
         continue; // not an option arg
       }
 
+      if (arg.startsWith("-//") || arg.startsWith("-@")) {
+        // Fail with a helpful error when an invalid option looks like an absolute negative target
+        // pattern or a typoed Starlark option.
+        throw new OptionsParsingException(String.format("Invalid options syntax: %s\n"
+                + "Note: Negative target patterns can only appear after the end of options marker"
+                + " ('--'). Flags corresponding to Starlark-defined build settings always start"
+                + " with '--', not '-'.",
+            arg));
+      }
+
       arg = swapShorthandAlias(arg);
 
       if (arg.equals("--")) { // "--" means all remaining args aren't options

--- a/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
@@ -2369,6 +2369,30 @@ public final class OptionsParserTest {
         .containsExactly("--second=hello");
   }
 
+  @Test
+  public void negativeTargetPatternsInOptions_failsDistinctively() {
+    OptionsParser parser = OptionsParser.builder().optionsClasses(ExampleFoo.class).build();
+    OptionsParsingException e = assertThrows(OptionsParsingException.class,
+        () -> parser.parse("//foo", "-//bar", "//baz"));
+    assertThat(e).hasMessageThat().contains("-//bar");
+    assertThat(e).hasMessageThat()
+        .contains("Negative target patterns can only appear after the end of options marker");
+    assertThat(e).hasMessageThat()
+        .contains("Flags corresponding to Starlark-defined build settings always start with '--'");
+  }
+
+  @Test
+  public void negativeExternalTargetPatternsInOptions_failsDistinctively() {
+    OptionsParser parser = OptionsParser.builder().optionsClasses(ExampleFoo.class).build();
+    OptionsParsingException e = assertThrows(OptionsParsingException.class,
+        () -> parser.parse("//foo", "-@repo//bar", "//baz"));
+    assertThat(e).hasMessageThat().contains("-@repo//bar");
+    assertThat(e).hasMessageThat()
+        .contains("Negative target patterns can only appear after the end of options marker");
+    assertThat(e).hasMessageThat()
+        .contains("Flags corresponding to Starlark-defined build settings always start with '--'");
+  }
+
   private static OptionInstanceOrigin createInvocationPolicyOrigin() {
     return createInvocationPolicyOrigin(/*implicitDependent=*/ null, /*expandedFrom=*/ null);
   }


### PR DESCRIPTION
`-//foo` and `-@repo//foo` are always invalid Bazel options, but are usually meant to be either negative target patterns (which have to come after the `--` separator) or Starlark options (which always start with `--`).

With this commit, the error shown to the user mentions these two situations and how to fix the issue in each case.