### PR TITLE
Add quotes to "Tip"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -738,7 +738,7 @@ public class Package {
           suggestedTarget == null ? null : String.format("did you mean '%s'?", suggestedTarget);
       String blazeQuerySuggestion =
           String.format(
-              "Tip: use `query %s:*` to see all the targets in that package",
+              "Tip: use `query \"%s:*\"` to see all the targets in that package",
               packageIdentifier.getDisplayForm(mainRepositoryMapping));
       return String.format(
           " (%s)", Joiner.on(" ").skipNulls().join(targetSuggestion, blazeQuerySuggestion));

--- a/src/test/java/com/google/devtools/build/lib/analysis/BuildViewTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BuildViewTest.java
@@ -699,8 +699,8 @@ public class BuildViewTest extends BuildViewTestBase {
     assertThat(result.hasError()).isTrue();
     assertContainsEvent(
         "no such target '//x:z': target 'z' not declared in package 'x' defined by"
-            + " /workspace/x/BUILD (Tip: use `query //x:*` to see all the targets in that package)"
-            + " and referenced by '//y:y'");
+            + " /workspace/x/BUILD (Tip: use `query \"//x:*\"` to see all the targets in that"
+            + " package) and referenced by '//y:y'");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/packages/ExportsFilesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/ExportsFilesTest.java
@@ -62,7 +62,7 @@ public class ExportsFilesTest extends PackageLoadingTestCase {
         .isEqualTo(
             "no such target '//pkg:baz.txt': target 'baz.txt' not declared in package 'pkg' "
                 + "defined by /workspace/pkg/BUILD (did you mean 'bar.txt'? Tip: use `query "
-                + "//pkg:*` to see all the targets in that package)");
+                + "\"//pkg:*\"` to see all the targets in that package)");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/packages/PackageFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/PackageFactoryTest.java
@@ -284,8 +284,8 @@ public final class PackageFactoryTest extends PackageLoadingTestCase {
         .hasMessageThat()
         .isEqualTo(
             "no such target '//foo:A': target 'A' not declared in package 'foo' defined by"
-                + " /workspace/foo/BUILD (Tip: use `query //foo:*` to see all the targets in that"
-                + " package)");
+                + " /workspace/foo/BUILD (Tip: use `query \"//foo:*\"` to see all the targets in"
+                + " that package)");
 
     // These are the only input files: BUILD, Z
     Set<String> inputFiles = Sets.newTreeSet();
@@ -423,8 +423,8 @@ public final class PackageFactoryTest extends PackageLoadingTestCase {
         .hasMessageThat()
         .isEqualTo(
             "no such target '//x:z.cc': target 'z.cc' not declared in package 'x' defined by"
-                + " /workspace/x/BUILD (did you mean 'x.cc'? Tip: use `query //x:*` to see all the"
-                + " targets in that package)");
+                + " /workspace/x/BUILD (did you mean 'x.cc'? Tip: use `query \"//x:*\"` to see all"
+                + " the targets in that package)");
 
     e = assertThrows(NoSuchTargetException.class, () -> pkg.getTarget("dir"));
     assertThat(e)

--- a/src/test/java/com/google/devtools/build/lib/pkgcache/CompileOneDependencyTransformerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/pkgcache/CompileOneDependencyTransformerTest.java
@@ -160,8 +160,8 @@ public class CompileOneDependencyTransformerTest extends PackageLoadingTestCase 
         .hasMessageThat()
         .isEqualTo(
             "no such target '//foo:missing.cc': target 'missing.cc' not declared in package "
-                + "'foo' defined by /workspace/foo/BUILD (Tip: use `query //foo:*` to see all the "
-                + "targets in that package)");
+                + "'foo' defined by /workspace/foo/BUILD (Tip: use `query \"//foo:*\"` to see all "
+                + "the targets in that package)");
 
     // Also, try a valid input file which has no dependent rules in its package.
     e = assertThrows(TargetParsingException.class, () -> parseCompileOneDep("//foo:baz/bang"));

--- a/src/test/java/com/google/devtools/build/lib/pkgcache/PackageLoadingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/pkgcache/PackageLoadingTest.java
@@ -237,7 +237,7 @@ public class PackageLoadingTest extends FoundationTestCase {
         .isEqualTo(
             "no such target '//pkg1:not-there': target 'not-there' "
                 + "not declared in package 'pkg1' defined by /workspace/pkg1/BUILD (Tip: use "
-                + "`query //pkg1:*` to see all the targets in that package)");
+                + "`query \"//pkg1:*\"` to see all the targets in that package)");
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
@@ -290,7 +290,7 @@ public abstract class AbstractQueryTest<T> {
             "no such target '//a:b': target 'b' not declared in package 'a' "
                 + "defined by "
                 + helper.getRootDirectory().getPathString()
-                + "/a/BUILD (Tip: use `query //a:*` to see all the targets in that package)");
+                + "/a/BUILD (Tip: use `query \"//a:*\"` to see all the targets in that package)");
     assertThat(failureDetail.getPackageLoading().getCode())
         .isEqualTo(FailureDetails.PackageLoading.Code.TARGET_MISSING);
   }


### PR DESCRIPTION
Add double quotes to the tip so that it can be copied and pasted and work from a shell. Just an ease of use thing.

PiperOrigin-RevId: 483980588
Change-Id: If5f87cb52d7d20da2ab8423800c68ea7b332a5fd