### PR TITLE
Infer CPUs for tvOS and watchOS when on Apple Silicon

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -193,10 +193,12 @@ public class AppleCommandLineOptions extends FragmentOptions {
   @VisibleForTesting static final String DEFAULT_IOS_CPU = "x86_64";
 
   /** The default watchos CPU value. */
-  public static final String DEFAULT_WATCHOS_CPU = "i386";
+  public static final String DEFAULT_WATCHOS_CPU =
+      CPU.getCurrent() == CPU.AARCH64 ? "arm64" : "i386";
 
   /** The default tvOS CPU value. */
-  public static final String DEFAULT_TVOS_CPU = "x86_64";
+  public static final String DEFAULT_TVOS_CPU =
+      CPU.getCurrent() == CPU.AARCH64 ? "sim_arm64" : "x86_64";
 
   /** The default macOS CPU value. */
   public static final String DEFAULT_MACOS_CPU =


### PR DESCRIPTION
This PR contains the same logical change as https://github.com/bazelbuild/bazel/commit/aaae8ce2881c8c1a5d4ad64f20d6e71aa372cf2e but for watchOS and tvOS. When on Apple Silicon, we should build for the right CPU architecture. This is `sim_arm64` for tvOS and `arm64` for watchOS.

On a separate note, I'm not sure if `i386` should be the default architecture for watchOS anymore. I'm happy to change that to `x86_64` to align with all the other platforms if people agree.

Closes #16547.

PiperOrigin-RevId: 483997916
Change-Id: I67b7f2e2edac5184787f3c3511dc49bb4aeef108