### PR TITLE
Fix release name detection from branch

### DIFF
--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -64,7 +64,7 @@ function get_release_candidate() {
 function get_release_name() {
   # Match branch name release-X.X.X[-pre.XXXXXXXX.X]rcY and return X.X.X[-pre.XXXXXXXX.X]
   # or match tag name X.X.X[-pre.XXXXXXXX.X] and return X.X.X[-pre.XXXXXXXX.X]
-   git_get_branch 2>/dev/null | grep -Po "(?<=release-)([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?(?=rc)" || git_get_tag | grep -Po "^([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?$" || true
+   git_get_branch 2>/dev/null | grep -Po "(?<=release-)([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?(?=rc)?" || git_get_tag | grep -Po "^([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?$" || true
 }
 
 # Returns whether this is a rolling release (or an RCs of one)


### PR DESCRIPTION
The regex in get_release_name() was invalid since it always expected "rc" to be part of the branch name. Consequently, it failed in release branches that didn't contain the proper tag yet.