### PR TITLE
Fix import instructions for Python runfiles library

### DIFF
--- a/tools/python/runfiles/runfiles.py
+++ b/tools/python/runfiles/runfiles.py
@@ -20,12 +20,12 @@ USAGE:
       py_binary(
           name = "my_binary",
           ...
-          deps = ["@rules_python//python/runfiles"],
+          deps = ["@bazel_tools//tools/python/runfiles"],
       )
 
 2.  Import the runfiles library.
 
-      from rules_python.python.runfiles import runfiles
+      from tools.python.runfiles import runfiles
 
 3.  Create a Runfiles object and use rlocation to look up runfile paths:
 
@@ -49,7 +49,7 @@ USAGE:
     the right environment variables for them:
 
       import subprocess
-      from rules_python.python.runfiles import runfiles
+      from tools.python.runfiles import runfiles
 
       r = runfiles.Create()
       env = {}


### PR DESCRIPTION
The rules_python version of the runfiles library has diverged and, since the import statement mentions a repository name, would not work with Bzlmod.

Instead, use a repo root relative import from `@bazel_tools` and only switch to rules_python once it has become the source of truth for the Python rules.

Work towards #16124