### PR TITLE
Remove warnings about ignored starlark options

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
@@ -131,15 +131,7 @@ public final class CleanCommand implements BlazeCommand {
   @Override
   public BlazeCommandResult exec(CommandEnvironment env, OptionsParsingResult options) {
     // Assert that there is no residue and warn about Starlark options.
-    List<String> starlarkOptions = options.getSkippedArgs();
     List<String> residue = options.getResidue();
-    if (!starlarkOptions.isEmpty()) {
-      env.getReporter()
-          .handle(
-              Event.warn(
-                  "Blaze clean does not support starlark options. Ignoring options: "
-                      + starlarkOptions));
-    }
     if (!residue.isEmpty()) {
       String message = "Unrecognized arguments: " + Joiner.on(' ').join(residue);
       env.getReporter().handle(Event.error(message));

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
@@ -189,16 +189,7 @@ public class InfoCommand implements BlazeCommand {
         }
       }
 
-      List<String> starlarkOptions = optionsParsingResult.getSkippedArgs();
       List<String> residue = optionsParsingResult.getResidue();
-      if (!starlarkOptions.isEmpty()) {
-        env.getReporter()
-            .handle(
-                Event.warn(
-                    "info command does not support starlark options. Ignoring options: "
-                        + starlarkOptions));
-      }
-
       env.getEventBus().post(new NoBuildEvent());
       if (!residue.isEmpty()) {
         ImmutableSet.Builder<String> unknownKeysBuilder = ImmutableSet.builder();


### PR DESCRIPTION
Neither clean nor info really make sense to have semantics changed from starlark flags, but if you have a starlark flag in your .bazelrc in the `build` section you see this warning.