### PR TITLE
Move Boost into C++ Docs; Add Libraries Section

### DIFF
--- a/site/en/docs/bazel-and-cpp.md
+++ b/site/en/docs/bazel-and-cpp.md
@@ -14,6 +14,10 @@ The following resources will help you work with Bazel on C++ projects:
 *  [Tutorial: Building a C++ project](/tutorials/cpp)
 *  [C++ common use cases](/tutorials/cpp-use-cases)
 *  [C/C++ rules](/reference/be/c-cpp)
+*  Essential Libraries
+   -  [Abseil](https://abseil.io/docs/cpp/quickstart){: .external}
+   -  [Boost](https://github.com/nelhage/rules_boost){: .external}
+   -  [HTTPS Requests: CPR and libcurl](https://github.com/hedronvision/bazel-make-cc-https-easy){: .external}
 *  [C++ toolchain configuration](/docs/cc-toolchain-config-reference)
 *  [Tutorial: Configuring C++ toolchains](/tutorials/cc-toolchain-config)
 *  [Integrating with C++ rules](/docs/integrating-with-rules-cc)

--- a/site/en/rules/index.md
+++ b/site/en/rules/index.md
@@ -14,7 +14,6 @@ This page describes the recommended, native, and non-native Bazel rules.
 Here is a selection of recommended rules:
 
 * [Android](/docs/bazel-and-android)
-* [Boost](https://github.com/nelhage/rules_boost){: .external}
 * [C / C++](/docs/bazel-and-cpp)
 * [Docker](https://github.com/bazelbuild/rules_docker){: .external}
 * [Go](https://github.com/bazelbuild/rules_go){: .external}


### PR DESCRIPTION
Hi wonderful Bazelers,

This is just a docs change.

Backstory: I'd been looking to make HTTPS requests across platforms from C++. A classic problem if there ever were one, networking being perhaps the most glaring omission in the C++ standard library. Thankfully, this is a problem Bazel can solve well, since most of the problem is the friction of using 3rd party libraries from C++. So, I spun up some build rules to make network requests easy, inspired by collaborating on the boost ones, and set off to add them to the docs.

Along the way, I noticed that the boost rules were in an odd spot: Listed at the language level alongside C++, rather than nested within C++. So I fixed that by nesting Boost inside, added Abseil, and then (hoping you'll forgive my hubris), I'd love to add the rules I just released, since I think they're a solution to a very real need. Perhaps rules for more famous, critical libraries can accumulate there over time, helping Bazel users get set up with the essential tools they need.

Thanks for your consideration!
Chris
(ex-Googler and author of [bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor), also in the docs.)