### PR TITLE
Emit executable target's repository name into repo mapping manifest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RepoMappingManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RepoMappingManifestAction.java
@@ -101,6 +101,12 @@ public class RepoMappingManifestAction extends AbstractFileWriteAction {
       throws InterruptedException, ExecException {
     return out -> {
       PrintWriter writer = new PrintWriter(out, /*autoFlush=*/ false, ISO_8859_1);
+
+      // The executable needs to be able to learn its own repository name. This is especially
+      // important for scripting languages that have no way to compile in this information and whose
+      // entrypoint is not invoked from a runfiles tree (e.g. shell scripts on Unix).
+      writer.format("%s\n", getOwner().getLabel().getRepository().getName());
+
       for (Entry entry : entries) {
         if (entry.targetRepoApparentName().isEmpty()) {
           // The apparent repo name can only be empty for the main repo. We skip this line as

--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
@@ -285,10 +285,8 @@ public final class RunfilesSupport {
   }
 
   /**
-   * Returns the foo.repo_mapping file if Bazel is run with transitive package tracking turned on
-   * (see {@code SkyframeExecutor#getForcedSingleSourceRootIfNoExecrootSymlinkCreation}) and any of
-   * the transitive packages come from a repository with strict deps (see {@code
-   * #collectRepoMappings}). Otherwise, returns null.
+   * Returns the foo.repo_mapping file if Bzlmod is enabled (see
+   * {@link #createRepoMappingManifestAction}). Otherwise, returns null.
    */
   @Nullable
   public Artifact getRepoMappingManifest() {

--- a/src/test/java/com/google/devtools/build/lib/analysis/RunfilesRepoMappingManifestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/RunfilesRepoMappingManifestTest.java
@@ -152,6 +152,7 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
 
     assertThat(getRepoMappingManifestForTarget("//:aaa"))
         .containsExactly(
+            "",
             ",aaa,_main",
             ",aaa_ws,_main",
             ",bbb,bbb~1.0",
@@ -160,7 +161,8 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
             "ddd~2.0,ddd,ddd~2.0")
         .inOrder();
     assertThat(getRepoMappingManifestForTarget("@@ccc~2.0//:ccc"))
-        .containsExactly("ccc~2.0,ccc,ccc~2.0", "ccc~2.0,ddd,ddd~2.0", "ddd~2.0,ddd,ddd~2.0")
+        .containsExactly("ccc~2.0", "ccc~2.0,ccc,ccc~2.0", "ccc~2.0,ddd,ddd~2.0",
+            "ddd~2.0,ddd,ddd~2.0")
         .inOrder();
   }
 
@@ -220,6 +222,7 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
 
     assertThat(getRepoMappingManifestForTarget("//:tooled"))
         .containsExactly(
+            "",
             ",main,_main",
             "bare_rule~1.0,bare_rule,bare_rule~1.0",
             "tooled_rule~1.0,bare_rule,bare_rule~1.0")

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -656,19 +656,23 @@ class BazelModuleTest(test_base.TestBase):
     self.RunBazel([bazel_command, '//:me'], allow_failure=False)
     with open(self.Path('bazel-bin/me.repo_mapping'), 'r') as f:
       self.assertEqual(
-          f.read().strip(), """,foo,foo~1.0
+          f.read(), """
+,foo,foo~1.0
 ,me,_main
 ,me_ws,_main
 foo~1.0,foo,foo~1.0
 foo~1.0,quux,quux~2.0
-quux~2.0,quux,quux~2.0""")
+quux~2.0,quux,quux~2.0
+""")
     self.RunBazel([bazel_command, '@bar//:bar'], allow_failure=False)
     with open(self.Path('bazel-bin/external/bar~2.0/bar.repo_mapping'),
               'r') as f:
       self.assertEqual(
-          f.read().strip(), """bar~2.0,bar,bar~2.0
+          f.read(), """bar~2.0
+bar~2.0,bar,bar~2.0
 bar~2.0,quux,quux~2.0
-quux~2.0,quux,quux~2.0""")
+quux~2.0,quux,quux~2.0
+""")
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Code in the top-level binary target that generates an executable needs to know its canonical repository name in order to look up runfiles with Bzlmod. If this information can not be compiled into the binary, e.g. because it is a shell script and doesn't use a launcher, bootstrapping runfiles discovery requires having this information available at a known location next to the executable.

This commit emits the executable target's canonical repository name as the first line of the repository mapping manifest.

Work towards #16124