### PR TITLE
Ignore AC if any of the outputs is missing from the CAS when building without the bytes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.buildeventstream.PathConverter;
 import com.google.devtools.build.lib.buildtool.buildevent.ProfilerStartedEvent;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.remote.common.MissingDigestsFinder.Intention;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext.CachePolicy;
 import com.google.devtools.build.lib.remote.options.RemoteBuildEventUploadMode;
@@ -247,7 +248,7 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
     if (digestsToQuery.isEmpty()) {
       return Single.just(knownRemotePaths);
     }
-    return toSingle(() -> remoteCache.findMissingDigests(context, digestsToQuery), executor)
+    return toSingle(() -> remoteCache.findMissingDigests(context, Intention.WRITE, digestsToQuery), executor)
         .onErrorResumeNext(
             error -> {
               reporterUploadError(error);

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -178,7 +178,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
 
   @Override
   public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-      RemoteActionExecutionContext context, Iterable<Digest> digests) {
+      RemoteActionExecutionContext context, Intention intention, Iterable<Digest> digests) {
     if (Iterables.isEmpty(digests)) {
       return Futures.immediateFuture(ImmutableSet.of());
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -34,6 +34,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.concurrent.ThreadSafety;
 import com.google.devtools.build.lib.exec.SpawnProgressEvent;
 import com.google.devtools.build.lib.remote.common.LazyFileOutputStream;
+import com.google.devtools.build.lib.remote.common.MissingDigestsFinder.Intention;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.ProgressStatusListener;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -115,11 +116,14 @@ public class RemoteCache extends AbstractReferenceCounted {
    * guaranteed to be a subset of {@code digests}.
    */
   public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-      RemoteActionExecutionContext context, Iterable<Digest> digests) {
-    if (Iterables.isEmpty(digests)) {
+      RemoteActionExecutionContext context, Intention intention, Iterable<Digest> digests) {
+    // 0 byte digest is never considered missing because we don't upload nor download it.
+    Iterable<Digest> nonEmptyDigests = Iterables.filter(digests,
+        digest -> digest.getSizeBytes() != 0);
+    if (Iterables.isEmpty(nonEmptyDigests)) {
       return immediateFuture(ImmutableSet.of());
     }
-    return cacheProtocol.findMissingDigests(context, digests);
+    return cacheProtocol.findMissingDigests(context, intention, nonEmptyDigests);
   }
 
   /** Upload the action result to the remote cache. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.common.MissingDigestsFinder.Intention;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
@@ -252,7 +253,7 @@ public class RemoteExecutionCache extends RemoteCache {
                                   if (digestsToQuery.isEmpty()) {
                                     return immediateFuture(ImmutableSet.of());
                                   }
-                                  return findMissingDigests(context, digestsToQuery);
+                                  return findMissingDigests(context, Intention.WRITE, digestsToQuery);
                                 },
                                 directExecutor())
                             .map(

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.actions.ActionUploadStartedEvent;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.remote.common.MissingDigestsFinder.Intention;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
@@ -465,7 +466,7 @@ public class UploadManifest {
 
     String outputPrefix = "cas/";
     Flowable<RxUtils.TransferResult> bulkTransfers =
-        toSingle(() -> remoteCache.findMissingDigests(context, digests), directExecutor())
+        toSingle(() -> remoteCache.findMissingDigests(context, Intention.WRITE, digests), directExecutor())
             .doOnSubscribe(d -> reportUploadStarted(reporter, action, outputPrefix, digests))
             .doOnError(error -> reportUploadFinished(reporter, action, outputPrefix, digests))
             .doOnDispose(() -> reportUploadFinished(reporter, action, outputPrefix, digests))

--- a/src/main/java/com/google/devtools/build/lib/remote/common/MissingDigestsFinder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/MissingDigestsFinder.java
@@ -21,11 +21,29 @@ import com.google.common.util.concurrent.ListenableFuture;
 public interface MissingDigestsFinder {
 
   /**
+   * The intention for the requested digests.
+   */
+  enum Intention {
+    /**
+     * Intents to read the requested digests. In case of a combined cache, the implementation should
+     * return the intersection of missing digests from each cache component because a following read
+     * operation on the digests could return the content.
+     */
+    READ,
+    /**
+     * Intents to upload for the missing digests. In case of a combined cache, the implementation
+     * should return the union of missing digests from each cache component so an upload will occur
+     * later to make sure the digest are stored on each cache component.
+     */
+    WRITE;
+  }
+
+  /**
    * Returns a set of digests that the remote cache does not know about. The returned set is
    * guaranteed to be a subset of {@code digests}.
    *
    * @param digests The list of digests to look for.
    */
   ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-      RemoteActionExecutionContext context, Iterable<Digest> digests);
+      RemoteActionExecutionContext context, Intention intention, Iterable<Digest> digests);
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.remote.common.LazyFileOutputStream;
@@ -108,15 +109,52 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
 
   @Override
   public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-      RemoteActionExecutionContext context, Iterable<Digest> digests) {
+      RemoteActionExecutionContext context, Intention intention, Iterable<Digest> digests) {
+    switch (intention) {
+      case READ:
+        return findMissingDigestsForRead(context, digests);
+      case WRITE:
+        return findMissingDigestsForWrite(context, digests);
+    }
+
+    throw new IllegalStateException("unreachable");
+  }
+
+  private ListenableFuture<ImmutableSet<Digest>> findMissingDigestsForRead(
+      RemoteActionExecutionContext context, Iterable<Digest> digests
+  ) {
+    ListenableFuture<ImmutableSet<Digest>> diskQuery = immediateFuture(ImmutableSet.of());
+    if (context.getReadCachePolicy().allowDiskCache()) {
+      diskQuery = diskCache.findMissingDigests(context, Intention.READ, digests);
+    }
+
+    ListenableFuture<ImmutableSet<Digest>> remoteQuery = immediateFuture(ImmutableSet.of());
+    if (context.getReadCachePolicy().allowRemoteCache()) {
+      remoteQuery = remoteCache.findMissingDigests(context, Intention.READ, digests);
+    }
+
+    ListenableFuture<ImmutableSet<Digest>> diskQueryFinal = diskQuery;
+    ListenableFuture<ImmutableSet<Digest>> remoteQueryFinal = remoteQuery;
+
+    return Futures.whenAllSucceed(remoteQueryFinal, diskQueryFinal)
+        .call(
+            () ->
+                ImmutableSet.copyOf(
+                    Sets.intersection(remoteQueryFinal.get(), diskQueryFinal.get())),
+            directExecutor());
+  }
+
+  private ListenableFuture<ImmutableSet<Digest>> findMissingDigestsForWrite(
+      RemoteActionExecutionContext context, Iterable<Digest> digests
+  ) {
     ListenableFuture<ImmutableSet<Digest>> diskQuery = immediateFuture(ImmutableSet.of());
     if (context.getWriteCachePolicy().allowDiskCache()) {
-      diskQuery = diskCache.findMissingDigests(context, digests);
+      diskQuery = diskCache.findMissingDigests(context, Intention.WRITE, digests);
     }
 
     ListenableFuture<ImmutableSet<Digest>> remoteQuery = immediateFuture(ImmutableSet.of());
     if (context.getWriteCachePolicy().allowRemoteCache()) {
-      remoteQuery = remoteCache.findMissingDigests(context, digests);
+      remoteQuery = remoteCache.findMissingDigests(context, Intention.WRITE, digests);
     }
 
     ListenableFuture<ImmutableSet<Digest>> diskQueryFinal = diskQuery;

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -688,7 +688,10 @@ public final class HttpCacheClient implements RemoteCacheClient {
 
   @Override
   public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-      RemoteActionExecutionContext context, Iterable<Digest> digests) {
+      RemoteActionExecutionContext context, Intention intention, Iterable<Digest> digests) {
+    if (intention == Intention.READ) {
+      throw new UnsupportedOperationException("HttpCache doesn't supported findMissingDigests.");
+    }
     return Futures.immediateFuture(ImmutableSet.copyOf(digests));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -428,7 +428,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     PathConverter pathConverter = artifactUploader.upload(files).get();
 
     // assert
-    verify(digestQuerier).findMissingDigests(any(), any());
+    verify(digestQuerier).findMissingDigests(any(), any(), any());
     verify(remoteCache).uploadFile(any(), eq(localDigest), any());
     assertThat(pathConverter.apply(remoteFile)).contains(remoteDigest.getHash());
     assertThat(pathConverter.apply(localFile)).contains(localDigest.getHash());
@@ -468,9 +468,10 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     doAnswer(
             invocationOnMock ->
                 missingDigestsFinder.findMissingDigests(
-                    invocationOnMock.getArgument(0), invocationOnMock.getArgument(1)))
+                    invocationOnMock.getArgument(0), invocationOnMock.getArgument(1),
+                    invocationOnMock.getArgument(2)))
         .when(cacheClient)
-        .findMissingDigests(any(), any());
+        .findMissingDigests(any(), any(), any());
 
     return new RemoteCache(
         CacheCapabilities.getDefaultInstance(), cacheClient, remoteOptions, DIGEST_UTIL);
@@ -500,7 +501,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
 
     @Override
     public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-        RemoteActionExecutionContext context, Iterable<Digest> digests) {
+        RemoteActionExecutionContext context, Intention intention, Iterable<Digest> digests) {
       ImmutableSet.Builder<Digest> missingDigests = ImmutableSet.builder();
       for (Digest digest : digests) {
         if (!knownDigests.contains(digest)) {
@@ -517,7 +518,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
 
     @Override
     public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-        RemoteActionExecutionContext context, Iterable<Digest> digests) {
+        RemoteActionExecutionContext context, Intention intention, Iterable<Digest> digests) {
       return Futures.immediateFuture(ImmutableSet.copyOf(digests));
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -83,6 +83,7 @@ import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.remote.RemoteExecutionService.RemoteActionResult;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
+import com.google.devtools.build.lib.remote.common.MissingDigestsFinder.Intention;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.CachedActionResult;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
@@ -1318,7 +1319,8 @@ public class RemoteExecutionServiceTest {
     assertThat(manifest.getActionResult()).isEqualTo(expectedResult.build());
 
     ImmutableList<Digest> toQuery = ImmutableList.of(fooDigest, quxDigest, barDigest);
-    assertThat(getFromFuture(cache.findMissingDigests(remoteActionExecutionContext, toQuery)))
+    assertThat(getFromFuture(
+        cache.findMissingDigests(remoteActionExecutionContext, Intention.WRITE, toQuery)))
         .isEmpty();
   }
 
@@ -1355,9 +1357,9 @@ public class RemoteExecutionServiceTest {
     expectedResult.addOutputDirectoriesBuilder().setPath("outputs/bar").setTreeDigest(barDigest);
     assertThat(manifest.getActionResult()).isEqualTo(expectedResult.build());
     assertThat(
-            getFromFuture(
-                cache.findMissingDigests(
-                    remoteActionExecutionContext, ImmutableList.of(barDigest))))
+        getFromFuture(
+            cache.findMissingDigests(
+                remoteActionExecutionContext, Intention.WRITE, ImmutableList.of(barDigest))))
         .isEmpty();
   }
 
@@ -1421,7 +1423,8 @@ public class RemoteExecutionServiceTest {
     assertThat(manifest.getActionResult()).isEqualTo(expectedResult.build());
 
     ImmutableList<Digest> toQuery = ImmutableList.of(wobbleDigest, quxDigest, barDigest);
-    assertThat(getFromFuture(cache.findMissingDigests(remoteActionExecutionContext, toQuery)))
+    assertThat(getFromFuture(
+        cache.findMissingDigests(remoteActionExecutionContext, Intention.WRITE, toQuery)))
         .isEmpty();
   }
 
@@ -1497,9 +1500,9 @@ public class RemoteExecutionServiceTest {
 
     // assert
     assertThat(
-            getFromFuture(
-                cache.findMissingDigests(
-                    remoteActionExecutionContext, ImmutableSet.of(emptyDigest))))
+        getFromFuture(
+            cache.findMissingDigests(
+                remoteActionExecutionContext, Intention.WRITE, ImmutableSet.of(emptyDigest))))
         .containsExactly(emptyDigest);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -614,6 +615,8 @@ public class RemoteSpawnCacheTest {
     RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
 
     ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
+    when(remoteCache.findMissingDigests(any(), any(), any()))
+        .thenReturn(Futures.immediateFuture(ImmutableSet.of()));
     when(remoteCache.downloadActionResult(
             any(RemoteActionExecutionContext.class), any(), /* inlineOutErr= */ eq(false)))
         .thenReturn(CachedActionResult.remote(success));
@@ -640,6 +643,8 @@ public class RemoteSpawnCacheTest {
     IOException downloadFailure = new IOException("downloadMinimal failed");
 
     ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
+    when(remoteCache.findMissingDigests(any(), any(), any()))
+        .thenReturn(Futures.immediateFuture(ImmutableSet.of()));
     when(remoteCache.downloadActionResult(
             any(RemoteActionExecutionContext.class), any(), /* inlineOutErr= */ eq(false)))
         .thenReturn(CachedActionResult.remote(success));

--- a/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
@@ -146,7 +146,7 @@ public class InMemoryCacheClient implements RemoteCacheClient {
 
   @Override
   public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(
-      RemoteActionExecutionContext context, Iterable<Digest> digests) {
+      RemoteActionExecutionContext context, Intention intention, Iterable<Digest> digests) {
     return executorService.submit(
         () -> {
           ImmutableSet.Builder<Digest> missingBuilder = ImmutableSet.builder();


### PR DESCRIPTION
Currently, when checking for the remote cache, we only check the whether an AC exists and its `exit_code` is `0` to decided whether we hit the cache.

This is fine for the normal mode because we immediately download all the outputs after hit the cache. If any of them is missing, we can detect the case, ignore the AC and continue to run the spawn.

However, for Build without the Bytes, we don't download the outputs until Bazel needs them which could happens later in the build. If the output is missing, we cannot rerun the generating action (unless with action rewinding which isn't available yet).

This PR fixes that by checking whether outputs are missing from CAS using `findMissingBlobs` when checking the AC for Build without the Bytes. If any of the outputs is missing, we ignore the AC and continue to run the spawn.

Note that, HttpCache currently doesn't know support `findMissingBlobs` so the check is disabled when using HttpCache.

Working towards #10880.