### PR TITLE
fix: export constraints.bzl file from @local_config_platform so it can be used in downstream bzl_library targets

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
@@ -175,7 +175,11 @@ public class LocalConfigPlatformFunction extends RepositoryFunction {
             "platform(name = 'host',",
             "  # Auto-detected host platform constraints.",
             "  constraint_values = HOST_CONSTRAINTS,",
-            ")"),
+            ")",
+            "exports_files([",
+            "  # Export constraints.bzl for use in downstream bzl_library targets.",
+            "  'constraints.bzl',",
+            "])"),
         repositoryName);
   }
 


### PR DESCRIPTION
Downstream rule sets may depend on `@local_config_platform//:constraints.bzl` but when they do there is no way easy way to make that load statement compatible with `bzl_library`. This change makes it possible to use `bzl_library` on starlark code that loads from `@local_config_platform//:constraints.bzl`.

For example,

```
bzl_library(
    name = "local_config_platform_constraints",
    srcs = ["@local_config_platform//:constraints.bzl"],
)

bzl_library(
    name = "platform_utils",
    srcs = ["//lib/private:platform_utils.bzl"],
    deps = [":local_config_platform_constraints"],
)
```
