### PR TITLE
Remove distdir_deps no longer used by Stardoc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -382,23 +382,6 @@ dist_http_archive(
     name = "io_bazel_skydoc",
 )
 
-# Stardoc recommends declaring its dependencies via "*_dependencies" functions.
-# This requires that the repositories these functions come from need to be
-# fetched unconditionally for everything (including just building bazel!), so
-# provide them as http_archives that can be shiped in the distdir, to keep the
-# distribution archive self-contained.
-dist_http_archive(
-    name = "io_bazel_rules_sass",
-)
-
-dist_http_archive(
-    name = "rules_nodejs",
-)
-
-dist_http_archive(
-    name = "build_bazel_rules_nodejs",
-)
-
 dist_http_archive(
     name = "platforms",
 )
@@ -608,22 +591,6 @@ exports_files(["WORKSPACE"], visibility = ["//visibility:public"])
 load("@io_bazel_skydoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
-
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-
-rules_sass_dependencies()
-
-load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")
-
-build_bazel_rules_nodejs_dependencies()
-
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
-
-node_repositories()
-
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-
-sass_repositories()
 
 register_execution_platforms("//:default_host_platform")  # buildozer: disable=positional-args
 

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -308,41 +308,6 @@ DIST_DEPS = {
             "additional_distfiles",
         ],
     },
-    # for Stardoc
-    "io_bazel_rules_sass": {
-        "archive": "1.25.0.zip",
-        "sha256": "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
-        "strip_prefix": "rules_sass-1.25.0",
-        "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
-            "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
-        ],
-        "used_in": [
-            "additional_distfiles",
-        ],
-    },
-    "build_bazel_rules_nodejs": {
-        "archive": "rules_nodejs-5.5.0.tar.gz",
-        "sha256": "0fad45a9bda7dc1990c47b002fd64f55041ea751fafc00cd34efb96107675778",
-        "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/5.5.0/rules_nodejs-5.5.0.tar.gz",
-            "https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.0/rules_nodejs-5.5.0.tar.gz",
-        ],
-        "used_in": [
-            "additional_distfiles",
-        ],
-    },
-    "rules_nodejs": {
-        "archive": "rules_nodejs-core-5.5.0.tar.gz",
-        "sha256": "4d48998e3fa1e03c684e6bdf7ac98051232c7486bfa412e5b5475bbaec7bb257",
-        "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/5.5.0/rules_nodejs-core-5.5.0.tar.gz",
-            "https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.0/rules_nodejs-core-5.5.0.tar.gz",
-        ],
-        "used_in": [
-            "additional_distfiles",
-        ],
-    },
     "desugar_jdk_libs": {
         # Commit 5847d6a06302136d95a14b4cbd4b55a9c9f1436e of 2021-03-10
         "archive": "5847d6a06302136d95a14b4cbd4b55a9c9f1436e.zip",


### PR DESCRIPTION
The version of Stardoc used by Bazel no longer relies on rules_nodejs or rules_sass.

Gets rid of this warning when building anything in the repo:
```
DEBUG: /home/user/.cache/bazel/_bazel_user/796b3b05d259febdf80296a632dc2e83/external/build_bazel_rules_nodejs/index.bzl:122:10: WARNING: check_rules_nodejs_version has been removed. This is a no-op, please remove the call.
```