### PR TITLE
Send remote actions to specific worker pools instead of machine types.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -212,6 +212,7 @@ REMOTE_PLATFORMS = ("rbe_ubuntu1804_java11",)
         exec_properties = {
             "dockerNetwork": "standard",
             "dockerPrivileged": "true",
+            "Pool": "default",
         },
         parents = ["@" + platform_name + "//config:platform"],
     )
@@ -227,7 +228,7 @@ REMOTE_PLATFORMS = ("rbe_ubuntu1804_java11",)
             "//:highcpu_machine",
         ],
         exec_properties = {
-            "gceMachineType": "e2-highcpu-32",
+            "Pool": "highcpu",
         },
         parents = ["//:" + platform_name + "_platform"],
     )


### PR DESCRIPTION
This ensures that nobody else sends requests to the separate worker pool I've set up, so that my performance measurements aren't disturbed.

Closes #15406.

PiperOrigin-RevId: 446988077