### PR TITLE
Build with incompatible_disallow_empty_glob

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,6 +34,9 @@ build:bzlmod --experimental_enable_bzlmod
 build --java_language_version=11
 build --tool_java_language_version=11
 
+# Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
+build --incompatible_disallow_empty_glob
+
 # User-specific .bazelrc
 try-import %workspace%/user.bazelrc
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BUILD
@@ -15,7 +15,6 @@ java_library(
     srcs = glob(["*.java"]),
     resources = glob(
         [
-            "*.txt",
             "*.WORKSPACE",
         ],
     ),


### PR DESCRIPTION
In order to flip the flag, all downstream projects should be adapted. However, it is hard to fix them all if there are constant regressions. Adding it to the CI will ensure that once the project can build with incompatible_disallow_empty_glob it can keep building like that.
See: bazelbuild/bazel#15327