### PR TITLE
[6.0.0] [remote/downloader] Don't include headers in `FetchBlobRequest`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/BUILD
@@ -22,7 +22,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
-        "//third_party:gson",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/grpc-java:grpc-jar",

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -350,29 +350,10 @@ public class GrpcRemoteDownloaderTest {
                 new URL("http://example.com/a"),
                 new URL("http://example.com/b"),
                 new URL("file:/not/limited/to/http")),
-            ImmutableMap.of(
-                new URI("http://example.com"),
-                ImmutableMap.of(
-                    "Some-Header", ImmutableList.of("some header content"),
-                    "Another-Header",
-                        ImmutableList.of("another header content", "even more header content")),
-                new URI("http://example.org"),
-                ImmutableMap.of(
-                    "Org-Header",
-                    ImmutableList.of("org header content", "and a second one", "and a third one"))),
             com.google.common.base.Optional.<Checksum>of(
                 Checksum.fromSubresourceIntegrity(
                     "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),
-            "canonical ID",
-            /* includeAllHeaders= */ false);
-
-    final String expectedAuthHeadersJson =
-        "{"
-            + "\"http://example.com\":{"
-            + "\"Another-Header\":\"another header content\","
-            + "\"Some-Header\":\"some header content\""
-            + "}"
-            + "}";
+            "canonical ID");
 
     assertThat(request)
         .isEqualTo(
@@ -387,63 +368,6 @@ public class GrpcRemoteDownloaderTest {
                         .setValue("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
                 .addQualifiers(
                     Qualifier.newBuilder().setName("bazel.canonical_id").setValue("canonical ID"))
-                .addQualifiers(
-                    Qualifier.newBuilder()
-                        .setName("bazel.auth_headers")
-                        .setValue(expectedAuthHeadersJson))
-                .build());
-  }
-
-  @Test
-  public void testFetchBlobRequestWithAllHeaders() throws Exception {
-    FetchBlobRequest request =
-        GrpcRemoteDownloader.newFetchBlobRequest(
-            "instance name",
-            ImmutableList.of(
-                new URL("http://example.com/a"),
-                new URL("http://example.com/b"),
-                new URL("file:/not/limited/to/http")),
-            ImmutableMap.of(
-                new URI("http://example.com"),
-                ImmutableMap.of(
-                    "Some-Header", ImmutableList.of("some header content"),
-                    "Another-Header",
-                        ImmutableList.of("another header content", "even more header content")),
-                new URI("http://example.org"),
-                ImmutableMap.of(
-                    "Org-Header",
-                    ImmutableList.of("org header content", "and a second one", "and a third one"))),
-            com.google.common.base.Optional.<Checksum>of(
-                Checksum.fromSubresourceIntegrity(
-                    "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),
-            "canonical ID",
-            /* includeAllHeaders= */ true);
-
-    final String expectedAuthHeadersJson =
-        "{"
-            + "\"http://example.com\":{"
-            + "\"Another-Header\":[\"another header content\",\"even more header content\"],"
-            + "\"Some-Header\":[\"some header content\"]"
-            + "}"
-            + "}";
-
-    assertThat(request)
-        .isEqualTo(
-            FetchBlobRequest.newBuilder()
-                .setInstanceName("instance name")
-                .addUris("http://example.com/a")
-                .addUris("http://example.com/b")
-                .addUris("file:/not/limited/to/http")
-                .addQualifiers(
-                    Qualifier.newBuilder()
-                        .setName("checksum.sri")
-                        .setValue("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
-                .addQualifiers(
-                    Qualifier.newBuilder().setName("bazel.canonical_id").setValue("canonical ID"))
-                .addQualifiers(
-                    Qualifier.newBuilder()
-                        .setName("bazel.auth_headers")
-                        .setValue(expectedAuthHeadersJson))
                 .build());
   }
 }


### PR DESCRIPTION
Including the headers in the request is very inefficient as credentials should never change the content of the downloaded archive. In fact, given that Bazel verifies the checksum of the downloaded file, the credentials cannot possibly used in a way where they influence the outcome of the download (other than deciding whether or not the user is allowed to download the blob at all). Hence, the credentials should not be included in the request.

Users that need to send credentials to the remote downloader should do so by passing the credentials as metadata to the gRPC call.

Note that the remote downloader is behind an experimental flag, so this change does not need to go thorugh the incompatible change process.

Closes #16595.

PiperOrigin-RevId: 485576157
Change-Id: I8afc7c818e4eed63ac1f70c3e4c2115a1d365830