### PR TITLE
Add android tools extension to bazel_tools

### DIFF
--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -33,3 +33,7 @@ register_toolchains("@local_config_sh//:local_sh_toolchain")
 
 remote_coverage_tools_extension = use_extension("//tools/test:extensions.bzl", "remote_coverage_tools_extension")
 use_repo(remote_coverage_tools_extension, "remote_coverage_tools")
+
+android_tools_extension = use_extension("//tools/android:extensions.bzl", "android_tools_extension")
+use_repo(android_tools_extension, "android_tools")
+use_repo(android_tools_extension, "android_gmaven_r8")

--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -35,5 +35,4 @@ remote_coverage_tools_extension = use_extension("//tools/test:extensions.bzl", "
 use_repo(remote_coverage_tools_extension, "remote_coverage_tools")
 
 android_tools_extension = use_extension("//tools/android:extensions.bzl", "android_tools_extension")
-use_repo(android_tools_extension, "android_tools")
-use_repo(android_tools_extension, "android_gmaven_r8")
+use_repo(android_tools_extension, "android_tools", "android_gmaven_r8")

--- a/tools/android/extension.bzl
+++ b/tools/android/extension.bzl
@@ -1,0 +1,36 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A module extension to bring in the android tools under
+@android_tools."""
+
+load("//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _android_tools_extension_impl(ctx):
+	# This must be kept in sync with the top-level WORKSPACE file.
+	http_archive(
+	    name = "android_tools",
+	    sha256 = "1afa4b7e13c82523c8b69e87f8d598c891ec7e2baa41d9e24e08becd723edb4d",  # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
+	    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.27.0.tar.gz",
+	)
+
+	# This must be kept in sync with the top-level WORKSPACE file.
+	http_jar(
+	    name = "android_gmaven_r8",
+	    sha256 = "8626ca32fb47aba7fddd2c897615e2e8ffcdb4d4b213572a2aefb3f838f01972",
+	    url = "https://maven.google.com/com/android/tools/r8/3.3.28/r8-3.3.28.jar",
+	)
+
+android_tools_extension = module_extension(
+    implementation = _android_tools_extension_impl,
+)


### PR DESCRIPTION
Without it `android_sdk_repository` doesn't work using bzlmod.

Without bzlmod this repositories are instantiated in `src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE`