### PR TITLE
Add --experimental_action_cache_store_output_metadata to the expansio…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -473,15 +473,17 @@ public final class RemoteOptions extends CommonRemoteOptions {
         "--nobuild_runfile_links",
         "--experimental_inmemory_jdeps_files",
         "--experimental_inmemory_dotd_files",
+        "--experimental_action_cache_store_output_metadata",
         "--remote_download_outputs=minimal"
       },
       category = "remote",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
-          "Does not download any remote build outputs to the local machine. This flag is a "
-              + "shortcut for three flags: --experimental_inmemory_jdeps_files, "
-              + "--experimental_inmemory_dotd_files and "
+          "Does not download any remote build outputs to the local machine. This flag is a shortcut"
+              + " for flags: --experimental_inmemory_jdeps_files,"
+              + " --experimental_inmemory_dotd_files,"
+              + " --experimental_action_cache_store_output_metadata and "
               + "--remote_download_outputs=minimal.")
   public Void remoteOutputsMinimal;
 
@@ -492,15 +494,17 @@ public final class RemoteOptions extends CommonRemoteOptions {
       expansion = {
         "--experimental_inmemory_jdeps_files",
         "--experimental_inmemory_dotd_files",
+        "--experimental_action_cache_store_output_metadata",
         "--remote_download_outputs=toplevel"
       },
       category = "remote",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
-          "Only downloads remote outputs of top level targets to the local machine. This flag is a "
-              + "shortcut for three flags: --experimental_inmemory_jdeps_files, "
-              + "--experimental_inmemory_dotd_files and "
+          "Only downloads remote outputs of top level targets to the local machine. This flag is a"
+              + " shortcut for flags: --experimental_inmemory_jdeps_files,"
+              + " --experimental_inmemory_dotd_files,"
+              + " --experimental_action_cache_store_output_metadata and "
               + "--remote_download_outputs=toplevel.")
   public Void remoteOutputsToplevel;
 

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -51,7 +51,6 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
     addOptions(
         "--remote_executor=grpc://localhost:" + worker.getPort(),
         "--remote_download_minimal",
-        "--experimental_action_cache_store_output_metadata",
         "--dynamic_local_strategy=standalone",
         "--dynamic_remote_strategy=remote");
   }

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -155,7 +155,6 @@ EOF
 
   bazel build \
     --experimental_ui_debug_all_events \
-    --experimental_action_cache_store_output_metadata \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_download_minimal \
     //a:foobar >& $TEST_log || fail "Failed to build //a:foobar"
@@ -171,7 +170,6 @@ EOF
 
   bazel build \
     --experimental_ui_debug_all_events \
-    --experimental_action_cache_store_output_metadata \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_download_minimal \
     //a:foobar >& $TEST_log || fail "Failed to build //a:foobar"
@@ -1173,14 +1171,6 @@ EOF
 }
 
 function test_download_toplevel_when_turn_remote_cache_off() {
-  download_toplevel_when_turn_remote_cache_off
-}
-
-function test_download_toplevel_when_turn_remote_cache_off_with_metadata() {
-  download_toplevel_when_turn_remote_cache_off --experimental_action_cache_store_output_metadata
-}
-
-function download_toplevel_when_turn_remote_cache_off() {
   # Test that BwtB doesn't cause build failure if remote cache is disabled in a following build.
   # See https://github.com/bazelbuild/bazel/issues/13882.
 
@@ -1215,7 +1205,6 @@ EOF
   bazel build \
     --remote_cache=grpc://localhost:${worker_port} \
     --remote_download_toplevel \
-    "$@" \
     //a:consumer >& $TEST_log || fail "Failed to download outputs"
   [[ -f bazel-bin/a/a.txt ]] || [[ -f bazel-bin/a/b.txt ]] \
     && fail "Expected outputs of producer are not downloaded"
@@ -1224,7 +1213,6 @@ EOF
   echo 'bar' > a/in.txt
   bazel build \
     --remote_download_toplevel \
-    "$@" \
     //a:consumer >& $TEST_log || fail "Failed to build without remote cache"
 }
 


### PR DESCRIPTION
…n of flag --remote_download_{toplevel,minimal}.

So users don't need to add it manually.

It is always desired to use this flag along with BwoB.

Closes #13912.