### PR TITLE
[6.0.0]Implement getDirectoryEntries and readdir for RemoteActionFileSystem.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTestBase.java
@@ -13,14 +13,18 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.ActionInputMap;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.junit.Test;
@@ -208,5 +212,120 @@ public abstract class RemoteActionFileSystemTestBase {
 
     assertThat(getRemoteFileSystem(actionFs).getPath(path).isDirectory()).isTrue();
     assertThat(getLocalFileSystem(actionFs).getPath(path).isDirectory()).isTrue();
+  }
+
+  interface DirectoryEntriesProvider {
+    ImmutableList<String> getDirectoryEntries(Path path) throws IOException;
+  }
+
+  private void readdirNonEmptyLocalDirectoryReadFromLocal(
+      DirectoryEntriesProvider directoryEntriesProvider) throws IOException {
+    FileSystem actionFs = createActionFileSystem();
+    PathFragment dir = getOutputPath("parent/dir");
+    actionFs.getPath(dir).createDirectoryAndParents();
+    writeLocalFile(actionFs, dir.getChild("file1"), "content1");
+    writeLocalFile(actionFs, dir.getChild("file2"), "content2");
+
+    ImmutableList<String> entries =
+        directoryEntriesProvider.getDirectoryEntries(actionFs.getPath(dir));
+
+    assertThat(entries).containsExactly("file1", "file2");
+  }
+
+  private void readdirNonEmptyInMemoryDirectoryReadFromMemory(
+      DirectoryEntriesProvider directoryEntriesProvider) throws IOException {
+    FileSystem actionFs = createActionFileSystem();
+    PathFragment dir = getOutputPath("parent/dir");
+    actionFs.getPath(dir).createDirectoryAndParents();
+    injectRemoteFile(actionFs, dir.getChild("file1"), "content1");
+    injectRemoteFile(actionFs, dir.getChild("file2"), "content2");
+
+    ImmutableList<String> entries =
+        directoryEntriesProvider.getDirectoryEntries(actionFs.getPath(dir));
+
+    assertThat(entries).containsExactly("file1", "file2");
+  }
+
+  private void readdirNonEmptyLocalAndInMemoryDirectoryCombineThem(
+      DirectoryEntriesProvider directoryEntriesProvider) throws IOException {
+    FileSystem actionFs = createActionFileSystem();
+    PathFragment dir = getOutputPath("parent/dir");
+    actionFs.getPath(dir).createDirectoryAndParents();
+    writeLocalFile(actionFs, dir.getChild("file1"), "content1");
+    writeLocalFile(actionFs, dir.getChild("file2"), "content2");
+    injectRemoteFile(actionFs, dir.getChild("file2"), "content2inmemory");
+    injectRemoteFile(actionFs, dir.getChild("file3"), "content3");
+
+    ImmutableList<String> entries =
+        directoryEntriesProvider.getDirectoryEntries(actionFs.getPath(dir));
+
+    assertThat(entries).containsExactly("file1", "file2", "file3");
+  }
+
+  private void readdirNothingThereThrowsFileNotFound(
+      DirectoryEntriesProvider directoryEntriesProvider) throws IOException {
+    FileSystem actionFs = createActionFileSystem();
+    PathFragment dir = getOutputPath("parent/dir");
+
+    assertThrows(
+        FileNotFoundException.class,
+        () -> directoryEntriesProvider.getDirectoryEntries(actionFs.getPath(dir)));
+  }
+
+  @Test
+  public void readdir_nonEmptyLocalDirectory_readFromLocal() throws IOException {
+    readdirNonEmptyLocalDirectoryReadFromLocal(
+        path ->
+            path.readdir(Symlinks.FOLLOW).stream().map(Dirent::getName).collect(toImmutableList()));
+  }
+
+  @Test
+  public void readdir_nonEmptyInMemoryDirectory_readFromMemory() throws IOException {
+    readdirNonEmptyInMemoryDirectoryReadFromMemory(
+        path ->
+            path.readdir(Symlinks.FOLLOW).stream().map(Dirent::getName).collect(toImmutableList()));
+  }
+
+  @Test
+  public void readdir_nonEmptyLocalAndInMemoryDirectory_combineThem() throws IOException {
+    readdirNonEmptyLocalAndInMemoryDirectoryCombineThem(
+        path ->
+            path.readdir(Symlinks.FOLLOW).stream().map(Dirent::getName).collect(toImmutableList()));
+  }
+
+  @Test
+  public void readdir_nothingThere_throwsFileNotFound() throws IOException {
+    readdirNothingThereThrowsFileNotFound(
+        path ->
+            path.readdir(Symlinks.FOLLOW).stream().map(Dirent::getName).collect(toImmutableList()));
+  }
+
+  @Test
+  public void getDirectoryEntries_nonEmptyLocalDirectory_readFromLocal() throws IOException {
+    readdirNonEmptyLocalDirectoryReadFromLocal(
+        path ->
+            path.getDirectoryEntries().stream().map(Path::getBaseName).collect(toImmutableList()));
+  }
+
+  @Test
+  public void getDirectoryEntries_nonEmptyInMemoryDirectory_readFromMemory() throws IOException {
+    readdirNonEmptyInMemoryDirectoryReadFromMemory(
+        path ->
+            path.getDirectoryEntries().stream().map(Path::getBaseName).collect(toImmutableList()));
+  }
+
+  @Test
+  public void getDirectoryEntries_nonEmptyLocalAndInMemoryDirectory_combineThem()
+      throws IOException {
+    readdirNonEmptyLocalAndInMemoryDirectoryCombineThem(
+        path ->
+            path.getDirectoryEntries().stream().map(Path::getBaseName).collect(toImmutableList()));
+  }
+
+  @Test
+  public void getDirectoryEntries_nothingThere_throwsFileNotFound() throws IOException {
+    readdirNothingThereThrowsFileNotFound(
+        path ->
+            path.getDirectoryEntries().stream().map(Path::getBaseName).collect(toImmutableList()));
   }
 }


### PR DESCRIPTION
So spawns can read content of directires within action exuection.

Part of https://github.com/bazelbuild/bazel/pull/16556.

PiperOrigin-RevId: 486918859
Change-Id: Ida86e4c927093d26f7f96d2f0c2aa0d1d74cc8a4