### PR TITLE
fix(rctx.download_and_extract): fix naming convention inconsistencies in rctx.download_and_extract

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -572,6 +572,13 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
                     + " \"txz\", \".tar.zst\", \".tzst\", \"tar.bz2\", \".ar\", or \".deb\""
                     + " here."),
         @Param(
+            name = "stripPrefix",
+            defaultValue = "''",
+            named = true,
+            doc =
+                "Deprecated: You can drop this parameter in preference"
+		+ "\nto strip_prefix (introduced for the purpose of naming consistency)."),
+	@Param(
             name = "strip_prefix",
             defaultValue = "''",
             named = true,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -572,7 +572,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
                     + " \"txz\", \".tar.zst\", \".tzst\", \"tar.bz2\", \".ar\", or \".deb\""
                     + " here."),
         @Param(
-            name = "stripPrefix",
+            name = "strip_prefix",
             defaultValue = "''",
             named = true,
             doc =

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -1685,7 +1685,7 @@ def _rule_impl(ctx):
   result = ctx.download_and_extract(
     url = [],
     type = "zip",
-    stripPrefix="ext",
+    strip_prefix="ext",
     sha256 = ctx.attr.sha256,
     allow_fail = True,
   )


### PR DESCRIPTION
fix naming convention inconsistencies in rctx.download_and_extract for stripPrefix resolving issue #16496