### PR TITLE
redact 'token' strings from logging

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/SafeRequestLogging.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SafeRequestLogging.java
@@ -21,14 +21,15 @@ import java.util.regex.Pattern;
 /** Utils for logging safely user commandlines. */
 public class SafeRequestLogging {
   private static final Pattern suppressFromLog =
-      Pattern.compile("--client_env=([^=]*(?:auth|pass|cookie)[^=]*)=", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "--client_env=([^=]*(?:auth|pass|cookie|token)[^=]*)=", Pattern.CASE_INSENSITIVE);
 
   private SafeRequestLogging() {}
 
   /**
    * Generates a string form of a request to be written to the logs, filtering the user environment
    * to remove anything that looks private. The current filter criteria removes any variable whose
-   * name includes "auth", "pass", or "cookie".
+   * name includes "auth", "pass", "cookie" or "token".
    *
    * @return the filtered request to write to the log.
    */

--- a/src/test/java/com/google/devtools/build/lib/runtime/SafeRequestLoggingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SafeRequestLoggingTest.java
@@ -70,6 +70,16 @@ public class SafeRequestLoggingTest {
   }
 
   @Test
+  public void testGetRequestLogStringStripsApparentTokenValues() {
+    assertThat(
+            SafeRequestLogging.getRequestLogString(
+                ImmutableList.of(
+                    "--client_env=service_ToKEn=notprinted", "--client_env=other=isprinted")))
+        .isEqualTo(
+            "[--client_env=service_ToKEn=__private_value_removed__, --client_env=other=isprinted]");
+  }
+
+  @Test
   public void testGetRequestLogIgnoresSensitiveTermsInValues() {
     assertThat(SafeRequestLogging.getRequestLogString(ImmutableList.of("--client_env=ok=COOKIE")))
         .isEqualTo("[--client_env=ok=COOKIE]");


### PR DESCRIPTION
It's common for users to set 'TOKEN' as an env var. While this is a little like whack-a-mole and we can't cover everything, this seems like a common string to redact.

Closes #16622.

PiperOrigin-RevId: 488392632
Change-Id: I7b48199cc140d6736cd145df63e03eeda747c7fb (cherry picked from commit 1940c5d68136ce2079efa8ff74d4e5fdf63ee3e6)