### PR TITLE
Flip `--incompatible_always_include_files_in_data`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -435,7 +435,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
   @Option(
       name = "incompatible_always_include_files_in_data",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},


### PR DESCRIPTION
RELNOTES[INC]: `--incompatible_always_include_files_in_data` is flipped to true. See https://github.com/bazelbuild/bazel/issues/16654 for details.