### PR TITLE
Add required `--add-opens` server JVM args also with non-embedded JDK

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -359,13 +359,10 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
   startup_options.AddJVMArgumentPrefix(jvm_path.GetParent().GetParent(),
                                        &result);
 
-  // TODO(b/109998449): only assume JDK >= 9 for embedded JDKs
-  if (!startup_options.GetEmbeddedJavabase().IsEmpty()) {
-    // quiet warnings from com.google.protobuf.UnsafeUtil,
-    // see: https://github.com/google/protobuf/issues/3781
-    result.push_back("--add-opens=java.base/java.nio=ALL-UNNAMED");
-    result.push_back("--add-opens=java.base/java.lang=ALL-UNNAMED");
-  }
+  // com.google.devtools.build.lib.unsafe.StringUnsafe uses reflection to access
+  // private fields in java.lang.String. The Bazel server requires Java 11, so
+  // this option is known to be supported.
+  result.push_back("--add-opens=java.base/java.lang=ALL-UNNAMED");
 
   result.push_back("-Xverify:none");
 


### PR DESCRIPTION
Since the Bazel server requires JDK 11 or higher to run, the `--add-opens` server JVM arg for `java.lang` can now be added unconditionally, which ensures support with JDK 17+.

Also removes the additional opens for `java.nio`, which was only needed to silence a protobuf warning that has since been fixed upstream.

Fixes #16705
Fixes #15831

Closes #16706.

PiperOrigin-RevId: 489372772
Change-Id: I880e2689f59b2d4420b1e2e0517697d7fb03abbc