### PR TITLE
Fix a race in ijar_test.

### DIFF
--- a/third_party/ijar/test/ijar_test.sh
+++ b/third_party/ijar/test/ijar_test.sh
@@ -106,8 +106,8 @@ function check_consistent_file_contents() {
   local actual="$(cat $1 | ${MD5SUM} | awk '{ print $1; }')"
   local filename="$(echo $1 | ${MD5SUM} | awk '{ print $1; }')"
   local expected="$actual"
-  if (echo "${expected_output}" | grep -q "^${filename} "); then
-    echo "${expected_output}" | grep -q "^${filename} ${actual}$" || {
+  if (grep -q "^${filename} " <<<"${expected_output}"); then
+    grep -q "^${filename} ${actual}$" <<<"${expected_output}" || {
       ls -l "$1"
       fail "output file contents differ"
     }


### PR DESCRIPTION
Detecting a string in bash with the pattern `echo "source text" | grep -q "string to match"` may have false negatives. Indeed, if the `grep -q` command finds its match early and exits successfully but quickly, the `echo` command will be killed by `SIGPIPE`, making the entire pipeline fail. Avoid this problem by replacing `echo` with heredoc strings.