### PR TITLE
Also collect clang resource directory with `-no-canonical-prefixes`

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -143,7 +143,7 @@ def _get_cxx_include_directories(repository_ctx, cc, lang_flag, additional_flags
 
     if _is_compiler_option_supported(repository_ctx, cc, "-print-resource-dir"):
         resource_dir = repository_ctx.execute(
-            [cc, "-print-resource-dir"],
+            [cc, "-print-resource-dir"] + additional_flags,
         ).stdout.strip() + "/share"
         inc_directories.append(_prepare_include_path(repository_ctx, resource_dir))
 


### PR DESCRIPTION
`clang -print-resource-dir` without `-no-canonical-prefixes` returns a different path than is actually used to include `asan_blacklist.txt` on macOS with non-Apple clang.

Closes #16792.

PiperOrigin-RevId: 489475662
Change-Id: If17f347d76f86e0ec5804f9e8789f44f46ab27b4