### PR TITLE
Improve list formatting in .bazelrc docs

### DIFF
--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -232,9 +232,10 @@ line. Entries are relative to the workspace root.
 ### The global bazelrc file {:#global-bazelrc}
 
 Bazel reads optional bazelrc files in this order:
-- System rc-file located at `etc/bazel.bazelrc`.
-- Workspace rc-file located at `$workspace/tools/bazel.rc`.
-- Home rc-file located at `$HOME/.bazelrc`
+
+1.  System rc-file located at `etc/bazel.bazelrc`.
+2.  Workspace rc-file located at `$workspace/tools/bazel.rc`.
+3.  Home rc-file located at `$HOME/.bazelrc`
 
 Each bazelrc file listed here has a corresponding flag which can be used to
 disable them (e.g. `--nosystem_rc`, `--noworkspace_rc`, `--nohome_rc`). You can


### PR DESCRIPTION
Hi wonderful Bazelers,

I was reading the [.bazelrc docs](https://bazel.build/run/bazelrc) and noticed that a [list at the end was getting rendered as a single line](https://bazel.build/run/bazelrc#global-bazelrc), probably because GitHub's markdown rendering handles the need for newlines before lists differently than whatever Bazel uses to generate HTML from the docs.

So, to try to leave things even better than I found them, I
1. Added a blank line above to try to fix that issue.
2. Since the list is intended to convey order, I changed it to an ordered (numbered) list. (Attempting to be maximally consistent with the other formatting in the doc: number, followed by two spaces, without blank lines in between for a short list.)

Thanks for reading!
Chris
(ex-Googler)