### PR TITLE
Include source files with `cquery --output=files`

### DIFF
--- a/site/en/query/cquery.md
+++ b/site/en/query/cquery.md
@@ -367,8 +367,8 @@ This option prints a list of the output files produced by each target matched
 by the query similar to the list printed at the end of a `bazel build`
 invocation. The output contains only the files advertised in the requested
 output groups as determined by the
-[`--output_groups`](/reference/command-line-reference#flag--output_groups) flag
-and never contains source files.
+[`--output_groups`](/reference/command-line-reference#flag--output_groups) flag.
+It does include source files.
 
 Note: The output of `bazel cquery --output=files //pkg:foo` contains the output
 files of `//pkg:foo` in *all* configurations that occur in the build (also see

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallback.java
@@ -17,6 +17,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactHelper;
+import com.google.devtools.build.lib.analysis.configuredtargets.InputFileConfiguredTarget;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
@@ -53,14 +54,17 @@ public class FilesOutputFormatterCallback extends CqueryThreadsafeCallback {
       throws IOException, InterruptedException {
     for (KeyedConfiguredTarget keyedTarget : partialResult) {
       ConfiguredTarget target = keyedTarget.getConfiguredTarget();
-      if (!TopLevelArtifactHelper.shouldConsiderForDisplay(target)) {
+      if (!TopLevelArtifactHelper.shouldConsiderForDisplay(target)
+          && !(target instanceof InputFileConfiguredTarget)) {
         continue;
       }
       TopLevelArtifactHelper.getAllArtifactsToBuild(target, topLevelArtifactContext)
           .getImportantArtifacts()
           .toList()
           .stream()
-          .filter(TopLevelArtifactHelper::shouldDisplay)
+          .filter(
+              artifact ->
+                  TopLevelArtifactHelper.shouldDisplay(artifact) || artifact.isSourceArtifact())
           .map(Artifact::getExecPathString)
           .forEach(this::addResult);
     }

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallbackTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -71,7 +72,7 @@ public class FilesOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
         "            runfiles = ctx.runfiles([runfile]),",
         "        ),",
         "        OutputGroupInfo(",
-        "            foobar = [output_group_only],",
+        "            foobar = [output_group_only, ctx.file.explicit_source_dep],",
         "        ),",
         "    ]",
         "r = rule(",
@@ -134,21 +135,34 @@ public class FilesOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
   @Test
   public void basicQuery_defaultOutputGroup() throws Exception {
     List<String> output = getOutput("//pkg:all", ImmutableList.of());
+    var sourceAndGeneratedFiles =
+        output.stream()
+            .collect(Collectors.<String>partitioningBy(path -> path.matches("^[^/]*-out/.*")));
+    assertThat(sourceAndGeneratedFiles.get(false)).containsExactly("pkg/BUILD", "defs/rules.bzl");
     assertContainsExactlyWithBinDirPrefix(
-        output, "pkg/main_default_file", "pkg/other_default_file");
+        sourceAndGeneratedFiles.get(true), "pkg/main_default_file", "pkg/other_default_file");
   }
 
   @Test
   public void basicQuery_defaultAndCustomOutputGroup() throws Exception {
     List<String> output = getOutput("//pkg:main", ImmutableList.of("+foobar"));
+    var sourceAndGeneratedFiles =
+        output.stream()
+            .collect(Collectors.<String>partitioningBy(path -> path.matches("^[^/]*-out/.*")));
+    assertThat(sourceAndGeneratedFiles.get(false)).containsExactly("pkg/BUILD", "defs/rules.bzl");
     assertContainsExactlyWithBinDirPrefix(
-        output, "pkg/main_default_file", "pkg/main_output_group_only");
+        sourceAndGeneratedFiles.get(true), "pkg/main_default_file", "pkg/main_output_group_only");
   }
 
   @Test
   public void basicQuery_customOutputGroupOnly() throws Exception {
     List<String> output = getOutput("//pkg:other", ImmutableList.of("foobar"));
-    assertContainsExactlyWithBinDirPrefix(output, "pkg/other_output_group_only");
+    var sourceAndGeneratedFiles =
+        output.stream()
+            .collect(Collectors.<String>partitioningBy(path -> path.matches("^[^/]*-out/.*")));
+    assertThat(sourceAndGeneratedFiles.get(false)).containsExactly("pkg/BUILD");
+    assertContainsExactlyWithBinDirPrefix(
+        sourceAndGeneratedFiles.get(true), "pkg/other_output_group_only");
   }
 
   private void assertContainsExactlyWithBinDirPrefix(

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -1430,4 +1430,18 @@ EOF
   expect_not_log "QueryException"
 }
 
+function test_files_include_source_files() {
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg
+  cat > $pkg/BUILD <<'EOF'
+filegroup(name="files", srcs=["BUILD"])
+alias(name="alias", actual="single_file")
+EOF
+  touch $pkg/single_file
+
+  bazel cquery --output=files //$pkg:all > output 2>"$TEST_log" || fail "Unexpected failure"
+  assert_contains "$pkg/BUILD" output
+  assert_contains "$pkg/single_file" output
+}
+
 run_suite "${PRODUCT_NAME} configured query tests"


### PR DESCRIPTION
RELNOTES[INC]: `cquery --output=files` also outputs source files.

Closes #16794.

PiperOrigin-RevId: 490403247
Change-Id: I3279b72a5b8dea93b58e22ecc2fbc24a40d9ae8b