### PR TITLE
Add auto-configured Unix toolchain support for `BAZEL_CONLYOPTS`

### DIFF
--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1752,4 +1752,68 @@ EOF
   bazel build //:main --repo_env=CC=clang || fail "Expected compiler flag to have value 'clang'"
 }
 
+function test_bazel_cxxopts() {
+  cat > BUILD.bazel <<'EOF'
+cc_binary(
+  name = "main_c",
+  srcs = ["main.c"],
+)
+cc_binary(
+  name = "main_cpp",
+  srcs = ["main.cpp"],
+)
+EOF
+  cat > main.c <<'EOF'
+#include <stdlib.h>
+int main() {
+  exit(EXIT_CODE);
+}
+EOF
+  cat > main.cpp <<'EOF'
+#include <stdlib.h>
+int main() {
+  exit(EXIT_CODE);
+}
+EOF
+
+  bazel build //:main_c \
+    --repo_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
+    --repo_env=BAZEL_CXXOPTS=-DEXIT_CODE=0 && fail "Expected C compilation to fail"
+  bazel run //:main_cpp \
+    --repo_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
+    --repo_env=BAZEL_CXXOPTS=-DEXIT_CODE=0 || fail "Expected C++ compilation to pass"
+}
+
+function test_bazel_conlyopts() {
+  cat > BUILD.bazel <<'EOF'
+cc_binary(
+  name = "main_c",
+  srcs = ["main.c"],
+)
+cc_binary(
+  name = "main_cpp",
+  srcs = ["main.cpp"],
+)
+EOF
+  cat > main.c <<'EOF'
+#include <stdlib.h>
+int main() {
+  exit(EXIT_CODE);
+}
+EOF
+  cat > main.cpp <<'EOF'
+#include <stdlib.h>
+int main() {
+  exit(EXIT_CODE);
+}
+EOF
+
+  bazel build //:main_cpp \
+    --repo_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
+    --repo_env=BAZEL_CONLYOPTS=-DEXIT_CODE=0 && fail "Expected C++ compilation to fail"
+  bazel run //:main_c \
+    --repo_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
+    --repo_env=BAZEL_CONLYOPTS=-DEXIT_CODE=0 || fail "Expected C compilation to pass"
+}
+
 run_suite "cc_integration_test"

--- a/tools/cpp/BUILD.tpl
+++ b/tools/cpp/BUILD.tpl
@@ -85,6 +85,7 @@ cc_toolchain_config(
     compile_flags = [%{compile_flags}],
     opt_compile_flags = [%{opt_compile_flags}],
     dbg_compile_flags = [%{dbg_compile_flags}],
+    conly_flags = [%{conly_flags}],
     cxx_flags = [%{cxx_flags}],
     link_flags = [%{link_flags}],
     link_libs = [%{link_libs}],

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -146,6 +146,7 @@ cc_autoconf = repository_rule(
         "ABI_VERSION",
         "BAZEL_COMPILER",
         "BAZEL_HOST_SYSTEM",
+        "BAZEL_CONLYOPTS",
         "BAZEL_CXXOPTS",
         "BAZEL_LINKOPTS",
         "BAZEL_LINKLIBS",

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -406,6 +406,13 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         },
     )
 
+    conly_opts = split_escaped(get_env_var(
+        repository_ctx,
+        "BAZEL_CONLYOPTS",
+        "",
+        False,
+    ), ":")
+
     cxx_opts = split_escaped(get_env_var(
         repository_ctx,
         "BAZEL_CXXOPTS",
@@ -446,7 +453,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
             bin_search_flags.append("-B" + str(ld_path.dirname))
     coverage_compile_flags, coverage_link_flags = _coverage_flags(repository_ctx, darwin)
     builtin_include_directories = _uniq(
-        _get_cxx_include_directories(repository_ctx, cc, "-xc") +
+        _get_cxx_include_directories(repository_ctx, cc, "-xc", conly_opts) +
         _get_cxx_include_directories(repository_ctx, cc, "-xc++", cxx_opts) +
         _get_cxx_include_directories(
             repository_ctx,
@@ -561,6 +568,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
                 ],
             ),
             "%{cxx_flags}": get_starlark_list(cxx_opts + _escaped_cplus_include_paths(repository_ctx)),
+            "%{conly_flags}": get_starlark_list(conly_opts),
             "%{link_flags}": get_starlark_list((
                 ["-fuse-ld=" + gold_or_lld_linker_path] if gold_or_lld_linker_path else []
             ) + _add_linker_option_if_supported(

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -216,6 +216,14 @@ def _impl(ctx):
                 with_features = [with_feature_set(features = ["opt"])],
             ),
             flag_set(
+                actions = [ACTION_NAMES.c_compile],
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.conly_flags,
+                    ),
+                ] if ctx.attr.conly_flags else []),
+            ),
+            flag_set(
                 actions = all_cpp_compile_actions + [ACTION_NAMES.lto_backend],
                 flag_groups = ([
                     flag_group(
@@ -1337,6 +1345,7 @@ cc_toolchain_config = rule(
         "compile_flags": attr.string_list(),
         "dbg_compile_flags": attr.string_list(),
         "opt_compile_flags": attr.string_list(),
+        "conly_flags": attr.string_list(),
         "cxx_flags": attr.string_list(),
         "link_flags": attr.string_list(),
         "archive_flags": attr.string_list(),


### PR DESCRIPTION
Since `BAZEL_CXXOPTS` is only used for C++ compilation, there was no way to pass in options for C compilation that would also be used when discovering built-in include directories with `-xc`.

When using the non-Xcode auto-configured toolchain on macOS, it can be necessary to specify the macOS SDK sysroot via a compiler flag. While this can usually be achieved by combining `--conlyopt` with `BAZEL_CXXOPTS`, this assumes that the built-in include directories returned with `-xc` are always a subset of those returned with `-xc++`. Having `BAZEL_CONLYOPTS` allows this situation to be navigated in a way that is clearly correct.

Also adds test coverage for `BAZEL_CXXOPTS`.