### PR TITLE
Make Java runfiles library compilable with JDK 8

### DIFF
--- a/tools/java/runfiles/Runfiles.java
+++ b/tools/java/runfiles/Runfiles.java
@@ -410,7 +410,8 @@ public final class Runfiles {
       return Collections.emptyMap();
     }
 
-    try (BufferedReader r = new BufferedReader(new FileReader(path, StandardCharsets.UTF_8))) {
+    try (BufferedReader r = new BufferedReader(
+        new InputStreamReader(new FileInputStream(path), StandardCharsets.UTF_8))) {
       return Collections.unmodifiableMap(
           r.lines()
               .filter(line -> !line.isEmpty())


### PR DESCRIPTION
The `FileReader(String,Charset)` constructor is not available in Java 8.

Fixes #16849
Work towards #16124