### PR TITLE
Replace no-cache for no-remote-cache

### DIFF
--- a/site/en/remote/caching.md
+++ b/site/en/remote/caching.md
@@ -250,12 +250,12 @@ build --remote_upload_local_results=false
 ### Exclude specific targets from using the remote cache {:#targets-remote-cache}
 
 To exclude specific targets from using the remote cache, tag the target with
-`no-cache`. For example:
+`no-remote-cache`. For example:
 
 ```starlark
 java_library(
     name = "target",
-    tags = ["no-cache"],
+    tags = ["no-remote-cache"],
 )
 ```
 


### PR DESCRIPTION
The documentation says that a target can be excluded from the remote cache with the tag no-cache.
This is not completely right, this would exclude also the target from the local cache. To remove it from the remote cache only no-remote-cache should be used.