### PR TITLE
Fix return value check of getpwuid_r in blaze util

### DIFF
--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -66,7 +66,7 @@ string GetOutputRoot() {
   struct passwd *pw = nullptr;
   int uid = getuid();
   int r = getpwuid_r(uid, &pwbuf, buf, 2048, &pw);
-  if (r != -1 && pw != nullptr) {
+  if (r == 0 && pw != nullptr) {
     return blaze_util::JoinPath(pw->pw_dir, ".cache/bazel");
   } else {
     return "/tmp";

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -54,7 +54,7 @@ string GetOutputRoot() {
     struct passwd *pw = nullptr;
     int uid = getuid();
     int r = getpwuid_r(uid, &pwbuf, buf, 2048, &pw);
-    if (r != -1 && pw != nullptr) {
+    if (r == 0 && pw != nullptr) {
       base = pw->pw_dir;
     }
   }


### PR DESCRIPTION
On success `getpwuid_r` returns zero, different error codes are used depending on the underlying error, not just `-1`.