### PR TITLE
Make Java runfiles library compilable with JDK 8

### DIFF
--- a/tools/java/runfiles/Runfiles.java
+++ b/tools/java/runfiles/Runfiles.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.runfiles;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.ref.SoftReference;
@@ -410,7 +409,9 @@ public final class Runfiles {
       return Collections.emptyMap();
     }
 
-    try (BufferedReader r = new BufferedReader(new FileReader(path, StandardCharsets.UTF_8))) {
+    try (BufferedReader r =
+        new BufferedReader(
+            new InputStreamReader(new FileInputStream(path), StandardCharsets.UTF_8))) {
       return Collections.unmodifiableMap(
           r.lines()
               .filter(line -> !line.isEmpty())


### PR DESCRIPTION
The `FileReader(String,Charset)` constructor is not available in Java 8.

Fixes #16849
Work towards #16124

Closes #16860.

PiperOrigin-RevId: 491310720
Change-Id: I26f7bce346038d10285b0a1ee7b29216ba151010