### PR TITLE
[6.0.0] Default --incompatible_strict_conflict_checks to true.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
@@ -91,8 +91,9 @@ public class AnalysisOptions extends OptionsBase {
   public boolean skyframePrepareAnalysis;
 
   @Option(
-      name = "experimental_strict_conflict_checks",
-      defaultValue = "false",
+      name = "incompatible_strict_conflict_checks",
+      oldName = "experimental_strict_conflict_checks",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       metadataTags = OptionMetadataTag.INCOMPATIBLE_CHANGE,
       effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -312,6 +312,8 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
 
   @Test
   public void symlinkToNestedFile() throws Exception {
+    addOptions("--noincompatible_strict_conflict_checks");
+
     write(
         "a/defs.bzl",
         "def _impl(ctx):",
@@ -364,6 +366,8 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
 
   @Test
   public void symlinkToNestedDirectory() throws Exception {
+    addOptions("--noincompatible_strict_conflict_checks");
+
     write(
         "a/defs.bzl",
         "def _impl(ctx):",


### PR DESCRIPTION
The downstream pipeline indicates that this is safe to flip: https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1346

Fixes #16729.

RELNOTES[INC]: `--incompatible_strict_conflict_checks` is flipped to true. See https://github.com/bazelbuild/bazel/issues/16729 for details.

PiperOrigin-RevId: 491324038
Change-Id: Iea8951867fa20f2aa1a67bf3ba3c86c26e4292de