### PR TITLE
Update the docs for `--strategy_regexp`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -110,7 +110,7 @@ public class ExecutionOptions extends OptionsBase {
           "Override which spawn strategy should be used to execute spawn actions that have "
               + "descriptions matching a certain regex_filter. See --per_file_copt for details on"
               + "regex_filter matching. "
-              + "The first regex_filter that matches the description is used. "
+              + "The last regex_filter that matches the description is used. "
               + "This option overrides other flags for specifying strategy. "
               + "Example: --strategy_regexp=//foo.*\\.cc,-//foo/bar=local means to run actions "
               + "using local strategy if their descriptions match //foo.*.cc but not //foo/bar. "


### PR DESCRIPTION
The behavior was changed in e194c827f363f1a0de42e757759daa0fc9052db9, and the user manual was updated, but not the actual option docs.

Fixes #15636.