### PR TITLE
Set `--experimental_action_listeners` to default in `exec` config

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -746,7 +746,7 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
   }
 
   public List<Label> getActionListeners() {
-    return options.actionListeners == null ? ImmutableList.of() : options.actionListeners;
+    return options.actionListeners;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
@@ -129,7 +129,7 @@ public class ExecutionTransitionFactory
       coreOptions.isHost = false;
       coreOptions.isExec = true;
       // Disable extra actions
-      coreOptions.actionListeners = null;
+      coreOptions.actionListeners = ImmutableList.of();
 
       // Then set the target to the saved execution platform if there is one.
       PlatformOptions platformOptions = execOptions.get(PlatformOptions.class);


### PR DESCRIPTION
Previously, the flag value was set to `null` rather than an empty list, which resulted in distinct yet equivalent configurations.

Fixes #16911 