### PR TITLE
Add tag to avoid cycles when depending on def_parser

### DIFF
--- a/third_party/def_parser/BUILD
+++ b/third_party/def_parser/BUILD
@@ -15,6 +15,9 @@ cc_library(
     name = "def_parser_lib",
     srcs = ["def_parser.cc"],
     hdrs = ["def_parser.h"],
+    tags = [
+        "__DONT_DEPEND_ON_DEF_PARSER__"
+    ],
 )
 
 cc_binary(
@@ -22,6 +25,9 @@ cc_binary(
     srcs = ["def_parser_main.cc"],
     deps = [
         ":def_parser_lib",
+    ],
+    tags = [
+        "__DONT_DEPEND_ON_DEF_PARSER__"
     ],
 )
 


### PR DESCRIPTION
When starlarkifying the _def_parser implicit dependency of cc_libraries we don't have a way to add a computed default in Starlark like we did in native but we can rely on a tag in the target to avoid def_parser related targets themselves adding a dependency to the def parser.