### PR TITLE
Always emit trailing zero in human-readable download progress

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -542,9 +542,9 @@ public final class Utils {
   }
 
   private static final ImmutableList<String> UNITS = ImmutableList.of("KiB", "MiB", "GiB", "TiB");
-  // Format as single digit decimal number, but skipping the trailing .0.
+  // Format as single digit decimal number.
   private static final DecimalFormat BYTE_COUNT_FORMAT =
-      new DecimalFormat("0.#", new DecimalFormatSymbols(Locale.US));
+      new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.US));
 
   /**
    * Converts the number of bytes to a human readable string, e.g. 1024 -> 1 KiB.

--- a/src/test/java/com/google/devtools/build/lib/remote/util/UtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/UtilsTest.java
@@ -26,14 +26,14 @@ public class UtilsTest {
   @Test
   public void bytesCountToDisplayString_works() {
     assertThat(bytesCountToDisplayString(1000)).isEqualTo("1000 B");
-    assertThat(bytesCountToDisplayString(1 << 10)).isEqualTo("1 KiB");
+    assertThat(bytesCountToDisplayString(1 << 10)).isEqualTo("1.0 KiB");
     assertThat(bytesCountToDisplayString((1 << 10) + (1 << 10) / 10)).isEqualTo("1.1 KiB");
-    assertThat(bytesCountToDisplayString(1 << 20)).isEqualTo("1 MiB");
+    assertThat(bytesCountToDisplayString(1 << 20)).isEqualTo("1.0 MiB");
     assertThat(bytesCountToDisplayString((1 << 20) + (1 << 20) / 10)).isEqualTo("1.1 MiB");
-    assertThat(bytesCountToDisplayString(1 << 30)).isEqualTo("1 GiB");
+    assertThat(bytesCountToDisplayString(1 << 30)).isEqualTo("1.0 GiB");
     assertThat(bytesCountToDisplayString((1 << 30) + (1 << 30) / 10)).isEqualTo("1.1 GiB");
-    assertThat(bytesCountToDisplayString(1L << 40)).isEqualTo("1 TiB");
+    assertThat(bytesCountToDisplayString(1L << 40)).isEqualTo("1.0 TiB");
     assertThat(bytesCountToDisplayString((1L << 40) + (1L << 40) / 10)).isEqualTo("1.1 TiB");
-    assertThat(bytesCountToDisplayString(1L << 50)).isEqualTo("1024 TiB");
+    assertThat(bytesCountToDisplayString(1L << 50)).isEqualTo("1024.0 TiB");
   }
 }


### PR DESCRIPTION
The human-readable download progress (e.g. "8.2 MiB") typically changes rapidly and, especially in the common "MiB" range, is very "jumpy" if the trailing digit is only shown if it's non-zero.