### PR TITLE
Use xcrun to invoke install_name_tool

### DIFF
--- a/tools/cpp/osx_cc_wrapper.sh.tpl
+++ b/tools/cpp/osx_cc_wrapper.sh.tpl
@@ -27,8 +27,6 @@
 #
 set -eu
 
-INSTALL_NAME_TOOL="/usr/bin/install_name_tool"
-
 LIBS=
 LIB_DIRS=
 RPATHS=
@@ -110,7 +108,7 @@ for rpath in ${RPATHS}; do
         if [[ -n "${libname-}" ]]; then
             libpath=$(get_library_path ${lib})
             if [ -n "${libpath}" ]; then
-                ${INSTALL_NAME_TOOL} -change $(get_otool_path "${libpath}") \
+                /usr/bin/xcrun install_name_tool -change $(get_otool_path "${libpath}") \
                     "@loader_path/${rpath}/${libname}" "${OUTPUT}"
             fi
         fi


### PR DESCRIPTION
`/usr/bin/install_name_tool` is a shim; it invokes install_name_tool in the current active Xcode.

This allows using this template file to configure toolchain on non-macOS. This doesn't change the behavior as both will end up invoking the same tool.

replaces https://github.com/bazelbuild/bazel/pull/13462