### PR TITLE
Replace `%{output_file_path}` with `%{output_execpath}` in docs

### DIFF
--- a/site/en/docs/cc-toolchain-config-reference.md
+++ b/site/en/docs/cc-toolchain-config-reference.md
@@ -568,7 +568,7 @@ within the flag value, which the compiler expands when adding the flag to the
 build command. For example:
 
     flag_group (
-        flags = ["%{output_file_path}"],
+        flags = ["%{output_execpath}"],
     )
 
 


### PR DESCRIPTION
`%{output_file_path}` is not available (anymore?).