### PR TITLE
Fix typo in http_archive name for py cov documentation

### DIFF
--- a/site/en/configure/coverage.md
+++ b/site/en/configure/coverage.md
@@ -201,7 +201,7 @@ Instead, add in your `WORKSPACE` e.g.
 
 ```starlark
 http_archive(
-    name = "coverage_linux_x86_64"",
+    name = "coverage_linux_x86_64",
     build_file_content = """
 py_library(
     name = "coverage",


### PR DESCRIPTION
Fixed a typo in the markdown documentation to avoid surprises when copy-paste the part.