### PR TITLE
[6.0.0] Fix runfiles creation with MANIFEST when building without the bytes

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -77,6 +77,32 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
+  public void disableRunfiles_buildSuccessfully() throws Exception {
+    // Disable on Windows since it fails for unknown reasons.
+    // TODO(chiwang): Enable it on windows.
+    if (OS.getCurrent() == OS.WINDOWS) {
+      return;
+    }
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  cmd = 'echo foo > $@',",
+        "  outs = ['foo.data'],",
+        ")",
+        "sh_test(",
+        "  name = 'foobar',",
+        "  srcs = ['test.sh'],",
+        "  data = [':foo'],",
+        ")");
+    write("test.sh");
+    getWorkspace().getRelative("test.sh").setExecutable(true);
+    addOptions("--build_runfile_links", "--enable_runfiles=no");
+
+    buildTarget("//:foobar");
+  }
+
+  @Test
   public void downloadOutputsWithRegex() throws Exception {
     write(
         "BUILD",
@@ -108,7 +134,6 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     if (OS.getCurrent() == OS.WINDOWS) {
       return;
     }
-
     writeOutputDirRule();
     write(
         "BUILD",
@@ -270,7 +295,6 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     if (OS.getCurrent() == OS.WINDOWS) {
       return;
     }
-
     addOptions("--internal_spawn_scheduler");
     addOptions("--strategy=Genrule=dynamic");
     addOptions("--experimental_local_execution_delay=9999999");
@@ -466,7 +490,6 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     if (OS.getCurrent() == OS.WINDOWS) {
       return;
     }
-
     // Test that tree artifact generated locally can be consumed by other actions.
     // See https://github.com/bazelbuild/bazel/issues/16789
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTestBase.java
@@ -826,4 +826,93 @@ public abstract class RemoteActionFileSystemTestBase {
     assertThat(getLocalFileSystem(actionFs).getPath(path).isWritable()).isFalse();
     assertThat(getLocalFileSystem(actionFs).getPath(path).isExecutable()).isTrue();
   }
+
+  @Test
+  public void getLastModifiedTime_fileDoesNotExist_throwError() throws IOException {
+    var actionFs = createActionFileSystem();
+    var path = getOutputPath("file");
+
+    assertThrows(FileNotFoundException.class, () -> actionFs.getPath(path).getLastModifiedTime());
+  }
+
+  @Test
+  public void getLastModifiedTime_onlyRemoteFile_returnRemote() throws IOException {
+    var actionFs = createActionFileSystem();
+    var path = getOutputPath("file");
+    injectRemoteFile(actionFs, path, "remote-content");
+
+    var mtime = actionFs.getPath(path).getLastModifiedTime();
+
+    assertThat(mtime).isEqualTo(getRemoteFileSystem(actionFs).getPath(path).getLastModifiedTime());
+  }
+
+  @Test
+  public void getLastModifiedTime_onlyLocalFile_returnLocal() throws IOException {
+    var actionFs = createActionFileSystem();
+    var path = getOutputPath("file");
+    writeLocalFile(actionFs, path, "local-content");
+
+    var mtime = actionFs.getPath(path).getLastModifiedTime();
+
+    assertThat(mtime).isEqualTo(getLocalFileSystem(actionFs).getPath(path).getLastModifiedTime());
+  }
+
+  @Test
+  public void getLastModifiedTime_localAndRemoteFile_returnRemote() throws IOException {
+    var actionFs = createActionFileSystem();
+    var path = getOutputPath("file");
+    injectRemoteFile(actionFs, path, "remote-content");
+    writeLocalFile(actionFs, path, "local-content");
+
+    var mtime = actionFs.getPath(path).getLastModifiedTime();
+
+    assertThat(mtime).isEqualTo(getRemoteFileSystem(actionFs).getPath(path).getLastModifiedTime());
+  }
+
+  @Test
+  public void setLastModifiedTime_fileDoesNotExist_throwError() throws IOException {
+    var actionFs = createActionFileSystem();
+    var path = getOutputPath("file");
+
+    assertThrows(FileNotFoundException.class, () -> actionFs.getPath(path).setLastModifiedTime(0));
+  }
+
+  @Test
+  public void setLastModifiedTime_onlyRemoteFile_successfullySet() throws IOException {
+    var actionFs = createActionFileSystem();
+    var path = getOutputPath("file");
+    injectRemoteFile(actionFs, path, "remote-content");
+    assertThat(actionFs.getPath(path).getLastModifiedTime()).isNotEqualTo(0);
+
+    actionFs.getPath(path).setLastModifiedTime(0);
+
+    assertThat(actionFs.getPath(path).getLastModifiedTime()).isEqualTo(0);
+  }
+
+  @Test
+  public void setLastModifiedTime_onlyLocalFile_successfullySet() throws IOException {
+    var actionFs = createActionFileSystem();
+    var path = getOutputPath("file");
+    writeLocalFile(actionFs, path, "local-content");
+    assertThat(actionFs.getPath(path).getLastModifiedTime()).isNotEqualTo(0);
+
+    actionFs.getPath(path).setLastModifiedTime(0);
+
+    assertThat(actionFs.getPath(path).getLastModifiedTime()).isEqualTo(0);
+  }
+
+  @Test
+  public void setLastModifiedTime_localAndRemoteFile_changeBoth() throws IOException {
+    var actionFs = createActionFileSystem();
+    var path = getOutputPath("file");
+    injectRemoteFile(actionFs, path, "remote-content");
+    writeLocalFile(actionFs, path, "local-content");
+    assertThat(getLocalFileSystem(actionFs).getPath(path).getLastModifiedTime()).isNotEqualTo(0);
+    assertThat(getRemoteFileSystem(actionFs).getPath(path).getLastModifiedTime()).isNotEqualTo(0);
+
+    actionFs.getPath(path).setLastModifiedTime(0);
+
+    assertThat(getLocalFileSystem(actionFs).getPath(path).getLastModifiedTime()).isEqualTo(0);
+    assertThat(getRemoteFileSystem(actionFs).getPath(path).getLastModifiedTime()).isEqualTo(0);
+  }
 }


### PR DESCRIPTION
`getLastModifiedTime` and `setLastModifiedTime` are used by `FileSystemUtils.copyFile` to copy files. When runfiles is disabled, `SymlinkTreeStrategy#createSymlinks` use it to copy MANIFEST file.

Fixes #16955.

Closes #16972.

PiperOrigin-RevId: 494712456
Change-Id: I9a77063f35e1f6e2559c02612790542e996994b8