### PR TITLE
Add --low_priority_bazelrc

### DIFF
--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -41,8 +41,8 @@ before the command (`build`, `test`, etc).
     This flag is optional but can also be specified multiple times.
 
     `/dev/null` indicates that all further `--low_priority_bazelrc`s will
-    be ignored, which is useful to disable the search for a user rc file,
-    such as in release builds.
+    be ignored, which is useful to disable the search for user-supplied
+    low-priority rc files, such as in release builds.
 
     For example:
 

--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -35,14 +35,32 @@ before the command (`build`, `test`, etc).
     The system-specified location may contain environment variable references,
     such as `${VAR_NAME}` on Unix or `%VAR_NAME%` on Windows.
 
-2.  **The workspace RC file**, unless `--noworkspace_rc` is present.
+2.  **The low-priority user-specified RC file**, if specified with
+    <code>--low_priority_bazelrc=<var>file</var></code>
+
+    This flag is optional but can also be specified multiple times.
+
+    `/dev/null` indicates that all further `--low_priority_bazelrc`s will
+    be ignored, which is useful to disable the search for a user rc file,
+    such as in release builds.
+
+    For example:
+
+    ```
+    --low_priority_bazelrc=x.rc --low_priority_bazelrc=y.rc --low_priority_bazelrc=/dev/null --low_priority_bazelrc=z.rc
+    ```
+
+    - `x.rc` and `y.rc` are read.
+    - `z.rc` is ignored due to the prior `/dev/null`.
+
+3.  **The workspace RC file**, unless `--noworkspace_rc` is present.
 
     Path: `.bazelrc` in your workspace directory (next to the main
     `WORKSPACE` file).
 
     It is not an error if this file does not exist.
 
-3.  **The home RC file**, unless `--nohome_rc` is present.
+4.  **The home RC file**, unless `--nohome_rc` is present.
 
     Path:
 
@@ -51,7 +69,7 @@ before the command (`build`, `test`, etc).
 
     It is not an error if this file does not exist.
 
-4.  **The user-specified RC file**, if specified with
+5.  **The user-specified RC file**, if specified with
     <code>--bazelrc=<var>file</var></code>
 
     This flag is optional but can also be specified multiple times.

--- a/src/main/cpp/bazel_startup_options.h
+++ b/src/main/cpp/bazel_startup_options.h
@@ -38,6 +38,7 @@ class BazelStartupOptions : public StartupOptions {
   std::string GetRcFileBaseName() const override { return ".bazelrc"; }
 
  private:
+  std::string user_low_priority_bazelrc_;
   std::string user_bazelrc_;
   bool use_system_rc;
   bool use_workspace_rc;

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelStartupOptionsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelStartupOptionsModule.java
@@ -47,6 +47,15 @@ public class BazelStartupOptionsModule extends BlazeModule {
                 + "Note: command line options will always supersede any option in bazelrc.")
     public String blazerc;
 
+    @Option(
+            name = "low_priority_bazelrc",
+            defaultValue = "null", // NOTE: purely decorative, rc files are read by the client.
+            documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+            effectTags = {OptionEffectTag.CHANGES_INPUTS},
+            valueHelp = "<path>",
+            help = "Exactly the same semantics as --bazelrc except applied before the workspace bazelrc rather than after.")
+    public String lowPriorityBlazerc;
+
     // For the system_rc, it can be /etc/bazel.bazelrc, or a special Windows value, or can be
     // custom-set by the Bazel distributor. We don't list a known path in the help output in order
     // to avoid misdocumentation here.

--- a/src/test/shell/integration/startup_options_test.sh
+++ b/src/test/shell/integration/startup_options_test.sh
@@ -118,4 +118,17 @@ function test_bazelrc_after_devnull_ignored() {
   expect_not_log "--definitely_invalid_config"
 }
 
+function test_workspace_overrides_low_priority_user_bazelrc() {
+  # Help message only visible with --help_verbosity=medium
+  help_message_in_description="--${PRODUCT_NAME}rc (a string; default: see description)"
+
+  echo "help --help_verbosity=short" > 1.rc
+  bazel "--low_priority_${PRODUCT_NAME}rc=1.rc" help startup_options &> $TEST_log || fail "Should pass"
+  expect_not_log "$help_message_in_description"
+
+  add_to_bazelrc "help --help_verbosity=medium"
+  bazel "--low_priority_${PRODUCT_NAME}rc=1.rc" help startup_options &> $TEST_log || fail "Should pass"
+  expect_log "$help_message_in_description"
+}
+
 run_suite "${PRODUCT_NAME} startup options test"


### PR DESCRIPTION
This startup flag behaves exactly as --bazelrc does, but is applied before the workspace bazelrc rather than after.

This is useful for people who write and distribute bazel wrappers (which appears to be most large companies). This allows a bazel wrapper to supply new _default_ values to flags, which a repo may choose to override.

Without this change, it's impossible for a bazel wrapper to decide to do something like set `--incompatible_enable_cc_toolchain_resolution` because they have no practical way of doing so. if they set this on the command line or in a .bazelrc file passed to the `--bazelrc` flag, it cannot be overridden other than on the command line. This flag allows a wrapper to point at a bazelrc file with extra defaults, which can be overridden in the repo bazelrc file.