### PR TITLE
Move BES upload check earlier, to prevent calling FindMissingBlobs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -212,14 +212,15 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
   }
 
   private boolean shouldUpload(PathMetadata path) {
-    boolean result =
-        path.getDigest() != null && !path.isRemote() && !path.isDirectory() && !path.isOmitted();
+    return path.getDigest() != null && !path.isRemote() && !path.isDirectory() && !path.isOmitted();
+  }
 
+  private boolean shouldUploadBasedOnUploadMode(PathMetadata path) {
     if (remoteBuildEventUploadMode == RemoteBuildEventUploadMode.MINIMAL) {
-      result = result && (isTestLog(path) || isProfile(path));
+      return isTestLog(path) || isProfile(path);
     }
 
-    return result;
+    return true;
   }
 
   private boolean isTestLog(PathMetadata path) {
@@ -236,7 +237,9 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
     List<PathMetadata> filesToQuery = new ArrayList<>();
     Set<Digest> digestsToQuery = new HashSet<>();
     for (PathMetadata path : paths) {
-      if (shouldQuery(path)) {
+      if (!shouldUploadBasedOnUploadMode(path)) {
+        continue;
+      } else if (shouldQuery(path)) {
         filesToQuery.add(path);
         digestsToQuery.add(path.getDigest());
       } else {


### PR DESCRIPTION
Before this change, every file referenced in the BEP would have a `FindMissingBlobs` call, which can be very expensive with hundreds of outputs. This could make `--experimental_remote_build_event_upload=minimal` a performance regression compared to `--experimental_build_event_upload_strategy=local`.