### PR TITLE
Deduplicate android asset dirs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidAssets.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidAssets.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.rules.android;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.analysis.FileProvider;
@@ -78,7 +79,7 @@ public class AndroidAssets {
     }
 
     ImmutableList.Builder<Artifact> assets = ImmutableList.builder();
-    ImmutableList.Builder<PathFragment> assetRoots = ImmutableList.builder();
+    ImmutableSet.Builder<PathFragment> assetRoots = ImmutableSet.builder();
 
     for (TransitiveInfoCollection target : assetTargets) {
       for (Artifact file : target.getProvider(FileProvider.class).getFilesToBuild().toList()) {
@@ -99,7 +100,7 @@ public class AndroidAssets {
       }
     }
 
-    return new AndroidAssets(assets.build(), assetRoots.build(), assetsDir.getPathString());
+    return new AndroidAssets(assets.build(), assetRoots.build().asList(), assetsDir.getPathString());
   }
 
   @Nullable

--- a/src/test/shell/bazel/android/android_integration_test.sh
+++ b/src/test/shell/bazel/android/android_integration_test.sh
@@ -464,4 +464,31 @@ EOF
   fi
 }
 
+function test_lots_of_assets {
+  write_hello_android_files
+  setup_android_sdk_support
+
+  cat > java/com/example/hello/BUILD <<'EOF'
+LONG_PATH = "a" * 200
+RANGE = [str(i) for i in range(5000)]
+
+android_binary(
+    name = "hello",
+    manifest = "AndroidManifest.xml",
+    srcs = glob(["*.java"]),
+    resource_files = glob(["res/**"]),
+    assets_dir = LONG_PATH,
+    assets = [":file" + i for i in RANGE],
+)
+
+[genrule(
+    name = "file" + i,
+    outs = [LONG_PATH + "/" + i],
+    cmd = "touch $@",
+) for i in RANGE]
+EOF
+
+  bazel build java/com/example/hello:hello || fail "build failed"
+}
+
 run_suite "Android integration tests"


### PR DESCRIPTION
This caused a crash in `ResourceProcessorBusyBox` due to running into an OS limit of `Argument list too long`.
There is also a report in bazelbuild/rules_android#314 that this patch can significantly improve resource processing time.

Fixes https://github.com/bazelbuild/rules_android/issues/314