### PR TITLE
Emit events when invocation policy overrides options

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -546,6 +546,11 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
     result.push_back("--invocation_policy=" +
                      startup_options.invocation_policy);
   }
+  if (startup_options.warn_on_invocation_policy_overrides) {
+    result.push_back("--warn_on_invocation_policy_overrides=true");
+  } else {
+    result.push_back("--warn_on_invocation_policy_overrides=false");
+  }
 
   result.push_back("--product_name=" + startup_options.product_name);
 

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -85,6 +85,7 @@ StartupOptions::StartupOptions(const string &product_name,
       connect_timeout_secs(30),
       local_startup_timeout_secs(120),
       have_invocation_policy_(false),
+      warn_on_invocation_policy_overrides(true),
       client_debug(false),
       preemptible(false),
       java_logging_formatter(
@@ -157,6 +158,7 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterUnaryStartupFlag("host_jvm_args");
   RegisterUnaryStartupFlag("host_jvm_profile");
   RegisterUnaryStartupFlag("invocation_policy");
+  RegisterNullaryStartupFlagNoRc("warn_on_invocation_policy_overrides", &warn_on_invocation_policy_overrides);
   RegisterUnaryStartupFlag("io_nice_level");
   RegisterUnaryStartupFlag("install_base");
   RegisterUnaryStartupFlag("macos_qos_class");

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -244,6 +244,9 @@ class StartupOptions {
   // Invocation policy can only be specified once.
   bool have_invocation_policy_;
 
+  // Whether to emit warn events on invocation policy overrides.
+  bool warn_on_invocation_policy_overrides;
+
   // Whether to output addition debugging information in the client.
   bool client_debug;
 

--- a/src/main/java/com/google/devtools/build/lib/events/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/events/BUILD
@@ -16,6 +16,7 @@ java_library(
         "//src/main/java/net/starlark/java/eval",
         "//src/main/java/net/starlark/java/syntax",
         "//third_party:error_prone_annotations",
+        "//third_party:flogger_checked_in",
         "//third_party:guava",
         "//third_party:jsr305",
     ],

--- a/src/main/java/com/google/devtools/build/lib/events/FixedLevelLoggingEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/events/FixedLevelLoggingEventHandler.java
@@ -1,0 +1,23 @@
+package com.google.devtools.build.lib.events;
+
+import com.google.common.flogger.GoogleLogger;
+
+import java.util.logging.Level;
+
+/**
+ * FixedLevelLoggingEventHandler logs events to a GoogleLogger at a fixed level.
+ */
+public class FixedLevelLoggingEventHandler implements EventHandler {
+    private final GoogleLogger logger;
+    private final Level logLevel;
+
+    public FixedLevelLoggingEventHandler(GoogleLogger logger, Level logLevel) {
+        this.logger = logger;
+        this.logLevel = logLevel;
+    }
+
+    @Override
+    public void handle(Event event) {
+        logger.at(logLevel).log("%s", event.getMessage());
+    }
+}

--- a/src/main/java/com/google/devtools/build/lib/events/TeeEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/events/TeeEventHandler.java
@@ -1,0 +1,18 @@
+package com.google.devtools.build.lib.events;
+
+/** TeeEventHandler forwards events to two delegate EventHandlers. */
+public class TeeEventHandler implements EventHandler {
+    private final EventHandler delegate1;
+    private final EventHandler delegate2;
+
+    public TeeEventHandler(EventHandler delegate1, EventHandler delegate2) {
+        this.delegate1 = delegate1;
+        this.delegate2 = delegate2;
+    }
+
+    @Override
+    public void handle(Event event) {
+        delegate1.handle(event);
+        delegate2.handle(event);
+    }
+}

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -302,8 +302,15 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
     BlazeOptionHandler optionHandler =
         new BlazeOptionHandler(
             runtime, workspace, command, commandAnnotation, optionsParser, invocationPolicy);
+    EventHandler invocationPolicyEventHandler =
+        runtime
+                .getStartupOptionsProvider()
+                .getOptions(BlazeServerStartupOptions.class)
+                .warnOnInvocationPolicyOverrides
+            ? storedEventHandler
+            : NullEventHandler.INSTANCE;
     DetailedExitCode earlyExitCode =
-        optionHandler.parseOptions(args, storedEventHandler, storedEventHandler);
+        optionHandler.parseOptions(args, storedEventHandler, invocationPolicyEventHandler);
     OptionsParsingResult options = optionHandler.getOptionsResult();
 
     // The initCommand call also records the start time for the timestamp granularity monitor.

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
+import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.events.PrintingEventHandler;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
@@ -301,7 +302,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
     BlazeOptionHandler optionHandler =
         new BlazeOptionHandler(
             runtime, workspace, command, commandAnnotation, optionsParser, invocationPolicy);
-    DetailedExitCode earlyExitCode = optionHandler.parseOptions(args, storedEventHandler);
+    DetailedExitCode earlyExitCode =
+        optionHandler.parseOptions(args, storedEventHandler, storedEventHandler);
     OptionsParsingResult options = optionHandler.getOptionsResult();
 
     // The initCommand call also records the start time for the timestamp granularity monitor.
@@ -571,7 +573,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
         optionHandler =
             new BlazeOptionHandler(
                 runtime, workspace, command, commandAnnotation, optionsParser, invocationPolicy);
-        earlyExitCode = optionHandler.parseOptions(args, reporter);
+        // We already handled events for flags in the first parse - don't re-emit them.
+        earlyExitCode = optionHandler.parseOptions(args, reporter, NullEventHandler.INSTANCE);
         if (!earlyExitCode.isSuccess()) {
           reporter.post(
               new NoBuildEvent(

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -288,7 +288,10 @@ public final class BlazeOptionHandler {
    *
    * @return {@code DetailedExitCode.success()} if everything went well, or some other value if not
    */
-  DetailedExitCode parseOptions(List<String> args, ExtendedEventHandler eventHandler) {
+  DetailedExitCode parseOptions(
+      List<String> args,
+      ExtendedEventHandler eventHandler,
+      EventHandler invocationPolicyEventHandler) {
     // The initialization code here was carefully written to parse the options early before we call
     // into the BlazeModule APIs, which means we must not generate any output to outErr, return, or
     // throw an exception. All the events happening here are instead stored in a temporary event
@@ -327,7 +330,10 @@ public final class BlazeOptionHandler {
               .build();
       InvocationPolicyEnforcer optionsPolicyEnforcer =
           new InvocationPolicyEnforcer(
-              combinedPolicy, Level.INFO, optionsParser.getConversionContext());
+              combinedPolicy,
+              invocationPolicyEventHandler,
+              Level.INFO,
+              optionsParser.getConversionContext());
       // Enforce the invocation policy. It is intentional that this is the last step in preparing
       // the options. The invocation policy is used in security-critical contexts, and may be used
       // as a last resort to override flags. That means that the policy can override flags set in

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -333,6 +333,16 @@ public class BlazeServerStartupOptions extends OptionsBase {
   public String invocationPolicy;
 
   @Option(
+      name = "warn_on_invocation_policy_overrides",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+      help =
+          "Whether to emit a warning event if a flag's value is overridden by an invocation"
+              + " policy.")
+  public boolean warnOnInvocationPolicyOverrides;
+
+  @Option(
       name = "command_port",
       defaultValue = "0",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CanonicalizeCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CanonicalizeCommand.java
@@ -221,7 +221,7 @@ public final class CanonicalizeCommand implements BlazeCommand {
 
     try {
       InvocationPolicyEnforcer invocationPolicyEnforcer =
-          new InvocationPolicyEnforcer(policy, Level.INFO, mainRepoMapping);
+          new InvocationPolicyEnforcer(policy, env.getReporter(), Level.INFO, mainRepoMapping);
       invocationPolicyEnforcer.enforce(parser, commandName);
 
       if (canonicalizeOptions.showWarnings) {
@@ -233,8 +233,7 @@ public final class CanonicalizeCommand implements BlazeCommand {
       // Print out the canonical invocation policy if requested.
       if (canonicalizeOptions.canonicalizePolicy) {
         InvocationPolicy effectivePolicy =
-            InvocationPolicyEnforcer.getEffectiveInvocationPolicy(
-                policy, parser, commandName, Level.INFO);
+            invocationPolicyEnforcer.getEffectiveInvocationPolicy(policy, parser, commandName);
         env.getReporter().getOutErr().printOutLn(effectivePolicy.toString());
       } else {
         // Otherwise, print out the canonical command line

--- a/src/main/java/com/google/devtools/common/options/BUILD
+++ b/src/main/java/com/google/devtools/common/options/BUILD
@@ -22,6 +22,7 @@ java_library(
     ],
     deps = [
         ":options_internal",
+        "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/protobuf:invocation_policy_java_proto",
         "//third_party:flogger",
         "//third_party:guava",

--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
@@ -265,7 +265,10 @@ public class BlazeRuntimeWrapper {
     // Enforce the test invocation policy once the options have been added
     InvocationPolicyEnforcer optionsPolicyEnforcer =
         new InvocationPolicyEnforcer(
-            runtime.getModuleInvocationPolicy(), Level.FINE, /*conversionContext=*/ null);
+            runtime.getModuleInvocationPolicy(),
+            env.getReporter(),
+            Level.FINE,
+            /*conversionContext=*/ null);
     try {
       optionsPolicyEnforcer.enforce(optionsParser, commandAnnotation.name());
     } catch (OptionsParsingException e) {

--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.buildtool.BuildResult;
 import com.google.devtools.build.lib.buildtool.BuildTool;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
 import com.google.devtools.build.lib.events.util.EventCollectionApparatus;
@@ -185,7 +186,7 @@ public class BlazeRuntimeWrapper {
     additionalOptionsClasses.addAll(
         BlazeCommandUtils.getOptions(
             command, runtime.getBlazeModules(), runtime.getRuleClassProvider()));
-    initializeOptionsParser(commandAnnotation);
+    initializeOptionsParser(commandAnnotation, events.reporter());
     commandCreated = true;
     if (env != null) {
       runtime.afterCommand(env, BlazeCommandResult.success());
@@ -257,7 +258,7 @@ public class BlazeRuntimeWrapper {
    * Initializes a new options parser, parsing all the options set by {@link
    * #addOptions(String...)}.
    */
-  private void initializeOptionsParser(Command commandAnnotation) throws OptionsParsingException {
+  private void initializeOptionsParser(Command commandAnnotation, EventHandler eventHandler) throws OptionsParsingException {
     // Create the options parser and parse all the options collected so far
     optionsParser = createOptionsParser(commandAnnotation);
     optionsParser.parse(optionsToParse);
@@ -266,7 +267,7 @@ public class BlazeRuntimeWrapper {
     InvocationPolicyEnforcer optionsPolicyEnforcer =
         new InvocationPolicyEnforcer(
             runtime.getModuleInvocationPolicy(),
-            env.getReporter(),
+            eventHandler,
             Level.FINE,
             /*conversionContext=*/ null);
     try {

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -423,7 +423,7 @@ public class BlazeOptionHandlerTest {
 
   @Test
   public void testParseOptions_argless() {
-    optionHandler.parseOptions(ImmutableList.of("c0"), eventHandler);
+    optionHandler.parseOptions(ImmutableList.of("c0"), eventHandler, eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
     assertThat(optionHandler.getRcfileNotes()).isEmpty();
@@ -431,7 +431,7 @@ public class BlazeOptionHandlerTest {
 
   @Test
   public void testParseOptions_residue() {
-    optionHandler.parseOptions(ImmutableList.of("c0", "res"), eventHandler);
+    optionHandler.parseOptions(ImmutableList.of("c0", "res"), eventHandler, eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).contains("res");
     assertThat(optionHandler.getRcfileNotes()).isEmpty();
@@ -458,7 +458,7 @@ public class BlazeOptionHandlerTest {
   @Test
   public void testParseOptions_explicitOption() {
     optionHandler.parseOptions(
-        ImmutableList.of("c0", "--test_multiple_string=explicit"), eventHandler);
+        ImmutableList.of("c0", "--test_multiple_string=explicit"), eventHandler, eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
     assertThat(optionHandler.getRcfileNotes()).isEmpty();
@@ -475,6 +475,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0=--test_multiple_string=rc_a",
             "--default_override=0:c0=--test_multiple_string=rc_b",
             "--rc_source=/somewhere/.blazerc"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -498,6 +499,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0=--test_multiple_string=rc1_b",
             "--rc_source=/somewhere/.blazerc",
             "--rc_source=/some/other/.blazerc"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -526,6 +528,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:common=--test_multiple_string=rc1_common",
             "--rc_source=/somewhere/.blazerc",
             "--rc_source=/some/other/.blazerc"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -556,6 +559,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0=--test_multiple_string=rc",
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -578,6 +582,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0=--test_multiple_string=rc_c0_2",
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -607,6 +612,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:common=--test_multiple_string=rc1_common",
             "--rc_source=/somewhere/.blazerc",
             "--rc_source=/some/other/.blazerc"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -639,6 +645,7 @@ public class BlazeOptionHandlerTest {
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit",
             "--config=conf"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -665,6 +672,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0:conf=--test_multiple_string=config",
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -694,6 +702,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:common:other=--test_multiple_string=othercommon",
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -728,6 +737,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0:conf=other",
             "--rc_source=/somewhere/.blazerc",
             "--config=conf"),
+        eventHandler,
         eventHandler);
 
     assertThat(eventHandler.getEvents())
@@ -760,6 +770,7 @@ public class BlazeOptionHandlerTest {
             "--test_multiple_string=explicit1",
             "--config=baz",
             "--test_multiple_string=explicit2"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -811,6 +822,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0:bar=--test_multiple_string=bar",
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit"),
+        eventHandler,
         eventHandler);
     assertThat(parser.getResidue()).isEmpty();
     assertThat(eventHandler.getEvents())
@@ -850,6 +862,7 @@ public class BlazeOptionHandlerTest {
             "--config=baz",
             "--config=foo",
             "--config=bar"),
+        eventHandler,
         eventHandler);
     assertThat(parser.getResidue()).isEmpty();
     assertThat(eventHandler.getEvents())
@@ -890,6 +903,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0:foo=--config=foo",
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(
@@ -911,6 +925,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0:bar=--config=foo",
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(
@@ -933,6 +948,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:common:other=--test_multiple_string=othercommon",
             "--rc_source=/somewhere/.blazerc",
             "--test_multiple_string=explicit"),
+        eventHandler,
         eventHandler);
     assertThat(parser.getResidue()).isEmpty();
     assertThat(eventHandler.getEvents())
@@ -1001,7 +1017,7 @@ public class BlazeOptionHandlerTest {
             .add("--config=alpha")
             .build();
 
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(parser.getResidue()).isEmpty();
     assertThat(optionHandler.getRcfileNotes())
         .containsExactly(
@@ -1056,7 +1072,7 @@ public class BlazeOptionHandlerTest {
             .add("--config=gamma")
             .build();
 
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(parser.getResidue()).isEmpty();
 
     // Expect the second --config=gamma to have started a second chain, and get warnings about both.
@@ -1091,6 +1107,7 @@ public class BlazeOptionHandlerTest {
             "c0",
             "--unconditional_warning",
             "You are forcing this warning to print for no apparent reason"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents())
         .containsExactly(
@@ -1107,6 +1124,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0:conf=--unconditional_warning="
                 + "config \"conf\" is deprecated, please stop using!",
             "--rc_source=/somewhere/.blazerc"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents()).isEmpty();
     assertThat(parser.getResidue()).isEmpty();
@@ -1122,6 +1140,7 @@ public class BlazeOptionHandlerTest {
             "--default_override=0:c0:conf=--unconditional_warning="
                 + "config \"conf\" is deprecated, please stop using!",
             "--rc_source=/somewhere/.blazerc"),
+        eventHandler,
         eventHandler);
     assertThat(eventHandler.getEvents())
         .containsExactly(Event.warn("config \"conf\" is deprecated, please stop using!"));
@@ -1141,6 +1160,7 @@ public class BlazeOptionHandlerTest {
             "--config=conf",
             "--default_override=0:c0:conf=--test_string=fromConf",
             "--rc_source=/somewhere/.blazerc"),
+        eventHandler,
         eventHandler);
     TestOptions parseResult = parser.getOptions(TestOptions.class);
     // In the in-place expansion, the config's expansion has precedence, but issues a warning since
@@ -1167,6 +1187,7 @@ public class BlazeOptionHandlerTest {
             "--test_string=explicitValue",
             "--default_override=0:c0:conf=--test_string=fromConf",
             "--rc_source=/somewhere/.blazerc"),
+        eventHandler,
         eventHandler);
     TestOptions parseResult = parser.getOptions(TestOptions.class);
     assertThat(eventHandler.getEvents()).isEmpty();

--- a/src/test/java/com/google/devtools/build/lib/runtime/FlagAliasTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/FlagAliasTest.java
@@ -58,7 +58,7 @@ public final class FlagAliasTest {
   public void useAliasWithNonStarlarkFlag() {
     ImmutableList<String> args =
         ImmutableList.of("c0", "--rc_source=/somewhere/.blazerc", "--flag_alias=foo=bar");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(
             Event.error(
@@ -70,7 +70,7 @@ public final class FlagAliasTest {
   public void useAliasWithValueAssignment() {
     ImmutableList<String> args =
         ImmutableList.of("c0", "--rc_source=/somewhere/.blazerc", "--flag_alias=foo=//bar=7");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(
             Event.error(
@@ -82,7 +82,7 @@ public final class FlagAliasTest {
   public void useAliasWithInvalidName() {
     ImmutableList<String> args =
         ImmutableList.of("c0", "--rc_source=/somewhere/.blazerc", "--flag_alias=bad$foo=//bar");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(
             Event.error(
@@ -94,7 +94,7 @@ public final class FlagAliasTest {
   public void useAliasWithoutEqualsInValue() {
     ImmutableList<String> args =
         ImmutableList.of("c0", "--rc_source=/somewhere/.blazerc", "--flag_alias=foo");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(
             Event.error(
@@ -106,7 +106,7 @@ public final class FlagAliasTest {
   public void useAliasWithoutEqualsInArg() {
     ImmutableList<String> args =
         ImmutableList.of("c0", "--rc_source=/somewhere/.blazerc", "--flag_alias", "foo=//bar");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.hasErrors()).isFalse();
   }
 
@@ -115,7 +115,7 @@ public final class FlagAliasTest {
     ImmutableList<String> args =
         ImmutableList.of(
             "c0", "--rc_source=/somewhere/.blazerc", "--flag_alias=foo=//bar", "--foo");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(parser.getSkippedArgs()).contains("--//bar");
   }
 
@@ -127,7 +127,7 @@ public final class FlagAliasTest {
             "--rc_source=/somewhere/.blazerc",
             "--flag_alias=foo=//bar",
             "--nofoo");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(Event.error("--nofoo :: Unrecognized option: --nofoo").withTag(BAD_OPTION_TAG));
   }
@@ -143,7 +143,7 @@ public final class FlagAliasTest {
             "--flag_alias=foo=//baz",
             "--foo");
     ImmutableList<String> expectedSkippedArgs = ImmutableList.of("--//bar", "--//baz");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(parser.getSkippedArgs()).isEqualTo(expectedSkippedArgs);
   }
 
@@ -156,7 +156,7 @@ public final class FlagAliasTest {
             "--default_override=0:c0=--foo",
             "--rc_source=/somewhere/.blazerc");
     ImmutableList<String> expectedSkippedArgs = ImmutableList.of("--//bar");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(parser.getSkippedArgs()).isEqualTo(expectedSkippedArgs);
   }
 
@@ -169,7 +169,7 @@ public final class FlagAliasTest {
             "--rc_source=/somewhere/.blazerc",
             "--foo");
     ImmutableList<String> expectedSkippedArgs = ImmutableList.of("--//bar");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(parser.getSkippedArgs()).isEqualTo(expectedSkippedArgs);
   }
 
@@ -179,7 +179,7 @@ public final class FlagAliasTest {
         ImmutableList.of(
             "c0", "--rc_source=/somewhere/.blazerc", "--flag_alias=foo=//bar", "--foo=7");
     ImmutableList<String> expectedSkippedArgs = ImmutableList.of("--//bar=7");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(parser.getSkippedArgs()).isEqualTo(expectedSkippedArgs);
   }
 
@@ -187,7 +187,7 @@ public final class FlagAliasTest {
   @Test
   public void aliasLogicSkipsNonDoubleDashArgs() {
     ImmutableList<String> args = ImmutableList.of("c0", "--rc_source=/somewhere/.blazerc", "-=");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(Event.error("-= :: Unrecognized option: -=").withTag(BAD_OPTION_TAG));
   }
@@ -200,7 +200,7 @@ public final class FlagAliasTest {
             "--default_override=0:c0=--foo=7",
             "--rc_source=/somewhere/.blazerc",
             "--flag_alias=foo=//bar");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(Event.error("--foo=7 :: Unrecognized option: --foo=7").withTag(BAD_OPTION_TAG));
   }
@@ -210,7 +210,7 @@ public final class FlagAliasTest {
     ImmutableList<String> args =
         ImmutableList.of(
             "c0", "--rc_source=/somewhere/.blazerc", "--foo=7", "--flag_alias=foo=//bar");
-    optionHandler.parseOptions(args, eventHandler);
+    optionHandler.parseOptions(args, eventHandler, eventHandler);
     assertThat(eventHandler.getEvents())
         .contains(Event.error("--foo=7 :: Unrecognized option: --foo=7").withTag(BAD_OPTION_TAG));
   }

--- a/src/test/java/com/google/devtools/common/options/BUILD
+++ b/src/test/java/com/google/devtools/common/options/BUILD
@@ -22,6 +22,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/java/com/google/devtools/common/options:invocation_policy",
         "//src/main/protobuf:invocation_policy_java_proto",

--- a/src/test/java/com/google/devtools/common/options/InvocationPolicyEnforcerTestBase.java
+++ b/src/test/java/com/google/devtools/common/options/InvocationPolicyEnforcerTestBase.java
@@ -16,6 +16,7 @@ package com.google.devtools.common.options;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.BaseEncoding;
+import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.runtime.BlazeServerStartupOptions;
 import com.google.devtools.build.lib.runtime.proto.InvocationPolicyOuterClass.InvocationPolicy;
 import java.io.ByteArrayOutputStream;
@@ -64,6 +65,7 @@ public class InvocationPolicyEnforcerTestBase {
     return new InvocationPolicyEnforcer(
         InvocationPolicyParser.parsePolicy(
             startupOptionsParser.getOptions(BlazeServerStartupOptions.class).invocationPolicy),
+            NullEventHandler.INSTANCE,
         Level.INFO,
         /*conversionContext=*/ null);
   }


### PR DESCRIPTION
Prior to this commit, messages were only logged to the server log indicating that user input was being ignored. This is a place users don't tend to look (or even know about) when debugging issues.

With this commit, we still log there, but additionally emit events to the console, which users are much more likely to notice.

Example output:
```console
% bazel --invocation_policy='flag_policies { flag_name: "test_env" set_value { flag_value: "SET_FROM_FLAG=by-policy" behavior: FINAL_VALUE_IGNORE_OVERRIDES } }' test :test --test_env=SET_FROM_FLAG=from-flag
WARNING: Setting value for option '--test_env' from invocation policy to 'SET_FROM_FLAG=by-policy', overriding value '[SET_FROM_FLAG=from-bazelrc, SET_FROM_FLAG=from-flag]' from '/path/to/.bazelrc, command line options'
INFO: Invocation ID: bdfa6f27-a7d8-4b2b-9b45-f2f4b1f905fc
...
```