### PR TITLE
Report `AspectCreationException` to the user

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -465,6 +465,10 @@ public final class ConfiguredTargetFunction implements SkyFunction {
       }
       throw new ReportedException(e);
     } catch (AspectCreationException e) {
+      if (!e.getMessage().isEmpty()) {
+        // Report the error to the user.
+        env.getListener().handle(Event.error(null, e.getMessage()));
+      }
       throw new ReportedException(
           new ConfiguredValueCreationException(
               targetAndConfiguration, e.getMessage(), e.getCauses(), e.getDetailedExitCode()));


### PR DESCRIPTION
Since ec4be003ec328ca593e93a724947259a5330a476, `AspectCreationException`s are no longer reported to the user, resulting in error messages such as:

```
ERROR: Analysis of target '//pkg:foo' failed; build aborted:
```

With this commit, the error looks like this instead:

```
ERROR: Evaluation of aspect //aspects:aspects.bzl%my_aspect on //pkg:foo failed: <causes...>
```

Context: https://github.com/bazelbuild/bazel-central-registry/pull/327