### PR TITLE
Naming inconsistency fixed : stripPrefix -> strip_prefix

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -473,7 +473,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       Object output,
       String stripPrefix,
       String strip_prefix,
-      Dict<?, ?> renameFiles, // <String, String> expected
+      Dict<?, ?> renameFiles, //  <String, String> expected
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     StarlarkPath archivePath = getPath("extract()", archive);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -472,12 +472,12 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       Object archive,
       Object output,
       String stripPrefix,
-      String strip_prefix,
+      // String strip_prefix,
       Dict<?, ?> renameFiles, // <String, String> expected
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     StarlarkPath archivePath = getPath("extract()", archive);
-    stripPrefix = (stripPrefix=="''") ? (strip_prefix) : (stripPrefix) ;
+    // stripPrefix = (stripPrefix=="''") ? (strip_prefix) : (stripPrefix) ;
 
     if (!archivePath.exists()) {
       throw new RepositoryFunctionException(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -445,6 +445,17 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
                     + " <code>build_file</code>, this field can be used to strip it from extracted"
                     + " files."),
         @Param(
+            name = "strip_prefix",
+            defaultValue = "''",
+            named = true,
+            doc =
+                "a directory prefix to strip from the extracted files."
+                    + "\nMany archives contain a top-level directory that contains all files in the"
+                    + " archive. Instead of needing to specify this prefix over and over in the"
+                    + " <code>build_file</code>, this field can be used to strip it from extracted"
+                    + " files."
+        ),
+        @Param(
             name = "rename_files",
             defaultValue = "{}",
             named = true,
@@ -460,6 +471,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       Object archive,
       Object output,
       String stripPrefix,
+      String strip_prefix,
       Dict<?, ?> renameFiles, // <String, String> expected
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
@@ -481,11 +493,13 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
             archive.toString(),
             output.toString(),
             stripPrefix,
+            strip_prefix,
             renameFilesMap,
             getIdentifyingStringForLogging(),
             thread.getCallerLocation());
     env.getListener().post(w);
 
+    stripPrefix = (stripPrefix=="''") ? (strip_prefix) : (stripPrefix) ;
     env.getListener()
         .post(
             new ExtractProgress(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -467,6 +467,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
                     + " contain non-Unicode filenames, or which have files that would extract to"
                     + " the same path on case-insensitive filesystems."),
       })
+
   public void extract(
       Object archive,
       Object output,
@@ -476,6 +477,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     StarlarkPath archivePath = getPath("extract()", archive);
+    stripPrefix = (stripPrefix=="''") ? (strip_prefix) : (stripPrefix) ;
 
     if (!archivePath.exists()) {
       throw new RepositoryFunctionException(
@@ -493,13 +495,11 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
             archive.toString(),
             output.toString(),
             stripPrefix,
-            strip_prefix,
             renameFilesMap,
             getIdentifyingStringForLogging(),
             thread.getCallerLocation());
     env.getListener().post(w);
 
-    stripPrefix = (stripPrefix=="''") ? (strip_prefix) : (stripPrefix) ;
     env.getListener()
         .post(
             new ExtractProgress(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -472,12 +472,12 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       Object archive,
       Object output,
       String stripPrefix,
-      // String strip_prefix,
+      String strip_prefix,
       Dict<?, ?> renameFiles, // <String, String> expected
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     StarlarkPath archivePath = getPath("extract()", archive);
-    // stripPrefix = (stripPrefix=="''") ? (strip_prefix) : (stripPrefix) ;
+    stripPrefix = (stripPrefix=="''") ? (strip_prefix) : (stripPrefix) ;
 
     if (!archivePath.exists()) {
       throw new RepositoryFunctionException(

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -1549,7 +1549,7 @@ public class ByteStreamUploaderTest {
   }
 
   /**
-   * An byte stream service where an upload for a given blob may or may not fail on the first
+   * A byte stream service where an upload for a given blob may or may not fail on the first
    * attempt but is guaranteed to succeed on the second try.
    */
   static class MaybeFailOnceUploadService extends ByteStreamImplBase {


### PR DESCRIPTION
Correction for the inconsistency mentioned at { https://github.com/bazelbuild/bazel/issues/16496 }.