### PR TITLE
Update ctexplain to run with bazel and newer python versions

### DIFF
--- a/third_party/py/frozendict/frozendict/__init__.py
+++ b/third_party/py/frozendict/frozendict/__init__.py
@@ -9,11 +9,15 @@ try:
 except ImportError:  # python < 2.7
     OrderedDict = NotImplemented
 
+try:
+    from collections import Mapping
+except ImportError:
+    from collections.abc import Mapping
 
 iteritems = getattr(dict, 'iteritems', dict.items) # py2-3 compatibility
 
 
-class frozendict(collections.Mapping):
+class frozendict(Mapping):
     """
     An immutable wrapper around dictionaries that implements the complete :py:class:`collections.Mapping`
     interface. It can be used as a drop-in replacement for dictionaries where immutability is desired.

--- a/tools/ctexplain/analyses/summary.py
+++ b/tools/ctexplain/analyses/summary.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from tools.ctexplain.types import ConfiguredTarget
 # Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.util as util
 
+import tools.ctexplain.util as util
+
 
 @dataclass(frozen=True)
 class _Summary():

--- a/tools/ctexplain/lib.py
+++ b/tools/ctexplain/lib.py
@@ -16,6 +16,7 @@ from typing import Tuple
 
 # Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.bazel_api as bazel_api
 from tools.ctexplain.types import ConfiguredTarget
+import tools.ctexplain.bazel_api as bazel_api
 
 
 def analyze_build(bazel: bazel_api.BazelApi, labels: Tuple[str, ...],


### PR DESCRIPTION
Use "bazel" instead of "blaze" as default binary.

Add option to specify bazel binary.

Import bazel_api, lib, util and summary from qualified path to avoid collisions for users using this as a module. It also requires fewer entries in PYTHONPATH.

Updated to run with Python 3.10. "Mapping" has been moved from collections to collections.abc.

Cope with spaces in label name for cquery output. Regular expression is used instead of split.