### PR TITLE
Handle CcInfo's from rules/aspects that didn't create them

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -395,6 +395,10 @@ def _filter_libraries_that_are_linked_dynamically(ctx, cc_linking_context, cpp_c
                 linked_statically_but_not_exported.setdefault(link_once_static_libs_map[owner], []).append(owner)
             else:
                 static_linker_inputs.append(linker_input)
+        else:
+            # This branch is taken when a library has an owner label from another rule, such as a
+            # rule that uses the CcInfo created by an aspect.
+            static_linker_inputs.append(linker_input)
 
     throw_linked_but_not_exported_errors(linked_statically_but_not_exported)
 


### PR DESCRIPTION
This happens when a rule returns the CcInfo from another rule or from an aspect. Open source example: https://github.com/protocolbuffers/upb/blob/main/bazel/upb_proto_library.bzl#L243