### PR TITLE
Note that bazel-bin does not change by transitions

### DIFF
--- a/site/en/remote/output-directories.md
+++ b/site/en/remote/output-directories.md
@@ -68,7 +68,7 @@ The directories are laid out as follows:
 &lt;workspace-name&gt;/                         <== The workspace directory
   bazel-my-project => <...my-project>     <== Symlink to execRoot
   bazel-out => <...bin>                   <== Convenience symlink to outputPath
-  bazel-bin => <...bin>                   <== Convenience symlink to most recent written bin dir $(BINDIR)
+  bazel-bin => <...bin>                   <== Convenience symlink to most recent written bin dir (excluding transitions) $(BINDIR)
   bazel-testlogs => <...testlogs>         <== Convenience symlink to the test logs directory
 
 /home/user/.cache/bazel/                  <== Root for all Bazel output on a machine: outputRoot

--- a/site/en/remote/output-directories.md
+++ b/site/en/remote/output-directories.md
@@ -68,7 +68,7 @@ The directories are laid out as follows:
 &lt;workspace-name&gt;/                         <== The workspace directory
   bazel-my-project => <...my-project>     <== Symlink to execRoot
   bazel-out => <...bin>                   <== Convenience symlink to outputPath
-  bazel-bin => <...bin>                   <== Convenience symlink to most recent written bin dir (excluding transitions) $(BINDIR)
+  bazel-bin => <...bin>                   <== Convenience symlink to most recent (excluding transitions) written bin dir $(BINDIR)
   bazel-testlogs => <...testlogs>         <== Convenience symlink to the test logs directory
 
 /home/user/.cache/bazel/                  <== Root for all Bazel output on a machine: outputRoot


### PR DESCRIPTION
A user was recently confused why something they built through a transition was not found in bazel-bin, despite the docs saying bazel-bin contains the "most recent written bin dir".

With configuration transitions, outputs can be written to multiple bin dirs so "most recent" is a bit meaningless. Add note that "most recent" excludes transitions.