### PR TITLE
ByteStreamUploader: add resourceName to error msg

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -310,13 +310,15 @@ class ByteStreamUploader {
 
         throw new IOException(
             format(
-                "compressed write incomplete: committed_size %d is" + " neither -1 nor total %d",
-                committedSize, expected));
+                "compressed write incomplete: committed_size %d is neither -1 nor total %d - %s",
+                committedSize, expected, resourceName));
       }
 
       // Uncompressed upload failed.
       throw new IOException(
-          format("write incomplete: committed_size %d for %d total", committedSize, expected));
+          format(
+              "write incomplete: committed_size %d for %d total - %s",
+              committedSize, expected, resourceName));
     }
 
     /**


### PR DESCRIPTION
It's difficult to debug such issues without the digest.

Change-Id: I8f300af521eb232b507bcd03016df1681d98b09a