### PR TITLE
Remove --apple_platforms applying to host

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -510,7 +510,6 @@ public class AppleCommandLineOptions extends FragmentOptions {
     exec.preferMutualXcode = preferMutualXcode;
     exec.includeXcodeExecutionRequirements = includeXcodeExecutionRequirements;
     exec.appleCrosstoolTop = appleCrosstoolTop;
-    exec.applePlatforms = applePlatforms;
     exec.incompatibleUseToolchainResolution = incompatibleUseToolchainResolution;
 
     // Save host option for further use.


### PR DESCRIPTION
If you're targeting an Apple platform like
`--apple_platforms=:ios_something`, you don't want this to apply to the host configuration, since that implies your host would be iOS as well. Today this was ignored because `applePlatformType` is hard coded to macOS a few lines up, but this still affects the configuration in a way you wouldn't expect.