### PR TITLE
Use remap_paths to android_tools

### DIFF
--- a/src/test/shell/BUILD
+++ b/src/test/shell/BUILD
@@ -29,6 +29,7 @@ gen_workspace_stanza(
         "rules_cc",
         "rules_java",
         "rules_license",
+        "rules_pkg",
         "rules_proto",
     ],
     template = "testenv.sh.tmpl",

--- a/src/test/shell/testenv.sh.tmpl
+++ b/src/test/shell/testenv.sh.tmpl
@@ -548,6 +548,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 EOF
 }
 
+function add_rules_pkg_to_workspace() {
+  cat >> "$1"<<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+{rules_pkg}
+EOF
+}
+
 function add_rules_proto_to_workspace() {
   cat >> "$1"<<EOF
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -569,6 +577,7 @@ EOF
   add_rules_cc_to_workspace "WORKSPACE"
   add_rules_java_to_workspace "WORKSPACE"
   add_rules_license_to_workspace "WORKSPACE"
+  add_rules_pkg_to_workspace "WORKSPACE"
   add_rules_proto_to_workspace "WORKSPACE"
 
   maybe_setup_python_windows_workspace

--- a/tools/android/runtime_deps/BUILD.bazel
+++ b/tools/android/runtime_deps/BUILD.bazel
@@ -4,7 +4,7 @@
 # extract all Android rules and tools out of Bazel and into rules_android
 # and tools_android.
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 filegroup(
     name = "srcs",
@@ -84,5 +84,9 @@ pkg_tar(
         "//src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:ImportDepsChecker_deploy.jar",
         "//src/tools/android/java/com/google/devtools/build/android:all_android_tools_deploy.jar",
     ],
+    remap_paths = {
+        "src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:ImportDepsChecker_deploy.jar": "ImportDepsChecker_deploy.jar",
+        "src/tools/android/java/com/google/devtools/build/android:all_android_tools_deploy.jar": "all_android_tools_deploy.jar",
+    },
     visibility = ["//src/test/shell/bazel:__subpackages__"],
 )


### PR DESCRIPTION
This ensures that the `all_android_tools_deploy.jar` and `ImportDepsChecker_deploy.jar` artifacts end up in the root of the `tar` where `exports_files` is able to reference them.

Before this PR the tar had the following directory structure:
```
  ./
  ./BUILD
  ./WORKSPACE
  ./desugar_jdk_libs.jar
  ./version.txt
  ./src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/ImportDepsChecker_deploy.jar
  ./src/tools/android/java/com/google/devtools/build/android/all_android_tools_deploy.jar
```


After:
```
  BUILD
  ImportDepsChecker_deploy.jar
  WORKSPACE
  all_android_tools_deploy.jar
  desugar_jdk_libs.jar
  version.txt
```