### PR TITLE
have 'bazel test' non-test targets depend on --remote_download_output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ToplevelArtifactsDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ToplevelArtifactsDownloader.java
@@ -184,9 +184,9 @@ public class ToplevelArtifactsDownloader {
           if (configuredTarget instanceof RuleConfiguredTarget) {
             var ruleConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
             var isTestRule = isTestRuleName(ruleConfiguredTarget.getRuleClassString());
-            return !isTestRule;
+            return !isTestRule && downloadToplevel;
           }
-          return true;
+          return downloadToplevel;
         } catch (InterruptedException ignored) {
           Thread.currentThread().interrupt();
           return false;


### PR DESCRIPTION
This fixes https://github.com/bazelbuild/bazel/issues/17190