### PR TITLE
Add path stripping to Java, spawn action keys

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -466,6 +466,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     }
     env.addTo(fp);
     fp.addStringMap(getExecutionInfo());
+    fp.addBoolean(stripOutputPaths);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -238,6 +238,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     }
     env.addTo(fp);
     fp.addStringMap(executionInfo);
+    fp.addBoolean(stripOutputPaths());
   }
 
   /**


### PR DESCRIPTION
This fixes a small incremental build issue with `--experimental_output_paths`:

Bazel uses action keys in its local action cache. Before running an action, it looks at:

- the action's input paths and digests
- the action's output paths and digests
- the action key (which identifies the action's semantics)

to determine if Bazel already ran that action with the same inputs and outputs already on the filesystem.

Without this fix, toggling path stripping won't invalidate the action cache. That means if you have a build that works normally but fails with path stripping, you can incorrectly get success on both builds:

```
$ bazel clean
$ bazel build //:MyJavaBinary --strategy Javac=worker,standalone
  <succeeds as a normal build>
$ bazel build //:MyJavaBinary --strategy Javac=worker,standalone --experimental_output_paths=strip
  <should fail because path stripping doesn't yet support local execution. But still succeeds!>
```

In contrast:

```
$ bazel clean
$ bazel build //:MyJavaBinary --strategy Javac=worker,standalone --experimental_output_paths=strip
  <fails as expected>
```

This second run fails as expected because the local action cache doesn't short-circuit the build.

You can test this phenomenon further by building with `--nouse_action_cache`.

For https://github.com/bazelbuild/bazel/issues/6526.