### PR TITLE
docs: add default to repository_cache flag help

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -42,7 +42,8 @@ public class RepositoryOptions extends OptionsBase {
       help =
           "Specifies the cache location of the downloaded values obtained "
               + "during the fetching of external repositories. An empty string "
-              + "as argument requests the cache to be disabled.")
+              + "as argument requests the cache to be disabled, "
+              + "otherwise the default of '<output_user_root>/cache/repos/v1' is used")
   public PathFragment experimentalRepositoryCache;
 
   @Option(


### PR DESCRIPTION
The docs currently state "default: see description" for the `--repository_cache` flag, but the description doesn't state the default, just the use of an empty value.