### PR TITLE
[6.1.0]Do not count tests as failed that have not started

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifier.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifier.java
@@ -216,7 +216,8 @@ public class TerminalTestResultNotifier implements TestResultNotifier {
     for (TestSummary summary : summaries) {
       if (TestResult.isBlazeTestStatusPassed(summary.getStatus())) {
         stats.passCount++;
-      } else if (summary.getStatus() == BlazeTestStatus.NO_STATUS) {
+      } else if (summary.getStatus() == BlazeTestStatus.NO_STATUS
+          || summary.getStatus() == BlazeTestStatus.BLAZE_HALTED_BEFORE_TESTING) {
         stats.noStatusCount++;
       } else if (summary.getStatus() == BlazeTestStatus.FAILED_TO_BUILD) {
         stats.failedToBuildCount++;


### PR DESCRIPTION
Before this commit, when the user interrupted a test run, tests that had not started until that point were counted as failed, whereas tests that were already running were counted as skipped.

With this commmit, both types of tests are counted as skipped.

Closes #17160.

PiperOrigin-RevId: 501495265
Change-Id: I4dd157c32d70eb46a02070251684899b84c9802e