### PR TITLE
Update R8 3.3.28 -> 4.0.48

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,20 +126,20 @@ distdir_tar(
     archives = [
         "android_tools_pkg-0.27.0.tar.gz",
         # for android_gmaven_r8
-        "r8-3.3.28.jar",
+        "r8-4.0.48.jar",
     ],
     dirname = "derived/distdir",
     dist_deps = {dep: attrs for dep, attrs in DIST_DEPS.items() if "additional_distfiles" in attrs["used_in"]},
     sha256 = {
         "android_tools_pkg-0.27.0.tar.gz": "1afa4b7e13c82523c8b69e87f8d598c891ec7e2baa41d9e24e08becd723edb4d",
-        "r8-3.3.28.jar": "8626ca32fb47aba7fddd2c897615e2e8ffcdb4d4b213572a2aefb3f838f01972",
+        "r8-4.0.48.jar": "f77d9a9ebda9e32092eac4dd8e11644a7362dfa60ed6a3a9d0d32de570bbf524",
     },
     urls = {
         "android_tools_pkg-0.27.0.tar.gz": [
             "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.27.0.tar.gz",
         ],
-        "r8-3.3.28.jar": [
-            "https://maven.google.com/com/android/tools/r8/3.3.28/r8-3.3.28.jar",
+        "r8-4.0.48.jar": [
+            "https://maven.google.com/com/android/tools/r8/4.0.48/r8-4.0.48.jar",
         ],
     },
 )
@@ -290,20 +290,20 @@ distdir_tar(
     name = "test_WORKSPACE_files",
     archives = [
         "android_tools_pkg-0.27.0.tar.gz",
-        "r8-3.3.28.jar",
+        "r8-4.0.48.jar",
     ],
     dirname = "test_WORKSPACE/distdir",
     dist_deps = {dep: attrs for dep, attrs in DIST_DEPS.items() if "test_WORKSPACE_files" in attrs["used_in"]},
     sha256 = {
         "android_tools_pkg-0.27.0.tar.gz": "1afa4b7e13c82523c8b69e87f8d598c891ec7e2baa41d9e24e08becd723edb4d",
-        "r8-3.3.28.jar": "8626ca32fb47aba7fddd2c897615e2e8ffcdb4d4b213572a2aefb3f838f01972",
+        "r8-4.0.48.jar": "f77d9a9ebda9e32092eac4dd8e11644a7362dfa60ed6a3a9d0d32de570bbf524",
     },
     urls = {
         "android_tools_pkg-0.27.0.tar.gz": [
             "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.27.0.tar.gz",
         ],
-        "r8-3.3.28.jar": [
-            "https://maven.google.com/com/android/tools/r8/3.3.28/r8-3.3.28.jar",
+        "r8-4.0.48.jar": [
+            "https://maven.google.com/com/android/tools/r8/4.0.48/r8-4.0.48.jar",
         ],
     },
 )
@@ -330,8 +330,8 @@ http_archive(
 # and tools/android/android_extensions.bzl
 http_jar(
     name = "android_gmaven_r8_for_testing",
-    sha256 = "8626ca32fb47aba7fddd2c897615e2e8ffcdb4d4b213572a2aefb3f838f01972",
-    url = "https://maven.google.com/com/android/tools/r8/3.3.28/r8-3.3.28.jar",
+    sha256 = "f77d9a9ebda9e32092eac4dd8e11644a7362dfa60ed6a3a9d0d32de570bbf524",
+    url = "https://maven.google.com/com/android/tools/r8/4.0.48/r8-4.0.48.jar",
 )
 
 dist_http_archive(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -13,6 +13,6 @@ maybe(
 maybe(
     http_jar,
     name = "android_gmaven_r8",
-    sha256 = "8626ca32fb47aba7fddd2c897615e2e8ffcdb4d4b213572a2aefb3f838f01972",
-    url = "https://maven.google.com/com/android/tools/r8/3.3.28/r8-3.3.28.jar",
+    sha256 = "f77d9a9ebda9e32092eac4dd8e11644a7362dfa60ed6a3a9d0d32de570bbf524",
+    url = "https://maven.google.com/com/android/tools/r8/4.0.48/r8-4.0.48.jar",
 )

--- a/tools/android/android_extensions.bzl
+++ b/tools/android/android_extensions.bzl
@@ -24,8 +24,8 @@ def _remote_android_tools_extensions_impl(_ctx):
     )
     http_jar(
         name = "android_gmaven_r8",
-        sha256 = "8626ca32fb47aba7fddd2c897615e2e8ffcdb4d4b213572a2aefb3f838f01972",
-        url = "https://maven.google.com/com/android/tools/r8/3.3.28/r8-3.3.28.jar",
+        sha256 = "f77d9a9ebda9e32092eac4dd8e11644a7362dfa60ed6a3a9d0d32de570bbf524",
+        url = "https://maven.google.com/com/android/tools/r8/4.0.48/r8-4.0.48.jar",
     )
 
 remote_android_tools_extensions = module_extension(


### PR DESCRIPTION
Pulling in the latest official release of R8 now that the jars have been pushed to [maven.google.com](https://maven.google.com/web/index.html?q=r8#com.android.tools:r8:4.0.48)