### PR TITLE
[6.1.0]Use long executable path instead of `argv[0]` in all launchers

### DIFF
--- a/site/en/extending/rules.md
+++ b/site/en/extending/rules.md
@@ -715,8 +715,8 @@ When an executable target is run with `bazel run` (or `test`), the root of the
 runfiles directory is adjacent to the executable. The paths relate as follows:
 
 ```python
-# Given executable_file and runfile_file:
-runfiles_root = executable_file.path + ".runfiles"
+# Given launcher_path and runfile_file:
+runfiles_root = launcher_path.path + ".runfiles"
 workspace_name = ctx.workspace_name
 runfile_path = runfile_file.short_path
 execution_root_relative_path = "%s/%s/%s" % (

--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -616,21 +616,24 @@ class LauncherTest(test_base.TestBase):
     if not self.IsWindows():
       return
     self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
-    self.ScratchFile('bin/BUILD', [
-        'java_binary(',
-        '  name = "bin_java",',
-        '  srcs = ["Main.java"],',
-        '  main_class = "Main",',
-        ')',
-        'sh_binary(',
-        '  name = "bin_sh",',
-        '  srcs = ["main.sh"],',
-        ')',
-        'py_binary(',
-        '  name = "bin_py",',
-        '  srcs = ["bin_py.py"],',
-        ')',
-    ])
+    self.ScratchFile(
+        'bin/BUILD',
+        [
+            'java_binary(',
+            '  name = "not_short_bin_java",',
+            '  srcs = ["Main.java"],',
+            '  main_class = "Main",',
+            ')',
+            'sh_binary(',
+            '  name = "not_short_bin_sh",',
+            '  srcs = ["main.sh"],',
+            ')',
+            'py_binary(',
+            '  name = "not_short_bin_py",',
+            '  srcs = ["not_short_bin_py.py"],',
+            ')',
+        ],
+    )
     self.ScratchFile('bin/Main.java', [
         'public class Main {',
         '  public static void main(String[] args) {'
@@ -641,9 +644,12 @@ class LauncherTest(test_base.TestBase):
     self.ScratchFile('bin/main.sh', [
         'echo "helloworld"',
     ])
-    self.ScratchFile('bin/bin_py.py', [
-        'print("helloworld")',
-    ])
+    self.ScratchFile(
+        'bin/not_short_bin_py.py',
+        [
+            'print("helloworld")',
+        ],
+    )
 
     exit_code, stdout, stderr = self.RunBazel(['info', 'bazel-bin'])
     self.AssertExitCode(exit_code, 0, stderr)
@@ -656,49 +662,130 @@ class LauncherTest(test_base.TestBase):
     long_dir_path = './' + '/'.join(
         [(c * 8 + '.' + c * 3) for c in string.ascii_lowercase])
 
+    # The 'not_short_' prefix ensures that the basenames are not already 8.3
+    # short paths. Due to the long directory path, the basename will thus be
+    # replaced with a short path such as "not_sh~1.exe" below.
     for f in [
-        'bin_java.exe',
-        'bin_java.exe.runfiles_manifest',
-        'bin_sh.exe',
-        'bin_sh',
-        'bin_sh.exe.runfiles_manifest',
-        'bin_py.exe',
-        'bin_py.zip',
-        'bin_py.exe.runfiles_manifest',
+        'not_short_bin_java.exe',
+        'not_short_bin_java.exe.runfiles_manifest',
+        'not_short_bin_sh.exe',
+        'not_short_bin_sh',
+        'not_short_bin_sh.exe.runfiles_manifest',
+        'not_short_bin_py.exe',
+        'not_short_bin_py.zip',
+        'not_short_bin_py.exe.runfiles_manifest',
     ]:
       self.CopyFile(
           os.path.join(bazel_bin, 'bin', f), os.path.join(long_dir_path, f))
 
-    long_binary_path = os.path.abspath(long_dir_path + '/bin_java.exe')
+    long_binary_path = os.path.abspath(
+        long_dir_path + '/not_short_bin_java.exe'
+    )
     # subprocess doesn't support long path without shell=True
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
     # Make sure we can launch the binary with a shortened Windows 8dot3 path
     short_binary_path = win32api.GetShortPathName(long_binary_path)
+    self.assertIn('~', os.path.basename(short_binary_path))
     exit_code, stdout, stderr = self.RunProgram([short_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
 
-    long_binary_path = os.path.abspath(long_dir_path + '/bin_sh.exe')
+    long_binary_path = os.path.abspath(long_dir_path + '/not_short_bin_sh.exe')
     # subprocess doesn't support long path without shell=True
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
     # Make sure we can launch the binary with a shortened Windows 8dot3 path
     short_binary_path = win32api.GetShortPathName(long_binary_path)
+    self.assertIn('~', os.path.basename(short_binary_path))
     exit_code, stdout, stderr = self.RunProgram([short_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
 
-    long_binary_path = os.path.abspath(long_dir_path + '/bin_py.exe')
+    long_binary_path = os.path.abspath(long_dir_path + '/not_short_bin_py.exe')
     # subprocess doesn't support long path without shell=True
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
     # Make sure we can launch the binary with a shortened Windows 8dot3 path
     short_binary_path = win32api.GetShortPathName(long_binary_path)
+    self.assertIn('~', os.path.basename(short_binary_path))
     exit_code, stdout, stderr = self.RunProgram([short_binary_path], shell=True)
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertEqual('helloworld', ''.join(stdout))
+
+  def testWindowsNativeLauncherInvalidArgv0(self):
+    if not self.IsWindows():
+      return
+    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
+    self.ScratchFile(
+        'bin/BUILD',
+        [
+            'java_binary(',
+            '  name = "bin_java",',
+            '  srcs = ["Main.java"],',
+            '  main_class = "Main",',
+            ')',
+            'sh_binary(',
+            '  name = "bin_sh",',
+            '  srcs = ["main.sh"],',
+            ')',
+            'py_binary(',
+            '  name = "bin_py",',
+            '  srcs = ["bin_py.py"],',
+            ')',
+        ],
+    )
+    self.ScratchFile(
+        'bin/Main.java',
+        [
+            'public class Main {',
+            (
+                '  public static void main(String[] args) {'
+                '    System.out.println("helloworld");'
+            ),
+            '  }',
+            '}',
+        ],
+    )
+    self.ScratchFile(
+        'bin/main.sh',
+        [
+            'echo "helloworld"',
+        ],
+    )
+    self.ScratchFile(
+        'bin/bin_py.py',
+        [
+            'print("helloworld")',
+        ],
+    )
+
+    exit_code, stdout, stderr = self.RunBazel(['info', 'bazel-bin'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    bazel_bin = stdout[0]
+
+    exit_code, _, stderr = self.RunBazel(['build', '//bin/...'])
+    self.AssertExitCode(exit_code, 0, stderr)
+
+    exit_code, stdout, stderr = self.RunProgram(
+        ['C:\\Invalid'],
+        executable=os.path.join(bazel_bin, 'bin', 'bin_java.exe'),
+    )
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertEqual('helloworld', ''.join(stdout))
+
+    exit_code, stdout, stderr = self.RunProgram(
+        ['C:\\Invalid'], executable=os.path.join(bazel_bin, 'bin', 'bin_sh.exe')
+    )
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertEqual('helloworld', ''.join(stdout))
+
+    exit_code, stdout, stderr = self.RunProgram(
+        ['C:\\Invalid'], executable=os.path.join(bazel_bin, 'bin', 'bin_py.exe')
+    )
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
 

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -52,11 +52,7 @@ ExitCode BashBinaryLauncher::Launch() {
 
   vector<wstring> origin_args = this->GetCommandlineArguments();
   wostringstream bash_command;
-  // In case the given binary path is a shortened Windows 8dot3 path, we need to
-  // convert it back to its long path form before using it to find the bash main
-  // file.
-  wstring full_binary_path = GetWindowsLongPath(origin_args[0]);
-  wstring bash_main_file = GetBinaryPathWithoutExtension(full_binary_path);
+  wstring bash_main_file = GetBinaryPathWithoutExtension(GetLauncherPath());
   bash_command << BashEscapeArg(bash_main_file);
   for (int i = 1; i < origin_args.size(); i++) {
     bash_command << L' ';

--- a/src/tools/launcher/bash_launcher.h
+++ b/src/tools/launcher/bash_launcher.h
@@ -22,9 +22,10 @@ namespace launcher {
 
 class BashBinaryLauncher : public BinaryLauncherBase {
  public:
-  BashBinaryLauncher(const LaunchDataParser::LaunchInfo& launch_info, int argc,
+  BashBinaryLauncher(const LaunchDataParser::LaunchInfo& launch_info,
+                     const std::wstring& launcher_path, int argc,
                      wchar_t* argv[])
-      : BinaryLauncherBase(launch_info, argc, argv) {}
+      : BinaryLauncherBase(launch_info, launcher_path, argc, argv) {}
   ~BashBinaryLauncher() override = default;
   ExitCode Launch() override;
 };

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -162,8 +162,7 @@ static void WriteJarClasspath(const wstring& jar_path,
 }
 
 wstring JavaBinaryLauncher::GetJunctionBaseDir() {
-  wstring binary_base_path =
-      GetBinaryPathWithExtension(this->GetCommandlineArguments()[0]);
+  wstring binary_base_path = GetBinaryPathWithExtension(GetLauncherPath());
   wstring result;
   if (!NormalizePath(binary_base_path + L".j", &result)) {
     die(L"Failed to get normalized junction base directory.");
@@ -191,8 +190,7 @@ void JavaBinaryLauncher::DeleteJunctionBaseDir() {
 }
 
 wstring JavaBinaryLauncher::CreateClasspathJar(const wstring& classpath) {
-  wstring binary_base_path =
-      GetBinaryPathWithoutExtension(this->GetCommandlineArguments()[0]);
+  wstring binary_base_path = GetBinaryPathWithoutExtension(GetLauncherPath());
   wstring abs_manifest_jar_dir_norm = GetManifestJarDir(binary_base_path);
 
   wostringstream manifest_classpath;
@@ -312,8 +310,7 @@ ExitCode JavaBinaryLauncher::Launch() {
   // Run deploy jar if needed, otherwise generate the CLASSPATH by rlocation.
   if (this->singlejar) {
     wstring deploy_jar =
-        GetBinaryPathWithoutExtension(this->GetCommandlineArguments()[0]) +
-        L"_deploy.jar";
+        GetBinaryPathWithoutExtension(GetLauncherPath()) + L"_deploy.jar";
     if (!DoesFilePathExist(deploy_jar.c_str())) {
       die(L"Option --singlejar was passed, but %s does not exist.\n  (You may "
           "need to build it explicitly.)",

--- a/src/tools/launcher/java_launcher.h
+++ b/src/tools/launcher/java_launcher.h
@@ -29,9 +29,10 @@ static const int MAX_ARG_STRLEN = 7000;
 
 class JavaBinaryLauncher : public BinaryLauncherBase {
  public:
-  JavaBinaryLauncher(const LaunchDataParser::LaunchInfo& launch_info, int argc,
+  JavaBinaryLauncher(const LaunchDataParser::LaunchInfo& launch_info,
+                     const std::wstring& launcher_path, int argc,
                      wchar_t* argv[])
-      : BinaryLauncherBase(launch_info, argc, argv),
+      : BinaryLauncherBase(launch_info, launcher_path, argc, argv),
         singlejar(false),
         print_javabin(false),
         classpath_limit(MAX_ARG_STRLEN) {}

--- a/src/tools/launcher/launcher.h
+++ b/src/tools/launcher/launcher.h
@@ -41,7 +41,8 @@ class BinaryLauncherBase {
   typedef std::unordered_map<std::wstring, std::wstring> ManifestFileMap;
 
  public:
-  BinaryLauncherBase(const LaunchDataParser::LaunchInfo& launch_info, int argc,
+  BinaryLauncherBase(const LaunchDataParser::LaunchInfo& launch_info,
+                     const std::wstring& launcher_path, int argc,
                      wchar_t* argv[]);
 
   virtual ~BinaryLauncherBase() = default;
@@ -77,13 +78,22 @@ class BinaryLauncherBase {
   // A launch function to be implemented for a specific language.
   virtual ExitCode Launch() = 0;
 
+  // Returns the path of the launcher's executable file.
+  //
+  // The returned path is always a long path, that is, it never contains 8.3
+  // style filenames.
+  std::wstring GetLauncherPath() const;
+
   // Return the runfiles directory of this binary.
   //
-  // The method appends ".exe.runfiles" to the first command line argument,
-  // converts forward slashes to back slashes, then returns that.
+  // The method appends ".exe.runfiles" to the path of the launcher executable,
+  // converts forward slashes to backslashes, then returns that.
   std::wstring GetRunfilesPath() const;
 
  private:
+  // The path of the launcher binary.
+  const std::wstring launcher_path;
+
   // A map to store all the launch information.
   const LaunchDataParser::LaunchInfo& launch_info;
 
@@ -127,7 +137,7 @@ class BinaryLauncherBase {
   // Expect the manifest file to be at
   //    1. <path>/<to>/<binary>/<target_name>.runfiles/MANIFEST
   // or 2. <path>/<to>/<binary>/<target_name>.runfiles_manifest
-  static std::wstring FindManifestFile(const wchar_t* argv0);
+  static std::wstring FindManifestFile(const wchar_t* launcher_path);
 
   // Parse manifest file into a map
   static void ParseManifestFile(ManifestFileMap* manifest_file_map,

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -56,14 +56,10 @@ ExitCode PythonBinaryLauncher::Launch() {
   vector<wstring> args = this->GetCommandlineArguments();
   wstring use_zip_file = this->GetLaunchInfoByKey(USE_ZIP_FILE);
   wstring python_file;
-  // In case the given binary path is a shortened Windows 8dot3 path, we need to
-  // convert it back to its long path form before using it to find the python
-  // file.
-  wstring full_binary_path = GetWindowsLongPath(executable_file_);
   if (use_zip_file == L"1") {
-    python_file = GetBinaryPathWithoutExtension(full_binary_path) + L".zip";
+    python_file = GetBinaryPathWithoutExtension(GetLauncherPath()) + L".zip";
   } else {
-    python_file = GetBinaryPathWithoutExtension(full_binary_path);
+    python_file = GetBinaryPathWithoutExtension(GetLauncherPath());
   }
 
   // Replace the first argument with python file path

--- a/src/tools/launcher/python_launcher.h
+++ b/src/tools/launcher/python_launcher.h
@@ -26,14 +26,11 @@ namespace launcher {
 class PythonBinaryLauncher : public BinaryLauncherBase {
  public:
   PythonBinaryLauncher(const LaunchDataParser::LaunchInfo& launch_info,
-                       std::wstring executable_file, int argc, wchar_t* argv[])
-      : BinaryLauncherBase(launch_info, argc, argv),
-        executable_file_(std::move(executable_file)) {}
+                       const std::wstring& launcher_path, int argc,
+                       wchar_t* argv[])
+      : BinaryLauncherBase(launch_info, launcher_path, argc, argv) {}
   ~PythonBinaryLauncher() override = default;
   ExitCode Launch() override;
-
- private:
-  std::wstring executable_file_;
 };
 
 }  // namespace launcher


### PR DESCRIPTION
`argv[0]` can differ from the path of the launcher executable. The latter can contain 8.3 style filenames, which need to be resolved to long paths before path manipulation (e.g. appending ".runfiles") can succeed.

The Python launcher handled this correctly, but other launchers didn't use the long executable path consistently.

Closes #16916.

PiperOrigin-RevId: 493615543
Change-Id: Ic8161890181c0110ecdf6893b9835e6f99d01097