### PR TITLE
[6.1.0]Set `--experimental_action_listeners` to default in `exec` config

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.analysis.config;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -732,7 +731,7 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
   }
 
   public List<Label> getActionListeners() {
-    return options.actionListeners == null ? ImmutableList.of() : options.actionListeners;
+    return options.actionListeners;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
@@ -129,7 +129,7 @@ public class ExecutionTransitionFactory
       coreOptions.isHost = false;
       coreOptions.isExec = true;
       // Disable extra actions
-      coreOptions.actionListeners = null;
+      coreOptions.actionListeners = ImmutableList.of();
 
       // Then set the target to the saved execution platform if there is one.
       PlatformOptions platformOptions = execOptions.get(PlatformOptions.class);


### PR DESCRIPTION
Previously, the flag value was set to `null` rather than an empty list, which resulted in distinct yet equivalent configurations.

Fixes #16911

Closes #16912.

PiperOrigin-RevId: 493175302
Change-Id: I7a34c988265f3a3d94f1720a7fc7ad501eb44247