### PR TITLE
[6.1.0]Fix `--nozip_undeclared_test_outputs` on Windows

### DIFF
--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -397,6 +397,60 @@ class BazelWindowsTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertIn('Hello from test!', '\n'.join(stdout))
 
+  def testZipUndeclaredTestOutputs(self):
+    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
+    self.ScratchFile(
+        'BUILD',
+        [
+            'sh_test(',
+            '  name = "foo_test",',
+            '  srcs = ["foo.sh"],',
+            ')',
+            '',
+        ],
+    )
+    self.ScratchFile(
+        'foo.sh',
+        [
+            'touch "$TEST_UNDECLARED_OUTPUTS_DIR/foo.txt"',
+        ],
+    )
+
+    exit_code, stdout, stderr = self.RunBazel(['info', 'bazel-testlogs'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    bazel_testlogs = stdout[0]
+
+    output_file = os.path.join(bazel_testlogs, 'foo_test/test.outputs/foo.txt')
+    output_zip = os.path.join(
+        bazel_testlogs, 'foo_test/test.outputs/outputs.zip'
+    )
+
+    # Run the test with undeclared outputs zipping.
+    exit_code, _, stderr = self.RunBazel(
+        [
+            'test',
+            '--zip_undeclared_test_outputs',
+            '//:foo_test',
+        ],
+    )
+    self.AssertExitCode(exit_code, 0, stderr)
+    # FIXME: The Windows test runner does not delete the undeclared outputs
+    #  after zipping, which differs from the behavior on other platforms.
+    self.assertTrue(os.path.exists(output_file))
+    self.assertTrue(os.path.exists(output_zip))
+
+    # Run the test without undeclared outputs zipping.
+    exit_code, _, stderr = self.RunBazel(
+        [
+            'test',
+            '--nozip_undeclared_test_outputs',
+            '//:foo_test',
+        ],
+    )
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertTrue(os.path.exists(output_file))
+    self.assertFalse(os.path.exists(output_zip))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1298,8 +1298,10 @@ bool StartSubprocess(const Path& path, const std::wstring& args,
 }
 
 bool ArchiveUndeclaredOutputs(const UndeclaredOutputs& undecl) {
-  if (undecl.root.Get().empty()) {
-    // TEST_UNDECLARED_OUTPUTS_DIR was undefined, there's nothing to archive.
+  if (undecl.root.Get().empty() || undecl.zip.Get().empty()) {
+    // TEST_UNDECLARED_OUTPUTS_DIR was undefined, so there's nothing to archive,
+    // or TEST_UNDECLARED_OUTPUTS_ZIP was undefined as
+    // --nozip_undeclared_test_outputs was specified.
     return true;
   }
 


### PR DESCRIPTION
Without this change, testing with `--nozip_undeclared_test_outputs` always fails with this error:

```
FATAL: MappedOutputFile(): CreateFileW() failed: (error: 3): The system cannot find the path specified.
```

Closes #16973.

PiperOrigin-RevId: 494953454
Change-Id: I8338e897a9e4f4fdcd6dad511ee8e777182fefcd