### PR TITLE
[6.1.0]Upload all logs in BEP even with minimal upload

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -63,6 +63,8 @@ import javax.annotation.Nullable;
 class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
     implements BuildEventArtifactUploader {
   private static final Pattern TEST_LOG_PATTERN = Pattern.compile(".*/bazel-out/[^/]*/testlogs/.*");
+  private static final Pattern BUILD_LOG_PATTERN =
+      Pattern.compile(".*/bazel-out/_tmp/actions/std(err|out)-.*");
 
   private final Executor executor;
   private final ExtendedEventHandler reporter;
@@ -216,14 +218,15 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
         path.getDigest() != null && !path.isRemote() && !path.isDirectory() && !path.isOmitted();
 
     if (remoteBuildEventUploadMode == RemoteBuildEventUploadMode.MINIMAL) {
-      result = result && (isTestLog(path) || isProfile(path));
+      result = result && (isLog(path) || isProfile(path));
     }
 
     return result;
   }
 
-  private boolean isTestLog(PathMetadata path) {
-    return TEST_LOG_PATTERN.matcher(path.getPath().getPathString()).matches();
+  private boolean isLog(PathMetadata path) {
+    return TEST_LOG_PATTERN.matcher(path.getPath().getPathString()).matches()
+        || BUILD_LOG_PATTERN.matcher(path.getPath().getPathString()).matches();
   }
 
   private boolean isProfile(PathMetadata path) {

--- a/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
+++ b/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
@@ -269,6 +269,29 @@ EOF
   expect_log "command.profile.gz.*bytestream://" || fail "should upload profile data"
 }
 
+function test_upload_minimal_upload_buildlogs() {
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ['foo.txt'],
+  cmd  = 'echo "stdout" && echo "stderr" >&2 && exit 1',
+  tags = ['no-remote'],
+)
+EOF
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --experimental_remote_build_event_upload=minimal \
+      --build_event_json_file=bep.json \
+      //a:foo >& $TEST_log || true
+
+  cat bep.json > $TEST_log
+  expect_log "stdout.*bytestream://" || fail "should upload stdout"
+  expect_log "stderr.*bytestream://" || fail "should upload stderr"
+  expect_log "command.profile.gz.*bytestream://" || fail "should upload profile data"
+}
+
 function test_upload_minimal_upload_profile() {
   mkdir -p a
   cat > a/BUILD <<EOF


### PR DESCRIPTION
When using --experimental_remote_build_event_upload=minimal, build action logs won't get uploaded. These logs are still very useful as when a build action fails, one would need to inspect them to figure out what has gone wrong. Forcing uploading stdout and stderr with this change.

Closes #17110.

PiperOrigin-RevId: 500723770
Change-Id: I5e2edb6356b55549cd160379273af9a1580945d3