### PR TITLE
[6.1.0]Allow pyd in extensions of dynamic libraries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -204,7 +204,9 @@ public final class CppFileTypes {
   // Minimized bitcode file emitted by the ThinLTO compile step and used just for LTO indexing.
   public static final FileType LTO_INDEXING_OBJECT_FILE = FileType.of(".indexing.o");
 
-  public static final FileType SHARED_LIBRARY = FileType.of(".so", ".dylib", ".dll");
+  // TODO(bazel-team): File types should not be read from this hard-coded list but should come from
+  // the toolchain instead. See https://github.com/bazelbuild/bazel/issues/17117
+  public static final FileType SHARED_LIBRARY = FileType.of(".so", ".dylib", ".dll", ".pyd");
   // Unix shared libraries can be passed to linker, but not .dll on Windows
   public static final FileType UNIX_SHARED_LIBRARY = FileType.of(".so", ".dylib");
   public static final FileType INTERFACE_SHARED_LIBRARY =

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
@@ -40,6 +40,13 @@ cc_binary(
 )
 
 cc_shared_library(
+    name = "python_module",
+    features = ["windows_export_all_symbols"],
+    roots = [":a_suffix"],
+    shared_lib_name = "python_module.pyd",
+)
+
+cc_shared_library(
     name = "a_so",
     features = ["windows_export_all_symbols"],
     roots = [":a_suffix"],

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -5296,10 +5296,10 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
             "'a.pic.o' does not have any of the allowed extensions .a, .lib, .pic.a or .rlib");
     assertThat(e)
         .hasMessageThat()
-        .contains("'a.ifso' does not have any of the allowed extensions .so, .dylib or .dll");
+        .contains("'a.ifso' does not have any of the allowed extensions .so, .dylib, .dll or .pyd");
     assertThat(e)
         .hasMessageThat()
-        .contains("'a.lib' does not have any of the allowed extensions .so, .dylib or .dll");
+        .contains("'a.lib' does not have any of the allowed extensions .so, .dylib, .dll or .pyd");
     assertThat(e)
         .hasMessageThat()
         .contains(


### PR DESCRIPTION
Long term fix should be to read the extensions from the toolchain.

RELNOTES:none
PiperOrigin-RevId: 499418087
Change-Id: I710285966cec5eff937c2fb7be728e5e93503cc7