### PR TITLE
Prepare backwards compatible usage of optional C++ toolchain

### DIFF
--- a/tools/cpp/BUILD.tools
+++ b/tools/cpp/BUILD.tools
@@ -57,6 +57,14 @@ constraint_value(
 
 cc_toolchain_alias(name = "current_cc_toolchain")
 
+# In future versions of Bazel, this target will not fail if no C++ toolchain is
+# available. Instead, it will not advertise the cc_common.CcToolchainInfo
+# provider.
+alias(
+    name = "optional_current_cc_toolchain",
+    actual = ":current_cc_toolchain",
+)
+
 cc_host_toolchain_alias(name = "current_cc_host_toolchain")
 
 cc_libc_top_alias(name = "current_libc_top")

--- a/tools/cpp/toolchain_utils.bzl
+++ b/tools/cpp/toolchain_utils.bzl
@@ -19,7 +19,7 @@ Utilities to help work with c++ toolchains.
 
 CPP_TOOLCHAIN_TYPE = "@bazel_tools//tools/cpp:toolchain_type"
 
-def find_cpp_toolchain(ctx):
+def find_cpp_toolchain(ctx, *, mandatory = True):
     """
     Finds the c++ toolchain.
 
@@ -29,6 +29,9 @@ def find_cpp_toolchain(ctx):
 
     Args:
       ctx: The rule context for which to find a toolchain.
+      mandatory: This is currently a no-op. In future releases of Bazel, if this
+        is set to False, this function will return None rather than fail if no
+        toolchain is found.
 
     Returns:
       A CcToolchainProvider.


### PR DESCRIPTION
By adding an alias and a no-op keyword argument now, rulesets can start using the new optional form of `find_cpp_toolchain` now and benefit from the toolchain actually being optional once that has been implemented in a future version of Bazel.

Work towards #16966