### PR TITLE
[6.1.0]Add -dead_strip in default opt link flags for darwin

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -617,7 +617,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
                 ],
             ),
             "%{opt_link_flags}": get_starlark_list(
-                [] if darwin else _add_linker_option_if_supported(
+                ["-Wl,-dead_strip"] if darwin else _add_linker_option_if_supported(
                     repository_ctx,
                     cc,
                     "-Wl,--gc-sections",


### PR DESCRIPTION
This is similar to the `--gc-sections` addition here. `-dead_strip` is supported on all versions of ld64 we care about.

Closes #16770.

PiperOrigin-RevId: 501557438
Change-Id: Ia5e1e94305361f10f1b20654d83edb76126b3056