### PR TITLE
[6.1.0]Accept tildes in --override_module

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -350,12 +350,12 @@ public class RepositoryOptions extends OptionsBase {
       OptionsUtils.AbsolutePathFragmentConverter absolutePathFragmentConverter =
           new OptionsUtils.AbsolutePathFragmentConverter();
       try {
-        var unused = absolutePathFragmentConverter.convert(pieces[1]);
+        var path = absolutePathFragmentConverter.convert(pieces[1]);
+        return ModuleOverride.create(pieces[0], path.toString());
       } catch (OptionsParsingException e) {
         throw new OptionsParsingException(
             "Module override directory must be an absolute path", input, e);
       }
-      return ModuleOverride.create(pieces[0], pieces[1]);
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
@@ -17,6 +17,8 @@ package com.google.devtools.build.lib.bazel.repository;
 import static com.google.common.base.StandardSystemProperty.USER_HOME;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.ModuleOverride;
+import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.ModuleOverrideConverter;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.RepositoryOverride;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.RepositoryOverrideConverter;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -58,6 +60,14 @@ public class RepositoryOptionsTest {
     RepositoryOverride actual = converter.convert("foo=~/bar");
     assertThat(actual.repositoryName()).isEqualTo(RepositoryName.createUnvalidated("foo"));
     assertThat(actual.path()).isEqualTo(PathFragment.create(USER_HOME.value() + "/bar"));
+  }
+
+  @Test
+  public void testModuleOverridePathWithTilde() throws Exception {
+    var converter = new ModuleOverrideConverter();
+    ModuleOverride actual = converter.convert("foo=~/bar");
+    assertThat(PathFragment.create(actual.path()))
+        .isEqualTo(PathFragment.create(USER_HOME.value() + "/bar"));
   }
 
   @Test


### PR DESCRIPTION
This is useful for adding this in your global ~/.bazelrc file for easy rules debugging.

See also https://github.com/bazelbuild/bazel/pull/15417

Closes #17218.

PiperOrigin-RevId: 502854597
Change-Id: Ic26289c6497edd31187dde2c7cda78c2177a56c4