### PR TITLE
[6.1.0]Improve error message for concurrent modification

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -189,7 +189,11 @@ final class RemoteSpawnCache implements SpawnCache {
             try (SilentCloseable c = prof.profile("RemoteCache.checkForConcurrentModifications")) {
               checkForConcurrentModifications();
             } catch (IOException | ForbiddenActionInputException e) {
-              remoteExecutionService.report(Event.warn(e.getMessage()));
+              String msg =
+                  "Skipping uploading outputs because of concurrent modifications "
+                      + "with --experimental_guard_against_concurrent_changes enabled: "
+                      + e.getMessage();
+              remoteExecutionService.report(Event.warn(msg));
               return;
             }
           }


### PR DESCRIPTION
Improve the error message logged when concurrent modifications occur and --experimental_guard_against_concurrent_changes is set.

Closes #17174.

PiperOrigin-RevId: 501012999
Change-Id: Id661ff2e5f98173323ebecb75b5e9825c8e0491e