### PR TITLE
[6.1.0]Emit LLVM coverage for source file paths with a `tmp` segment

### DIFF
--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -93,7 +93,7 @@ function llvm_coverage_lcov() {
   done < "${COVERAGE_MANIFEST}"
 
   "${LLVM_COV}" export -instr-profile "${output_file}.data" -format=lcov \
-      -ignore-filename-regex='/tmp/.+' \
+      -ignore-filename-regex='^/tmp/.+' \
       ${object_param} | sed 's#/proc/self/cwd/##' > "${output_file}"
 }
 


### PR DESCRIPTION
The LLVM LCOV coverage collection logic attempted to filter out source files under `/tmp/`, but instead filtered out all source files with paths containing the substring `/tmp/`. Under macOS, where Bazel's output base lies under `/private/var/tmp`, this matched every output base absolute path.

Closes #16852.

PiperOrigin-RevId: 500973551
Change-Id: I6c890f38c19eedec83cdf0ea99f021eb85f4e697