### PR TITLE
[6.1.0]Find `libtool` when using `BAZEL_USE_CPP_ONLY_TOOLCHAIN`.

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -169,6 +169,7 @@ cc_autoconf = repository_rule(
         "CPLUS_INCLUDE_PATH",
         "DEVELOPER_DIR",
         "GCOV",
+        "LIBTOOL",
         "HOMEBREW_RUBY_PATH",
         "SYSTEMROOT",
         "USER",

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -384,7 +384,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
     )
     if darwin:
         overriden_tools["gcc"] = "cc_wrapper.sh"
-        overriden_tools["ar"] = "/usr/bin/libtool"
+        overriden_tools["ar"] = _find_generic(repository_ctx, "libtool", "LIBTOOL", overriden_tools)
     auto_configure_warning_maybe(repository_ctx, "CC used: " + str(cc))
     tool_paths = _get_tool_paths(repository_ctx, overriden_tools)
     cc_toolchain_identifier = escape_string(get_env_var(


### PR DESCRIPTION
Instead of hardcoding `/usr/bin/libtool` which requires Xcode / Xcode CLT installed, which `BAZEL_USE_CPP_ONLY_TOOLCHAIN` is meant to avoid.

Related to https://github.com/bazelbuild/bazel/issues/16009.

Closes #16010.

PiperOrigin-RevId: 503922158
Change-Id: I64392ada951938d612dd0b28141e6b2e4ee6952c