### PR TITLE
Documentation: fix heading significance

### DIFF
--- a/site/en/configure/json-trace-profile.md
+++ b/site/en/configure/json-trace-profile.md
@@ -47,7 +47,7 @@ You can use these keyboard controls to navigate:
     between two events.
 *   Press `?` to learn about all controls.
 
-## `bazel analyze-profile`
+### `bazel analyze-profile`
 
 The Bazel subcommand [`analyze-profile`](/docs/user-manual#analyze-profile)
 consumes a profile format and prints cumulative statistics for


### PR DESCRIPTION
One of the headings is an h2, although it should be a h3

Follow-up to #17034