### PR TITLE
Replace `localjdk` with `local_jdk` in docs

### DIFF
--- a/site/en/docs/bazel-and-java.md
+++ b/site/en/docs/bazel-and-java.md
@@ -335,7 +335,7 @@ version may be grouped with `.bazelrc` configs":
 
 ```python
 build:java8 --java_language_version=8
-build:java8 --java_runtime_version=localjdk_8
+build:java8 --java_runtime_version=local_jdk_8
 build:java11 --java_language_version=11
 build:java11 --java_runtime_version=remotejdk_11
 ```

--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -344,8 +344,8 @@ example:
 
 downloads JDK 11 from a remote repository and run the Java application using it.
 
-Default value is `localjdk`.
-Possible values are: `localjdk`, `localjdk_{{ "<var>" }}version{{ "</var>" }}`,
+Default value is `local_jdk`.
+Possible values are: `local_jdk`, `local_jdk_{{ "<var>" }}version{{ "</var>" }}`,
 `remotejdk_11`, and `remote_jdk17`.
 You can extend the values by registering custom JVM using either
 `local_java_repository` or `remote_java_repostory` repository rules.


### PR DESCRIPTION
The default local toolchain is called `local_jdk`, not `localjdk`.