### PR TITLE
Fix Java coverage collection with Java 8 runtime

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoLCOVFormatter.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoLCOVFormatter.java
@@ -70,7 +70,7 @@ public class JacocoLCOVFormatter {
       private Map<String, ISourceFileCoverage> sourceToFileCoverage = new TreeMap<>();
 
       private String getExecPathForEntryName(String classPath) {
-        if (execPathsOfUninstrumentedFiles.isEmpty()) {
+        if (!execPathsOfUninstrumentedFiles.isPresent()) {
           return classPath;
         }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainRule.java
@@ -281,8 +281,6 @@ public final class JavaToolchainRule<C extends JavaToolchain> implements RuleDef
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
             attr("jacocorunner", LABEL)
-                // This needs to be in the execution configuration.
-                .cfg(ExecutionTransitionFactory.create())
                 .allowedFileTypes(FileTypeSet.ANY_FILE)
                 .exec())
         /* <!-- #BLAZE_RULE(java_toolchain).ATTRIBUTE(proguard_allowlister) -->


### PR DESCRIPTION
`JacocoCoverageRunner` is run with the target runtime, not the exec runtime, and thus needs to be compatible with a Java 8 runtime.

Fixes #17165 