### PR TITLE
Fix worker and multiplex workers for DexBuilder and Desugar actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -362,6 +362,15 @@ public final class BazelRulesModule extends BlazeModule {
         help = "This option is deprecated and has no effect.")
     public boolean shortenObjFilePath;
 
+    @Deprecated
+    @Option(
+        name = "use_workers_with_dexbuilder",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.EXECUTION},
+        help = "This option is deprecated and has no effect.")
+    public boolean useWorkersWithDexbuilder;
+
     @Option(
         name = "force_ignore_dash_static",
         defaultValue = "false",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -281,6 +281,15 @@ public final class BazelRulesModule extends BlazeModule {
         help = "Deprecated no-op. Use --experimental_dynamic_local_load_factor instead.")
     @Deprecated
     public boolean skipFirstBuild;
+
+    @Option(
+        name = "use_workers_with_dexbuilder",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.EXECUTION},
+        help = "This option is deprecated and has no effect.")
+    @Deprecated
+    public boolean useWorkersWithDexbuilder;
   }
 
   /** This is where deprecated Bazel-specific options only used by the build command go to die. */
@@ -361,15 +370,6 @@ public final class BazelRulesModule extends BlazeModule {
         defaultValue = "true",
         help = "This option is deprecated and has no effect.")
     public boolean shortenObjFilePath;
-
-    @Deprecated
-    @Option(
-        name = "use_workers_with_dexbuilder",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.EXECUTION},
-        help = "This option is deprecated and has no effect.")
-    public boolean useWorkersWithDexbuilder;
 
     @Option(
         name = "force_ignore_dash_static",

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -534,14 +534,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     public List<String> dexoptsSupportedInDexSharder;
 
     @Option(
-        name = "use_workers_with_dexbuilder",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.EXECUTION},
-        help = "Whether dexbuilder supports being run in local worker mode.")
-    public boolean useWorkersWithDexbuilder;
-
-    @Option(
         name = "experimental_android_rewrite_dexes_with_rex",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
@@ -1100,7 +1092,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
       exec.dexoptsSupportedInIncrementalDexing = dexoptsSupportedInIncrementalDexing;
       exec.dexoptsSupportedInDexMerger = dexoptsSupportedInDexMerger;
       exec.dexoptsSupportedInDexSharder = dexoptsSupportedInDexSharder;
-      exec.useWorkersWithDexbuilder = useWorkersWithDexbuilder;
       exec.manifestMerger = manifestMerger;
       exec.manifestMergerOrder = manifestMergerOrder;
       exec.allowAndroidLibraryDepsWithoutSrcs = allowAndroidLibraryDepsWithoutSrcs;
@@ -1128,7 +1119,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final ImmutableList<String> targetDexoptsThatPreventIncrementalDexing;
   private final ImmutableList<String> dexoptsSupportedInDexMerger;
   private final ImmutableList<String> dexoptsSupportedInDexSharder;
-  private final boolean useWorkersWithDexbuilder;
   private final boolean desugarJava8;
   private final boolean desugarJava8Libs;
   private final boolean checkDesugarDeps;
@@ -1184,7 +1174,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
         ImmutableList.copyOf(options.nonIncrementalPerTargetDexopts);
     this.dexoptsSupportedInDexMerger = ImmutableList.copyOf(options.dexoptsSupportedInDexMerger);
     this.dexoptsSupportedInDexSharder = ImmutableList.copyOf(options.dexoptsSupportedInDexSharder);
-    this.useWorkersWithDexbuilder = options.useWorkersWithDexbuilder;
     this.desugarJava8 = options.desugarJava8;
     this.desugarJava8Libs = options.desugarJava8Libs;
     this.checkDesugarDeps = options.checkDesugarDeps;
@@ -1317,12 +1306,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   @Override
   public ImmutableList<String> getTargetDexoptsThatPreventIncrementalDexing() {
     return targetDexoptsThatPreventIncrementalDexing;
-  }
-
-  /** Whether to assume the dexbuilder tool supports local worker mode. */
-  @Override
-  public boolean useWorkersWithDexbuilder() {
-    return useWorkersWithDexbuilder;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -897,10 +897,11 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
         },
         help = "Enable persistent Android dex and desugar actions by using workers.",
         expansion = {
+          "--internal_persistent_android_dex_desugar",
           "--strategy=Desugar=worker",
           "--strategy=DexBuilder=worker",
         })
-    public Void persistentDexDesugar;
+    public Void persistentAndroidDexDesugar;
 
     @Option(
         name = "persistent_multiplex_android_dex_desugar",
@@ -913,10 +914,9 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
         help = "Enable persistent multiplexed Android dex and desugar actions by using workers.",
         expansion = {
           "--persistent_android_dex_desugar",
-          "--modify_execution_info=Desugar=+supports-multiplex-workers",
-          "--modify_execution_info=DexBuilder=+supports-multiplex-workers",
+          "--internal_persistent_multiplex_android_dex_desugar",
         })
-    public Void persistentMultiplexDexDesugar;
+    public Void persistentMultiplexAndroidDexDesugar;
 
     @Option(
         name = "persistent_multiplex_android_tools",
@@ -965,6 +965,36 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
         defaultValue = "false",
         help = "Tracking flag for when multiplexed busybox workers are enabled.")
     public boolean persistentMultiplexBusyboxTools;
+
+    /**
+     * We use this option to decide when to enable workers for busybox tools. This flag is also a
+     * guard against enabling workers using nothing but --persistent_android_resource_processor.
+     *
+     * <p>Consequently, we use this option to decide between param files or regular command line
+     * parameters. If we're not using workers or on Windows, there's no need to always use param
+     * files for I/O performance reasons.
+     */
+    @Option(
+        name = "internal_persistent_android_dex_desugar",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {
+          OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS,
+          OptionEffectTag.EXECUTION,
+        },
+        defaultValue = "false",
+        help = "Tracking flag for when dexing and desugaring workers are enabled.")
+    public boolean persistentDexDesugar;
+
+    @Option(
+        name = "internal_persistent_multiplex_android_dex_desugar",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {
+          OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS,
+          OptionEffectTag.EXECUTION,
+        },
+        defaultValue = "false",
+        help = "Tracking flag for when multiplexed dexing and desugaring workers are enabled.")
+    public boolean persistentMultiplexDexDesugar;
 
     @Option(
         name = "experimental_remove_r_classes_from_instrumentation_test_jar",
@@ -1145,6 +1175,8 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final boolean dataBindingAndroidX;
   private final boolean persistentBusyboxTools;
   private final boolean persistentMultiplexBusyboxTools;
+  private final boolean persistentDexDesugar;
+  private final boolean persistentMultiplexDexDesugar;
   private final boolean filterRJarsFromAndroidTest;
   private final boolean removeRClassesFromInstrumentationTestJar;
   private final boolean alwaysFilterDuplicateClassesFromAndroidTest;
@@ -1205,6 +1237,8 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     this.dataBindingAndroidX = options.dataBindingAndroidX;
     this.persistentBusyboxTools = options.persistentBusyboxTools;
     this.persistentMultiplexBusyboxTools = options.persistentMultiplexBusyboxTools;
+    this.persistentDexDesugar = options.persistentDexDesugar;
+    this.persistentMultiplexDexDesugar = options.persistentMultiplexDexDesugar;
     this.filterRJarsFromAndroidTest = options.filterRJarsFromAndroidTest;
     this.removeRClassesFromInstrumentationTestJar =
         options.removeRClassesFromInstrumentationTestJar;
@@ -1454,6 +1488,16 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   @Override
   public boolean persistentMultiplexBusyboxTools() {
     return persistentMultiplexBusyboxTools;
+  }
+
+  @Override
+  public boolean persistentDexDesugar() {
+    return persistentDexDesugar;
+  }
+
+  @Override
+  public boolean persistentMultiplexDexDesugar() {
+    return persistentMultiplexDexDesugar;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
@@ -531,13 +531,15 @@ public class DexArchiveAspect extends NativeAspectClass implements ConfiguredAsp
         new SpawnAction.Builder()
             .useDefaultShellEnvironment()
             .setExecutable(ruleContext.getExecutablePrerequisite(desugarPrereqName))
-            .setExecutionInfo(createDexingDesugaringExecRequirements(ruleContext).build())
             .addInput(jar)
             .addTransitiveInputs(bootclasspath)
             .addTransitiveInputs(classpath)
             .addOutput(result)
             .setMnemonic("Desugar")
-            .setProgressMessage("Desugaring %s for Android", jar.prettyPrint());
+            .setProgressMessage("Desugaring %s for Android", jar.prettyPrint())
+            .setExecutionInfo(createDexingDesugaringExecRequirements(ruleContext)
+                .putAll(ExecutionRequirements.WORKER_MODE_ENABLED)
+                .build());
 
     // SpawnAction.Builder.build() is documented as being safe for re-use. So we can call build here
     // to get the action's inputs for vetting path stripping safety, then call it again later to

--- a/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
@@ -658,9 +658,6 @@ public class DexArchiveAspect extends NativeAspectClass implements ConfiguredAsp
     dexbuilder
         .addCommandLine(args.build(), ParamFileInfo.builder(UNQUOTED).setUseAlways(true).build())
         .stripOutputPaths(stripOutputPaths);
-    if (getAndroidConfig(ruleContext).useWorkersWithDexbuilder()) {
-      dexbuilder.setExecutionInfo(ExecutionRequirements.WORKER_MODE_ENABLED);
-    }
     ruleContext.registerAction(dexbuilder.build(ruleContext));
     return dexArchive;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
@@ -539,7 +539,7 @@ public class DexArchiveAspect extends NativeAspectClass implements ConfiguredAsp
             .setProgressMessage("Desugaring %s for Android", jar.prettyPrint())
             .setExecutionInfo(createDexingDesugaringExecRequirements(ruleContext)
                 .putAll(ExecutionRequirements.WORKER_MODE_ENABLED)
-                .build());
+                .buildKeepingLast());
 
     // SpawnAction.Builder.build() is documented as being safe for re-use. So we can call build here
     // to get the action's inputs for vetting path stripping safety, then call it again later to
@@ -632,7 +632,7 @@ public class DexArchiveAspect extends NativeAspectClass implements ConfiguredAsp
             .setExecutable(ruleContext.getExecutablePrerequisite(dexbuilderPrereq))
             .setExecutionInfo(createDexingDesugaringExecRequirements(ruleContext)
                 .putAll(TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
-                .build())
+                .buildKeepingLast())
             // WorkerSpawnStrategy expects the last argument to be @paramfile
             .addInput(jar)
             .addOutput(dexArchive)

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
@@ -94,13 +94,6 @@ public interface AndroidConfigurationApi extends StarlarkValue {
       documented = false)
   ImmutableList<String> getTargetDexoptsThatPreventIncrementalDexing();
 
-  @StarlarkMethod(
-      name = "use_workers_with_dexbuilder",
-      structField = true,
-      doc = "",
-      documented = false)
-  boolean useWorkersWithDexbuilder();
-
   @StarlarkMethod(name = "desugar_java8", structField = true, doc = "", documented = false)
   boolean desugarJava8();
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
@@ -232,6 +232,20 @@ public interface AndroidConfigurationApi extends StarlarkValue {
   boolean persistentMultiplexBusyboxTools();
 
   @StarlarkMethod(
+      name = "persistent_android_dex_desugar",
+      structField = true,
+      doc = "",
+      documented = false)
+  boolean persistentDexDesugar();
+
+  @StarlarkMethod(
+      name = "persistent_multiplex_android_dex_desugar",
+      structField = true,
+      doc = "",
+      documented = false)
+  boolean persistentMultiplexDexDesugar();
+
+  @StarlarkMethod(
       name = "get_output_directory_name",
       structField = true,
       doc = "",

--- a/src/test/shell/bazel/android/desugarer_integration_test.sh
+++ b/src/test/shell/bazel/android/desugarer_integration_test.sh
@@ -124,10 +124,24 @@ function test_java_8_android_binary_worker_strategy() {
   setup_android_sdk_support
   create_java_8_android_binary
 
-  bazel build \
-   --strategy=Desugar=worker \
-   --desugar_for_android //java/bazel:bin \
-      || fail "build failed"
+  assert_build //java/bazel:bin \
+    --persistent_android_dex_desugar \
+    --worker_verbose &> $TEST_log
+  expect_log "Created new non-sandboxed Desugar worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed DexBuilder worker (id [0-9]\+)"
+}
+
+function test_java_8_android_binary_multiplex_worker_strategy() {
+  create_new_workspace
+  setup_android_sdk_support
+  create_java_8_android_binary
+
+  assert_build //java/bazel:bin \
+    --experimental_worker_multiplex \
+    --persistent_multiplex_android_dex_desugar \
+    --worker_verbose &> $TEST_log
+  expect_log "Created new non-sandboxed Desugar multiplex-worker (id [0-9]\+)"
+  expect_log "Created new non-sandboxed DexBuilder multiplex-worker (id [0-9]\+)"
 }
 
 run_suite "Android desugarer integration tests"

--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -47,8 +47,6 @@ java_binary(
     runtime_deps = ["//src/tools/android/java/com/google/devtools/build/android/r8"],
 )
 
-# NOTE: d8 dex builder doesn't support the persistent worker mode at the moment. To use this config,
-# without a build error, --nouse_workers_with_dexbuilder flag must also be specified.
 config_setting(
     name = "d8_incremental_dexing",
     values = {


### PR DESCRIPTION
Fixing up the DexBuilder and Desugar actions so that they correctly spawn worker or multiplexed worker actions. `--modify_execution_info` doesn't work as expected and is not additive, which results in the previous execution infos being removed.