### PR TITLE
Remove O1 from sanitizer feature flag defaults

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -151,7 +151,6 @@ def _sanitizer_feature(name = "", specific_compile_flags = [], specific_link_fla
                 actions = all_compile_actions,
                 flag_groups = [
                     flag_group(flags = [
-                        "-O1",
                         "-fno-omit-frame-pointer",
                         "-fno-sanitize-recover=all",
                     ] + specific_compile_flags),

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -2582,7 +2582,6 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = [
-                            "-O1",
                             "-gline-tables-only",
                             "-fno-omit-frame-pointer",
                             "-fno-sanitize-recover=all",


### PR DESCRIPTION
This PR removes `-O1` from the current set of sanitizer related feature flags defaults.

**Context and Repro**
1. Heap buffer overflow in the following code block is not caught by asan.

example.cc
```
#include <cstdlib>

int main(int argc, char **argv) {
  int *array = new int[100];
  array[0] = 0;
  int res = array[argc + 100];  // BOOM
  delete [] array;
  return res;
}
```
BUILD
```
cc_binary(
  name = 'example',
  srcs = ['example.cc'],
  features = ['asan'],
)
```
execute:
```
bazel run :example
```

**Expectation:**
Address sanitizer should detect and report heap buffer overflow.

But this doesn't happen in the above case. It is because of O1 being applied by default and since this is added at the last, it also overrides explicit copts passed(O0). It would be nice if the optimization level is a bit de-coupled from the default group here.