### PR TITLE
documentation: clarify combined cache

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
@@ -31,7 +31,7 @@
     cached remotely (but it may be cached locally; it may also be executed remotely).
     Note: for the purposes of this tag, the disk-cache is considered a local cache, whereas
     the http and gRPC caches are considered remote.
-    If a combined cache is specified (i.e. a cache with local and remote components),
+    If a combination of local disk cache and remote cache are used (combined cache),
     it's treated as a remote cache and disabled entirely unless <code>--incompatible_remote_results_ignore_disk</code>
     is set in which case the local components will be used.
   </li>

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -324,7 +324,7 @@ public final class RemoteOptions extends CommonRemoteOptions {
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
       help =
           "If set to true, --noremote_upload_local_results and --noremote_accept_cached will not"
-              + " apply to the disk cache. If a combined cache is used:\n"
+              + " apply to the disk cache. If both --disk_cache and --remote_cache are set (combined cache):\n"
               + "\t--noremote_upload_local_results will cause results to be written to the disk"
               + " cache, but not uploaded to the remote cache.\n"
               + "\t--noremote_accept_cached will result in Bazel checking for results in the disk"


### PR DESCRIPTION
In Bazel, a Combined Cache is in effect when both Local Disk Cache (--disk_cache=) and Remote Cache (--remote_cache=) are set. This concept, however, only exists in Bazel source code and not defined anywhere in Bazel's documentation.

Let's clarify Combined Cache concept in the doc to explain to users what it is.