### PR TITLE
Add .wasm cc dynamic library extension

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ArtifactCategory.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ArtifactCategory.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 public enum ArtifactCategory {
   STATIC_LIBRARY("lib", ".a", ".lib"),
   ALWAYSLINK_STATIC_LIBRARY("lib", ".lo", ".lo.lib"),
-  DYNAMIC_LIBRARY("lib", ".so", ".dylib", ".dll"),
+  DYNAMIC_LIBRARY("lib", ".so", ".dylib", ".dll", ".wasm"),
   EXECUTABLE("", "", ".exe", ".wasm"),
   INTERFACE_LIBRARY("lib", ".ifso", ".tbd", ".if.lib", ".lib"),
   PIC_FILE("", ".pic"),


### PR DESCRIPTION
Similar to #16091 except also allow the `.wasm` extension for dynamic libraries.