### PR TITLE
Add the missing toolchain in `@bazel_tools//tools/cpp:everything` for cpu s390x

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
@@ -98,6 +98,9 @@ public final class BazelMockCcSupport extends MockCcSupport {
       result.add(CcToolchainConfig.getCcToolchainConfigForCpu("darwin_arm64"));
     }
 
+    if (System.getProperty("os.arch").equals("s390x"))
+      result.add(CcToolchainConfig.getCcToolchainConfigForCpu("s390x"));
+
     return result.build();
   }
 }


### PR DESCRIPTION
The following test cases failed on s390x and the log showed: cc_toolchain_suite `@bazel_tools//tools/cpp:everything` does not contain a toolchain for cpu `s390x`.
 

- //src/test/java/com/google/devtools/build/lib/buildtool:CompileOneDependencyIntegrationTest
- //src/test/java/com/google/devtools/build/lib/buildtool:DanglingSymlinkTest
- //src/test/java/com/google/devtools/build/lib/buildtool:KeepGoingTest
- //src/test/java/com/google/devtools/build/lib/buildtool:MiscAnalysisTest
- //src/test/java/com/google/devtools/build/lib/buildtool:SkymeldBuildIntegrationTest
- //src/test/java/com/google/devtools/build/lib/remote:BuildWithoutTheBytesIntegrationTest
- //src/test/java/com/google/devtools/build/lib/skyframe/rewinding:RewindingTest

 
This PR fixes the issue by adding the missing toolchain on s390x in ` BazelMockCcSupport.java` and the above test cases will pass after applying it. The code change won't cause any regressions on other archs.

Fixes #17383 .

Signed-off-by: Kun-Lu <kun.lu@ibm.com>