### PR TITLE
Remove `*.so` from `UNNECESSARY_DYNAMIC_LIBRARIES` on cpu s390x

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -599,11 +599,11 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
     "//src/conditions:windows": "*.so *.jnilib",
     "//src/conditions:darwin": "*.so *.dll",
     "//src/conditions:linux_x86_64": "*.jnilib *.dll",
-    # The .so file is an x86 one, so we can just remove it if the CPU is not x86
+    "//src/conditions:linux_s390x": "*.jnilib *.dll",
+    # The .so file is an x86/s390x one, so we can just remove it if the CPU is not x86/s390x
     "//src/conditions:arm": "*.so *.jnilib *.dll",
     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
     "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
-    "//src/conditions:linux_s390x": "*.so *.jnilib *.dll",
     "//src/conditions:freebsd": "*.so *.jnilib *.dll",
     "//src/conditions:openbsd": "*.so *.jnilib *.dll",
     # Default is to play it safe -- better have a big binary than a slow binary


### PR DESCRIPTION
Test cases such as ` //src/test/shell/bazel/remote:remote_execution_mtls_test`, ` //src/test/shell/bazel/remote:remote_execution_tls_test` and `//src/test/java/com/google/devtools/build/lib/remote:remote` failed on s390x because the runtime could not find `libnetty_tcnative_linux_s390_64.so` when running these test cases.
 
The configuration of ` UNNECESSARY_DYNAMIC_LIBRARIES` in ` third_party/BUILD` should be altered since the `.so` file also works on s390x, otherwise `libnetty_tcnative_linux_s390_64.so` will be removed after it's extracted from `netty-tcnative-boringssl-static` jar file.
 
This PR does the above mentioned changes and the relevant test cases would pass on s390x after applying it. The code change won't cause any regressions on other archs.

Fixes #17385 .

Signed-off-by: Kun-Lu <kun.lu@ibm.com>