### PR TITLE
Fix the configuration of target `prebuilt_singlejar` on cpu s390x

### DIFF
--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -173,6 +173,7 @@ alias(
     name = "ijar_prebuilt_binary",
     actual = select({
         "//src/conditions:linux_x86_64": ":ijar_prebuilt_binary_linux",
+        "//src/conditions:linux_s390x": ":ijar_prebuilt_binary_linux",
         "//src/conditions:darwin": ":ijar_prebuilt_binary_darwin",
         "//src/conditions:windows": ":ijar_prebuilt_binary_windows",
     }),
@@ -203,6 +204,7 @@ alias(
     name = "prebuilt_singlejar",
     actual = select({
         "//src/conditions:linux_x86_64": ":prebuilt_singlejar_linux",
+        "//src/conditions:linux_s390x": ":prebuilt_singlejar_linux",
         "//src/conditions:darwin": ":prebuilt_singlejar_darwin",
         "//src/conditions:windows": ":prebuilt_singlejar_windows",
     }),


### PR DESCRIPTION
When being run on s390x, the sub-test ` test_default_java_toolchain_prebuiltToolchain` in test case `//src/test/shell/bazel:bazel_java_test_defaults` will fail due to the incorrect configuration of target `@bazel_tools//tools/jdk:prebuilt_singlejar`.
 
This PR adds conditions on `linux_s390x` for target `ijar_prebuilt_binary` and `prebuilt_singlejar` to address this issue.

The code change will fix the test failure on s390x and won't cause any regressions on other archs.

Fixes #17387 .

Signed-off-by: Kun-Lu <kun.lu@ibm.com>