### PR TITLE
Support running tests on the target platform

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.analysis;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.devtools.build.lib.analysis.test.ExecutionInfo.DEFAULT_TEST_RUNNER_EXEC_GROUP;
 import static com.google.devtools.build.lib.packages.ExecGroup.DEFAULT_EXEC_GROUP_NAME;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -407,6 +408,38 @@ public final class RuleContext extends TargetContext
   @Override
   public ActionOwner getActionOwner() {
     return getActionOwner(DEFAULT_EXEC_GROUP_NAME);
+  }
+
+  /**
+   * Returns a special action owner for test actions. Test actions should run on the target platform
+   * rather than the host platform. Note that the value is not cached (on the assumption that this
+   * method is only called once).
+   */
+  public ActionOwner getTestActionOwner() {
+    PlatformInfo testExecutionPlatform;
+    ImmutableMap<String, String> testExecProperties;
+
+    // If we have a toolchain, pull the target platform out of it.
+    if (toolchainContexts != null) {
+      // TODO(https://github.com/bazelbuild/bazel/issues/17466): This doesn't respect execution
+      // properties coming from the target's `exec_properties` attribute.
+      // src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java has a
+      // test to test for it when it gets figured out.
+      testExecutionPlatform = toolchainContexts.getTargetPlatform();
+      testExecProperties = testExecutionPlatform.execProperties();
+    } else {
+      testExecutionPlatform = null;
+      testExecProperties = getExecGroups().getExecProperties(DEFAULT_TEST_RUNNER_EXEC_GROUP);
+    }
+
+    ActionOwner actionOwner =
+        createActionOwner(
+            rule, aspectDescriptors, getConfiguration(), testExecProperties, testExecutionPlatform);
+
+    if (actionOwner == null) {
+      actionOwner = getActionOwner();
+    }
+    return actionOwner;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -187,6 +187,16 @@ public final class TestActionBuilder {
     return this;
   }
 
+  private ActionOwner getTestActionOwner() {
+    if (this.executionRequirements != null) {
+      ActionOwner owner = ruleContext.getActionOwner(this.executionRequirements.getExecGroup());
+      if (owner != null) {
+        return owner;
+      }
+    }
+    return ruleContext.getTestActionOwner();
+  }
+
   private ActionOwner getOwner() {
     ActionOwner owner =
         ruleContext.getActionOwner(
@@ -386,6 +396,9 @@ public final class TestActionBuilder {
       testRunfilesSupplier = SingleRunfilesSupplier.create(runfilesSupport);
     }
 
+    ActionOwner actionOwner =
+        testConfiguration.useTargetPlatformForTests() ? getTestActionOwner() : getOwner();
+
     // Use 1-based indices for user friendliness.
     for (int shard = 0; shard < shardRuns; shard++) {
       String shardDir = shardRuns > 1 ? String.format("shard_%d_of_%d", shard + 1, shards) : null;
@@ -429,7 +442,7 @@ public final class TestActionBuilder {
         // TODO(b/234923262): Take exec_group into consideration when selecting sh tools
         TestRunnerAction testRunnerAction =
             new TestRunnerAction(
-                getOwner(),
+                actionOwner,
                 inputs,
                 testRunfilesSupplier,
                 testActionExecutable,

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -281,6 +281,16 @@ public class TestConfiguration extends Fragment {
         help = "If true, undeclared test outputs will be archived in a zip file.")
     public boolean zipUndeclaredTestOutputs;
 
+    @Option(
+        name = "use_target_platform_for_tests",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+        effectTags = {OptionEffectTag.EXECUTION},
+        help =
+            "If true, then Bazel will use the target platform for running tests rather than "
+                + "the test exec group.")
+    public boolean useTargetPlatformForTests;
+
     @Override
     public FragmentOptions getExec() {
       // Options here are either:
@@ -379,6 +389,10 @@ public class TestConfiguration extends Fragment {
 
   public boolean getZipUndeclaredTestOutputs() {
     return options.zipUndeclaredTestOutputs;
+  }
+
+  public boolean useTargetPlatformForTests() {
+    return options.useTargetPlatformForTests;
   }
 
   /**


### PR DESCRIPTION
This adds an --use_target_platform_for_tests option that changes tests to use the execution properties from the target platform rather than the host platform. I believe that the code is currently incorrect - if the host and target platforms differ, then tests are cross-compiled for the target platform, but use the execution properties for the host platform.

This matters for remote execution, where host and target platform may be different CPU architectures and operating systems (e.g., compiling on x64 Linux and running on ARM64 Mac). Currently, such tests will typically fail to run if they contain architecture or OS-specific code.

Based on work by Ulf Adams <ulf@engflow.com> and updated by tristan.maat@codethink.co.uk

Progress on #10799.

RELNOTES: Add --use_target_platform_for_tests which uses the target platform for executing tests instead of the execution platform.