### PR TITLE
Add `--skip_incompatible_explicit_targets` option

### DIFF
--- a/site/en/extending/platforms.md
+++ b/site/en/extending/platforms.md
@@ -162,7 +162,8 @@ In other words, `test_suite` targets on the command line behave like `:all` and
 `test_suite` targets with incompatible tests to also be incompatible.
 
 Explicitly specifying an incompatible target on the command line results in an
-error message and a failed build.
+error message and a failed build unless `--skip_incompatible_explicit_targets`
+is enabled:
 
 ```console
 $ bazel build --platforms=//:myplatform //:target_incompatible_with_myplatform

--- a/site/en/extending/platforms.md
+++ b/site/en/extending/platforms.md
@@ -162,8 +162,7 @@ In other words, `test_suite` targets on the command line behave like `:all` and
 `test_suite` targets with incompatible tests to also be incompatible.
 
 Explicitly specifying an incompatible target on the command line results in an
-error message and a failed build unless `--skip_incompatible_explicit_targets`
-is enabled:
+error message and a failed build.
 
 ```console
 $ bazel build --platforms=//:myplatform //:target_incompatible_with_myplatform
@@ -172,6 +171,9 @@ ERROR: Target //:target_incompatible_with_myplatform is incompatible and cannot 
 ...
 FAILED: Build did NOT complete successfully
 ```
+
+Incompatible explicit targets are silently skipped if
+`--skip_incompatible_explicit_targets` is enabled.
 
 ### More expressive constraints {:#expressive-constraints}
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
@@ -52,6 +52,15 @@ public class AnalysisOptions extends OptionsBase {
   public int maxConfigChangesToShow;
 
   @Option(
+    name = "skip_incompatible_explicit_targets",
+    defaultValue = "false",
+    documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+    effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+    help = "Skip incompatible targets that are explicitly listed on the command line."
+  )
+  public boolean skipIncompatibleExplicitTargets;
+
+  @Option(
       name = "experimental_extra_action_filter",
       defaultValue = "",
       converter = RegexFilter.RegexFilterConverter.class,

--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
@@ -56,7 +56,11 @@ public class AnalysisOptions extends OptionsBase {
     defaultValue = "false",
     documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
     effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-    help = "Skip incompatible targets that are explicitly listed on the command line."
+    help =
+        "Skip incompatible targets that are explicitly listed on the command line. "
+        + "By default, building such targets results in an error but they are "
+        + "silently skipped when this option is enabled. See: "
+        + "https://bazel.build/extending/platforms#skipping-incompatible-targets"
   )
   public boolean skipIncompatibleExplicitTargets;
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
@@ -211,6 +211,7 @@ public class BuildView {
       ImmutableMap<String, String> aspectsParameters,
       AnalysisOptions viewOptions,
       boolean keepGoing,
+      boolean skipIncompatibleExplicitTargets,
       boolean checkForActionConflicts,
       QuiescingExecutors executors,
       TopLevelArtifactContext topLevelOptions,
@@ -426,6 +427,7 @@ public class BuildView {
                     getCoverageArtifactsHelper(
                         configuredTargets, allTargetsToTest, eventHandler, eventBus, loadingResult),
                 keepGoing,
+                skipIncompatibleExplicitTargets,
                 targetOptions.get(CoreOptions.class).strictConflictChecks,
                 checkForActionConflicts,
                 executors,
@@ -492,7 +494,11 @@ public class BuildView {
 
         PlatformRestrictionsResult platformRestrictions =
             topLevelConstraintSemantics.checkPlatformRestrictions(
-                skyframeAnalysisResult.getConfiguredTargets(), explicitTargetPatterns, keepGoing);
+                skyframeAnalysisResult.getConfiguredTargets(),
+                explicitTargetPatterns,
+                keepGoing,
+                skipIncompatibleExplicitTargets
+            );
 
         if (!platformRestrictions.targetsWithErrors().isEmpty()) {
           // If there are any errored targets (e.g. incompatible targets that are explicitly

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
@@ -112,7 +112,8 @@ public class TopLevelConstraintSemantics {
       ConfiguredTarget configuredTarget,
       ExtendedEventHandler eventHandler,
       boolean eagerlyThrowError,
-      boolean explicitlyRequested)
+      boolean explicitlyRequested,
+      boolean skipIncompatibleExplicitTargets)
       throws TargetCompatibilityCheckException {
 
     RuleContextConstraintSemantics.IncompatibleCheckResult incompatibleCheckResult =
@@ -124,7 +125,7 @@ public class TopLevelConstraintSemantics {
     // We need the label in unambiguous form here. I.e. with the "@" prefix for targets in the
     // main repository. explicitTargetPatterns is also already in the unambiguous form to make
     // comparison succeed regardless of the provided form.
-    if (explicitlyRequested) {
+    if (!skipIncompatibleExplicitTargets && explicitlyRequested) {
       if (eagerlyThrowError) {
         // Use the slightly simpler form for printing error messages. I.e. no "@" prefix for
         // targets in the main repository.
@@ -136,7 +137,8 @@ public class TopLevelConstraintSemantics {
               String.format(TARGET_INCOMPATIBLE_ERROR_TEMPLATE, configuredTarget.getLabel(), "")));
       return PlatformCompatibility.INCOMPATIBLE_EXPLICIT;
     }
-    // If this is not an explicitly requested target we can safely skip it.
+    // We can safely skip this target if it wasn't explicitly requested or we've been instructed
+    // to skip explicitly requested targets.
     return PlatformCompatibility.INCOMPATIBLE_IMPLICIT;
   }
 
@@ -240,8 +242,8 @@ public class TopLevelConstraintSemantics {
    * the command line should be skipped.
    *
    * <p>Targets that are incompatible with the target platform and *are* explicitly requested on the
-   * command line are errored. Having one or more errored targets will cause the entire build to
-   * fail with an error message.
+   * command line are errored unless --skip_incompatible_explicit_targets is enabled. Having one or
+   * more errored targets will cause the entire build to fail with an error message.
    *
    * @param topLevelTargets the build's top-level targets
    * @param explicitTargetPatterns the set of explicit target patterns specified by the user on the
@@ -254,7 +256,8 @@ public class TopLevelConstraintSemantics {
   public PlatformRestrictionsResult checkPlatformRestrictions(
       ImmutableSet<ConfiguredTarget> topLevelTargets,
       ImmutableSet<Label> explicitTargetPatterns,
-      boolean keepGoing)
+      boolean keepGoing,
+      boolean skipIncompatibleExplicitTargets)
       throws ViewCreationFailedException {
     ImmutableSet.Builder<ConfiguredTarget> incompatibleTargets = ImmutableSet.builder();
     ImmutableSet.Builder<ConfiguredTarget> incompatibleButRequestedTargets = ImmutableSet.builder();
@@ -266,7 +269,8 @@ public class TopLevelConstraintSemantics {
                 target,
                 eventHandler,
                 /*eagerlyThrowError=*/ !keepGoing,
-                explicitTargetPatterns.contains(target.getLabel()));
+                explicitTargetPatterns.contains(target.getLabel()),
+                skipIncompatibleExplicitTargets);
         if (PlatformCompatibility.INCOMPATIBLE_EXPLICIT.equals(platformCompatibility)) {
           incompatibleButRequestedTargets.add(target);
         } else if (PlatformCompatibility.INCOMPATIBLE_IMPLICIT.equals(platformCompatibility)) {

--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisAndExecutionPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisAndExecutionPhaseRunner.java
@@ -241,7 +241,7 @@ public final class AnalysisAndExecutionPhaseRunner {
             request.getAspectsParameters(),
             request.getViewOptions(),
             request.getKeepGoing(),
-            request.getBuildOptions().skipIncompatibleExplicitTargets,
+            request.getViewOptions().skipIncompatibleExplicitTargets,
             request.getCheckForActionConflicts(),
             env.getQuiescingExecutors(),
             request.getTopLevelArtifactContext(),

--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisAndExecutionPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisAndExecutionPhaseRunner.java
@@ -241,6 +241,7 @@ public final class AnalysisAndExecutionPhaseRunner {
             request.getAspectsParameters(),
             request.getViewOptions(),
             request.getKeepGoing(),
+            request.getBuildOptions().skipIncompatibleExplicitTargets,
             request.getCheckForActionConflicts(),
             env.getQuiescingExecutors(),
             request.getTopLevelArtifactContext(),

--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
@@ -247,6 +247,7 @@ public final class AnalysisPhaseRunner {
               request.getAspectsParameters(),
               request.getViewOptions(),
               request.getKeepGoing(),
+              request.getBuildOptions().skipIncompatibleExplicitTargets,
               request.getCheckForActionConflicts(),
               env.getQuiescingExecutors(),
               request.getTopLevelArtifactContext(),

--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
@@ -247,7 +247,7 @@ public final class AnalysisPhaseRunner {
               request.getAspectsParameters(),
               request.getViewOptions(),
               request.getKeepGoing(),
-              request.getBuildOptions().skipIncompatibleExplicitTargets,
+              request.getViewOptions().skipIncompatibleExplicitTargets,
               request.getCheckForActionConflicts(),
               env.getQuiescingExecutors(),
               request.getTopLevelArtifactContext(),

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -535,6 +535,15 @@ public class BuildRequestOptions extends OptionsBase {
   @Nullable
   public PathFragment aqueryDumpAfterBuildOutputFile;
 
+  @Option(
+    name = "skip_incompatible_explicit_targets",
+    defaultValue = "false",
+    documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+    effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+    help = "Skip incompatible targets that are explicitly listed on the command line."
+  )
+  public boolean skipIncompatibleExplicitTargets;
+
   /**
    * Converter for jobs: Takes keyword ({@value #FLAG_SYNTAX}). Values must be between 1 and
    * MAX_JOBS.

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -535,15 +535,6 @@ public class BuildRequestOptions extends OptionsBase {
   @Nullable
   public PathFragment aqueryDumpAfterBuildOutputFile;
 
-  @Option(
-    name = "skip_incompatible_explicit_targets",
-    defaultValue = "false",
-    documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
-    effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-    help = "Skip incompatible targets that are explicitly listed on the command line."
-  )
-  public boolean skipIncompatibleExplicitTargets;
-
   /**
    * Converter for jobs: Takes keyword ({@value #FLAG_SYNTAX}). Values must be between 1 and
    * MAX_JOBS.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BuildDriverFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BuildDriverFunction.java
@@ -182,7 +182,8 @@ public class BuildDriverFunction implements SkyFunction {
                   state,
                   configuredTarget,
                   buildConfigurationValue,
-                  buildDriverKey.isExplicitlyRequested());
+                  buildDriverKey.isExplicitlyRequested(),
+                  buildDriverKey.shouldSkipIncompatibleExplicitTargets());
           if (isConfiguredTargetCompatible == null) {
             return null;
           }
@@ -273,7 +274,8 @@ public class BuildDriverFunction implements SkyFunction {
       State state,
       ConfiguredTarget configuredTarget,
       BuildConfigurationValue buildConfigurationValue,
-      boolean isExplicitlyRequested)
+      boolean isExplicitlyRequested,
+      boolean skipIncompatibleExplicitTargets)
       throws InterruptedException, TargetCompatibilityCheckException {
 
     if (!state.checkedForPlatformCompatibility) {
@@ -282,7 +284,8 @@ public class BuildDriverFunction implements SkyFunction {
               configuredTarget,
               env.getListener(),
               /*eagerlyThrowError=*/ true,
-              isExplicitlyRequested);
+              isExplicitlyRequested,
+              skipIncompatibleExplicitTargets);
       state.checkedForPlatformCompatibility = true;
       switch (platformCompatibility) {
         case INCOMPATIBLE_EXPLICIT:

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BuildDriverKey.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BuildDriverKey.java
@@ -29,6 +29,7 @@ public final class BuildDriverKey implements CPUHeavySkyKey {
   private final TestType testType;
   private final boolean strictActionConflictCheck;
   private final boolean explicitlyRequested;
+  private final boolean skipIncompatibleExplicitTargets;
   private final boolean isTopLevelAspectDriver;
 
   private BuildDriverKey(
@@ -36,12 +37,14 @@ public final class BuildDriverKey implements CPUHeavySkyKey {
       TopLevelArtifactContext topLevelArtifactContext,
       boolean strictActionConflictCheck,
       boolean explicitlyRequested,
+      boolean skipIncompatibleExplicitTargets,
       boolean isTopLevelAspectDriver,
       TestType testType) {
     this.actionLookupKey = actionLookupKey;
     this.topLevelArtifactContext = topLevelArtifactContext;
     this.strictActionConflictCheck = strictActionConflictCheck;
     this.explicitlyRequested = explicitlyRequested;
+    this.skipIncompatibleExplicitTargets = skipIncompatibleExplicitTargets;
     this.isTopLevelAspectDriver = isTopLevelAspectDriver;
     this.testType = testType;
   }
@@ -50,12 +53,14 @@ public final class BuildDriverKey implements CPUHeavySkyKey {
       ActionLookupKey actionLookupKey,
       TopLevelArtifactContext topLevelArtifactContext,
       boolean strictActionConflictCheck,
-      boolean explicitlyRequested) {
+      boolean explicitlyRequested,
+      boolean skipIncompatibleExplicitTargets) {
     return new BuildDriverKey(
         actionLookupKey,
         topLevelArtifactContext,
         strictActionConflictCheck,
         explicitlyRequested,
+        skipIncompatibleExplicitTargets,
         /*isTopLevelAspectDriver=*/ true,
         TestType.NOT_TEST);
   }
@@ -65,12 +70,14 @@ public final class BuildDriverKey implements CPUHeavySkyKey {
       TopLevelArtifactContext topLevelArtifactContext,
       boolean strictActionConflictCheck,
       boolean explicitlyRequested,
+      boolean skipIncompatibleExplicitTargets,
       TestType testType) {
     return new BuildDriverKey(
         actionLookupKey,
         topLevelArtifactContext,
         strictActionConflictCheck,
         explicitlyRequested,
+        skipIncompatibleExplicitTargets,
         /*isTopLevelAspectDriver=*/ false,
         testType);
   }
@@ -97,6 +104,10 @@ public final class BuildDriverKey implements CPUHeavySkyKey {
 
   public boolean isExplicitlyRequested() {
     return explicitlyRequested;
+  }
+
+  public boolean shouldSkipIncompatibleExplicitTargets() {
+    return skipIncompatibleExplicitTargets;
   }
 
   public boolean isTopLevelAspectDriver() {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeBuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeBuildView.java
@@ -537,6 +537,7 @@ public final class SkyframeBuildView {
       BuildResultListener buildResultListener,
       CoverageReportActionsWrapperSupplier coverageReportActionsWrapperSupplier,
       boolean keepGoing,
+      boolean skipIncompatibleExplicitTargets,
       boolean strictConflictCheck,
       boolean checkForActionConflicts,
       QuiescingExecutors executors,
@@ -573,6 +574,7 @@ public final class SkyframeBuildView {
                         strictConflictCheck,
                         /* explicitlyRequested= */ explicitTargetPatterns.contains(
                             ctKey.getLabel()),
+                        skipIncompatibleExplicitTargets,
                         determineTestType(
                             testsToRun,
                             labelTargetMap,
@@ -589,7 +591,8 @@ public final class SkyframeBuildView {
                         k,
                         topLevelArtifactContext,
                         strictConflictCheck,
-                        /*explicitlyRequested=*/ explicitTargetPatterns.contains(k.getLabel())))
+                        /*explicitlyRequested=*/ explicitTargetPatterns.contains(k.getLabel()),
+                        skipIncompatibleExplicitTargets))
             .collect(ImmutableSet.toImmutableSet());
     List<DetailedExitCode> detailedExitCodes = new ArrayList<>();
     MultiThreadPoolsQuiescingExecutor executor =

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewForTesting.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewForTesting.java
@@ -211,6 +211,7 @@ public class BuildViewForTesting {
         aspectsParameters,
         viewOptions,
         keepGoing,
+        /* skipIncompatibleExplicitTargets= */ false,
         /* checkForActionConflicts= */ true,
         QuiescingExecutorsImpl.forTesting(),
         topLevelOptions,


### PR DESCRIPTION
This adds an argument to skip incompatible targets even if they were explicitly requested on the command line. This is useful for CI to allow it to build changed targets from rdeps queries without needing to filter them all through a cquery to check if they are compatible.

Closes #17403

RELNOTES: Add `--skip_incompatible_explicit_targets` option