### PR TITLE
Fix email address for product@bazel.build

### DIFF
--- a/site/en/community/users.md
+++ b/site/en/community/users.md
@@ -7,7 +7,7 @@ Book: /_book.yaml
 
 Note: Using Bazel? You can add your company on
 [StackShare](https://stackshare.io/bazel). To add yourself to this page,
-contact [product@bazel.build](mailto:produc@bazel.build).
+contact [product@bazel.build](mailto:product@bazel.build).
 
 This page lists companies and OSS projects that are known to use Bazel.
 This does not constitute an endorsement.


### PR DESCRIPTION
The link mailto address does not match the text for that link. I'm guessing the mailto address is the incorrect one