### PR TITLE
Execute java prebuilt toolchain tests only on supported platforms

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -188,6 +188,21 @@ sh_test(
 )
 
 sh_test(
+    name = "bazel_java_test_defaults_prebuilt",
+    srcs = ["bazel_java_test_defaults_prebuilt.sh"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+    target_compatible_with = select({
+        "@platforms//os:linux": ["@platforms//cpu:x86_64"],
+        "@platforms//os:macos": [],
+        "@platforms//os:windows": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    })
+)
+
+sh_test(
     name = "bazel_java17_test",
     srcs = ["bazel_java17_test.sh"],
     args = [

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -221,25 +221,6 @@ EOF
   expect_not_log ":JavaBuilder"
 }
 
-# PREBUILT_TOOLCHAIN_CONFIGURATION shall use prebuilt ijar and singlejar binaries.
-function test_default_java_toolchain_prebuiltToolchain() {
-  cat > BUILD <<EOF
-load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "PREBUILT_TOOLCHAIN_CONFIGURATION")
-default_java_toolchain(
-  name = "prebuilt_toolchain",
-  configuration = PREBUILT_TOOLCHAIN_CONFIGURATION,
-)
-EOF
-
-  bazel build //:prebuilt_toolchain || fail "default_java_toolchain target failed to build"
-  bazel cquery 'deps(//:prebuilt_toolchain)' >& $TEST_log || fail "failed to query //:prebuilt_toolchain"
-
-  expect_log "ijar/ijar\(.exe\)\? "
-  expect_log "singlejar/singlejar_local"
-  expect_not_log "ijar/ijar.cc"
-  expect_not_log "singlejar/singlejar_main.cc"
-}
-
 # NONPREBUILT_TOOLCHAIN_CONFIGURATION shall compile ijar and singlejar from sources.
 function test_default_java_toolchain_nonprebuiltToolchain() {
   cat > BUILD <<EOF

--- a/src/test/shell/bazel/bazel_java_test_defaults_prebuilt.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults_prebuilt.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tests Java prebuilt toolchains.
+#
+
+set -euo pipefail
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+    if [[ -f "$0.runfiles_manifest" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+      export RUNFILES_DIR="$0.runfiles"
+    fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
+# PREBUILT_TOOLCHAIN_CONFIGURATION shall use prebuilt ijar and singlejar binaries.
+function test_default_java_toolchain_prebuiltToolchain() {
+  cat > BUILD <<EOF
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "PREBUILT_TOOLCHAIN_CONFIGURATION")
+default_java_toolchain(
+  name = "prebuilt_toolchain",
+  configuration = PREBUILT_TOOLCHAIN_CONFIGURATION,
+)
+EOF
+
+  bazel build //:prebuilt_toolchain || fail "default_java_toolchain target failed to build"
+  bazel cquery 'deps(//:prebuilt_toolchain)' >& $TEST_log || fail "failed to query //:prebuilt_toolchain"
+
+  expect_log "ijar/ijar\(.exe\)\? "
+  expect_log "singlejar/singlejar_local"
+  expect_not_log "ijar/ijar.cc"
+  expect_not_log "singlejar/singlejar_main.cc"
+}
+
+run_suite "Java prebuilt toolchains tests."


### PR DESCRIPTION
The prebuilt tools are only compiled for linux_x86_63, windows and darwin. The test will fail if executed anywhere else, and so should be skipped in those cases.

This change extracts out the prebuilt test into it's own target and sets `target_compatible_with` to the supported platforms.

Fixes https://github.com/bazelbuild/bazel/issues/17387