### PR TITLE
[6.1.0]Allow -v to libtool

### DIFF
--- a/tools/objc/libtool.sh
+++ b/tools/objc/libtool.sh
@@ -107,7 +107,7 @@ function parse_option() {
         done < "$path" || exit 1
         ;;
       # Flags with no args
-      -static|-s|-a|-c|-L|-T|-D|-no_warning_for_no_symbols)
+      -static|-s|-a|-c|-L|-T|-D|-v|-no_warning_for_no_symbols)
         ARGS+=("${ARG}")
         ;;
       # Single-arg flags

--- a/tools/objc/libtool_check_unique.cc
+++ b/tools/objc/libtool_check_unique.cc
@@ -26,7 +26,7 @@ using std::vector;
 
 const regex libRegex = regex(".*\\.a$");
 const regex noArgFlags =
-    regex("-static|-s|-a|-c|-L|-T|-D|-no_warning_for_no_symbols");
+    regex("-static|-s|-a|-c|-L|-T|-D|-v|-no_warning_for_no_symbols");
 const regex singleArgFlags = regex("-arch_only|-syslibroot|-o");
 
 string getBasename(const string &path) {


### PR DESCRIPTION
This is useful for debugging. Without it being in these lists the static archive fails

Closes #16367.

PiperOrigin-RevId: 508325556
Change-Id: I6d0b2c19123132f0d8a41e8925de9c57197a10bf