### PR TITLE
Generate shorter transition output directory suffixes

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2237,7 +2237,7 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
         .contains("-Xlinker -rpath -Xlinker $ORIGIN/../../../k8-fastbuild-ST-");
     assertThat(Joiner.on(" ").join(linkArgv))
         .contains("-L" + TestConstants.PRODUCT_NAME + "-out/k8-fastbuild-ST-");
-    assertThat(Joiner.on(" ").join(linkArgv)).containsMatch("-lST-[0-9a-f]+_transition_Slibdep2");
+    assertThat(Joiner.on(" ").join(linkArgv)).containsMatch("-lST-[0-9a-z]+_transition_Slibdep2");
     assertThat(Joiner.on(" ").join(linkArgv))
         .doesNotContain("-L" + TestConstants.PRODUCT_NAME + "-out/k8-fastbuild/bin/_solib_k8");
     assertThat(Joiner.on(" ").join(linkArgv)).doesNotContain("-ltransition_Slibdep2");


### PR DESCRIPTION
Reduces the length of the hash fragment by three characters, which helps with Windows path length limitations. By switching from base16 to base32 encoding, this decreases the entropy by only 3 bits (down to 45 bits).

Work towards #14023