### PR TITLE
Remove default -s flag from macOS libtool invocation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -611,7 +611,7 @@ public class CppActionConfigs {
                         "    action: 'c++-link-static-library'",
                         "    flag_group {",
                         ifLinux(platform, "flag: 'rcsD'"),
-                        ifMac(platform, "flag: '-static'", "flag: '-s'"),
+                        ifMac(platform, "flag: '-static'"),
                         "    }",
                         "    flag_group {",
                         "      expand_if_all_available: 'output_execpath'",


### PR DESCRIPTION
-s is the default but it's not supported by llvm's libtool replacement which results in failed links. I don't think we really care about the specifics here, so since it's the default for most folks we can drop it.