### PR TITLE
[6.1.0]Fix Java coverage collection with Java 8 runtime

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoLCOVFormatter.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoLCOVFormatter.java
@@ -70,7 +70,7 @@ public class JacocoLCOVFormatter {
       private Map<String, ISourceFileCoverage> sourceToFileCoverage = new TreeMap<>();
 
       private String getExecPathForEntryName(String classPath) {
-        if (execPathsOfUninstrumentedFiles.isEmpty()) {
+        if (!execPathsOfUninstrumentedFiles.isPresent()) {
           return classPath;
         }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainRule.java
@@ -282,8 +282,6 @@ public final class JavaToolchainRule<C extends JavaToolchain> implements RuleDef
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
             attr("jacocorunner", LABEL)
-                // This needs to be in the execution configuration.
-                .cfg(ExecutionTransitionFactory.create())
                 .allowedFileTypes(FileTypeSet.ANY_FILE)
                 .exec())
         /* <!-- #BLAZE_RULE(java_toolchain).ATTRIBUTE(proguard_allowlister) -->


### PR DESCRIPTION
`JacocoCoverageRunner` is run with the target runtime, not the exec runtime, and thus needs to be compatible with a Java 8 runtime.

Fixes #17165

Closes #17338.

PiperOrigin-RevId: 509123073
Change-Id: I41d7255e1f3c3dd3864082899d5dc9ab2cc82027