### PR TITLE
[6.1.0]Add a flag to disable execution log sorting.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -123,6 +123,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/protobuf:failure_details_java_proto",
+        "//src/main/protobuf:spawn_java_proto",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -473,6 +473,17 @@ public class ExecutionOptions extends OptionsBase {
   public PathFragment executionLogJsonFile;
 
   @Option(
+      name = "execution_log_sort",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Whether to sort the execution log. Set to false to improve memory"
+              + " performance, at the cost of producing the log in nondeterministic"
+              + " order.")
+  public boolean executionLogSort;
+
+  @Option(
       name = "experimental_split_xml_generation",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -326,4 +326,8 @@ public class SpawnLogContext implements ActionContext {
         .setSizeBytes(fileSize)
         .build();
   }
+
+  public boolean shouldSort() {
+    return executionOptions.executionLogSort;
+  }
 }


### PR DESCRIPTION
This may improve performance when the execution log gets very large. The default is still to sort, so this is a backwards-compatible change.

Closes #17354.
Closes #17111.

PiperOrigin-RevId: 509822315
Change-Id: If948ec4a933389b6f8405985813dd76c549c445c