### PR TITLE
Increase timeouts for macOS toolchain setup

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -71,7 +71,7 @@ def _compile_cc_file_single_arch(repository_ctx, src_name, out_name):
         "-o",
         out_name,
         src_name,
-    ], 60)
+    ])
     if (xcrun_result.return_code != 0):
         error_msg = (
             "return code {code}, stderr: {err}, stdout: {out}"
@@ -107,7 +107,7 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
         "-o",
         out_name,
         src_name,
-    ], 60)
+    ])
 
     if xcrun_result.return_code == 0:
         xcrun_result = repository_ctx.execute([
@@ -120,7 +120,7 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
             "--sign",
             "-",
             out_name,
-        ], 60)
+        ])
         if xcrun_result.return_code != 0:
             error_msg = (
                 "codesign return code {code}, stderr: {err}, stdout: {out}"

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -17,8 +17,6 @@
    installed on the local host.
 """
 
-_EXECUTE_TIMEOUT = 120
-
 def _search_string(fullstring, prefix, suffix):
     """Returns the substring between two given substrings of a larger string.
 
@@ -55,8 +53,7 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir)
     repository_ctx.report_progress("Fetching SDK information for Xcode %s" % version)
     xcodebuild_result = repository_ctx.execute(
         ["xcrun", "xcodebuild", "-version", "-sdk"],
-        _EXECUTE_TIMEOUT,
-        {"DEVELOPER_DIR": developer_dir},
+        environment = {"DEVELOPER_DIR": developer_dir},
     )
     if (xcodebuild_result.return_code != 0):
         error_msg = (
@@ -135,7 +132,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
         "-o",
         "xcode-locator-bin",
         xcodeloc_src_path,
-    ], _EXECUTE_TIMEOUT)
+    ])
 
     if (xcrun_result.return_code != 0):
         suggestion = ""
@@ -156,7 +153,6 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
     repository_ctx.report_progress("Running xcode-locator")
     xcode_locator_result = repository_ctx.execute(
         ["./xcode-locator-bin", "-v"],
-        _EXECUTE_TIMEOUT,
     )
     if (xcode_locator_result.return_code != 0):
         error_msg = (
@@ -195,7 +191,7 @@ def _darwin_build_file(repository_ctx):
         "xcrun",
         "xcodebuild",
         "-version",
-    ], _EXECUTE_TIMEOUT)
+    ])
 
     (toolchains, xcodeloc_err) = run_xcode_locator(
         repository_ctx,


### PR DESCRIPTION
This switches all macOS toolchain setup compiles and executes to use the default timeout of 600s. This should help avoid issues on GitHub actions where these timeout and cause build failures. The common case shouldn't really be affected.

https://github.com/bazelbuild/bazel/issues/17437