### PR TITLE
[6.1.0] Allow the timeout value for execute calls on a mac to be set via an environment variable

### DIFF
--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -17,7 +17,7 @@
    installed on the local host.
 """
 
-_EXECUTE_TIMEOUT = 120
+OSX_EXECUTE_TIMEOUT = 120
 
 def _search_string(fullstring, prefix, suffix):
     """Returns the substring between two given substrings of a larger string.
@@ -45,7 +45,7 @@ def _search_sdk_output(output, sdkname):
     """Returns the sdk version given xcodebuild stdout and an sdkname."""
     return _search_string(output, "(%s" % sdkname, ")")
 
-def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir):
+def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir, timeout):
     """Returns a string containing an xcode_version build target."""
     build_contents = ""
     decorated_aliases = []
@@ -55,7 +55,7 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir)
     repository_ctx.report_progress("Fetching SDK information for Xcode %s" % version)
     xcodebuild_result = repository_ctx.execute(
         ["xcrun", "xcodebuild", "-version", "-sdk"],
-        _EXECUTE_TIMEOUT,
+        timeout,
         {"DEVELOPER_DIR": developer_dir},
     )
     if (xcodebuild_result.return_code != 0):
@@ -118,6 +118,11 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
     repository_ctx.report_progress("Building xcode-locator")
     xcodeloc_src_path = str(repository_ctx.path(xcode_locator_src_label))
     env = repository_ctx.os.environ
+    if "BAZEL_OSX_EXECUTE_TIMEOUT" in env:
+        timeout = int(env["BAZEL_OSX_EXECUTE_TIMEOUT"])
+    else:
+        timeout = OSX_EXECUTE_TIMEOUT
+
     xcrun_result = repository_ctx.execute([
         "env",
         "-i",
@@ -135,7 +140,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
         "-o",
         "xcode-locator-bin",
         xcodeloc_src_path,
-    ], _EXECUTE_TIMEOUT)
+    ], timeout)
 
     if (xcrun_result.return_code != 0):
         suggestion = ""
@@ -156,7 +161,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
     repository_ctx.report_progress("Running xcode-locator")
     xcode_locator_result = repository_ctx.execute(
         ["./xcode-locator-bin", "-v"],
-        _EXECUTE_TIMEOUT,
+        timeout,
     )
     if (xcode_locator_result.return_code != 0):
         error_msg = (
@@ -188,6 +193,12 @@ def _darwin_build_file(repository_ctx):
     """Evaluates local system state to create xcode_config and xcode_version targets."""
     repository_ctx.report_progress("Fetching the default Xcode version")
     env = repository_ctx.os.environ
+
+    if "BAZEL_OSX_EXECUTE_TIMEOUT" in env:
+        timeout = int(env["BAZEL_OSX_EXECUTE_TIMEOUT"])
+    else:
+        timeout = OSX_EXECUTE_TIMEOUT
+
     xcodebuild_result = repository_ctx.execute([
         "env",
         "-i",
@@ -195,7 +206,7 @@ def _darwin_build_file(repository_ctx):
         "xcrun",
         "xcodebuild",
         "-version",
-    ], _EXECUTE_TIMEOUT)
+    ], timeout)
 
     (toolchains, xcodeloc_err) = run_xcode_locator(
         repository_ctx,
@@ -229,6 +240,7 @@ def _darwin_build_file(repository_ctx):
             version,
             aliases,
             developer_dir,
+            timeout,
         )
         target_label = "':%s'" % target_name
         target_names.append(target_label)


### PR DESCRIPTION
In certain setups, these calls to xcrun during bazel setup have been reported to sometimes take more than 2 minutes (see
https://github.com/bazelbuild/bazel/issues/17437).  We have already bumped this timeout multiple times, which is currently 60 for some calls and 120 for others. Standardize the default timeout to 120, and allow the timeout to be override via BAZEL_OSX_EXECUTE_TIMEOUT, to allow individual enviroments to increase that even more if needed.

PiperOrigin-RevId: 510200188
Change-Id: I664eb7979c4fd2b46ccc87d073f319c1e6041d77

https://github.com/bazelbuild/bazel/issues/17437