### PR TITLE
Increase default macOS toolchain setup time

### DIFF
--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -17,7 +17,7 @@
    installed on the local host.
 """
 
-OSX_EXECUTE_TIMEOUT = 120
+OSX_EXECUTE_TIMEOUT = 600
 
 def _search_string(fullstring, prefix, suffix):
     """Returns the substring between two given substrings of a larger string.


### PR DESCRIPTION
This should help avoid timeouts without users having to manually override this value. They can manually override it if they want to bring it down

https://github.com/bazelbuild/bazel/pull/17519