### PR TITLE
Remove optimize_for from execution_statistics.proto.

### DIFF
--- a/src/main/protobuf/execution_statistics.proto
+++ b/src/main/protobuf/execution_statistics.proto
@@ -18,7 +18,6 @@ package tools.protos;
 
 option java_package = "com.google.devtools.build.lib.shell";
 option java_outer_classname = "Protos";
-option optimize_for = LITE_RUNTIME;
 
 // Verbatim representation of the rusage structure returned by getrusage(2).
 // For further details on all these cryptic names, see that manual page.


### PR DESCRIPTION
```
[libprotobuf WARNING external/com_google_protobuf/src/google/protobuf/compiler/java/file.cc:247] The optimize_for = LITE_RUNTIME option is no longer supported by protobuf Java code generator and is ignored--protoc will always generate full runtime code for Java. To use Java Lite runtime, users should use the Java Lite plugin instead. See:
  https://github.com/protocolbuffers/protobuf/blob/main/java/lite.md
```