### PR TITLE
[6.1.0] Bump version number in runfiles.bash init code

### DIFF
--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -67,8 +67,8 @@
 #     up the library's runtime location, thus we have a chicken-and-egg problem.
 #     Insert the following code snippet to the top of your main script:
 #
-#       # --- begin runfiles.bash initialization v2 ---
-#       # Copy-pasted from the Bazel Bash runfiles library v2.
+#       # --- begin runfiles.bash initialization v3 ---
+#       # Copy-pasted from the Bazel Bash runfiles library v3.
 #       set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
 #       source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 #         source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
@@ -76,7 +76,7 @@
 #         source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
 #         source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
 #         { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-#       # --- end runfiles.bash initialization v2 ---
+#       # --- end runfiles.bash initialization v3 ---
 #
 #
 # 3.  Use rlocation to look up runfile paths.


### PR DESCRIPTION
The version number wasn't updated in 839ce7f5c40240d8b6f49c416c3769e226f43fee.

Closes #17511.

PiperOrigin-RevId: 510985230
Change-Id: Iff6006a17e4882e1225d5fc02d26d8c3f932f361