### PR TITLE
[6.1.0] Properly report repo fetch progress during main repo mapping computation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/buildevent/MainRepoMappingComputationStartingEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/buildevent/MainRepoMappingComputationStartingEvent.java
@@ -1,0 +1,21 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.buildtool.buildevent;
+
+/**
+ * Event fired right before main repo mapping computation starts (between the two rounds of option
+ * parsing).
+ */
+public class MainRepoMappingComputationStartingEvent {}

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.bugreport.BugReporter;
 import com.google.devtools.build.lib.bugreport.Crash;
 import com.google.devtools.build.lib.bugreport.CrashContext;
 import com.google.devtools.build.lib.buildeventstream.BuildEventProtocolOptions;
+import com.google.devtools.build.lib.buildtool.buildevent.MainRepoMappingComputationStartingEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.ProfilerStartedEvent;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
@@ -547,6 +548,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
 
         // Compute the repo mapping of the main repo and re-parse options so that we get correct
         // values for label-typed options.
+        env.getEventBus().post(new MainRepoMappingComputationStartingEvent());
         try {
           RepositoryMapping mainRepoMapping =
               env.getSkyframeExecutor().getMainRepoMapping(reporter);

--- a/src/main/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTracker.java
@@ -35,6 +35,7 @@ final class SkymeldUiStateTracker extends UiStateTracker {
     // We explicitly define a starting status, which can be used to determine what to display in
     // cases before the build has started.
     BUILD_NOT_STARTED,
+    COMPUTING_MAIN_REPO_MAPPING,
     BUILD_STARTED,
     TARGET_PATTERN_PARSING,
     LOADING_COMPLETE,
@@ -77,6 +78,9 @@ final class SkymeldUiStateTracker extends UiStateTracker {
     switch (buildStatus) {
       case BUILD_NOT_STARTED:
         return;
+      case COMPUTING_MAIN_REPO_MAPPING:
+        writeBaseProgress("Computing main repo mapping", "", terminalWriter);
+        break;
       case BUILD_STARTED:
         writeBaseProgress("Loading", "", terminalWriter);
         break;
@@ -149,6 +153,11 @@ final class SkymeldUiStateTracker extends UiStateTracker {
         terminalWriter.newline().append("    " + progress.getSecond());
       }
     }
+  }
+
+  @Override
+  void mainRepoMappingComputationStarted() {
+    buildStatus = BuildStatus.COMPUTING_MAIN_REPO_MAPPING;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventTransportClosedE
 import com.google.devtools.build.lib.buildtool.buildevent.BuildCompleteEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.BuildStartingEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.ExecutionProgressReceiverAvailableEvent;
+import com.google.devtools.build.lib.buildtool.buildevent.MainRepoMappingComputationStartingEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.TestFilteringCompleteEvent;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.events.Event;
@@ -517,10 +518,20 @@ public final class UiEventHandler implements EventHandler {
   }
 
   @Subscribe
-  public void buildStarted(BuildStartingEvent event) {
+  public void mainRepoMappingComputationStarted(MainRepoMappingComputationStartingEvent event) {
     synchronized (this) {
       buildRunning = true;
     }
+    maybeAddDate();
+    stateTracker.buildStarted();
+    // As a new phase started, inform immediately.
+    ignoreRefreshLimitOnce();
+    refresh();
+    startUpdateThread();
+  }
+
+  @Subscribe
+  public void buildStarted(BuildStartingEvent event) {
     maybeAddDate();
     stateTracker.buildStarted();
     // As a new phase started, inform immediately.

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -409,6 +409,11 @@ class UiStateTracker {
     this.sampleSize = Math.max(1, sampleSize);
   }
 
+  void mainRepoMappingComputationStarted() {
+    status = "Computing main repo mapping";
+    additionalMessage = "";
+  }
+
   void buildStarted() {
     status = "Loading";
     additionalMessage = "";

--- a/src/test/java/com/google/devtools/build/lib/runtime/UiEventHandlerStdOutAndStdErrTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/UiEventHandlerStdOutAndStdErrTest.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.buildtool.BuildRequest;
 import com.google.devtools.build.lib.buildtool.BuildResult;
 import com.google.devtools.build.lib.buildtool.buildevent.BuildCompleteEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.BuildStartingEvent;
+import com.google.devtools.build.lib.buildtool.buildevent.MainRepoMappingComputationStartingEvent;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.testutil.ManualClock;
@@ -70,23 +71,24 @@ public final class UiEventHandlerStdOutAndStdErrTest {
     OutErr outErr = null;
     switch (testedOutput) {
       case STDOUT:
-        outErr = OutErr.create(/*out=*/ output, /*err=*/ mock(OutputStream.class));
+        outErr = OutErr.create(/* out= */ output, /* err= */ mock(OutputStream.class));
         eventKind = EventKind.STDOUT;
         break;
       case STDERR:
-        outErr = OutErr.create(/*out=*/ mock(OutputStream.class), /*err=*/ output);
+        outErr = OutErr.create(/* out= */ mock(OutputStream.class), /* err= */ output);
         eventKind = EventKind.STDERR;
         break;
     }
 
     uiEventHandler =
-        new UiEventHandler(outErr, uiOptions, new ManualClock(), /*workspacePathFragment=*/ null);
+        new UiEventHandler(outErr, uiOptions, new ManualClock(), /* workspacePathFragment= */ null);
+    uiEventHandler.mainRepoMappingComputationStarted(new MainRepoMappingComputationStartingEvent());
     uiEventHandler.buildStarted(
         BuildStartingEvent.create(
             "outputFileSystemType",
-            /*usesInMemoryFileSystem=*/ false,
+            /* usesInMemoryFileSystem= */ false,
             mock(BuildRequest.class),
-            /*workspace=*/ null,
+            /* workspace= */ null,
             "/pwd"));
   }
 
@@ -169,7 +171,7 @@ public final class UiEventHandlerStdOutAndStdErrTest {
     uiOptions.eventFilters = ImmutableList.of();
     createUiEventHandler(uiOptions);
     if (testedOutput == TestedOutput.STDERR) {
-      assertThat(output.flushed).hasSize(1);
+      assertThat(output.flushed).hasSize(2);
       output.flushed.clear();
     }
     // Unterminated strings are saved in memory and not pushed out at all.
@@ -190,9 +192,9 @@ public final class UiEventHandlerStdOutAndStdErrTest {
     uiEventHandler.handle(Event.error("Show me this!"));
     uiEventHandler.afterCommand(new AfterCommandEvent());
 
-    assertThat(output.flushed.size()).isEqualTo(4);
-    assertThat(output.flushed.get(2)).contains("Show me this!");
-    assertThat(output.flushed.get(3)).doesNotContain("\033[1A\033[K");
+    assertThat(output.flushed.size()).isEqualTo(5);
+    assertThat(output.flushed.get(3)).contains("Show me this!");
+    assertThat(output.flushed.get(4)).doesNotContain("\033[1A\033[K");
   }
 
   private Event output(String message) {

--- a/src/test/java/com/google/devtools/build/lib/testutil/ManualClock.java
+++ b/src/test/java/com/google/devtools/build/lib/testutil/ManualClock.java
@@ -15,6 +15,8 @@
 package com.google.devtools.build.lib.testutil;
 
 import com.google.devtools.build.lib.clock.Clock;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -42,5 +44,10 @@ public final class ManualClock implements Clock {
 
   public long advanceMillis(long time) {
     return currentTimeMillis.addAndGet(time);
+  }
+
+  @CanIgnoreReturnValue
+  public long advance(Duration duration) {
+    return advanceMillis(duration.toMillis());
   }
 }


### PR DESCRIPTION
This ends up as simple as firing an event and letting UiEventHandler know that the build has started.

Fixes https://github.com/bazelbuild/bazel/issues/16927.

Fixes https://github.com/bazelbuild/bazel/issues/16338.

PiperOrigin-RevId: 511177491
Change-Id: I479b116cf896731b7238410ce14f7e249da6c390