### PR TITLE
Remove 'darwin' CPU value

### DIFF
--- a/site/en/concepts/platforms.md
+++ b/site/en/concepts/platforms.md
@@ -401,8 +401,8 @@ flags:
   --apple_platform_type=ios
     //platforms:ios
 
-  # Maps "--cpu=darwin --apple_platform_type=macos" to "//platform:macos".
-  --cpu=darwin
+  # Maps "--cpu=darwin_x86_64 --apple_platform_type=macos" to "//platform:macos".
+  --cpu=darwin_x86_64
   --apple_platform_type=macos
     //platforms:macos
 ```

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
@@ -36,7 +36,7 @@ public class AutoCpuConverter extends Converter.Contextless<String> {
         case DARWIN:
           switch (CPU.getCurrent()) {
             case X86_64:
-              return "darwin";
+              return "darwin_x86_64";
             case AARCH64:
               return "darwin_arm64";
             default:

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/ApplePlatform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/ApplePlatform.java
@@ -56,11 +56,8 @@ public enum ApplePlatform implements ApplePlatformApi {
       ImmutableSet.of("tvos_arm64");
   private static final ImmutableSet<String> CATALYST_TARGET_CPUS =
       ImmutableSet.of("catalyst_x86_64");
-  // "darwin" is included because that's currently the default when on macOS, and
-  // migrating it would be a breaking change more details:
-  // https://github.com/bazelbuild/bazel/pull/7062
   private static final ImmutableSet<String> MACOS_TARGET_CPUS =
-      ImmutableSet.of("darwin_x86_64", "darwin_arm64", "darwin_arm64e", "darwin");
+      ImmutableSet.of("darwin_x86_64", "darwin_arm64", "darwin_arm64e");
 
   private static final ImmutableSet<String> BIT_32_TARGET_CPUS =
       ImmutableSet.of("ios_i386", "ios_armv7", "ios_armv7s", "watchos_i386", "watchos_armv7k");

--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -34,7 +34,7 @@ _WATCHOS_DEVICE_TARGET_CPUS = ["watchos_armv7k", "watchos_arm64_32"]
 _TVOS_SIMULATOR_TARGET_CPUS = ["tvos_x86_64", "tvos_sim_arm64"]
 _TVOS_DEVICE_TARGET_CPUS = ["tvos_arm64"]
 _CATALYST_TARGET_CPUS = ["catalyst_x86_64"]
-_MACOS_TARGET_CPUS = ["darwin_x86_64", "darwin_arm64", "darwin_arm64e", "darwin"]
+_MACOS_TARGET_CPUS = ["darwin_x86_64", "darwin_arm64", "darwin_arm64e"]
 
 def _strip_extension(file):
     if file.extension == "":

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -59,7 +59,7 @@ ios_cpus = struct(
     TVOS_SIMULATOR_TARGET_CPUS = ["tvos_x86_64", "tvos_sim_arm64"],
     TVOS_DEVICE_TARGET_CPUS = ["tvos_arm64"],
     CATALYST_TARGET_CPUS = ["catalyst_x86_64"],
-    MACOS_TARGET_CPUS = ["darwin_x86_64", "darwin_arm64", "darwin_arm64e", "darwin"],
+    MACOS_TARGET_CPUS = ["darwin_x86_64", "darwin_arm64", "darwin_arm64e"],
 )
 
 cpp_file_types = struct(

--- a/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
@@ -35,7 +35,7 @@ public final class BazelMockCcSupport extends MockCcSupport {
   private BazelMockCcSupport() {}
 
   private static final ImmutableList<String> CROSSTOOL_ARCHS =
-      ImmutableList.of("piii", "k8", "armeabi-v7a", "ppc", "darwin");
+      ImmutableList.of("piii", "k8", "armeabi-v7a", "ppc", "darwin_x86_64");
 
   @Override
   protected String getRealFilesystemCrosstoolTopPath() {
@@ -94,7 +94,7 @@ public final class BazelMockCcSupport extends MockCcSupport {
     result.add(CcToolchainConfig.builder().build());
 
     if (OS.getCurrent() == OS.DARWIN) {
-      result.add(CcToolchainConfig.getCcToolchainConfigForCpu("darwin"));
+      result.add(CcToolchainConfig.getCcToolchainConfigForCpu("darwin_x86_64"));
       result.add(CcToolchainConfig.getCcToolchainConfigForCpu("darwin_arm64"));
     }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/util/Crosstool.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/Crosstool.java
@@ -612,8 +612,7 @@ public final class Crosstool {
     StringBuilder compilerMap =
         new StringBuilder()
             .append("'k8': ':cc-compiler-darwin_x86_64',\n")
-            .append("'aarch64': ':cc-compiler-darwin_x86_64',\n")
-            .append("'darwin': ':cc-compiler-darwin_x86_64',\n");
+            .append("'aarch64': ':cc-compiler-darwin_x86_64',\n");
     Set<String> seenCpus = new LinkedHashSet<>();
     for (CcToolchainConfig toolchain : ccToolchainConfigList) {
       if (seenCpus.add(toolchain.getTargetCpu())) {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
@@ -709,8 +709,8 @@ public class CcCommonTest extends BuildViewTestCase {
 
   @Test
   public void testCcLibraryWithDashStaticOnDarwin() throws Exception {
-    getAnalysisMock().ccSupport().setupCcToolchainConfigForCpu(mockToolsConfig, "darwin");
-    useConfiguration("--cpu=darwin");
+    getAnalysisMock().ccSupport().setupCcToolchainConfigForCpu(mockToolsConfig, "darwin_x86_64");
+    useConfiguration("--cpu=darwin_x86_64");
     checkError(
         "badlib",
         "lib_with_dash_static",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcHostToolchainAliasTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcHostToolchainAliasTest.java
@@ -48,7 +48,7 @@ public class CcHostToolchainAliasTest extends BuildViewTestCase {
         "    'k8|gcc-4.4.0': '//b:toolchain_b',",
         "    'k8|compiler': '//b:toolchain_b',",
         "    'x64_windows|windows_msys64': '//b:toolchain_b',",
-        "    'darwin|compiler': '//b:toolchain_b',",
+        "    'darwin_x86_64|compiler': '//b:toolchain_b',",
         "})",
         "cc_toolchain(",
         "    name = 'toolchain_b',",

--- a/src/test/shell/bazel/apple/BUILD
+++ b/src/test/shell/bazel/apple/BUILD
@@ -6,11 +6,6 @@ filegroup(
     visibility = ["//src/test/shell/bazel:__pkg__"],
 )
 
-config_setting(
-    name = "darwin",
-    values = {"host_cpu": "darwin"},
-)
-
 sh_library(
     name = "apple_common",
     testonly = 1,
@@ -21,7 +16,7 @@ filegroup(
     name = "objc-deps",
     testonly = 1,
     srcs = select({
-        ":darwin": [
+        "//src/conditions:darwin": [
             "//tools/osx:xcode-locator",
         ],
         "//conditions:default": [],

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -635,11 +635,6 @@ create_compiler_config_setting(
 )
 
 config_setting(
-    name = "darwin",
-    values = {"host_cpu": "darwin"},
-)
-
-config_setting(
     name = "k8",
     values = {"host_cpu": "k8"},
 )

--- a/tools/cpp/lib_cc_configure.bzl
+++ b/tools/cpp/lib_cc_configure.bzl
@@ -183,7 +183,7 @@ def get_cpu_value(repository_ctx):
     arch = repository_ctx.os.arch
     if os_name.startswith("mac os"):
         # Check if we are on x86_64 or arm64 and return the corresponding cpu value.
-        return "darwin" + ("_arm64" if arch == "aarch64" else "")
+        return "darwin_" + ("arm64" if arch == "aarch64" else "x86_64")
     if os_name.find("freebsd") != -1:
         return "freebsd"
     if os_name.find("openbsd") != -1:

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -34,18 +34,12 @@ DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
 genrule(
     name = "xcode-locator-genrule",
     srcs = select({
-        ":darwin": ["xcode_locator.m"],
-        ":darwin_x86_64": ["xcode_locator.m"],
-        ":darwin_arm64": ["xcode_locator.m"],
-        ":darwin_arm64e": ["xcode_locator.m"],
+        "//src/conditions:darwin": ["xcode_locator.m"],
         "//conditions:default": ["xcode_locator_stub.sh"],
     }),
     outs = ["xcode-locator"],
     cmd = select({
-        ":darwin": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
-        ":darwin_x86_64": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
-        ":darwin_arm64": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
-        ":darwin_arm64e": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
+        "//src/conditions:darwin": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
         "//conditions:default": "cp $< $@",
     }),
     local = 1,
@@ -53,12 +47,6 @@ genrule(
 )
 
 # TODO(cparsons): Consolidate with config_settings under //src
-config_setting(
-    name = "darwin",
-    values = {"cpu": "darwin"},
-    visibility = ["//visibility:public"],
-)
-
 config_setting(
     name = "darwin_x86_64",
     values = {"cpu": "darwin_x86_64"},


### PR DESCRIPTION
This is another attempt to remove the legacy 'darwin' CPU string which actually means darwin_x86_64. The previous attempt was reverted here https://github.com/bazelbuild/bazel/commit/e96b8ca0c244e1a6a747b98b8f01e2526c9db862

RELNOTES[INC]: Remove 'darwin' as a CPU value, use 'darwin_x86_64' instead
