### PR TITLE
Add option for relative convenience symlinks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -238,7 +238,7 @@ public class BuildRequestOptions extends OptionsBase {
               + "workspace after the build) will be managed. Possible values:\n"
               + "  normal (default): Each kind of convenience symlink will be created or deleted, "
               + "as determined by the build.\n"
-              + "  relative: As normal but relative links will be created if possible."
+              + "  relative: As normal but relative links will be created."
               + "  clean: All symlinks will be unconditionally deleted.\n"
               + "  ignore: Symlinks will be left alone.\n"
               + "  log_only: Generate log messages as if 'normal' were passed, but don't actually "
@@ -575,7 +575,7 @@ public class BuildRequestOptions extends OptionsBase {
   enum ConvenienceSymlinksMode {
     /** Will manage symlinks based on the symlink prefix. */
     NORMAL,
-    /** Will manage symlinks based on the symlink prefix, but create relative links when possible. */
+    /** Will manage symlinks based on the symlink prefix, but create relative links. */
     RELATIVE,
     /** Will clean up any existing symlinks. */
     CLEAN,

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -238,6 +238,7 @@ public class BuildRequestOptions extends OptionsBase {
               + "workspace after the build) will be managed. Possible values:\n"
               + "  normal (default): Each kind of convenience symlink will be created or deleted, "
               + "as determined by the build.\n"
+              + "  relative: As normal but relative links will be created if possible."
               + "  clean: All symlinks will be unconditionally deleted.\n"
               + "  ignore: Symlinks will be left alone.\n"
               + "  log_only: Generate log messages as if 'normal' were passed, but don't actually "
@@ -574,6 +575,8 @@ public class BuildRequestOptions extends OptionsBase {
   enum ConvenienceSymlinksMode {
     /** Will manage symlinks based on the symlink prefix. */
     NORMAL,
+    /** Will manage symlinks based on the symlink prefix, but create relative links when possible. */
+    RELATIVE,
     /** Will clean up any existing symlinks. */
     CLEAN,
     /** Will not create or clean up any symlinks. */

--- a/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
@@ -333,7 +333,7 @@ public final class OutputDirectoryLinksUtils {
     }
     try {
       PathFragment targetForLink =
-          target.startsWith(base) && relativeSymlinks
+          relativeSymlinks
               ? target.relativeTo(base)
               : target.asFragment();
       FileSystemUtils.ensureSymbolicLink(link, targetForLink);


### PR DESCRIPTION
Extending --experimental_convenience_symlinks with a new option "relative" and setting up convenience link creation to honour that option, if the target path begins with the base path.