### PR TITLE
Include generated code in instrumented files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
@@ -208,7 +208,7 @@ public final class InstrumentedFilesCollector {
       for (TransitiveInfoCollection dep :
           getPrerequisitesForAttributes(ruleContext, spec.sourceAttributes)) {
         for (Artifact artifact : dep.getProvider(FileProvider.class).getFilesToBuild().toList()) {
-          if (artifact.isSourceArtifact() &&
+          if (!artifact.isDirectory() &&
               spec.instrumentedFileTypes.matches(artifact.getFilename())) {
             localSourcesBuilder.add(artifact);
           }


### PR DESCRIPTION
We are using a code generator that replaces the source code with generated code before feeding to the compiler. We are collecting the code coverage on the generated code so we can map it back to the original source code.

This was possible before Bazel 6, but started to fail after Bazel 6 because it comes with a newer version of [coverage_output_generator](https://github.com/bazelbuild/bazel/blob/6.0.0/distdir_deps.bzl#L363), which ignores files not included in `coverage_common.instrumented_files_info`.

This PR makes `coverage_common.instrumented_files_info` return both regular and generated/derived source files.

