### PR TITLE
Include Bazel version information in profile metadata.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/profiler/BUILD
@@ -34,6 +34,7 @@ java_library(
     deps = [
         ":network_metrics_collector",
         "//src/main/java/com/google/devtools/build/lib/actions:resource_estimator",
+        "//src/main/java/com/google/devtools/build/lib/analysis:blaze_version_info",
         "//src/main/java/com/google/devtools/build/lib/bugreport",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/collect:extrema",

--- a/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.profiler;
 
 
 import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.profiler.Profiler.TaskData;
 import com.google.gson.stream.JsonWriter;
 import java.io.BufferedOutputStream;
@@ -174,6 +175,7 @@ class JsonTraceFileWriter implements Runnable {
         writer.beginObject();
         writer.name("otherData");
         writer.beginObject();
+        writer.name("bazel_version").value(BlazeVersionInfo.instance().getReleaseName());
         writer.name("build_id").value(buildID.toString());
         writer.name("output_base").value(outputBase);
         writer.name("date").value(new Date().toString());


### PR DESCRIPTION
This is helpful when building tools on top of the JSON profile which might to need to distinguish with what Bazel version the profile was written to be able to parse or interpret it correctly.