### PR TITLE
Add MS_BIND|MS_REC to the mount of `/proc`

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -441,8 +441,12 @@ static void MakeFilesystemMostlyReadOnly() {
 static void MountProc() {
   // Mount a new proc on top of the old one, because the old one still refers to
   // our parent PID namespace.
-  if (mount("/proc", "/proc", "proc", MS_NODEV | MS_NOEXEC | MS_NOSUID,
-            nullptr) < 0) {
+  // Despite using MS_BIND, this actually mounts a new one that uses our PID
+  // namespace. MS_BIND is necessary to handle some forms of mounts inside the
+  // old proc, otherwise we get EINVAL for trying to reveal files hidden by
+  // those mounts.
+  if (mount("/proc", "/proc", "proc",
+            MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_REC | MS_BIND, nullptr) < 0) {
     DIE("mount");
   }
 }

--- a/src/test/shell/integration/linux-sandbox_test.sh
+++ b/src/test/shell/integration/linux-sandbox_test.sh
@@ -270,6 +270,17 @@ function test_dev_shm_is_writable() {
     &> $TEST_log || fail
 }
 
+# docker with `--gpus all` does things like this (with subdirectories instead of
+# the whole thing), and we want to ensure linux-sandbox works under that.
+function test_with_mount_in_proc() {
+  unshare --map-root-user --mount --pid --fork --mount-proc -- bash - <<EOF
+set -euo pipefail
+# Pick a victim directory that will always exist but won't break linux-sandbox or true if empty.
+mount -t tmpfs tmpfs /proc/driver
+$linux_sandbox $SANDBOX_DEFAULT_OPTS -- /bin/true
+EOF
+}
+
 function assert_linux_sandbox_exec_time() {
   local user_time_low="$1"; shift
   local user_time_high="$1"; shift


### PR DESCRIPTION
Despite the usual meanings of these flags, this isn't actually a bind mount for `proc`, which doesn't appear to be documented anywhere.

Otherwise it fails if there are any other mounts under the host `/proc`. I think this is due to the behavior documented on the `mount(2)` manpage for bind mounting:

> EINVAL In an unprivileged mount namespace (i.e., a mount namespace
> owned by a user namespace that was created by an unprivileged user), a
> bind  mount  operation  (MS_BIND) was attempted without specifying
> (MS_REC), which would have revealed the filesystem tree underneath
> one of the submounts of the directory being bound.

I ended up in this scenario with docker and `--gpus all` (with some additional flags to make it work even without the `--gpus all`).