### PR TITLE
Remove asm as a dependency for some java plugins

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -216,7 +216,6 @@ java_plugin(
     deps = [
         ":apache_commons_collections",
         ":apache_velocity",
-        ":asm",
         ":auto_common",
         ":auto_service_lib",
         ":auto_value_value",
@@ -275,7 +274,6 @@ java_plugin(
     deps = [
         ":apache_commons_collections",
         ":apache_velocity",
-        ":asm",
         ":auto_common",
         ":auto_service_lib",
         ":auto_value_value",
@@ -290,7 +288,6 @@ java_plugin(
     deps = [
         ":apache_commons_collections",
         ":apache_velocity",
-        ":asm",
         ":auto_common",
         ":auto_service_lib",
         ":auto_value_value",


### PR DESCRIPTION
Apparently asm isn't really necessary for building those java plugins, removing it means one less dependency for the Bazel binary.

For now, asm jars are still checked in third_party and required by java_tools.