### PR TITLE
Add exec_kind to RunnerCount in BEP

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -872,6 +872,7 @@ message BuildMetrics {
     message RunnerCount {
       string name = 1;
       int32 count = 2;
+      string exec_kind = 3;
     }
     repeated RunnerCount runner_count = 6;
   }

--- a/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
@@ -266,9 +266,15 @@ class MetricsCollector {
     spawnSummary
         .entrySet()
         .forEach(
-            e ->
-                actionSummary.addRunnerCount(
-                    RunnerCount.newBuilder().setName(e.getKey()).setCount(e.getValue()).build()));
+            e -> {
+              RunnerCount.Builder builder = RunnerCount.newBuilder();
+              builder.setName(e.getKey()).setCount(e.getValue());
+              String execKind = spawnStats.getExecKindFor(e.getKey());
+              if (execKind != null) {
+                builder.setExecKind(execKind);
+              }
+              actionSummary.addRunnerCount(builder.build());
+            });
     return actionSummary.build();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/runtime/SpawnStatsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SpawnStatsTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.runtime;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.devtools.build.lib.actions.ActionResult;
+import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import java.util.ArrayList;
 import org.junit.Before;
@@ -214,5 +215,24 @@ public final class SpawnStatsTest {
     }
     assertThat(SpawnStats.convertSummaryToString(stats.getSummary()))
         .isEqualTo("11 processes: 1 remote cache hit, 2 internal, 3 a, 2 b, 1 c, 2 z.");
+  }
+
+  private final SpawnResult rC =
+    new SpawnResult.Builder().setStatus(SpawnResult.Status.SUCCESS)
+      .setSpawnMetrics(SpawnMetrics.Builder.forExec(SpawnMetrics.ExecKind.OTHER).build()).setRunnerName("fgh").build();
+
+  @Test
+  public void getExecKindDefined() {
+    ArrayList<SpawnResult> spawns = new ArrayList<>();
+    spawns.add(rC);
+    stats.countActionResult(ActionResult.create(spawns));
+    assertThat(stats.getExecKindFor("fgh")).isEqualTo(SpawnMetrics.ExecKind.OTHER.toString());
+  }
+
+  @Test
+  public void getExecKindNotDefined() {
+    stats.getSummary();
+    assertThat(stats.getExecKindFor("total")).isNull();
+    assertThat(stats.getExecKindFor("internal")).isNull();
   }
 }


### PR DESCRIPTION
Solves #17296 .

The execution kind of runners is now stored in the RunnerCount message of the Build Event Protocol. For runners where execution kind is not applicable, e.g. "total", no value is set. The exec_kind field has been set as a string field rather than using an enum to avoid implicit dependencies between the Java code and the protobuf.