### PR TITLE
[6.1.0] Add an --incompatible_strict_conflict_checks alias for --experimental_strict_conflict_checks.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
@@ -91,7 +91,8 @@ public class AnalysisOptions extends OptionsBase {
   public boolean skyframePrepareAnalysis;
 
   @Option(
-      name = "experimental_strict_conflict_checks",
+      name = "incompatible_strict_conflict_checks",
+      oldName = "experimental_strict_conflict_checks",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       metadataTags = OptionMetadataTag.INCOMPATIBLE_CHANGE,


### PR DESCRIPTION
I'm about to attempt this flag flip to see what breaks.

PiperOrigin-RevId: 487251570
Change-Id: Ia0e95ac4a1e04421cfdcd311c4500feef08c77d0