### PR TITLE
[6.1.0] Handle remote cache eviction when uploading inputs for remote actions.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -34,6 +34,7 @@ java_library(
             "Retrier.java",
             "AbstractActionInputPrefetcher.java",
             "ToplevelArtifactsDownloader.java",
+            "LeaseService.java",
         ],
     ),
     exports = [
@@ -46,13 +47,13 @@ java_library(
         ":ReferenceCountedChannel",
         ":Retrier",
         ":abstract_action_input_prefetcher",
+        ":lease_service",
         ":toplevel_artifacts_downloader",
         "//src/main/java/com/google/devtools/build/lib:build-request-options",
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib:runtime/command_line_path_factory",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_input_helper",
-        "//src/main/java/com/google/devtools/build/lib/actions:action_lookup_data",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
@@ -83,6 +84,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/disk",
         "//src/main/java/com/google/devtools/build/lib/remote/downloader",
         "//src/main/java/com/google/devtools/build/lib/remote/grpc",
@@ -185,6 +187,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
@@ -217,6 +220,18 @@ java_library(
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//third_party:flogger",
         "//third_party:guava",
+        "//third_party:jsr305",
+    ],
+)
+
+java_library(
+    name = "lease_service",
+    srcs = ["LeaseService.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/actions:action_lookup_data",
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/skyframe",
         "//third_party:jsr305",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/remote/LeaseService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/LeaseService.java
@@ -1,0 +1,76 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import com.google.devtools.build.lib.actions.Action;
+import com.google.devtools.build.lib.actions.ActionCacheUtils;
+import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionLookupData;
+import com.google.devtools.build.lib.actions.ActionLookupValue;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.cache.ActionCache;
+import com.google.devtools.build.skyframe.MemoizingEvaluator;
+import java.util.HashMap;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/** A lease service that manages the lease of remote blobs. */
+public class LeaseService {
+  private final MemoizingEvaluator memoizingEvaluator;
+  @Nullable private final ActionCache actionCache;
+
+  public LeaseService(MemoizingEvaluator memoizingEvaluator, @Nullable ActionCache actionCache) {
+    this.memoizingEvaluator = memoizingEvaluator;
+    this.actionCache = actionCache;
+  }
+
+  /** Clean up internal state when files are evicted from remote CAS. */
+  public void handleMissingInputs(Set<ActionInput> missingActionInputs) {
+    if (missingActionInputs.isEmpty()) {
+      return;
+    }
+
+    var actions = new HashMap<ActionLookupData, Action>();
+
+    try {
+      for (ActionInput actionInput : missingActionInputs) {
+        if (actionInput instanceof Artifact.DerivedArtifact) {
+          Artifact.DerivedArtifact output = (Artifact.DerivedArtifact) actionInput;
+          ActionLookupData actionLookupData = output.getGeneratingActionKey();
+          var actionLookupValue =
+              memoizingEvaluator.getExistingValue(actionLookupData.getActionLookupKey());
+          if (actionLookupValue instanceof ActionLookupValue) {
+            Action action =
+                ((ActionLookupValue) actionLookupValue)
+                    .getAction(actionLookupData.getActionIndex());
+            actions.put(actionLookupData, action);
+          }
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    if (!actions.isEmpty()) {
+      var actionKeys = actions.keySet();
+      memoizingEvaluator.delete(key -> key instanceof ActionLookupData && actionKeys.contains(key));
+
+      if (actionCache != null) {
+        for (var action : actions.values()) {
+          ActionCacheUtils.removeCacheEntry(actionCache, action);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -64,6 +64,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
@@ -371,10 +372,14 @@ public class RemoteExecutionService {
           spawn,
           context,
           (Object nodeKey, InputWalker walker) -> {
-            subMerkleTrees.add(buildMerkleTreeVisitor(nodeKey, walker, metadataProvider));
+            subMerkleTrees.add(
+                buildMerkleTreeVisitor(
+                    nodeKey, walker, metadataProvider, context.getPathResolver()));
           });
       if (!outputDirMap.isEmpty()) {
-        subMerkleTrees.add(MerkleTree.build(outputDirMap, metadataProvider, execRoot, digestUtil));
+        subMerkleTrees.add(
+            MerkleTree.build(
+                outputDirMap, metadataProvider, execRoot, context.getPathResolver(), digestUtil));
       }
       return MerkleTree.merge(subMerkleTrees, digestUtil);
     } else {
@@ -394,16 +399,20 @@ public class RemoteExecutionService {
           toolSignature == null ? ImmutableSet.of() : toolSignature.toolInputs,
           context.getMetadataProvider(),
           execRoot,
+          context.getPathResolver(),
           digestUtil);
     }
   }
 
   private MerkleTree buildMerkleTreeVisitor(
-      Object nodeKey, InputWalker walker, MetadataProvider metadataProvider)
+      Object nodeKey,
+      InputWalker walker,
+      MetadataProvider metadataProvider,
+      ArtifactPathResolver artifactPathResolver)
       throws IOException, ForbiddenActionInputException {
     MerkleTree result = merkleTreeCache.getIfPresent(nodeKey);
     if (result == null) {
-      result = uncachedBuildMerkleTreeVisitor(walker, metadataProvider);
+      result = uncachedBuildMerkleTreeVisitor(walker, metadataProvider, artifactPathResolver);
       merkleTreeCache.put(nodeKey, result);
     }
     return result;
@@ -411,14 +420,23 @@ public class RemoteExecutionService {
 
   @VisibleForTesting
   public MerkleTree uncachedBuildMerkleTreeVisitor(
-      InputWalker walker, MetadataProvider metadataProvider)
+      InputWalker walker,
+      MetadataProvider metadataProvider,
+      ArtifactPathResolver artifactPathResolver)
       throws IOException, ForbiddenActionInputException {
     ConcurrentLinkedQueue<MerkleTree> subMerkleTrees = new ConcurrentLinkedQueue<>();
     subMerkleTrees.add(
-        MerkleTree.build(walker.getLeavesInputMapping(), metadataProvider, execRoot, digestUtil));
+        MerkleTree.build(
+            walker.getLeavesInputMapping(),
+            metadataProvider,
+            execRoot,
+            artifactPathResolver,
+            digestUtil));
     walker.visitNonLeaves(
         (Object subNodeKey, InputWalker subWalker) -> {
-          subMerkleTrees.add(buildMerkleTreeVisitor(subNodeKey, subWalker, metadataProvider));
+          subMerkleTrees.add(
+              buildMerkleTreeVisitor(
+                  subNodeKey, subWalker, metadataProvider, artifactPathResolver));
         });
     return MerkleTree.merge(subMerkleTrees, digestUtil);
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -957,9 +957,13 @@ public final class RemoteModule extends BlazeModule {
               });
       env.getEventBus().register(toplevelArtifactsDownloader);
 
+      var leaseService =
+          new LeaseService(
+              env.getSkyframeExecutor().getEvaluator(),
+              env.getBlazeWorkspace().getPersistentActionCache());
+
       remoteOutputService.setActionInputFetcher(actionInputFetcher);
-      remoteOutputService.setMemoizingEvaluator(env.getSkyframeExecutor().getEvaluator());
-      remoteOutputService.setActionCache(env.getBlazeWorkspace().getPersistentActionCache());
+      remoteOutputService.setLeaseService(leaseService);
       env.getEventBus().register(remoteOutputService);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -557,7 +557,11 @@ public class RemoteSpawnRunner implements SpawnRunner {
       catastrophe = true;
     } else if (remoteCacheFailed) {
       status = Status.REMOTE_CACHE_FAILED;
-      detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_FAILED;
+      if (remoteOptions.useNewExitCodeForLostInputs) {
+        detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_EVICTED;
+      } else {
+        detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_FAILED;
+      }
       catastrophe = false;
     } else {
       status = Status.EXECUTION_FAILED;

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
@@ -11,13 +11,24 @@ filegroup(
 )
 
 java_library(
-    name = "common",
-    srcs = glob(["*.java"]),
+    name = "cache_not_found_exception",
+    srcs = ["CacheNotFoundException.java"],
     deps = [
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_library(
+    name = "common",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["CacheNotFoundException.java"],
+    ),
+    deps = [
+        ":cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_input_helper",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
-        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_input_expander",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -15,7 +15,7 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote/common",
-        "//src/main/java/com/google/devtools/build/lib/remote/options",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -21,6 +21,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_version_info",
         "//src/main/java/com/google/devtools/build/lib/authandtls",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:auth",

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -222,11 +223,13 @@ public class MerkleTree {
       SortedMap<PathFragment, ActionInput> inputs,
       MetadataProvider metadataProvider,
       Path execRoot,
+      ArtifactPathResolver artifactPathResolver,
       DigestUtil digestUtil)
       throws IOException {
     try (SilentCloseable c = Profiler.instance().profile("MerkleTree.build(ActionInput)")) {
       DirectoryTree tree =
-          DirectoryTreeBuilder.fromActionInputs(inputs, metadataProvider, execRoot, digestUtil);
+          DirectoryTreeBuilder.fromActionInputs(
+              inputs, metadataProvider, execRoot, artifactPathResolver, digestUtil);
       return build(tree, digestUtil);
     }
   }
@@ -247,12 +250,13 @@ public class MerkleTree {
       Set<PathFragment> toolInputs,
       MetadataProvider metadataProvider,
       Path execRoot,
+      ArtifactPathResolver artifactPathResolver,
       DigestUtil digestUtil)
       throws IOException {
     try (SilentCloseable c = Profiler.instance().profile("MerkleTree.build(ActionInput)")) {
       DirectoryTree tree =
           DirectoryTreeBuilder.fromActionInputs(
-              inputs, toolInputs, metadataProvider, execRoot, digestUtil);
+              inputs, toolInputs, metadataProvider, execRoot, artifactPathResolver, digestUtil);
       return build(tree, digestUtil);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -24,6 +24,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/remote:ExecutionStatusException",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -491,6 +491,20 @@ public abstract class ActionInputPrefetcherTestBase {
     assertThat(tempPathGenerator.getTempDir().getDirectoryEntries()).isEmpty();
   }
 
+  @Test
+  public void missingInputs_addedToList() {
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Map<HashCode, byte[]> cas = new HashMap<>();
+    Artifact a = createRemoteArtifact("file", "hello world", metadata, /* cas= */ null);
+    MetadataProvider metadataProvider = new StaticMetadataProvider(metadata);
+    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
+
+    assertThrows(
+        Exception.class, () -> wait(prefetcher.prefetchFiles(metadata.keySet(), metadataProvider)));
+
+    assertThat(prefetcher.getMissingActionInputs()).contains(a);
+  }
+
   protected static void wait(ListenableFuture<Void> future)
       throws IOException, ExecException, InterruptedException {
     try {
@@ -505,7 +519,7 @@ public abstract class ActionInputPrefetcherTestBase {
       }
       throw new IOException(e);
     } catch (InterruptedException e) {
-      future.cancel(/*mayInterruptIfRunning=*/ true);
+      future.cancel(/* mayInterruptIfRunning= */ true);
       throw e;
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -75,6 +75,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/remote",
         "//src/main/java/com/google/devtools/build/lib/remote:abstract_action_input_prefetcher",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/disk",
         "//src/main/java/com/google/devtools/build/lib/remote/grpc",
         "//src/main/java/com/google/devtools/build/lib/remote/http",

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -503,6 +503,7 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
     getOutputPath("a/bar.out").delete();
     getOutputBase().getRelative("action_cache").deleteTreesBelow();
     restartServer();
+    addOptions("--incompatible_remote_use_new_exit_code_for_lost_inputs");
 
     // Clean build, foo.out isn't downloaded
     buildTarget("//a:bar");

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -424,7 +424,7 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
   }
 
   @Test
-  public void remoteCacheEvictBlobs_exitWithCode39() throws Exception {
+  public void remoteCacheEvictBlobs_whenPrefetchingInput_exitWithCode39() throws Exception {
     // Arrange: Prepare workspace and populate remote cache
     write(
         "a/BUILD",
@@ -459,7 +459,7 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
     assertOutputDoesNotExist("a/foo.out");
 
     // Act: Evict blobs from remote cache and do an incremental build
-    worker.restart();
+    evictAllBlobs();
     write("a/bar.in", "updated bar");
     var error = assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
 
@@ -471,5 +471,152 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
                 + " during builds");
     assertThat(error).hasMessageThat().contains(String.format("%s/%s", hashCode, bytes.length));
     assertThat(error.getDetailedExitCode().getExitCode().getNumericExitCode()).isEqualTo(39);
+  }
+
+  @Test
+  public void remoteCacheEvictBlobs_whenUploadingInput_exitWithCode39() throws Exception {
+    // Arrange: Prepare workspace and populate remote cache
+    write(
+        "a/BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  srcs = ['foo.in'],",
+        "  outs = ['foo.out'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'bar',",
+        "  srcs = ['foo.out', 'bar.in'],",
+        "  outs = ['bar.out'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")");
+    write("a/foo.in", "foo");
+    write("a/bar.in", "bar");
+
+    // Populate remote cache
+    setDownloadAll();
+    buildTarget("//a:bar");
+    waitDownloads();
+    var bytes = FileSystemUtils.readContent(getOutputPath("a/foo.out"));
+    var hashCode = getDigestHashFunction().getHashFunction().hashBytes(bytes);
+    getOutputPath("a/foo.out").delete();
+    getOutputPath("a/bar.out").delete();
+    getOutputBase().getRelative("action_cache").deleteTreesBelow();
+    restartServer();
+
+    // Clean build, foo.out isn't downloaded
+    buildTarget("//a:bar");
+    assertOutputDoesNotExist("a/foo.out");
+
+    // Act: Evict blobs from remote cache and do an incremental build
+    evictAllBlobs();
+    write("a/bar.in", "updated bar");
+    var error = assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
+
+    // Assert: Exit code is 39
+    assertThat(error).hasMessageThat().contains(String.format("%s/%s", hashCode, bytes.length));
+    assertThat(error.getDetailedExitCode().getExitCode().getNumericExitCode()).isEqualTo(39);
+  }
+
+  @Test
+  public void remoteCacheEvictBlobs_whenUploadingInputFile_incrementalBuildCanContinue()
+      throws Exception {
+    // Arrange: Prepare workspace and populate remote cache
+    write(
+        "a/BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  srcs = ['foo.in'],",
+        "  outs = ['foo.out'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'bar',",
+        "  srcs = ['foo.out', 'bar.in'],",
+        "  outs = ['bar.out'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")");
+    write("a/foo.in", "foo");
+    write("a/bar.in", "bar");
+
+    // Populate remote cache
+    buildTarget("//a:bar");
+    getOutputPath("a/foo.out").delete();
+    getOutputPath("a/bar.out").delete();
+    getOutputBase().getRelative("action_cache").deleteTreesBelow();
+    restartServer();
+
+    // Clean build, foo.out isn't downloaded
+    setDownloadToplevel();
+    buildTarget("//a:bar");
+    assertOutputDoesNotExist("a/foo.out");
+
+    // Evict blobs from remote cache
+    evictAllBlobs();
+
+    // trigger build error
+    write("a/bar.in", "updated bar");
+    // Build failed because of remote cache eviction
+    assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
+
+    // Act: Do an incremental build without "clean" or "shutdown"
+    buildTarget("//a:bar");
+    waitDownloads();
+
+    // Assert: target was successfully built
+    assertValidOutputFile("a/bar.out", "foo" + lineSeparator() + "updated bar" + lineSeparator());
+  }
+
+  @Test
+  public void remoteCacheEvictBlobs_whenUploadingInputTree_incrementalBuildCanContinue()
+      throws Exception {
+    // Arrange: Prepare workspace and populate remote cache
+    write("BUILD");
+    writeOutputDirRule();
+    write(
+        "a/BUILD",
+        "load('//:output_dir.bzl', 'output_dir')",
+        "output_dir(",
+        "  name = 'foo.out',",
+        "  manifest = ':manifest',",
+        ")",
+        "genrule(",
+        "  name = 'bar',",
+        "  srcs = ['foo.out', 'bar.in'],",
+        "  outs = ['bar.out'],",
+        "  cmd = '( ls $(location :foo.out); cat $(location :bar.in) ) > $@',",
+        ")");
+    write("a/manifest", "file-inside");
+    write("a/bar.in", "bar");
+
+    // Populate remote cache
+    buildTarget("//a:bar");
+    getOutputPath("a/foo.out").deleteTreesBelow();
+    getOutputPath("a/bar.out").delete();
+    getOutputBase().getRelative("action_cache").deleteTreesBelow();
+    restartServer();
+
+    // Clean build, foo.out isn't downloaded
+    buildTarget("//a:bar");
+    assertOutputDoesNotExist("a/foo.out/file-inside");
+
+    // Evict blobs from remote cache
+    evictAllBlobs();
+
+    // trigger build error
+    setDownloadToplevel();
+    write("a/bar.in", "updated bar");
+    // Build failed because of remote cache eviction
+    assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
+
+    // Act: Do an incremental build without "clean" or "shutdown"
+    buildTarget("//a:bar");
+    waitDownloads();
+
+    // Assert: target was successfully built
+    assertValidOutputFile(
+        "a/bar.out",
+        "file-inside" + lineSeparator() + "updated bar" + lineSeparator(),
+        /* isLocal= */ true);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -86,13 +86,19 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
   }
 
   @Override
-  protected void assertOutputEquals(String realContent, String expectedContent) throws Exception {
+  protected void assertOutputEquals(String realContent, String expectedContent, boolean isLocal)
+      throws Exception {
     assertThat(realContent).isEqualTo(expectedContent);
   }
 
   @Override
   protected void assertOutputContains(String content, String contains) throws Exception {
     assertThat(content).contains(contains);
+  }
+
+  @Override
+  protected void evictAllBlobs() throws Exception {
+    worker.restart();
   }
 
   @After
@@ -465,101 +471,5 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
                 + " during builds");
     assertThat(error).hasMessageThat().contains(String.format("%s/%s", hashCode, bytes.length));
     assertThat(error.getDetailedExitCode().getExitCode().getNumericExitCode()).isEqualTo(39);
-  }
-
-  @Test
-  public void remoteCacheEvictBlobs_incrementalBuildCanContinue() throws Exception {
-    // Arrange: Prepare workspace and populate remote cache
-    write(
-        "a/BUILD",
-        "genrule(",
-        "  name = 'foo',",
-        "  srcs = ['foo.in'],",
-        "  outs = ['foo.out'],",
-        "  cmd = 'cat $(SRCS) > $@',",
-        ")",
-        "genrule(",
-        "  name = 'bar',",
-        "  srcs = ['foo.out', 'bar.in'],",
-        "  outs = ['bar.out'],",
-        "  cmd = 'cat $(SRCS) > $@',",
-        "  tags = ['no-remote-exec'],",
-        ")");
-    write("a/foo.in", "foo");
-    write("a/bar.in", "bar");
-
-    // Populate remote cache
-    buildTarget("//a:bar");
-    getOutputPath("a/foo.out").delete();
-    getOutputPath("a/bar.out").delete();
-    getOutputBase().getRelative("action_cache").deleteTreesBelow();
-    restartServer();
-
-    // Clean build, foo.out isn't downloaded
-    buildTarget("//a:bar");
-    assertOutputDoesNotExist("a/foo.out");
-
-    // Evict blobs from remote cache
-    worker.restart();
-
-    // trigger build error
-    write("a/bar.in", "updated bar");
-    // Build failed because of remote cache eviction
-    assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
-
-    // Act: Do an incremental build without "clean" or "shutdown"
-    buildTarget("//a:bar");
-
-    // Assert: target was successfully built
-    assertValidOutputFile("a/bar.out", "foo" + lineSeparator() + "updated bar" + lineSeparator());
-  }
-
-  @Test
-  public void remoteCacheEvictBlobs_treeArtifact_incrementalBuildCanContinue() throws Exception {
-    // Arrange: Prepare workspace and populate remote cache
-    write("BUILD");
-    writeOutputDirRule();
-    write(
-        "a/BUILD",
-        "load('//:output_dir.bzl', 'output_dir')",
-        "output_dir(",
-        "  name = 'foo.out',",
-        "  manifest = ':manifest',",
-        ")",
-        "genrule(",
-        "  name = 'bar',",
-        "  srcs = ['foo.out', 'bar.in'],",
-        "  outs = ['bar.out'],",
-        "  cmd = '( ls $(location :foo.out); cat $(location :bar.in) ) > $@',",
-        "  tags = ['no-remote-exec'],",
-        ")");
-    write("a/manifest", "file-inside");
-    write("a/bar.in", "bar");
-
-    // Populate remote cache
-    buildTarget("//a:bar");
-    getOutputPath("a/foo.out").deleteTreesBelow();
-    getOutputPath("a/bar.out").delete();
-    getOutputBase().getRelative("action_cache").deleteTreesBelow();
-    restartServer();
-
-    // Clean build, foo.out isn't downloaded
-    buildTarget("//a:bar");
-    assertOutputDoesNotExist("a/foo.out/file-inside");
-
-    // Evict blobs from remote cache
-    worker.restart();
-
-    // trigger build error
-    write("a/bar.in", "updated bar");
-    // Build failed because of remote cache eviction
-    assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
-
-    // Act: Do an incremental build without "clean" or "shutdown"
-    buildTarget("//a:bar");
-
-    // Assert: target was successfully built
-    assertValidOutputFile(
-        "a/bar.out", "file-inside" + lineSeparator() + "updated bar" + lineSeparator());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -42,10 +42,12 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
 
   protected abstract void setDownloadAll();
 
-  protected abstract void assertOutputEquals(String realContent, String expectedContent)
-      throws Exception;
+  protected abstract void assertOutputEquals(
+      String realContent, String expectedContent, boolean isLocal) throws Exception;
 
   protected abstract void assertOutputContains(String content, String contains) throws Exception;
+
+  protected abstract void evictAllBlobs() throws Exception;
 
   protected void waitDownloads() throws Exception {
     // Trigger afterCommand of modules so that downloads are waited.
@@ -731,6 +733,104 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     assertThat(executedAction.getPrimaryOutput().getFilename()).isEqualTo("foo.txt");
   }
 
+  @Test
+  public void remoteCacheEvictBlobs_incrementalBuildCanContinue() throws Exception {
+    // Arrange: Prepare workspace and populate remote cache
+    write(
+        "a/BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  srcs = ['foo.in'],",
+        "  outs = ['foo.out'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")",
+        "genrule(",
+        "  name = 'bar',",
+        "  srcs = ['foo.out', 'bar.in'],",
+        "  outs = ['bar.out'],",
+        "  cmd = 'cat $(SRCS) > $@',",
+        ")");
+    write("a/foo.in", "foo");
+    write("a/bar.in", "bar");
+
+    // Populate remote cache
+    buildTarget("//a:bar");
+    getOutputPath("a/foo.out").delete();
+    getOutputPath("a/bar.out").delete();
+    getOutputBase().getRelative("action_cache").deleteTreesBelow();
+    restartServer();
+
+    // Clean build, foo.out isn't downloaded
+    buildTarget("//a:bar");
+    assertOutputDoesNotExist("a/foo.out");
+
+    // Evict blobs from remote cache
+    evictAllBlobs();
+
+    // trigger build error
+    write("a/bar.in", "updated bar");
+    addOptions("--strategy_regexp=.*bar=local");
+    // Build failed because of remote cache eviction
+    assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
+
+    // Act: Do an incremental build without "clean" or "shutdown"
+    buildTarget("//a:bar");
+
+    // Assert: target was successfully built
+    assertValidOutputFile("a/bar.out", "foo" + lineSeparator() + "updated bar" + lineSeparator());
+  }
+
+  @Test
+  public void remoteCacheEvictBlobs_treeArtifact_incrementalBuildCanContinue() throws Exception {
+    // Arrange: Prepare workspace and populate remote cache
+    write("BUILD");
+    writeOutputDirRule();
+    write(
+        "a/BUILD",
+        "load('//:output_dir.bzl', 'output_dir')",
+        "output_dir(",
+        "  name = 'foo.out',",
+        "  manifest = ':manifest',",
+        ")",
+        "genrule(",
+        "  name = 'bar',",
+        "  srcs = ['foo.out', 'bar.in'],",
+        "  outs = ['bar.out'],",
+        "  cmd = '( ls $(location :foo.out); cat $(location :bar.in) ) > $@',",
+        ")");
+    write("a/manifest", "file-inside");
+    write("a/bar.in", "bar");
+
+    // Populate remote cache
+    buildTarget("//a:bar");
+    getOutputPath("a/foo.out").deleteTreesBelow();
+    getOutputPath("a/bar.out").delete();
+    getOutputBase().getRelative("action_cache").deleteTreesBelow();
+    restartServer();
+
+    // Clean build, foo.out isn't downloaded
+    buildTarget("//a:bar");
+    assertOutputDoesNotExist("a/foo.out/file-inside");
+
+    // Evict blobs from remote cache
+    evictAllBlobs();
+
+    // trigger build error
+    write("a/bar.in", "updated bar");
+    addOptions("--strategy_regexp=.*bar=local");
+    // Build failed because of remote cache eviction
+    assertThrows(BuildFailedException.class, () -> buildTarget("//a:bar"));
+
+    // Act: Do an incremental build without "clean" or "shutdown"
+    buildTarget("//a:bar");
+
+    // Assert: target was successfully built
+    assertValidOutputFile(
+        "a/bar.out",
+        "file-inside" + lineSeparator() + "updated bar" + lineSeparator(),
+        /* isLocal= */ true);
+  }
+
   protected void assertOutputsDoNotExist(String target) throws Exception {
     for (Artifact output : getArtifacts(target)) {
       assertWithMessage(
@@ -757,12 +857,17 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     Artifact output = getOnlyElement(getArtifacts(target));
     assertThat(output.getFilename()).isEqualTo(filename);
     assertThat(output.getPath().exists()).isTrue();
-    assertOutputEquals(readContent(output.getPath(), UTF_8), content);
+    assertOutputEquals(readContent(output.getPath(), UTF_8), content, /* isLocal= */ false);
   }
 
   protected void assertValidOutputFile(String binRelativePath, String content) throws Exception {
+    assertValidOutputFile(binRelativePath, content, /* isLocal= */ false);
+  }
+
+  protected void assertValidOutputFile(String binRelativePath, String content, boolean isLocal)
+      throws Exception {
     Path output = getOutputPath(binRelativePath);
-    assertOutputEquals(readContent(output, UTF_8), content);
+    assertOutputEquals(readContent(output, UTF_8), content, isLocal);
     assertThat(output.isReadable()).isTrue();
     assertThat(output.isWritable()).isFalse();
     assertThat(output.isExecutable()).isTrue();

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -734,7 +734,8 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
-  public void remoteCacheEvictBlobs_incrementalBuildCanContinue() throws Exception {
+  public void remoteCacheEvictBlobs_whenPrefetchingInputFile_incrementalBuildCanContinue()
+      throws Exception {
     // Arrange: Prepare workspace and populate remote cache
     write(
         "a/BUILD",
@@ -781,7 +782,8 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
-  public void remoteCacheEvictBlobs_treeArtifact_incrementalBuildCanContinue() throws Exception {
+  public void remoteCacheEvictBlobs_whenPrefetchingInputTree_incrementalBuildCanContinue()
+      throws Exception {
     // Arrange: Prepare workspace and populate remote cache
     write("BUILD");
     writeOutputDirRule();

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -79,7 +79,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
@@ -1637,7 +1636,7 @@ public class ByteStreamUploaderTest {
   /* Custom Chunker used to track number of open files */
   private static class TestChunker extends Chunker {
 
-    TestChunker(Supplier<InputStream> dataSupplier, long size, int chunkSize, boolean compressed) {
+    TestChunker(ChunkDataSupplier dataSupplier, long size, int chunkSize, boolean compressed) {
       super(dataSupplier, size, chunkSize, compressed);
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkerTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.github.luben.zstd.Zstd;
 import com.google.devtools.build.lib.remote.Chunker.Chunk;
+import com.google.devtools.build.lib.remote.Chunker.ChunkDataSupplier;
 import com.google.protobuf.ByteString;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -26,7 +27,6 @@ import java.io.InputStream;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -126,7 +126,7 @@ public class ChunkerTest {
 
     byte[] data = new byte[] {1, 2};
     final AtomicReference<InputStream> in = new AtomicReference<>();
-    Supplier<InputStream> supplier =
+    ChunkDataSupplier supplier =
         () -> {
           in.set(Mockito.spy(new ByteArrayInputStream(data)));
           return in.get();

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -51,6 +51,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.events.NullEventHandler;
@@ -109,6 +110,7 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
             ImmutableSortedMap.of(execPath, virtualActionInput),
             fakeFileCache,
             execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
             DIGEST_UTIL);
     Digest digest = DIGEST_UTIL.compute(virtualActionInput.getBytes().toByteArray());
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -152,21 +152,6 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
         .contains(String.format("%s/%s", digest.getHash(), digest.getSizeBytes()));
   }
 
-  @Test
-  public void missingInputs_addedToList() {
-    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
-    Map<HashCode, byte[]> cas = new HashMap<>();
-    Artifact a = createRemoteArtifact("file", "hello world", metadata, /* cas= */ null);
-    MetadataProvider metadataProvider = new StaticMetadataProvider(metadata);
-    AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
-
-    assertThrows(
-        ExecException.class,
-        () -> wait(prefetcher.prefetchFiles(metadata.keySet(), metadataProvider)));
-
-    assertThat(prefetcher.getMissingActionInputs()).contains(a);
-  }
-
   private RemoteCache newCache(
       RemoteOptions options, DigestUtil digestUtil, Map<HashCode, byte[]> cas) {
     Map<Digest, byte[]> cacheEntries = Maps.newHashMapWithExpectedSize(cas.size());

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -1796,14 +1796,14 @@ public class RemoteExecutionServiceTest {
 
     // assert first time
     // Called for: manifests, runfiles, nodeRoot1, nodeFoo1 and nodeBar.
-    verify(service, times(5)).uncachedBuildMerkleTreeVisitor(any(), any());
+    verify(service, times(5)).uncachedBuildMerkleTreeVisitor(any(), any(), any());
 
     // act second time
     service.buildRemoteAction(spawn2, context2);
 
     // assert second time
     // Called again for: manifests, runfiles, nodeRoot2 and nodeFoo2 but not nodeBar (cached).
-    verify(service, times(5 + 4)).uncachedBuildMerkleTreeVisitor(any(), any());
+    verify(service, times(5 + 4)).uncachedBuildMerkleTreeVisitor(any(), any(), any());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.MetadataProvider;
@@ -149,6 +150,11 @@ public class RemoteSpawnCacheTest {
         @Override
         public MetadataProvider getMetadataProvider() {
           return fakeFileCache;
+        }
+
+        @Override
+        public ArtifactPathResolver getPathResolver() {
+          return ArtifactPathResolver.forExecRoot(execRoot);
         }
 
         @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
@@ -50,7 +51,11 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
     }
 
     return DirectoryTreeBuilder.fromActionInputs(
-        inputFiles, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+        inputFiles,
+        new StaticMetadataProvider(metadata),
+        execRoot,
+        ArtifactPathResolver.forExecRoot(execRoot),
+        digestUtil);
   }
 
   @Test
@@ -63,7 +68,11 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
 
     DirectoryTree tree =
         DirectoryTreeBuilder.fromActionInputs(
-            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+            sortedInputs,
+            new StaticMetadataProvider(metadata),
+            execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
+            digestUtil);
     assertLexicographicalOrder(tree);
 
     assertThat(directoriesAtDepth(0, tree)).containsExactly("srcs");
@@ -108,7 +117,11 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
 
     DirectoryTree tree =
         DirectoryTreeBuilder.fromActionInputs(
-            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+            sortedInputs,
+            new StaticMetadataProvider(metadata),
+            execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
+            digestUtil);
     assertLexicographicalOrder(tree);
 
     assertThat(directoriesAtDepth(0, tree)).containsExactly("srcs");
@@ -152,7 +165,11 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
 
     DirectoryTree tree =
         DirectoryTreeBuilder.fromActionInputs(
-            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+            sortedInputs,
+            new StaticMetadataProvider(metadata),
+            execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
+            digestUtil);
     assertLexicographicalOrder(tree);
 
     assertThat(directoriesAtDepth(0, tree)).containsExactly("srcs");

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeTest.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
@@ -72,6 +73,7 @@ public class MerkleTreeTest {
             Collections.emptySortedMap(),
             new StaticMetadataProvider(Collections.emptyMap()),
             execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
             digestUtil);
     Digest emptyDigest = digestUtil.compute(new byte[0]);
     assertThat(tree.getRootDigest()).isEqualTo(emptyDigest);
@@ -108,7 +110,12 @@ public class MerkleTreeTest {
 
     // act
     MerkleTree tree =
-        MerkleTree.build(sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+        MerkleTree.build(
+            sortedInputs,
+            new StaticMetadataProvider(metadata),
+            execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
+            digestUtil);
 
     // assert
     Digest expectedRootDigest = digestUtil.compute(rootDir);
@@ -157,14 +164,32 @@ public class MerkleTreeTest {
 
     MerkleTree treeEmpty =
         MerkleTree.build(
-            new TreeMap<>(), new StaticMetadataProvider(metadata), execRoot, digestUtil);
+            new TreeMap<>(),
+            new StaticMetadataProvider(metadata),
+            execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
+            digestUtil);
     MerkleTree tree1 =
-        MerkleTree.build(sortedInputs1, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+        MerkleTree.build(
+            sortedInputs1,
+            new StaticMetadataProvider(metadata),
+            execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
+            digestUtil);
     MerkleTree tree2 =
-        MerkleTree.build(sortedInputs2, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+        MerkleTree.build(
+            sortedInputs2,
+            new StaticMetadataProvider(metadata),
+            execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
+            digestUtil);
     MerkleTree treeAll =
         MerkleTree.build(
-            sortedInputsAll, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+            sortedInputsAll,
+            new StaticMetadataProvider(metadata),
+            execRoot,
+            ArtifactPathResolver.forExecRoot(execRoot),
+            digestUtil);
 
     // act
     MerkleTree mergedTreeEmpty = MerkleTree.merge(Arrays.asList(), digestUtil);

--- a/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -24,6 +24,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",
         "//src/main/java/com/google/devtools/build/lib/remote",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/test/java/com/google/devtools/build/lib/remote/util/FakeSpawnExecutionContext.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/FakeSpawnExecutionContext.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -120,6 +121,11 @@ public class FakeSpawnExecutionContext implements SpawnExecutionContext {
   @Override
   public SpawnInputExpander getSpawnInputExpander() {
     return new SpawnInputExpander(execRoot, /* strict= */ false);
+  }
+
+  @Override
+  public ArtifactPathResolver getPathResolver() {
+    return ArtifactPathResolver.forExecRoot(execRoot);
   }
 
   @Override

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
@@ -21,6 +21,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/remote",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/disk",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",


### PR DESCRIPTION
Previously, we handle remote cache eviction when downloading inputs for local actions. However, it's possible that when Bazel need to re-execute an remote action, it detected that some inputs are missing from remote CAS. In this case, Bazel will try to upload inputs by reading from local filesystem. Since the inputs were generated remotely, not downloaded and evicted remotely, the upload will fail with FileNotFoundException.

This CL changes the code to correctly handles above case by reading through ActionFS when uploading inputs and propagate CacheNotFoundException.

Related to #16660.

PiperOrigin-RevId: 512568547
Change-Id: I3a28cadbb6285fa3727e1603f37abf8843c093c9