### PR TITLE
Fix Bazel 6.0 crash regression

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -2252,6 +2252,8 @@ java_library(
     srcs = ["constraints/IncompatibleTargetChecker.java"],
     deps = [
         ":analysis_cluster",
+        ":constraints/environment_collection",
+        ":constraints/supported_environments",
         ":file_provider",
         ":incompatible_platform_provider",
         ":test/test_configuration",

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Predicates.notNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.ConfiguredTargetValue;
@@ -234,7 +235,10 @@ public class IncompatibleTargetChecker {
             .put(incompatiblePlatformProvider)
             .add(RunfilesProvider.simple(Runfiles.EMPTY))
             .add(fileProvider)
-            .add(filesToRunProvider);
+            .add(filesToRunProvider)
+            .add(
+                new SupportedEnvironments(
+                    EnvironmentCollection.EMPTY, EnvironmentCollection.EMPTY, ImmutableMap.of()));
     if (configuration.hasFragment(TestConfiguration.class)) {
       // Create a dummy TestProvider instance so that other parts of the code base stay happy. Even
       // though this test will never execute, some code still expects the provider.

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -475,6 +475,38 @@ function test_failure_on_incompatible_top_level_target() {
   expect_log '^FAILED: Build did NOT complete successfully'
 }
 
+# https://github.com/bazelbuild/bazel/issues/17561 regression test: incompatible
+# target skipping doesn't crash with --auto_cpu_environment_group.
+function test_failure_on_incompatible_top_level_target_and_auto_cpu_environment_group() {
+  cat >> target_skipping/BUILD <<EOF
+sh_test(
+    name = "always_incompatible",
+    srcs = [":pass.sh"],
+    target_compatible_with = [":not_compatible"],
+)
+EOF
+
+  mkdir -p buildenv/cpus
+  cat >> buildenv/cpus/BUILD <<EOF
+environment(name = "foo_cpu")
+environment_group(
+    name = "cpus",
+    defaults = [":foo_cpu"],
+    environments = [":foo_cpu"],
+)
+EOF
+
+  bazel build \
+    --nobuild \
+    --cpu=foo_cpu \
+    --auto_cpu_environment_group=//buildenv/cpus:cpus \
+    --build_event_text_file=$TEST_log \
+    //target_skipping:all &> "${TEST_log}" \
+        || fail "Bazel failed unexpectedly."
+
+  expect_log 'Target //target_skipping:always_incompatible build was skipped'
+}
+
 # Crudely validates that the build event protocol contains useful information
 # when targets are skipped due to incompatibilities.
 function test_build_event_protocol() {


### PR DESCRIPTION
Stop crashes when incompatible target skipping mixes with ---auto_cpu_environment_group.

Fixes https://github.com/bazelbuild/bazel/issues/17561.

Closes #17590.

Change-Id: If5960a6abb08f8fe4f2643af6249c8528b7a2c51
PiperOrigin-RevId: 512820070