### PR TITLE
Add ActionCacheStatistics to BEP

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
@@ -26,6 +26,7 @@ proto_library(
     name = "build_event_stream_proto",
     srcs = ["build_event_stream.proto"],
     deps = [
+        "//src/main/protobuf:action_cache_proto",
         "//src/main/protobuf:command_line_proto",
         "//src/main/protobuf:failure_details_proto",
         "//src/main/protobuf:invocation_policy_proto",

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -18,6 +18,7 @@ package build_event_stream;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
+import "src/main/protobuf/action_cache.proto";
 import "src/main/protobuf/command_line.proto";
 import "src/main/protobuf/failure_details.proto";
 import "src/main/protobuf/invocation_policy.proto";
@@ -874,6 +875,8 @@ message BuildMetrics {
       int32 count = 2;
     }
     repeated RunnerCount runner_count = 6;
+
+    blaze.ActionCacheStatistics action_cache_statistics = 7;
   }
   ActionSummary action_summary = 1;
 

--- a/src/main/java/com/google/devtools/build/lib/metrics/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/metrics/BUILD
@@ -48,6 +48,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/worker:worker_metric",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe_graph_stats_event",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/main/protobuf:action_cache_java_proto",
         "//third_party:error_prone_annotations",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.actions.ActionCompletionEvent;
 import com.google.devtools.build.lib.actions.ActionResultReceivedEvent;
 import com.google.devtools.build.lib.actions.AnalysisGraphStatsEvent;
 import com.google.devtools.build.lib.actions.TotalAndConfiguredTargetOnlyMetric;
+import com.google.devtools.build.lib.actions.cache.Protos.ActionCacheStatistics;
 import com.google.devtools.build.lib.analysis.AnalysisPhaseCompleteEvent;
 import com.google.devtools.build.lib.analysis.AnalysisPhaseStartedEvent;
 import com.google.devtools.build.lib.analysis.NoBuildRequestFinishedEvent;
@@ -212,6 +213,12 @@ class MetricsCollector {
     return WorkerMetricsCollector.instance().collectMetrics().stream()
         .map(WorkerMetric::toProto)
         .collect(toImmutableList());
+  }
+
+  @SuppressWarnings("unused")
+  @Subscribe
+  private void logActionCacheStatistics(ActionCacheStatistics stats) {
+    actionSummary.setActionCacheStatistics(stats);
   }
 
   private BuildMetrics createBuildMetrics() {


### PR DESCRIPTION
Solves #17315 .

The field action_cache_statistics has been added to the ActionSummary message of the BuildMetrics message in the build event protocol. This field is defined with the already-existing ActionCacheStatistics message and is set in the MetricsCollector when the action cache is saved.