### PR TITLE
Remove supports_dynamic_linker_feature from macOS unix crosstool

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -1383,7 +1383,6 @@ def _impl(ctx):
             user_link_flags_feature,
             default_link_libs_feature,
             fdo_optimize_feature,
-            supports_dynamic_linker_feature,
             dbg_feature,
             opt_feature,
             user_compile_flags_feature,


### PR DESCRIPTION
This feature isn't supported on macOS, and it isn't part of the Xcode CC toolchain, but it is left over here from when it was supported in the past.

https://github.com/bazelbuild/bazel/commit/ec5553352f2f661d39ac4cf665dd9b3c779e614c

Fixes: https://github.com/bazelbuild/bazel/pull/16414#issuecomment-1447374727