### PR TITLE
Skip coverage for cpp targets when they are not instrumented

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -212,7 +212,7 @@ public abstract class CcModule
       // flipped.
       buildOptions = ruleContext.getConfiguration().getOptions();
       if (!ruleContext.instrumentCoverage(Starlark.NONE) && cppConfiguration.collectCodeCoverage()) {
-        // When --collect-code-coverage is passed, CcCommon.configureFeaturesOrThrowEvalException() would
+        // When --collect_code_coverage is passed, CcCommon.configureFeaturesOrThrowEvalException() would
         // try to add "coverage" to the requested list of features. Adding "coverage" to the unsupported
         // feature here to avoid that.
         unsupportedFeaturesSetBuilder.add("coverage");


### PR DESCRIPTION
Currently Bazel adds coverage flags to C compiler and linker when `--collect_code_coverage` is given. This is not always necessary, because the C library may not be instrumented, and only the Go code that depend on the C library is instrumented. So we don't need to recompile C library in this case.