### PR TITLE
Store TTL in RemoteFileArtifactValue

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -76,7 +76,7 @@ public class CompactPersistentActionCache implements ActionCache {
 
   private static final int NO_INPUT_DISCOVERY_COUNT = -1;
 
-  private static final int VERSION = 15;
+  private static final int VERSION = 16;
 
   private static final class ActionMap extends PersistentMap<Integer, byte[]> {
     private final Clock clock;
@@ -466,6 +466,8 @@ public class CompactPersistentActionCache implements ActionCache {
 
     VarInt.putVarInt(value.getLocationIndex(), sink);
 
+    VarInt.putVarLong(value.getExpireAtEpochMilli(), sink);
+
     Optional<PathFragment> materializationExecPath = value.getMaterializationExecPath();
     if (materializationExecPath.isPresent()) {
       VarInt.putVarInt(1, sink);
@@ -476,10 +478,11 @@ public class CompactPersistentActionCache implements ActionCache {
   }
 
   private static final int MAX_REMOTE_METADATA_SIZE =
-      DigestUtils.ESTIMATED_SIZE
-          + VarInt.MAX_VARLONG_SIZE
-          + VarInt.MAX_VARINT_SIZE
-          + VarInt.MAX_VARINT_SIZE;
+      DigestUtils.ESTIMATED_SIZE // digest
+          + VarInt.MAX_VARLONG_SIZE // size
+          + VarInt.MAX_VARINT_SIZE // locationIndex
+          + VarInt.MAX_VARINT_SIZE // expireAtEpochMilli
+          + VarInt.MAX_VARINT_SIZE; // materializationExecPath
 
   private static RemoteFileArtifactValue decodeRemoteMetadata(
       StringIndexer indexer, ByteBuffer source) throws IOException {
@@ -488,6 +491,8 @@ public class CompactPersistentActionCache implements ActionCache {
     long size = VarInt.getVarLong(source);
 
     int locationIndex = VarInt.getVarInt(source);
+
+    long expireAtEpochMilli = VarInt.getVarLong(source);
 
     PathFragment materializationExecPath = null;
     int numMaterializationExecPath = VarInt.getVarInt(source);
@@ -499,7 +504,7 @@ public class CompactPersistentActionCache implements ActionCache {
           PathFragment.create(getStringForIndex(indexer, VarInt.getVarInt(source)));
     }
 
-    return RemoteFileArtifactValue.create(digest, size, locationIndex, materializationExecPath);
+    return RemoteFileArtifactValue.create(digest, size, locationIndex, expireAtEpochMilli, materializationExecPath);
   }
 
   /** @return action data encoded as a byte[] array. */

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -203,7 +203,7 @@ public final class RemoteOptions extends CommonRemoteOptions {
       defaultValue = "60s",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
-      converter = RemoteTimeoutConverter.class,
+      converter = RemoteDurationConverter.class,
       help =
           "The maximum amount of time to wait for remote execution and cache calls. For the REST"
               + " cache, this is both the connect and the read timeout. Following units can be"
@@ -223,24 +223,6 @@ public final class RemoteOptions extends CommonRemoteOptions {
               + "to no longer correspond to the canonical name of the remote execution service. "
               + "When not set, it will default to \"${hostname}/${instance_name}\".")
   public String remoteBytestreamUriPrefix;
-
-  /** Returns the specified duration. Assumes seconds if unitless. */
-  public static class RemoteTimeoutConverter extends Converter.Contextless<Duration> {
-    private static final Pattern UNITLESS_REGEX = Pattern.compile("^[0-9]+$");
-
-    @Override
-    public Duration convert(String input) throws OptionsParsingException {
-      if (UNITLESS_REGEX.matcher(input).matches()) {
-        input += "s";
-      }
-      return new Converters.DurationConverter().convert(input, /*conversionContext=*/ null);
-    }
-
-    @Override
-    public String getTypeDescription() {
-      return "An immutable length of time.";
-    }
-  }
 
   @Option(
       name = "remote_accept_cached",

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -463,7 +463,13 @@ public class ActionCacheCheckerTest {
   private RemoteFileArtifactValue createRemoteFileMetadata(
       String content, @Nullable PathFragment materializationExecPath) {
     byte[] bytes = content.getBytes(UTF_8);
-    return RemoteFileArtifactValue.create(digest(bytes), bytes.length, 1, materializationExecPath);
+    return RemoteFileArtifactValue.create(digest(bytes), bytes.length, 1, /* expireAtEpochMilli= */ -1, materializationExecPath);
+  }
+
+  private RemoteFileArtifactValue createRemoteFileMetadata(
+      String content, long expireAtEpochMilli, @Nullable PathFragment materializationExecPath) {
+    byte[] bytes = content.getBytes(UTF_8);
+    return RemoteFileArtifactValue.create(digest(bytes), bytes.length, 1, expireAtEpochMilli, materializationExecPath);
   }
 
   private static TreeArtifactValue createTreeMetadata(
@@ -586,6 +592,33 @@ public class ActionCacheCheckerTest {
     assertThat(entry).isNotNull();
     assertThat(entry.getOutputFile(output)).isEqualTo(createRemoteFileMetadata(content));
     assertThat(metadataHandler.getMetadata(output)).isEqualTo(createRemoteFileMetadata(content));
+  }
+
+  @Test
+  public void saveOutputMetadata_remoteFileExpired_remoteFileMetadataNotLoaded() throws Exception {
+    cacheChecker = createActionCacheChecker(/*storeOutputMetadata=*/ true);
+    Artifact output = createArtifact(artifactRoot, "bin/dummy");
+    String content = "content";
+    Action action = new InjectOutputFileMetadataAction(output, createRemoteFileMetadata(content, /* expireAtEpochMilli= */ 0, /* materializationExecPath= */ null));
+    MetadataHandler metadataHandler = new FakeMetadataHandler();
+
+    runAction(action);
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            action,
+            /* resolvedCacheArtifacts= */ null,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            metadataHandler,
+            /* artifactExpander= */ null,
+            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* loadCachedOutputMetadata= */ true);
+
+    assertThat(output.getPath().exists()).isFalse();
+    assertThat(token).isNotNull();
+    ActionCache.Entry entry = cache.get(output.getExecPathString());
+    assertThat(entry).isNull();
   }
 
   @Test
@@ -997,6 +1030,44 @@ public class ActionCacheCheckerTest {
     assertThat(entry.getOutputTree(output))
         .isEqualTo(SerializableTreeArtifactValue.createSerializable(expectedMetadata).get());
     assertThat(metadataHandler.getTreeArtifactValue(output)).isEqualTo(expectedMetadata);
+  }
+
+  @Test
+  public void saveOutputMetadata_treeFileExpired_treeMetadataNotLoaded() throws Exception {
+    cacheChecker = createActionCacheChecker(/*storeOutputMetadata=*/ true);
+    SpecialArtifact output =
+        createTreeArtifactWithGeneratingAction(artifactRoot, PathFragment.create("bin/dummy"));
+    ImmutableMap<String, RemoteFileArtifactValue> children =
+        ImmutableMap.of(
+            "file1", createRemoteFileMetadata("content1"),
+            "file2", createRemoteFileMetadata("content2", /* expireAtEpochMilli= */ 0, /* materializationExecPath= */ null));
+    Action action =
+        new InjectOutputTreeMetadataAction(
+            output,
+            createTreeMetadata(
+                output,
+                children,
+                /* archivedArtifactValue= */ Optional.empty(),
+                /* materializationExecPath= */ Optional.empty()));
+    MetadataHandler metadataHandler = new FakeMetadataHandler();
+
+    runAction(action);
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            action,
+            /* resolvedCacheArtifacts= */ null,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            metadataHandler,
+            /* artifactExpander= */ null,
+            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            /* loadCachedOutputMetadata= */ true);
+
+    assertThat(output.getPath().exists()).isFalse();
+    assertThat(token).isNotNull();
+    ActionCache.Entry entry = cache.get(output.getExecPathString());
+    assertThat(entry).isNull();
   }
 
   private static void writeContentAsLatin1(Path path, String content) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/actions/CompletionContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/CompletionContextTest.java
@@ -40,7 +40,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CompletionContextTest {
   private static final FileArtifactValue DUMMY_METADATA =
-      RemoteFileArtifactValue.create(/*digest=*/ new byte[0], /*size=*/ 0, /*locationIndex=*/ 0);
+      RemoteFileArtifactValue.create(/*digest=*/ new byte[0], /*size=*/ 0, /*locationIndex=*/ 0, /* expireAtEpochMilli= */ -1);
 
   private Path execRoot;
   private ArtifactRoot outputRoot;

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -198,7 +199,10 @@ public class CompactPersistentActionCacheTest {
   }
 
   private RemoteFileArtifactValue createRemoteMetadata(
-      Artifact artifact, String content, @Nullable PathFragment materializationExecPath) {
+      Artifact artifact,
+      String content,
+      long expireAtEpochMilli,
+      @Nullable PathFragment materializationExecPath) {
     byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
     byte[] digest =
         artifact
@@ -208,7 +212,14 @@ public class CompactPersistentActionCacheTest {
             .getHashFunction()
             .hashBytes(bytes)
             .asBytes();
-    return RemoteFileArtifactValue.create(digest, bytes.length, 1, materializationExecPath);
+    return RemoteFileArtifactValue.create(
+        digest, bytes.length, 1, expireAtEpochMilli, materializationExecPath);
+  }
+
+  private RemoteFileArtifactValue createRemoteMetadata(
+      Artifact artifact, String content, @Nullable PathFragment materializationExecPath) {
+    return createRemoteMetadata(
+        artifact, content, /* expireAtEpochMilli= */ -1, materializationExecPath);
   }
 
   private RemoteFileArtifactValue createRemoteMetadata(Artifact artifact, String content) {
@@ -250,6 +261,24 @@ public class CompactPersistentActionCacheTest {
     entry = cache.get(key);
 
     assertThat(entry.getOutputFile(artifact)).isEqualTo(metadata);
+  }
+
+  @Test
+  public void putAndGet_savesRemoteFileMetadata_withExpireAtEpochMilli() {
+    String key = "key";
+    ActionCache.Entry entry =
+        new ActionCache.Entry(key, ImmutableMap.of(), false, OutputPermissions.READONLY);
+    Artifact artifact = ActionsTestUtil.DUMMY_ARTIFACT;
+    long expireAtEpochMilli = Instant.now().toEpochMilli();
+    RemoteFileArtifactValue metadata =
+        createRemoteMetadata(
+            artifact, "content", expireAtEpochMilli, /* materializationExecPath= */ null);
+    entry.addOutputFile(artifact, metadata, /*saveFileMetadata=*/ true);
+
+    cache.put(key, entry);
+    entry = cache.get(key);
+
+    assertThat(entry.getOutputFile(artifact).getExpireAtEpochMilli()).isEqualTo(expireAtEpochMilli);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -104,6 +104,7 @@ public abstract class ActionInputPrefetcherTestBase {
             hashCode.asBytes(),
             contentsBytes.length,
             /* locationIndex= */ 1,
+            /* expireAtEpochMilli= */ -1,
             materializationExecPath);
     metadata.put(a, f);
     if (cas != null) {
@@ -154,7 +155,10 @@ public abstract class ActionInputPrefetcherTestBase {
       HashCode hashCode = HASH_FUNCTION.getHashFunction().hashBytes(contents);
       RemoteFileArtifactValue childValue =
           RemoteFileArtifactValue.create(
-              hashCode.asBytes(), contents.length, /* locationIndex= */ 1);
+              hashCode.asBytes(),
+              contents.length,
+              /* locationIndex= */ 1,
+              /* expireAtEpochMilli= */ -1);
       treeBuilder.putChild(child, childValue);
       metadata.put(child, childValue);
       cas.put(hashCode, contents);

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -442,7 +442,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     byte[] b = contents.getBytes(StandardCharsets.UTF_8);
     HashCode h = HashCode.fromString(DIGEST_UTIL.compute(b).getHash());
     FileArtifactValue f =
-        RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 1);
+        RemoteFileArtifactValue.create(
+            h.asBytes(), b.length, /* locationIndex= */ 1, /* expireAtEpochMilli= */ -1);
     inputs.putWithNoDepOwner(a, f);
     return a;
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -326,7 +326,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
     HashCode hashCode = HASH_FUNCTION.getHashFunction().hashBytes(contentBytes);
     ((RemoteActionFileSystem) actionFs)
-        .injectRemoteFile(path, hashCode.asBytes(), contentBytes.length);
+        .injectRemoteFile(
+            path, hashCode.asBytes(), contentBytes.length, /* expireAtEpochMilli= */ -1);
   }
 
   @Override
@@ -342,7 +343,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     byte[] b = contents.getBytes(StandardCharsets.UTF_8);
     HashCode h = HASH_FUNCTION.getHashFunction().hashBytes(b);
     RemoteFileArtifactValue f =
-        RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 1);
+        RemoteFileArtifactValue.create(
+            h.asBytes(), b.length, /* locationIndex= */ 1, /* expireAtEpochMilli= */ -1);
     inputs.putWithNoDepOwner(a, f);
     return a;
   }
@@ -364,7 +366,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
       byte[] b = entry.getValue().getBytes(StandardCharsets.UTF_8);
       HashCode h = HASH_FUNCTION.getHashFunction().hashBytes(b);
       RemoteFileArtifactValue childMeta =
-          RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 0);
+          RemoteFileArtifactValue.create(
+              h.asBytes(), b.length, /* locationIndex= */ 0, /* expireAtEpochMilli= */ -1);
       builder.putChild(child, childMeta);
     }
     return builder.build();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -23,6 +23,7 @@ import static com.google.devtools.build.lib.vfs.FileSystemUtils.readContent;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -965,7 +966,8 @@ public class RemoteExecutionServiceTest {
         .injectRemoteFile(
             eq(execRoot.asFragment().getRelative(a1.getExecPath())),
             eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()));
+            eq(d1.getSizeBytes()),
+            anyLong());
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
     assertThat(outputBase.readdir(Symlinks.NOFOLLOW)).isEmpty();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -1005,12 +1007,14 @@ public class RemoteExecutionServiceTest {
         .injectRemoteFile(
             eq(execRoot.asFragment().getRelative(a1.getExecPath())),
             eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()));
+            eq(d1.getSizeBytes()),
+            anyLong());
     verify(actionFileSystem)
         .injectRemoteFile(
             eq(execRoot.asFragment().getRelative(a2.getExecPath())),
             eq(toBinaryDigest(d2)),
-            eq(d2.getSizeBytes()));
+            eq(d2.getSizeBytes()),
+            anyLong());
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
     assertThat(outputBase.readdir(Symlinks.NOFOLLOW)).isEmpty();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -1063,12 +1067,14 @@ public class RemoteExecutionServiceTest {
         .injectRemoteFile(
             eq(execRoot.asFragment().getRelative("outputs/dir/file1")),
             eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()));
+            eq(d1.getSizeBytes()),
+            anyLong());
     verify(actionFileSystem)
         .injectRemoteFile(
             eq(execRoot.asFragment().getRelative("outputs/dir/a/file2")),
             eq(toBinaryDigest(d2)),
-            eq(d2.getSizeBytes()));
+            eq(d2.getSizeBytes()),
+            anyLong());
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
     assertThat(outputBase.readdir(Symlinks.NOFOLLOW)).isEmpty();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -1201,12 +1207,14 @@ public class RemoteExecutionServiceTest {
         .injectRemoteFile(
             eq(execRoot.asFragment().getRelative(a1.getExecPath())),
             eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()));
+            eq(d1.getSizeBytes()),
+            anyLong());
     verify(actionFileSystem)
         .injectRemoteFile(
             eq(execRoot.asFragment().getRelative(a2.getExecPath())),
             eq(toBinaryDigest(d2)),
-            eq(d2.getSizeBytes()));
+            eq(d2.getSizeBytes()),
+            anyLong());
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
     assertThat(outputBase.readdir(Symlinks.NOFOLLOW)).isEmpty();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -1254,7 +1262,8 @@ public class RemoteExecutionServiceTest {
         .injectRemoteFile(
             eq(execRoot.asFragment().getRelative(a1.getExecPath())),
             eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()));
+            eq(d1.getSizeBytes()),
+            anyLong());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
@@ -79,7 +79,7 @@ public class RemoteOptionsTest {
     try {
       int seconds = 60;
       Duration convert =
-          new RemoteOptions.RemoteTimeoutConverter().convert(String.valueOf(seconds));
+          new CommonRemoteOptions.RemoteDurationConverter().convert(String.valueOf(seconds));
       assertThat(Duration.ofSeconds(seconds)).isEqualTo(convert);
     } catch (OptionsParsingException e) {
       fail(e.getMessage());
@@ -90,7 +90,8 @@ public class RemoteOptionsTest {
   public void testRemoteTimeoutOptionsConverterWithUnit() {
     try {
       int milliseconds = 60;
-      Duration convert = new RemoteOptions.RemoteTimeoutConverter().convert(milliseconds + "ms");
+      Duration convert =
+          new CommonRemoteOptions.RemoteDurationConverter().convert(milliseconds + "ms");
       assertThat(Duration.ofMillis(milliseconds)).isEqualTo(convert);
     } catch (OptionsParsingException e) {
       fail(e.getMessage());

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionExecutionValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionExecutionValueTest.java
@@ -43,10 +43,16 @@ import org.junit.runners.JUnit4;
 public class ActionExecutionValueTest {
   private static final FileArtifactValue VALUE_1 =
       RemoteFileArtifactValue.create(
-          /* digest= */ new byte[0], /* size= */ 0, /* locationIndex= */ 1);
+          /* digest= */ new byte[0],
+          /* size= */ 0,
+          /* locationIndex= */ 1,
+          /* expireAtEpochMilli= */ -1);
   private static final FileArtifactValue VALUE_2 =
       RemoteFileArtifactValue.create(
-          /* digest= */ new byte[0], /* size= */ 0, /* locationIndex= */ 2);
+          /* digest= */ new byte[0],
+          /* size= */ 0,
+          /* locationIndex= */ 2,
+          /* expireAtEpochMilli= */ -1);
 
   private static final ActionLookupKey KEY = mock(ActionLookupKey.class);
   private static final ActionLookupData ACTION_LOOKUP_DATA_1 = ActionLookupData.create(KEY, 1);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandlerTest.java
@@ -307,7 +307,9 @@ public final class ActionMetadataHandlerTest {
     assertThat(chmodCalls).containsExactly(outputPath, 0555);
 
     // Inject a remote file of size 42.
-    handler.injectFile(artifact, RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 42, 0));
+    handler.injectFile(
+        artifact,
+        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 42, 0, /* expireAtEpochMilli= */ -1));
     assertThat(handler.getMetadata(artifact).getSize()).isEqualTo(42);
 
     // Reset this output, which will make the handler stat the file again.
@@ -331,7 +333,9 @@ public final class ActionMetadataHandlerTest {
     byte[] digest = new byte[] {1, 2, 3};
     int size = 10;
     handler.injectFile(
-        artifact, RemoteFileArtifactValue.create(digest, size, /* locationIndex= */ 1));
+        artifact,
+        RemoteFileArtifactValue.create(
+            digest, size, /* locationIndex= */ 1, /* expireAtEpochMilli= */ -1));
 
     FileArtifactValue v = handler.getMetadata(artifact);
     assertThat(v).isNotNull();
@@ -354,7 +358,8 @@ public final class ActionMetadataHandlerTest {
             /* outputs= */ ImmutableSet.of(treeArtifact));
     handler.prepareForActionExecution();
 
-    RemoteFileArtifactValue childValue = RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1);
+    RemoteFileArtifactValue childValue =
+        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1, /* expireAtEpochMilli= */ -1);
 
     assertThrows(IllegalArgumentException.class, () -> handler.injectFile(child, childValue));
     assertThat(handler.getOutputStore().getAllArtifactData()).isEmpty();
@@ -378,7 +383,8 @@ public final class ActionMetadataHandlerTest {
             /* outputs= */ ImmutableSet.of(treeArtifact));
     handler.prepareForActionExecution();
 
-    RemoteFileArtifactValue value = RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1);
+    RemoteFileArtifactValue value =
+        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1, /* expireAtEpochMilli= */ -1);
     handler.injectFile(output, value);
 
     assertThat(handler.getOutputStore().getAllArtifactData()).containsExactly(output, value);
@@ -402,10 +408,12 @@ public final class ActionMetadataHandlerTest {
         TreeArtifactValue.newBuilder(treeArtifact)
             .putChild(
                 TreeFileArtifact.createTreeOutput(treeArtifact, "foo"),
-                RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1))
+                RemoteFileArtifactValue.create(
+                    new byte[] {1, 2, 3}, 5, 1, /* expireAtEpochMilli= */ -1))
             .putChild(
                 TreeFileArtifact.createTreeOutput(treeArtifact, "bar"),
-                RemoteFileArtifactValue.create(new byte[] {4, 5, 6}, 10, 1))
+                RemoteFileArtifactValue.create(
+                    new byte[] {4, 5, 6}, 10, 1, /* expireAtEpochMilli= */ -1))
             .build();
 
     handler.injectTree(treeArtifact, tree);
@@ -638,7 +646,8 @@ public final class ActionMetadataHandlerTest {
     assertThat(handler.getMetadata(unknown)).isNull();
 
     OutputStore newStore = new OutputStore();
-    FileArtifactValue knownMetadata = RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1);
+    FileArtifactValue knownMetadata =
+        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1, /* expireAtEpochMilli= */ -1);
     newStore.putArtifactData(known, knownMetadata);
     ActionMetadataHandler newHandler = handler.transformAfterInputDiscovery(newStore);
     assertThat(newHandler.getOutputStore()).isNotEqualTo(handler.getOutputStore());

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.io.BaseEncoding;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -78,6 +79,10 @@ public final class FileArtifactValueTest {
         .addEqualityGroup(
             FileArtifactValue.createForDirectoryWithMtime(2),
             FileArtifactValue.createForDirectoryWithMtime(2))
+        .addEqualityGroup(
+            // expireAtEpochMilli doesn't contribute to the equality
+            RemoteFileArtifactValue.create(toBytes("00112233445566778899AABBCCDDEEFF"), 1, 1, 1),
+            RemoteFileArtifactValue.create(toBytes("00112233445566778899AABBCCDDEEFF"), 1, 1, 2))
         .addEqualityGroup(FileArtifactValue.OMITTED_FILE_MARKER)
         .addEqualityGroup(FileArtifactValue.MISSING_FILE_MARKER)
         .addEqualityGroup(FileArtifactValue.DEFAULT_MIDDLEMAN)

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -1324,10 +1324,15 @@ public final class FilesystemValueCheckerTest {
   }
 
   private RemoteFileArtifactValue createRemoteFileArtifactValue(String contents) {
+    return createRemoteFileArtifactValue(contents, /* expireAtEpochMilli= */ -1);
+  }
+
+  private RemoteFileArtifactValue createRemoteFileArtifactValue(String contents, long expireAtEpochMilli) {
     byte[] data = contents.getBytes();
     DigestHashFunction hashFn = fs.getDigestFunction();
     HashCode hash = hashFn.getHashFunction().hashBytes(data);
-    return RemoteFileArtifactValue.create(hash.asBytes(), data.length, -1);
+    return RemoteFileArtifactValue.create(
+        hash.asBytes(), data.length, -1, expireAtEpochMilli);
   }
 
   @Test
@@ -1385,6 +1390,45 @@ public final class FilesystemValueCheckerTest {
   }
 
   @Test
+  public void testRemoteArtifactsExpired() throws Exception {
+    // Test that if injected remote artifacts expired, they are considered as dirty.
+    SkyKey actionKey1 = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);
+    SkyKey actionKey2 = ActionLookupData.create(ACTION_LOOKUP_KEY, 1);
+
+    Artifact out1 = createDerivedArtifact("foo");
+    Artifact out2 = createDerivedArtifact("bar");
+    Map<SkyKey, SkyValue> metadataToInject = new HashMap<>();
+    metadataToInject.put(
+        actionKey1,
+        actionValueWithRemoteArtifact(out1, createRemoteFileArtifactValue("foo-content")));
+    metadataToInject.put(
+        actionKey2,
+        actionValueWithRemoteArtifact(out2, createRemoteFileArtifactValue("bar-content", /* expireAtEpochMilli= */ 0)));
+    differencer.inject(metadataToInject);
+
+    EvaluationContext evaluationContext =
+        EvaluationContext.newBuilder()
+            .setKeepGoing(false)
+            .setParallelism(1)
+            .setEventHandler(NullEventHandler.INSTANCE)
+            .build();
+    assertThat(
+        evaluator
+            .evaluate(ImmutableList.of(actionKey1, actionKey2), evaluationContext)
+            .hasError())
+        .isFalse();
+    assertThat(
+        new FilesystemValueChecker(/*tsgm=*/ null, SyscallCache.NO_CACHE, FSVC_THREADS_FOR_TEST)
+            .getDirtyActionValues(
+                evaluator.getValues(),
+                /* batchStatter= */ null,
+                ModifiedFileSet.EVERYTHING_MODIFIED,
+                /* trustRemoteArtifacts= */ true,
+                (ignored, ignored2) -> {}))
+        .containsExactly(actionKey2);
+  }
+
+  @Test
   public void testRemoteAndLocalTreeArtifacts() throws Exception {
     // Test that injected remote tree artifacts are trusted by the FileSystemValueChecker
     // and that local files always takes preference over remote files.
@@ -1418,7 +1462,7 @@ public final class FilesystemValueCheckerTest {
                     evaluator.getValues(),
                     /* batchStatter= */ null,
                     ModifiedFileSet.EVERYTHING_MODIFIED,
-                    /* trustRemoteArtifacts= */ false,
+                    /* trustRemoteArtifacts= */ true,
                     (ignored, ignored2) -> {}))
         .isEmpty();
 
@@ -1431,8 +1475,46 @@ public final class FilesystemValueCheckerTest {
                     evaluator.getValues(),
                     /* batchStatter= */ null,
                     ModifiedFileSet.EVERYTHING_MODIFIED,
-                    /* trustRemoteArtifacts= */ false,
+                    /* trustRemoteArtifacts= */ true,
                     (ignored, ignored2) -> {}))
+        .containsExactly(actionKey);
+  }
+
+  @Test
+  public void testRemoteTreeArtifactsExpired() throws Exception {
+    // Test that if injected remote tree artifacts are expired, they are considered as dirty.
+    SkyKey actionKey = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);
+
+    SpecialArtifact treeArtifact = createTreeArtifact("dir");
+    treeArtifact.getPath().createDirectoryAndParents();
+    TreeArtifactValue tree =
+        TreeArtifactValue.newBuilder(treeArtifact)
+            .putChild(
+                TreeFileArtifact.createTreeOutput(treeArtifact, "foo"),
+                createRemoteFileArtifactValue("foo-content"))
+            .putChild(
+                TreeFileArtifact.createTreeOutput(treeArtifact, "bar"),
+                createRemoteFileArtifactValue("bar-content", /* expireAtEpochMilli= */ 0))
+            .build();
+
+    differencer.inject(ImmutableMap.of(actionKey, actionValueWithTreeArtifact(treeArtifact, tree)));
+
+    EvaluationContext evaluationContext =
+        EvaluationContext.newBuilder()
+            .setKeepGoing(false)
+            .setParallelism(1)
+            .setEventHandler(NullEventHandler.INSTANCE)
+            .build();
+    assertThat(evaluator.evaluate(ImmutableList.of(actionKey), evaluationContext).hasError())
+        .isFalse();
+    assertThat(
+        new FilesystemValueChecker(/*tsgm=*/ null, SyscallCache.NO_CACHE, FSVC_THREADS_FOR_TEST)
+            .getDirtyActionValues(
+                evaluator.getValues(),
+                /* batchStatter= */ null,
+                ModifiedFileSet.EVERYTHING_MODIFIED,
+                /* trustRemoteArtifacts= */ true,
+                (ignored, ignored2) -> {}))
         .containsExactly(actionKey);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactBuildTest.java
@@ -616,10 +616,16 @@ public final class TreeArtifactBuildTest extends TimestampBuilderTestCase {
     SpecialArtifact out = createTreeArtifact("output");
     RemoteFileArtifactValue remoteFile1 =
         RemoteFileArtifactValue.create(
-            Hashing.sha256().hashString("one", UTF_8).asBytes(), /*size=*/ 3, /*locationIndex=*/ 1);
+            Hashing.sha256().hashString("one", UTF_8).asBytes(),
+            /*size=*/ 3,
+            /*locationIndex=*/ 1,
+            /* expireAtEpochMilli= */ -1);
     RemoteFileArtifactValue remoteFile2 =
         RemoteFileArtifactValue.create(
-            Hashing.sha256().hashString("two", UTF_8).asBytes(), /*size=*/ 3, /*locationIndex=*/ 2);
+            Hashing.sha256().hashString("two", UTF_8).asBytes(),
+            /*size=*/ 3,
+            /*locationIndex=*/ 2,
+            /* expireAtEpochMilli= */ -1);
 
     Action action =
         new SimpleTestAction(out) {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
@@ -711,7 +711,7 @@ public final class TreeArtifactValueTest {
   }
 
   private static FileArtifactValue metadataWithId(int id) {
-    return RemoteFileArtifactValue.create(new byte[] {(byte) id}, id, id);
+    return RemoteFileArtifactValue.create(new byte[] {(byte) id}, id, id, /* expireAtEpochMilli= */ -1);
   }
 
   private static FileArtifactValue metadataWithIdNoDigest(int id) {


### PR DESCRIPTION
When building without the bytes, Bazel stores `RemoteFileArtifactValue` in skyframe (inmemory) and in local action cache which represents a file that is stored remotely. Bazel assumes that the remote file will never expire which is wrong. In practice, remote cache often evict files due to space constraint, and when it happens, the builds could fail.

This PR introduces flag `--experimental_remote_cache_ttl` which tells Bazel at least how long the remote cache could store a file after returning a reference of it to Bazel. Bazel calculates the TTL of the file and store it in the `RemoteFileArtifactValue`. In an incremental build, Bazel will discard the `RemoteFileArtifactValue` and rerun the generating actions if it finds out that the `RemoteFileArtifactValue` is expired. The new field `expireAtEpochMilli` replaces `actionId` (deleted by f62a8b9f6a7e840c648f44f094390c3b85b236df), so there shouldn't be memory regression.

There are two places Bazel checks the TTL:
1. If the skyframe has in-memory state about previous builds (e.g. incremental builds), the `SkyValue`s are marked as dirty if the `RemoteFileArtifactValue` is expired.
2. When checking local action cache, if the `RemoteFileArtifactValue` is expired, the cache entry is ignored.

So that the generating actions can be re-executed.

Part of #16660.
