### PR TITLE
Revert "Use target_compatible_with for Java runtimes"

### DIFF
--- a/site/en/docs/bazel-and-java.md
+++ b/site/en/docs/bazel-and-java.md
@@ -183,7 +183,7 @@ remote_java_repository(
   name = "openjdk_canary_linux_arm",
   prefix = "openjdk_canary", # Can be used with --java_runtime_version=openjdk_canary_11
   version = "11",            # or --java_runtime_version=11
-  target_compatible_with = [ # Specifies constraints this JVM is compatible with
+  exec_compatible_with = [   # Specifies constraints this JVM is compatible with
     "@platforms//cpu:arm",
     "@platforms//os:linux",
   ],

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.tmpl
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.tmpl
@@ -21,7 +21,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk11_linux}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
@@ -32,7 +32,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk11_linux_aarch64}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
@@ -43,7 +43,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk11_linux_ppc64le}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:ppc",
     ],
@@ -54,7 +54,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk11_linux_s390x}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:s390x",
     ],
@@ -65,7 +65,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk11_macos}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:macos",
         "@platforms//cpu:x86_64",
     ],
@@ -76,7 +76,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk11_macos_aarch64}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:macos",
         "@platforms//cpu:aarch64",
     ],
@@ -87,7 +87,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk11_win}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],
@@ -109,7 +109,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk17_linux}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
@@ -131,7 +131,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk17_macos}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:macos",
         "@platforms//cpu:x86_64",
     ],
@@ -142,7 +142,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk17_macos_aarch64}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:macos",
         "@platforms//cpu:aarch64",
     ],
@@ -153,7 +153,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk17_win}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.tmpl
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.tmpl
@@ -98,7 +98,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk11_win_arm64}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:arm64",
     ],
@@ -120,7 +120,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk17_linux_aarch64}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
@@ -163,7 +163,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk17_win_arm64}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:arm64",
     ],
@@ -174,7 +174,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk19_linux}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
@@ -185,7 +185,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk19_linux_aarch64}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
@@ -196,7 +196,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk19_macos}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:macos",
         "@platforms//cpu:x86_64",
     ],
@@ -207,7 +207,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk19_macos_aarch64}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:macos",
         "@platforms//cpu:aarch64",
     ],
@@ -218,7 +218,7 @@ maybe(
 maybe(
     remote_java_repository,
     {remotejdk19_win}
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],

--- a/tools/jdk/remote_java_repository.bzl
+++ b/tools/jdk/remote_java_repository.bzl
@@ -31,17 +31,17 @@ _toolchain_config = repository_rule(
     },
 )
 
-def remote_java_repository(name, version, target_compatible_with = None, prefix = "remotejdk", **kwargs):
+def remote_java_repository(name, version, exec_compatible_with, prefix = "remotejdk", **kwargs):
     """Imports and registers a JDK from a http archive.
 
-    Toolchain resolution is determined with target_compatible_with
+    Toolchain resolution is determined with exec_compatible_with
     parameter and constrained with --java_runtime_version flag either having value
     of "version" or "{prefix}_{version}" parameters.
 
     Args:
       name: A unique name for this rule.
       version: Version of the JDK imported.
-      target_compatible_with: Target platform constraints (CPU and OS) for this JDK.
+      exec_compatible_with: Platform constraints (CPU and OS) for this JDK.
       prefix: Optional alternative prefix for configuration flag value used to determine this JDK.
       **kwargs: Refer to http_archive documentation
     """
@@ -73,7 +73,7 @@ alias(
 )
 toolchain(
     name = "toolchain",
-    target_compatible_with = {target_compatible_with},
+    exec_compatible_with = {exec_compatible_with},
     target_settings = [":version_or_prefix_version_setting"],
     toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
     toolchain = "{toolchain}",
@@ -81,7 +81,7 @@ toolchain(
 """.format(
             prefix = prefix,
             version = version,
-            target_compatible_with = target_compatible_with,
+            exec_compatible_with = exec_compatible_with,
             toolchain = "@{repo}//:jdk".format(repo = name),
         ),
     )


### PR DESCRIPTION
See #17085

d5559c16ac008b86345fbbade5d600181a2fce6f changed the JDK definitions used when you specify --java_runtime_version=remotejdk_11 (or other version) so that the toolchains were resolved using target_compatible_with instead of exec_compatible_with.  I think that this was not correct because:

1. Semantically, most JDKs compile .class files that can run on any platform.  The current form requires you be targeting a platform that has a known-to-bazel JDK.
2. This breaks RBE and cross compilation.  Because the toolchains specify only target_compatible_with, bazel will completely disregard the exec platform's OS and other constraints when choosing the appropriate JDK to use.
3. This breaks builds entirely in polyglot repos that have java_library targets.  If you accidentally hit that target with a glob when targeting a platform not available in the JDK list, the build fails with a toolchain resolution error.  Can't even fix it with target_compatible_with.

Closes #17085