### PR TITLE
Silence setlocale warnings in Java stub

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -97,9 +97,15 @@ function is_macos() {
 function available_utf8_locale() {
   # Both C.UTF-8 and en_US.UTF-8 do not cause any language-specific effects
   # when set as LC_CTYPE, but neither is certain to exist on all systems.
-  if [[ $(LC_CTYPE=C.UTF-8 locale charmap 2>/dev/null) == "UTF-8" ]]; then
+  #
+  # https://github.com/bazelbuild/bazel/pull/17670: Note that the use of "env"
+  # is important in these calls. Without "env", bash itself seems to pick up
+  # the LC_CTYPE change as soon as the variable is defined and may emit a
+  # warning when the locale files are not present. By using "env", bash never
+  # sees the change and the 2>/dev/null redirection does the right thing.
+  if [[ "$(env LC_CTYPE=C.UTF-8 locale charmap 2>/dev/null)" == "UTF-8" ]]; then
     echo "C.UTF-8"
-  elif [[ $(LC_CTYPE=en_US.UTF-8 locale charmap 2>/dev/null) == "UTF-8" ]]; then
+  elif [[ "$(env LC_CTYPE=en_US.UTF-8 locale charmap 2>/dev/null)" == "UTF-8" ]]; then
     echo "en_US.UTF-8"
   fi
 }


### PR DESCRIPTION
Since 17cfa015d73, the java_stub_template.txt file calls into the locale tool to check for the presence of cetain locales.  These calls correctly send error messages to stderr.

Unfortunately, *bash* itself is doing locale lookups as soon as it sees that the LANG or LC_* variables are touched, and this results in warnings that pollute the output.  In our builds, the output is polluted with hundreds of warnings like these:

```
bazel-out/aarch64-opt-exec-CF41B97/bin/external/bfg/lang/java/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParserCli: line 100: warning: setlocale: LC_CTYPE: cannot change locale (): No such file or directory
bazel-out/aarch64-opt-exec-CF41B97/bin/external/bfg/lang/java/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParserCli: line 102: warning: setlocale: LC_CTYPE: cannot change locale (): No such file or directory
```

There is nothing we can do to avoid these warnings.  Trying to set the LANG or LC_* variables via --action_env and --host_action_env has no effect (other than trigger more/different warnings).

The problem stems from https://bugzilla.redhat.com/show_bug.cgi?id=1361965, which has been fixed in various distros but hasn't made its way to the one we are currently using.

Given that it's bash that is complaining, we can easily side-step this issue by patching the template and wrapping the problematic invocations behind "env".  In this way, bash never gets to see the locale changes. This change does precisely this.