### PR TITLE
Specify tar file format explicitly

### DIFF
--- a/tools/build_defs/pkg/archive.py
+++ b/tools/build_defs/pkg/archive.py
@@ -47,7 +47,7 @@ class TarFileWriter(object):
     self.preserve_mtime = preserve_tar_mtimes
 
     self.fileobj = None
-    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj)
+    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj, format=tarfile.GNU_FORMAT)
     self.members = set([])
     self.directories = set([])
 

--- a/tools/build_defs/pkg/archive.py
+++ b/tools/build_defs/pkg/archive.py
@@ -32,13 +32,15 @@ class TarFileWriter(object):
   def __init__(self,
                name,
                root_directory='./',
-               preserve_tar_mtimes=False):
+               preserve_tar_mtimes=False,
+               tar_format=tarfile.DEFAULT_FORMAT):
     """TarFileWriter wraps tarfile.open().
 
     Args:
       name: the tar file name.
       root_directory: virtual root to prepend to elements in the archive.
       preserve_tar_mtimes: if true, keep file mtimes from input tar file.
+      tar_format: format of tarfile.
     """
     mode = 'w:'
     self.name = name
@@ -47,7 +49,7 @@ class TarFileWriter(object):
     self.preserve_mtime = preserve_tar_mtimes
 
     self.fileobj = None
-    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj, format=tarfile.GNU_FORMAT)
+    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj, format=tar_format)
     self.members = set([])
     self.directories = set([])
 

--- a/tools/build_defs/pkg/archive_test.py
+++ b/tools/build_defs/pkg/archive_test.py
@@ -219,5 +219,11 @@ class TarFileWriterTest(unittest.TestCase):
     ]
     self.assertTarFileContent(self.tempfile, content)
 
+  def testTarFileFormat(self):
+    for format_ in (tarfile.USTAR_FORMAT, tarfile.PAX_FORMAT, tarfile.GNU_FORMAT):
+      with archive.TarFileWriter(self.tempfile, tar_format=format_) as f:
+        pass
+      self.assertEqual(f.tar.format, format_)
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
In Python 3.8. [default format](https://docs.python.org/3/library/tarfile.html#tarfile.DEFAULT_FORMAT) of tarfiles was changed to `PAX_FORMAT`.

`dpkg` rejects deb packages that use tarfiles with PAX format with an "unsupported PAX tar header type" message.

Added optional parameter `--format` to set tar format explicitly. If it's not set `tarfile.DEFAULT_FORMAT` would be used.

see related:
* https://github.com/bazelbuild/rules_pkg/pull/217
* https://github.com/bazelbuild/rules_pkg/pull/601