### PR TITLE
Remove tools/python/private/defs.bzl from filegroup

### DIFF
--- a/tools/python/BUILD.tools
+++ b/tools/python/BUILD.tools
@@ -37,7 +37,6 @@ exports_files([
 filegroup(
     name = "bzl_srcs",
     srcs = glob(["*.bzl"]) + [
-        "private/defs.bzl", # TODO(#9029): remove after the uses in bazel/third_party are removed
         "private/py_test_alias.bzl",
     ],
     visibility = ["//tools:__pkg__"],


### PR DESCRIPTION
This file was deleted in d7f248555f83d0f1825441e6c2a8be6e4bdcf985 so it being here breaks stardoc usage that relies on this filegroup