### PR TITLE
Specify an explicit locale for all `to{Lower,Upper}Case` calls 

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/util/TestIntegration.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/util/TestIntegration.java
@@ -16,6 +16,7 @@ package com.google.testing.junit.runner.util;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.EnumMap;
+import java.util.Locale;
 import java.util.Map;
 
 /** TestIntegration represents an external link that is integrated with the test results. */
@@ -66,7 +67,7 @@ public class TestIntegration {
 
     /** Gets the string representation of the current enum. */
     public String getXmlAttributeName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/docgen/RuleDocumentation.java
+++ b/src/main/java/com/google/devtools/build/docgen/RuleDocumentation.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.docgen.DocgenConsts.RuleType;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -157,7 +158,7 @@ public class RuleDocumentation implements Comparable<RuleDocumentation> {
    */
   @VisibleForTesting
   static String normalize(String s) {
-    return s.toLowerCase()
+    return s.toLowerCase(Locale.ROOT)
         .replace("+", "p")
         .replaceAll("[()]", "")
         .replaceAll("[\\s/]", "-")
@@ -298,12 +299,12 @@ public class RuleDocumentation implements Comparable<RuleDocumentation> {
       if (attributeDoc.isCommonType()) {
         sb.append(String.format("<a href=\"%s#%s.%s\">%s</a>",
             COMMON_DEFINITIONS_PAGE,
-            attributeDoc.getGeneratedInRule(ruleName).toLowerCase(),
+            attributeDoc.getGeneratedInRule(ruleName).toLowerCase(Locale.ROOT),
             attrName,
             attrName));
       } else {
         sb.append(String.format("<a href=\"#%s.%s\">%s</a>",
-            attributeDoc.getGeneratedInRule(ruleName).toLowerCase(),
+            attributeDoc.getGeneratedInRule(ruleName).toLowerCase(Locale.ROOT),
             attrName,
             attrName));
       }
@@ -322,7 +323,7 @@ public class RuleDocumentation implements Comparable<RuleDocumentation> {
     switch (key) {
       case DocgenConsts.VAR_IMPLICIT_OUTPUTS:
         return String.format("<h4 id=\"%s_implicit_outputs\">Implicit output targets</h4>\n%s",
-            ruleName.toLowerCase(), value);
+            ruleName.toLowerCase(Locale.ROOT), value);
       default:
         return value;
     }

--- a/src/main/java/com/google/devtools/build/docgen/RuleFamily.java
+++ b/src/main/java/com/google/devtools/build/docgen/RuleFamily.java
@@ -21,6 +21,7 @@ import com.google.common.escape.Escaper;
 import com.google.devtools.build.docgen.DocgenConsts.RuleType;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Helper class for representing a rule family in the rule summary table template.
@@ -71,7 +72,7 @@ public class RuleFamily {
    * "c-cpp".
    */
   static String normalize(String s) {
-    return FAMILY_NAME_ESCAPER.escape(s.toLowerCase()).replaceAll("[-]+", "-");
+    return FAMILY_NAME_ESCAPER.escape(s.toLowerCase(Locale.ROOT)).replaceAll("[-]+", "-");
   }
 
   public int size() {

--- a/src/main/java/com/google/devtools/build/docgen/StarlarkDocumentationProcessor.java
+++ b/src/main/java/com/google/devtools/build/docgen/StarlarkDocumentationProcessor.java
@@ -307,7 +307,7 @@ public final class StarlarkDocumentationProcessor {
     }
 
     public String getTemplateIdentifier() {
-      return name().toLowerCase().replace("_", "-");
+      return name().toLowerCase(Locale.ROOT).replace("_", "-");
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/FilesetTraversalParamsFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FilesetTraversalParamsFactory.java
@@ -46,7 +46,7 @@ public final class FilesetTraversalParamsFactory {
 
     @Override
     public String toString() {
-      return super.toString().toLowerCase();
+      return super.toString().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
@@ -58,6 +58,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
@@ -514,7 +515,8 @@ public class AndroidNdkRepositoryFunction extends AndroidRepositoryFunction {
                 tp ->
                     String.format(
                         "  %s_path = '%s'",
-                        tp.getName().toLowerCase().replaceAll("-", "_"), tp.getPath()))
+                        tp.getName().toLowerCase(Locale.ROOT).replaceAll("-", "_"),
+                        tp.getPath()))
             .collect(ImmutableList.toImmutableList()));
     return bigConditional.add("").build();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/StlImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/StlImpl.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.view.config.crosstool.CrosstoolConfig.CToolchain;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -36,9 +37,9 @@ public abstract class StlImpl {
     private final String fileExtension;
 
     RuntimeType(String fileExtension) {
-      this.name = name().toLowerCase();
+      this.name = name().toLowerCase(Locale.ROOT);
       this.fileExtension = fileExtension;
-    }    
+    }
   }
 
   private final Map<String, String> fileGroupNameToFileGlobs = new LinkedHashMap<>();

--- a/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -130,7 +131,7 @@ public final class XcodeLocalEnvProvider implements LocalEnvProvider {
       String developerDir, String sdkVersion, String appleSdkPlatform)
       throws IOException, InterruptedException {
     try {
-      String sdkString = appleSdkPlatform.toLowerCase() + sdkVersion;
+      String sdkString = appleSdkPlatform.toLowerCase(Locale.ROOT) + sdkVersion;
       Map<String, String> env =
           Strings.isNullOrEmpty(developerDir)
               ? ImmutableMap.<String, String>of()
@@ -193,7 +194,7 @@ public final class XcodeLocalEnvProvider implements LocalEnvProvider {
       throws IOException, InterruptedException {
     try {
       return sdkRootCache.computeIfAbsent(
-          developerDir + ":" + appleSdkPlatform.toLowerCase() + ":" + sdkVersion,
+          developerDir + ":" + appleSdkPlatform.toLowerCase(Locale.ROOT) + ":" + sdkVersion,
           (key) -> {
             try {
               String sdkRoot = querySdkRoot(developerDir, sdkVersion, appleSdkPlatform);

--- a/src/main/java/com/google/devtools/build/lib/includescanning/IncludeParser.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/IncludeParser.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -120,7 +121,7 @@ class IncludeParser {
     final String findFilter;
 
     private Rule(String type, String pattern, String findRoot, String findFilter) {
-      this.type = Type.valueOf(type.trim().toUpperCase());
+      this.type = Type.valueOf(type.trim().toUpperCase(Locale.ROOT));
       this.pattern = Pattern.compile("^" + pattern + "$");
       this.findRoot = findRoot.replace('\\', '$');
       this.findFilter = findFilter;

--- a/src/main/java/com/google/devtools/build/lib/packages/EnumFilterConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/EnumFilterConverter.java
@@ -19,6 +19,7 @@ import com.google.devtools.common.options.OptionsParsingException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -65,7 +66,7 @@ class EnumFilterConverter<E extends Enum<E>> extends Converter.Contextless<Set<E
     EnumSet<E> excludedSet = EnumSet.noneOf(typeClass);
     for (String value : input.split(",", -1)) {
       boolean excludeFlag = value.startsWith("-");
-      String s = (excludeFlag ? value.substring(1) : value).toUpperCase();
+      String s = (excludeFlag ? value.substring(1) : value).toUpperCase(Locale.ROOT);
       if (!allowedValues.contains(s)) {
         throw new OptionsParsingException("Invalid " + prettyEnumName + " filter '" + value +
             "' in the input '" + input + "'");
@@ -91,6 +92,6 @@ class EnumFilterConverter<E extends Enum<E>> extends Converter.Contextless<Set<E
   @Override
   public final String getTypeDescription() {
     return "comma-separated list of values: "
-        + StringUtil.joinEnglishList(allowedValues).toLowerCase();
+        + StringUtil.joinEnglishList(allowedValues).toLowerCase(Locale.ROOT);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/packages/License.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/License.java
@@ -210,9 +210,9 @@ public final class License implements LicenseApi {
   @Override
   public String toString() {
     if (exceptions.isEmpty()) {
-      return licenseTypes.toString().toLowerCase();
+      return licenseTypes.toString().toLowerCase(Locale.ROOT);
     } else {
-      return licenseTypes.toString().toLowerCase() + " with exceptions " + exceptions;
+      return licenseTypes.toString().toLowerCase(Locale.ROOT) + " with exceptions " + exceptions;
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/TestSize.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TestSize.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.packages;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.common.options.OptionsParsingException;
+import java.util.Locale;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -41,7 +42,7 @@ public enum TestSize {
   static {
     ImmutableMap.Builder<String, TestSize> builder = ImmutableMap.builder();
     for (TestSize size : TestSize.values()) {
-      builder.put(size.name().toLowerCase(), size);
+      builder.put(size.name().toLowerCase(Locale.ROOT), size);
     }
     CANONICAL_LOWER_CASE_NAME_TABLE = builder.buildOrThrow();
   }
@@ -94,7 +95,7 @@ public enum TestSize {
    */
   @Nullable
   public static TestSize getTestSize(String attr) {
-    if (!attr.equals(attr.toLowerCase())) {
+    if (!attr.equals(attr.toLowerCase(Locale.ROOT))) {
       return null;
     }
     try {
@@ -107,7 +108,7 @@ public enum TestSize {
   /** Normal practice is to always use size tags as lower case strings. */
   @Override
   public String toString() {
-    return super.toString().toLowerCase();
+    return super.toString().toLowerCase(Locale.ROOT);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/TestTimeout.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TestTimeout.java
@@ -121,7 +121,7 @@ public enum TestTimeout {
    */
   @Nullable
   public static TestTimeout getTestTimeout(String attr) {
-    if (!attr.equals(attr.toLowerCase())) {
+    if (!attr.equals(attr.toLowerCase(Locale.ROOT))) {
       return null;
     }
     try {
@@ -138,7 +138,7 @@ public enum TestTimeout {
   @Nullable
   public static TestTimeout getTestTimeout(Rule testTarget) {
     String attr = NonconfigurableAttributeMapper.of(testTarget).get("timeout", Type.STRING);
-    if (!attr.equals(attr.toLowerCase())) {
+    if (!attr.equals(attr.toLowerCase(Locale.ROOT))) {
       return null; // attribute values must be lowercase
     }
     try {
@@ -150,14 +150,14 @@ public enum TestTimeout {
 
   @Override
   public String toString() {
-    return super.toString().toLowerCase();
+    return super.toString().toLowerCase(Locale.ROOT);
   }
 
   /**
    * We print to upper case to make the test timeout warnings more readable.
    */
   public String prettyPrint() {
-    return super.toString().toUpperCase();
+    return super.toString().toUpperCase(Locale.ROOT);
   }
 
   @Deprecated // use getTimeout instead

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -112,6 +112,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -236,7 +237,7 @@ public final class RemoteModule extends BlazeModule {
                   || status == HttpResponseStatus.SERVICE_UNAVAILABLE.code()
                   || status == HttpResponseStatus.GATEWAY_TIMEOUT.code();
         } else if (e instanceof IOException) {
-          String msg = e.getMessage().toLowerCase();
+          String msg = e.getMessage().toLowerCase(Locale.ROOT);
           if (msg.contains("connection reset by peer")) {
             retry = true;
           } else if (msg.contains("operation timed out")) {

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -39,6 +39,7 @@ import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
 import java.util.List;
+import java.util.Locale;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkValue;
 
@@ -165,9 +166,9 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
 
     public static List<String> getAttributeValues() {
       return ImmutableList.of(
-          LEGACY.name().toLowerCase(),
-          ANDROID.name().toLowerCase(),
-          FORCE_ANDROID.name().toLowerCase(),
+          LEGACY.name().toLowerCase(Locale.ROOT),
+          ANDROID.name().toLowerCase(Locale.ROOT),
+          FORCE_ANDROID.name().toLowerCase(Locale.ROOT),
           getRuleAttributeDefault());
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidRuleClasses.java
@@ -58,6 +58,7 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.Serializat
 import com.google.devtools.build.lib.util.FileType;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import java.util.List;
+import java.util.Locale;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkInt;
 
@@ -920,7 +921,7 @@ public final class AndroidRuleClasses {
 
     /** Returns the attribute value that specifies this mode. */
     public String getAttributeValue() {
-      return toString().toLowerCase();
+      return toString().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/rules/android/WriteAdbArgsAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/WriteAdbArgsAction.java
@@ -33,6 +33,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import javax.annotation.Nullable;
 
 /**
@@ -153,7 +154,7 @@ public final class WriteAdbArgsAction extends AbstractFileWriteAction {
           ps.printf("--verbosity=%s\n", incrementalInstallVerbosity);
         }
 
-        ps.printf("--start=%s\n", start.name().toLowerCase());
+        ps.printf("--start=%s\n", start.name().toLowerCase(Locale.ROOT));
 
         if (userHomeDirectory != null) {
           ps.printf("--user_home_dir=%s\n", userHomeDirectory);

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleConfiguration.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
@@ -412,7 +413,7 @@ public class AppleConfiguration extends Fragment implements AppleConfigurationAp
   public String getOutputDirectoryName() {
     List<String> components = new ArrayList<>();
     if (!appleCpus.appleSplitCpu().isEmpty()) {
-      components.add(applePlatformType.toString().toLowerCase());
+      components.add(applePlatformType.toString().toLowerCase(Locale.ROOT));
       components.add(appleCpus.appleSplitCpu());
 
       if (options.getMinimumOsVersion() != null) {

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/ApplePlatform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/ApplePlatform.java
@@ -267,7 +267,7 @@ public enum ApplePlatform implements ApplePlatformApi {
 
     @Override
     public String toString() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ArtifactCategory.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ArtifactCategory.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.rules.cpp;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Locale;
 
 /**
  * A category of artifacts that are candidate input/output to an action, for which the toolchain can
@@ -60,7 +61,7 @@ public enum ArtifactCategory {
             .add(extraAllowedExtensions)
             .build();
 
-    this.starlarkName = toString().toLowerCase();
+    this.starlarkName = toString().toLowerCase(Locale.ROOT);
   }
 
   public String getStarlarkName() {
@@ -69,7 +70,7 @@ public enum ArtifactCategory {
 
   /** Returns the name of the category. */
   public String getCategoryName() {
-    return this.toString().toLowerCase();
+    return this.toString().toLowerCase(Locale.ROOT);
   }
 
   public String getDefaultPrefix() {

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/AppleDebugOutputsInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/AppleDebugOutputsInfo.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.starlarkbuildapi.apple.AppleDebugOutputsApi;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import net.starlark.java.eval.Dict;
 
@@ -57,7 +58,7 @@ public final class AppleDebugOutputsInfo extends NativeInfo
 
     @Override
     public String toString() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -467,7 +467,7 @@ public final class HelpCommand implements BlazeCommand {
           result.append(
               String.format(
                   "<td id=\"effect_tag_%s\"><code>%s</code></td>\n",
-                  tag, tag.name().toLowerCase()));
+                  tag, tag.name().toLowerCase(Locale.ROOT)));
           result.append(String.format("<td>%s</td>\n", HTML_ESCAPER.escape(tagDescription)));
           result.append("</tr>\n");
         }
@@ -486,7 +486,7 @@ public final class HelpCommand implements BlazeCommand {
             result.append(
                 String.format(
                     "<td id=\"metadata_tag_%s\"><code>%s</code></td>\n",
-                    tag, tag.name().toLowerCase()));
+                    tag, tag.name().toLowerCase(Locale.ROOT)));
             result.append(String.format("<td>%s</td>\n", HTML_ESCAPER.escape(tagDescription)));
             result.append("</tr>\n");
           }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec/AutoCodecProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec/AutoCodecProcessor.java
@@ -35,6 +35,7 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -281,9 +282,9 @@ public class AutoCodecProcessor extends AbstractProcessor {
   private static String getNameFromGetter(ExecutableElement method) {
     String name = method.getSimpleName().toString();
     if (name.startsWith("get")) {
-      return name.substring(3, 4).toLowerCase() + name.substring(4);
+      return name.substring(3, 4).toLowerCase(Locale.ROOT) + name.substring(4);
     } else if (name.startsWith("is")) {
-      return name.substring(2, 3).toLowerCase() + name.substring(3);
+      return name.substring(2, 3).toLowerCase(Locale.ROOT) + name.substring(3);
     } else {
       return name;
     }
@@ -515,7 +516,8 @@ public class AutoCodecProcessor extends AbstractProcessor {
             parameter.getSimpleName(),
             sanitizeTypeParameter(parameter.asType(), env),
             UnsafeProvider.class,
-            typeKind.isPrimitive() ? firstLetterUpper(typeKind.toString().toLowerCase()) : "Object",
+            typeKind.isPrimitive() ? firstLetterUpper(
+                typeKind.toString().toLowerCase(Locale.ROOT)) : "Object",
             parameter.getSimpleName());
         marshallers.writeSerializationCode(
             new SerializationCodeGenerator.Context(

--- a/src/main/java/com/google/devtools/build/lib/util/CommandBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CommandBuilder.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -154,7 +155,7 @@ public final class CommandBuilder {
 
       // Automatically enable CMD.EXE use if we are executing something else besides "*.exe" file.
       // When use CMD.EXE to invoke a bat/cmd file, the file path must have '\' instead of '/'
-      if (!command.toLowerCase().endsWith(".exe")) {
+      if (!command.toLowerCase(Locale.ROOT).endsWith(".exe")) {
         useShell = true;
         modifiedArgv.set(0, argv0.replace('/', '\\'));
       }

--- a/src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java
@@ -40,6 +40,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.TimeZone;
@@ -552,7 +553,7 @@ public final class SimpleLogHandler extends Handler {
             builderValue,
             configuredName,
             val -> {
-              val = val.trim().toLowerCase();
+              val = val.trim().toLowerCase(Locale.ROOT);
               if ("true".equals(val) || "1".equals(val)) {
                 return true;
               } else if ("false".equals(val) || "0".equals(val)) {
@@ -644,7 +645,7 @@ public final class SimpleLogHandler extends Handler {
         name = name.substring(0, firstDot);
       }
     }
-    return name.toLowerCase();
+    return name.toLowerCase(Locale.ROOT);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/Dirent.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Dirent.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.vfs;
 
 import com.google.common.base.Preconditions;
+import java.util.Locale;
 import java.util.Objects;
 
 /** Directory entry representation returned by {@link Path#readdir}. */
@@ -66,7 +67,7 @@ public final class Dirent implements Comparable<Dirent> {
 
   @Override
   public String toString() {
-    return name + "[" + type.toString().toLowerCase() + "]";
+    return name + "[" + type.toString().toLowerCase(Locale.ROOT) + "]";
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/WindowsOsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/WindowsOsPathPolicy.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.windows.WindowsFileOperations;
 import com.google.devtools.build.lib.windows.WindowsShortPath;
 import java.io.IOException;
+import java.util.Locale;
 
 @VisibleForTesting
 class WindowsOsPathPolicy implements OsPathPolicy {
@@ -191,7 +192,7 @@ class WindowsOsPathPolicy implements OsPathPolicy {
     if (s == null) {
       return 0;
     }
-    return s.toLowerCase().hashCode();
+    return s.toLowerCase(Locale.ROOT).hashCode();
   }
 
   @Override

--- a/src/main/java/net/starlark/java/spelling/SpellChecker.java
+++ b/src/main/java/net/starlark/java/spelling/SpellChecker.java
@@ -14,6 +14,7 @@
 
 package net.starlark.java.spelling;
 
+import java.util.Locale;
 import javax.annotation.Nullable;
 
 /**
@@ -84,9 +85,9 @@ public final class SpellChecker {
     String best = null;
     // Heuristic: the expected number of typos depends on the length of the word.
     int bestDistance = Math.min(5, (input.length() + 1) / 2);
-    input = input.toLowerCase();
+    input = input.toLowerCase(Locale.ROOT);
     for (String candidate : words) {
-      int d = editDistance(input, candidate.toLowerCase(), bestDistance);
+      int d = editDistance(input, candidate.toLowerCase(Locale.ROOT), bestDistance);
       if (d >= 0 && d < bestDistance) {
         bestDistance = d;
         best = candidate;

--- a/src/main/java/net/starlark/java/syntax/Resolver.java
+++ b/src/main/java/net/starlark/java/syntax/Resolver.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -68,7 +69,7 @@ public final class Resolver extends NodeVisitor {
 
     @Override
     public String toString() {
-      return super.toString().toLowerCase();
+      return super.toString().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -98,6 +98,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -901,7 +902,7 @@ public class HttpCacheClientTest {
                   HttpHeaderNames.WWW_AUTHENTICATE,
                   "Bearer realm=\"localhost\","
                       + "error=\""
-                      + errorType.name().toLowerCase()
+                      + errorType.name().toLowerCase(Locale.ROOT)
                       + "\","
                       + "error_description=\"The access token expired\"");
         }

--- a/src/test/java/com/google/devtools/build/lib/vfs/WindowsPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/WindowsPathTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.vfs.WindowsOsPathPolicy.ShortPathResolver;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +39,7 @@ public class WindowsPathTest extends PathAbstractTest {
       String result = "";
       for (int i = 0; i < segments.length; ) {
         String segment = segments[i];
-        String queryString = (result + segment).toLowerCase();
+        String queryString = (result + segment).toLowerCase(Locale.ROOT);
         segment = resolutions.getOrDefault(queryString, segment);
         result = result + segment;
         ++i;

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidResourceProcessor.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidResourceProcessor.java
@@ -50,6 +50,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -239,7 +240,7 @@ public class AndroidResourceProcessor {
       @Nullable Path publicResourcesOut)
       throws IOException {
     try (JunctionCreator junctions =
-        System.getProperty("os.name").toLowerCase().startsWith("windows")
+        System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
             ? new WindowsJunctionCreator(Files.createDirectories(tempRoot.resolve("juncts")))
             : new NoopJunctionCreator()) {
       sourceOut = junctions.create(sourceOut);

--- a/src/tools/android/java/com/google/devtools/build/android/xml/AttrXmlResourceValue.java
+++ b/src/tools/android/java/com/google/devtools/build/android/xml/AttrXmlResourceValue.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -289,7 +290,7 @@ public final class AttrXmlResourceValue implements XmlResourceValue {
       if (TAG_FLAG.equals(tagName)) {
         formatNames.add(FLAGS);
       } else {
-        formatNames.add(tagName.getLocalPart().toLowerCase());
+        formatNames.add(tagName.getLocalPart().toLowerCase(Locale.ROOT));
       }
     }
 

--- a/src/tools/android/java/com/google/devtools/build/android/xml/PluralXmlResourceValue.java
+++ b/src/tools/android/java/com/google/devtools/build/android/xml/PluralXmlResourceValue.java
@@ -35,6 +35,7 @@ import com.google.protobuf.CodedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
@@ -157,7 +158,7 @@ public class PluralXmlResourceValue implements XmlResourceValue {
     Map<String, String> items = new LinkedHashMap<>();
 
     for (Plural.Entry entry : plural.getEntryList()) {
-      String name = entry.getArity().toString().toLowerCase();
+      String name = entry.getArity().toString().toLowerCase(Locale.ROOT);
       String value =
           XmlEscapers.xmlContentEscaper().escape(
               entry.getItem()

--- a/src/tools/starlark/java/com/google/devtools/starlark/common/DocstringUtils.java
+++ b/src/tools/starlark/java/com/google/devtools/starlark/common/DocstringUtils.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -399,7 +400,8 @@ public final class DocstringUtils {
     }
 
     private String checkForNonStandardDeprecation(String line) {
-      if (line.toLowerCase().startsWith("deprecated:") || line.contains("DEPRECATED")) {
+      if (line.toLowerCase(Locale.ROOT).startsWith("deprecated:") || line.contains(
+          "DEPRECATED")) {
         error(
             "use a 'Deprecated:' section for deprecations, similar to a 'Returns:' section:\n\n"
                 + "Deprecated:\n"


### PR DESCRIPTION
Java's `String#to{Lower,Upper}Case()` is locale-dependent, which can
lead to unexpected results in locales with special case mappings in the
ASCII range (e.g. in a Turkish locale, a capital ASCII `I` lowercases to
a non-ASCII variant of `i`).

This is prevented by specifying a local without such case mappings. This
commit uses `Locale.ROOT` as the canonical choice with the same case
mapping behavior as other common locales such as `Locale.ENGLISH` or
`Locale.US`.

Follow-up changes could use Guava's `Ascii.to{Lower,Upper}Case` instead,
but whether this is safe may depend on the context, which makes this
replacement unsuitable to perform across the repo.

Fixes #17541
