### PR TITLE
Don't attempt to expand derived template artifacts.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/BUILD
@@ -144,6 +144,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis:actions/template_expansion_action",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/query2/engine",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -322,15 +322,14 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
     }
 
     if (action instanceof TemplateExpansionAction) {
+      TemplateExpansionAction templateExpansionAction = (TemplateExpansionAction) action;
       stringBuilder
           .append("  Template: ")
-          .append(
-              ((TemplateExpansionAction) action)
-                  .getTemplate()
-                  .getContent(ArtifactPathResolver.IDENTITY))
+          .append(AqueryUtils.getTemplateContent(templateExpansionAction))
           .append("\n");
+
       stringBuilder.append("  Substitutions: [\n");
-      for (Substitution substitution : ((TemplateExpansionAction) action).getSubstitutions()) {
+      for (Substitution substitution : templateExpansionAction.getSubstitutions()) {
         stringBuilder
             .append("    {")
             .append(substitution.getKey())

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/AqueryUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/AqueryUtils.java
@@ -70,4 +70,13 @@ public class AqueryUtils {
 
     return true;
   }
+
+  public static String getTemplateContent(TemplateExpansionAction action) throws IOException {
+    // If the template artifact is a DerivedArtifact, it is only available during the execution
+    // phase. It's therefore not possible to read its content from the FileSystem at this moment.
+    if (action.getTemplate().getTemplateArtifact() instanceof DerivedArtifact) {
+      return action.getTemplate().toString();
+    }
+    return action.getTemplate().getContent(ArtifactPathResolver.IDENTITY);
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
@@ -268,11 +268,10 @@ public class ActionGraphDump {
     }
 
     if (action instanceof TemplateExpansionAction) {
-      actionBuilder.setTemplateContent(
-          ((TemplateExpansionAction) action)
-              .getTemplate()
-              .getContent(ArtifactPathResolver.IDENTITY));
-      for (Substitution substitution : ((TemplateExpansionAction) action).getSubstitutions()) {
+      TemplateExpansionAction templateExpansionAction = (TemplateExpansionAction) action;
+      actionBuilder.setTemplateContent(AqueryUtils.getTemplateContent(templateExpansionAction));
+
+      for (Substitution substitution : templateExpansionAction.getSubstitutions()) {
         try {
           actionBuilder.addSubstitutions(
               AnalysisProtosV2.KeyValuePair.newBuilder()

--- a/src/test/shell/integration/aquery_test.sh
+++ b/src/test/shell/integration/aquery_test.sh
@@ -1505,6 +1505,74 @@ EOF
   assert_contains "\"value\": \"123456\"" output
 }
 
+# Cre: @keith https://github.com/bazelbuild/bazel/pull/17682
+function test_aquery_multiple_expand_templates() {
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
+
+  cat > "$pkg/template.txt" <<'EOF'
+The token: {TOKEN1}
+EOF
+
+  cat > "$pkg/test.bzl" <<EOF
+def _impl(ctx):
+    template1 = ctx.actions.declare_file("first.txt")
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = template1,
+        substitutions = {
+            "{TOKEN1}": "{TOKEN2}",
+        },
+    )
+    template2 = ctx.actions.declare_file("second.txt")
+    ctx.actions.expand_template(
+        template = template1,
+        output = template2,
+        substitutions = {
+            "{TOKEN2}": "123456",
+        },
+    )
+    return [DefaultInfo(files = depset([template2]))]
+test_template = rule(
+    _impl,
+    attrs = {
+        "_template": attr.label(
+            default = Label("//$pkg:template.txt"),
+            allow_single_file = True,
+        ),
+    },
+)
+EOF
+
+  cat > "$pkg/BUILD" <<'EOF'
+load('test.bzl', 'test_template')
+test_template(name='foo')
+EOF
+
+  # aquery returns template content and substitutions of TemplateExpand actions.
+  QUERY="//$pkg:foo"
+
+  bazel aquery --output=text ${QUERY} > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+
+  # TODO: The ideal behavior includes this  too
+  # assert_contains "Template: The token: {TOKEN1}" output
+  assert_contains "Template: ARTIFACT: $pkg/template.txt" output
+  assert_contains "{{TOKEN1}: {TOKEN2}}" output
+  assert_contains "{{TOKEN2}: 123456}" output
+
+  bazel aquery --output=jsonproto ${QUERY} > output 2> "$TEST_log" \
+    || fail "Expected success"
+
+  # TODO: The ideal behavior includes this  too
+  # assert_contains "\"templateContent\": \"The token" output
+  assert_contains "\"key\": \"{TOKEN1}\"" output
+  assert_contains "\"value\": \"{TOKEN2}\"" output
+  assert_contains "\"key\": \"{TOKEN2}\"" output
+  assert_contains "\"value\": \"123456\"" output
+}
+
 # Regression test for b/205753626.
 # This test case isn't testing aquery for correctness, just using aquery as a
 # vehicle for testing lower-level logic.


### PR DESCRIPTION
Derived template artifacts can't be read before the execution phase. This PR instead prints out the template "content" in the original `"ARTIFACT: <path_to_artifact"` format.