### PR TITLE
Revert "Add -dead_strip in default opt link flags for darwin (#17312)"

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -617,7 +617,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
                 ],
             ),
             "%{opt_link_flags}": get_starlark_list(
-                ["-Wl,-dead_strip"] if darwin else _add_linker_option_if_supported(
+                [] if darwin else _add_linker_option_if_supported(
                     repository_ctx,
                     cc,
                     "-Wl,--gc-sections",


### PR DESCRIPTION
This reverts commit 0f9912ba8a6780a124478fd3ff4fb91b64dbae53 to fix the regression reported in #17686 
