### PR TITLE
Fix wasm dynamic library extension crash

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -206,7 +206,7 @@ public final class CppFileTypes {
 
   // TODO(bazel-team): File types should not be read from this hard-coded list but should come from
   // the toolchain instead. See https://github.com/bazelbuild/bazel/issues/17117
-  public static final FileType SHARED_LIBRARY = FileType.of(".so", ".dylib", ".dll", ".pyd");
+  public static final FileType SHARED_LIBRARY = FileType.of(".so", ".dylib", ".dll", ".pyd", ".wasm");
   // Unix shared libraries can be passed to linker, but not .dll on Windows
   public static final FileType UNIX_SHARED_LIBRARY = FileType.of(".so", ".dylib");
   public static final FileType INTERFACE_SHARED_LIBRARY =

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -387,7 +387,7 @@ ARCHIVE = [".a", ".lib"]
 PIC_ARCHIVE = [".pic.a"]
 ALWAYSLINK_LIBRARY = [".lo"]
 ALWAYSLINK_PIC_LIBRARY = [".pic.lo"]
-SHARED_LIBRARY = [".so", ".dylib", ".dll"]
+SHARED_LIBRARY = [".so", ".dylib", ".dll", ".wasm"]
 INTERFACE_SHARED_LIBRARY = [".ifso", ".tbd", ".lib", ".dll.a"]
 OBJECT_FILE = [".o", ".obj"]
 PIC_OBJECT_FILE = [".pic.o"]
@@ -569,12 +569,13 @@ def _is_versioned_shared_library_extension_valid(shared_library_name):
 def _is_valid_shared_library_name(shared_library_name):
     if (shared_library_name.endswith(".so") or
         shared_library_name.endswith(".dll") or
-        shared_library_name.endswith(".dylib")):
+        shared_library_name.endswith(".dylib") or
+        shared_library_name.endswith(".wasm")):
         return True
 
     return _is_versioned_shared_library_extension_valid(shared_library_name)
 
-_SHARED_LIBRARY_EXTENSIONS = ["so", "dll", "dylib"]
+_SHARED_LIBRARY_EXTENSIONS = ["so", "dll", "dylib", "wasm"]
 
 def _is_valid_shared_library_artifact(shared_library):
     if (shared_library.extension in _SHARED_LIBRARY_EXTENSIONS):

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -5297,10 +5297,10 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
             "'a.pic.o' does not have any of the allowed extensions .a, .lib, .pic.a or .rlib");
     assertThat(e)
         .hasMessageThat()
-        .contains("'a.ifso' does not have any of the allowed extensions .so, .dylib, .dll or .pyd");
+        .contains("'a.ifso' does not have any of the allowed extensions .so, .dylib, .dll, .pyd or .wasm");
     assertThat(e)
         .hasMessageThat()
-        .contains("'a.lib' does not have any of the allowed extensions .so, .dylib, .dll or .pyd");
+        .contains("'a.lib' does not have any of the allowed extensions .so, .dylib, .dll, .pyd or .wasm");
     assertThat(e)
         .hasMessageThat()
         .contains(


### PR DESCRIPTION
This is an amendment to #17374

We have a C++ toolchain config that's being developed to support standalone wasm. We discovered that #17374 wasn't complete. Our example was poorly written and didn't actually create a wasm dynamic library. These changes allow us to successfully create a standalone wasm dynamic library. Sorry for the botched attempt previously.

I would like to add tests, but I'm unsure how to approach such a tests considering the automatic toolchain doesn't support wasm AFAICT.
