### PR TITLE
Force the Bazel server Java runtime to use the root locale

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -402,6 +402,13 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
 
   // Force use of latin1 for file names.
   result.push_back("-Dfile.encoding=ISO-8859-1");
+  // Force into the root locale to ensure consistent behavior of string
+  // operations across machines (e.g. in the tr_TR locale, capital ASCII 'I'
+  // turns into a special Unicode 'i' when converted to lower case).
+  // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Locale.html#ROOT
+  result.push_back("-Duser.country=");
+  result.push_back("-Duser.language=");
+  result.push_back("-Duser.variant=");
 
   if (startup_options.host_jvm_debug) {
     BAZEL_LOG(USER)


### PR DESCRIPTION
This ensures consistent behavior of string operations even if the individual operations do not set a locale.

Without this change, Bazel can't operate in e.g. a Turkish locale, where it fails with error messages such as:

In rule 'test', size 'medium' is not a valid size.

This is because Turkish case mapping rules make it so that a capital ASCII 'I' lowercases to a non-ASCII variant of 'i'.

Fixes #17541