### PR TITLE
[6.2.0] Remove actionId from RemoteFileArtifactValue.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -109,15 +109,6 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     return 0;
   }
 
-  /**
-   * Remote action source identifier for the file.
-   *
-   * <p>"" indicates that a remote action output was not the source of this artifact.
-   */
-  public String getActionId() {
-    return "";
-  }
-
   /** Returns {@code true} if the file only exists remotely. */
   public boolean isRemote() {
     return false;
@@ -550,35 +541,27 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     protected final byte[] digest;
     protected final long size;
     protected final int locationIndex;
-    protected final String actionId;
 
-    private RemoteFileArtifactValue(byte[] digest, long size, int locationIndex, String actionId) {
-      this.digest = Preconditions.checkNotNull(digest, actionId);
+    private RemoteFileArtifactValue(byte[] digest, long size, int locationIndex) {
+      this.digest = Preconditions.checkNotNull(digest);
       this.size = size;
       this.locationIndex = locationIndex;
-      this.actionId = actionId;
-    }
-
-    public static RemoteFileArtifactValue create(
-        byte[] digest, long size, int locationIndex, String actionId) {
-      return new RemoteFileArtifactValue(digest, size, locationIndex, actionId);
     }
 
     public static RemoteFileArtifactValue create(byte[] digest, long size, int locationIndex) {
-      return new RemoteFileArtifactValue(digest, size, locationIndex, /* actionId= */ "");
+      return new RemoteFileArtifactValue(digest, size, locationIndex);
     }
 
     public static RemoteFileArtifactValue create(
         byte[] digest,
         long size,
         int locationIndex,
-        String actionId,
         @Nullable PathFragment materializationExecPath) {
       if (materializationExecPath != null) {
         return new RemoteFileArtifactValueWithMaterializationPath(
-            digest, size, locationIndex, actionId, materializationExecPath);
+            digest, size, locationIndex, materializationExecPath);
       }
-      return new RemoteFileArtifactValue(digest, size, locationIndex, actionId);
+      return new RemoteFileArtifactValue(digest, size, locationIndex);
     }
 
     @Override
@@ -590,13 +573,12 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       RemoteFileArtifactValue that = (RemoteFileArtifactValue) o;
       return Arrays.equals(digest, that.digest)
           && size == that.size
-          && locationIndex == that.locationIndex
-          && Objects.equals(actionId, that.actionId);
+          && locationIndex == that.locationIndex;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(Arrays.hashCode(digest), size, locationIndex, actionId);
+      return Objects.hash(Arrays.hashCode(digest), size, locationIndex);
     }
 
     @Override
@@ -617,11 +599,6 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     @Override
     public long getSize() {
       return size;
-    }
-
-    @Override
-    public String getActionId() {
-      return actionId;
     }
 
     @Override
@@ -651,7 +628,6 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
           .add("digest", bytesToString(digest))
           .add("size", size)
           .add("locationIndex", locationIndex)
-          .add("actionId", actionId)
           .toString();
     }
   }
@@ -667,12 +643,8 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     private final PathFragment materializationExecPath;
 
     private RemoteFileArtifactValueWithMaterializationPath(
-        byte[] digest,
-        long size,
-        int locationIndex,
-        String actionId,
-        PathFragment materializationExecPath) {
-      super(digest, size, locationIndex, actionId);
+        byte[] digest, long size, int locationIndex, PathFragment materializationExecPath) {
+      super(digest, size, locationIndex);
       this.materializationExecPath = Preconditions.checkNotNull(materializationExecPath);
     }
 
@@ -692,14 +664,12 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       return Arrays.equals(digest, that.digest)
           && size == that.size
           && locationIndex == that.locationIndex
-          && Objects.equals(actionId, that.actionId)
           && Objects.equals(materializationExecPath, that.materializationExecPath);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(
-          Arrays.hashCode(digest), size, locationIndex, actionId, materializationExecPath);
+      return Objects.hash(Arrays.hashCode(digest), size, locationIndex, materializationExecPath);
     }
 
     @Override
@@ -708,7 +678,6 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
           .add("digest", bytesToString(digest))
           .add("size", size)
           .add("locationIndex", locationIndex)
-          .add("actionId", actionId)
           .add("materializationExecPath", materializationExecPath)
           .toString();
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -76,7 +76,7 @@ public class CompactPersistentActionCache implements ActionCache {
 
   private static final int NO_INPUT_DISCOVERY_COUNT = -1;
 
-  private static final int VERSION = 14;
+  private static final int VERSION = 15;
 
   private static final class ActionMap extends PersistentMap<Integer, byte[]> {
     private final Clock clock;
@@ -466,8 +466,6 @@ public class CompactPersistentActionCache implements ActionCache {
 
     VarInt.putVarInt(value.getLocationIndex(), sink);
 
-    VarInt.putVarInt(indexer.getOrCreateIndex(value.getActionId()), sink);
-
     Optional<PathFragment> materializationExecPath = value.getMaterializationExecPath();
     if (materializationExecPath.isPresent()) {
       VarInt.putVarInt(1, sink);
@@ -491,8 +489,6 @@ public class CompactPersistentActionCache implements ActionCache {
 
     int locationIndex = VarInt.getVarInt(source);
 
-    String actionId = getStringForIndex(indexer, VarInt.getVarInt(source));
-
     PathFragment materializationExecPath = null;
     int numMaterializationExecPath = VarInt.getVarInt(source);
     if (numMaterializationExecPath > 0) {
@@ -503,8 +499,7 @@ public class CompactPersistentActionCache implements ActionCache {
           PathFragment.create(getStringForIndex(indexer, VarInt.getVarInt(source)));
     }
 
-    return RemoteFileArtifactValue.create(
-        digest, size, locationIndex, actionId, materializationExecPath);
+    return RemoteFileArtifactValue.create(digest, size, locationIndex, materializationExecPath);
   }
 
   /** @return action data encoded as a byte[] array. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -104,7 +104,7 @@ class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
       throws IOException {
     checkArgument(metadata.isRemote(), "Cannot download file that is not a remote file.");
     RequestMetadata requestMetadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, metadata.getActionId(), null);
+        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "prefetcher", null);
     RemoteActionExecutionContext context = RemoteActionExecutionContext.create(requestMetadata);
 
     Digest digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -812,7 +812,6 @@ public class RemoteExecutionService {
     FileSystem actionFileSystem = action.getSpawnExecutionContext().getActionFileSystem();
     checkState(actionFileSystem instanceof RemoteActionFileSystem);
 
-    RemoteActionExecutionContext context = action.getRemoteActionExecutionContext();
     RemoteActionFileSystem remoteActionFileSystem = (RemoteActionFileSystem) actionFileSystem;
 
     for (Map.Entry<Path, DirectoryMetadata> entry : metadata.directories()) {
@@ -827,8 +826,7 @@ public class RemoteExecutionService {
         remoteActionFileSystem.injectRemoteFile(
             file.path().asFragment(),
             DigestUtil.toBinaryDigest(file.digest()),
-            file.digest().getSizeBytes(),
-            context.getRequestMetadata().getActionId());
+            file.digest().getSizeBytes());
       }
     }
 
@@ -836,8 +834,7 @@ public class RemoteExecutionService {
       remoteActionFileSystem.injectRemoteFile(
           file.path().asFragment(),
           DigestUtil.toBinaryDigest(file.digest()),
-          file.digest().getSizeBytes(),
-          context.getRequestMetadata().getActionId());
+          file.digest().getSizeBytes());
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -463,8 +463,7 @@ public class ActionCacheCheckerTest {
   private RemoteFileArtifactValue createRemoteFileMetadata(
       String content, @Nullable PathFragment materializationExecPath) {
     byte[] bytes = content.getBytes(UTF_8);
-    return RemoteFileArtifactValue.create(
-        digest(bytes), bytes.length, 1, "action-id", materializationExecPath);
+    return RemoteFileArtifactValue.create(digest(bytes), bytes.length, 1, materializationExecPath);
   }
 
   private static TreeArtifactValue createTreeMetadata(

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -208,8 +208,7 @@ public class CompactPersistentActionCacheTest {
             .getHashFunction()
             .hashBytes(bytes)
             .asBytes();
-    return RemoteFileArtifactValue.create(
-        digest, bytes.length, 1, "action-id", materializationExecPath);
+    return RemoteFileArtifactValue.create(digest, bytes.length, 1, materializationExecPath);
   }
 
   private RemoteFileArtifactValue createRemoteMetadata(Artifact artifact, String content) {

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -100,7 +100,6 @@ public abstract class ActionInputPrefetcherTestBase {
             hashCode.asBytes(),
             contentsBytes.length,
             /* locationIndex= */ 1,
-            "action-id",
             materializationExecPath);
     metadata.put(a, f);
     if (cas != null) {
@@ -136,7 +135,7 @@ public abstract class ActionInputPrefetcherTestBase {
           TreeFileArtifact.createTreeOutput(parent, PathFragment.create(entry.getKey()));
       RemoteFileArtifactValue childValue =
           RemoteFileArtifactValue.create(
-              hashCode.asBytes(), contentsBytes.length, /* locationIndex= */ 1, "action-id");
+              hashCode.asBytes(), contentsBytes.length, /* locationIndex= */ 1);
       treeBuilder.putChild(child, childValue);
       metadata.put(child, childValue);
       cas.put(hashCode, contentsBytes);

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -442,7 +442,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     byte[] b = contents.getBytes(StandardCharsets.UTF_8);
     HashCode h = HashCode.fromString(DIGEST_UTIL.compute(b).getHash());
     FileArtifactValue f =
-        RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 1, "action-id");
+        RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 1);
     inputs.putWithNoDepOwner(a, f);
     return a;
   }
@@ -512,8 +512,6 @@ public class ByteStreamBuildEventArtifactUploaderTest {
   }
 
   private static class AllMissingDigestsFinder implements MissingDigestsFinder {
-
-    public static final AllMissingDigestsFinder INSTANCE = new AllMissingDigestsFinder();
 
     @Override
     public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -326,7 +326,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
     HashCode hashCode = HASH_FUNCTION.getHashFunction().hashBytes(contentBytes);
     ((RemoteActionFileSystem) actionFs)
-        .injectRemoteFile(path, hashCode.asBytes(), contentBytes.length, "action-id");
+        .injectRemoteFile(path, hashCode.asBytes(), contentBytes.length);
   }
 
   @Override
@@ -342,7 +342,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     byte[] b = contents.getBytes(StandardCharsets.UTF_8);
     HashCode h = HASH_FUNCTION.getHashFunction().hashBytes(b);
     RemoteFileArtifactValue f =
-        RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 1, "action-id");
+        RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 1);
     inputs.putWithNoDepOwner(a, f);
     return a;
   }
@@ -364,8 +364,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
       byte[] b = entry.getValue().getBytes(StandardCharsets.UTF_8);
       HashCode h = HASH_FUNCTION.getHashFunction().hashBytes(b);
       RemoteFileArtifactValue childMeta =
-          RemoteFileArtifactValue.create(
-              h.asBytes(), b.length, /* locationIndex= */ 0, "action-id");
+          RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 0);
       builder.putChild(child, childMeta);
     }
     return builder.build();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -949,8 +949,9 @@ public class RemoteExecutionServiceTest {
     Artifact a1 = ActionsTestUtil.createArtifact(artifactRoot, "file1");
     verify(actionFileSystem)
         .injectRemoteFile(
-            eq(execRoot.asFragment().getRelative(a1.getExecPath())), eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()), any());
+            eq(execRoot.asFragment().getRelative(a1.getExecPath())),
+            eq(toBinaryDigest(d1)),
+            eq(d1.getSizeBytes()));
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
     assertThat(outputBase.readdir(Symlinks.NOFOLLOW)).isEmpty();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -988,12 +989,14 @@ public class RemoteExecutionServiceTest {
     Artifact a2 = ActionsTestUtil.createArtifact(artifactRoot, "file2");
     verify(actionFileSystem)
         .injectRemoteFile(
-            eq(execRoot.asFragment().getRelative(a1.getExecPath())), eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()), any());
+            eq(execRoot.asFragment().getRelative(a1.getExecPath())),
+            eq(toBinaryDigest(d1)),
+            eq(d1.getSizeBytes()));
     verify(actionFileSystem)
         .injectRemoteFile(
-            eq(execRoot.asFragment().getRelative(a2.getExecPath())), eq(toBinaryDigest(d2)),
-            eq(d2.getSizeBytes()), any());
+            eq(execRoot.asFragment().getRelative(a2.getExecPath())),
+            eq(toBinaryDigest(d2)),
+            eq(d2.getSizeBytes()));
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
     assertThat(outputBase.readdir(Symlinks.NOFOLLOW)).isEmpty();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -1044,12 +1047,14 @@ public class RemoteExecutionServiceTest {
     assertThat(inMemoryOutput).isNull();
     verify(actionFileSystem)
         .injectRemoteFile(
-            eq(execRoot.asFragment().getRelative("outputs/dir/file1")), eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()), eq(action.getActionId()));
+            eq(execRoot.asFragment().getRelative("outputs/dir/file1")),
+            eq(toBinaryDigest(d1)),
+            eq(d1.getSizeBytes()));
     verify(actionFileSystem)
         .injectRemoteFile(
-            eq(execRoot.asFragment().getRelative("outputs/dir/a/file2")), eq(toBinaryDigest(d2)),
-            eq(d2.getSizeBytes()), eq(action.getActionId()));
+            eq(execRoot.asFragment().getRelative("outputs/dir/a/file2")),
+            eq(toBinaryDigest(d2)),
+            eq(d2.getSizeBytes()));
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
     assertThat(outputBase.readdir(Symlinks.NOFOLLOW)).isEmpty();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -1180,12 +1185,14 @@ public class RemoteExecutionServiceTest {
     // The in memory file also needs to be injected as an output
     verify(actionFileSystem)
         .injectRemoteFile(
-            eq(execRoot.asFragment().getRelative(a1.getExecPath())), eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()), eq(action.getActionId()));
+            eq(execRoot.asFragment().getRelative(a1.getExecPath())),
+            eq(toBinaryDigest(d1)),
+            eq(d1.getSizeBytes()));
     verify(actionFileSystem)
         .injectRemoteFile(
-            eq(execRoot.asFragment().getRelative(a2.getExecPath())), eq(toBinaryDigest(d2)),
-            eq(d2.getSizeBytes()), eq(action.getActionId()));
+            eq(execRoot.asFragment().getRelative(a2.getExecPath())),
+            eq(toBinaryDigest(d2)),
+            eq(d2.getSizeBytes()));
     Path outputBase = checkNotNull(artifactRoot.getRoot().asPath());
     assertThat(outputBase.readdir(Symlinks.NOFOLLOW)).isEmpty();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
@@ -1205,15 +1212,15 @@ public class RemoteExecutionServiceTest {
     Spawn spawn =
         new SimpleSpawn(
             new FakeOwner("foo", "bar", "//dummy:label"),
-            /*arguments=*/ ImmutableList.of(),
-            /*environment=*/ ImmutableMap.of(),
-            /*executionInfo=*/ ImmutableMap.of(REMOTE_EXECUTION_INLINE_OUTPUTS, "outputs/file1"),
-            /*runfilesSupplier=*/ null,
-            /*filesetMappings=*/ ImmutableMap.of(),
-            /*inputs=*/ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
-            /*tools=*/ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
-            /*outputs=*/ ImmutableSet.of(a1),
-            /*mandatoryOutputs=*/ ImmutableSet.of(),
+            /* arguments= */ ImmutableList.of(),
+            /* environment= */ ImmutableMap.of(),
+            /* executionInfo= */ ImmutableMap.of(REMOTE_EXECUTION_INLINE_OUTPUTS, "outputs/file1"),
+            /* runfilesSupplier= */ null,
+            /* filesetMappings= */ ImmutableMap.of(),
+            /* inputs= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            /* outputs= */ ImmutableSet.of(a1),
+            /* mandatoryOutputs= */ ImmutableSet.of(),
             ResourceSet.ZERO);
 
     RemoteActionFileSystem actionFileSystem = mock(RemoteActionFileSystem.class);
@@ -1231,8 +1238,9 @@ public class RemoteExecutionServiceTest {
     // The in memory file metadata also should not have been injected.
     verify(actionFileSystem, never())
         .injectRemoteFile(
-            eq(execRoot.asFragment().getRelative(a1.getExecPath())), eq(toBinaryDigest(d1)),
-            eq(d1.getSizeBytes()), eq(action.getActionId()));
+            eq(execRoot.asFragment().getRelative(a1.getExecPath())),
+            eq(toBinaryDigest(d1)),
+            eq(d1.getSizeBytes()));
   }
 
   @Test
@@ -1609,7 +1617,7 @@ public class RemoteExecutionServiceTest {
       executorService.execute(
           () -> {
             try {
-              service.uploadInputsIfNotPresent(action, /*force=*/ false);
+              service.uploadInputsIfNotPresent(action, /* force= */ false);
             } catch (Throwable e) {
               if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
@@ -1655,7 +1663,7 @@ public class RemoteExecutionServiceTest {
               if (shouldInterrupt) {
                 Thread.currentThread().interrupt();
               }
-              service.uploadInputsIfNotPresent(action, /*force=*/ false);
+              service.uploadInputsIfNotPresent(action, /* force= */ false);
             } catch (Throwable e) {
               if (!(shouldInterrupt && e instanceof InterruptedException)) {
                 error.set(e);
@@ -1768,20 +1776,20 @@ public class RemoteExecutionServiceTest {
     Spawn spawn1 =
         new SimpleSpawn(
             new FakeOwner("foo", "bar", "//dummy:label"),
-            /*arguments=*/ ImmutableList.of(),
-            /*environment=*/ ImmutableMap.of(),
-            /*executionInfo=*/ ImmutableMap.of(),
-            /*inputs=*/ nodeRoot1,
-            /*outputs=*/ ImmutableSet.of(),
+            /* arguments= */ ImmutableList.of(),
+            /* environment= */ ImmutableMap.of(),
+            /* executionInfo= */ ImmutableMap.of(),
+            /* inputs= */ nodeRoot1,
+            /* outputs= */ ImmutableSet.of(),
             ResourceSet.ZERO);
     Spawn spawn2 =
         new SimpleSpawn(
             new FakeOwner("foo", "bar", "//dummy:label"),
-            /*arguments=*/ ImmutableList.of(),
-            /*environment=*/ ImmutableMap.of(),
-            /*executionInfo=*/ ImmutableMap.of(),
-            /*inputs=*/ nodeRoot2,
-            /*outputs=*/ ImmutableSet.of(),
+            /* arguments= */ ImmutableList.of(),
+            /* environment= */ ImmutableMap.of(),
+            /* executionInfo= */ ImmutableMap.of(),
+            /* inputs= */ nodeRoot2,
+            /* outputs= */ ImmutableSet.of(),
             ResourceSet.ZERO);
 
     FakeSpawnExecutionContext context1 = newSpawnExecutionContext(spawn1);
@@ -1939,11 +1947,11 @@ public class RemoteExecutionServiceTest {
       NestedSet<? extends ActionInput> inputs) {
     return new SimpleSpawn(
         new FakeOwner("foo", "bar", "//dummy:label"),
-        /*arguments=*/ ImmutableList.of(),
-        /*environment=*/ ImmutableMap.of(),
-        /*executionInfo=*/ executionInfo,
-        /*inputs=*/ inputs,
-        /*outputs=*/ outputs,
+        /* arguments= */ ImmutableList.of(),
+        /* environment= */ ImmutableMap.of(),
+        /* executionInfo= */ executionInfo,
+        /* inputs= */ inputs,
+        /* outputs= */ outputs,
         ResourceSet.ZERO);
   }
 
@@ -1969,7 +1977,7 @@ public class RemoteExecutionServiceTest {
     return new RemoteExecutionService(
         directExecutor(),
         reporter,
-        /*verboseFailures=*/ true,
+        /* verboseFailures= */ true,
         execRoot,
         remotePathResolver,
         "none",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandlerTest.java
@@ -112,12 +112,13 @@ public final class ActionMetadataHandlerTest {
   public void withNonArtifactInput() throws Exception {
     ActionInput input = ActionInputHelper.fromPath("foo/bar");
     FileArtifactValue metadata =
-        FileArtifactValue.createForNormalFile(new byte[] {1, 2, 3}, /*proxy=*/ null, /*size=*/ 10L);
+        FileArtifactValue.createForNormalFile(
+            new byte[] {1, 2, 3}, /* proxy= */ null, /* size= */ 10L);
     ActionInputMap map = new ActionInputMap(1);
     map.putWithNoDepOwner(input, metadata);
     assertThat(map.getMetadata(input)).isEqualTo(metadata);
     ActionMetadataHandler handler =
-        createHandler(map, /*forInputDiscovery=*/ false, /*outputs=*/ ImmutableSet.of());
+        createHandler(map, /* forInputDiscovery= */ false, /* outputs= */ ImmutableSet.of());
     assertThat(handler.getMetadata(input)).isNull();
     assertThat(chmodCalls).isEmpty();
   }
@@ -127,11 +128,12 @@ public final class ActionMetadataHandlerTest {
     PathFragment path = PathFragment.create("src/a");
     Artifact artifact = ActionsTestUtil.createArtifactWithRootRelativePath(sourceRoot, path);
     FileArtifactValue metadata =
-        FileArtifactValue.createForNormalFile(new byte[] {1, 2, 3}, /*proxy=*/ null, /*size=*/ 10L);
+        FileArtifactValue.createForNormalFile(
+            new byte[] {1, 2, 3}, /* proxy= */ null, /* size= */ 10L);
     ActionInputMap map = new ActionInputMap(1);
     map.putWithNoDepOwner(artifact, metadata);
     ActionMetadataHandler handler =
-        createHandler(map, /*forInputDiscovery=*/ false, /*outputs=*/ ImmutableSet.of());
+        createHandler(map, /* forInputDiscovery= */ false, /* outputs= */ ImmutableSet.of());
     assertThat(handler.getMetadata(artifact)).isEqualTo(metadata);
     assertThat(chmodCalls).isEmpty();
   }
@@ -142,7 +144,9 @@ public final class ActionMetadataHandlerTest {
     Artifact artifact = ActionsTestUtil.createArtifactWithRootRelativePath(sourceRoot, path);
     ActionMetadataHandler handler =
         createHandler(
-            new ActionInputMap(0), /*forInputDiscovery=*/ false, /*outputs=*/ ImmutableSet.of());
+            new ActionInputMap(0),
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of());
     Exception e = assertThrows(IllegalStateException.class, () -> handler.getMetadata(artifact));
     assertThat(e).hasMessageThat().contains(artifact + " is not present in declared outputs");
     assertThat(chmodCalls).isEmpty();
@@ -154,7 +158,7 @@ public final class ActionMetadataHandlerTest {
     Artifact artifact = ActionsTestUtil.createArtifactWithRootRelativePath(sourceRoot, path);
     ActionMetadataHandler handler =
         createHandler(
-            new ActionInputMap(0), /*forInputDiscovery=*/ true, /*outputs=*/ ImmutableSet.of());
+            new ActionInputMap(0), /* forInputDiscovery= */ true, /* outputs= */ ImmutableSet.of());
     assertThat(handler.getMetadata(artifact)).isNull();
     assertThat(chmodCalls).isEmpty();
   }
@@ -165,7 +169,7 @@ public final class ActionMetadataHandlerTest {
     Artifact artifact = ActionsTestUtil.createArtifactWithRootRelativePath(outputRoot, path);
     ActionMetadataHandler handler =
         createHandler(
-            new ActionInputMap(0), /*forInputDiscovery=*/ true, /*outputs=*/ ImmutableSet.of());
+            new ActionInputMap(0), /* forInputDiscovery= */ true, /* outputs= */ ImmutableSet.of());
     assertThat(handler.getMetadata(artifact)).isNull();
     assertThat(chmodCalls).isEmpty();
   }
@@ -178,8 +182,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(artifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(artifact));
     assertThat(handler.getMetadata(artifact)).isNotNull();
     assertThat(chmodCalls).isEmpty();
   }
@@ -191,8 +195,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(artifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(artifact));
     assertThrows(FileNotFoundException.class, () -> handler.getMetadata(artifact));
     assertThat(chmodCalls).isEmpty();
   }
@@ -203,7 +207,9 @@ public final class ActionMetadataHandlerTest {
     Artifact artifact = ActionsTestUtil.createArtifactWithRootRelativePath(outputRoot, path);
     ActionMetadataHandler handler =
         createHandler(
-            new ActionInputMap(0), /*forInputDiscovery=*/ false, /*outputs=*/ ImmutableSet.of());
+            new ActionInputMap(0),
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of());
     assertThrows(IllegalStateException.class, () -> handler.getMetadata(artifact));
     assertThat(chmodCalls).isEmpty();
   }
@@ -216,7 +222,7 @@ public final class ActionMetadataHandlerTest {
     Artifact artifact = TreeFileArtifact.createTreeOutput(treeArtifact, "baz");
     ActionMetadataHandler handler =
         createHandler(
-            new ActionInputMap(0), /*forInputDiscovery=*/ true, /*outputs=*/ ImmutableSet.of());
+            new ActionInputMap(0), /* forInputDiscovery= */ true, /* outputs= */ ImmutableSet.of());
     assertThat(handler.getMetadata(artifact)).isNull();
     assertThat(chmodCalls).isEmpty();
   }
@@ -232,8 +238,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(treeArtifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(treeArtifact));
     assertThat(handler.getMetadata(artifact)).isNotNull();
     assertThat(chmodCalls).isEmpty();
   }
@@ -246,7 +252,9 @@ public final class ActionMetadataHandlerTest {
     Artifact artifact = TreeFileArtifact.createTreeOutput(treeArtifact, "baz");
     ActionMetadataHandler handler =
         createHandler(
-            new ActionInputMap(0), /*forInputDiscovery=*/ false, /*outputs=*/ ImmutableSet.of());
+            new ActionInputMap(0),
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of());
     assertThrows(IllegalStateException.class, () -> handler.getMetadata(artifact));
     assertThat(chmodCalls).isEmpty();
   }
@@ -266,8 +274,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(treeArtifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(treeArtifact));
 
     FileArtifactValue treeMetadata = handler.getMetadata(treeArtifact);
     FileArtifactValue child1Metadata = handler.getMetadata(child1);
@@ -290,8 +298,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ true,
-            /*outputs=*/ ImmutableSet.of(artifact));
+            /* forInputDiscovery= */ true,
+            /* outputs= */ ImmutableSet.of(artifact));
     handler.prepareForActionExecution();
 
     // The handler doesn't have any info. It'll stat the file and discover that it's 10 bytes long.
@@ -299,8 +307,7 @@ public final class ActionMetadataHandlerTest {
     assertThat(chmodCalls).containsExactly(outputPath, 0555);
 
     // Inject a remote file of size 42.
-    handler.injectFile(
-        artifact, RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 42, 0, "ultimate-answer"));
+    handler.injectFile(artifact, RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 42, 0));
     assertThat(handler.getMetadata(artifact).getSize()).isEqualTo(42);
 
     // Reset this output, which will make the handler stat the file again.
@@ -317,14 +324,14 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ true,
-            /*outputs=*/ ImmutableSet.of(artifact));
+            /* forInputDiscovery= */ true,
+            /* outputs= */ ImmutableSet.of(artifact));
     handler.prepareForActionExecution();
 
     byte[] digest = new byte[] {1, 2, 3};
     int size = 10;
     handler.injectFile(
-        artifact, RemoteFileArtifactValue.create(digest, size, /*locationIndex=*/ 1, "action-id"));
+        artifact, RemoteFileArtifactValue.create(digest, size, /* locationIndex= */ 1));
 
     FileArtifactValue v = handler.getMetadata(artifact);
     assertThat(v).isNotNull();
@@ -343,8 +350,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(treeArtifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(treeArtifact));
     handler.prepareForActionExecution();
 
     RemoteFileArtifactValue childValue = RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1);
@@ -367,8 +374,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(treeArtifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(treeArtifact));
     handler.prepareForActionExecution();
 
     RemoteFileArtifactValue value = RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1);
@@ -387,18 +394,18 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(treeArtifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(treeArtifact));
     handler.prepareForActionExecution();
 
     TreeArtifactValue tree =
         TreeArtifactValue.newBuilder(treeArtifact)
             .putChild(
                 TreeFileArtifact.createTreeOutput(treeArtifact, "foo"),
-                RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1, "foo"))
+                RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1))
             .putChild(
                 TreeFileArtifact.createTreeOutput(treeArtifact, "bar"),
-                RemoteFileArtifactValue.create(new byte[] {4, 5, 6}, 10, 1, "bar"))
+                RemoteFileArtifactValue.create(new byte[] {4, 5, 6}, 10, 1))
             .build();
 
     handler.injectTree(treeArtifact, tree);
@@ -415,7 +422,7 @@ public final class ActionMetadataHandlerTest {
     // child is missing, getExistingFileArtifactValue will throw.
     ActionExecutionValue actionExecutionValue =
         ActionExecutionValue.createFromOutputStore(
-            handler.getOutputStore(), /*outputSymlinks=*/ null, new NullAction());
+            handler.getOutputStore(), /* outputSymlinks= */ null, new NullAction());
     tree.getChildren().forEach(actionExecutionValue::getExistingFileArtifactValue);
   }
 
@@ -465,7 +472,7 @@ public final class ActionMetadataHandlerTest {
         PathFragment.create(identifier + "_symlink"),
         PathFragment.create(identifier),
         digest,
-        /*isGeneratedTarget=*/ true,
+        /* isGeneratedTarget= */ true,
         outputRoot.getExecPath());
   }
 
@@ -484,8 +491,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(omitted, consumed));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(omitted, consumed));
 
     handler.prepareForActionExecution();
     handler.markOmitted(omitted);
@@ -509,8 +516,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(omittedTree, consumedTree));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(omittedTree, consumedTree));
 
     handler.prepareForActionExecution();
     handler.markOmitted(omittedTree);
@@ -533,8 +540,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(output));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(output));
     handler.prepareForActionExecution();
 
     FileArtifactValue metadata = handler.getMetadata(output);
@@ -588,8 +595,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(treeArtifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(treeArtifact));
     handler.prepareForActionExecution();
 
     FileArtifactValue treeMetadata = handler.getMetadata(treeArtifact);
@@ -625,8 +632,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ true,
-            /*outputs=*/ ImmutableSet.of(known));
+            /* forInputDiscovery= */ true,
+            /* outputs= */ ImmutableSet.of(known));
 
     // Unknown artifact returns null during input discovery.
     assertThat(handler.getMetadata(unknown)).isNull();
@@ -654,8 +661,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(treeArtifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(treeArtifact));
     assertThat(handler.getTreeArtifactChildren(treeArtifact)).isEmpty();
   }
 
@@ -673,8 +680,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(artifact, treeArtifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(artifact, treeArtifact));
     OutputStore store = handler.getOutputStore();
 
     FileArtifactValue artifactMetadata1 = handler.getMetadata(artifact);
@@ -704,7 +711,9 @@ public final class ActionMetadataHandlerTest {
   public void cannotEnterExecutionModeTwice() {
     ActionMetadataHandler handler =
         createHandler(
-            new ActionInputMap(0), /*forInputDiscovery=*/ false, /*outputs=*/ ImmutableSet.of());
+            new ActionInputMap(0),
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of());
     handler.prepareForActionExecution();
     assertThrows(IllegalStateException.class, handler::prepareForActionExecution);
   }
@@ -718,8 +727,8 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(artifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(artifact));
 
     FileArtifactValue getMetadataResult = handler.getMetadata(artifact);
     assertThat(getMetadataResult).isNotNull();
@@ -727,7 +736,7 @@ public final class ActionMetadataHandlerTest {
     scratch.overwriteFile(artifact.getPath().getPathString(), "2");
     FileArtifactValue fileArtifactValueFromArtifactResult =
         ActionMetadataHandler.fileArtifactValueFromArtifact(
-            artifact, /*statNoFollow=*/ null, SyscallCache.NO_CACHE, /*tsgm=*/ null);
+            artifact, /* statNoFollow= */ null, SyscallCache.NO_CACHE, /* tsgm= */ null);
     assertThat(fileArtifactValueFromArtifactResult).isNotNull();
 
     assertThat(fileArtifactValueFromArtifactResult.couldBeModifiedSince(getMetadataResult))
@@ -743,15 +752,15 @@ public final class ActionMetadataHandlerTest {
     ActionMetadataHandler handler =
         createHandler(
             new ActionInputMap(0),
-            /*forInputDiscovery=*/ false,
-            /*outputs=*/ ImmutableSet.of(artifact));
+            /* forInputDiscovery= */ false,
+            /* outputs= */ ImmutableSet.of(artifact));
 
     FileArtifactValue getMetadataResult = handler.getMetadata(artifact);
     assertThat(getMetadataResult).isNotNull();
 
     FileArtifactValue fileArtifactValueFromArtifactResult =
         ActionMetadataHandler.fileArtifactValueFromArtifact(
-            artifact, /*statNoFollow=*/ null, SyscallCache.NO_CACHE, /*tsgm=*/ null);
+            artifact, /* statNoFollow= */ null, SyscallCache.NO_CACHE, /* tsgm= */ null);
     assertThat(fileArtifactValueFromArtifactResult).isNotNull();
 
     assertThat(fileArtifactValueFromArtifactResult.couldBeModifiedSince(getMetadataResult))

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -1327,7 +1327,7 @@ public final class FilesystemValueCheckerTest {
     byte[] data = contents.getBytes();
     DigestHashFunction hashFn = fs.getDigestFunction();
     HashCode hash = hashFn.getHashFunction().hashBytes(data);
-    return RemoteFileArtifactValue.create(hash.asBytes(), data.length, -1, "action-id");
+    return RemoteFileArtifactValue.create(hash.asBytes(), data.length, -1);
   }
 
   @Test


### PR DESCRIPTION
actionId was added by https://github.com/bazelbuild/bazel/pull/11236 to track download requests for input prefetches.

However, according to the REAPI spec, action_id is

> An identifier that ties multiple requests to the same action. For example, multiple requests to the CAS, Action Cache, and Execution API are used in order to compile foo.cc.

The input prefetches are requested by local actions that depend on outputs of remote executed action (which is identified by the action_id). These requests are not part of generating action hence shouldn't be bound with the action_id.

We could include ActionExecutionMetadata of the local action for the requests for the tracking purpose, but that desires another CL.

PiperOrigin-RevId: 510430853
Change-Id: I8d64a4f7033320a394e02a2b11498f09a3d15310