### PR TITLE
Add support for alias targets to cquery's `providers`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTarget.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.BuildConfigurationKey;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.Structure;
 
 /**
@@ -109,5 +110,14 @@ public interface ConfiguredTarget extends TransitiveInfoCollection, Structure {
    */
   default ConfiguredTarget unwrapIfMerged() {
     return this;
+  }
+
+  /**
+   * This is only intended to be called from the query dialects of Starlark.
+   *
+   * @return a map of provider names to their values
+   */
+  default Dict<String, Object> getProvidersDict() {
+    return null;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/AbstractConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/AbstractConfiguredTarget.java
@@ -255,12 +255,4 @@ public abstract class AbstractConfiguredTarget implements ConfiguredTarget, Visi
   public void repr(Printer printer) {
     printer.append("<unknown target " + getLabel() + ">");
   }
-
-  /**
-   * Returns a map of provider names to their values. This is only intended to be called from the
-   * query dialects of Starlark. Implement in subclasses which can have providers.
-   */
-  public Dict<String, Object> getProvidersDict() {
-    return null;
-  }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -21,7 +21,6 @@ import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
-import com.google.devtools.build.lib.analysis.configuredtargets.AbstractConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -121,10 +120,7 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
           @Param(name = "target"),
         })
     public Object providers(ConfiguredTarget target) {
-      if (!(target instanceof AbstractConfiguredTarget)) {
-        return Starlark.NONE;
-      }
-      Dict<String, Object> ret = ((AbstractConfiguredTarget) target).getProvidersDict();
+      Dict<String, Object> ret = target.getProvidersDict();
       if (ret == null) {
         return Starlark.NONE;
       }

--- a/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.packages.PackageSpecification.PackageGroupC
 import com.google.devtools.build.lib.packages.Provider;
 import com.google.devtools.build.lib.skyframe.BuildConfigurationKey;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -194,6 +195,11 @@ public final class AliasConfiguredTarget implements ConfiguredTarget, Structure 
   @Override
   public Label getOriginalLabel() {
     return label;
+  }
+
+  @Override
+  public Dict<String, Object> getProvidersDict() {
+    return actual.getProvidersDict();
   }
 
   @Override


### PR DESCRIPTION
When applied to an `alias` target, the `providers` function of `cquery`'s `--output=starlark` mode now returns the providers of the aliased target rather than `None`.

This is achieved by moving `getProvidersDict` from `AbstractConfiguredTarget` up to `ConfiguredTarget`.

Fixes #17749