### PR TITLE
Remove layering_check feature on darwin

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -494,7 +494,8 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         ["/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"],
     )
 
-    if is_clang:
+    generate_modulemap = is_clang and not darwin
+    if generate_modulemap:
         repository_ctx.file("module.modulemap", _generate_system_module_map(
             repository_ctx,
             builtin_include_directories,
@@ -508,7 +509,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         {
             "%{cc_toolchain_identifier}": cc_toolchain_identifier,
             "%{name}": cpu_value,
-            "%{modulemap}": ("\":module.modulemap\"" if is_clang else "None"),
+            "%{modulemap}": ("\":module.modulemap\"" if generate_modulemap else "None"),
             "%{cc_compiler_deps}": get_starlark_list([":builtin_include_directory_paths"] + (
                 [":cc_wrapper"] if darwin else []
             )),

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -1445,7 +1445,7 @@ def _impl(ctx):
             unfiltered_compile_flags_feature,
             treat_warnings_as_errors_feature,
             archive_param_file_feature,
-        ] + layering_check_features(ctx.attr.compiler)
+        ]
 
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,


### PR DESCRIPTION
Using this feature isn't supported by the Xcode based toolchain on macOS, and generating a modulemap for the entire macOS SDK takes a huge amount of time. This disables this feature on macOS until there's a better solution to those performance issues.

Fixes https://github.com/bazelbuild/bazel/pull/16619#issuecomment-1465785062