### PR TITLE
Allow specifying target and exec constrains in remote_java_repository

### DIFF
--- a/tools/jdk/remote_java_repository.bzl
+++ b/tools/jdk/remote_java_repository.bzl
@@ -31,7 +31,7 @@ _toolchain_config = repository_rule(
     },
 )
 
-def remote_java_repository(name, version, target_compatible_with = None, prefix = "remotejdk", **kwargs):
+def remote_java_repository(name, version, exec_compatible_with = None, target_compatible_with = None, prefix = "remotejdk", **kwargs):
     """Imports and registers a JDK from a http archive.
 
     Toolchain resolution is determined with target_compatible_with
@@ -73,6 +73,7 @@ alias(
 )
 toolchain(
     name = "toolchain",
+    exec_compatible_with = {exec_compatible_with},
     target_compatible_with = {target_compatible_with},
     target_settings = [":version_or_prefix_version_setting"],
     toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
@@ -81,6 +82,7 @@ toolchain(
 """.format(
             prefix = prefix,
             version = version,
+            exec_compatible_with = exec_compatible_with,
             target_compatible_with = target_compatible_with,
             toolchain = "@{repo}//:jdk".format(repo = name),
         ),


### PR DESCRIPTION
This is a continuation of https://github.com/bazelbuild/bazel/commit/27fe30bb7cc1fdea7c60d7f73774149c0dd21457
This is useful for setting constraints on java toolchains.