### PR TITLE
Run the Android integration tests remotely again.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -75,8 +75,8 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-# android_sdk_repository(name = "androidsdk")
-# android_ndk_repository(name = "androidndk")
+android_sdk_repository(name = "androidsdk")
+android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_starlark_test, follow the
 # instructions above for the Android integration tests and uncomment the

--- a/src/test/shell/bazel/android/BUILD
+++ b/src/test/shell/bazel/android/BUILD
@@ -37,9 +37,7 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
         # bzlmod test requires network
         "requires-network",
@@ -55,9 +53,7 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -71,8 +67,6 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
-    tags = ["no-remote"],
 )
 
 android_sh_test(
@@ -85,9 +79,7 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -101,8 +93,6 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
-    tags = ["no-remote"],
 )
 
 android_sh_test(
@@ -115,9 +105,7 @@ android_sh_test(
         "//src/test/shell/bazel:test-deps",
     ],
     shard_count = 3,
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -134,7 +122,7 @@ android_sh_test(
         "//src/test/shell/bazel:test-deps",
     ],
     shard_count = 6,
-    # See https://github.com/bazelbuild/bazel/issues/8235
+    # Disable remote execution because we're over the input limit (70k).
     tags = [
         "no-remote",
         "no_windows",
@@ -150,8 +138,6 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
-    tags = ["no-remote"],
 )
 
 android_sh_test(
@@ -163,9 +149,7 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -180,9 +164,7 @@ android_sh_test(
         "//src/test/shell/bazel:test-deps",
     ],
     shard_count = 4,
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -197,6 +179,4 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
-    tags = ["no-remote"],
 )


### PR DESCRIPTION
Run the Android integration tests remotely again.

The dynamic linking issue that required local execution has been fixed.

This should speed up Bazel CI runs, as we previously couldn't benefit from previously cached test results.

One of the tests must remain non-remote because it currently exceeds the RBE input limit (70k files). This is tracked in #17784.

Fixes https://github.com/bazelbuild/bazel/issues/8235.