### PR TITLE
Restructure ActionStager and CommandAdjuster

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
@@ -173,7 +173,7 @@ public class CommandLines {
           String paramArg =
               SingleStringArgFormatter.format(
                   paramFileInfo.getFlagFormatString(),
-                  pathStripper.strip(paramFileExecPath).getPathString());
+                  pathStripper.map(paramFileExecPath).getPathString());
           arguments.addElement(paramArg);
           cmdLineLength += paramArg.length() + 1;
 
@@ -494,7 +494,7 @@ public class CommandLines {
         @Nullable ArtifactExpander artifactExpander, CommandAdjuster pathStripper)
         throws CommandLineExpansionException, InterruptedException {
       if (arg instanceof PathStrippable) {
-        return ImmutableList.of(((PathStrippable) arg).expand(pathStripper::strip));
+        return ImmutableList.of(((PathStrippable) arg).expand(pathStripper::map));
       }
       return ImmutableList.of(CommandLineItem.expandToCommandLine(arg));
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
@@ -22,6 +22,7 @@ import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Interner;
+import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
@@ -373,11 +374,11 @@ public class CustomCommandLine extends CommandLine {
       }
 
       private String expandToCommandLine(Object object, PathStripper.CommandAdjuster pathStripper) {
-        // It'd be nice to build this into DerivedArtifact's CommandLine interface so we don't have
-        // to explicitly check if an object is a DerivedArtifact. Unfortunately that would require
-        // a lot more dependencies on the Java library DerivedArtifact is built into.
-        return pathStripper != null && object instanceof DerivedArtifact
-            ? pathStripper.strip((DerivedArtifact) object)
+        // It'd be nice to build this into ActionInput's CommandLine interface so we don't have
+        // to explicitly check if an object is a ActionInput. Unfortunately that would require
+        // a lot more dependencies on the Java library ActionInput is built into.
+        return pathStripper != null && object instanceof ActionInput
+            ? pathStripper.getMappedExecPathString((ActionInput) object)
             : CommandLineItem.expandToCommandLine(object);
       }
 
@@ -1324,10 +1325,10 @@ public class CustomCommandLine extends CommandLine {
         } else {
           i = ((ArgvFragment) substitutedArg).eval(arguments, i, builder, getPathStripper());
         }
-      } else if (substitutedArg instanceof DerivedArtifact) {
-        builder.add(getPathStripper().strip((DerivedArtifact) substitutedArg));
+      } else if (substitutedArg instanceof ActionInput) {
+        builder.add(getPathStripper().getMappedExecPathString((ActionInput) substitutedArg));
       } else if (substitutedArg instanceof PathFragment) {
-        builder.add(getPathStripper().strip(((PathFragment) substitutedArg)).getPathString());
+        builder.add(getPathStripper().map(((PathFragment) substitutedArg)).getPathString());
       } else {
         builder.add(CommandLineItem.expandToCommandLine(substitutedArg));
       }
@@ -1338,8 +1339,8 @@ public class CustomCommandLine extends CommandLine {
   private void evalSimpleVectorArg(Iterable<?> arg, ImmutableList.Builder<String> builder) {
     for (Object value : arg) {
       builder.add(
-          value instanceof DerivedArtifact
-              ? getPathStripper().strip((DerivedArtifact) value)
+          value instanceof ActionInput
+              ? getPathStripper().getMappedExecPathString((ActionInput) value)
               : CommandLineItem.expandToCommandLine(value));
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -425,12 +425,12 @@ public final class StarlarkAction extends SpawnAction implements ActionCacheAwar
      * specific actions we're interested in.
      *
      * <p>The difference between this and {@link
-     * PathStripper.CommandAdjuster#stripCustomStarlarkArgs} is this triggers Bazel's standard path
+     * PathStripper.CommandAdjuster#mapCustomStarlarkArgs} is this triggers Bazel's standard path
      * stripping logic for chosen mnemonics while {@link
-     * PathStripper.CommandAdjuster#stripCustomStarlarkArgs} custom-adjusts certain command line
+     * PathStripper.CommandAdjuster#mapCustomStarlarkArgs} custom-adjusts certain command line
      * parameters the standard logic can't handle. For example, Starlark rules that only set {@code
      * ctx.actions.args().add(file_handle)} need an entry here but not in {@link
-     * PathStripper.CommandAdjuster#stripCustomStarlarkArgs} because standard path stripping logic
+     * PathStripper.CommandAdjuster#mapCustomStarlarkArgs} because standard path stripping logic
      * handles that interface.
      */
     private static boolean stripOutputPaths(

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -755,7 +755,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
         result.add(expandToCommandLine(arg, stripPaths));
       }
     }
-    return ImmutableList.copyOf(stripPaths.stripCustomStarlarkArgs(result));
+    return ImmutableList.copyOf(stripPaths.mapCustomStarlarkArgs(result));
   }
 
   private static String expandToCommandLine(Object object, CommandAdjuster pathStripper) {
@@ -763,7 +763,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
     // to explicitly check if an object is a DerivedArtifact. Unfortunately that would require
     // a lot more dependencies on the Java library DerivedArtifact is built into.
     return object instanceof DerivedArtifact
-        ? pathStripper.strip(((DerivedArtifact) object).getExecPath()).getPathString()
+        ? pathStripper.map(((DerivedArtifact) object).getExecPath()).getPathString()
         : CommandLineItem.expandToCommandLine(object);
   }
 


### PR DESCRIPTION
In more general implementations, paths will be "mapped" rather than just "stripped", which should be reflected in the method names.

Also makes it so that both interfaces use the same method signatures for similar functionality, potentially allowing them to be merged into a single interface in a follow-up change.