### PR TITLE
Add support for .tbz file extension in repository_ctx.download_and_extract

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
@@ -102,7 +102,7 @@ public class DecompressorValue implements SkyValue {
       return TarXzFunction.INSTANCE;
     } else if (baseName.endsWith(".tar.zst") || baseName.endsWith(".tzst")) {
       return TarZstFunction.INSTANCE;
-    } else if (baseName.endsWith(".tar.bz2")) {
+    } else if (baseName.endsWith(".tar.bz2") || baseName.endsWith(".tbz")) {
       return TarBz2Function.INSTANCE;
     } else if (baseName.endsWith(".ar") || baseName.endsWith(".deb")) {
       return ArFunction.INSTANCE;
@@ -110,7 +110,7 @@ public class DecompressorValue implements SkyValue {
       throw new RepositoryFunctionException(
           Starlark.errorf(
               "Expected a file with a .zip, .jar, .war, .aar, .tar, .tar.gz, .tgz, .tar.xz, .txz,"
-                  + " .tar.zst, .tzst, .tar.bz2, .ar or .deb suffix (got %s)",
+                  + " .tar.zst, .tzst, .tar.bz2, .tbz, .ar or .deb suffix (got %s)",
               archivePath),
           Transience.PERSISTENT);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -569,7 +569,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
                     + " the URL."
                     + " If the file has no extension, you can explicitly specify either \"zip\","
                     + " \"jar\", \"war\", \"aar\", \"tar\", \"tar.gz\", \"tgz\", \"tar.xz\","
-                    + " \"txz\", \".tar.zst\", \".tzst\", \"tar.bz2\", \".ar\", or \".deb\""
+                    + " \"txz\", \".tar.zst\", \".tzst\", \"tar.bz2\", \".tbz\", \".ar\", or \".deb\""
                     + " here."),
         @Param(
             name = "stripPrefix",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/DecompressorValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/DecompressorValueTest.java
@@ -57,6 +57,8 @@ public class DecompressorValueTest {
     unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.bz2");
     unused = DecompressorValue.getDecompressor(path);
+    path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tbz");
+    unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.ar");
     unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.deb");


### PR DESCRIPTION
The `download_and_extract` function supported `.tar.bz2` files, but did not recognize `.tbz` as a valid file extension for those. This commit simply adds support for this, in the code, in the test and in the doc.

Fixes #17824