### PR TITLE
[6.2.0] Include build-tools/X.Y.Z/{lib,lib64}/** in the minimal set of SDK files used by the Android integration tests.

### DIFF
--- a/tools/android/android_sdk_repository_template.bzl
+++ b/tools/android/android_sdk_repository_template.bzl
@@ -90,6 +90,7 @@ def create_android_sdk_rules(
             "build-tools/%s/lib/d8.jar" % build_tools_directory,
             "build-tools/%s/lib/dx.jar" % build_tools_directory,
             "build-tools/%s/mainDexClasses.rules" % build_tools_directory,
+            ":build_tools_libs",
         ] + [
             "platforms/android-%d/%s" % (api_level, filename)
             for api_level in api_levels


### PR DESCRIPTION
This is necessary to reenable remote caching/execution for these tests (and make CI runs faster!). In the absence of this change, the tests will fail because the aapt/appt2/aidl/zipalign tools can't be dynamically linked in the remote environment. See issue #8235.

We need to wait until this change makes it into a Bazel release before reenabling the tests, as they inherit the SDK files from the Bazel that runs them.

Related to #8235.

PiperOrigin-RevId: 517180365
Change-Id: I2baa66af15af85349187e75e3acd4e3cb5d84a49