### PR TITLE
[6.2.0]Fix seeking of empty chunkers.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Chunker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Chunker.java
@@ -159,14 +159,14 @@ public class Chunker {
   public void seek(long toOffset) throws IOException {
     // For compressed stream, we need to reinitialize the stream since the offset refers to the
     // uncompressed form.
-    if (initialized && toOffset >= offset && !compressed) {
+    if (initialized && size > 0 && toOffset >= offset && !compressed) {
       ByteStreams.skipFully(data, toOffset - offset);
       offset = toOffset;
     } else {
       reset();
       initialize(toOffset);
     }
-    if (data.finished()) {
+    if (size > 0 && data.finished()) {
       close();
     }
   }
@@ -216,7 +216,7 @@ public class Chunker {
     maybeInitialize();
 
     if (size == 0) {
-      data = null;
+      close();
       return emptyChunk;
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkerTest.java
@@ -84,8 +84,17 @@ public class ChunkerTest {
 
   @Test
   public void emptyData() throws Exception {
-    byte[] data = new byte[0];
-    Chunker chunker = Chunker.builder().setInput(data).build();
+    var inp =
+        new ByteArrayInputStream(new byte[0]) {
+          private boolean closed;
+
+          @Override
+          public void close() throws IOException {
+            closed = true;
+            super.close();
+          }
+        };
+    Chunker chunker = Chunker.builder().setInput(0, inp).build();
 
     assertThat(chunker.hasNext()).isTrue();
 
@@ -96,6 +105,7 @@ public class ChunkerTest {
     assertThat(next.getOffset()).isEqualTo(0);
 
     assertThat(chunker.hasNext()).isFalse();
+    assertThat(inp.closed).isTrue();
 
     assertThrows(NoSuchElementException.class, () -> chunker.next());
   }
@@ -191,6 +201,21 @@ public class ChunkerTest {
     assertThat(chunk.getOffset()).isEqualTo(8);
     assertThat(chunk.getData().toByteArray()).isEqualTo(new byte[] {8, 9});
     assertThat(chunker.hasNext()).isFalse();
+  }
+
+  @Test
+  public void seekEmptyData() throws IOException {
+    var chunker = Chunker.builder().setInput(new byte[0]).build();
+    for (var i = 0; i < 2; i++) {
+      chunker.seek(0);
+      var next = chunker.next();
+      assertThat(next).isNotNull();
+      assertThat(next.getData()).isEmpty();
+      assertThat(next.getOffset()).isEqualTo(0);
+
+      assertThat(chunker.hasNext()).isFalse();
+      assertThrows(NoSuchElementException.class, chunker::next);
+    }
   }
 
   @Test


### PR DESCRIPTION
Empty chunkers are strange in that they emit one empty chunk and then end. This change makes them properly resetable. Previously, reset() on a empty chunker could result in a NullPointerException.

Also, it's important to call close() on the underlying data stream even if it's empty.

Closes #17797.
Commit: [cfef67d](https://github.com/bazelbuild/bazel/commit/cfef67da634996f09e5f2509e198cc73c88ce8b2) 

PiperOrigin-RevId: 517119206
Change-Id: Iff7908d6cd0633aa2a355ea89f8e647a9fefffcd