### PR TITLE
Auto-label opened issues

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,13 @@
+# Add labels to opened issues based on what's in the issue description
+
+"type: feature request":
+    - 'Description of the feature request'
+
+"type: bug":
+    - 'Description of the bug'
+
+
+# Add the 'untriaged' label to all opened issues
+
+"untriaged":
+    - ''

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,21 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v2.5
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/issue-labeler.yml
+        enable-versioned-regex: 0
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-assignees@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          assignees: bazelbuild/triage


### PR DESCRIPTION
Update parts of the issue triage process. 

When a new issue is opened,
- Add the "untriaged" label
- Add the "type: bug" or "type: feature request" label (based on issue templates), if applicable
- Assign to `@bazelbuild/triage` who will then:
	- Verify that the issue is valid and reproduce/close, if possible
	- Add/remove labels as needed, e.g. team-X, more-data-needed
	- Unassign themselves
	