### PR TITLE
Use COVERAGE_RCFILE environment variable if specified.

### DIFF
--- a/tools/python/python_bootstrap_template.txt
+++ b/tools/python/python_bootstrap_template.txt
@@ -388,11 +388,13 @@ def _RunForCoverage(python_program, main_filename, args, env,
         directory under the runfiles tree, and will recursively delete the
         runfiles directory if set.
   """
-  # We need for coveragepy to use relative paths.  This can only be configured
-  # via an rc file, so we need to make one.
-  rcfile_name = os.path.join(os.environ['COVERAGE_DIR'], '.coveragerc')
-  with open(rcfile_name, "w") as rcfile:
-    rcfile.write('''[run]
+  rcfile_name = os.environ.get('COVERAGE_RCFILE', None)
+  if rcfile_name is None or not os.path.exists(rcfile_name):
+      # We need for coveragepy to use relative paths.  This can only be configured
+      # via an rc file, so we need to make one.
+      rcfile_name = os.path.join(os.environ['COVERAGE_DIR'], '.coveragerc')
+      with open(rcfile_name, "w") as rcfile:
+          rcfile.write('''[run]
 relative_files = True
 ''')
   PrintVerboseCoverage('Coverage entrypoint:', coverage_entrypoint)


### PR DESCRIPTION
Fixes #17844

Python coverage does not allow to modify a generated coverage rcfile with content
```
[run]
relative_files = True
```
and it would be nice to have a possibility to use a developer-defined rc file, eg. pyproject.toml, in bazel coverage actions.

The PR adds a check if [`COVERAGE_RCFILE` variable](https://coverage.readthedocs.io/en/latest/config.html) is set and if the referenced rc file exists then the user-specified path will be used in `--rcfile` command line option, otherwise previous behaviour is preserved.
