### PR TITLE
Use less subshells and `tee`s in running tests with `bazel run`.

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -323,9 +323,9 @@ if [[ "${EXPERIMENTAL_SPLIT_XML_GENERATION}" == "1" ]]; then
   fi
 else
   if [ -z "$COVERAGE_DIR" ]; then
-    ("${TEST_PATH}" "$@" 2> >(tee -a "${XML_OUTPUT_FILE}.log" >&2) 1> >(tee -a "${XML_OUTPUT_FILE}.log") 2>&1) <&0 &
+    ("${TEST_PATH}" "$@" 2>&1 | tee -a "${XML_OUTPUT_FILE}.log") <&0 &
   else
-    ("$1" "$TEST_PATH" "${@:3}" 2> >(tee -a "${XML_OUTPUT_FILE}.log" >&2) 1> >(tee -a "${XML_OUTPUT_FILE}.log") 2>&1) <&0 &
+    ("$1" "$TEST_PATH" "${@:3}" 2>&1 | tee -a "${XML_OUTPUT_FILE}.log") <&0 &
   fi
 fi
 childPid=$!


### PR DESCRIPTION
Fixes #17754.

What we have seen prior to this change was that sometimes for quick tests the output was swallowed. After a lot of poking it became clear that the culprit is the use of subshell and `tee`, e.g. if you remove `tee` completely from the picture the behavior never shows up.

The issue is that with a fast test, `tee` seems to be killed (or its parent subshell) before the printing the output to stdout.

With this change, we reduce the number of subshells and processes to set up and reduce the chance of the race condition but not remove it.

However, for practical purposes, the race condition is gone.

With the reproduction steps in #17754, and this command
```
for i in {1..10000}; do /tmp/bazel run :foo &> /tmp/log ; grep -q "useful echo" /tmp/log ; if [ $? -eq 0 ]; then echo -n '+'; else  echo -n '-'; fi; done
```
a bazel from head fails ~3900 out of 10000 times.

After this commit, it never failed.