### PR TITLE
Push down forceExclusiveIfLocalTestsInParallel() into SpawnStrategy

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnStrategy.java
@@ -63,4 +63,15 @@ public interface SpawnStrategy {
   // TODO(katre): Remove once strategies are only instantiated if used, the callback can then be
   //  done upon construction.
   default void usedContext(ActionContext.ActionContextRegistry actionContextRegistry) {}
+
+  /**
+   * Returns {@code true} to indicate that "exclusive-if-local" tests should be treated as regular
+   * parallel tests.
+   *
+   * <p>Returning {@code true} may make sense for certain remote spawn strategies where running
+   * tests in sequence would be wasteful.
+   */
+  default boolean forceExclusiveIfLocalTestsInParallel() {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -398,6 +398,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/exec:bin_tools",
         "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
+        "//src/main/java/com/google/devtools/build/lib/exec:spawn_strategy_registry",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_strategy_resolver",
         "//src/main/java/com/google/devtools/build/lib/exec:streamed_test_output",
         "//src/main/java/com/google/devtools/build/lib/exec:test_log_helper",

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionContext.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.view.test.TestStatus.TestResultData;
@@ -102,9 +103,7 @@ public interface TestActionContext extends ActionContext {
    * <p>Returning {@code true} may make sense for certain remote test execution strategies where
    * running tests in sequence would be wasteful.
    */
-  default boolean forceExclusiveIfLocalTestsInParallel() {
-    return false;
-  }
+  boolean forceExclusiveIfLocalTestsInParallel(SpawnStrategyRegistry spawnStrategyRegistry);
 
   /** Creates a cached test result. */
   TestResult newCachedTestResult(Path execRoot, TestRunnerAction action, TestResultData cached)

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
@@ -45,6 +45,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.OutputFilter;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
+import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
 import com.google.devtools.build.lib.pkgcache.LoadingFailedException;
 import com.google.devtools.build.lib.profiler.ProfilePhase;
 import com.google.devtools.build.lib.profiler.Profiler;
@@ -205,7 +206,9 @@ public class BuildTool {
           analysisResult = analysisResult.withExclusiveTestsAsParallelTests();
         }
         if (!analysisResult.getExclusiveIfLocalTests().isEmpty()
-            && executionTool.getTestActionContext().forceExclusiveIfLocalTestsInParallel()) {
+            && executionTool
+                   .getTestActionContext()
+                   .forceExclusiveIfLocalTestsInParallel(executionTool.getSpawnStrategyRegistry())) {
           analysisResult = analysisResult.withExclusiveIfLocalTestsAsParallelTests();
         }
 
@@ -354,7 +357,7 @@ public class BuildTool {
                   public boolean forceExclusiveIfLocalTestsInParallel() {
                     return executionTool
                         .getTestActionContext()
-                        .forceExclusiveIfLocalTestsInParallel();
+                        .forceExclusiveIfLocalTestsInParallel(executionTool.getSpawnStrategyRegistry());
                   }
                 });
         buildCompleted = true;

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -203,6 +203,10 @@ public class ExecutionTool {
     this.spawnStrategyRegistry = spawnStrategyRegistry;
   }
 
+  SpawnStrategyRegistry getSpawnStrategyRegistry() {
+    return spawnStrategyRegistry;
+  }
+
   Executor getExecutor() throws AbruptExitException {
     if (executor == null) {
       executor = createExecutor();

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -350,6 +350,7 @@ java_library(
         ":bin_tools",
         ":execution_options",
         ":spawn_exec_exception",
+        ":spawn_strategy_registry",
         ":spawn_strategy_resolver",
         ":standalone_test_result",
         ":test_policy",

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import com.google.devtools.build.lib.actions.SpawnStrategy;
 import com.google.devtools.build.lib.actions.TestExecException;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.test.TestAttempt;
@@ -47,6 +48,7 @@ import com.google.devtools.build.lib.buildeventstream.TestFileNameConstants;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
 import com.google.devtools.build.lib.server.FailureDetails.Execution.Code;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.TestAction;
@@ -83,6 +85,14 @@ public class StandaloneTestStrategy extends TestStrategy {
           .put("TEST_TMPDIR", TestPolicy.TEST_TMP_DIR)
           .put("RUN_UNDER_RUNFILES", "1")
           .build();
+
+  @Override
+  public boolean forceExclusiveIfLocalTestsInParallel(SpawnStrategyRegistry spawnStrategyRegistry) {
+    List<? extends SpawnStrategy> strategies =
+        spawnStrategyRegistry
+            .getStrategies(null, TestRunnerAction.MNEMONIC, null);
+    return !strategies.isEmpty() && strategies.get(0).forceExclusiveIfLocalTestsInParallel();
+  }
 
   public static final TestPolicy DEFAULT_LOCAL_POLICY = new TestPolicy(ENV_VARS);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -171,6 +171,7 @@ final class RemoteActionContextProvider {
   public void registerRemoteSpawnStrategy(SpawnStrategyRegistry.Builder registryBuilder) {
     ExecutionOptions executionOptions =
         checkNotNull(env.getOptions().getOptions(ExecutionOptions.class));
+    RemoteExecutionService remoteExecutionService = getRemoteExecutionService();
     RemoteSpawnRunner spawnRunner =
         new RemoteSpawnRunner(
             env.getExecRoot(),
@@ -180,9 +181,9 @@ final class RemoteActionContextProvider {
             env.getReporter(),
             retryScheduler,
             logDir,
-            getRemoteExecutionService());
+            remoteExecutionService);
     registryBuilder.registerStrategy(
-        new RemoteSpawnStrategy(env.getExecRoot(), spawnRunner, executionOptions), "remote");
+        new RemoteSpawnStrategy(env.getExecRoot(), remoteExecutionService, spawnRunner, executionOptions), "remote");
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -343,6 +343,11 @@ public class RemoteExecutionService {
         && Spawns.mayBeExecutedRemotely(spawn);
   }
 
+  public boolean forceExclusiveIfLocalTestsInParallel() {
+    return remoteCache instanceof RemoteExecutionCache
+        && remoteExecutor != null;
+  }
+
   private SortedMap<PathFragment, ActionInput> buildOutputDirMap(Spawn spawn) {
     TreeMap<PathFragment, ActionInput> outputDirMap = new TreeMap<>();
     for (ActionInput output : spawn.getOutputFiles()) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnStrategy.java
@@ -23,12 +23,22 @@ import com.google.devtools.build.lib.vfs.Path;
  * strategy also support offloading the work to a remote worker.
  */
 final class RemoteSpawnStrategy extends AbstractSpawnStrategy {
-  RemoteSpawnStrategy(Path execRoot, SpawnRunner spawnRunner, ExecutionOptions executionOptions) {
+
+  private final RemoteExecutionService remoteExecutionService;
+
+  RemoteSpawnStrategy(Path execRoot, RemoteExecutionService remoteExecutionService, SpawnRunner spawnRunner, ExecutionOptions executionOptions) {
     super(execRoot, spawnRunner, executionOptions);
+
+    this.remoteExecutionService = remoteExecutionService;
   }
 
   @Override
   public String toString() {
     return "remote";
+  }
+
+  @Override
+  public boolean forceExclusiveIfLocalTestsInParallel() {
+    return remoteExecutionService.forceExclusiveIfLocalTestsInParallel();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/BUILD
@@ -115,6 +115,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:transitive_info_provider",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/exec:spawn_strategy_registry",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/rules/core",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test",

--- a/src/main/java/com/google/devtools/build/lib/rules/test/ExclusiveTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/ExclusiveTestStrategy.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.analysis.test.TestActionContext;
 import com.google.devtools.build.lib.analysis.test.TestResult;
 import com.google.devtools.build.lib.analysis.test.TestRunnerAction;
+import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.view.test.TestStatus.TestResultData;
 import java.io.IOException;
@@ -48,6 +49,11 @@ public class ExclusiveTestStrategy implements TestActionContext {
   @Override
   public boolean isTestKeepGoing() {
     return parent.isTestKeepGoing();
+  }
+
+  @Override
+  public boolean forceExclusiveIfLocalTestsInParallel(SpawnStrategyRegistry spawnStrategyRegistry) {
+    return parent.forceExclusiveIfLocalTestsInParallel(spawnStrategyRegistry);
   }
 
   @Override


### PR DESCRIPTION
TestActionContext has this method right now, which is used to control whether "exclusive-if-local" tests may run in parallel or not. Unfortunately, in Bazel only the default implementation is used, which always returns false. This causes tests to be run sequentially, even if run remotely.

In order to implement this function properly, we need to call into the underlying SpawnStrategy to ask it whether tests may run in parallel. That's why we add an equally named method to that interface.

A single invocation of Bazel may use multiple instances of SpawnStrategy, controlled through the --strategy flag. In our case we need to consider the SpawnRunner associated with action mnemonic "TestRunner". For that we need to pass down the SpawnStrategyRegistry.

Fixes: #17834