### PR TITLE
[6.2.0]Suggest alternatives for typoed rule attribute names

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -81,6 +81,7 @@ import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.spelling.SpellChecker;
 import net.starlark.java.syntax.Location;
 
 /**
@@ -2146,7 +2147,16 @@ public class RuleClass {
       if (attrIndex == null) {
         rule.reportError(
             String.format(
-                "%s: no such attribute '%s' in '%s' rule", rule.getLabel(), attributeName, name),
+                "%s: no such attribute '%s' in '%s' rule%s",
+                rule.getLabel(),
+                attributeName,
+                name,
+                SpellChecker.didYouMean(
+                    attributeName,
+                    rule.getAttributes().stream()
+                        .filter(Attribute::isDocumented)
+                        .map(Attribute::getName)
+                        .collect(ImmutableList.toImmutableList()))),
             eventHandler);
         continue;
       }


### PR DESCRIPTION
Closes #17847.
Commit: [745ca28](https://github.com/bazelbuild/bazel/commit/745ca288770253225d5d96069038a5d735eda69b)

PiperOrigin-RevId: 518664847
Change-Id: I99d09be093e785c7d1ad437d40866423638be118