### PR TITLE
Remove macOS CLT from toolchain setup

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -488,10 +488,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
             cc,
             "-xc++",
             cxx_opts + no_canonical_prefixes_opt + ["-stdlib=libc++"],
-        ) +
-        # Always included in case the user has Xcode + the CLT installed, both
-        # paths can be used interchangeably
-        ["/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"],
+        ),
     )
 
     if is_clang:


### PR DESCRIPTION
Theoretically these should be picked up by the calls above that fetch the actual include paths given the current compiler. At some point when I added this it seemed like that wasn't the case if you had both Xcode and the CLT installed, but I cannot reproduce that case to debug. This otherwise massively increased the toolchain setup time when generating the module map.

Fixes https://github.com/bazelbuild/bazel/pull/16619#issuecomment-1465785062