### PR TITLE
Updates to PR labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,3 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4
+      if: ${{ github.event.pull_request.draft == 'false' }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,8 @@
-name: "Pull Request Labeler"
+name: "PR Labeler"
+
 on:
-- pull_request_target
+  pull_request_target:
+    types: ["opened"]
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4
-      if: ${{ github.event.pull_request.draft == 'false' }}
+      if: ${{ github.event.pull_request.draft == false }}


### PR DESCRIPTION
- explicitly run only when a PR is opened
- don't run on draft PRs