### PR TITLE
Relax JSON parser, ensure duplicate keys are overridden

### DIFF
--- a/src/main/java/net/starlark/java/lib/json/Json.java
+++ b/src/main/java/net/starlark/java/lib/json/Json.java
@@ -287,7 +287,8 @@ public final class Json implements StarlarkValue {
               + " a decimal point or an exponent. Although JSON has no syntax "
               + " for non-finite values, very large values may be decoded as infinity.\n"
               + "<li>a JSON object is parsed as a new unfrozen Starlark dict."
-              + " Keys must be unique strings.\n"
+              + " If the same key string occurs more than once in the object, the last"
+              + " value for the key is kept.\n"
               + "<li>a JSON array is parsed as new unfrozen Starlark list.\n"
               + "</ul>\n"
               + "Decoding fails if x is not a valid JSON encoding.\n",
@@ -398,11 +399,7 @@ public final class Json implements StarlarkValue {
               }
               i++; // ':'
               Object value = parse();
-              int sz = dict.size();
               dict.putEntry((String) key, value); // can't fail
-              if (dict.size() == sz) {
-                throw Starlark.errorf("object has duplicate key: %s", Starlark.repr(key));
-              }
               c = next();
               if (c != ',') {
                 if (c != '}') {

--- a/src/test/java/net/starlark/java/eval/testdata/json.star
+++ b/src/test/java/net/starlark/java/eval/testdata/json.star
@@ -80,6 +80,9 @@ assert_eq(json.decode('"\\u0123"'), 'ģ')
 assert_eq(json.decode('\t[\t1,\r2,\n3]\n'), [1, 2, 3]) # whitespace other than ' '
 assert_eq(json.decode('\n{\t"a":\r1\t}\n'), {'a': 1}) # same, with dict
 assert_eq(json.decode(r'"\\\/\"\n\r\t"'), "\\/\"\n\r\t") # TODO(adonovan): test \b\f when Starlark/Java supports them
+assert_eq(json.decode('{"x": 1, "x": 2}'), {"x": 2})
+assert_eq(json.decode('{"x": {"y": 1, "y": 2}}'), {"x": {"y": 2}})
+assert_eq(json.decode('{"x": {"y": 1, "z": 1}, "x": {"y": 2}}'), {"x": {"y": 2}})
 
 # We accept UTF-16 strings that have been arbitrarily truncated,
 # as many Java and JavaScript programs emit them.
@@ -123,7 +126,6 @@ assert_fails(lambda: json.decode('[1, 2}'), "got \"}\", want ',' or ']'")
 assert_fails(lambda: json.decode('{"one": 1'), "unexpected end of file")
 assert_fails(lambda: json.decode('{"one" 1'), 'after object key, got "1", want \':\'')
 assert_fails(lambda: json.decode('{"one": 1 "two": 2'), "in object, got ..\"., want ',' or '}'")
-assert_fails(lambda: json.decode('{"x": 1, "x": 2}'), 'object has duplicate key: "x"')
 assert_fails(lambda: json.decode('{1:2}'), "got int for object key, want string")
 assert_fails(lambda: json.decode('{"one": 1,'), "unexpected end of file")
 assert_fails(lambda: json.decode('{"one": 1, }'), 'unexpected character "}"')


### PR DESCRIPTION
Resolves #15605

Requested to be cherry-picked into 6.2.0 at https://github.com/bazelbuild/bazel/issues/15605#issuecomment-1481512613 in order to fix npm_import.