### PR TITLE
Fixing windows launcher maker compilation with mingw-gcc

### DIFF
--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -216,7 +216,7 @@ FILETIME WindowsFileMtime::GetFuture(WORD years) {
   GetSystemTimeAsFileTime(&result);
 
   // 1 year in FILETIME.
-  constexpr ULONGLONG kOneYear = 365ULL * 24 * 60 * 60 * 10'000'000;
+  constexpr ULONGLONG kOneYear = 365ULL * 24 * 60 * 60 * 10000000;
 
   ULARGE_INTEGER result_value;
   result_value.LowPart = result.dwLowDateTime;

--- a/src/main/cpp/util/port.h
+++ b/src/main/cpp/util/port.h
@@ -140,7 +140,9 @@ char (&ArraySizeHelper(const T (&array)[N]))[N];
 // wherever else it appears. Find some way to not have to declare a pid_t here,
 // either by making PID handling platform-independent or some other idea; remove
 // the following typedef afterwards.
+#ifndef __MINGW32__
 typedef int pid_t;
+#endif  // __MINGW32__
 #endif  // _WIN32
 
 #endif  // BAZEL_SRC_MAIN_CPP_UTIL_PORT_H_

--- a/src/main/cpp/util/strings.h
+++ b/src/main/cpp/util/strings.h
@@ -29,7 +29,7 @@ namespace blaze_util {
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52015.
 template <typename T>
 std::string ToString(const T &value) {
-#if defined(__CYGWIN__) || defined(__MINGW32__)
+#if defined(__CYGWIN__)
   std::ostringstream oss;
   oss << value;
   return oss.str();

--- a/src/tools/launcher/launcher_maker.cc
+++ b/src/tools/launcher/launcher_maker.cc
@@ -54,13 +54,13 @@ int main(int argc, char** argv) {
   std::wstring winfo_params = windows_path(argv[2]);
   std::wstring woutput_path = windows_path(argv[3]);
 
-  std::ifstream src(wlauncher_path, std::ios::binary);
+  std::ifstream src(wlauncher_path.c_str(), std::ios::binary);
   if (!src.good()) {
     fprintf(stderr, "Failed to open %ls: %s\n", wlauncher_path.c_str(),
             strerror(errno));
     return 1;
   }
-  std::ofstream dst(woutput_path, std::ios::binary);
+  std::ofstream dst(woutput_path.c_str(), std::ios::binary);
   if (!dst.good()) {
     fprintf(stderr, "Failed to create %ls: %s\n", woutput_path.c_str(),
             strerror(errno));
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
   }
   dst << src.rdbuf();
 
-  std::ifstream info_file(winfo_params);
+  std::ifstream info_file(winfo_params.c_str());
   if (!info_file.good()) {
     fprintf(stderr, "Failed to open %ls: %s\n", winfo_params.c_str(),
             strerror(errno));


### PR DESCRIPTION
src/tools/launcher/launcher_maker.cc : fix paths passed to fstream()

src/main/cpp/util/file_windows.cc : Using quotes to split integer literals is a c++14 feature 

src/main/cpp/util/port.h : `pid_t` is already defined with mingw

src/main/cpp/util/strings.h : `std::to_string` has been added to mingw, workaround is no longer necessary