### PR TITLE
starlark: Reduce allocations for `find`/`indexof` without `end`

### DIFF
--- a/src/test/java/net/starlark/java/eval/testdata/bench_string.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bench_string.star
@@ -1,0 +1,12 @@
+_haystack = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+_needle = "nostraaad"
+
+def _bench_find_with_start(b, start):
+    for _ in range(b.n):
+        _haystack.find(_needle, start)
+
+def bench_find(b):
+    _bench_find_with_start(b, 0)
+
+def bench_find_with_start(b):
+    _bench_find_with_start(b, 1)


### PR DESCRIPTION
By using the overload of `String#indexOf` that accepts a starting position, the common case of Starlark string forward searches that extend to the end of the string no longer requires allocations.

Before:
```
benchmark                        ops     cpu/op    wall/op   steps/op   alloc/op
bench_find                  33554431      223ns      221ns          6       143B
bench_find_with_start       33554431      238ns      236ns          6       631B
```

After:
```
benchmark                        ops     cpu/op    wall/op   steps/op   alloc/op
bench_find                  33554431      221ns      219ns          6       143B
bench_find_with_start       33554431      210ns      210ns          6       143B
```