### PR TITLE
Remove `LITE_RUNTIME` usage

### DIFF
--- a/src/main/protobuf/execution_statistics.proto
+++ b/src/main/protobuf/execution_statistics.proto
@@ -18,7 +18,6 @@ package tools.protos;
 
 option java_package = "com.google.devtools.build.lib.shell";
 option java_outer_classname = "Protos";
-option optimize_for = LITE_RUNTIME;
 
 // Verbatim representation of the rusage structure returned by getrusage(2).
 // For further details on all these cryptic names, see that manual page.


### PR DESCRIPTION
Protobuf no longer supports this option.