### PR TITLE
[6.2.0]Support (workspace) relative paths in --override_module

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -131,7 +131,12 @@ public class RepositoryOptions extends OptionsBase {
       converter = RepositoryOverrideConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "Overrides a repository with a local directory.")
+      help =
+          "Override a repository with a local path in the form of <repository name>=<path>. If the"
+              + " given path is an absolute path, it will be used as it is. If the given path is a"
+              + " relative path, it is relative to the current working directory. If the given path"
+              + " starts with '%workspace%, it is relative to the workspace root, which is the"
+              + " output of `bazel info workspace`")
   public List<RepositoryOverride> repositoryOverrides;
 
   @Option(
@@ -141,7 +146,12 @@ public class RepositoryOptions extends OptionsBase {
       converter = ModuleOverrideConverter.class,
       documentationCategory = OptionDocumentationCategory.BZLMOD,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "Overrides a module with a local directory.")
+      help =
+          "Override a module with a local path in the form of <module name>=<path>. If the given"
+              + " path is an absolute path, it will be used as it is. If the given path is a"
+              + " relative path, it is relative to the current working directory. If the given path"
+              + " starts with '%workspace%, it is relative to the workspace root, which is the"
+              + " output of `bazel info workspace`")
   public List<ModuleOverride> moduleOverrides;
 
   @Option(
@@ -305,17 +315,10 @@ public class RepositoryOptions extends OptionsBase {
         throw new OptionsParsingException(
             "Repository overrides must be of the form 'repository-name=path'", input);
       }
-      OptionsUtils.AbsolutePathFragmentConverter absolutePathFragmentConverter =
-          new OptionsUtils.AbsolutePathFragmentConverter();
-      PathFragment path;
+      OptionsUtils.PathFragmentConverter pathConverter = new OptionsUtils.PathFragmentConverter();
+      String pathString = pathConverter.convert(pieces[1]).getPathString();
       try {
-        path = absolutePathFragmentConverter.convert(pieces[1]);
-      } catch (OptionsParsingException e) {
-        throw new OptionsParsingException(
-            "Repository override directory must be an absolute path", input, e);
-      }
-      try {
-        return RepositoryOverride.create(RepositoryName.create(pieces[0]), path);
+        return RepositoryOverride.create(RepositoryName.create(pieces[0]), pathString);
       } catch (LabelSyntaxException e) {
         throw new OptionsParsingException("Invalid repository name given to override", input, e);
       }
@@ -347,15 +350,9 @@ public class RepositoryOptions extends OptionsBase {
                 pieces[0]));
       }
 
-      OptionsUtils.AbsolutePathFragmentConverter absolutePathFragmentConverter =
-          new OptionsUtils.AbsolutePathFragmentConverter();
-      try {
-        var path = absolutePathFragmentConverter.convert(pieces[1]);
-        return ModuleOverride.create(pieces[0], path.toString());
-      } catch (OptionsParsingException e) {
-        throw new OptionsParsingException(
-            "Module override directory must be an absolute path", input, e);
-      }
+      OptionsUtils.PathFragmentConverter pathConverter = new OptionsUtils.PathFragmentConverter();
+      String pathString = pathConverter.convert(pieces[1]).getPathString();
+      return ModuleOverride.create(pieces[0], pathString);
     }
 
     @Override
@@ -368,13 +365,13 @@ public class RepositoryOptions extends OptionsBase {
   @AutoValue
   public abstract static class RepositoryOverride {
 
-    private static RepositoryOverride create(RepositoryName repositoryName, PathFragment path) {
+    private static RepositoryOverride create(RepositoryName repositoryName, String path) {
       return new AutoValue_RepositoryOptions_RepositoryOverride(repositoryName, path);
     }
 
     public abstract RepositoryName repositoryName();
 
-    public abstract PathFragment path();
+    public abstract String path();
   }
 
   /** A module override, represented by a name and an absolute path to a module. */

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
@@ -45,21 +45,22 @@ public class RepositoryOptionsTest {
   public void testOverrideConverter() throws Exception {
     RepositoryOverride actual = converter.convert("foo=/bar");
     assertThat(actual.repositoryName()).isEqualTo(RepositoryName.createUnvalidated("foo"));
-    assertThat(actual.path()).isEqualTo(PathFragment.create("/bar"));
+    assertThat(PathFragment.create(actual.path())).isEqualTo(PathFragment.create("/bar"));
   }
 
   @Test
   public void testOverridePathWithEqualsSign() throws Exception {
     RepositoryOverride actual = converter.convert("foo=/bar=/baz");
     assertThat(actual.repositoryName()).isEqualTo(RepositoryName.createUnvalidated("foo"));
-    assertThat(actual.path()).isEqualTo(PathFragment.create("/bar=/baz"));
+    assertThat(PathFragment.create(actual.path())).isEqualTo(PathFragment.create("/bar=/baz"));
   }
 
   @Test
   public void testOverridePathWithTilde() throws Exception {
     RepositoryOverride actual = converter.convert("foo=~/bar");
     assertThat(actual.repositoryName()).isEqualTo(RepositoryName.createUnvalidated("foo"));
-    assertThat(actual.path()).isEqualTo(PathFragment.create(USER_HOME.value() + "/bar"));
+    assertThat(PathFragment.create(actual.path()))
+        .isEqualTo(PathFragment.create(USER_HOME.value() + "/bar"));
   }
 
   @Test
@@ -68,6 +69,15 @@ public class RepositoryOptionsTest {
     ModuleOverride actual = converter.convert("foo=~/bar");
     assertThat(PathFragment.create(actual.path()))
         .isEqualTo(PathFragment.create(USER_HOME.value() + "/bar"));
+  }
+
+  @Test
+  public void testModuleOverrideRelativePath() throws Exception {
+    var converter = new ModuleOverrideConverter();
+    ModuleOverride actual = converter.convert("foo=%workspace%/bar");
+    assertThat(actual.path()).isEqualTo("%workspace%/bar");
+    actual = converter.convert("foo=../../bar");
+    assertThat(actual.path()).isEqualTo("../../bar");
   }
 
   @Test
@@ -85,10 +95,4 @@ public class RepositoryOptionsTest {
     converter.convert("foo/bar=/baz");
   }
 
-  @Test
-  public void testInvalidPathOverride() throws Exception {
-    expectedException.expect(OptionsParsingException.class);
-    expectedException.expectMessage("Repository override directory must be an absolute path");
-    converter.convert("foo=bar");
-  }
 }

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -379,7 +379,8 @@ class BazelModuleTest(test_base.TestBase):
             in line for line in stderr
         ]))
 
-  def testCommandLineModuleOverride(self):
+  def testCmdAbsoluteModuleOverride(self):
+    # test commandline_overrides takes precedence over local_path_override
     self.ScratchFile('MODULE.bazel', [
         'bazel_dep(name = "ss", version = "1.0")',
         'local_path_override(',
@@ -406,14 +407,92 @@ class BazelModuleTest(test_base.TestBase):
     ])
     self.ScratchFile('bb/WORKSPACE')
 
-    _, _, stderr = self.RunBazel([
-        'build', '--experimental_enable_bzlmod', '@ss//:all',
-        '--override_module', 'ss=' + self.Path('bb')
-    ],
-                                 allow_failure=False)
+    _, _, stderr = self.RunBazel(
+        ['build', '@ss//:all', '--override_module', 'ss=' + self.Path('bb')],
+        allow_failure=False,
+    )
     # module file override should be ignored, and bb directory should be used
     self.assertIn(
         'Target @ss~override//:choose_me up-to-date (nothing to build)', stderr)
+
+  def testCmdRelativeModuleOverride(self):
+    self.ScratchFile('aa/WORKSPACE')
+    self.ScratchFile(
+        'aa/MODULE.bazel',
+        [
+            'bazel_dep(name = "ss", version = "1.0")',
+        ],
+    )
+    self.ScratchFile('aa/BUILD')
+
+    self.ScratchFile('aa/cc/BUILD')
+
+    self.ScratchFile('bb/WORKSPACE')
+    self.ScratchFile(
+        'bb/MODULE.bazel',
+        [
+            'module(name="ss")',
+        ],
+    )
+    self.ScratchFile(
+        'bb/BUILD',
+        [
+            'filegroup(name = "choose_me")',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(
+        [
+            'build',
+            '@ss//:all',
+            '--override_module',
+            'ss=../../bb',
+            '--enable_bzlmod',
+        ],
+        cwd=self.Path('aa/cc'),
+        allow_failure=False,
+    )
+    self.assertIn(
+        'Target @ss~override//:choose_me up-to-date (nothing to build)', stderr
+    )
+
+  def testCmdWorkspaceRelativeModuleOverride(self):
+    self.ScratchFile('WORKSPACE')
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "ss", version = "1.0")',
+        ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile('aa/BUILD')
+    self.ScratchFile('bb/WORKSPACE')
+    self.ScratchFile(
+        'bb/MODULE.bazel',
+        [
+            'module(name="ss")',
+        ],
+    )
+    self.ScratchFile(
+        'bb/BUILD',
+        [
+            'filegroup(name = "choose_me")',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(
+        [
+            'build',
+            '@ss//:all',
+            '--override_module',
+            'ss=%workspace%/bb',
+        ],
+        cwd=self.Path('aa'),
+        allow_failure=False,
+    )
+    self.assertIn(
+        'Target @ss~override//:choose_me up-to-date (nothing to build)', stderr
+    )
 
   def testDownload(self):
     data_path = self.ScratchFile('data.txt', ['some data'])

--- a/src/test/shell/bazel/workspace_test.sh
+++ b/src/test/shell/bazel/workspace_test.sh
@@ -263,21 +263,18 @@ local_repository(
     path = "original",
 )
 EOF
+  # Test absolute path
   bazel build --override_repository="o=$PWD/override" @o//:gen &> $TEST_log \
     || fail "Expected build to succeed"
   assert_contains "override" bazel-genfiles/external/o/gen.out
-
+  # Test no override used
   bazel build @o//:gen &> $TEST_log \
     || fail "Expected build to succeed"
   assert_contains "original" bazel-genfiles/external/o/gen.out
-
-  bazel build --override_repository="o=$PWD/override" @o//:gen &> $TEST_log \
+  # Test relative path (should be relative to working directory)
+  bazel build --override_repository="o=override" @o//:gen &> $TEST_log \
     || fail "Expected build to succeed"
   assert_contains "override" bazel-genfiles/external/o/gen.out
-
-  bazel build @o//:gen &> $TEST_log \
-    || fail "Expected build to succeed"
-  assert_contains "original" bazel-genfiles/external/o/gen.out
 
   # For multiple override options, the latest should win
   bazel build --override_repository=o=/ignoreme \
@@ -285,6 +282,13 @@ EOF
         @o//:gen &> $TEST_log \
     || fail "Expected build to succeed"
   assert_contains "override" bazel-genfiles/external/o/gen.out
+
+  # Test workspace relative path
+  mkdir -p dummy
+  cd dummy
+  bazel build --override_repository="o=%workspace%/override" @o//:gen &> $TEST_log \
+    || fail "Expected build to succeed"
+  assert_contains "override" ../bazel-genfiles/external/o/gen.out
 
 }
 


### PR DESCRIPTION
closes https://github.com/bazelbuild/bazel/issues/17551
Commit: [f7627e0](https://github.com/bazelbuild/bazel/commit/f7627e00bf96c9159ab79a32afc4f6a622f0deeb)


PiperOrigin-RevId: 519710834
Change-Id: I992d68e40b600ba921000d34d878186701baad2c