### PR TITLE
Avoid unnecessary copying when building Merkle trees.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.MetadataProvider;
@@ -300,7 +299,7 @@ public class MerkleTree {
             subDirs.put(dir.getPathSegment(), subMerkleTree);
           }
           MerkleTree mt =
-              buildMerkleTree(new TreeSet<>(files), new TreeSet<>(symlinks), subDirs, digestUtil);
+              buildMerkleTree(files, symlinks, subDirs, digestUtil);
           m.put(dirname, mt);
         });
     MerkleTree rootMerkleTree = m.get(PathFragment.EMPTY_FRAGMENT);
@@ -326,11 +325,11 @@ public class MerkleTree {
     }
 
     // Some differ, do a full merge.
-    SortedSet<DirectoryTree.FileNode> files = Sets.newTreeSet();
+    SortedSet<DirectoryTree.FileNode> files = new TreeSet<>();
     for (MerkleTree merkleTree : merkleTrees) {
       files.addAll(merkleTree.getFiles());
     }
-    SortedSet<DirectoryTree.SymlinkNode> symlinks = Sets.newTreeSet();
+    SortedSet<DirectoryTree.SymlinkNode> symlinks = new TreeSet<>();
     for (MerkleTree merkleTree : merkleTrees) {
       symlinks.addAll(merkleTree.getSymlinks());
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -121,9 +122,9 @@ public abstract class DirectoryTreeTest {
     // Assert the lexicographical order as defined by the remote execution protocol
     tree.visit(
         (PathFragment dirname,
-            List<FileNode> files,
-            List<SymlinkNode> symlinks,
-            List<DirectoryNode> dirs) -> {
+            SortedSet<FileNode> files,
+            SortedSet<SymlinkNode> symlinks,
+            SortedSet<DirectoryNode> dirs) -> {
           assertThat(files).isInStrictOrder();
           assertThat(dirs).isInStrictOrder();
         });
@@ -141,9 +142,9 @@ public abstract class DirectoryTreeTest {
     List<DirectoryNode> directoryNodes = new ArrayList<>();
     tree.visit(
         (PathFragment dirname,
-            List<FileNode> files,
-            List<SymlinkNode> symlinks,
-            List<DirectoryNode> dirs) -> {
+            SortedSet<FileNode> files,
+            SortedSet<SymlinkNode> symlinks,
+            SortedSet<DirectoryNode> dirs) -> {
           int currDepth = dirname.segmentCount();
           if (currDepth == depth) {
             directoryNodes.addAll(dirs);
@@ -156,9 +157,9 @@ public abstract class DirectoryTreeTest {
     List<FileNode> fileNodes = new ArrayList<>();
     tree.visit(
         (PathFragment dirname,
-            List<FileNode> files,
-            List<SymlinkNode> symlinks,
-            List<DirectoryNode> dirs) -> {
+            SortedSet<FileNode> files,
+            SortedSet<SymlinkNode> symlinks,
+            SortedSet<DirectoryNode> dirs) -> {
           int currDepth = dirname.segmentCount();
           if (currDepth == depth) {
             fileNodes.addAll(files);


### PR DESCRIPTION
Instead of accumulating a single set of children in DirectoryTreeBuilder and later splitting it up into file, symlink and subdirectory sets, we can accumulate the latter directly.