### PR TITLE
Fail early if `use_extension` has a bad label

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -329,6 +329,23 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                 "dep~2.0~myext2~myext"));
   }
 
+  @Test
+  public void useExtensionBadLabelFails() throws Exception {
+    Module root =
+        Module.builder()
+            .addExtensionUsage(createModuleExtensionUsage("@foo//:defs.bzl", "bar"))
+            .build();
+    ImmutableMap<ModuleKey, Module> depGraph = ImmutableMap.of(ModuleKey.ROOT, root);
+
+    resolutionFunctionMock.setDepGraph(depGraph);
+    EvaluationResult<BazelDepGraphValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelDepGraphValue.KEY), evaluationContext);
+    if (!result.hasError()) {
+      fail("expected error about @foo not being visible, but succeeded");
+    }
+    assertThat(result.getError().toString()).contains("no repo visible as '@foo' here");
+  }
+
   private static class BazelModuleResolutionFunctionMock implements SkyFunction {
 
     private ImmutableMap<ModuleKey, Module> depGraph = ImmutableMap.of();


### PR DESCRIPTION
PiperOrigin-RevId: 520627028
Change-Id: Ib42df77b02674b3ea55639e163e369afbedebce9