### PR TITLE
Check target incompatibility before toolchain resolution

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -331,6 +331,7 @@ java_library(
         ":make_variable_supplier",
         ":options_diff_predicate",
         ":package_specification_provider",
+        ":platform_configuration",
         ":platform_options",
         ":provider_collection",
         ":repo_mapping_manifest_action",

--- a/src/main/java/com/google/devtools/build/lib/analysis/Util.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Util.java
@@ -96,6 +96,18 @@ public abstract class Util {
       }
     }
 
+    if (ruleContext.getRule().useToolchainResolution()) {
+      // Rules that participate in toolchain resolution implicitly depend on the target platform to
+      // check whether it matches the constraints in the target_compatible_with attribute.
+      if (ruleContext.getConfiguration().hasFragment(PlatformConfiguration.class)) {
+        PlatformConfiguration platformConfiguration = ruleContext.getConfiguration().getFragment(
+            PlatformConfiguration.class);
+        maybeImplicitDeps.add(
+            ConfiguredTargetKey.builder().setLabel(platformConfiguration.getTargetPlatform())
+                .setConfiguration(ruleContext.getConfiguration()).build());
+      }
+    }
+
     ToolchainCollection<ResolvedToolchainContext> toolchainContexts =
         ruleContext.getToolchainContexts();
     if (toolchainContexts != null) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.analysis.constraints;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact;
@@ -98,10 +99,12 @@ public class IncompatibleTargetChecker {
    * </ul>
    */
   public static class IncompatibleTargetProducer implements StateMachine, Consumer<SkyValue> {
+
     private final Target target;
     @Nullable // Non-null when the target has an associated rule.
     private final BuildConfigurationValue configuration;
     private final ConfigConditions configConditions;
+    // Non-null when the target has an associated rule and does not opt out of toolchain resolution.
     @Nullable private final PlatformInfo platformInfo;
     @Nullable private final NestedSetBuilder<Package> transitivePackages;
 
@@ -134,7 +137,7 @@ public class IncompatibleTargetChecker {
     @Nullable
     public StateMachine step(Tasks tasks, ExtendedEventHandler listener) {
       Rule rule = target.getAssociatedRule();
-      if (rule == null || rule.getRuleClass().equals("toolchain") || platformInfo == null) {
+      if (rule == null || !rule.useToolchainResolution() || platformInfo == null) {
         sink.accept(Optional.empty());
         return null;
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrerequisiteProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrerequisiteProducer.java
@@ -337,7 +337,8 @@ public final class PrerequisiteProducer {
           return false;
         }
 
-        if (!checkForIncompatibleTarget(env, state, transitivePackages)) {
+        if (!checkForIncompatibleTarget(env, state, targetAndConfiguration, configConditions,
+            platformInfo, transitivePackages)) {
           return false;
         }
       }
@@ -460,8 +461,10 @@ public final class PrerequisiteProducer {
    *
    * @return false if a {@code Skyframe} restart is needed.
    */
-  private boolean checkForIncompatibleTarget(
-      Environment env, State state, @Nullable NestedSetBuilder<Package> transitivePackages)
+  private static boolean checkForIncompatibleTarget(
+      Environment env, State state, TargetAndConfiguration targetAndConfiguration,
+      @Nullable ConfigConditions configConditions, @Nullable PlatformInfo targetPlatformInfo,
+      @Nullable NestedSetBuilder<Package> transitivePackages)
       throws InterruptedException, IncompatibleTargetException {
     if (state.incompatibleTarget == null) {
       if (state.incompatibleTargetProducer == null) {
@@ -471,7 +474,7 @@ public final class PrerequisiteProducer {
                     targetAndConfiguration.getTarget(),
                     targetAndConfiguration.getConfiguration(),
                     configConditions,
-                    platformInfo,
+                    targetPlatformInfo,
                     transitivePackages,
                     state));
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrerequisiteProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrerequisiteProducer.java
@@ -326,6 +326,7 @@ public final class PrerequisiteProducer {
       if (targetAndConfiguration.getTarget() instanceof Rule
           && ((Rule) targetAndConfiguration.getTarget()).useToolchainResolution()) {
         platformInfo = loadTargetPlatformInfo(env);
+        // loadTargetPlatformInfo may return null even when no deps are missing.
         if (env.valuesMissing()) {
           return false;
         }
@@ -429,11 +430,13 @@ public final class PrerequisiteProducer {
     return true;
   }
 
+  // May return null even when no deps are missing, use env.valuesMissing() to check.
   private PlatformInfo loadTargetPlatformInfo(Environment env)
       throws InterruptedException, ToolchainException {
     PlatformConfiguration platformConfiguration = targetAndConfiguration.getConfiguration()
         .getFragment(PlatformConfiguration.class);
     if (platformConfiguration == null) {
+      // No restart required in this case.
       return null;
     }
     Label targetPlatformLabel = platformConfiguration.getTargetPlatform();

--- a/src/test/java/com/google/devtools/build/lib/analysis/BuildViewTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BuildViewTest.java
@@ -46,6 +46,7 @@ import com.google.devtools.build.lib.packages.Type.ConversionException;
 import com.google.devtools.build.lib.pkgcache.LoadingFailureEvent;
 import com.google.devtools.build.lib.skyframe.ActionLookupConflictFindingFunction;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
+import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.testutil.TestConstants.InternalTestExecutionMode;
 import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
 import com.google.devtools.build.lib.util.Pair;
@@ -502,7 +503,8 @@ public class BuildViewTest extends BuildViewTestBase {
     Iterable<Label> labels = Iterables.transform(targets, TransitiveInfoCollection::getLabel);
     assertThat(labels)
         .containsExactly(
-            Label.parseCanonical("//package:inner"), Label.parseCanonical("//package:file"));
+            Label.parseCanonical("//package:inner"), Label.parseCanonical("//package:file"),
+            Label.parseCanonical(TestConstants.PLATFORM_LABEL));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
@@ -424,6 +424,9 @@ public final class GenRuleConfiguredTargetTest extends BuildViewTestCase {
           assertThat(getConfiguration(prereq)).isNull();
           foundSetup = true;
           break;
+        case "host":
+          // Ignore the dependency on the target platform.
+          break;
         default:
           fail("unexpected prerequisite " + prereq + " (name: " + name + ")");
       }

--- a/src/test/java/com/google/devtools/build/lib/metrics/MetricsCollectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/metrics/MetricsCollectorTest.java
@@ -619,8 +619,8 @@ public class MetricsCollectorTest extends BuildIntegrationTestCase {
     addOptions("--experimental_merged_skyframe_analysis_execution");
     BuildGraphMetrics expected =
         BuildGraphMetrics.newBuilder()
-            .setActionLookupValueCount(3)
-            .setActionLookupValueCountNotIncludingAspects(3)
+            .setActionLookupValueCount(8)
+            .setActionLookupValueCountNotIncludingAspects(8)
             .setActionCount(2)
             .setActionCountNotIncludingAspects(2)
             .setInputFileConfiguredTargetCount(1)

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -1584,4 +1584,33 @@ EOF
   expect_not_log "${debug_message5}"
 }
 
+function test_skipping_with_missing_toolchain() {
+  mkdir -p missing_toolchain
+
+  cat > missing_toolchain/BUILD <<'EOF'
+load(":rule.bzl", "my_rule")
+
+toolchain_type(name = "my_toolchain_type")
+
+my_rule(
+    name = "my_rule",
+    target_compatible_with = ["@platforms//:incompatible"],
+)
+EOF
+
+  cat > missing_toolchain/rule.bzl <<'EOF'
+def _my_rule_impl(ctx):
+    pass
+
+my_rule = rule(
+    _my_rule_impl,
+    toolchains = ["//missing_toolchain:my_toolchain_type"],
+)
+EOF
+
+  bazel build --show_result=10 //missing_toolchain:all &> "${TEST_log}" \
+    || fail "Bazel failed unexpectedly."
+  expect_log "Target //missing_toolchain:my_rule was skipped"
+}
+
 run_suite "target_compatible_with tests"


### PR DESCRIPTION
Known missing toolchains are a valid reason for declaring a target incompatible and should not result in the target failing to build rather than being skipped as incompatible.

This is realized by moving the check for target incompatibility to the beginning of `PrerequisiteProducer#evaluate`, which requires fetching the target platform and config conditions.