### PR TITLE
[6.2.0]Enable C++ deps pruning on Windows when PARSE_SHOWINCLUDES is available.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -337,6 +337,10 @@ public class CppCompileActionBuilder {
     return result.build();
   }
 
+  private boolean shouldParseShowIncludes() {
+    return featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES);
+  }
+
   /**
    * Returns the list of mandatory inputs for the {@link CppCompileAction} as configured.
    */
@@ -352,7 +356,7 @@ public class CppCompileActionBuilder {
     if (grepIncludes != null) {
       realMandatoryInputsBuilder.add(grepIncludes);
     }
-    if (!shouldScanIncludes && dotdFile == null) {
+    if (!shouldScanIncludes && dotdFile == null && !shouldParseShowIncludes()) {
       realMandatoryInputsBuilder.addTransitive(ccCompilationContext.getDeclaredIncludeSrcs());
       realMandatoryInputsBuilder.addTransitive(additionalPrunableHeaders);
     }
@@ -473,8 +477,7 @@ public class CppCompileActionBuilder {
   }
 
   public boolean dotdFilesEnabled() {
-    return cppSemantics.needsDotdInputPruning(configuration)
-        && !featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES);
+    return cppSemantics.needsDotdInputPruning(configuration) && !shouldParseShowIncludes();
   }
 
   public boolean serializedDiagnosticsFilesEnabled() {


### PR DESCRIPTION
This fixes #14947.

Closes #17928.
Commit: [788801a](https://github.com/bazelbuild/bazel/commit/788801a8fd30985a1831de805172d257c6f63691
)
PiperOrigin-RevId: 521446074
Change-Id: I4bc155f0245bc1933e86cd0b37762263437ed1fe