### PR TITLE
Fix CI breakages for release-6.2.0

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -216,6 +216,10 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
       # https://github.com/bazelbuild/bazel/issues/17447
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17456
+      - "-//src/test/shell/bazel:bazel_determinism_test"
+      # https://github.com/bazelbuild/bazel/issues/17457
+      - "-//src/test/shell/bazel:jdeps_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -158,7 +158,7 @@ tasks:
       - build
       - test
   macos:
-    xcode_version: "13.0"
+    xcode_version: "14.2"
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
@@ -214,6 +214,8 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
       # https://github.com/bazelbuild/bazel/issues/17411
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17447
+      - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -209,6 +209,10 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
       # https://github.com/bazelbuild/bazel/issues/17447
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17456
+      - "-//src/test/shell/bazel:bazel_determinism_test"
+      # https://github.com/bazelbuild/bazel/issues/17457
+      - "-//src/test/shell/bazel:jdeps_test"
   windows:
     shards: 4
     batch_commands:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -148,7 +148,7 @@ tasks:
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/import_deps_checker/..."
   macos:
-    xcode_version: "13.0"
+    xcode_version: "14.2"
     shards: 5
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -207,6 +207,8 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
       # https://github.com/bazelbuild/bazel/issues/17411
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17447
+      - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
   windows:
     shards: 4
     batch_commands:


### PR DESCRIPTION
- Pin Xcode version to 14.2, due to recent CI infrastructure change, Xcode 13.0 is no longer available.
- Disable GitRepositoryBlackBoxTest, bazel_determinism_test and jdeps_test