### PR TITLE
Rename `--experimental_remote_build_event_upload` to `--remote_build_event_upload`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -265,14 +265,15 @@ public final class RemoteOptions extends CommonRemoteOptions {
       effectTags = {OptionEffectTag.UNKNOWN},
       deprecationWarning =
           "--incompatible_remote_build_event_upload_respect_no_cache has been deprecated in favor"
-              + " of --experimental_remote_build_event_upload=minimal.",
+              + " of --remote_build_event_upload=minimal.",
       help =
           "If set to true, outputs referenced by BEP are not uploaded to remote cache if the"
               + " generating action cannot be cached remotely.")
   public boolean incompatibleRemoteBuildEventUploadRespectNoCache;
 
   @Option(
-      name = "experimental_remote_build_event_upload",
+      name = "remote_build_event_upload",
+      oldName = "experimental_remote_build_event_upload",
       defaultValue = "all",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},

--- a/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
+++ b/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
@@ -109,7 +109,7 @@ EOF
 
   bazel build \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"
 
@@ -130,7 +130,7 @@ EOF
 
   bazel build \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"
 
@@ -151,7 +151,7 @@ EOF
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
       --remote_upload_local_results=false \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"
 
@@ -176,7 +176,7 @@ EOF
       --disk_cache=$cache_dir \
       --incompatible_remote_results_ignore_disk \
       --remote_upload_local_results=false \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"
 
@@ -208,7 +208,7 @@ EOF
 
   bazel build \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
       //a:foo-alias >& $TEST_log || fail "Failed to build"
 
@@ -254,7 +254,7 @@ EOF
 
   bazel build \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"
 
@@ -280,7 +280,7 @@ EOF
 
   bazel test \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
       //a:test >& $TEST_log || fail "Failed to build"
 
@@ -303,7 +303,7 @@ EOF
 
   bazel build \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || true
 
@@ -324,7 +324,7 @@ EOF
 
   bazel build \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_remote_build_event_upload=minimal \
+      --remote_build_event_upload=minimal \
       --profile=mycommand.profile.gz \
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"


### PR DESCRIPTION
RELNOTES: `--experimental_remote_build_event_upload` has been renamed to `--remote_build_event_upload`