### PR TITLE
[6.2.0]Add attribute 'provides = [CcInfo]' to '_cc_proto_aspect'

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_proto_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_proto_library.bzl
@@ -261,6 +261,7 @@ _cc_proto_aspect = aspect(
     attr_aspects = ["deps"],
     fragments = ["cpp", "proto"],
     required_providers = [ProtoInfo],
+    provides = [CcInfo],
     attrs = {
         "_aspect_cc_proto_toolchain": attr.label(
             default = configuration_field(fragment = "proto", name = "proto_toolchain_for_cc"),


### PR DESCRIPTION
Commit: [70ce837](https://github.com/bazelbuild/bazel/commit/70ce8378638290295e17fb62e735a239f22672e6)

PiperOrigin-RevId: 518797574
Change-Id: I76d765743d59c580ee98731c694a5d0ead4ec730