### PR TITLE
Rename `--experimental_remote_cache_compression` to `--remote_cache_compression`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -251,8 +251,7 @@ class RemoteServerCapabilities {
       if (remoteOptions.cacheCompression
           && !cacheCap.getSupportedCompressorsList().contains(Compressor.Value.ZSTD)) {
         result.addError(
-            "--experimental_remote_cache_compression requested but remote does not support"
-                + " compression");
+            "--remote_cache_compression requested but remote does not support compression");
       }
 
       // Check result cache priority is in the supported range.

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -407,7 +407,8 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public boolean incompatibleRemoteDanglingSymlinks;
 
   @Option(
-      name = "experimental_remote_cache_compression",
+      name = "remote_cache_compression",
+      oldName = "experimental_remote_cache_compression",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},


### PR DESCRIPTION
We (and most of our customers) been using this in production for a long time, and at least since 6.0 haven’t run into any issue. It should no longer be marked experimental.

RELNOTES: `--experimental_remote_cache_compression` has been renamed to `--remote_cache_compression`