### PR TITLE
Rename `--experimental_action_cache_store_output_metadata` to `--action_cache_store_output_metadata`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -410,7 +410,8 @@ public class BuildRequestOptions extends OptionsBase {
   public boolean useActionCache;
 
   @Option(
-      name = "experimental_action_cache_store_output_metadata",
+      name = "action_cache_store_output_metadata",
+      oldName = "experimental_action_cache_store_output_metadata",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -451,9 +451,9 @@ public final class RemoteOptions extends CommonRemoteOptions {
       defaultValue = "null",
       expansion = {
         "--nobuild_runfile_links",
+        "--action_cache_store_output_metadata",
         "--experimental_inmemory_jdeps_files",
         "--experimental_inmemory_dotd_files",
-        "--experimental_action_cache_store_output_metadata",
         "--remote_download_outputs=minimal"
       },
       category = "remote",
@@ -461,9 +461,8 @@ public final class RemoteOptions extends CommonRemoteOptions {
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
           "Does not download any remote build outputs to the local machine. This flag is a shortcut"
-              + " for flags: --experimental_inmemory_jdeps_files,"
-              + " --experimental_inmemory_dotd_files,"
-              + " --experimental_action_cache_store_output_metadata and "
+              + " for flags: --action_cache_store_output_metadata,"
+              + " --experimental_inmemory_jdeps_files, --experimental_inmemory_dotd_files, and "
               + "--remote_download_outputs=minimal.")
   public Void remoteOutputsMinimal;
 
@@ -472,9 +471,9 @@ public final class RemoteOptions extends CommonRemoteOptions {
       oldName = "experimental_remote_download_toplevel",
       defaultValue = "null",
       expansion = {
+        "--action_cache_store_output_metadata",
         "--experimental_inmemory_jdeps_files",
         "--experimental_inmemory_dotd_files",
-        "--experimental_action_cache_store_output_metadata",
         "--remote_download_outputs=toplevel"
       },
       category = "remote",
@@ -482,9 +481,8 @@ public final class RemoteOptions extends CommonRemoteOptions {
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
           "Only downloads remote outputs of top level targets to the local machine. This flag is a"
-              + " shortcut for flags: --experimental_inmemory_jdeps_files,"
-              + " --experimental_inmemory_dotd_files,"
-              + " --experimental_action_cache_store_output_metadata and "
+              + " shortcut for flags: --action_cache_store_output_metadata,"
+              + " --experimental_inmemory_jdeps_files, --experimental_inmemory_dotd_files, and "
               + "--remote_download_outputs=toplevel.")
   public Void remoteOutputsToplevel;
 


### PR DESCRIPTION
This is now enabled by default when using `--remote_download_{minimal,toplevel}`. It’s stable and shouldn’t have the experimental label anymore.

RELNOTES: `--experimental_action_cache_store_output_metadata` has been renamed to `--action_cache_store_output_metadata`