### PR TITLE
Diff against a dedicated exec version of the baseline configuration 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -984,7 +984,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     exec.affectedByStarlarkTransition = affectedByStarlarkTransition;
     exec.outputDirectoryNamingScheme = outputDirectoryNamingScheme;
     exec.compilationMode = hostCompilationMode;
-    exec.isExec = false;
+    exec.isExec = true;
     exec.execConfigurationDistinguisherScheme = execConfigurationDistinguisherScheme;
     exec.outputPathsMode = outputPathsMode;
     exec.enableRunfiles = enableRunfiles;
@@ -1048,6 +1048,9 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     exec.allowUnresolvedSymlinks = allowUnresolvedSymlinks;
 
     exec.usePlatformsRepoForConstraints = usePlatformsRepoForConstraints;
+
+    // Disable extra actions
+    exec.actionListeners = ImmutableList.of();
     return exec;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -611,7 +611,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
-      metadataTags = {OptionMetadataTag.INTERNAL},
+      metadataTags = {OptionMetadataTag.INTERNAL, OptionMetadataTag.EXPLICIT_IN_OUTPUT_PATH},
       help = "Shows whether these options are set for an execution configuration.")
   public boolean isExec;
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
@@ -153,6 +153,10 @@ public class ExecutionTransitionFactory
       // TODO(blaze-configurability-team): These updates probably requires a bit too much knowledge
       //   of exactly how the immutable state and mutable state of BuildOptions is interacting.
       //   Might be good to have an option to wipeout that state rather than cloning so much.
+      // Note: It is important for correctness that the platformSuffix encodes whether the current
+      //   configuration is an exec configuration or not as this determines which baseline config
+      //   is used when computing the diff-based output directory suffix with
+      //   --experimental_output_directory_naming_scheme=diff_against_baseline.
       switch (coreOptions.execConfigurationDistinguisherScheme) {
         case LEGACY:
           coreOptions.platformSuffix =

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ExecutionTransitionFactory.java
@@ -124,11 +124,6 @@ public class ExecutionTransitionFactory
       BuildOptionsView execOptions =
           new BuildOptionsView(options.underlying().createExecOptions(), FRAGMENTS);
 
-      CoreOptions coreOptions = checkNotNull(execOptions.get(CoreOptions.class));
-      coreOptions.isExec = true;
-      // Disable extra actions
-      coreOptions.actionListeners = ImmutableList.of();
-
       // Then set the target to the saved execution platform if there is one.
       PlatformOptions platformOptions = execOptions.get(PlatformOptions.class);
       if (platformOptions != null) {
@@ -154,7 +149,7 @@ public class ExecutionTransitionFactory
 
       // The conditional use of a Builder above may have replaced result and underlying options
       //   with a clone so must refresh it.
-      coreOptions = result.get(CoreOptions.class);
+      CoreOptions coreOptions = result.get(CoreOptions.class);
       // TODO(blaze-configurability-team): These updates probably requires a bit too much knowledge
       //   of exactly how the immutable state and mutable state of BuildOptions is interacting.
       //   Might be good to have an option to wipeout that state rather than cloning so much.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BuildConfigurationFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BuildConfigurationFunction.java
@@ -100,7 +100,9 @@ public final class BuildConfigurationFunction implements SkyFunction {
       if (platformMappingValue == null) {
         return null;
       }
-      BuildOptions baselineOptions = PrecomputedValue.BASELINE_CONFIGURATION.get(env);
+      BuildOptions baselineOptions = targetOptions.get(CoreOptions.class).isExec
+          ? PrecomputedValue.EXEC_BASELINE_CONFIGURATION.get(env)
+          : PrecomputedValue.BASELINE_CONFIGURATION.get(env);
       try {
         BuildOptions mappedBaselineOptions =
             BuildConfigurationKey.withPlatformMapping(platformMappingValue, baselineOptions)

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
@@ -98,6 +98,8 @@ public final class PrecomputedValue implements SkyValue {
   // Unsharable because of complications in deserializing BuildOptions on startup due to caching.
   public static final Precomputed<BuildOptions> BASELINE_CONFIGURATION =
       new Precomputed<>("baseline_configuration", /*shareable=*/ false);
+  public static final Precomputed<BuildOptions> EXEC_BASELINE_CONFIGURATION =
+      new Precomputed<>("exec_baseline_configuration", /*shareable=*/ false);
 
   private final Object value;
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -1271,6 +1271,8 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory, Configur
 
   public void setBaselineConfiguration(BuildOptions buildOptions) {
     PrecomputedValue.BASELINE_CONFIGURATION.set(injectable(), buildOptions);
+    PrecomputedValue.EXEC_BASELINE_CONFIGURATION.set(injectable(),
+        buildOptions.createExecOptions());
   }
 
   public void injectExtraPrecomputedValues(List<PrecomputedValue.Injected> extraPrecomputedValues) {

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/ConfigurationTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/ConfigurationTestCase.java
@@ -136,6 +136,10 @@ public abstract class ConfigurationTestCase extends FoundationTestCase {
                 BuildOptions.getDefaultBuildOptionsForFragments(
                     ImmutableList.of(CoreOptions.class))),
             PrecomputedValue.injected(
+                PrecomputedValue.EXEC_BASELINE_CONFIGURATION,
+                BuildOptions.getDefaultBuildOptionsForFragments(
+                    ImmutableList.of(CoreOptions.class)).createExecOptions()),
+            PrecomputedValue.injected(
                 RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE, Optional.empty()),
             PrecomputedValue.injected(
                 RepositoryDelegatorFunction.REPOSITORY_OVERRIDES, ImmutableMap.of()),


### PR DESCRIPTION
When `--experimental_output_directory_naming_scheme` is set to
`diff_against_baseline`, the current configuration is diffed against a
baseline and a hash of the diff is appended to the output directory.

If a target that is built in the exec configuration transitions further,
the diff would, before this change, include the (substantial) set of
flags that differ between the top-level target and exec configuration.
This made caching less efficient across builds that change flags that
are reset by the exec configuration, e.g. `--collect_code_coverage`.

This is fixed by comparing exec configuration against a dedicated exec
version of the top-level target configuration, which is safe since
`is exec configuration` itself is explicit in the output path even with
non-default values of `--experimental_exec_configuration_distinguisher`.

This includes a cleanup: Now that the host configuration is gone, fixed
changes to the `CoreOptions` when switching to the exec configuration are
better handled in `CoreOptions#getExec`.

Work towards bazelbuild/rules_go#3472