### PR TITLE
Report failures to add permissions with JavaIoFileSystem

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -176,7 +176,9 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
     if (!file.exists()) {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
     }
-    file.setReadable(readable);
+    if (!file.setReadable(readable) && readable) {
+      throw new IOException(String.format("Failed to make %s readable", path));
+    }
   }
 
   @Override
@@ -185,7 +187,9 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
     if (!file.exists()) {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
     }
-    file.setWritable(writable);
+    if (!file.setWritable(writable) && writable) {
+      throw new IOException(String.format("Failed to make %s writable", path));
+    }
   }
 
   @Override
@@ -194,7 +198,9 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
     if (!file.exists()) {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
     }
-    file.setExecutable(executable);
+    if (!file.setExecutable(executable) && executable) {
+      throw new IOException(String.format("Failed to make %s executable", path));
+    }
   }
 
   @Override
@@ -464,12 +470,12 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
       }
 
       @Override
-      public long getSize() throws IOException {
+      public long getSize() {
         return attributes.size();
       }
 
       @Override
-      public long getLastModifiedTime() throws IOException {
+      public long getLastModifiedTime() {
         return attributes.lastModifiedTime().toMillis();
       }
 

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -182,12 +182,12 @@ public class WindowsFileSystem extends JavaIoFileSystem {
           }
 
           @Override
-          public long getSize() throws IOException {
+          public long getSize() {
             return attributes.size();
           }
 
           @Override
-          public long getLastModifiedTime() throws IOException {
+          public long getLastModifiedTime() {
             return attributes.lastModifiedTime().toMillis();
           }
 


### PR DESCRIPTION
Previously the return value of the `File#setX` functions was not
checked, thus masking potential errors. Since these functions are
expected to fail on Windows if asked to remove a permission, errors are
only reported when attempting to add one.

Also removes misleading `throws` declarations that may mask similar
issues of this type.