### PR TITLE
Make set{Executable,Readable} noops in WindowsFileSystem

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -221,6 +221,18 @@ public class WindowsFileSystem extends JavaIoFileSystem {
     return super.isDirectory(path, followSymlinks);
   }
 
+  @Override
+  protected void setReadable(PathFragment path, boolean readable) {
+    // Windows does not have a notion of readable files.
+    // https://github.com/openjdk/jdk/blob/e52a2aeeacaeb26c801b6e31f8e67e61b1ea2de3/src/java.base/windows/native/libjava/WinNTFileSystem_md.c#L473-L476
+  }
+
+  @Override
+  protected void setExecutable(PathFragment path, boolean executable) {
+    // Windows does not have a notion of executable files.
+    // https://github.com/openjdk/jdk/blob/e52a2aeeacaeb26c801b6e31f8e67e61b1ea2de3/src/java.base/windows/native/libjava/WinNTFileSystem_md.c#L473-L476
+  }
+
   /**
    * Returns true if the path refers to a directory junction, directory symlink, or regular symlink.
    *


### PR DESCRIPTION
Windows does not have the concept of readable or executable files, so these calls would eventually end up in noop calls. Making them noops right away skips an unnecessary existence check.