### PR TITLE
Allow null values from apkSigningMethodV4

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.docgen.annot.DocCategory;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.StarlarkValue;
+import javax.annotation.Nullable;
 
 /** Configuration fragment for Android rules. */
 @StarlarkBuiltin(
@@ -68,6 +69,7 @@ public interface AndroidConfigurationApi extends StarlarkValue {
   boolean apkSigningMethodV2();
 
   @StarlarkMethod(name = "apk_signing_method_v4", structField = true, doc = "", documented = false, allowReturnNones = true)
+  @Nullable
   Boolean apkSigningMethodV4();
 
   @StarlarkMethod(name = "assume_min_sdk_version", structField = true, doc = "", documented = false)

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
@@ -67,7 +67,7 @@ public interface AndroidConfigurationApi extends StarlarkValue {
   @StarlarkMethod(name = "apk_signing_method_v2", structField = true, doc = "", documented = false)
   boolean apkSigningMethodV2();
 
-  @StarlarkMethod(name = "apk_signing_method_v4", structField = true, doc = "", documented = false)
+  @StarlarkMethod(name = "apk_signing_method_v4", structField = true, doc = "", documented = false, allowReturnNones = true)
   Boolean apkSigningMethodV4();
 
   @StarlarkMethod(name = "assume_min_sdk_version", structField = true, doc = "", documented = false)


### PR DESCRIPTION
Trying to access the field from starark when null crashes bazel. apkSigningMethodV4 is implemented using Boolean instead of boolean and thus can return null values. The method is annotated with @Nullable in java but disallows null return values in starlark.