### PR TITLE
Disable visibility checking for toolchains.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelPrerequisiteValidator.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelPrerequisiteValidator.java
@@ -40,7 +40,7 @@ public class BazelPrerequisiteValidator extends CommonPrerequisiteValidator {
 
   @Override
   protected boolean checkVisibilityForToolchains(RuleContext.Builder context) {
-    return true;
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Visibility checking for toolchains seems like a fine thing to do, but c2d06b9ba95d9ad800a3d1e7880dd8f2185ff504 enabled it without any consideration for backwards compatibility.