### PR TITLE
Fix broken links to “JSON Trace Profile” page

### DIFF
--- a/site/en/advanced/performance/build-performance-breakdown.md
+++ b/site/en/advanced/performance/build-performance-breakdown.md
@@ -116,9 +116,10 @@ increase the statistical significance of your measurement.
 
 - **Wall time** is the real world time elapsed.
    - If _only_ wall time regresses, we suggest collecting a
-     [JSON trace profile](/configure/json-trace-profile) and looking for
-     differences. Otherwise, it would likely be more efficient to investigate
-     other regressed metrics as they could have affected the wall time.
+     [JSON trace profile](/advanced/performance/json-trace-profile) and looking
+     for differences. Otherwise, it would likely be more efficient to
+     investigate other regressed metrics as they could have affected the wall
+     time.
 
 - **CPU time** is the time spent by the CPU executing user code.
    - If the CPU time regresses across two project commits, we suggest collecting
@@ -134,7 +135,8 @@ increase the statistical significance of your measurement.
 
 Using the
 [`--experimental_collect_load_average_in_profiler`](https://github.com/bazelbuild/bazel/blob/6.0.0/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java#L306-L312)
-flag introduced in Bazel 6.0, the [JSON trace profiler](/configure/json-trace-profile) collects the
+flag introduced in Bazel 6.0, the
+[JSON trace profiler](/advanced/performance/json-trace-profile) collects the
 system load average during the invocation.
 
 ![Profile that includes system load average](/docs/images/json-trace-profile-system-load-average.png "Profile that includes system load average")
@@ -187,8 +189,8 @@ be problematic. Bazel collects metrics on its workers, in particular, the
 `WorkerMetrics.WorkerStats.worker_memory_in_kb` field tells how much memory
 workers use (by mnemonic).
 
-The [JSON trace profiler](/configure/json-trace-profile) also collects
-persistent worker memory usage during the invocation by passing in the
+The [JSON trace profiler](/advanced/performance/json-trace-profile) also
+collects persistent worker memory usage during the invocation by passing in the
 [`--experimental_collect_system_network_usage`](https://github.com/bazelbuild/bazel/blob/6.0.0/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java#L314-L320)
 flag (new in Bazel 6.0).
 
@@ -214,9 +216,10 @@ monitoring the network traffic during the invocation using the
 `NetworkMetrics.SystemNetworkStats` proto from the [BEP](/remote/bep)
 (requires passing `--experimental_collect_system_network_usage`).
 
-Furthermore, [JSON trace profiles](/configure/json-trace-profile) allow you
-to view system-wide network usage throughout the course of the build by passing
-the `--experimental_collect_system_network_usage` flag (new in Bazel 6.0).
+Furthermore, [JSON trace profiles](/advanced/performance/json-trace-profile)
+allow you to view system-wide network usage throughout the course of the build
+by passing the `--experimental_collect_system_network_usage` flag (new in Bazel
+6.0).
 
 ![Profile that includes system-wide network usage](/docs/images/json-trace-profile-network-usage.png "Profile that includes system-wide network usage")
 

--- a/site/en/advanced/performance/build-performance-metrics.md
+++ b/site/en/advanced/performance/build-performance-metrics.md
@@ -45,8 +45,9 @@ query modes, that allows you to customize your queries according to your needs.
 ## JSON Trace Profiles {:#json-trace-profiles}
 
 For every build-like Bazel invocation, Bazel writes a trace profile in JSON
-format. The [JSON trace profile](/configure/json-trace-profile) can be very
-useful to quickly understand what Bazel spent time on during the invocation.
+format. The [JSON trace profile](/advanced/performance/json-trace-profile) can
+be very useful to quickly understand what Bazel spent time on during the
+invocation.
 
 ## Execution Log {:#execution-log}
 

--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -2216,8 +2216,8 @@ Example:
 ### `analyze-profile` {:#analyze-profile}
 
 The `analyze-profile` command analyzes a
-[JSON trace profile](/config/json-trace-profile) previously gathered during a
-Bazel invocation.
+[JSON trace profile](/advanced/performance/json-trace-profile) previously
+gathered during a Bazel invocation.
 
 ### `canonicalize-flags` {:#canonicalize-flags}
 

--- a/site/en/rules/performance.md
+++ b/site/en/rules/performance.md
@@ -203,8 +203,8 @@ symlink in your workspace directory.
 
 ## Performance profiling {:#performance-profiling}
 
-The [JSON trace profile](/configure/json-trace-profile) can be very useful
-to quickly understand what Bazel spent time on during the invocation.
+The [JSON trace profile](/advanced/performance/json-trace-profile) can be very
+useful to quickly understand what Bazel spent time on during the invocation.
 
 ## Memory profiling {:#memory-profiling}
 


### PR DESCRIPTION
New location: https://bazel.build/advanced/performance/json-trace-profile