### PR TITLE
[4.2.4]Bump minimum supported macOS versions to 10.13

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -121,6 +121,9 @@ tasks:
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/import_deps_checker/..."
+      # Disable test failing due to infra change
+      - "-//src/test/shell/bazel:git_repository_test"
+      - "-//src/test/shell/bazel:starlark_git_repository_test"      
     include_json_profile:
       - build
       - test
@@ -199,6 +202,9 @@ tasks:
       - "-//src/test/shell/bazel/android:android_ndk_integration_test"
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel/android:android_ndk_integration_test_with_head_android_tools"
+      # Disable test failing due to infra change
+      - "-//src/test/shell/bazel:git_repository_test"
+      - "-//src/test/shell/bazel:starlark_git_repository_test"
     include_json_profile:
       - build
       - test
@@ -239,6 +245,9 @@ tasks:
       - "//tools/python/..."
       # C++ coverage is not supported on macOS yet.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      # Disable test failing due to infra change
+      - "-//src/test/shell/bazel:git_repository_test"
+      - "-//src/test/shell/bazel:starlark_git_repository_test"      
     include_json_profile:
       - build
       - test
@@ -265,6 +274,9 @@ tasks:
       - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//src:all_windows_tests"
+      # Disable test failing due to infra change
+      - "-//src/test/shell/bazel:git_repository_test"
+      - "-//src/test/shell/bazel:starlark_git_repository_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -79,7 +79,7 @@ tasks:
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/buildjar/..."
-      - "-//src/java_tools/import_deps_checker/..."
+      - "-//src/java_tools/import_deps_checker/..."      
   ubuntu1804:
     environment:
       USE_BAZEL_VERSION: 4.2.2
@@ -118,6 +118,9 @@ tasks:
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/import_deps_checker/..."
+      # Disable test failing due to infra change
+      - "-//src/test/shell/bazel:git_repository_test"
+      - "-//src/test/shell/bazel:starlark_git_repository_test"      
   ubuntu1804_clang:
     platform: ubuntu1804
     environment:
@@ -191,6 +194,9 @@ tasks:
       - "-//src/test/shell/bazel/android:android_ndk_integration_test"
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel/android:android_ndk_integration_test_with_head_android_tools"
+      # Disable test failing due to infra change
+      - "-//src/test/shell/bazel:git_repository_test"
+      - "-//src/test/shell/bazel:starlark_git_repository_test"      
   macos:
     environment:
       USE_BAZEL_VERSION: 4.2.2
@@ -232,6 +238,9 @@ tasks:
       - "-//src/java_tools/import_deps_checker/..."
       # C++ coverage is not supported on macOS yet.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      # Disable test failing due to infra change
+      - "-//src/test/shell/bazel:git_repository_test"
+      - "-//src/test/shell/bazel:starlark_git_repository_test"      
   windows:
     environment:
       USE_BAZEL_VERSION: 4.2.2
@@ -256,6 +265,9 @@ tasks:
       - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//src:all_windows_tests"
+      # Disable test failing due to infra change
+      - "-//src/test/shell/bazel:git_repository_test"
+      - "-//src/test/shell/bazel:starlark_git_repository_test"      
   rbe_ubuntu1604:
     environment:
       USE_BAZEL_VERSION: 4.2.2

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -79,7 +79,7 @@ tasks:
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/buildjar/..."
-      - "-//src/java_tools/import_deps_checker/..."      
+      - "-//src/java_tools/import_deps_checker/..."
   ubuntu1804:
     environment:
       USE_BAZEL_VERSION: 4.2.2

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -407,7 +407,7 @@ cp $OUTPUT_DIR/libblaze.jar ${ARCHIVE_DIR}
 # TODO(b/28965185): Remove when xcode-locator is no longer required in embedded_binaries.
 log "Compiling xcode-locator..."
 if [[ $PLATFORM == "darwin" ]]; then
-  run /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/xcode-locator tools/osx/xcode_locator.m
+  run /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/xcode-locator tools/osx/xcode_locator.m
 else
   cp tools/osx/xcode_locator_stub.sh ${ARCHIVE_DIR}/xcode-locator
 fi

--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -83,57 +83,6 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
              "https://github.com/bazelbuild/bazel/issues with the following:\n" +
              error_msg)
 
-def _compile_cc_file(repository_ctx, src_name, out_name, timeout):
-    env = repository_ctx.os.environ
-    xcrun_result = repository_ctx.execute([
-        "env",
-        "-i",
-        "DEVELOPER_DIR={}".format(env.get("DEVELOPER_DIR", default = "")),
-        "xcrun",
-        "--sdk",
-        "macosx",
-        "clang",
-        "-mmacosx-version-min=10.13",
-        "-std=c++11",
-        "-lc++",
-        "-arch",
-        "arm64",
-        "-arch",
-        "x86_64",
-        "-Wl,-no_adhoc_codesign",
-        "-Wl,-no_uuid",
-        "-O3",
-        "-o",
-        out_name,
-        src_name,
-    ], timeout)
-
-    if xcrun_result.return_code == 0:
-        xcrun_result = repository_ctx.execute([
-            "env",
-            "-i",
-            "codesign",
-            "--identifier",  # Required to be reproducible across archs
-            out_name,
-            "--force",
-            "--sign",
-            "-",
-            out_name,
-        ], timeout)
-        if xcrun_result.return_code != 0:
-            error_msg = (
-                "codesign return code {code}, stderr: {err}, stdout: {out}"
-            ).format(
-                code = xcrun_result.return_code,
-                err = xcrun_result.stderr,
-                out = xcrun_result.stdout,
-            )
-            fail(out_name + " failed to generate. Please file an issue at " +
-                 "https://github.com/bazelbuild/bazel/issues with the following:\n" +
-                 error_msg)
-    else:
-        _compile_cc_file_single_arch(repository_ctx, src_name, out_name, timeout)
-
 def configure_osx_toolchain(repository_ctx, cpu_value, overriden_tools):
     """Configure C++ toolchain on macOS.
 

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -29,8 +29,7 @@ exports_files([
 
 DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
   /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
-      -framework Foundation -arch arm64 -arch x86_64 -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
-  env -i codesign --identifier $@ --force --sign - $@
+      -framework Foundation -o $@ $<
 """
 
 genrule(

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -28,8 +28,9 @@ exports_files([
 ])
 
 DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
-  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices \
-      -framework Foundation -o $@ $<
+  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
+      -framework Foundation -arch arm64 -arch x86_64 -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
+  env -i codesign --identifier $@ --force --sign - $@
 """
 
 genrule(

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -124,7 +124,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
         "--sdk",
         "macosx",
         "clang",
-        "-mmacosx-version-min=10.9",
+        "-mmacosx-version-min=10.13",
         "-fobjc-arc",
         "-framework",
         "CoreServices",


### PR DESCRIPTION
As per https://developer.apple.com/support/xcode/ Xcode from 14.0 no longer supports targeting 10.9, and attempting to do so may fail in obscure ways.

10.13 is still 5+ years old, so we retain coverage for a reasonable range on macOS versions.

Closes #17451.
Commit: [43dadb2](https://github.com/bazelbuild/bazel/commit/43dadb275b3f9690242bf2d94a0757c721d231a9)

PiperOrigin-RevId: 511577111
Change-Id: I770ff101f52d16f2fc402f054579740b650986cc