### PR TITLE
[6.1.2] Bazel CI: Temporarily disable GitRepositoryBlackBoxTest

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -216,6 +216,10 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
       # https://github.com/bazelbuild/bazel/issues/17447
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17456
+      - "-//src/test/shell/bazel:bazel_determinism_test"
+      # https://github.com/bazelbuild/bazel/issues/17457
+      - "-//src/test/shell/bazel:jdeps_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -214,6 +214,8 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
       # https://github.com/bazelbuild/bazel/issues/17411
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17447
+      - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -209,6 +209,10 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
       # https://github.com/bazelbuild/bazel/issues/17447
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17456
+      - "-//src/test/shell/bazel:bazel_determinism_test"
+      # https://github.com/bazelbuild/bazel/issues/17457
+      - "-//src/test/shell/bazel:jdeps_test"
   windows:
     shards: 4
     batch_commands:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -207,6 +207,8 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
       # https://github.com/bazelbuild/bazel/issues/17411
       - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17447
+      - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
   windows:
     shards: 4
     batch_commands:


### PR DESCRIPTION
Workaround for #17447

PiperOrigin-RevId: 508079185
Change-Id: Ia0b6fc478d0ce32241a2da3aae05c22e045db88a