### PR TITLE
[4.2.4] Bump minimum supported macOS versions to 10.13

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -407,7 +407,7 @@ cp $OUTPUT_DIR/libblaze.jar ${ARCHIVE_DIR}
 # TODO(b/28965185): Remove when xcode-locator is no longer required in embedded_binaries.
 log "Compiling xcode-locator..."
 if [[ $PLATFORM == "darwin" ]]; then
-  run /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/xcode-locator tools/osx/xcode_locator.m
+  run /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/xcode-locator tools/osx/xcode_locator.m
 else
   cp tools/osx/xcode_locator_stub.sh ${ARCHIVE_DIR}/xcode-locator
 fi

--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -28,6 +28,7 @@ load(
 
 def _get_escaped_xcode_cxx_inc_directories(repository_ctx, cc, xcode_toolchains):
     """Compute the list of default C++ include paths on Xcode-enabled darwin.
+
     Args:
       repository_ctx: The repository context.
       cc: The default C++ compiler on the local system.
@@ -84,6 +85,7 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
 
 def configure_osx_toolchain(repository_ctx, cpu_value, overriden_tools):
     """Configure C++ toolchain on macOS.
+
     Args:
       repository_ctx: The repository context.
       overriden_tools: dictionary of overriden tools.

--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -28,7 +28,6 @@ load(
 
 def _get_escaped_xcode_cxx_inc_directories(repository_ctx, cc, xcode_toolchains):
     """Compute the list of default C++ include paths on Xcode-enabled darwin.
-
     Args:
       repository_ctx: The repository context.
       cc: The default C++ compiler on the local system.
@@ -63,7 +62,7 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
         "--sdk",
         "macosx",
         "clang",
-        "-mmacosx-version-min=10.9",
+        "-mmacosx-version-min=10.13",
         "-std=c++11",
         "-lc++",
         "-O3",
@@ -85,7 +84,6 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
 
 def configure_osx_toolchain(repository_ctx, cpu_value, overriden_tools):
     """Configure C++ toolchain on macOS.
-
     Args:
       repository_ctx: The repository context.
       overriden_tools: dictionary of overriden tools.

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -28,7 +28,7 @@ exports_files([
 ])
 
 DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
-  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices \
+  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
       -framework Foundation -o $@ $<
 """
 

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -124,7 +124,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
         "--sdk",
         "macosx",
         "clang",
-        "-mmacosx-version-min=10.9",
+        "-mmacosx-version-min=10.13",
         "-fobjc-arc",
         "-framework",
         "CoreServices",


### PR DESCRIPTION
As per https://developer.apple.com/support/xcode/ Xcode from 14.0 no longer supports targeting 10.9, and attempting to do so may fail in obscure ways.

10.13 is still 5+ years old, so we retain coverage for a reasonable range on macOS versions.

Closes #17451.

PiperOrigin-RevId: 511577111
Change-Id: I770ff101f52d16f2fc402f054579740b650986cc