### PR TITLE
[6.2.0]Add exception message to 'failed to create output directory'

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -1394,7 +1394,8 @@ public final class SkyframeActionExecutor {
           action.getOutputs(), artifactPathResolver);
     } catch (CreateOutputDirectoryException e) {
       throw toActionExecutionException(
-          String.format("failed to create output directory '%s'", e.directoryPath),
+          String.format(
+              "failed to create output directory '%s': %s", e.directoryPath, e.getMessage()),
           e,
           action,
           null,
@@ -1436,7 +1437,7 @@ public final class SkyframeActionExecutor {
     } catch (IOException e) {
       String message =
           String.format(
-              "failed to create output directory for output streams'%s': %s",
+              "failed to create output directory for output streams '%s': %s",
               fileOutErr.getErrorPath(), e.getMessage());
       DetailedExitCode code =
           createDetailedExitCode(message, Code.ACTION_FS_OUT_ERR_DIRECTORY_CREATION_FAILURE);


### PR DESCRIPTION
It looks like all of the similar code paths in this file properly attach the exception message to the error message, while this one does not. Omitting the message makes it hard to figure out the root cause.

While there, make a minor error message string formatting improvement.

Closes #17951.
Commit: [27e4c62](https://github.com/bazelbuild/bazel/commit/27e4c6243524156d880bd04e834db5ebdb0a69af)

PiperOrigin-RevId: 523461253
Change-Id: I96e434d0934c26ecc696cf386362ee17a6588cc5