### PR TITLE
Put --experimental_build_transitive_python_runfiles in the graveyard.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -300,6 +300,15 @@ public final class BazelRulesModule extends BlazeModule {
         metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
         help = "When enabled java_common.compile only accepts JavaPluginInfo for plugins.")
     public boolean requireJavaPluginInfo;
+
+    @Option(
+        name = "experimental_build_transitive_python_runfiles",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        help = "No-op",
+        oldName = "incompatible_build_transitive_python_runfiles")
+    public boolean buildTransitiveRunfilesTrees;
   }
 
   /** This is where deprecated Bazel-specific options only used by the build command go to die. */

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PyBuiltins.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PyBuiltins.java
@@ -266,44 +266,6 @@ public abstract class PyBuiltins implements StarlarkValue {
         .expand(attributeName, expression);
   }
 
-  // TODO(b/232136319): Remove this once the --experimental_build_transitive_python_runfiles
-  // flag is flipped and removed.
-  @StarlarkMethod(
-      name = "new_empty_runfiles_with_middleman",
-      doc = "Create an empty runfiles object with the current ctx's middleman attached.",
-      parameters = {
-        @Param(name = "ctx", positional = false, named = true, defaultValue = "unbound"),
-        @Param(
-            name = "runfiles_for_runfiles_support",
-            positional = false,
-            named = true,
-            defaultValue = "unbound",
-            doc =
-                "Runfiles used to create RunfilesSupport; they are not added to the "
-                    + "returned runfiles object."),
-        @Param(
-            name = "executable_for_runfiles_support",
-            positional = false,
-            named = true,
-            defaultValue = "unbound",
-            doc =
-                "File; used to create RunfilesSupport; they are not added to the "
-                    + "returned runfiles object."),
-      })
-  public Object newEmptyRunfilesWithMiddleman(
-      StarlarkRuleContext starlarkCtx, Runfiles runfiles, Artifact executable)
-      throws EvalException, InterruptedException {
-    // NOTE: The RunfilesSupport created here must exactly match the one done as part of Starlark
-    // rule processing, otherwise action output conflicts occur. See
-    // https://github.com/bazelbuild/bazel/blob/1940c5d68136ce2079efa8ff74d4e5fdf63ee3e6/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtil.java#L642-L651
-    RunfilesSupport runfilesSupport =
-        RunfilesSupport.withExecutable(starlarkCtx.getRuleContext(), runfiles, executable);
-    return new Runfiles.Builder(
-            starlarkCtx.getWorkspaceName(), starlarkCtx.getConfiguration().legacyExternalRunfiles())
-        .addLegacyExtraMiddleman(runfilesSupport.getRunfilesMiddleman())
-        .build();
-  }
-
   @StarlarkMethod(
       name = "create_repo_mapping_manifest",
       doc = "Write a repo_mapping file for the given runfiles",

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonConfiguration.java
@@ -45,7 +45,6 @@ public class PythonConfiguration extends Fragment implements StarlarkValue {
   private final PythonVersion version;
   private final PythonVersion defaultVersion;
   private final TriState buildPythonZip;
-  private final boolean buildTransitiveRunfilesTrees;
 
   // TODO(brandjon): Remove this once migration to PY3-as-default is complete.
   private final boolean py2OutputsAreSuffixed;
@@ -65,7 +64,6 @@ public class PythonConfiguration extends Fragment implements StarlarkValue {
     this.version = pythonVersion;
     this.defaultVersion = pythonOptions.getDefaultPythonVersion();
     this.buildPythonZip = pythonOptions.buildPythonZip;
-    this.buildTransitiveRunfilesTrees = pythonOptions.buildTransitiveRunfilesTrees;
     this.py2OutputsAreSuffixed = pythonOptions.incompatiblePy2OutputsAreSuffixed;
     this.useToolchains = pythonOptions.incompatibleUsePythonToolchains;
     this.defaultToExplicitInitPy = pythonOptions.incompatibleDefaultToExplicitInitPy;
@@ -152,14 +150,6 @@ public class PythonConfiguration extends Fragment implements StarlarkValue {
       default:
         return OS.getCurrent() == OS.WINDOWS;
     }
-  }
-
-  /**
-   * Return whether to build the runfiles trees of py_binary targets that appear in the transitive
-   * data runfiles of another binary.
-   */
-  public boolean buildTransitiveRunfilesTrees() {
-    return buildTransitiveRunfilesTrees;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonOptions.java
@@ -236,18 +236,6 @@ public class PythonOptions extends FragmentOptions {
   public boolean incompatibleUsePythonToolchains;
 
   @Option(
-      name = "experimental_build_transitive_python_runfiles",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS, OptionEffectTag.AFFECTS_OUTPUTS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "Build the runfiles trees of py_binary targets that appear in the transitive "
-              + "data runfiles of another binary.",
-      oldName = "incompatible_build_transitive_python_runfiles")
-  public boolean buildTransitiveRunfilesTrees;
-
-  @Option(
       name = "incompatible_default_to_explicit_init_py",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.GENERIC_INPUTS,
@@ -372,7 +360,6 @@ public class PythonOptions extends FragmentOptions {
     hostPythonOptions.incompatiblePy2OutputsAreSuffixed = incompatiblePy2OutputsAreSuffixed;
     hostPythonOptions.buildPythonZip = buildPythonZip;
     hostPythonOptions.incompatibleUsePythonToolchains = incompatibleUsePythonToolchains;
-    hostPythonOptions.buildTransitiveRunfilesTrees = buildTransitiveRunfilesTrees;
     hostPythonOptions.incompatibleAllowPythonVersionTransitions =
         incompatibleAllowPythonVersionTransitions;
     hostPythonOptions.incompatibleDefaultToExplicitInitPy = incompatibleDefaultToExplicitInitPy;

--- a/src/test/shell/integration/python_test.sh
+++ b/src/test/shell/integration/python_test.sh
@@ -126,31 +126,4 @@ EOF
   bazel test --test_output=streamed //test:a &> $TEST_log || fail "test failed"
 }
 
-function test_building_transitive_py_binary_runfiles_trees() {
-  touch main.py script.sh
-  chmod u+x script.sh
-  cat > BUILD <<'EOF'
-load("@rules_python//python:py_binary.bzl", "py_binary")
-
-py_binary(
-    name = 'py-tool',
-    srcs = ['main.py'],
-    main = 'main.py',
-)
-
-sh_binary(
-    name = 'sh-tool',
-    srcs = ['script.sh'],
-    data = [':py-tool'],
-)
-EOF
-  # Stamping is disabled so that the invocation doesn't time out. What
-  # happens is Google has stamping enabled by default, which causes the
-  # Starlark rule implementation to run an action, which then tries to run
-  # remotely, but network access is disabled by default, so it times out.
-
-  bazel build --noexperimental_build_transitive_python_runfiles --nostamp :sh-tool
-  [ ! -e "bazel-bin/py-tool${EXE_EXT}.runfiles" ] || fail "py_binary runfiles tree built"
-}
-
 run_suite "Tests for the Python rules"


### PR DESCRIPTION
It's a no-op; mark it as such.