### PR TITLE
Use Recursive Mount Option when attempting to mount proc in linux sandbox

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -441,7 +441,9 @@ static void MakeFilesystemMostlyReadOnly() {
 static void MountProc() {
   // Mount a new proc on top of the old one, because the old one still refers to
   // our parent PID namespace.
-  if (mount("/proc", "/proc", "proc", MS_NODEV | MS_NOEXEC | MS_NOSUID,
+  // Some Docker runtimes, such as nvidia, mounted proc already for gpu use 
+  // Without Recursive Bind, attempting to mount nvidia drivers would fail.
+  if (mount("/proc", "/proc", "proc", MS_REC | MS_BIND | MS_NODEV | MS_NOEXEC | MS_NOSUID,
             nullptr) < 0) {
     DIE("mount");
   }


### PR DESCRIPTION
Currently on Bazel 6.0.0

**Problem**: Due to Nvidia [Runtime Mounting Proc](https://github.com/NVIDIA/nvidia-docker/issues/1638#issuecomment-1442860898), when running bazel within a docker container, we hit 
```
src/main/tools/linux-sandbox-pid1.cc:441: "mount": Operation not permitted
```

We see that there's a nested proc mount
```
unshare --mount --map-root-user --pid --fork
# mount | grep proc
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
tmpfs on /proc/driver/nvidia type tmpfs (rw,nosuid,nodev,noexec,relatime,mode=555,inode64)
proc on /proc/driver/nvidia/gpus/0000:b3:00.0 type proc (ro,nosuid,nodev,noexec,relatime)
```

Whilst I know this is nvidia problem and limited to local execution, it would be nice to be able to use linux-sandbox within a docker container w/ access to Nvidia runtime.

**Proposal**:
Add recursive bind option when mounting proc.
Given that proc is mounted as read only, I don't think the recursive mount would be an issue?