### PR TITLE
Remove support for disabling @_builtins.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
@@ -232,10 +232,9 @@ public /*final*/ class ConfiguredRuleClassProvider
      * Sets the resource path to the builtins_bzl.zip resource.
      *
      * <p>This value is required for production uses. For uses in tests, this may be left null, but
-     * the resulting rule class provider will not work with {@code
-     * --experimental_builtins_bzl_path=%bundled%}. Alternatively, tests may call {@link
-     * #useDummyBuiltinsBzl} if they do not rely on any native rules that may be migratable to
-     * Starlark.
+     * the resulting rule class provider will not work with {@code --builtins_bzl_path=%bundled%}.
+     * Alternatively, tests may call {@link #useDummyBuiltinsBzl} if they do not rely on any native
+     * rules that may be migratable to Starlark.
      */
     @CanIgnoreReturnValue
     public Builder setBuiltinsBzlZipResource(String name) {
@@ -264,7 +263,7 @@ public /*final*/ class ConfiguredRuleClassProvider
      * Sets the relative location of the builtins_bzl directory within a Bazel source tree.
      *
      * <p>This is required if the rule class provider will be used with {@code
-     * --experimental_builtins_bzl_path=%workspace%}, but can be skipped in unit tests.
+     * --builtins_bzl_path=%workspace%}, but can be skipped in unit tests.
      */
     @CanIgnoreReturnValue
     public Builder setBuiltinsBzlPackagePathInSource(String path) {
@@ -562,7 +561,7 @@ public /*final*/ class ConfiguredRuleClassProvider
       // Determine the bundled builtins root, if it exists.
       Root builtinsRoot;
       if (builtinsBzlZipResource == null && !useDummyBuiltinsBzlInsteadOfResource) {
-        // Use of --experimental_builtins_bzl_path=%bundled% is disallowed.
+        // Use of --builtins_bzl_path=%bundled% is disallowed.
         builtinsRoot = null;
       } else {
         BundledFileSystem fs = new BundledFileSystem();
@@ -650,19 +649,17 @@ public /*final*/ class ConfiguredRuleClassProvider
   private final RepositoryName toolsRepository;
 
   /**
-   * Where the builtins bzl files are located (if not overridden by
-   * --experimental_builtins_bzl_path). Note that this lives in a separate InMemoryFileSystem.
+   * Where the builtins bzl files are located (if not overridden by --builtins_bzl_path). Note that
+   * this lives in a separate InMemoryFileSystem.
    *
-   * <p>May be null in tests, in which case --experimental_builtins_bzl_path must point to a
-   * builtins root.
+   * <p>May be null in tests, in which case --builtins_bzl_path must point to a builtins root.
    */
   @Nullable private final Root bundledBuiltinsRoot;
 
   /**
    * The relative location of the builtins_bzl directory within a Bazel source tree.
    *
-   * <p>May be null in tests, in which case --experimental_builtins_bzl_path may not be
-   * "%workspace%".
+   * <p>May be null in tests, in which case --builtins_bzl_path may not be "%workspace%".
    */
   @Nullable private final String builtinsBzlPackagePathInSource;
 

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClassProvider.java
@@ -34,19 +34,18 @@ public interface RuleClassProvider extends RuleDefinitionEnvironment {
 
   /**
    * Where the bundled builtins bzl files are located. These are the builtins files used if {@code
-   * --experimental_builtins_bzl_path} is set to {@code %bundled%}. Note that this root lives in a
-   * separate {@link InMemoryFileSystem}.
+   * --builtins_bzl_path} is set to {@code %bundled%}. Note that this root lives in a separate
+   * {@link InMemoryFileSystem}.
    *
-   * <p>May be null in tests, in which case {@code --experimental_builtins_bzl_path} must point to
-   * the builtins root to be used.
+   * <p>May be null in tests, in which case {@code --builtins_bzl_path} must point to the builtins
+   * root to be used.
    */
   Root getBundledBuiltinsRoot();
 
   /**
    * The relative location of the builtins_bzl directory within a Bazel source tree.
    *
-   * <p>May be null in tests, in which case --experimental_builtins_bzl_path may not be
-   * "%workspace%".
+   * <p>May be null in tests, in which case --builtins_bzl_path may not be "%workspace%".
    */
   String getBuiltinsBzlPackagePathInSource();
 

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -94,13 +94,12 @@ public final class BuildLanguageOptions extends OptionsBase {
       help = "No-op.")
   public boolean incompatibleDisallowSymlinkFileToDir;
 
-  // TODO(#11437): Delete the special empty string value so that it's on unconditionally.
   @Option(
-      name = "experimental_builtins_bzl_path",
+      name = "builtins_bzl_path",
+      oldName = "experimental_builtins_bzl_path",
       defaultValue = "%bundled%",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.LOSES_INCREMENTAL_STATE, OptionEffectTag.BUILD_FILE_SEMANTICS},
-      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
       help =
           "This flag tells Bazel how to find the \"@_builtins\" .bzl files that govern how "
               + "predeclared symbols for BUILD and .bzl files are defined. This flag is only "
@@ -111,9 +110,8 @@ public final class BuildLanguageOptions extends OptionsBase {
               + "builtins_bzl/ directory, such as one in a Bazel source tree workspace. A literal "
               + "value of \"%workspace%\" is equivalent to the relative package path of "
               + "builtins_bzl/ within a Bazel source tree; this should only be used when running "
-              + "Bazel within its own source tree. Finally, a value of the empty string disables "
-              + "the builtins injection mechanism entirely.")
-  public String experimentalBuiltinsBzlPath;
+              + "Bazel within its own source tree.")
+  public String builtinsBzlPath;
 
   @Option(
       name = "experimental_builtins_dummy",
@@ -710,7 +708,7 @@ public final class BuildLanguageOptions extends OptionsBase {
                 INCOMPATIBLE_STOP_EXPORTING_LANGUAGE_MODULES,
                 incompatibleStopExportingLanguageModules)
             .setBool(INCOMPATIBLE_ALLOW_TAGS_PROPAGATION, experimentalAllowTagsPropagation)
-            .set(EXPERIMENTAL_BUILTINS_BZL_PATH, experimentalBuiltinsBzlPath)
+            .set(BUILTINS_BZL_PATH, builtinsBzlPath)
             .setBool(EXPERIMENTAL_BUILTINS_DUMMY, experimentalBuiltinsDummy)
             .set(EXPERIMENTAL_BUILTINS_INJECTION_OVERRIDE, experimentalBuiltinsInjectionOverride)
             .setBool(EXPERIMENTAL_BZL_VISIBILITY, experimentalBzlVisibility)
@@ -888,8 +886,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       "-incompatible_disable_non_executable_java_binary";
 
   // non-booleans
-  public static final StarlarkSemantics.Key<String> EXPERIMENTAL_BUILTINS_BZL_PATH =
-      new StarlarkSemantics.Key<>("experimental_builtins_bzl_path", "%bundled%");
+  public static final StarlarkSemantics.Key<String> BUILTINS_BZL_PATH =
+      new StarlarkSemantics.Key<>("builtins_bzl_path", "%bundled%");
   public static final StarlarkSemantics.Key<List<String>> EXPERIMENTAL_BUILTINS_INJECTION_OVERRIDE =
       new StarlarkSemantics.Key<>("experimental_builtins_injection_override", ImmutableList.of());
   public static final StarlarkSemantics.Key<Long> MAX_COMPUTATION_STEPS =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
@@ -1558,22 +1558,17 @@ public class PackageFunction implements SkyFunction {
       preludeBindings = prelude.getGlobals();
     }
 
-    // Construct static environment for resolution/compilation.
-    // The Resolver.Module defines the set of accessible names
-    // (plus special errors for flag-disabled ones), but it is
-    // materialized as an ephemeral eval.Module such as will be
-    // used later during execution; the two environments must match.
-    // TODO(#11437): Remove conditional once disabling injection is no longer allowed.
-    Map<String, Object> predeclared =
-        semantics.get(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_BZL_PATH).isEmpty()
-            ? packageFactory
-                .getRuleClassProvider()
-                .getBazelStarlarkEnvironment()
-                .getUninjectedBuildEnv()
-            : starlarkBuiltinsValue.predeclaredForBuild;
+    // Construct static environment for resolution/compilation.  The Resolver.Module defines the set
+    // of accessible names (plus special errors for flag-disabled ones), but it is materialized as
+    // an ephemeral eval.Module such as will be used later during execution; the two environments
+    // must match.
+    Map<String, Object> predeclared = starlarkBuiltinsValue.predeclaredForBuild;
     if (preludeBindings != null) {
-      predeclared = new HashMap<>(predeclared);
-      predeclared.putAll(preludeBindings);
+      predeclared =
+          ImmutableMap.<String, Object>builder()
+              .putAll(predeclared)
+              .putAll(preludeBindings)
+              .buildKeepingLast();
     }
     Module module = Module.withPredeclared(semantics, predeclared);
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunction.java
@@ -137,10 +137,6 @@ public class StarlarkBuiltinsFunction implements SkyFunction {
     if (starlarkSemantics == null) {
       return null;
     }
-    // Return the empty value if builtins injection is disabled.
-    if (starlarkSemantics.get(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_BZL_PATH).isEmpty()) {
-      return StarlarkBuiltinsValue.createEmpty(starlarkSemantics);
-    }
 
     // Load exports.bzl. If we were requested using inlining, make sure to inline the call back into
     // BzlLoadFunction.

--- a/src/main/starlark/builtins_bzl/BUILD
+++ b/src/main/starlark/builtins_bzl/BUILD
@@ -1,5 +1,5 @@
 # This directory serves as the root of the builtins_bzl tree for Bazel, both in
-# source form and at runtime when --experimental_builtins_bzl_path is set to
+# source form and at runtime when --builtins_bzl_path is set to
 # %workspace%.
 #
 # Because we use globs to gather builtins sources, there should be no

--- a/src/main/starlark/builtins_bzl/README.md
+++ b/src/main/starlark/builtins_bzl/README.md
@@ -4,5 +4,5 @@ a modified dialect of Bazel's Build Language, and cannot be loaded as regular
 information.
 
 When updating .bzl files in this directory, the effect may be observed
-immediately if --experimental_builtins_bzl_path is set to "%workspace%", or
+immediately if --builtins_bzl_path is set to "%workspace%", or
 after a Bazel server restart if it's set to "%bundled%".

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -123,7 +123,7 @@ public class ConsistencyTest {
         // <== Add new options here in alphabetic order ==>
         "--experimental_disable_external_package=" + rand.nextBoolean(),
         "--experimental_sibling_repository_layout=" + rand.nextBoolean(),
-        "--experimental_builtins_bzl_path=" + rand.nextDouble(),
+        "--builtins_bzl_path=" + rand.nextDouble(),
         "--experimental_builtins_dummy=" + rand.nextBoolean(),
         "--experimental_bzl_visibility=" + rand.nextBoolean(),
         "--experimental_enable_android_migration_apis=" + rand.nextBoolean(),
@@ -168,7 +168,7 @@ public class ConsistencyTest {
         // <== Add new options here in alphabetic order ==>
         .setBool(BuildLanguageOptions.EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, rand.nextBoolean())
-        .set(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_BZL_PATH, String.valueOf(rand.nextDouble()))
+        .set(BuildLanguageOptions.BUILTINS_BZL_PATH, String.valueOf(rand.nextDouble()))
         .setBool(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_DUMMY, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_BZL_VISIBILITY, rand.nextBoolean())
         .setBool(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BuiltinsInjectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BuiltinsInjectionTest.java
@@ -183,7 +183,7 @@ public class BuiltinsInjectionTest extends BuildViewTestCase {
   protected ConfiguredRuleClassProvider createRuleClassProvider() {
     // Set up a bare-bones ConfiguredRuleClassProvider. Aside from being minimalistic, this heads
     // off the possibility that we somehow grow an implicit dependency on production builtins code,
-    // which would break since we're overwriting --experimental_builtins_bzl_path.
+    // which would break since we're overwriting --builtins_bzl_path.
     ConfiguredRuleClassProvider.Builder builder = new ConfiguredRuleClassProvider.Builder();
     TestRuleClassProvider.addMinimalRules(builder);
     // Add some mock symbols to override.
@@ -210,7 +210,7 @@ public class BuiltinsInjectionTest extends BuildViewTestCase {
 
   private void setBuildLanguageOptionsWithBuiltinsStaging(String... options) throws Exception {
     ArrayList<String> newOptions = new ArrayList<>();
-    newOptions.add("--experimental_builtins_bzl_path=tools/builtins_staging");
+    newOptions.add("--builtins_bzl_path=tools/builtins_staging");
     Collections.addAll(newOptions, options);
     setBuildLanguageOptions(newOptions.toArray(new String[] {}));
   }
@@ -447,42 +447,6 @@ public class BuiltinsInjectionTest extends BuildViewTestCase {
         .contains(
             "Failed to apply declared builtins: "
                 + "got NoneType for 'exported_toplevels dict', want dict");
-  }
-
-  // TODO(#11437): Remove once disabling is not allowed.
-  @Test
-  public void injectionDisabledByFlag() throws Exception {
-    writeExportsBzl(
-        "exported_toplevels = {'overridable_symbol': 'new_value'}",
-        "exported_rules = {'overridable_rule': 'new_rule'}",
-        "exported_to_java = {}");
-    writePkgBuild("print('In BUILD: overridable_rule :: %s' % overridable_rule)");
-    writePkgBzl(
-        "print('In bzl: overridable_symbol :: %s' % overridable_symbol)",
-        "print('In bzl: overridable_rule :: %s' % native.overridable_rule)");
-    setBuildLanguageOptions("--experimental_builtins_bzl_path=");
-
-    buildAndAssertSuccess();
-    assertContainsEvent("In bzl: overridable_symbol :: original_value");
-    assertContainsEvent("In bzl: overridable_rule :: <built-in rule overridable_rule>");
-    assertContainsEvent("In BUILD: overridable_rule :: <built-in rule overridable_rule>");
-  }
-
-  // TODO(#11437): Remove once disabling is not allowed.
-  @Test
-  public void exportsBzlMayBeInErrorWhenInjectionIsDisabled() throws Exception {
-    writeExportsBzl( //
-        "PARSE ERROR");
-    writePkgBuild("print('In BUILD: overridable_rule :: %s' % overridable_rule)");
-    writePkgBzl(
-        "print('In bzl: overridable_symbol :: %s' % overridable_symbol)",
-        "print('In bzl: overridable_rule :: %s' % native.overridable_rule)");
-    setBuildLanguageOptions("--experimental_builtins_bzl_path=");
-
-    buildAndAssertSuccess();
-    assertContainsEvent("In bzl: overridable_symbol :: original_value");
-    assertContainsEvent("In bzl: overridable_rule :: <built-in rule overridable_rule>");
-    assertContainsEvent("In BUILD: overridable_rule :: <built-in rule overridable_rule>");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BuiltinsIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BuiltinsIntegrationTest.java
@@ -32,7 +32,7 @@ public class BuiltinsIntegrationTest extends BuildViewTestCase {
 
   // The _builtins_dummy symbol is used within BuiltinsIntegrationTest to confirm that
   // BuildViewTestCase sets up the builtins root properly, and by builtins_injection_test.sh to
-  // confirm that --experimental_builtins_bzl_path is working. The dummy symbol should not be
+  // confirm that --builtins_bzl_path is working. The dummy symbol should not be
   // exposed to user programs.
   @Test
   public void builtinsDummyIsNotAPublicApi() throws Exception {
@@ -49,8 +49,7 @@ public class BuiltinsIntegrationTest extends BuildViewTestCase {
   public void builtinsInjectionWorksInBuildViewTestCase() throws Exception {
     scratch.file("pkg/BUILD", "load(':foo.bzl', 'foo')");
     scratch.file("pkg/foo.bzl", "foo = 1; print(\"dummy :: \" + str(_builtins_dummy))");
-    setBuildLanguageOptions(
-        "--experimental_builtins_bzl_path=%bundled%", "--experimental_builtins_dummy=true");
+    setBuildLanguageOptions("--builtins_bzl_path=%bundled%", "--experimental_builtins_dummy=true");
 
     getConfiguredTarget("//pkg:BUILD");
     // The production builtins bzl code overwrites the dummy from "original value" to "overridden

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
@@ -1130,7 +1130,7 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
 
   @Test
   public void testBuiltinsInjectionFailure() throws Exception {
-    setBuildLanguageOptions("--experimental_builtins_bzl_path=tools/builtins_staging");
+    setBuildLanguageOptions("--builtins_bzl_path=tools/builtins_staging");
     scratch.file(
         "tools/builtins_staging/exports.bzl",
         "1 // 0  # <-- dynamic error",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
@@ -682,7 +682,7 @@ public class PackageFunctionTest extends BuildViewTestCase {
 
   @Test
   public void testBuiltinsInjectionFailure() throws Exception {
-    setBuildLanguageOptions("--experimental_builtins_bzl_path=tools/builtins_staging");
+    setBuildLanguageOptions("--builtins_bzl_path=tools/builtins_staging");
     scratch.file(
         "tools/builtins_staging/exports.bzl",
         "1 // 0  # <-- dynamic error",
@@ -1627,7 +1627,7 @@ public class PackageFunctionTest extends BuildViewTestCase {
 
     @Test
     public void testPreludeCanShadowInjectedPredeclareds() throws Exception {
-      setBuildLanguageOptions("--experimental_builtins_bzl_path=tools/builtins_staging");
+      setBuildLanguageOptions("--builtins_bzl_path=tools/builtins_staging");
       scratch.file(
           "tools/builtins_staging/exports.bzl",
           "exported_toplevels = {}",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunctionTest.java
@@ -57,7 +57,7 @@ public class StarlarkBuiltinsFunctionTest extends BuildViewTestCase {
   /** Sets up exports.bzl with the given contents and evaluates the {@code @_builtins}. */
   private EvaluationResult<StarlarkBuiltinsValue> evalBuiltins(String... lines) throws Exception {
     scratch.file("tools/builtins_staging/exports.bzl", lines);
-    setBuildLanguageOptions("--experimental_builtins_bzl_path=tools/builtins_staging");
+    setBuildLanguageOptions("--builtins_bzl_path=tools/builtins_staging");
 
     SkyKey key = StarlarkBuiltinsValue.key();
     return SkyframeExecutorTestUtils.evaluate(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
@@ -1061,7 +1061,7 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
   public void testInstrumentedFilesInfo_coverageSupportFiles_depset() throws Exception {
     // Only builtins can pass coverage_support_files to coverage_common.instrumented_files_info.
     // Override extra_action since builtins can only be injected over preexisting native symbols.
-    setBuildLanguageOptions("--experimental_builtins_bzl_path=tools/builtins");
+    setBuildLanguageOptions("--builtins_bzl_path=tools/builtins");
     scratch.file(
         "tools/builtins/exports.bzl",
         "",
@@ -1098,7 +1098,7 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
   public void testInstrumentedFilesInfo_coverageSupportFiles_sequence() throws Exception {
     // Only builtins can pass coverage_support_files to coverage_common.instrumented_files_info.
     // Override extra_action since builtins can only be injected over preexisting native symbols.
-    setBuildLanguageOptions("--experimental_builtins_bzl_path=tools/builtins");
+    setBuildLanguageOptions("--builtins_bzl_path=tools/builtins");
     scratch.file(
         "tools/builtins/exports.bzl",
         "",

--- a/src/test/shell/integration/builtins_injection_test.sh
+++ b/src/test/shell/integration/builtins_injection_test.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # End-to-end test for builtins injection and the various values of
-# --experimental_builtins_bzl_path.
+# --builtins_bzl_path.
 
 # --- begin runfiles.bash initialization ---
 # Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
@@ -96,22 +96,9 @@ exported_to_java = {}
 EOF
 
 
-  # With injection disabled.
-  #
-  # TODO(#11437): Remove this case once builtins injection can no longer be
-  # disabled. Note that eventually, rule migration to Starlark will cause
-  # implicit dependencies/tools to rely on injection, so even a trivial build
-  # without injection may break. (That may also mean we have to update this test
-  # at some point, so that the other builtins roots are based on the one in the
-  # install base, instead of being virtually empty.)
-  bazel build --nobuild //pkg:BUILD --experimental_builtins_dummy=true \
-      --experimental_builtins_bzl_path= \
-      &>"$TEST_log" || fail "bazel build failed"
-  expect_log "dummy :: original value"
-
   # Using the builtins root that's bundled with bazel.
   bazel build --nobuild //pkg:BUILD --experimental_builtins_dummy=true \
-      --experimental_builtins_bzl_path=%bundled% \
+      --builtins_bzl_path=%bundled% \
       &>"$TEST_log" || fail "bazel build failed"
   # "overridden value" comes from the exports.bzl in production Bazel.
   expect_log "dummy :: overridden value"
@@ -119,14 +106,14 @@ EOF
   # Using the builtins root located within the client workspace, as if we're
   # running Bazel in its own source tree.
   bazel build --nobuild //pkg:BUILD --experimental_builtins_dummy=true \
-      --experimental_builtins_bzl_path=%workspace% \
+      --builtins_bzl_path=%workspace% \
       &>"$TEST_log" || fail "bazel build failed"
   expect_log "dummy :: workspace value"
 
   # Using the builtins root at the path given to the flag. (Need not be within
   # workspace, though this one is.)
   bazel build --nobuild //pkg:BUILD --experimental_builtins_dummy=true \
-      --experimental_builtins_bzl_path=alternate \
+      --builtins_bzl_path=alternate \
       &>"$TEST_log" || fail "bazel build failed"
   expect_log "dummy :: alternate value"
 
@@ -137,14 +124,14 @@ exported_rules = {}
 exported_to_java = {}
 EOF
   bazel build --nobuild //pkg:BUILD --experimental_builtins_dummy=true \
-      --experimental_builtins_bzl_path=alternate \
+      --builtins_bzl_path=alternate \
       &>"$TEST_log" || fail "bazel build failed"
   expect_log "dummy :: second alternate value"
 
   # Ensure builtins .bzl files aren't visible to bazel query the way normal .bzl
   # files are.
   bazel query 'buildfiles(//pkg:BUILD)' --experimental_builtins_dummy=true \
-      --experimental_builtins_bzl_path=alternate \
+      --builtins_bzl_path=alternate \
       &>"$TEST_log" || fail "bazel query failed"
   expect_not_log "exports.bzl"
 }


### PR DESCRIPTION
Various Starlark rules have completely replaced their native variants, so completely disabling builtins is no longer needed.

Rename --experimental_builtins_bzl_path to --builtins_bzl_path.

https://github.com/bazelbuild/bazel/issues/11437