### PR TITLE
Turn applicable_licenses on platforms into a no-op.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformBaseRule.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.analysis.BaseRuleClasses;
 import com.google.devtools.build.lib.analysis.PlatformConfiguration;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
+import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.ToolchainResolutionMode;
 import com.google.devtools.build.lib.packages.Type;
@@ -41,6 +42,13 @@ public class PlatformBaseRule implements RuleDefinition{
                 // No need to show up in ":all", etc. target patterns.
                 .value(ImmutableList.of("manual"))
                 .nonconfigurable("low-level attribute, used in platform configuration"))
+        .override(
+            // A platform is essentially a constant which is never linked into a target.
+            // This will, in a very hacky way, suppress picking up default_applicable_licenses
+            attr("applicable_licenses", BuildType.LABEL_LIST)
+                .value(ImmutableList.of())
+                .allowedFileTypes()
+                .nonconfigurable("fundamental constant, used in platform configuration"))
         .exemptFromConstraintChecking("this rule helps *define* a constraint")
         .useToolchainResolution(ToolchainResolutionMode.DISABLED)
         .removeAttribute("deps")
@@ -57,5 +65,4 @@ public class PlatformBaseRule implements RuleDefinition{
         .ancestors(BaseRuleClasses.NativeActionCreatingRule.class)
         .build();
   }
-
 }


### PR DESCRIPTION
Backport of Ic12306f5a405c88bd65acf3b8ec419328ce663f3

If we are doing a fresh 6.1.2, then this is good. Otherwise, I will wait for 6.2