### PR TITLE
Update py abseil files to PY3

### DIFF
--- a/third_party/py/abseil/BUILD
+++ b/third_party/py/abseil/BUILD
@@ -12,7 +12,7 @@ py_library(
     name = "abseil",
     srcs = glob(["**/*.py"]),
     imports = ["."],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = ["//third_party/py/six"],
 )


### PR DESCRIPTION
Part of my hypothesis that the previous PY2AND3 designation was causing `python` to be selected as an interpreter rather than `python3`, which causes build/runtime issues on newer systems.

edit: my hypothesis ended up being incorrect, but I think this would still be good to merge so that we can reduce the chances of python2.* toolchain selection.