### PR TITLE
add externalInclude information to compilation_context

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
@@ -229,6 +229,17 @@ public final class CcCompilationContext implements CcCompilationContextApi<Artif
   }
 
   @Override
+  public Depset getStarlarkExternalIncludeDirs() {
+    return Depset.of(
+        String.class,
+        NestedSetBuilder.wrap(
+            Order.STABLE_ORDER,
+            getExternalIncludeDirs().stream()
+                .map(PathFragment::getSafePathString)
+                .collect(ImmutableList.toImmutableList())));
+  }
+
+  @Override
   public Depset getStarlarkQuoteIncludeDirs() {
     return Depset.of(
         String.class,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcCompilationContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcCompilationContextApi.java
@@ -85,6 +85,14 @@ public interface CcCompilationContextApi<FileT extends FileApi> extends Starlark
   Depset getStarlarkIncludeDirs();
 
   @StarlarkMethod(
+      name = "external_includes",
+      doc =
+          "Returns the set of search paths (as strings) for external header files referenced by angle"
+              + " bracket. Usually passed with -isystem.",
+      structField = true)
+  Depset getStarlarkExternalIncludeDirs();
+
+  @StarlarkMethod(
       name = "quote_includes",
       doc =
           "Returns the set of search paths (as strings) for header files referenced by quotes,"


### PR DESCRIPTION
Hi bazel team

I use an aspect to run clangtidy on the codebase. It is based on https://github.com/erenon/bazel_clang_tidy.

To check my codebase with `-Werror`, I use the "new" feature `external_include_path` requested by https://github.com/bazelbuild/bazel/issues/12009, introduced by commit https://github.com/bazelbuild/bazel/commit/08936aecb96f2937c61bdedfebcf1c5a41a0786d.

Now my clangtidy rules did not work anymore of course. As you can see in https://github.com/erenon/bazel_clang_tidy/blob/master/clang_tidy/clang_tidy.bzl, all the different include paths are being passed to the clang-tidy executable. I now also needed to pass the new external_includes to `clang-tidy`.

This PR adds `external_includes` to the `compilation_context` object. I looked at the style of the other `includes` and hope it is in line with your expectations.