### PR TITLE
Add `alias_label` struct field to all targets

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTarget.java
@@ -39,6 +39,9 @@ public interface ConfiguredTarget extends TransitiveInfoCollection, Structure {
   /** All <code>ConfiguredTarget</code>s have a "label" field. */
   String LABEL_FIELD = "label";
 
+  /** All <code>ConfiguredTarget</code>s have an "alias_label" field. */
+  String ALIAS_LABEL_FIELD = "alias_label";
+
   /** All <code>ConfiguredTarget</code>s have a "files" field. */
   String FILES_FIELD = "files";
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/AbstractConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/AbstractConfiguredTarget.java
@@ -66,6 +66,7 @@ public abstract class AbstractConfiguredTarget implements ConfiguredTarget, Visi
   // attributed to normal user-specified providers).
   private static final ImmutableSet<String> SPECIAL_FIELD_NAMES =
       ImmutableSet.of(
+          ALIAS_LABEL_FIELD,
           LABEL_FIELD,
           FILES_FIELD,
           DEFAULT_RUNFILES_FIELD,
@@ -141,6 +142,9 @@ public abstract class AbstractConfiguredTarget implements ConfiguredTarget, Visi
     switch (name) {
       case LABEL_FIELD:
         return getLabel();
+      case ALIAS_LABEL_FIELD:
+        // Overridden in AliasConfiguredTarget.
+        return Starlark.NONE;
       case ACTIONS_FIELD_NAME:
         // Depending on subclass, the 'actions' field will either be unsupported or of type
         // java.util.List, which needs to be converted to Sequence before being returned.

--- a/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
@@ -163,15 +163,19 @@ public final class AliasConfiguredTarget implements ConfiguredTarget, Structure 
 
   @Override
   public Object getValue(String name) {
-    if (name.equals(LABEL_FIELD)) {
-      return getLabel();
-    } else if (name.equals(FILES_FIELD)) {
-      // A shortcut for files to build in Starlark. FileConfiguredTarget and RuleConfiguredTarget
-      // always has FileProvider and Error- and PackageGroupConfiguredTarget-s shouldn't be
-      // accessible in Starlark.
-      return Depset.of(Artifact.class, getProvider(FileProvider.class).getFilesToBuild());
+    switch (name) {
+      case LABEL_FIELD:
+        return getLabel();
+      case ALIAS_LABEL_FIELD:
+        return getOriginalLabel();
+      case FILES_FIELD:
+        // A shortcut for files to build in Starlark. FileConfiguredTarget and RuleConfiguredTarget
+        // always has FileProvider and Error- and PackageGroupConfiguredTarget-s shouldn't be
+        // accessible in Starlark.
+        return Depset.of(Artifact.class, getProvider(FileProvider.class).getFilesToBuild());
+      default:
+        return actual.getValue(name);
     }
-    return actual.getValue(name);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/core/TransitiveInfoCollectionApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/core/TransitiveInfoCollectionApi.java
@@ -33,7 +33,14 @@ import net.starlark.java.eval.StarlarkValue;
             + "<ul>\n" //
             + "<li><h3 id='modules.Target.label'>label</h3>\n" //
             + "<code><a href='../builtins/Label.html'>Label</a> Target.label</code><br/>\n" //
-            + "The identifier of the target.</li>\n" //
+            + "The label of the target after following all <code><a " //
+            + "href='general.html#alias>alias</a></code>es.</li>\n" //
+            //
+            + "<ul>\n" //
+            + "<li><h3 id='modules.Target.alias_label'>alias_label</h3>\n" //
+            + "<code><a href='../builtins/Label.html'>Label</a> Target.alias_label</code><br/>\n" //
+            + "The label of the target if it is an <code><a" //
+            + "href='general.html#alias>alias</a></code>, otherwise <code>None</code>.</li>\n" //
             //
             + "<li><h3 id='modules.Target.files'>files</h3>\n" //
             + "<code><a href='../builtins/depset.html'>depset</a> Target.files </code><br/>\n" //


### PR DESCRIPTION
This allows rules to obtain the label of an `alias` target rather than only the label of the target an alias chain ultimately resolves to. The former is the label as specified by the user on the rule, which can be important to know for e.g. fixup messages and manual implementations of location expansion.

Fixes #11044 