### PR TITLE
[Bootstrap Template] Fixed bootstrap template not being passed to py_binary from py_runtime on bazel latest

### DIFF
--- a/src/main/starlark/builtins_bzl/common/python/py_executable_bazel.bzl
+++ b/src/main/starlark/builtins_bzl/common/python/py_executable_bazel.bzl
@@ -290,11 +290,13 @@ def _expand_bootstrap_template(
 
     if runtime:
         shebang = runtime.stub_shebang
+        template = runtime.bootstrap_template
     else:
         shebang = DEFAULT_STUB_SHEBANG
+        tempalate = ctx.file._bootstrap_template
 
     ctx.actions.expand_template(
-        template = ctx.file._bootstrap_template,
+        template = template,
         output = output,
         substitutions = {
             "%shebang%": shebang,

--- a/src/main/starlark/builtins_bzl/common/python/py_executable_bazel.bzl
+++ b/src/main/starlark/builtins_bzl/common/python/py_executable_bazel.bzl
@@ -293,7 +293,7 @@ def _expand_bootstrap_template(
         template = runtime.bootstrap_template
     else:
         shebang = DEFAULT_STUB_SHEBANG
-        tempalate = ctx.file._bootstrap_template
+        template = ctx.file._bootstrap_template
 
     ctx.actions.expand_template(
         template = template,

--- a/src/test/java/com/google/devtools/build/lib/rules/python/PythonStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/PythonStarlarkApiTest.java
@@ -121,7 +121,7 @@ public class PythonStarlarkApiTest extends BuildViewTestCase {
         "        interpreter = ctx.file.interpreter,",
         "        files = depset(direct = ctx.files.files, transitive=[info.files]),",
         "        python_version = info.python_version,",
-        "        bootstrap_template=ctx.file.bootstrap_template,)]",
+        "        bootstrap_template =ctx.file.bootstrap_template)]",
         "",
         "userruntime = rule(",
         "    implementation = _userruntime_impl,",
@@ -129,7 +129,7 @@ public class PythonStarlarkApiTest extends BuildViewTestCase {
         "        'runtime': attr.label(),",
         "        'interpreter': attr.label(allow_single_file=True),",
         "        'files': attr.label_list(allow_files=True),",
-        "        'bootstrap_template': attr.label_list(allow_files=True),",
+        "        'bootstrap_template': attr.label(allow_single_file=True),",
         "    },",
         ")");
     scratch.file(
@@ -150,7 +150,7 @@ public class PythonStarlarkApiTest extends BuildViewTestCase {
         "    runtime = ':pyruntime',",
         "    interpreter = ':userintr',",
         "    files = ['userdata.txt'],",
-        "    bootstrap_template = bootstrap.txt,",
+        "    bootstrap_template = 'bootstrap.txt',",
         ")",
         "py_runtime_pair(",
         "    name = 'userruntime_pair',",

--- a/src/test/java/com/google/devtools/build/lib/rules/python/PythonStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/PythonStarlarkApiTest.java
@@ -121,7 +121,7 @@ public class PythonStarlarkApiTest extends BuildViewTestCase {
         "        interpreter = ctx.file.interpreter,",
         "        files = depset(direct = ctx.files.files, transitive=[info.files]),",
         "        python_version = info.python_version,",
-        "        bootstrap_template =ctx.file.bootstrap_template)]",
+        "        bootstrap_template = ctx.file.bootstrap_template)]",
         "",
         "userruntime = rule(",
         "    implementation = _userruntime_impl,",

--- a/src/test/java/com/google/devtools/build/lib/rules/python/PythonStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/PythonStarlarkApiTest.java
@@ -120,7 +120,8 @@ public class PythonStarlarkApiTest extends BuildViewTestCase {
         "    return [PyRuntimeInfo(",
         "        interpreter = ctx.file.interpreter,",
         "        files = depset(direct = ctx.files.files, transitive=[info.files]),",
-        "        python_version = info.python_version)]",
+        "        python_version = info.python_version,",
+        "        bootstrap_template=ctx.file.bootstrap_template,)]",
         "",
         "userruntime = rule(",
         "    implementation = _userruntime_impl,",
@@ -128,6 +129,7 @@ public class PythonStarlarkApiTest extends BuildViewTestCase {
         "        'runtime': attr.label(),",
         "        'interpreter': attr.label(allow_single_file=True),",
         "        'files': attr.label_list(allow_files=True),",
+        "        'bootstrap_template': attr.label_list(allow_files=True),",
         "    },",
         ")");
     scratch.file(
@@ -148,6 +150,7 @@ public class PythonStarlarkApiTest extends BuildViewTestCase {
         "    runtime = ':pyruntime',",
         "    interpreter = ':userintr',",
         "    files = ['userdata.txt'],",
+        "    bootstrap_template = bootstrap.txt,",
         ")",
         "py_runtime_pair(",
         "    name = 'userruntime_pair',",


### PR DESCRIPTION
This PR fixes a small bug where the bootstrap template runtime file was not being passed to Py Binary. This broke the bootstrap template feature on bazel latest authored in https://github.com/bazelbuild/bazel/pull/16806

