### PR TITLE
Experimental Incredibuild Integration: My Implementation and Request for Suggestions

### DIFF
--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -705,7 +705,7 @@ int ExecuteDaemon(const blaze_util::Path& exe,
   std::wstringstream newcmdline;
   newcmdline 
     << L"C:\\Program Files (x86)\\IncrediBuild\\IbConsole.exe "
-    << "/Title=\"Bazel Build\" /AllowRemote=\"cl,link\" /SILENT /AVOIDLOCAL=ON /Command=\""
+    << "/Title=\"Bazel Build\" /AllowRemote=\"cl,link\" /SILENT /Command=\""
     << cmdline.cmdline << "\"";
   wcsncpy(cmdline.cmdline, newcmdline.str().c_str(), MAX_CMDLINE_LENGTH - 1);
 

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -25,6 +25,8 @@
 #include <shlobj.h>        // SHGetKnownFolderPath
 #include <stdarg.h>        // va_start, va_end, va_list
 
+#include <iostream>
+
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
@@ -699,6 +701,13 @@ int ExecuteDaemon(const blaze_util::Path& exe,
 
   CmdLine cmdline;
   CreateCommandLine(&cmdline, exe, wesc_args_vector);
+
+  std::wstringstream newcmdline;
+  newcmdline 
+    << L"C:\\Program Files (x86)\\IncrediBuild\\IbConsole.exe "
+    << "/Title=\"Bazel Build\" /AllowRemote=\"cl,link\" /SILENT /AVOIDLOCAL=ON /Command=\""
+    << cmdline.cmdline << "\"";
+  wcsncpy(cmdline.cmdline, newcmdline.str().c_str(), MAX_CMDLINE_LENGTH - 1);
 
   BOOL ok;
   {

--- a/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceFallback.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceFallback.java
@@ -26,7 +26,7 @@ public class LocalHostResourceFallback {
   private static final ResourceSet DEFAULT_RESOURCES =
       ResourceSet.create(
           3.0 * (Runtime.getRuntime().maxMemory() >> 20),
-          Runtime.getRuntime().availableProcessors(),
+          1024, // Runtime.getRuntime().availableProcessors(),
           Integer.MAX_VALUE);
 
   public static ResourceSet getLocalHostResources() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilter.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilter.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -162,7 +163,7 @@ public class ShowIncludesFilter {
     public void write(int b) throws IOException {
       buffer.write(b);
       if (b == NEWLINE) {
-        String line = buffer.toString(StandardCharsets.UTF_8.name());
+        String line = buffer.toString(Charset.forName("GBK"));
         boolean prefixMatched = false;
         for (String prefix : SHOW_INCLUDES_PREFIXES) {
           if (line.startsWith(prefix)) {

--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -290,7 +290,7 @@ int WaitableProcess::WaitFor(int64_t timeout_msec,
     ULONG_PTR CompletionKey;
     LPOVERLAPPED Overlapped;
     while (GetQueuedCompletionStatus(ioport_, &CompletionCode,
-                                     &CompletionKey, &Overlapped, INFINITE) &&
+                                     &CompletionKey, &Overlapped, 200) &&
            !((HANDLE)CompletionKey == (HANDLE)job_ &&
              CompletionCode == JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO)) {
       // Still waiting...

--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -289,12 +289,12 @@ int WaitableProcess::WaitFor(int64_t timeout_msec,
     DWORD CompletionCode;
     ULONG_PTR CompletionKey;
     LPOVERLAPPED Overlapped;
-    while (GetQueuedCompletionStatus(ioport_, &CompletionCode,
-                                     &CompletionKey, &Overlapped, 200) &&
-           !((HANDLE)CompletionKey == (HANDLE)job_ &&
-             CompletionCode == JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO)) {
-      // Still waiting...
-    }
+    // while (GetQueuedCompletionStatus(ioport_, &CompletionCode,
+    //                                  &CompletionKey, &Overlapped, 200) &&
+    //        !((HANDLE)CompletionKey == (HANDLE)job_ &&
+    //          CompletionCode == JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO)) {
+    //   // Still waiting...
+    // }
 
     job_ = INVALID_HANDLE_VALUE;
     ioport_ = INVALID_HANDLE_VALUE;


### PR DESCRIPTION
I am attempting to migrate a project built with Visual Studio + IncrediBuild to Bazel. Additionally, in order to make use of the IncrediBuild Helpers deployed in my organization, I am hoping to accelerate Bazel with IncrediBuild. Therefore, I have made some attempts. The code included in this PR is working properly on my computer, but this is only a simple example code. I am not very familiar with these kind of things, so I hope you can provide some advice.

Next, I will explain several changes I have made.

1. Use IbConsole to start Bazel server. In this way, IncrediBuild can monitor the subprocesses initiated by Bazel server and send them to other computers for parallel execution as needed. I plan to add a command line argument for it.

2. Adjust the degree of parallelism limit. Currently, Bazel's Local strategy uses a maximum of the number of build processes equal to the number of CPU cores for building. In the IncrediBuild environment, similar restrictions should be relaxed. By changing the CPU core number in `DEFAULT_RESOURCES`, some parallelism can be increased, but it is still limited to around 130. I hope someone can tell me where to make changes.

3. Change the way of parsing the output of MSVC's /ShowIncludes. My computer and Visual Studio use English, but some IncrediBuild Helpers use Simplified Chinese. I found that the prefix of /ShowIncludes on other machines is encoded in GB (GBK or GB18030), not UTF8. Therefore, the parsing method needs to be changed. I prefer to match the prefix based on the byte stream, and then convert the other parts to String. However, I have no experience with character encoding and hope to get some advice.

4. I found that `GetQueuedCompletionStatus` always does not return in the IncrediBuild environment. Changing the timeout to other values can solve the problem. I think this is a bug in IncrediBuild. However, I also have no experience with Windows API programming and do not know if there is a better solution.