### PR TITLE
docs: remove external links from build encyclopedia nav

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/be/be-toc.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/be-toc.vm
@@ -25,39 +25,3 @@ toc:
       path: /reference/be/${ruleFamily.id}
 #end
 #end
-    - title: AppEngine
-      path: https://github.com/bazelbuild/rules_appengine
-      status: external
-    - title: Apple (Swift, iOS, macOS, tvOS, watchOS)
-      path: https://github.com/bazelbuild/rules_apple
-      status: external
-    - title: C#
-      path: https://github.com/bazelbuild/rules_dotnet
-      status: external
-    - title: D
-      path: https://github.com/bazelbuild/rules_d
-      status: external
-    - title: Docker
-      path: https://github.com/bazelbuild/rules_docker
-      status: external
-    - title: Groovy
-      path: https://github.com/bazelbuild/rules_groovy
-      status: external
-    - title: Go
-      path: https://github.com/bazelbuild/rules_go
-      status: external
-    - title: JavaScript (Closure)
-      path: https://github.com/bazelbuild/rules_closure
-      status: external
-    - title: Jsonnet
-      path: https://github.com/bazelbuild/rules_jsonnet
-      status: external
-    - title: Rust
-      path: https://github.com/bazelbuild/rules_rust
-      status: external
-    - title: Sass
-      path: https://github.com/bazelbuild/rules_sass
-      status: external
-    - title: Scala
-      path: https://github.com/bazelbuild/rules_scala
-      status: external


### PR DESCRIPTION
These are a mix of current and stale. For example, 'JavaScript (Closure)' is used by almost no one, as far as I know. I could imagine trying to update this instead of remove it, however there's not a good process for the Bazel team to keep updating an external 'catalog' of rules.

Note, there's a file next to the one I've edited, be-nav.vm, but I cannot find where that appears on the site. Maybe it's dead code?