### PR TITLE
Add attribute validation to IncompatibleTargetChecker.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
@@ -107,7 +107,7 @@ public class IncompatibleTargetChecker {
       Environment env,
       @Nullable PlatformInfo platformInfo,
       NestedSetBuilder<Package> transitivePackages)
-      throws InterruptedException {
+      throws ConfiguredAttributeMapper.ValidationException, InterruptedException {
     Target target = targetAndConfiguration.getTarget();
     Rule rule = target.getAssociatedRule();
 
@@ -124,7 +124,7 @@ public class IncompatibleTargetChecker {
     }
 
     // Resolve the constraint labels.
-    List<Label> labels = attrs.get("target_compatible_with", BuildType.LABEL_LIST);
+    List<Label> labels = attrs.getAndValidate("target_compatible_with", BuildType.LABEL_LIST);
     ImmutableList<ConfiguredTargetKey> constraintKeys =
         labels.stream()
             .map(

--- a/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
@@ -127,7 +127,7 @@ public class ConfiguredAttributeMapper extends AbstractAttributeMapper {
    * Variation of {@link #get} that throws an informative exception if the attribute can't be
    * resolved due to intrinsic contradictions in the configuration.
    */
-  private <T> T getAndValidate(String attributeName, Type<T> type) throws ValidationException {
+  public <T> T getAndValidate(String attributeName, Type<T> type) throws ValidationException {
     SelectorList<T> selectorList = getSelectorList(attributeName, type);
     if (selectorList == null) {
       // This is a normal attribute.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -307,6 +307,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/io:inconsistent_filesystem_exception",
         "//src/main/java/com/google/devtools/build/lib/io:process_package_directory_exception",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/packages:configured_attribute_mapper",
         "//src/main/java/com/google/devtools/build/lib/packages:exec_group",
         "//src/main/java/com/google/devtools/build/lib/packages:globber",
         "//src/main/java/com/google/devtools/build/lib/packages:globber_utils",


### PR DESCRIPTION
This causes errors with configurable `target_compatible_with` to be reported as errors, rather than causing a Bazel crash.

Fixes bazelbuild#18021.

(This is functionally the same change as
ebfb529a78978c3cfd1d93141c7762f908698df9, but applied to the release-6.2.0 branch)