### PR TITLE
Prevent non-hermetic worker flagfile reads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -61,6 +61,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
+import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.XattrProvider;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
@@ -240,6 +241,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
   private WorkRequest createWorkRequest(
       Spawn spawn,
       SpawnExecutionContext context,
+      SandboxInputs inputFiles,
       List<String> flagfiles,
       Map<VirtualActionInput, byte[]> virtualInputDigests,
       InputMetadataProvider inputFileCache,
@@ -247,7 +249,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
       throws IOException, InterruptedException {
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
     for (String flagfile : flagfiles) {
-      expandArgument(execRoot, flagfile, requestBuilder);
+      expandArgument(inputFiles, flagfile, requestBuilder);
     }
 
     List<ActionInput> inputs =
@@ -292,27 +294,32 @@ final class WorkerSpawnRunner implements SpawnRunner {
    * <p>Also check that the argument is not an external repository label, because they start with
    * `@` and are not flagfile locations.
    *
-   * @param execRoot the current execroot of the build (relative paths will be assumed to be
-   *     relative to this directory).
-   * @param arg the argument to expand.
+   * @param inputs         the inputs to locate flag files in.
+   * @param arg            the argument to expand.
    * @param requestBuilder the WorkRequest to whose arguments the expanded arguments will be added.
    * @throws java.io.IOException if one of the files containing options cannot be read.
    */
-  static void expandArgument(Path execRoot, String arg, WorkRequest.Builder requestBuilder)
+  static void expandArgument(SandboxInputs inputs, String arg, WorkRequest.Builder requestBuilder)
       throws IOException, InterruptedException {
     if (arg.startsWith("@") && !arg.startsWith("@@") && !isExternalRepositoryLabel(arg)) {
       if (Thread.interrupted()) {
         throw new InterruptedException();
       }
       String argValue = arg.substring(1);
-      Path path = execRoot.getRelative(argValue);
+      RootedPath path = inputs.getFiles().get(PathFragment.create(argValue));
+      if (path == null) {
+        throw new IOException(
+            String.format("Failed to read @-argument '%s': file is not a declared input",
+                argValue));
+      }
       try {
-        for (String line : FileSystemUtils.readLines(path, UTF_8)) {
-          expandArgument(execRoot, line, requestBuilder);
+        for (String line : FileSystemUtils.readLines(path.asPath(), UTF_8)) {
+          expandArgument(inputs, line, requestBuilder);
         }
       } catch (IOException e) {
         throw new IOException(
-            String.format("Failed to read @-argument '%s' from file '%s'.", argValue, path), e);
+            String.format("Failed to read @-argument '%s' from file '%s'.", argValue,
+                path.asPath().getPathString()), e);
       }
     } else {
       requestBuilder.addArguments(arg);
@@ -411,8 +418,8 @@ final class WorkerSpawnRunner implements SpawnRunner {
               context.speculating() ? ResourcePriority.DYNAMIC_WORKER : ResourcePriority.LOCAL);
       workerOwner.setWorker(handle.getWorker());
       workerOwner.getWorker().setReporter(workerOptions.workerVerbose ? reporter : null);
-      request =
-          createWorkRequest(spawn, context, flagFiles, virtualInputDigests, inputFileCache, key);
+      request = createWorkRequest(spawn, context, inputFiles, flagFiles, virtualInputDigests,
+          inputFileCache, key);
 
       // We acquired a worker and resources -- mark that as queuing time.
       spawnMetrics.setQueueTimeInMs((int) queueStopwatch.elapsed().toMillis());

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
@@ -59,6 +59,9 @@ import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Root;
+import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.build.lib.worker.WorkerPoolImpl.WorkerPoolConfig;
@@ -516,7 +519,11 @@ public class WorkerSpawnRunnerTest {
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
     FileSystemUtils.writeIsoLatin1(fs.getPath("/file"), "arg1\n@file2\nmulti arg\n");
     FileSystemUtils.writeIsoLatin1(fs.getPath("/file2"), "arg2\narg3");
-    WorkerSpawnRunner.expandArgument(fs.getPath("/"), "@file", requestBuilder);
+    SandboxInputs inputs = new SandboxInputs(
+        ImmutableMap.of(PathFragment.create("file"), asRootedPath("/file"),
+            PathFragment.create("file2"), asRootedPath("/file2")), ImmutableMap.of(),
+        ImmutableMap.of(), ImmutableMap.of());
+    WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder);
     assertThat(requestBuilder.getArgumentsList())
         .containsExactly("arg1", "arg2", "arg3", "multi arg", "");
   }
@@ -526,20 +533,43 @@ public class WorkerSpawnRunnerTest {
       throws IOException, InterruptedException {
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
     FileSystemUtils.writeIsoLatin1(fs.getPath("/file"), "arg1\n@@nonfile\n@foo//bar\narg2");
-    WorkerSpawnRunner.expandArgument(fs.getPath("/"), "@file", requestBuilder);
+    SandboxInputs inputs = new SandboxInputs(
+        ImmutableMap.of(PathFragment.create("file"), asRootedPath("/file")), ImmutableMap.of(),
+        ImmutableMap.of(), ImmutableMap.of());
+    WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder);
     assertThat(requestBuilder.getArgumentsList())
         .containsExactly("arg1", "@@nonfile", "@foo//bar", "arg2");
   }
 
   @Test
-  public void testExpandArgument_failsOnMissingFile() throws IOException {
+  public void testExpandArgument_failsOnMissingFile() {
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
+    SandboxInputs inputs = new SandboxInputs(ImmutableMap.of(PathFragment.create("file"),
+        asRootedPath("/dir/file")), ImmutableMap.of(),
+        ImmutableMap.of(), ImmutableMap.of());
     IOException e =
         assertThrows(
             IOException.class,
-            () -> WorkerSpawnRunner.expandArgument(fs.getPath("/dir/"), "@file", requestBuilder));
+            () -> WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder));
     assertThat(e).hasMessageThat().contains("file");
     assertThat(e).hasMessageThat().contains("/dir/file");
+  }
+
+  @Test
+  public void testExpandArgument_failsOnUndeclaredInput() {
+    WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
+    SandboxInputs inputs = new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(),
+        ImmutableMap.of(), ImmutableMap.of());
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () -> WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder));
+    assertThat(e).hasMessageThat().contains("file");
+    assertThat(e).hasMessageThat().contains("declared input");
+  }
+
+  private RootedPath asRootedPath(String path) {
+    return RootedPath.toRootedPath(Root.absoluteRoot(fs), fs.getPath(path));
   }
 
   private static String logMarker(String text) {

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnStrategyTest.java
@@ -17,8 +17,12 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.vfs.FileSystem;
-import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Root;
+import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import java.io.File;
@@ -47,9 +51,13 @@ public class WorkerSpawnStrategyTest {
       flags.forEach(pw::println);
     }
 
-    Path execRoot = fs.getPath(folder.getRoot().getAbsolutePath());
+    RootedPath path = RootedPath.toRootedPath(Root.absoluteRoot(fs),
+        fs.getPath(flagfile.getAbsolutePath()));
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
-    WorkerSpawnRunner.expandArgument(execRoot, "@flagfile.txt", requestBuilder);
+    SandboxInputs inputs = new SandboxInputs(
+        ImmutableMap.of(PathFragment.create("flagfile.txt"), path), ImmutableMap.of(),
+        ImmutableMap.of(), ImmutableMap.of());
+    WorkerSpawnRunner.expandArgument(inputs, "@flagfile.txt", requestBuilder);
 
     assertThat(requestBuilder.getArgumentsList()).containsExactlyElementsIn(flags);
   }


### PR DESCRIPTION
A worker command line referencing a flag file that is not an input to the action now results in an error instead of a non-hermetic file read.

Work towards #6526