### PR TITLE
Use `Args#add_all` to add a directory in Java bootstrap action

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -233,7 +233,7 @@ def _bootclasspath_impl(ctx):
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED")
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED")
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED")
-    args.add("-cp", class_dir.path)
+    args.add_all("-cp", [class_dir], expand_directories = False)
     args.add("DumpPlatformClassPath")
     args.add(bootclasspath)
 


### PR DESCRIPTION
This allows `StarlarkCustomCommandLine` to recognize the argument as an `Artifact` and map its path according to `--experimental_output_paths`.

Work towards #6526