### PR TITLE
Rename `--experimental_remote_grpc_log` to `--remote_grpc_log`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -405,11 +405,11 @@ public final class RemoteModule extends BlazeModule {
     }
 
     ClientInterceptor loggingInterceptor = null;
-    if (remoteOptions.experimentalRemoteGrpcLog != null) {
+    if (remoteOptions.remoteGrpcLog != null) {
       try {
         rpcLogFile =
             new AsynchronousFileOutputStream(
-                env.getWorkingDirectory().getRelative(remoteOptions.experimentalRemoteGrpcLog));
+                env.getWorkingDirectory().getRelative(remoteOptions.remoteGrpcLog));
       } catch (IOException e) {
         handleInitFailure(env, e, Code.RPC_LOG_FAILURE);
         return;

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -378,7 +378,8 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public boolean experimentalGuardAgainstConcurrentChanges;
 
   @Option(
-      name = "experimental_remote_grpc_log",
+      name = "remote_grpc_log",
+      oldName = "experimental_remote_grpc_log",
       defaultValue = "null",
       category = "remote",
       documentationCategory = OptionDocumentationCategory.REMOTE,
@@ -391,7 +392,7 @@ public final class RemoteOptions extends CommonRemoteOptions {
               + "protobufs with each message prefixed by a varint denoting the size of the"
               + " following serialized protobuf message, as performed by the method "
               + "LogEntry.writeDelimitedTo(OutputStream).")
-  public PathFragment experimentalRemoteGrpcLog;
+  public PathFragment remoteGrpcLog;
 
   @Option(
       name = "incompatible_remote_symlinks",


### PR DESCRIPTION
GRPC logging has been in use since the start of REAPI application to bazel, and is sufficiently stable and supported by tools_remote/remote_client

RELNOTES: `--experimental_remote_grpc_log` has been renamed to `--remote_grpc_log`