### PR TITLE
[6.2.0] Check for the nullness of AspectValue.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ConfiguredTargetValueAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ConfiguredTargetValueAccessor.java
@@ -37,7 +37,6 @@ import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.WalkableGraph;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -162,8 +161,8 @@ public class ConfiguredTargetValueAccessor implements TargetAccessor<KeyedConfig
   }
 
   /** Returns the AspectValues that are attached to the given configuredTarget. */
-  public Collection<AspectValue> getAspectValues(
-      KeyedConfiguredTargetValue keyedConfiguredTargetValue) throws InterruptedException {
+  public Set<AspectValue> getAspectValues(KeyedConfiguredTargetValue keyedConfiguredTargetValue)
+      throws InterruptedException {
     Set<AspectValue> result = new HashSet<>();
     SkyKey skyKey = configuredTargetKeyExtractor.extractKey(keyedConfiguredTargetValue);
     Iterable<SkyKey> revDeps =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
@@ -283,9 +283,18 @@ public class ActionGraphDump {
     aqueryOutputHandler.outputAction(actionBuilder.build());
   }
 
-  public void dumpAspect(AspectValue aspectValue, ConfiguredTargetValue configuredTargetValue)
-      throws CommandLineExpansionException, InterruptedException, IOException,
+  public void dumpAspect(
+      @Nullable AspectValue aspectValue, ConfiguredTargetValue configuredTargetValue)
+      throws CommandLineExpansionException,
+          InterruptedException,
+          IOException,
           TemplateExpansionException {
+    // It's possible for a value from a previous build on the same server to be missing
+    // e.g. after having cleared the analysis cache.
+    if (aspectValue == null) {
+      return;
+    }
+
     ConfiguredTarget configuredTarget = configuredTargetValue.getConfiguredTarget();
     if (!includeInActionGraph(configuredTarget.getLabel().toString())) {
       return;


### PR DESCRIPTION
This should have been included in unknown commit (which added the same check for text output).

FIXES #15716.
Commit https://github.com/bazelbuild/bazel/commit/8a41be90cf24258db14a8ca1be7c4334d0076dd5

PiperOrigin-RevId: 525434548
Change-Id: I5fc80fa1f81ccf5f7b0d8b5d826d8418e2239306