### PR TITLE
Fix typo in example code

### DIFF
--- a/site/en/extending/platforms.md
+++ b/site/en/extending/platforms.md
@@ -226,7 +226,7 @@ cc_library(
     target_compatible_with = select({
         "@platforms//cpu:arm": ["@platforms//:incompatible"],
         "//conditions:default": [],
-    ],
+    }),
 )
 ```
 


### PR DESCRIPTION
Fix a typo terminating the `target_compatible_with` line. The fix makes it easier to copy and paste the relevant portion from the code example.