### PR TITLE
[6.2.0] default_java_toolchain.bzl cherry-picks to fix regression

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -53,6 +53,7 @@ DEFAULT_JAVACOPTS = [
     "-Xep:IgnoredPureGetter:OFF",
     "-Xep:EmptyTopLevelDeclaration:OFF",
     "-Xep:LenientFormatStringValidation:OFF",
+    "-Xep:ReturnMissingNullable:OFF",
 ]
 
 # java_toolchain parameters without specifying javac, java.compiler,

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -38,6 +38,11 @@ BASE_JDK9_JVM_OPTS = [
     # TODO(b/64485048): Disable this option in persistent worker mode only.
     # Disable symlinks resolution cache since symlinks in exec root change
     "-Dsun.io.useCanonCaches=false",
+
+    # Since https://bugs.openjdk.org/browse/JDK-8153723, JVM logging goes to stdout. This
+    # makes it go to stderr instead.
+    "-Xlog:disable",
+    "-Xlog:all=warning:stderr:uptime,level,tags",
 ]
 
 JDK9_JVM_OPTS = BASE_JDK9_JVM_OPTS

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -52,6 +52,7 @@ DEFAULT_JAVACOPTS = [
     # https://github.com/bazelbuild/bazel/issues/16996
     "-Xep:IgnoredPureGetter:OFF",
     "-Xep:EmptyTopLevelDeclaration:OFF",
+    "-Xep:LenientFormatStringValidation:OFF",
 ]
 
 # java_toolchain parameters without specifying javac, java.compiler,

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -49,6 +49,8 @@ DEFAULT_JAVACOPTS = [
     "-parameters",
     # https://github.com/bazelbuild/bazel/issues/15219
     "-Xep:ReturnValueIgnored:OFF",
+    # https://github.com/bazelbuild/bazel/issues/16996
+    "-Xep:IgnoredPureGetter:OFF",
     "-Xep:EmptyTopLevelDeclaration:OFF",
 ]
 


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/commit/3b5789473db34481e4d121d08461c19961bf729b Disable 'IgnoredPureGetter'
https://github.com/bazelbuild/bazel/commit/33a3b01d7ecfcf27102e8cde1253dac987f4a958 Make LenientFormatStringValidation a warning
https://github.com/bazelbuild/bazel/commit/e80ca154239d189a69323048eba0cd6c31e60da4 Make ReturnMissingNullable a warning
https://github.com/bazelbuild/bazel/commit/abea37b3519172ce8810e765b10aa377ef70de3b Redirect JVM warnings to stderr in general.

(https://github.com/bazelbuild/bazel/commit/8d9a06ed7e2b08efe71a4e181a94e244804673bb Make EmptyTopLevelDeclaration a warning -- already cherry-picked into 6.2 earlier)