### PR TITLE
[6.2.0] Fix crash on multiple output symlinks with BwoB

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1254,7 +1254,7 @@ public class RemoteExecutionService {
               String.format(
                   "Symlinks in action outputs are not yet supported by --remote_download_minimal,"
                       + " falling back to downloading all action outputs due to output symlink %s",
-                  Iterables.getOnlyElement(metadata.symlinks()).path())));
+                  Iterables.get(metadata.symlinks(), 0).path())));
       return true;
     }
     return false;

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -418,8 +418,8 @@ EOF
 genrule(
   name = "foo",
   srcs = ["input.txt"],
-  outs = ["output.txt", "output_symlink"],
-  cmd = "cp $< $(location :output.txt) && ln -s output.txt $(location output_symlink)",
+  outs = ["output.txt", "output_symlink", "output_symlink_2"],
+  cmd = "cp $< $(location :output.txt) && ln -s output.txt $(location output_symlink) && ln -s output.txt $(location output_symlink_2)",
 )
 EOF
 


### PR DESCRIPTION
Fixes an issue introduced by ca30372e210a638cfce8334b6dc3396c83424baa.

Fixes https://github.com/bazelbuild/rules_go/issues/3545

Closes #18207.
Commit https://github.com/bazelbuild/bazel/commit/519eef48ee166cfcc4fb8e92d4728483ecc4fd40

PiperOrigin-RevId: 527160752
Change-Id: I8baa3b8f855e22226ba83155e56fd9889a1f2051