### PR TITLE
Expose inherited part of action environment to Starlark tests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -56,6 +56,7 @@ import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Sequence;
+import net.starlark.java.eval.StarlarkList;
 
 /**
  * Abstract implementation of Action which implements basic functionality: the inputs, outputs, and
@@ -645,6 +646,11 @@ public abstract class AbstractAction extends ActionKeyComputer implements Action
   @Override
   public Dict<String, String> getEnv() {
     return Dict.immutableCopyOf(getEnvironment().getFixedEnv());
+  }
+
+  @Override
+  public Sequence<String> getInheritedEnv() {
+    return StarlarkList.immutableCopyOf(getClientEnvironmentVariables());
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/ActionApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/ActionApi.java
@@ -133,6 +133,14 @@ public interface ActionApi extends StarlarkValue {
   Dict<String, String> getEnv();
 
   @StarlarkMethod(
+      name = "inherited_env",
+      structField = true,
+      doc =
+          "The list of environment variable names whose values are inherited from the shell"
+              + " environment for this action.")
+  Sequence<String> getInheritedEnv();
+
+  @StarlarkMethod(
       name = "execution_info",
       structField = true,
       doc =

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -2651,8 +2651,8 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     List<String> envInherit =
         Sequence.cast(envInheritUnchecked, String.class, "test").getImmutableList();
     // Depending on the OS of the host, the environment may contain other variables inherited from
-    // the client environment (possibly in modified form), such as LD_LIBRARY_PATH.
-    assertThat(envInherit).containsAtLeast("MY_VAR", "PATH");
+    // the client environment (possibly in modified form), such as PATH or LD_LIBRARY_PATH.
+    assertThat(envInherit).contains("MY_VAR");
   }
 
   @Test


### PR DESCRIPTION
Starlark tests can use the new `Action#inherited_env` field to get a list of environment variables the action inherits from the client environment, obtained from `AbstractAction#getClientEnvironmentVariables`.