### PR TITLE
[1/3] Bump grpc from 1.47.0 to 1.48.1

### DIFF
--- a/third_party/grpc/BUILD
+++ b/third_party/grpc/BUILD
@@ -30,6 +30,8 @@ license(
 exports_files([
     "grpc_1.47.0.patch",
     "grpc_1.47.0.win_arm64.patch",
+    "grpc_1.48.1.patch",
+    "grpc_1.48.1.win_arm64.patch",
 ])
 
 package(

--- a/third_party/grpc/README.bazel.md
+++ b/third_party/grpc/README.bazel.md
@@ -5,7 +5,7 @@ This directory contains the gRPC libraries needed by Bazel, sourced from
 
 | Repo             | Current   |
 | ---------------- | --------- |
-| `grpc/grpc`      | `v1.41.0` |
+| `grpc/grpc`      | `v1.47.0` |
 
 ## Updating `third_party/grpc`
 
@@ -13,7 +13,7 @@ This requires 3 pull requests:
 
 1. Update `third_party/grpc` to include files from new version
 
-2. Switch `distdir_deps.bzl`, `scripts/bootstrap/compile.sh`, and any other references to new version
+2. Switch `distdir_deps.bzl`, `WORKSPACE`, and any other references to new version
 
 3. Remove older version from `third_party/grpc`
 

--- a/third_party/grpc/grpc_1.48.1.patch
+++ b/third_party/grpc/grpc_1.48.1.patch
@@ -1,0 +1,99 @@
+diff --git a/bazel/grpc_build_system.bzl b/bazel/grpc_build_system.bzl
+index 7bb6b8bdb9..7644107b70 100644
+--- a/bazel/grpc_build_system.bzl
++++ b/bazel/grpc_build_system.bzl
+@@ -30,8 +30,6 @@
+ load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+ load("//bazel:copts.bzl", "GRPC_DEFAULT_COPTS")
+ load("@upb//bazel:upb_proto_library.bzl", "upb_proto_library", "upb_proto_reflection_library")
+-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+-load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
+
+ # The set of pollers to test against if a test exercises polling
+ POLLERS = ["epoll1", "poll"]
+@@ -237,10 +235,6 @@
+     test_lib_ios = name + "_test_lib_ios"
+     ios_tags = tags + ["manual", "ios_cc_test"]
+     test_runner = "ios_x86_64_sim_runner_" + name
+-    ios_test_runner(
+-        name = test_runner,
+-        device_type = "iPhone X",
+-    )
+     if not any([t for t in tags if t.startswith("no_test_ios")]):
+         native.objc_library(
+             name = test_lib_ios,
+@@ -253,15 +247,6 @@
+             testonly = 1,
+         )
+         ios_test_deps = [":" + test_lib_ios]
+-        ios_unit_test(
+-            name = name + "_on_ios",
+-            size = kwargs.get("size"),
+-            data = kwargs.get("data"),
+-            tags = ios_tags,
+-            minimum_os_version = "9.0",
+-            runner = test_runner,
+-            deps = ios_test_deps,
+-        )
+
+ def expand_tests_for_each_poller_and_engine(name, srcs, deps, tags, args, exclude_pollers, uses_event_engine):
+     """Common logic used to parameterize tests for every poller and EventEngine.
+@@ -603,4 +588,4 @@
+     native.config_setting(
+         name = "python3",
+         flag_values = {"@bazel_tools//tools/python:python_version": "PY3"},
+-    )
++    )
+diff --git a/bazel/grpc_deps.bzl b/bazel/grpc_deps.bzl
+index 09fcad95a2..9b737e5deb 100644
+--- a/bazel/grpc_deps.bzl 
++++ b/bazel/grpc_deps.bzl
+@@ -82,7 +82,7 @@
+
+     native.bind(
+         name = "madler_zlib",
+-        actual = "@zlib//:zlib",
++        actual = "@//third_party/zlib",
+     )
+
+     native.bind(
+diff --git a/bazel/grpc_extra_deps.bzl b/bazel/grpc_extra_deps.bzl
+index 09fcad95a2..9b737e5deb 100644
+--- a/bazel/grpc_extra_deps.bzl
++++ b/bazel/grpc_extra_deps.bzl
+@@ -13,14 +13,9 @@
+ # limitations under the License.
+ """Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl."""
+
+-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+-load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+-load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+ load("@com_envoyproxy_protoc_gen_validate//:dependencies.bzl", "go_third_party")
+ load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+-load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
+-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+ load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+
+ def grpc_extra_deps(ignore_version_differences = False):
+@@ -50,20 +45,6 @@
+
+     upb_deps()
+
+-    api_dependencies()
+-
+-    go_rules_dependencies()
+-    go_register_toolchains(version = "1.18")
+-    gazelle_dependencies()
+-
+-    # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is
+-    # needed for building C++ xDS protos
+-    go_third_party()
+-
+-    apple_rules_dependencies(ignore_version_differences = ignore_version_differences)
+-
+-    apple_support_dependencies()
+-
+     # Initialize Google APIs with only C++ and Python targets
+     switched_rules_by_language(
+         name = "com_google_googleapis_imports",

--- a/third_party/grpc/grpc_1.48.1.win_arm64.patch
+++ b/third_party/grpc/grpc_1.48.1.win_arm64.patch
@@ -1,0 +1,25 @@
+From 6ce08c3da545358074eb66dc4202e0474fa5be1b Mon Sep 17 00:00:00 2001
+From: Niyas Sait <niyas.sait@linaro.org>
+Date: Fri, 26 Nov 2021 02:43:37 -0800
+Subject: [PATCH] add workarounds to compile for win/arm64
+
+---
+ src/core/lib/transport/transport.cc | 8 ++++----
+ third_party/cares/cares.BUILD       | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/third_party/cares/cares.BUILD b/third_party/cares/cares.BUILD
+index 7939021a25..430791aa8d 100644
+--- a/third_party/cares/cares.BUILD
++++ b/third_party/cares/cares.BUILD
+@@ -22,7 +22,7 @@ config_setting(
+
+ config_setting(
+     name = "windows",
+-    values = {"cpu": "x64_windows"},
++    constraint_values = ["@platforms//os:windows"],
+ )
+
+ # Android is not officially supported through C++.
+--
+2.33.0.windows.2


### PR DESCRIPTION
PART 1: prepare third_party/grpc files for new version
Composed PR: #18216.

Fixes https://github.com/bazelbuild/bazel/issues/18167.

abseil-cpp is missing stdint.h header include, that broke recent compiler versions. This problem was fixed in this commit upstream: [1].

Due to another commit: [2] in abseil-cpp, we also have to bump grpc as well to make them compatible.

[1] https://github.com/abseil/abseil-cpp/commit/36a4b073f1e7e02ed7d1ac140767e36f82f09b7c
[2] https://github.com/abseil/abseil-cpp/commit/b8bbe92f84ffe1e249016cfe8b79efdffb7a35c1