### PR TITLE
correct platform rule doc link

### DIFF
--- a/site/en/extending/platforms.md
+++ b/site/en/extending/platforms.md
@@ -73,7 +73,7 @@ workspace. They are referenced by label and subject to the usual visibility
 controls. If visibility allows, you can extend an existing constraint setting by
 defining your own value for it.
 
-The [`platform`](/reference/be/platform#platform) rule introduces a new platform with
+The [`platform`](/reference/be/platforms-and-toolchains#platform) rule introduces a new platform with
 certain choices of constraint values. The
 following creates a platform named `linux_x86`, and says that it describes any
 environment that runs a Linux operating system on an x86_64 architecture with a


### PR DESCRIPTION
The previous link for the platform rule in [extending/platforms](https://bazel.build/extending/platforms) was 404ing.