### PR TITLE
Remove j2objc annotations from Bazel's Guava

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -343,14 +343,19 @@ filegroup(
     ],
 )
 
-java_library(
+# TODO(https://github.com/bazelbuild/bazel/issues/18214): After fixing Guava leak
+# in test-runner, the guava target can be reverted back to java_library
+java_import(
     name = "guava",
+    jars = [
+        "@maven//:com_google_guava_guava_file",
+        "@maven//:com_google_guava_failureaccess_file",
+    ],
     applicable_licenses = [":guava_license"],
     exports = [
         ":error_prone_annotations",
         ":jcip_annotations",
         ":jsr305",
-        "@maven//:com_google_guava_guava",
     ],
 )
 


### PR DESCRIPTION
After https://github.com/bazelbuild/bazel/commit/205ba06a677fd1db428ca3cd154f4e585e8e45d4, Bazel's //third_party:guava started to export j2objc annotations.

This commit strips it.

That's important because Guava is leaking into the test's compilation path, so the leak should be minimal.

After this commit java_tools need to be released again in order to fix j2objc annotations leak.