### PR TITLE
Amend BwoB test for action with a symlink output.

### DIFF
--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -411,22 +411,46 @@ EOF
 
 function test_symlink_outputs_warning_with_minimal() {
   mkdir -p a
-  cat > a/input.txt <<'EOF'
-Input file
+  touch a/file1.txt a/file2.txt
+  cat > a/defs.bzl <<'EOF'
+def _impl(ctx):
+  commands = []
+  outputs = []
+  for target, name in ctx.attr.symlink_map.items():
+    sym = ctx.actions.declare_symlink(name)
+    file = target.files.to_list()[0]
+    outputs.append(sym)
+    commands.append("ln -s {} {}".format(file.path, sym.path))
+
+  ctx.actions.run_shell(
+    outputs = outputs,
+    command = " && ".join(commands),
+  )
+
+  return DefaultInfo(files = depset(outputs))
+
+symlinks = rule(
+  implementation = _impl,
+  attrs = {
+    "symlink_map": attr.label_keyed_string_dict(allow_files = True),
+  },
+)
 EOF
   cat > a/BUILD <<'EOF'
-genrule(
-  name = "foo",
-  srcs = ["input.txt"],
-  outs = ["output.txt", "output_symlink", "output_symlink_2"],
-  cmd = "cp $< $(location :output.txt) && ln -s output.txt $(location output_symlink) && ln -s output.txt $(location output_symlink_2)",
+load(":defs.bzl", "symlinks")
+symlinks(
+  name = "sym",
+  symlink_map = {
+    "file1.txt": "sym1",
+    "file2.txt": "sym2",
+  },
 )
 EOF
 
   bazel build \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_download_minimal \
-    //a:foo >& $TEST_log || fail "Expected build of //a:foo to succeed"
+    //a:sym >& $TEST_log || fail "Expected build of //a:foo to succeed"
   expect_log "Symlinks in action outputs are not yet supported"
 }
 


### PR DESCRIPTION
"Running a remote action with a symlink output" could mean one of two things:

(1) The action declares an output symlink which is reported as a symlink by the remote executor.

(2) The action declares an output non-symlink which is reported as a symlink by the remote executor.

While I believe (1) should be supported, I'm much less convinced about (2), because it amounts to asking Bazel to resolve the symlink given incomplete knowledge about the filesystem where it was produced; this is generally impossible and potentially non-hermetic. (While we could support only hermetic cases, e.g. by requiring it to resolve against one of the other action outputs, that still requires a degree of sophistication that doesn't exist today.)

Therefore, this PR replaces (2) with (1) in the test added by ca30372, so that it accurately reflects the work to be done.