### PR TITLE
Conditionally set output_paths based on Remote Executor capabilities

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ApiVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ApiVersion.java
@@ -23,12 +23,21 @@ public class ApiVersion implements Comparable<ApiVersion> {
   public final int patch;
   public final String prerelease;
 
+  // The version of the Remote Execution API that Bazel supports initially.
+  public static final ApiVersion twoPointZero =
+      new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build());
+  // The version of the Remote Execution API that starts supporting the
+  // Command.output_paths and ActionResult.output_symlinks fields.
+  public static final ApiVersion twoPointOne =
+      new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(1).build());
+  // The latest version of the Remote Execution API that Bazel is compatible with.
+  public static final ApiVersion twoPointTwo =
+      new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(2).build());
+
   // The current lowest/highest versions (inclusive) of the Remote Execution API that Bazel
   // supports. These fields will need to be updated together with all version changes.
-  public static final ApiVersion low =
-      new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build());
-  public static final ApiVersion high =
-      new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build());
+  public static final ApiVersion low = twoPointZero;
+  public static final ApiVersion high = twoPointTwo;
 
   public ApiVersion(int major, int minor, int patch, String prerelease) {
     this.major = major;

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -29,6 +29,7 @@ import build.bazel.remote.execution.v2.FindMissingBlobsRequest;
 import build.bazel.remote.execution.v2.FindMissingBlobsResponse;
 import build.bazel.remote.execution.v2.GetActionResultRequest;
 import build.bazel.remote.execution.v2.RequestMetadata;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.UpdateActionResultRequest;
 import com.google.bytestream.ByteStreamGrpc;
 import com.google.bytestream.ByteStreamGrpc.ByteStreamStub;
@@ -261,6 +262,11 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
   @Override
   public CacheCapabilities getCacheCapabilities() throws IOException {
     return channel.getServerCapabilities().getCacheCapabilities();
+  }
+
+  @Override
+  public ServerCapabilities getServerCapabilities() throws IOException {
+    return channel.getServerCapabilities();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -26,6 +26,7 @@ import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.flogger.GoogleLogger;
@@ -122,6 +123,13 @@ public class RemoteCache extends AbstractReferenceCounted {
       return immediateFuture("");
     }
     return remoteCacheClient.getAuthority();
+  }
+
+  public ServerCapabilities getServerCapabilities() throws IOException {
+    if (remoteCacheClient == null) {
+      return ServerCapabilities.getDefaultInstance();
+    }
+    return remoteCacheClient.getServerCapabilities();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
@@ -18,6 +18,7 @@ import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.vfs.Path;
@@ -32,6 +33,8 @@ import java.io.OutputStream;
  */
 public interface RemoteCacheClient extends MissingDigestsFinder {
   CacheCapabilities getCacheCapabilities() throws IOException;
+
+  ServerCapabilities getServerCapabilities() throws IOException;
 
   ListenableFuture<String> getAuthority();
 

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -17,6 +17,7 @@ import build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
@@ -608,6 +609,11 @@ public final class HttpCacheClient implements RemoteCacheClient {
             ActionCacheUpdateCapabilities.newBuilder().setUpdateEnabled(true).build())
         .setSymlinkAbsolutePathStrategy(SymlinkAbsolutePathStrategy.Value.ALLOWED)
         .build();
+  }
+
+  @Override
+  public ServerCapabilities getServerCapabilities() {
+    return ServerCapabilities.newBuilder().setCacheCapabilities(getCacheCapabilities()).build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -414,6 +414,16 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public boolean cacheCompression;
 
   @Option(
+      name = "incompatible_remote_use_output_paths",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "If enabled, check if the remote server(s) support remote execution API v2.1 or newer."
+              + "If yes, use the newer Command.output_paths field. Default is false.")
+  public boolean useOutputPaths;
+
+  @Option(
       name = "experimental_remote_cache_compression_threshold",
       // Based on discussions in #18997, `~100` is the break even point where the compression
       // actually helps the builds.

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -38,6 +38,7 @@ import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
+import build.bazel.remote.execution.v2.ExecutionCapabilities;
 import build.bazel.remote.execution.v2.FileNode;
 import build.bazel.remote.execution.v2.NodeProperties;
 import build.bazel.remote.execution.v2.NodeProperty;
@@ -46,6 +47,7 @@ import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.OutputSymlink;
 import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.RequestMetadata;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.SymlinkNode;
 import build.bazel.remote.execution.v2.Tree;
 import com.google.common.base.Throwables;
@@ -153,6 +155,22 @@ public class RemoteExecutionServiceTest {
   private final Reporter reporter = new Reporter(new EventBus());
   private final StoredEventHandler eventHandler = new StoredEventHandler();
 
+  // In the past, Bazel only supports RemoteApi version 2.0.
+  // Use this to ensure we are backward compatible with Servers that only support 2.0.
+  private final ServerCapabilities legacyRemoteExecutorCapabilities =
+      ServerCapabilities.newBuilder()
+          .setLowApiVersion(ApiVersion.twoPointZero.toSemVer())
+          .setHighApiVersion(ApiVersion.twoPointZero.toSemVer())
+          .setExecutionCapabilities(ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
+          .build();
+
+  private final ServerCapabilities remoteExecutorCapabilities =
+      ServerCapabilities.newBuilder()
+          .setLowApiVersion(ApiVersion.low.toSemVer())
+          .setHighApiVersion(ApiVersion.high.toSemVer())
+          .setExecutionCapabilities(ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
+          .build();
+
   RemoteOptions remoteOptions;
   private FileSystem fs;
   private Path execRoot;
@@ -171,6 +189,7 @@ public class RemoteExecutionServiceTest {
     reporter.addHandler(eventHandler);
 
     remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.useOutputPaths = true;
 
     fs = new InMemoryFileSystem(new JavaClock(), DigestHashFunction.SHA256);
 
@@ -196,7 +215,9 @@ public class RemoteExecutionServiceTest {
     outErr = new FileOutErr(stdout, stderr);
 
     cache = spy(new InMemoryRemoteCache(spy(new InMemoryCacheClient()), remoteOptions, digestUtil));
+    doReturn(remoteExecutorCapabilities).when(cache).getServerCapabilities();
     executor = mock(RemoteExecutionClient.class);
+    when(executor.getServerCapabilities()).thenReturn(remoteExecutorCapabilities);
 
     RequestMetadata metadata =
         TracingMetadataUtils.buildMetadata("none", "none", "action-id", null);
@@ -215,9 +236,28 @@ public class RemoteExecutionServiceTest {
 
     RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
 
-    assertThat(remoteAction.getCommand().getOutputFilesList()).containsExactly(execPath.toString());
-    assertThat(remoteAction.getCommand().getOutputPathsList()).containsExactly(execPath.toString());
+    assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
     assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputPathsList()).containsExactly(execPath.toString());
+  }
+
+  @Test
+  public void legacy_buildRemoteAction_withRegularFileAsOutput() throws Exception {
+    doReturn(legacyRemoteExecutorCapabilities).when(cache).getServerCapabilities();
+    when(executor.getServerCapabilities()).thenReturn(legacyRemoteExecutorCapabilities);
+    PathFragment execPath = execRoot.getRelative("path/to/tree").asFragment();
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(ActionsTestUtil.createArtifactWithExecPath(artifactRoot, execPath))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).containsExactly(execPath.toString());
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputPathsList()).isEmpty();
   }
 
   @Test
@@ -234,7 +274,28 @@ public class RemoteExecutionServiceTest {
     RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
 
     assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputPathsList()).containsExactly("path/to/dir");
+  }
+
+  @Test
+  public void legacy_buildRemoteAction_withTreeArtifactAsOutput() throws Exception {
+    doReturn(legacyRemoteExecutorCapabilities).when(cache).getServerCapabilities();
+    when(executor.getServerCapabilities()).thenReturn(legacyRemoteExecutorCapabilities);
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(
+                ActionsTestUtil.createTreeArtifactWithGeneratingAction(
+                    artifactRoot, PathFragment.create("path/to/dir")))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
     assertThat(remoteAction.getCommand().getOutputDirectoriesList()).containsExactly("path/to/dir");
+    assertThat(remoteAction.getCommand().getOutputPathsList()).isEmpty();
   }
 
   @Test
@@ -250,9 +311,29 @@ public class RemoteExecutionServiceTest {
 
     RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
 
-    assertThat(remoteAction.getCommand().getOutputFilesList()).containsExactly("path/to/link");
+    assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
     assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
     assertThat(remoteAction.getCommand().getOutputPathsList()).containsExactly("path/to/link");
+  }
+
+  @Test
+  public void legacy_buildRemoteAction_withUnresolvedSymlinkAsOutput() throws Exception {
+    doReturn(legacyRemoteExecutorCapabilities).when(cache).getServerCapabilities();
+    when(executor.getServerCapabilities()).thenReturn(legacyRemoteExecutorCapabilities);
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(
+                ActionsTestUtil.createUnresolvedSymlinkArtifactWithExecPath(
+                    artifactRoot, PathFragment.create("path/to/link")))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).containsExactly("path/to/link");
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputPathsList()).isEmpty();
   }
 
   @Test
@@ -266,8 +347,43 @@ public class RemoteExecutionServiceTest {
 
     RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
 
+    assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputPathsList()).containsExactly("path/to/file");
+  }
+
+  @Test
+  public void legacy_buildRemoteAction_withActionInputFileAsOutput() throws Exception {
+    doReturn(legacyRemoteExecutorCapabilities).when(cache).getServerCapabilities();
+    when(executor.getServerCapabilities()).thenReturn(legacyRemoteExecutorCapabilities);
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(ActionInputHelper.fromPath(PathFragment.create("path/to/file")))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
     assertThat(remoteAction.getCommand().getOutputFilesList()).containsExactly("path/to/file");
     assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputPathsList()).isEmpty();
+  }
+
+  @Test
+  public void buildRemoteAction_withActionInputDirectoryAsOutput() throws Exception {
+    Spawn spawn =
+        new SpawnBuilder("dummy")
+            .withOutput(ActionInputHelper.fromPath(PathFragment.create("path/to/dir")))
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService();
+
+    RemoteAction remoteAction = service.buildRemoteAction(spawn, context);
+
+    assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputPathsList()).containsExactly("path/to/dir");
   }
 
   @Test
@@ -2367,10 +2483,8 @@ public class RemoteExecutionServiceTest {
         .containsExactly(
             PathFragment.create("outputs/bin/input1"), mappedInput,
             PathFragment.create("outputs/bin/input2"), unmappedInput);
-    assertThat(remoteAction.getCommand().getOutputFilesList())
-        .containsExactly("outputs/bin/dir/output1", "outputs/bin/other_dir/output2");
-    assertThat(remoteAction.getCommand().getOutputDirectoriesList())
-        .containsExactly("outputs/bin/output_dir");
+    assertThat(remoteAction.getCommand().getOutputFilesList()).isEmpty();
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList()).isEmpty();
     assertThat(remoteAction.getCommand().getOutputPathsList())
         .containsExactly(
             "outputs/bin/dir/output1", "outputs/bin/other_dir/output2", "outputs/bin/output_dir");

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -758,7 +758,9 @@ public class RemoteSpawnCacheTest {
   @Test
   public void pathMappedActionIsDeduplicated() throws Exception {
     // arrange
-    RemoteSpawnCache cache = createRemoteSpawnCache();
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.useOutputPaths = true;
+    RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
 
     SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild");
     FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
@@ -967,7 +969,9 @@ public class RemoteSpawnCacheTest {
   @Test
   public void deduplicatedActionWithNonZeroExitCodeIsACacheMiss() throws Exception {
     // arrange
-    RemoteSpawnCache cache = createRemoteSpawnCache();
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.useOutputPaths = true;
+    RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
 
     SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild");
     FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
@@ -1016,7 +1020,9 @@ public class RemoteSpawnCacheTest {
   @Test
   public void deduplicatedActionWithMissingOutputIsACacheMiss() throws Exception {
     // arrange
-    RemoteSpawnCache cache = createRemoteSpawnCache();
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.useOutputPaths = true;
+    RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
 
     SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild");
     FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -40,8 +40,10 @@ import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
 import build.bazel.remote.execution.v2.ExecuteRequest;
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import build.bazel.remote.execution.v2.ExecutedActionMetadata;
+import build.bazel.remote.execution.v2.ExecutionCapabilities;
 import build.bazel.remote.execution.v2.ExecutionStage.Value;
 import build.bazel.remote.execution.v2.LogFile;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableList;
@@ -172,6 +174,13 @@ public class RemoteSpawnRunnerTest {
   private static final String SIMPLE_ACTION_ID =
       "31aea267dc597b047a9b6993100415b6406f82822318dc8988e4164a535b51ee";
 
+  private final ServerCapabilities remoteExecutorCapabilities =
+      ServerCapabilities.newBuilder()
+          .setLowApiVersion(ApiVersion.low.toSemVer())
+          .setHighApiVersion(ApiVersion.high.toSemVer())
+          .setExecutionCapabilities(ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
+          .build();
+
   @Before
   public final void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
@@ -194,8 +203,9 @@ public class RemoteSpawnRunnerTest {
     remoteOptions = Options.getDefaults(RemoteOptions.class);
 
     retryService = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
-
     when(cache.hasRemoteCache()).thenReturn(true);
+    doReturn(remoteExecutorCapabilities).when(cache).getServerCapabilities();
+    when(executor.getServerCapabilities()).thenReturn(remoteExecutorCapabilities);
     when(cache.remoteActionCacheSupportsUpdate()).thenReturn(true);
   }
 
@@ -288,6 +298,7 @@ public class RemoteSpawnRunnerTest {
     // Test that if a non-cachable spawn is executed locally due to the local fallback,
     // that its result is not uploaded to the remote cache.
 
+    remoteOptions.useOutputPaths = true;
     remoteOptions.remoteAcceptCached = true;
     remoteOptions.remoteLocalFallback = true;
     remoteOptions.remoteUploadLocalResults = true;
@@ -307,6 +318,7 @@ public class RemoteSpawnRunnerTest {
     runner.exec(spawn, policy);
 
     verify(localRunner).exec(spawn, policy);
+    verify(cache).getServerCapabilities();
     verify(cache).ensureInputsPresent(any(), any(), any(), anyBoolean(), any());
     verify(cache, atLeastOnce()).hasRemoteCache();
     verify(cache, atLeastOnce()).hasDiskCache();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -293,6 +293,7 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
         ImmutableList.of(
             Maps.immutableEntry("CacheKey1", "CacheValue1"),
             Maps.immutableEntry("CacheKey2", "CacheValue2"));
+    remoteOptions.useOutputPaths = true;
 
     retryService = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
     RemoteRetrier retrier =
@@ -312,6 +313,8 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
                         .build();
                 ServerCapabilities caps =
                     ServerCapabilities.newBuilder()
+                        .setLowApiVersion(ApiVersion.low.toSemVer())
+                        .setHighApiVersion(ApiVersion.high.toSemVer())
                         .setExecutionCapabilities(
                             ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
                         .build();
@@ -375,7 +378,6 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
                     .setName("VARIABLE")
                     .setValue("value")
                     .build())
-            .addAllOutputFiles(ImmutableList.of("bar", "foo"))
             .addAllOutputPaths(ImmutableList.of("bar", "foo"))
             .build();
     cmdDigest = DIGEST_UTIL.compute(command);

--- a/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
@@ -17,6 +17,7 @@ import build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
@@ -115,6 +116,11 @@ public class InMemoryCacheClient implements RemoteCacheClient {
             ActionCacheUpdateCapabilities.newBuilder().setUpdateEnabled(true).build())
         .setSymlinkAbsolutePathStrategy(SymlinkAbsolutePathStrategy.Value.ALLOWED)
         .build();
+  }
+
+  @Override
+  public ServerCapabilities getServerCapabilities() {
+    return ServerCapabilities.getDefaultInstance();
   }
 
   @Override

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -305,27 +305,44 @@ final class ExecutionServer extends ExecutionImplBase {
     Path workingDirectory = execRoot.getRelative(command.getWorkingDirectory());
     workingDirectory.createDirectoryAndParents();
 
-    List<Path> outputs =
-        new ArrayList<>(command.getOutputDirectoriesCount() + command.getOutputFilesCount());
-
-    for (String output : command.getOutputFilesList()) {
-      Path file = workingDirectory.getRelative(output);
-      if (file.exists()) {
-        throw new FileAlreadyExistsException("Output file already exists: " + file);
-      }
-      file.getParentDirectory().createDirectoryAndParents();
-      outputs.add(file);
-    }
-    for (String output : command.getOutputDirectoriesList()) {
-      Path file = workingDirectory.getRelative(output);
-      if (file.exists()) {
-        if (!file.isDirectory()) {
-          throw new FileAlreadyExistsException(
-              "Non-directory exists at output directory path: " + file);
+    List<Path> outputs;
+    if (command.getOutputPathsCount() == 0) {
+      outputs =
+          new ArrayList<>(command.getOutputDirectoriesCount() + command.getOutputFilesCount());
+      for (String output : command.getOutputFilesList()) {
+        var file = workingDirectory.getRelative(output);
+        if (file.exists()) {
+          throw new FileAlreadyExistsException("Output file already exists: " + file);
         }
+        file.getParentDirectory().createDirectoryAndParents();
+        outputs.add(file);
       }
-      file.getParentDirectory().createDirectoryAndParents();
-      outputs.add(file);
+      for (String output : command.getOutputDirectoriesList()) {
+        Path file = workingDirectory.getRelative(output);
+        if (file.exists()) {
+          if (!file.isDirectory()) {
+            throw new FileAlreadyExistsException(
+                "Non-directory exists at output directory path: " + file);
+          }
+        }
+        file.getParentDirectory().createDirectoryAndParents();
+        outputs.add(file);
+      }
+    } else {
+      outputs = new ArrayList<>(command.getOutputPathsCount());
+      for (String output : command.getOutputPathsList()) {
+        var file = workingDirectory.getRelative(output);
+        // Since https://github.com/bazelbuild/bazel/pull/15818,
+        // Bazel includes all expected output directories as part of Action's inputs.
+        //
+        // Ensure no output file exists before execution happen.
+        // Ignore if output directories pre-exist.
+        if (file.exists() && !file.isDirectory()) {
+          throw new FileAlreadyExistsException("Output file already exists: " + file);
+        }
+        file.getParentDirectory().createDirectoryAndParents();
+        outputs.add(file);
+      }
     }
 
     // TODO(ulfjack): This is basically a copy of LocalSpawnRunner. Ideally, we'd use that
@@ -454,8 +471,8 @@ final class ExecutionServer extends ExecutionImplBase {
     com.google.devtools.build.lib.shell.Command cmd =
         new com.google.devtools.build.lib.shell.Command(
             new String[] {"id", "-u"},
-            /*environmentVariables=*/ null,
-            /*workingDirectory=*/ null,
+            /* environmentVariables= */ null,
+            /* workingDirectory= */ null,
             uidTimeout);
     try {
       ByteArrayOutputStream stdout = new ByteArrayOutputStream();

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -188,7 +188,7 @@ public final class RemoteWorker {
     } else {
       execServer = null;
     }
-    this.capabilitiesServer = new CapabilitiesServer(digestUtil, execServer != null);
+    this.capabilitiesServer = new CapabilitiesServer(digestUtil, execServer != null, workerOptions);
   }
 
   public Server startServer() throws IOException {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorkerOptions.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorkerOptions.java
@@ -28,66 +28,70 @@ public class RemoteWorkerOptions extends OptionsBase {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   @Option(
-    name = "listen_port",
-    defaultValue = "8080",
-    category = "build_worker",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    help = "Listening port for the netty server."
-  )
+      name = "listen_port",
+      defaultValue = "8080",
+      category = "build_worker",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "Listening port for the netty server.")
   public int listenPort;
 
   @Option(
-    name = "work_path",
-    defaultValue = "null",
-    category = "build_worker",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    help = "A directory for the build worker to do work."
-  )
+      name = "work_path",
+      defaultValue = "null",
+      category = "build_worker",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "A directory for the build worker to do work.")
   public String workPath;
 
   @Option(
-    name = "cas_path",
-    defaultValue = "null",
-    category = "build_worker",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    help = "A directory for the build worker to store it's files in. If left unset, and if no "
-        + "other store is set, the worker falls back to an in-memory store."
-  )
+      name = "cas_path",
+      defaultValue = "null",
+      category = "build_worker",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "A directory for the build worker to store it's files in. If left unset, and if no "
+              + "other store is set, the worker falls back to an in-memory store.")
   public String casPath;
 
   @Option(
-    name = "debug",
-    defaultValue = "false",
-    category = "build_worker",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    help =
-        "Turn this on for debugging remote job failures. There will be extra messages and the "
-            + "work directory will be preserved in the case of failure."
-  )
+      name = "debug",
+      defaultValue = "false",
+      category = "build_worker",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Turn this on for debugging remote job failures. There will be extra messages and the "
+              + "work directory will be preserved in the case of failure.")
   public boolean debug;
 
   @Option(
-    name = "pid_file",
-    defaultValue = "null",
-    category = "build_worker",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    help = "File for writing the process id for this worker when it is fully started."
-  )
+      name = "legacy_api",
+      defaultValue = "false",
+      category = "build_worker",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "Restrict worker to RemoteApi version 2.0 capabilities")
+  public boolean legacyApi;
+
+  @Option(
+      name = "pid_file",
+      defaultValue = "null",
+      category = "build_worker",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "File for writing the process id for this worker when it is fully started.")
   public String pidFile;
 
   @Option(
-    name = "sandboxing",
-    defaultValue = "false",
-    category = "build_worker",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    help = "If supported on this platform, use sandboxing for increased hermeticity."
-  )
+      name = "sandboxing",
+      defaultValue = "false",
+      category = "build_worker",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "If supported on this platform, use sandboxing for increased hermeticity.")
   public boolean sandboxing;
 
   @Option(
@@ -111,13 +115,12 @@ public class RemoteWorkerOptions extends OptionsBase {
   public List<String> sandboxingTmpfsDirs;
 
   @Option(
-    name = "sandboxing_block_network",
-    defaultValue = "false",
-    category = "build_worker",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    help = "When using sandboxing, block network access for running actions."
-  )
+      name = "sandboxing_block_network",
+      defaultValue = "false",
+      category = "build_worker",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "When using sandboxing, block network access for running actions.")
   public boolean sandboxingBlockNetwork;
 
   @Option(


### PR DESCRIPTION
This is a follow up to #18269, toward the discussion in #18202.

Bump the Remote API supported version to v2.1.

Based on the Capability of the Remote Executor, either use output_paths
field or the legacy fields output_files and output_directories.
