### PR TITLE
Delete .git directory from git_repository external repositories when using strip_prefix

### DIFF
--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -162,6 +162,9 @@ EOF
   bazel run //planets:planet-info >& $TEST_log \
     || echo "Expected build/run to succeed"
   expect_log "Pluto is a dwarf planet"
+
+  git_repos_count=$(find $(bazel info output_base)/external/pluto -type d -name .git | wc -l)
+  assert_equals $git_repos_count 0
 }
 
 function test_git_repository() {
@@ -290,6 +293,9 @@ EOF
   else
       expect_log "Pluto is a dwarf planet"
   fi
+
+  git_repos_count=$(find $(bazel info output_base)/external/pluto -type d -name .git | wc -l)
+  assert_equals $git_repos_count 0
 }
 
 # Test cloning a Git repository that has a submodule using the

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -173,7 +173,10 @@ def _git_repository_implementation(ctx):
     update = _clone_or_update_repo(ctx)
     workspace_and_buildfile(ctx)
     patch(ctx)
-    ctx.delete(ctx.path(".git"))
+    if ctx.attr.strip_prefix:
+        ctx.delete(ctx.path(".tmp_git_root/.git"))
+    else:
+        ctx.delete(ctx.path(".git"))
     return _update_git_attrs(ctx.attr, _common_attrs.keys(), update)
 
 git_repository = repository_rule(


### PR DESCRIPTION
Leaving the `.git` directory in an external repository makes the rule not reproducible since this directory contains timestamps of when the fetch occurred. When strip_prefix is not specified, this directory is correctly cleaned up but not when strip_prefix is specified, since the `.git` directory lives in `.tmp_git_root`.

Note that we cannot delete the whole `.tmp_git_root` directory, since the items in the root are symlinks to here.

Fixes #18152.