### PR TITLE
[6.2.0] Remove j2objc annotations from Bazel's Guava

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -473,8 +473,14 @@ filegroup(
     ],
 )
 
-distrib_java_import(
+# TODO(https://github.com/bazelbuild/bazel/issues/18214): After fixing Guava leak
+# in test-runner, the guava target can be reverted back to java_library
+java_import(
     name = "guava",
+    jars = [
+        "@maven//:com_google_guava_guava_file",
+        "@maven//:com_google_guava_failureaccess_file",
+    ],
     applicable_licenses = [":guava_license"],
     enable_distributions = ["debian"],
     jars = [


### PR DESCRIPTION
Partial commit for third_party/*, see #18256.

After https://github.com/bazelbuild/bazel/commit/205ba06a677fd1db428ca3cd154f4e585e8e45d4, Bazel's //third_party:guava started to export j2objc annotations.

This commit strips it.

That's important because Guava is leaking into the test's compilation path, so the leak should be minimal.

After this commit java_tools need to be released again in order to fix j2objc annotations leak.

PR: https://github.com/bazelbuild/bazel/pull/18256
Commit: https://github.com/bazelbuild/bazel/commit/413a8ba8471726a2515e0b771fdf7a0a3cd213a0