### PR TITLE
[6.2.0] Remove j2objc annotations from Bazel's Guava

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -473,11 +473,15 @@ filegroup(
     ],
 )
 
-distrib_java_import(
+# TODO(https://github.com/bazelbuild/bazel/issues/18214): After fixing Guava leak
+# in test-runner, the guava target can be reverted back to java_library
+java_import(
     name = "guava",
     applicable_licenses = [":guava_license"],
     enable_distributions = ["debian"],
     jars = [
+        "@maven//:com_google_guava_guava_file",
+        "@maven//:com_google_guava_failureaccess_file",
         "guava/failureaccess-1.0.1.jar",
         "guava/guava-31.1-jre.jar",
     ],

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -478,12 +478,9 @@ filegroup(
 java_import(
     name = "guava",
     applicable_licenses = [":guava_license"],
-    enable_distributions = ["debian"],
     jars = [
         "@maven//:com_google_guava_guava_file",
         "@maven//:com_google_guava_failureaccess_file",
-        "guava/failureaccess-1.0.1.jar",
-        "guava/guava-31.1-jre.jar",
     ],
     exports = [
         ":error_prone_annotations",


### PR DESCRIPTION
Partial commit for third_party/*, see #18256.