### PR TITLE
Add documentation and tests for `cc_test` implicit output targets

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcTestRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcTestRule.java
@@ -28,7 +28,6 @@ import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
 import com.google.devtools.build.lib.packages.TriState;
 import com.google.devtools.build.lib.rules.cpp.CppConfiguration;
-import com.google.devtools.build.lib.rules.cpp.CppRuleClasses;
 import com.google.devtools.build.lib.util.OS;
 
 /**
@@ -41,7 +40,19 @@ public final class BazelCcTestRule implements RuleDefinition {
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
     return builder
         .requiresConfigurationFragments(CppConfiguration.class)
-        .setImplicitOutputsFunction(CppRuleClasses.CC_BINARY_DEBUG_PACKAGE)
+        /*<!-- #BLAZE_RULE(cc_test).IMPLICIT_OUTPUTS -->
+        <ul>
+        <li><code><var>name</var>.stripped</code> (only built if explicitly requested): A stripped
+          version of the binary. <code>strip -g</code> is run on the binary to remove debug
+          symbols.  Additional strip options can be provided on the command line using
+          <code>--stripopt=-foo</code>. This output is only built if explicitly requested.</li>
+        <li><code><var>name</var>.dwp</code> (only built if explicitly requested): If
+          <a href="https://gcc.gnu.org/wiki/DebugFission">Fission</a> is enabled: a debug
+          information package file suitable for debugging remotely deployed binaries. Else: an
+          empty file.</li>
+        </ul>
+        <!-- #END_BLAZE_RULE.IMPLICIT_OUTPUTS -->*/
+        .setImplicitOutputsFunction(BazelCppRuleClasses.CC_BINARY_IMPLICIT_OUTPUTS)
         // We don't want C++ tests to be dynamically linked by default on Windows,
         // because windows_export_all_symbols is not enabled by default, and it cannot solve
         // all symbols visibility issues, for example, users still have to use __declspec(dllimport)

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
@@ -360,7 +360,8 @@ public abstract class AbstractQueryTest<T> {
     writeFile(
         "c/BUILD",
         "genrule(name='c', srcs=['p', 'q'], outs=['r', 's'], cmd=':')",
-        "cc_binary(name='d', srcs=['e.cc'], data=['r'])");
+        "cc_binary(name='d', srcs=['e.cc'], data=['r'])",
+        "cc_test(name='f', srcs=['g.cc'])");
   }
 
   @Test
@@ -368,19 +369,19 @@ public abstract class AbstractQueryTest<T> {
     writeBuildFiles2();
     assertThat(evalToString("c:*"))
         .isEqualTo(
-            "//c:BUILD //c:c //c:d //c:d.dwp //c:d.stripped //c:e.cc //c:p //c:q //c:r //c:s");
-    assertThat(evalToString("kind(rule, c:*)")).isEqualTo("//c:c //c:d");
+            "//c:BUILD //c:c //c:d //c:d.dwp //c:d.stripped //c:e.cc //c:f //c:f.dwp //c:f.stripped //c:g.cc //c:p //c:q //c:r //c:s");
+    assertThat(evalToString("kind(rule, c:*)")).isEqualTo("//c:c //c:d //c:f");
     assertThat(evalToString("kind(genrule, c:*)")).isEqualTo("//c:c");
-    assertThat(evalToString("kind(cc.*, c:*)")).isEqualTo("//c:d");
+    assertThat(evalToString("kind(cc.*, c:*)")).isEqualTo("//c:d //c:f");
     assertThat(evalToString("kind(file, c:*)"))
-        .isEqualTo("//c:BUILD //c:d.dwp //c:d.stripped //c:e.cc //c:p //c:q //c:r //c:s");
+        .isEqualTo("//c:BUILD //c:d.dwp //c:d.stripped //c:e.cc //c:f.dwp //c:f.stripped //c:g.cc //c:p //c:q //c:r //c:s");
     assertThat(evalToString("kind(gener.*, c:*)"))
-        .isEqualTo("//c:d.dwp //c:d.stripped //c:r //c:s");
+        .isEqualTo("//c:d.dwp //c:d.stripped //c:f.dwp //c:f.stripped //c:r //c:s");
     assertThat(evalToString("kind(gen.*, c:*)"))
-        .isEqualTo("//c:c //c:d.dwp //c:d.stripped //c:r //c:s");
-    assertThat(evalToString("kind(source, c:*)")).isEqualTo("//c:BUILD //c:e.cc //c:p //c:q");
+        .isEqualTo("//c:c //c:d.dwp //c:d.stripped //c:f.dwp //c:f.stripped //c:r //c:s");
+    assertThat(evalToString("kind(source, c:*)")).isEqualTo("//c:BUILD //c:e.cc //c:g.cc //c:p //c:q");
     assertThat(evalToString("kind('source file', c:*)"))
-        .isEqualTo("//c:BUILD //c:e.cc //c:p //c:q");
+        .isEqualTo("//c:BUILD //c:e.cc //c:g.cc //c:p //c:q");
   }
 
   @Test
@@ -388,11 +389,11 @@ public abstract class AbstractQueryTest<T> {
     writeBuildFiles2();
     assertThat(evalToString("c:*"))
         .isEqualTo(
-            "//c:BUILD //c:c //c:d //c:d.dwp //c:d.stripped //c:e.cc //c:p //c:q //c:r //c:s");
+            "//c:BUILD //c:c //c:d //c:d.dwp //c:d.stripped //c:e.cc //c:f //c:f.dwp //c:f.stripped //c:g.cc //c:p //c:q //c:r //c:s");
     assertThat(evalToString("filter(BUILD, c:*)")).isEqualTo("//c:BUILD");
-    assertThat(evalToString("filter('\\.cc$', c:*)")).isEqualTo("//c:e.cc");
-    assertThat(evalToString("filter(//c.*cc$, c:*)")).isEqualTo("//c:e.cc");
-    assertThat(evalToString("filter(:.$, c:*)")).isEqualTo("//c:c //c:d //c:p //c:q //c:r //c:s");
+    assertThat(evalToString("filter('\\.cc$', c:*)")).isEqualTo("//c:e.cc //c:g.cc");
+    assertThat(evalToString("filter(//c.*cc$, c:*)")).isEqualTo("//c:e.cc //c:g.cc");
+    assertThat(evalToString("filter(:.$, c:*)")).isEqualTo("//c:c //c:d //c:f //c:p //c:q //c:r //c:s");
   }
 
   @Test
@@ -400,8 +401,8 @@ public abstract class AbstractQueryTest<T> {
     writeBuildFiles2();
     writeBuildFilesWithConfigurableAttributes();
 
-    assertThat(evalToString("attr(name, '.*', '//c:*')")).isEqualTo("//c:c //c:d");
-    assertThat(evalToString("attr(name, '.+', '//c:*')")).isEqualTo("//c:c //c:d");
+    assertThat(evalToString("attr(name, '.*', '//c:*')")).isEqualTo("//c:c //c:d //c:f");
+    assertThat(evalToString("attr(name, '.+', '//c:*')")).isEqualTo("//c:c //c:d //c:f");
     assertThat(evalToString("attr(name, '.*d.*', '//c:*')")).isEqualTo("//c:d");
 
     assertThat(evalToString("attr(name, '.*e.*', '//c:*')")).isEmpty();
@@ -414,17 +415,17 @@ public abstract class AbstractQueryTest<T> {
 
     assertThat(evalToString("c:*"))
         .isEqualTo(
-            "//c:BUILD //c:c //c:d //c:d.dwp //c:d.stripped //c:e.cc //c:p //c:q //c:r //c:s");
+            "//c:BUILD //c:c //c:d //c:d.dwp //c:d.stripped //c:e.cc //c:f //c:f.dwp //c:f.stripped //c:g.cc //c:p //c:q //c:r //c:s");
     assertThat(evalToString("attr(cmd,':', c:*)")).isEqualTo("//c:c");
     // Using "empty" pattern will just check existence of the attribute.
     assertThat(evalToString("attr(cmd,'', c:*)")).isEqualTo("//c:c");
-    assertThat(evalToString("attr(linkshared, 0, c:*)")).isEqualTo("//c:d");
+    assertThat(evalToString("attr(linkshared, 0, c:*)")).isEqualTo("//c:d //c:f");
     assertThat(evalToString("attr('data', 'r', c:*)")).isEqualTo("//c:d");
     // Empty list attribute value always resolves to '[]'. If list attribute has
     // more than one value, the will be delimited with ','.
-    assertThat(evalToString("attr('deps', '\\[\\]', c:*)")).isEqualTo("//c:d");
-    assertThat(evalToString("attr('deps', '^..$', c:*)")).isEqualTo("//c:d");
-    assertThat(evalToString("attr('srcs', '\\[[^,]+\\]', c:*)")).isEqualTo("//c:d");
+    assertThat(evalToString("attr('deps', '\\[\\]', c:*)")).isEqualTo("//c:d //c:f");
+    assertThat(evalToString("attr('deps', '^..$', c:*)")).isEqualTo("//c:d //c:f");
+    assertThat(evalToString("attr('srcs', '\\[[^,]+\\]', c:*)")).isEqualTo("//c:d //c:f");
 
     // Configurable attributes:
     if (testConfigurableAttributes()) {

--- a/src/test/shell/bazel/android/android_ndk_integration_test.sh
+++ b/src/test/shell/bazel/android/android_ndk_integration_test.sh
@@ -370,6 +370,33 @@ EOF
     || fail "build failed with --features=compiler_param_file"
 }
 
+function test_stripped_cc_test() {
+  create_new_workspace
+  setup_android_sdk_support
+  setup_android_ndk_support
+  cat > BUILD <<EOF
+cc_test(
+    name = "foo",
+    srcs = ["foo.cc"],
+)
+EOF
+  cat > foo.cc <<EOF
+int main() { return 0; }
+EOF
+  bazel build //:foo.stripped \
+    --cpu=armeabi-v7a \
+    --crosstool_top=//external:android/crosstool \
+    --host_crosstool_top=@bazel_tools//tools/cpp:toolchain \
+    || fail "build failed"
+
+  bazel build //:foo.stripped \
+    --features=compiler_param_file \
+    --cpu=armeabi-v7a \
+    --crosstool_top=//external:android/crosstool \
+    --host_crosstool_top=@bazel_tools//tools/cpp:toolchain \
+    || fail "build failed with --features=compiler_param_file"
+}
+
 function test_crosstool_stlport() {
   create_new_workspace
   setup_android_sdk_support

--- a/src/test/shell/bazel/cpp_darwin_integration_test.sh
+++ b/src/test/shell/bazel/cpp_darwin_integration_test.sh
@@ -96,6 +96,22 @@ EOF
       fail "Stripping failed, debug symbols still found in the stripped binary"
 }
 
+function test_osx_test_strip() {
+  mkdir -p cpp/osx_test_strip
+  cat > cpp/osx_test_strip/BUILD <<EOF
+cc_test(
+  name = "main",
+  srcs = ["main.cc"],
+)
+EOF
+  cat > cpp/osx_test_strip/main.cc <<EOF
+int main() { return 0; }
+EOF
+  assert_build //cpp/osx_test_strip:main.stripped
+  ! dsymutil -s bazel-bin/cpp/osx_test_strip/main | grep N_FUN || \
+      fail "Stripping failed, debug symbols still found in the stripped binary"
+}
+
 # Regression test for https://github.com/bazelbuild/bazel/pull/12046
 function test_osx_sandboxed_cc_library_build() {
   mkdir -p cpp/osx_sandboxed_cc_library_build


### PR DESCRIPTION
#18018 implies that the implicit output targets added by the `cc_binary` rule (documented [here](https://bazel.build/reference/be/c-cpp#cc_binary_implicit_outputs)) are not mirrored by the `cc_test` rule. However, it appears that Bazel 6.0 does in fact have the implicit output targets of the `cc_binary` rule mirrored by the `cc_test` rule. Given that Bazel 6.0 already seems to have the implicit output targets mirrored by the `cc_test` rule, I figured that no source code changes are required for Bazel 6.0. However, I couldn't find documentation for this feature, and I couldn't find tests either. I did the following:

- I added documentation for the implicit output targets under the `cc_test` rule.
- I added unit tests for the implicit output targets under the `cc_test` rule.
- I added integration tests for the implicit output targets under the `cc_test` rule.