### PR TITLE
Bump c++ standard to c++14 per default

### DIFF
--- a/tools/cpp/bsd_cc_toolchain_config.bzl
+++ b/tools/cpp/bsd_cc_toolchain_config.bzl
@@ -160,7 +160,7 @@ def _impl(ctx):
             ),
             flag_set(
                 actions = all_cpp_compile_actions + [ACTION_NAMES.lto_backend],
-                flag_groups = [flag_group(flags = ["-std=c++0x"])],
+                flag_groups = [flag_group(flags = ["-std=c++14"])],
             ),
         ],
     )

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -1,6 +1,6 @@
 # pylint: disable=g-bad-file-header
 # Copyright 2016 The Bazel Authors. All rights reserved.
-#
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -416,7 +416,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
     cxx_opts = split_escaped(get_env_var(
         repository_ctx,
         "BAZEL_CXXOPTS",
-        "-std=c++0x",
+        "-std=c++14",
         False,
     ), ":")
 

--- a/tools/cpp/windows_cc_toolchain_config.bzl
+++ b/tools/cpp/windows_cc_toolchain_config.bzl
@@ -1184,7 +1184,7 @@ def _impl(ctx):
                         ACTION_NAMES.lto_backend,
                         ACTION_NAMES.clif_match,
                     ],
-                    flag_groups = [flag_group(flags = ["-std=gnu++0x"])],
+                    flag_groups = [flag_group(flags = ["-std=gnu++14"])],
                 ),
             ],
         )


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/bazel/issues/18181.

Closes: #18280.
