### PR TITLE
[6.2.0] Fine tune the number of test jobs running in parallel to avoid timeout on Intel macOS platform

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -184,6 +184,8 @@ tasks:
       - "--test_env=TEST_REPOSITORY_HOME=$HOME/bazeltest/external"
       # Configure and enable tests that require access to the network.
       - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      # Fine tune the number of test jobs running in parallel to avoid timeout
+      - "--local_test_jobs=8"
     test_targets:
       - "//scripts/..."
       - "//src/test/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -173,6 +173,8 @@ tasks:
       - "--test_env=TEST_REPOSITORY_HOME=$HOME/bazeltest/external"
       # Configure and enable tests that require access to the network.
       - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      # Fine tune the number of test jobs running in parallel to avoid timeout
+      - "--local_test_jobs=8"
     test_targets:
       - "//scripts/..."
       - "//src/main/starlark/tests/builtins_bzl/..."


### PR DESCRIPTION
After https://github.com/bazelbuild/continuous-integration/pull/1600, Bazel CI sets the default value of --local_test_jobs on macOS x86_64 platform to 18, which caused many tests to timeout: https://buildkite.com/bazel/bazel-bazel/builds/23062

RELNOTES:
PiperOrigin-RevId: 527575401
Change-Id: I43ad0f74df4bf2f8c46c9e0b52b6ef62948040af

Commit: https://github.com/bazelbuild/bazel/commit/bf188c12cb8ad9164ab78564d142699fdc37efaa