### PR TITLE
[6.2.0] Update java_tools v12.2

### DIFF
--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -371,80 +371,80 @@ DIST_DEPS = {
             "remote_java_tools_test",
             "remote_java_tools_for_testing",
         ],
-        "archive": "java_tools-v12.1.zip",
-        "sha256": "0db35ec44745fd15b77d9df954e70a4fcf74554dd5bfe3f6e6cb6bbdc1f1c649",
+        "archive": "java_tools-v12.2.zip",
+        "sha256": "c284bcd37d27d2a83b14834811d5afb9a289ce4fcc27c91e49952f415d91424a",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.1/java_tools-v12.1.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.1/java_tools-v12.1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools-v12.2.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools-v12.2.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
         ],
-        "package_version": "12.1",
+        "package_version": "12.2",
     },
     "remote_java_tools_linux": {
         "aliases": [
             "remote_java_tools_test_linux",
             "remote_java_tools_linux_for_testing",
         ],
-        "archive": "java_tools_linux-v12.1.zip",
-        "sha256": "093ecac3b42fcbc3621d08edc3ae3c8b0bc2bf56a0d9a85ddcdb1e0bcf10cbc7",
+        "archive": "java_tools_linux-v12.2.zip",
+        "sha256": "49de7ee1167bf377ce594d3ac796579b831a5bbaa0224eaa42b9b99ef2e23d24",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.1/java_tools_linux-v12.1.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.1/java_tools_linux-v12.1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools_linux-v12.2.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools_linux-v12.2.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
         ],
-        "package_version": "12.1",
+        "package_version": "12.2",
     },
     "remote_java_tools_windows": {
         "aliases": [
             "remote_java_tools_test_windows",
             "remote_java_tools_windows_for_testing",
         ],
-        "archive": "java_tools_windows-v12.1.zip",
-        "sha256": "1df7cc7fac54f437f43c24c019462e13058f394fdba5a64f566b92e8af18d0cf",
+        "archive": "java_tools_windows-v12.2.zip",
+        "sha256": "7455d69d8156a0867a274e39e51e06dd4c25141096275d8def5e27db492ce1ae",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.1/java_tools_windows-v12.1.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.1/java_tools_windows-v12.1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools_windows-v12.2.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools_windows-v12.2.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
         ],
-        "package_version": "12.1",
+        "package_version": "12.2",
     },
     "remote_java_tools_darwin_x86_64": {
         "aliases": [
             "remote_java_tools_test_darwin_x86_64",
             "remote_java_tools_darwin_x86_64_for_testing",
         ],
-        "archive": "java_tools_darwin_x86_64-v12.1.zip",
-        "sha256": "16ca145203a62a1fcd6ae50513c0935d938591cb309b9b1172e257c57873f60d",
+        "archive": "java_tools_darwin_x86_64-v12.2.zip",
+        "sha256": "940e50ca43effa43e4008eb57b2a504f5593ec919e883a4cdc66bdc35989829b",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.1/java_tools_darwin_x86_64-v12.1.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.1/java_tools_darwin_x86_64-v12.1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools_darwin_x86_64-v12.2.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools_darwin_x86_64-v12.2.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
         ],
-        "package_version": "12.1",
+        "package_version": "12.2",
     },
     "remote_java_tools_darwin_arm64": {
         "aliases": [
             "remote_java_tools_test_darwin_arm64",
             "remote_java_tools_darwin_arm64_for_testing",
         ],
-        "archive": "java_tools_darwin_arm64-v12.1.zip",
-        "sha256": "1d8e575e558782c2ceec0940e424f0e2df56b0df3d7fae68333eaceef2c4e41c",
+        "archive": "java_tools_darwin_arm64-v12.2.zip",
+        "sha256": "d50209005c3bf1b7803be2ff47e56192836c4b0bdff20245456a2e0bd43a6914",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.1/java_tools_darwin_arm64-v12.1.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.1/java_tools_darwin_arm64-v12.1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools_darwin_arm64-v12.2.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools_darwin_arm64-v12.2.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
         ],
-        "package_version": "12.1",
+        "package_version": "12.2",
     },
     "remotejdk11_linux": {
         "aliases": [


### PR DESCRIPTION
Closes #18282.
Commit https://github.com/bazelbuild/bazel/commit/e0242479af14aeb3d8444947cdaf540d8ec7ff3a

PiperOrigin-RevId: 529056829
Change-Id: Icb5797022ee79d23f74dea403402e0107cf1affa