### PR TITLE
Use wall-time for credential helper invalidation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/BUILD
@@ -13,7 +13,10 @@ filegroup(
 
 java_library(
     name = "credential_module",
-    srcs = ["CredentialModule.java"],
+    srcs = [
+        "CredentialModule.java",
+        "SystemMillisTicker.java",
+    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib/authandtls",
@@ -26,7 +29,10 @@ java_library(
     name = "credentialhelper",
     srcs = glob(
         ["*.java"],
-        exclude = ["CredentialModule.java"],
+        exclude = [
+            "CredentialModule.java",
+            "SystemMillisTicker.java",
+        ],
     ),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/events",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialModule.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialModule.java
@@ -27,7 +27,7 @@ import java.time.Duration;
 /** A module whose sole purpose is to hold the credential cache which is shared by other modules. */
 public class CredentialModule extends BlazeModule {
   private final Cache<URI, ImmutableMap<String, ImmutableList<String>>> credentialCache =
-      Caffeine.newBuilder().expireAfterWrite(Duration.ZERO).build();
+      Caffeine.newBuilder().expireAfterWrite(Duration.ZERO).ticker(SystemMillisTicker.INSTANCE).build();
 
   /** Returns the credential cache. */
   public Cache<URI, ImmutableMap<String, ImmutableList<String>>> getCredentialCache() {

--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/SystemMillisTicker.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/SystemMillisTicker.java
@@ -1,0 +1,35 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.authandtls.credentialhelper;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+
+/**
+ * SystemMillisTicker is a Ticker which uses the unix epoch as its fixed reference point.
+ *
+ * It is preferable to com.github.benmanes.caffeine.cache.Ticker.SystemTicker because that class
+ * doesn't increment its time-source while the system is asleep, which isn't appropriate when
+ * expiring tokens which have wall-time-based expiry policies.
+ */
+public class SystemMillisTicker implements Ticker {
+    public static final SystemMillisTicker INSTANCE = new SystemMillisTicker();
+
+    private SystemMillisTicker() {}
+
+    @Override
+    public long read() {
+        return System.currentTimeMillis() * 1_000_000;
+    }
+}


### PR DESCRIPTION
Previously we were using time intervals which excluded time spent with the system sleeping, which is not appropriate for expiring tokens which expire based on wall-time duration.