### PR TITLE
cquery docs: `analysis.proto` -> `analysis_v2.proto`

### DIFF
--- a/site/en/query/cquery.md
+++ b/site/en/query/cquery.md
@@ -324,7 +324,7 @@ outputs the same information without the options diff.
 
 This option causes the resulting targets to be printed in a binary protocol
 buffer form. The definition of the protocol buffer can be found at
-[src/main/protobuf/analysis.proto](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/analysis_v2.proto){: .external}.
+[src/main/protobuf/analysis_v2.proto](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/analysis_v2.proto){: .external}.
 
 `CqueryResult` is the top level message containing the results of the cquery. It
 has a list of `ConfiguredTarget` messages and a list of `Configuration`


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/10540

`analysis.proto` was deleted in https://github.com/bazelbuild/bazel/commit/d67dc88c5dd25edfad72173d2c85170370611725.