### PR TITLE
Ignore hash string casing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
+import com.google.common.base.Ascii;
 import com.google.common.hash.HashCode;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
 import java.util.Base64;
@@ -44,7 +45,7 @@ public class Checksum {
     if (!keyType.isValid(hash)) {
       throw new InvalidChecksumException(keyType, hash);
     }
-    return new Checksum(keyType, HashCode.fromString(hash));
+    return new Checksum(keyType, HashCode.fromString(Ascii.toLowerCase(hash)));
   }
 
   /** Constructs a new Checksum from a hash in Subresource Integrity format. */

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -221,6 +221,22 @@ EOF
   assert_contains "test content" "${base_external_path}/test_dir/test_file"
 }
 
+function test_http_archive_upper_case_sha() {
+  cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = 'test_zstd_repo',
+    url = 'file://$(rlocation io_bazel/src/test/shell/bazel/testdata/zstd_test_archive.tar.zst)',
+    sha256 = '12B0116F2A3C804859438E102A8A1D5F494C108D1B026DA9F6CA55FB5107C7E9',
+    build_file_content = 'filegroup(name="x", srcs=glob(["*"]))',
+)
+EOF
+  bazel build @test_zstd_repo//...
+
+  base_external_path=bazel-out/../external/test_zstd_repo
+  assert_contains "test content" "${base_external_path}/test_dir/test_file"
+}
+
 function test_http_archive_no_server() {
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
Fixes this crash when e.g. the `sha256` attribute is passed an upper case string:

```
Caused by: java.lang.IllegalArgumentException: Illegal hexadecimal character: D
        at com.google.common.hash.HashCode.decode(HashCode.java:360)
        at com.google.common.hash.HashCode.fromString(HashCode.java:346)
        at com.google.devtools.build.lib.bazel.repository.downloader.Checksum.fromString(Checksum.java:47)
        at com.google.devtools.build.lib.bazel.repository.starlark.StarlarkBaseExternalContext.validateChecksum(StarlarkBaseExternalContext.java:302)
        at com.google.devtools.build.lib.bazel.repository.starlark.StarlarkBaseExternalContext.downloadAndExtract(StarlarkBaseExternalContext.java:650)
        ...
```

Fixes #18291