### PR TITLE
Fix BazelTestRunner compatibility with jre8

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4Bazel.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4Bazel.java
@@ -23,6 +23,7 @@ import com.google.testing.junit.runner.sharding.ShardingEnvironment;
 import com.google.testing.junit.runner.sharding.ShardingFilters;
 import com.google.testing.junit.runner.util.MemoizingSupplier;
 import java.io.PrintStream;
+import java.util.Collections;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.junit.runner.Request;
@@ -83,7 +84,7 @@ public final class JUnit4Bazel {
         stdoutStream,
         config,
         setOfRunListeners,
-        Set.of());
+        Collections.emptySet());
   }
 
   /** A builder for instantiating {@link JUnit4Bazel}. */

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4RunnerModule.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4RunnerModule.java
@@ -31,6 +31,8 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -127,17 +129,18 @@ class JUnit4RunnerModule {
       JUnit4Config config,
       Supplier<TestSuiteModel> testSuiteModelSupplier,
       CancellableRequestFactory cancellableRequestFactory) {
-    return Set.of(
-        new JUnit4TestStackTraceListener(
-            new SignalHandlers(SignalHandlers.createRealHandlerInstaller()), System.err),
-        new JUnit4TestXmlListener(
+    Set<RunListener> listeners = new HashSet<>();
+    listeners.add(new JUnit4TestStackTraceListener(
+        new SignalHandlers(SignalHandlers.createRealHandlerInstaller()), System.err));
+    listeners.add(new JUnit4TestXmlListener(
             testSuiteModelSupplier,
             cancellableRequestFactory,
             new SignalHandlers(SignalHandlers.createRealHandlerInstaller()),
             new ProvideXmlStreamFactory(() -> config).get(),
-            System.err),
-        new JUnit4TestNameListener(provideCurrentRunningTest()),
-        JUnit4RunnerBaseModule.provideTextListener(stdout()));
+            System.err));
+    listeners.add(new JUnit4TestNameListener(provideCurrentRunningTest()));
+    listeners.add(JUnit4RunnerBaseModule.provideTextListener(stdout()));
+    return Collections.unmodifiableSet(listeners);
   }
 
   CancellableRequestFactory cancellableRequestFactory() {


### PR DESCRIPTION
Removes usages of Set.of() that were introduced in javase9

Fixes https://github.com/bazelbuild/bazel/issues/18300