### PR TITLE
java_tools v12.3 rc1 updates (for testing)

### DIFF
--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -402,11 +402,10 @@ DIST_DEPS = {
             "remote_java_tools_test",
             "remote_java_tools_for_testing",
         ],
-        "archive": "java_tools-v12.2.zip",
-        "sha256": "c284bcd37d27d2a83b14834811d5afb9a289ce4fcc27c91e49952f415d91424a",
+        "archive": "java_tools-v12.3-rc1.zip",
+        "sha256": "cbb62ecfef61568ded46260a8e8e8430755db7ec9638c0c7ff668a656f6c042f",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools-v12.2.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools-v12.2.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.3/java_tools-v12.3-rc1.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
@@ -418,11 +417,10 @@ DIST_DEPS = {
             "remote_java_tools_test_linux",
             "remote_java_tools_linux_for_testing",
         ],
-        "archive": "java_tools_linux-v12.2.zip",
-        "sha256": "49de7ee1167bf377ce594d3ac796579b831a5bbaa0224eaa42b9b99ef2e23d24",
+        "archive": "java_tools_linux-v12.3-rc1.zip",
+        "sha256": "32157b5218b151009f5b99bf5e2f65e28823d269dfbba8cd57e7da5e7cdd291d",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools_linux-v12.2.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools_linux-v12.2.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.3/java_tools_linux-v12.3-rc1.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
@@ -434,11 +432,10 @@ DIST_DEPS = {
             "remote_java_tools_test_windows",
             "remote_java_tools_windows_for_testing",
         ],
-        "archive": "java_tools_windows-v12.2.zip",
-        "sha256": "7455d69d8156a0867a274e39e51e06dd4c25141096275d8def5e27db492ce1ae",
+        "archive": "java_tools_windows-v12.3-rc1.zip",
+        "sha256": "ec6f91387d2353eacb0ca0492f35f68c5c7b0e7a80acd1fb825088b4b069fab1",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools_windows-v12.2.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools_windows-v12.2.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.3/java_tools_windows-v12.3-rc1.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
@@ -450,11 +447,10 @@ DIST_DEPS = {
             "remote_java_tools_test_darwin_x86_64",
             "remote_java_tools_darwin_x86_64_for_testing",
         ],
-        "archive": "java_tools_darwin_x86_64-v12.2.zip",
-        "sha256": "940e50ca43effa43e4008eb57b2a504f5593ec919e883a4cdc66bdc35989829b",
+        "archive": "java_tools_darwin_x86_64-v12.3-rc1.zip",
+        "sha256": "3c3fb1967a0f35c73ff509505de53ca4611518922a6b7c8c22a468aa7503132c",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools_darwin_x86_64-v12.2.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools_darwin_x86_64-v12.2.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.3/java_tools_darwin_x86_64-v12.3-rc1.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",
@@ -466,11 +462,10 @@ DIST_DEPS = {
             "remote_java_tools_test_darwin_arm64",
             "remote_java_tools_darwin_arm64_for_testing",
         ],
-        "archive": "java_tools_darwin_arm64-v12.2.zip",
-        "sha256": "d50209005c3bf1b7803be2ff47e56192836c4b0bdff20245456a2e0bd43a6914",
+        "archive": "java_tools_darwin_arm64-v12.3-rc1.zip",
+        "sha256": "29aa0c2de4e3cf45bc55d2995ba803ecbd1173a8d363860abbc309551db7931b",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.2/java_tools_darwin_arm64-v12.2.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.2/java_tools_darwin_arm64-v12.2.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.3/java_tools_darwin_arm64-v12.3-rc1.zip",
         ],
         "used_in": [
             "test_WORKSPACE_files",


### PR DESCRIPTION
Pushing java_tools v12.3 rc1 updates to this new branch to test in the rules_kotlin pipeline, due to busy CI