### PR TITLE
python: make py_runtime_pair respect --incompatible_python_disable_py2 (fail when py2_runtime specified)

### DIFF
--- a/tools/python/toolchain.bzl
+++ b/tools/python/toolchain.bzl
@@ -37,10 +37,9 @@ def _py_runtime_pair_impl(ctx):
     else:
         py3_runtime = None
 
-    # TODO: Uncomment this after --incompatible_python_disable_py2 defaults to true
-    # if _is_py2_disabled(ctx) and py2_runtime != None:
-    #     fail("Using Python 2 is not supported and disabled; see " +
-    #          "https://github.com/bazelbuild/bazel/issues/15684")
+    if _is_py2_disabled(ctx) and py2_runtime != None:
+        fail("Using Python 2 is not supported and disabled; see " +
+             "https://github.com/bazelbuild/bazel/issues/15684")
 
     return [platform_common.ToolchainInfo(
         py2_runtime = py2_runtime,


### PR DESCRIPTION
The `--incompatible_python_disable_py2` flag now defaults to true, so per https://github.com/bazelbuild/bazel/issues/15684, this guard can be enabled.