### PR TITLE
Fix incorrectly-rendered intra-doc link lower down in cquery docs

### DIFF
--- a/site/en/query/cquery.md
+++ b/site/en/query/cquery.md
@@ -537,7 +537,7 @@ different niches. Consider the following to decide which is right for you:
     that `query` avoids. For example,
     if `"//foo"` exists in two configurations, which one
     should `cquery "deps(//foo)"` use?
-    The `[config](#config)`</code> function can help with this.
+    The [`config`](#config) function can help with this.
 *   As a newer tool, `cquery` lacks support for certain use
     cases. See [Known issues](#known-issues) for details.
 


### PR DESCRIPTION
Similar to #18324--separating only because I saw it later and because I wanted to check in that there wasn't some important reason for the </code>, keeping the other one an obvious merge.

[Therefore, weakly, transitively related to #18289.]