### PR TITLE
Error if repository name isn't supplied

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -220,6 +220,9 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
 
         // TODO(adonovan): is this cast safe? Check.
         String name = (String) kwargs.get("name");
+        if (name == null) {
+          throw Starlark.errorf("argument 'name' is required");
+        }
         WorkspaceFactoryHelper.addMainRepoEntry(packageBuilder, name);
         WorkspaceFactoryHelper.addRepoMappings(packageBuilder, kwargs, name);
         return WorkspaceFactoryHelper.createAndAddRepositoryRule(


### PR DESCRIPTION
Currently, this results in a server crash along the lines of:
```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node '[/redacted]/[WORKSPACE.bazel], 1' (requested by nodes 'com.google.devtools.build.lib.skyframe.ExternalPackageFunction$$Lambda$231/0x0000000800df7998@34f133c')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:642)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:382)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: net.starlark.java.eval.Starlark$UncheckedEvalException: NullPointerException thrown during Starlark evaluation (WORKSPACE)
	at <starlark>.repository_rule(<builtin>:0)
	at <starlark>.<toplevel>(/redacted/WORKSPACE.bazel:3)
Caused by: java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "name" is null
	at com.google.devtools.build.lib.cmdline.RepositoryName.create(RepositoryName.java:71)
	at com.google.devtools.build.lib.packages.WorkspaceFactoryHelper.addMainRepoEntry(WorkspaceFactoryHelper.java:106)
	at com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule$RepositoryRuleFunction.createRuleLegacy(StarlarkRepositoryModule.java:228)
	at com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule$RepositoryRuleFunction.call(StarlarkRepositoryModule.java:185)
```