### PR TITLE
Verify bootclasspath version is at most compilation runtime version

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/BUILD
@@ -41,6 +41,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/compilation_mode",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/core_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/execution_transition_factory",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/no_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -241,9 +241,12 @@ def _bootclasspath_impl(ctx):
     system = [f for f in ctx.files.target_javabase if f.basename in system_files]
     if len(system) != len(system_files):
         system = None
+    version = 0
     if ctx.attr.target_javabase:
+        runtime_info = ctx.attr.target_javabase[java_common.JavaRuntimeInfo]
         inputs.extend(ctx.files.target_javabase)
-        args.add(ctx.attr.target_javabase[java_common.JavaRuntimeInfo].java_home)
+        args.add(runtime_info.java_home)
+        version = runtime_info.version
 
     ctx.actions.run(
         executable = str(host_javabase.java_executable_exec_path),
@@ -257,6 +260,7 @@ def _bootclasspath_impl(ctx):
         java_common.BootClassPathInfo(
             bootclasspath = [bootclasspath],
             system = system,
+            version = version,
         ),
         OutputGroupInfo(jar = [bootclasspath]),
     ]


### PR DESCRIPTION
The bootclasspath is loaded by the Java toolchain's runtime used for compilation and thus needs to be compatible with it, otherwise this triggers errors such as:

```
error: cannot access module-info
  bad class file: /modules/jdk.net/module-info.class
    class file has wrong version 64.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
error: cannot access module-info
  bad class file: /modules/jdk.accessibility/module-info.class
    class file has wrong version 64.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
error: cannot access module-info
  bad class file: /modules/jdk.internal.vm.compiler.management/module-info.class
    class file has wrong version 64.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
```

Work towards #17281