### PR TITLE
buildtool: fail build when user time-traveled to the past

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildResult.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildResult.java
@@ -73,6 +73,14 @@ public final class BuildResult {
   }
 
   /**
+   * Return the time (according to System.currentTimeMillis()) at which the service of this request
+   * was initiated.
+   */
+  public long getStartTime() {
+    return startTimeMillis;
+  }
+
+  /**
    * Record the time (according to System.currentTimeMillis()) at which the service of this request
    * was completed.
    */

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -306,8 +306,9 @@ message RemoteOptions {
 
 message ClientEnvironment {
   enum Code {
-    CLIENT_ENVIRONMENT_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
-    CLIENT_CWD_MALFORMED = 1 [(metadata) = { exit_code: 2 }];
+    CLIENT_ENVIRONMENT_UNKNOWN = 0 [ (metadata) = {exit_code : 37} ];
+    CLIENT_CWD_MALFORMED = 1 [ (metadata) = {exit_code : 2} ];
+    CLIENT_INVALID_CLOCK = 2 [ (metadata) = {exit_code : 36} ];
   }
 
   Code code = 1;


### PR DESCRIPTION
Detect when system clock on client's environment was updated to a time
in the past and fail that build instead of reporting negative build
duration.

---

We have a tenant who have user updating local clock mid-build, resulting in
negative build duration in BES.  Let's not support such time-travel use cases
and fail the build with relevant error message.

I looked at setting up some a test case for this but it resulted in a rather
relatively complex modification of `BlazeRuntimeWrapper` to mock
`BlazeClock.instance()` to modify `runtime.getClock()` call. Given how rare
this case is to reproduce, I don't think it's worth the effort to pursue such
test.
