### PR TITLE
loomy repo fetching proof of concept

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -299,6 +299,7 @@ public class BazelRepositoryModule extends BlazeModule {
 
     RepositoryOptions repoOptions = env.getOptions().getOptions(RepositoryOptions.class);
     if (repoOptions != null) {
+      starlarkRepositoryFunction.setUseLoom(repoOptions.useLoomForRepoFetching);
       downloadManager.setDisableDownload(repoOptions.disableDownload);
       if (repoOptions.repositoryDownloaderRetries >= 0) {
         downloadManager.setRetries(repoOptions.repositoryDownloaderRetries);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -237,6 +237,14 @@ public class RepositoryOptions extends OptionsBase {
   public String downloaderConfig;
 
   @Option(
+      name = "use_loom_for_repo_fetching",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "Whether to use Loom for repo fetching.")
+  public boolean useLoomForRepoFetching;
+
+  @Option(
       name = "ignore_dev_dependency",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.BZLMOD,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoFetchingSkyKeyComputeState.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoFetchingSkyKeyComputeState.java
@@ -1,0 +1,120 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.starlark;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.events.Reportable;
+import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
+import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
+import com.google.devtools.build.skyframe.SkyFunction.Environment;
+import com.google.devtools.build.skyframe.SkyFunction.Environment.SkyKeyComputeState;
+import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.SkyValue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * Captures state that persists across different invocations of {@link
+ * com.google.devtools.build.lib.rules.repository.RepositoryDelegatorFunction}, specifically {@link
+ * StarlarkRepositoryFunction}.
+ */
+class RepoFetchingSkyKeyComputeState implements SkyKeyComputeState {
+
+  /**
+   * Common interface for a message that can be sent from the worker thread back to the host
+   * Skyframe thread.
+   */
+  sealed interface Message
+      permits Message.NewSkyframeDependency, Message.Done, Message.Error, Message.Event {
+
+    /** Indicates that a new SkyFrame dependency is requested. */
+    record NewSkyframeDependency<
+            E1 extends Exception, E2 extends Exception, E3 extends Exception, E4 extends Exception>(
+        SkyKey key,
+        @Nullable Class<E1> e1,
+        @Nullable Class<E2> e2,
+        @Nullable Class<E3> e3,
+        @Nullable Class<E4> e4,
+        SettableFuture<SkyValue> valueFuture)
+        implements Message {}
+
+    /** Indicates that the fetching is done and has yielded the given result. */
+    record Done(RepositoryDirectoryValue.Builder result) implements Message {}
+
+    /** Indicates that an exception occurred during the fetch. */
+    record Error(RepositoryFunctionException ex) implements Message {}
+
+    /** Indicates that a reportable event occurred during the fetch. */
+    record Event(Reportable reportable) implements Message {}
+  }
+
+  private final BlockingQueue<Message> messages = new ArrayBlockingQueue<>(8);
+  private Thread worker = null;
+  private final AtomicReference<SettableFuture<Void>> messageFuture = new AtomicReference<>();
+
+  boolean isWorkerRunning() {
+    return worker != null;
+  }
+
+  void startWorker(Runnable r) {
+    worker = Thread.startVirtualThread(r);
+  }
+
+  void postMessage(Message message) throws InterruptedException {
+    messages.put(message);
+    SettableFuture<Void> future = messageFuture.getAndSet(null);
+    if (future != null) {
+      future.set(null);
+      if (future.isCancelled()) {
+        throw new InterruptedException();
+      }
+    }
+  }
+
+  @Nullable
+  Message receiveMessage() throws InterruptedException {
+    return messages.poll(10, TimeUnit.MILLISECONDS);
+  }
+
+  void registerMessageListener(Environment env) {
+    SettableFuture<Void> future = SettableFuture.create();
+    env.dependOnFuture(future);
+    Preconditions.checkState(messageFuture.getAndSet(future) == null);
+  }
+
+  @Override
+  public void close() {
+    if (worker != null) {
+      worker.interrupt();
+      worker = null;
+    }
+    {
+      SettableFuture<Void> future = messageFuture.getAndSet(null);
+      if (future != null) {
+        future.cancel(true);
+      }
+    }
+    for (Message message : messages) {
+      if (message instanceof Message.NewSkyframeDependency<?, ?, ?, ?> newDep) {
+        newDep.valueFuture.cancel(true);
+      }
+    }
+    messages.clear();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoFetchingWorkerSkyFunctionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoFetchingWorkerSkyFunctionEnvironment.java
@@ -1,0 +1,165 @@
+package com.google.devtools.build.lib.bazel.repository.starlark;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.bazel.repository.starlark.RepoFetchingSkyKeyComputeState.Message;
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.events.Reportable;
+import com.google.devtools.build.skyframe.SkyFunction;
+import com.google.devtools.build.skyframe.SkyFunctionException;
+import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.SkyValue;
+import com.google.devtools.build.skyframe.SkyframeLookupResult;
+import com.google.devtools.build.skyframe.Version;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link com.google.devtools.build.skyframe.SkyFunction.Environment} implementation whose {@link
+ * #getValue} and {@link #getValueOrThrow} methods do not return {@code null} when the {@link
+ * SkyValue} in question is not available. Instead, it blocks on a {@link SettableFuture} until the
+ * {@link SkyValue} in question is available.
+ */
+class RepoFetchingWorkerSkyFunctionEnvironment
+    implements SkyFunction.Environment, SkyframeLookupResult, ExtendedEventHandler {
+  private final RepoFetchingSkyKeyComputeState state;
+
+  RepoFetchingWorkerSkyFunctionEnvironment(RepoFetchingSkyKeyComputeState state) {
+    this.state = state;
+  }
+
+  @Override
+  public boolean valuesMissing() {
+    // Contrary to popular belief, I never miss. *wink*
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public SkyValue getValue(SkyKey depKey) throws InterruptedException {
+    return getValueOrThrow(depKey, null, null, null, null);
+  }
+
+  @Nullable
+  @Override
+  public <E1 extends Exception> SkyValue getValueOrThrow(SkyKey depKey, Class<E1> e1)
+      throws E1, InterruptedException {
+    return getValueOrThrow(depKey, e1, null, null, null);
+  }
+
+  @Nullable
+  @Override
+  public <E1 extends Exception, E2 extends Exception> SkyValue getValueOrThrow(
+      SkyKey depKey, Class<E1> e1, Class<E2> e2) throws E1, E2, InterruptedException {
+    return getValueOrThrow(depKey, e1, e2, null, null);
+  }
+
+  @Nullable
+  @Override
+  public <E1 extends Exception, E2 extends Exception, E3 extends Exception>
+      SkyValue getValueOrThrow(SkyKey depKey, Class<E1> e1, Class<E2> e2, Class<E3> e3)
+          throws E1, E2, E3, InterruptedException {
+    return getValueOrThrow(depKey, e1, e2, e3, null);
+  }
+
+  @Nullable
+  @Override
+  public <E1 extends Exception, E2 extends Exception, E3 extends Exception, E4 extends Exception>
+      SkyValue getValueOrThrow(
+          SkyKey depKey, Class<E1> e1, Class<E2> e2, Class<E3> e3, Class<E4> e4)
+          throws E1, E2, E3, E4, InterruptedException {
+    SettableFuture<SkyValue> future = SettableFuture.create();
+    state.postMessage(new Message.NewSkyframeDependency<>(depKey, e1, e2, e3, e4, future));
+    try {
+      return future.get();
+    } catch (ExecutionException e) {
+      SkyFunctionException.throwIfInstanceOf((Exception) e.getCause(), e1, e2, e3, e4);
+      throw new IllegalStateException("somehow we have a stray e: " + e.getMessage(), e.getCause());
+    }
+  }
+
+  @Override
+  public SkyframeLookupResult getValuesAndExceptions(Iterable<? extends SkyKey> depKeys) {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public <E1 extends Exception, E2 extends Exception, E3 extends Exception> SkyValue getOrThrow(
+      SkyKey skyKey, @Nullable Class<E1> e1, @Nullable Class<E2> e2, @Nullable Class<E3> e3)
+      throws E1, E2, E3 {
+    try {
+      return getValueOrThrow(skyKey, e1, e2, e3);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
+  }
+
+  @Override
+  public boolean queryDep(SkyKey key, QueryDepCallback resultCallback) {
+    throw new UnsupportedOperationException("queryDep");
+  }
+
+  @Override
+  public ExtendedEventHandler getListener() {
+    return this;
+  }
+
+  private void report(Reportable reportable) {
+    try {
+      state.postMessage(new Message.Event(reportable));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  public void handle(Event event) {
+    report(event);
+  }
+
+  @Override
+  public void post(Postable obj) {
+    report(obj);
+  }
+
+  @Override
+  public void registerDependencies(Iterable<SkyKey> keys) {
+    throw new UnsupportedOperationException("registerDependencies");
+  }
+
+  @Override
+  public boolean inErrorBubblingForSkyFunctionsThatCanFullyRecoverFromErrors() {
+    throw new UnsupportedOperationException(
+        "inErrorBubblingForSkyFunctionsThatCanFullyRecoverFromErrors");
+  }
+
+  @Override
+  public void dependOnFuture(ListenableFuture<?> future) {
+    throw new UnsupportedOperationException("dependOnFuture");
+  }
+
+  @Override
+  public boolean restartPermitted() {
+    return false;
+  }
+
+  @Override
+  public SkyframeLookupResult getLookupHandleForPreviouslyRequestedDeps() {
+    return this;
+  }
+
+  @Override
+  public <T extends SkyKeyComputeState> T getState(Supplier<T> stateSupplier) {
+    throw new UnsupportedOperationException("getState");
+  }
+
+  @Nullable
+  @Override
+  public Version getMaxTransitiveSourceVersionSoFar() {
+    throw new UnsupportedOperationException("getMaxTransitiveSourceVersionSoFar");
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.packages.NoSuchPackageException;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.repository.ExternalPackageException;
+import com.google.devtools.build.lib.repository.RepositoryFetchProgress;
 import com.google.devtools.build.lib.skyframe.ActionEnvironmentFunction;
 import com.google.devtools.build.lib.skyframe.AlreadyReportedException;
 import com.google.devtools.build.lib.skyframe.PackageLookupFunction;
@@ -131,6 +132,23 @@ public abstract class RepositoryFunction {
               || e instanceof ExternalPackageException,
           e);
     }
+  }
+
+  public static void setupRepoRoot(Path repoRoot) throws RepositoryFunctionException {
+    try {
+      repoRoot.deleteTree();
+      Preconditions.checkNotNull(repoRoot.getParentDirectory()).createDirectoryAndParents();
+    } catch (IOException e) {
+      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    }
+  }
+
+  protected void setupRepoRootBeforeFetching(Path repoRoot) throws RepositoryFunctionException {
+    setupRepoRoot(repoRoot);
+  }
+
+  public void reportSkyframeRestart(Environment env, RepositoryName repoName) {
+    env.getListener().post(RepositoryFetchProgress.ongoing(repoName, "Restarting."));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/skyframe/SkyFunctionException.java
+++ b/src/main/java/com/google/devtools/build/skyframe/SkyFunctionException.java
@@ -102,7 +102,8 @@ public abstract class SkyFunctionException extends Exception {
     }
   }
 
-  static <E1 extends Exception, E2 extends Exception, E3 extends Exception, E4 extends Exception>
+  public static <
+          E1 extends Exception, E2 extends Exception, E3 extends Exception, E4 extends Exception>
       void throwIfInstanceOf(
           @Nullable Exception e,
           @Nullable Class<E1> exceptionClass1,


### PR DESCRIPTION
Work towards https://github.com/bazelbuild/bazel/issues/10515

This implements the proof of concept of putting repo fetching logic onto a separate virtual thread, which simply blocks when a Skyframe dependency is needed. The actual Skyframe-managed thread itself is subject to restarts, and unblocks the virtual thread when it gets the SkyValue.

This additionally includes a small change to allow SkyKeyComputeState to be cleaned up, which I'm starting to think is unnecessary.