### PR TITLE
Flip `--incompatible_check_sharding_support`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -293,7 +293,7 @@ public class TestConfiguration extends Fragment {
 
     @Option(
         name = "incompatible_check_sharding_support",
-        defaultValue = "false",
+        defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
         metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
         effectTags = {OptionEffectTag.UNKNOWN},

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -70,6 +70,7 @@ class TestWrapperTest(test_base.TestBase):
         'bat_test(',
         '    name = "sharded_test",',
         '    content = [',
+        '        "type nul > %TEST_SHARD_STATUS_FILE%",',
         '        "@echo STATUS=%TEST_SHARD_STATUS_FILE%",',
         '        "@echo INDEX=%TEST_SHARD_INDEX% TOTAL=%TEST_TOTAL_SHARDS%",',
         '    ],',

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -540,9 +540,10 @@ EOF
 function test_xml_fallback_for_sharded_test() {
   mkdir -p dir
 
-  cat <<EOF > dir/test.sh
+  cat <<'EOF' > dir/test.sh
 #!/bin/sh
-exit \$((TEST_SHARD_INDEX == 1))
+touch "$TEST_SHARD_STATUS_FILE"
+exit $((TEST_SHARD_INDEX == 1))
 EOF
 
   chmod +x dir/test.sh


### PR DESCRIPTION
RELNOTES[INC]: `--incompatible_check_sharding_support` is enabled by default. Sharded tests with test runners that do not properly advertise support for test sharding will fail. Refer to https://github.com/bazelbuild/bazel/issues/18339 for migration advice.