### PR TITLE
Improve --incompatible_disable_native_android_rules usability

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidSemantics.java
@@ -40,7 +40,7 @@ public class BazelAndroidSemantics implements AndroidSemantics {
 
   private static final ImmutableSet<PackageIdentifier> STARLARK_MIGRATION_NATIVE_USAGE_ALLOW_LIST =
       // Internal package identifiers that are allowed to use the native Android rules until they
-      // can be fully  moved into the rules_andorid Starlark implementation.
+      // can be fully moved into the rules_android Starlark implementation.
       ImmutableSet.<PackageIdentifier>builder()
           .add(
               PackageIdentifier.createUnchecked(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidSemantics.java
@@ -14,10 +14,12 @@
 package com.google.devtools.build.lib.bazel.rules.android;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
+import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.rules.android.AndroidBinary;
@@ -36,8 +38,18 @@ import com.google.devtools.build.lib.rules.java.JavaTargetAttributes;
 public class BazelAndroidSemantics implements AndroidSemantics {
   public static final BazelAndroidSemantics INSTANCE = new BazelAndroidSemantics();
 
-  private BazelAndroidSemantics() {
-  }
+  private static final ImmutableSet<PackageIdentifier> STARLARK_MIGRATION_NATIVE_USAGE_ALLOW_LIST =
+      // Internal package identifiers that are allowed to use the native Android rules until they
+      // can be fully  moved into the rules_andorid Starlark implementation.
+      ImmutableSet.<PackageIdentifier>builder()
+          .add(
+              PackageIdentifier.createUnchecked(
+                  "bazel_tools",
+                  "src/tools/android/java/com/google/devtools/build/android/incrementaldeployment"))
+          .add(PackageIdentifier.createUnchecked("bazel_tools", "tools/android"))
+          .build();
+
+  private BazelAndroidSemantics() {}
 
   @Override
   public String getNativeDepsFileName() {
@@ -110,6 +122,11 @@ public class BazelAndroidSemantics implements AndroidSemantics {
 
   @Override
   public void registerMigrationRuleError(RuleContext ruleContext) throws RuleErrorException {
+    if (STARLARK_MIGRATION_NATIVE_USAGE_ALLOW_LIST.contains(
+        ruleContext.getLabel().getPackageIdentifier())) {
+      return;
+    }
+
     ruleContext.attributeError(
         "tags",
         "The native Android rules are deprecated. Please use the Starlark Android rules by adding "


### PR DESCRIPTION
Adding an internal allow list to the `--incompatible_disable_native_android_rules` so that it doesn't error out immediately when evaluating the mobiel-install `bazel_tools` targets. https://github.com/bazelbuild/bazel/blob/65b49a2ee3968bbfd53d6ae4f954b9d840ace68a/src/tools/android/java/com/google/devtools/build/android/incrementaldeployment/BUILD.tools#L3

Some example errors that we see when we flip this flag to ensure that all targets are using the Starlark rules instead of the native rules:

```
(11:04:57) ERROR: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/bazel_tools/tools/android/BUILD:14:27: in tags attribute of android_tools_defaults_jar rule @bazel_tools//tools/android:android_jar: The native Android rules are deprecated. Please use the Starlark Android rules by adding the following load statement to the BUILD file: load("@build_bazel_rules_android//android:rules.bzl", "android_tools_defaults_jar"). See http://github.com/bazelbuild/rules_android.
(11:04:57) ERROR: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/bazel_tools/tools/android/BUILD:14:27: Analysis of target '@bazel_tools//tools/android:android_jar' failed
```

```
(11:06:06) ERROR: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/bazel_tools/src/tools/android/java/com/google/devtools/build/android/incrementaldeployment/BUILD:11:16: in tags attribute of android_library rule @bazel_tools//src/tools/android/java/com/google/devtools/build/android/incrementaldeployment:incremental_split_stub_application: The native Android rules are deprecated. Please use the Starlark Android rules by adding the following load statement to the BUILD file: load("@build_bazel_rules_android//android:rules.bzl", "android_library"). See http://github.com/bazelbuild/rules_android.
(11:06:06) ERROR: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/bazel_tools/src/tools/android/java/com/google/devtools/build/android/incrementaldeployment/BUILD:11:16: Analysis of target '@bazel_tools//src/tools/android/java/com/google/devtools/build/android/incrementaldeployment:incremental_split_stub_application' failed
```