### PR TITLE
Simplify building stardoc from a separate repo

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -345,17 +345,15 @@ filegroup(
 
 # TODO(https://github.com/bazelbuild/bazel/issues/18214): After fixing Guava leak
 # in test-runner, the guava target can be reverted back to java_library
-java_import(
+java_library(
     name = "guava",
-    jars = [
-        "@maven//:com_google_guava_guava_file",
-        "@maven//:com_google_guava_failureaccess_file",
-    ],
     applicable_licenses = [":guava_license"],
     exports = [
         ":error_prone_annotations",
         ":jcip_annotations",
         ":jsr305",
+        "@maven//:com_google_guava_failureaccess",
+        "@maven//:com_google_guava_guava",
     ],
 )
 


### PR DESCRIPTION
Removes a reference to rules_jvm_external internals to allow stardoc to more easily build Bazel as a dependency in the stardoc workspace.