### PR TITLE
Use clock_gettime instead of gettimeofday for monotonic time on macOS

### DIFF
--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -135,12 +135,12 @@ string GetSelfPath(const char* argv0) {
 }
 
 uint64_t GetMillisecondsMonotonic() {
-  struct timeval ts = {};
-  if (gettimeofday(&ts, nullptr) < 0) {
+  struct timespec ts = {};
+  if (clock_gettime(CLOCK_UPTIME_RAW, &ts) < 0) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
-        << "error calling gettimeofday: " << GetLastErrorString();
+        << "error calling clock_gettime: " << GetLastErrorString();
   }
-  return ts.tv_sec * 1000LL + ts.tv_usec / 1000LL;
+  return ts.tv_sec * 1000LL + ts.tv_nsec / 1000000LL;
 }
 
 uint64_t GetMillisecondsSinceProcessStart() {


### PR DESCRIPTION
As described in #12680, the implementation of `GetMillisecondsMonotonic` is not actually monotonic on macOS, because `gettimeofday` can go backwards as a result of NTP time syncs. When this happens, computing duration overflows and fails execution with a message like:

```
ERROR: While parsing option --startup_time=18446744073709551598: '18446744073709551598' is not a long
```

This PR changes the implementation to use `clock_gettime`, which is available since macOS 10.12, with the `CLOCK_UPTIME_RAW` option. `CLOCK_UPTIME_RAW` is defined to mean: 
```
clock that increments monotonically, in the same manner as CLOCK_MONOTONIC_RAW, but that does not increment while the system is asleep
```

This seems appropriate for `GetMillisecondsMonotonic` which is used exclusively for measuring execution durations.

Fixes #12680