### PR TITLE
Fix and optimize `Runfiles#fingerprint` 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionKeyContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionKeyContext.java
@@ -35,6 +35,11 @@ public class ActionKeyContext {
     nestedSetFingerprintCache.addNestedSetToFingerprint(mapFn, fingerprint, nestedSet);
   }
 
+  public static <T> String describedNestedSetFingerprint(
+      CommandLineItem.MapFn<? super T> mapFn, NestedSet<T> nestedSet) {
+    return NestedSetFingerprintCache.describedNestedSetFingerprint(mapFn, nestedSet);
+  }
+
   public void clear() {
     nestedSetFingerprintCache.clear();
   }

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionKeyContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionKeyContext.java
@@ -35,8 +35,15 @@ public class ActionKeyContext {
     nestedSetFingerprintCache.addNestedSetToFingerprint(mapFn, fingerprint, nestedSet);
   }
 
-  public static <T> String describedNestedSetFingerprint(
-      CommandLineItem.MapFn<? super T> mapFn, NestedSet<T> nestedSet) {
+  public <T> void addNestedSetToFingerprint(
+      CommandLineItem.ExceptionlessMapFn<? super T> mapFn,
+      Fingerprint fingerprint,
+      NestedSet<T> nestedSet) {
+    nestedSetFingerprintCache.addNestedSetToFingerprint(mapFn, fingerprint, nestedSet);
+  }
+
+  public static <T> String describeNestedSetFingerprint(
+      CommandLineItem.ExceptionlessMapFn<? super T> mapFn, NestedSet<T> nestedSet) {
     return NestedSetFingerprintCache.describedNestedSetFingerprint(mapFn, nestedSet);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/CommandLineItem.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CommandLineItem.java
@@ -29,6 +29,12 @@ public interface CommandLineItem {
         throws CommandLineExpansionException, InterruptedException;
   }
 
+  /** A {@link CommandLineItem.MapFn} that does not throw. */
+  interface ExceptionlessMapFn<T> extends CommandLineItem.MapFn<T> {
+    @Override
+    void expandToCommandLine(T object, Consumer<String> args);
+  }
+
   /**
    * Use this map function when parametrizing over a limited set of values.
    *

--- a/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
@@ -1183,15 +1183,19 @@ public final class Runfiles implements RunfilesApi {
   }
 
   /** Fingerprint this {@link Runfiles} tree. */
-  public void fingerprint(ActionKeyContext actionKeyContext, Fingerprint fp)
-      throws CommandLineExpansionException, InterruptedException {
+  public void fingerprint(ActionKeyContext actionKeyContext, Fingerprint fp) {
     fp.addInt(conflictPolicy.ordinal());
     fp.addBoolean(legacyExternalRunfiles);
     fp.addPath(suffix);
 
-    actionKeyContext.addNestedSetToFingerprint(SYMLINK_ENTRY_MAP_FN, fp, symlinks);
-    actionKeyContext.addNestedSetToFingerprint(SYMLINK_ENTRY_MAP_FN, fp, rootSymlinks);
-    actionKeyContext.addNestedSetToFingerprint(RUNFILES_AND_EXEC_PATH_MAP_FN, fp, artifacts);
+    try {
+      actionKeyContext.addNestedSetToFingerprint(SYMLINK_ENTRY_MAP_FN, fp, symlinks);
+      actionKeyContext.addNestedSetToFingerprint(SYMLINK_ENTRY_MAP_FN, fp, rootSymlinks);
+      actionKeyContext.addNestedSetToFingerprint(RUNFILES_AND_EXEC_PATH_MAP_FN, fp, artifacts);
+    } catch (CommandLineExpansionException | InterruptedException e) {
+      // The MapFns used above do not throw any exceptions.
+      throw new IllegalStateException(e);
+    }
 
     emptyFilesSupplier.fingerprint(fp);
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.analysis;
 
+import static com.google.devtools.build.lib.actions.ActionKeyContext.describedNestedSetFingerprint;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -22,7 +24,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
+import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLineExpansionException;
+import com.google.devtools.build.lib.actions.CommandLineItem;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -49,6 +54,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
@@ -70,11 +76,18 @@ import net.starlark.java.syntax.Location;
 public final class Runfiles implements RunfilesApi {
 
   private static class DummyEmptyFilesSupplier implements EmptyFilesSupplier {
+    private static final UUID GUID = UUID.fromString("36437db7-820b-4386-85b4-f7205a2018ae");
+
     private DummyEmptyFilesSupplier() {}
 
     @Override
     public Iterable<PathFragment> getExtraPaths(Set<PathFragment> manifestPaths) {
       return ImmutableList.of();
+    }
+
+    @Override
+    public void fingerprint(Fingerprint fp) {
+      fp.addUUID(GUID);
     }
   }
 
@@ -151,6 +164,18 @@ public final class Runfiles implements RunfilesApi {
   // It is important to declare this *after* the DUMMY_SYMLINK_EXPANDER to avoid NPEs
   public static final Runfiles EMPTY = new Builder().build();
 
+  private static final CommandLineItem.MapFn<SymlinkEntry> SYMLINK_ENTRY_MAP_FN =
+      (symlink, args) -> {
+        args.accept(symlink.getPathString());
+        args.accept(symlink.getArtifact().getExecPathString());
+      };
+
+  private static final CommandLineItem.MapFn<Artifact> RUNFILES_AND_EXEC_PATH_MAP_FN =
+      (artifact, args) -> {
+        args.accept(artifact.getRunfilesPathString());
+        args.accept(artifact.getExecPathString());
+      };
+
   /**
    * The directory to put all runfiles under.
    *
@@ -198,6 +223,8 @@ public final class Runfiles implements RunfilesApi {
   public interface EmptyFilesSupplier {
     /** Calculate additional empty files to add based on the existing manifest paths. */
     Iterable<PathFragment> getExtraPaths(Set<PathFragment> manifestPaths);
+
+    void fingerprint(Fingerprint fingerprint);
   }
 
   /** Generates extra (empty file) inputs. */
@@ -1155,65 +1182,32 @@ public final class Runfiles implements RunfilesApi {
     }
   }
 
-  /**
-   * Fingerprint this {@link Runfiles} tree.
-   */
-  public void fingerprint(Fingerprint fp) {
+  /** Fingerprint this {@link Runfiles} tree. */
+  public void fingerprint(ActionKeyContext actionKeyContext, Fingerprint fp)
+      throws CommandLineExpansionException, InterruptedException {
+    fp.addInt(conflictPolicy.ordinal());
     fp.addBoolean(legacyExternalRunfiles);
     fp.addPath(suffix);
-    Map<PathFragment, Artifact> symlinks = getSymlinksAsMap(null);
-    fp.addInt(symlinks.size());
-    for (Map.Entry<PathFragment, Artifact> symlink : symlinks.entrySet()) {
-      fp.addPath(symlink.getKey());
-      fp.addPath(symlink.getValue().getExecPath());
-    }
-    Map<PathFragment, Artifact> rootSymlinks = getRootSymlinksAsMap(null);
-    fp.addInt(rootSymlinks.size());
-    for (Map.Entry<PathFragment, Artifact> rootSymlink : rootSymlinks.entrySet()) {
-      fp.addPath(rootSymlink.getKey());
-      fp.addPath(rootSymlink.getValue().getExecPath());
-    }
 
-    for (Artifact artifact : artifacts.toList()) {
-      fp.addPath(artifact.getRunfilesPath());
-      fp.addPath(artifact.getExecPath());
-    }
+    actionKeyContext.addNestedSetToFingerprint(SYMLINK_ENTRY_MAP_FN, fp, symlinks);
+    actionKeyContext.addNestedSetToFingerprint(SYMLINK_ENTRY_MAP_FN, fp, rootSymlinks);
+    actionKeyContext.addNestedSetToFingerprint(RUNFILES_AND_EXEC_PATH_MAP_FN, fp, artifacts);
 
-    for (String name : getEmptyFilenames().toList()) {
-      fp.addString(name);
-    }
+    emptyFilesSupplier.fingerprint(fp);
   }
-  /** Describes the inputs {@link fingerprint} uses to aid describeKey() descriptions. */
+
+  /** Describes the inputs {@link #fingerprint} uses to aid describeKey() descriptions. */
   public String describeFingerprint() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(String.format("legacyExternalRunfiles: %s\n", legacyExternalRunfiles));
-    sb.append(String.format("suffix: %s\n", suffix));
-
-    var symlinks = getSymlinksAsMap(null);
-    sb.append(String.format("symlinksSize: %s\n", symlinks.size()));
-    for (var symlink : symlinks.entrySet()) {
-      sb.append(
-          String.format(
-              "symlink: '%s' to '%s'\n", symlink.getKey(), symlink.getValue().getExecPath()));
-    }
-
-    var rootSymlinks = getRootSymlinksAsMap(null);
-    sb.append(String.format("rootSymlinksSize: %s\n", rootSymlinks.size()));
-    for (var symlink : rootSymlinks.entrySet()) {
-      sb.append(
-          String.format(
-              "rootSymlink: '%s' to '%s'\n", symlink.getKey(), symlink.getValue().getExecPath()));
-    }
-
-    for (Artifact artifact : artifacts.toList()) {
-      sb.append(
-          String.format(
-              "artifact: '%s' '%s'\n", artifact.getRunfilesPath(), artifact.getExecPath()));
-    }
-
-    for (String name : getEmptyFilenames().toList()) {
-      sb.append(String.format("emptyFilename: '%s'\n", name));
-    }
-    return sb.toString();
+    return String.format("conflictPolicy: %s\n", conflictPolicy)
+        + String.format("legacyExternalRunfiles: %s\n", legacyExternalRunfiles)
+        + String.format("suffix: %s\n", suffix)
+        + String.format(
+            "symlinks: %s\n", describedNestedSetFingerprint(SYMLINK_ENTRY_MAP_FN, symlinks))
+        + String.format(
+            "rootSymlinks: %s\n", describedNestedSetFingerprint(SYMLINK_ENTRY_MAP_FN, rootSymlinks))
+        + String.format(
+            "artifacts: %s\n",
+            describedNestedSetFingerprint(RUNFILES_AND_EXEC_PATH_MAP_FN, artifacts))
+        + String.format("emptyFilesSupplier: %s\n", emptyFilesSupplier.getClass().getName());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.analysis.actions.AbstractFileWriteAction;
 import com.google.devtools.build.lib.analysis.actions.DeterministicWriter;
 import com.google.devtools.build.lib.analysis.starlark.UnresolvedSymlinkAction;
@@ -249,10 +250,10 @@ public final class SourceManifestAction extends AbstractFileWriteAction {
   protected void computeKey(
       ActionKeyContext actionKeyContext,
       @Nullable Artifact.ArtifactExpander artifactExpander,
-      Fingerprint fp) {
+      Fingerprint fp) throws CommandLineExpansionException, InterruptedException {
     fp.addString(GUID);
     fp.addBoolean(remotableSourceManifestActions);
-    runfiles.fingerprint(fp);
+    runfiles.fingerprint(actionKeyContext, fp);
     fp.addBoolean(repoMappingManifest != null);
     if (repoMappingManifest != null) {
       fp.addPath(repoMappingManifest.getExecPath());

--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -24,7 +24,6 @@ import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.analysis.actions.AbstractFileWriteAction;
 import com.google.devtools.build.lib.analysis.actions.DeterministicWriter;
 import com.google.devtools.build.lib.analysis.starlark.UnresolvedSymlinkAction;
@@ -250,7 +249,7 @@ public final class SourceManifestAction extends AbstractFileWriteAction {
   protected void computeKey(
       ActionKeyContext actionKeyContext,
       @Nullable Artifact.ArtifactExpander artifactExpander,
-      Fingerprint fp) throws CommandLineExpansionException, InterruptedException {
+      Fingerprint fp) {
     fp.addString(GUID);
     fp.addBoolean(remotableSourceManifestActions);
     runfiles.fingerprint(actionKeyContext, fp);

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
@@ -24,7 +24,6 @@ import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -208,7 +207,7 @@ public final class SymlinkTreeAction extends AbstractAction {
   protected void computeKey(
       ActionKeyContext actionKeyContext,
       @Nullable Artifact.ArtifactExpander artifactExpander,
-      Fingerprint fp) throws CommandLineExpansionException, InterruptedException {
+      Fingerprint fp) {
     fp.addString(GUID);
     fp.addNullableString(filesetRoot);
     fp.addBoolean(enableRunfiles);

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -207,7 +208,7 @@ public final class SymlinkTreeAction extends AbstractAction {
   protected void computeKey(
       ActionKeyContext actionKeyContext,
       @Nullable Artifact.ArtifactExpander artifactExpander,
-      Fingerprint fp) {
+      Fingerprint fp) throws CommandLineExpansionException, InterruptedException {
     fp.addString(GUID);
     fp.addNullableString(filesetRoot);
     fp.addBoolean(enableRunfiles);
@@ -224,7 +225,7 @@ public final class SymlinkTreeAction extends AbstractAction {
     // safe to add more fields in the future.
     fp.addBoolean(runfiles != null);
     if (runfiles != null) {
-      runfiles.fingerprint(fp);
+      runfiles.fingerprint(actionKeyContext, fp);
     }
     fp.addBoolean(repoMappingManifest != null);
     if (repoMappingManifest != null) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -19,13 +19,16 @@ import com.google.devtools.build.lib.rules.python.PythonSemantics;
 import com.google.devtools.build.lib.rules.python.PythonUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.Serializable;
+import java.util.UUID;
 import java.util.function.Predicate;
 
 /** Functionality specific to the Python rules in Bazel. */
 public class BazelPythonSemantics implements PythonSemantics {
 
+  private static final UUID GUID = UUID.fromString("0211a192-1b1e-40e6-80e9-7352360b12b1");
   public static final Runfiles.EmptyFilesSupplier GET_INIT_PY_FILES =
-      new PythonUtils.GetInitPyFiles((Predicate<PathFragment> & Serializable) source -> false);
+      new PythonUtils.GetInitPyFiles(
+          (Predicate<PathFragment> & Serializable) source -> false, GUID);
 
   @Override
   public Runfiles.EmptyFilesSupplier getEmptyRunfilesSupplier() {

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -417,6 +417,7 @@ java_library(
         ":symlink_tree_helper",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
         "//src/main/java/com/google/devtools/build/lib/actions:fileset_output_symlink",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/profiler",

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategy.java
@@ -24,7 +24,6 @@ import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.MissingExpansionException;
-import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
@@ -164,11 +163,7 @@ public final class SymlinkTreeStrategy implements SymlinkTreeActionContext {
       // If we don't have an input manifest, then create a file containing a fingerprint of
       // the runfiles object.
       Fingerprint fp = new Fingerprint();
-      try {
-        action.getRunfiles().fingerprint(actionExecutionContext.getActionKeyContext(), fp);
-      } catch (CommandLineExpansionException | InterruptedException e) {
-        throw createLinkFailureException(outputManifest, new IOException(e));
-      }
+      action.getRunfiles().fingerprint(actionExecutionContext.getActionKeyContext(), fp);
       String hexDigest = fp.hexDigestAndReset();
       try {
         FileSystemUtils.writeContentAsLatin1(outputManifest, hexDigest);

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonUtils.java
@@ -45,6 +45,8 @@ public final class PythonUtils {
      * The Predicate isPackageInit's .test(source) should be true when a given source is known to be
      * a valid __init__.py file equivalent, meaning no empty __init__.py file need be created.
      * Useful for custom Python runtimes that may have non-standard Python package import logic.
+     * @param guid a UUID that uniquely identifies the particular isPackageInit predicate for the
+     *             purpose of fingerprinting this {@link Runfiles.EmptyFilesSupplier} instance
      */
     public GetInitPyFiles(Predicate<PathFragment> isPackageInit, UUID guid) {
       this.isPackageInit = isPackageInit;

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonUtils.java
@@ -16,9 +16,11 @@ package com.google.devtools.build.lib.rules.python;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.util.FileType;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 
 /** Various utility methods for Python support. */
@@ -37,19 +39,26 @@ public final class PythonUtils {
    */
   public static class GetInitPyFiles implements Runfiles.EmptyFilesSupplier {
     private final Predicate<PathFragment> isPackageInit;
+    private final UUID guid;
 
     /**
      * The Predicate isPackageInit's .test(source) should be true when a given source is known to be
      * a valid __init__.py file equivalent, meaning no empty __init__.py file need be created.
      * Useful for custom Python runtimes that may have non-standard Python package import logic.
      */
-    public GetInitPyFiles(Predicate<PathFragment> isPackageInit) {
+    public GetInitPyFiles(Predicate<PathFragment> isPackageInit, UUID guid) {
       this.isPackageInit = isPackageInit;
+      this.guid = guid;
     }
 
     @Override
     public Set<PathFragment> getExtraPaths(Set<PathFragment> manifestPaths) {
       return getInitPyFiles(manifestPaths);
+    }
+
+    @Override
+    public void fingerprint(Fingerprint fp) {
+      fp.addUUID(guid);
     }
 
     /**

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -332,6 +332,7 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/util",

--- a/src/test/java/com/google/devtools/build/lib/analysis/RunfilesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/RunfilesTest.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.skyframe.BuildConfigurationKey;
 import com.google.devtools.build.lib.testutil.FoundationTestCase;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.skyframe.SkyFunctionName;
@@ -41,6 +42,7 @@ import com.google.devtools.common.options.OptionsParsingException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Mutability;
@@ -634,11 +636,17 @@ public class RunfilesTest extends FoundationTestCase {
             .addSymlink(PathFragment.create("my-symlink"), artifact)
             .addRootSymlink(PathFragment.create("my-root-symlink"), artifact)
             .setEmptyFilesSupplier(
-                (manifestPaths) ->
-                    manifestPaths
-                        .stream()
+                new Runfiles.EmptyFilesSupplier() {
+                  @Override
+                  public Iterable<PathFragment> getExtraPaths(Set<PathFragment> manifestPaths) {
+                    return manifestPaths.stream()
                         .map((f) -> f.replaceName(f.getBaseName() + "-empty"))
-                        .collect(ImmutableList.toImmutableList()))
+                        .collect(ImmutableList.toImmutableList());
+                  }
+
+                  @Override
+                  public void fingerprint(Fingerprint fingerprint) {}
+                })
             .build();
     assertThat(runfiles.getEmptyFilenames().toList())
         .containsExactly("my-artifact-empty", "my-symlink-empty");

--- a/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategyTest.java
@@ -35,12 +35,14 @@ import com.google.devtools.build.lib.analysis.actions.SymlinkTreeAction;
 import com.google.devtools.build.lib.analysis.actions.SymlinkTreeActionContext;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.events.StoredEventHandler;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.OutputService;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -83,7 +85,16 @@ public final class SymlinkTreeStrategyTest extends BuildViewTestCase {
 
     Runfiles runfiles =
         new Runfiles.Builder("TESTING", false)
-            .setEmptyFilesSupplier((paths) -> ImmutableList.of(PathFragment.create("dir/empty")))
+            .setEmptyFilesSupplier(
+                new Runfiles.EmptyFilesSupplier() {
+                  @Override
+                  public Iterable<PathFragment> getExtraPaths(Set<PathFragment> manifestPaths) {
+                    return ImmutableList.of(PathFragment.create("dir/empty"));
+                  }
+
+                  @Override
+                  public void fingerprint(Fingerprint fingerprint) {}
+                })
             .addArtifact(runfile)
             .build();
     SymlinkTreeAction action =
@@ -130,7 +141,16 @@ public final class SymlinkTreeStrategyTest extends BuildViewTestCase {
 
     Runfiles runfiles =
         new Runfiles.Builder("TESTING", false)
-            .setEmptyFilesSupplier((paths) -> ImmutableList.of(PathFragment.create("dir/empty")))
+            .setEmptyFilesSupplier(
+                new Runfiles.EmptyFilesSupplier() {
+                  @Override
+                  public Iterable<PathFragment> getExtraPaths(Set<PathFragment> manifestPaths) {
+                    return ImmutableList.of(PathFragment.create("dir/empty"));
+                  }
+
+                  @Override
+                  public void fingerprint(Fingerprint fingerprint) {}
+                })
             .addArtifact(runfile)
             .build();
     SymlinkTreeAction action =


### PR DESCRIPTION
The fingerprint did not include the conflict policy and some of the collections' sizes. It also didn't use the cache for fingerprints of `NestedSet`s and instead always flattened the sets.

The new `fingerprint` method on `EmptyFilesSupplier` makes it possible to drop the call to `Runfiles#getEmptyFilenames`, which would still end up flattening the sets.

See https://groups.google.com/g/bazel-discuss/c/KrUg6ZPky80