### PR TITLE
Reenable remote caching/execution for most of the Android integration tests.

### DIFF
--- a/src/test/shell/bazel/android/BUILD
+++ b/src/test/shell/bazel/android/BUILD
@@ -37,8 +37,8 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
+        # See https://github.com/bazelbuild/bazel/issues/18431.
         "no-remote",
         "no_windows",
         # bzlmod test requires network
@@ -55,9 +55,7 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -71,8 +69,6 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
-    tags = ["no-remote"],
 )
 
 android_sh_test(
@@ -85,8 +81,8 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
+        # See https://github.com/bazelbuild/bazel/issues/17784.
         "no-remote",
         "no_windows",
     ],
@@ -101,8 +97,6 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
-    tags = ["no-remote"],
 )
 
 android_sh_test(
@@ -115,9 +109,7 @@ android_sh_test(
         "//src/test/shell/bazel:test-deps",
     ],
     shard_count = 3,
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -134,8 +126,8 @@ android_sh_test(
         "//src/test/shell/bazel:test-deps",
     ],
     shard_count = 6,
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
+        # See https://github.com/bazelbuild/bazel/issues/17784.
         "no-remote",
         "no_windows",
     ],
@@ -150,8 +142,6 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
-    tags = ["no-remote"],
 )
 
 android_sh_test(
@@ -163,9 +153,7 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -180,9 +168,7 @@ android_sh_test(
         "//src/test/shell/bazel:test-deps",
     ],
     shard_count = 4,
-    # See https://github.com/bazelbuild/bazel/issues/8235
     tags = [
-        "no-remote",
         "no_windows",
     ],
 )
@@ -197,6 +183,4 @@ android_sh_test(
         "//external:android_sdk_for_testing",
         "//src/test/shell/bazel:test-deps",
     ],
-    # See https://github.com/bazelbuild/bazel/issues/8235
-    tags = ["no-remote"],
 )


### PR DESCRIPTION
Some still fail remotely and remain disabled; see https://github.com/bazelbuild/bazel/issues/17784 and https://github.com/bazelbuild/bazel/issues/18431.

Fixes https://github.com/bazelbuild/bazel/issues/8235.