### PR TITLE
[6.3.0] Allow overrides in non-root modules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -138,9 +138,6 @@ public class ModuleFileFunction implements SkyFunction {
           moduleKey,
           module.getVersion());
     }
-    if (!moduleFileGlobals.buildOverrides().isEmpty()) {
-      throw errorf(Code.BAD_MODULE, "The MODULE.bazel file of %s declares overrides", moduleKey);
-    }
 
     return NonRootModuleFileValue.create(module, moduleFileHash);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -623,8 +623,8 @@ public class ModuleFileGlobals {
       doc =
           "Specifies that a dependency should still come from a registry, but its version should"
               + " be pinned, or its registry overridden, or a list of patches applied. This"
-              + " directive can only be used by the root module; in other words, if a module"
-              + " specifies any overrides, it cannot be used as a dependency by others.",
+              + " directive only takes effect in the root module; in other words, if a module"
+              + " is used as a dependency by others, its own overrides are ignored.",
       parameters = {
         @Param(
             name = "module_name",
@@ -703,9 +703,9 @@ public class ModuleFileGlobals {
       name = "multiple_version_override",
       doc =
           "Specifies that a dependency should still come from a registry, but multiple versions of"
-              + " it should be allowed to coexist. This directive can only be used by the root"
-              + " module; in other words, if a module specifies any overrides, it cannot be used"
-              + " as a dependency by others.",
+              + " it should be allowed to coexist. This directive only takes effect in the root"
+              + " module; in other words, if a module is used as a dependency by others, its own"
+              + " overrides are ignored.",
       parameters = {
         @Param(
             name = "module_name",
@@ -756,9 +756,9 @@ public class ModuleFileGlobals {
       name = "archive_override",
       doc =
           "Specifies that this dependency should come from an archive file (zip, gzip, etc) at a"
-              + " certain location, instead of from a registry. This directive can only be used by"
-              + " the root module; in other words, if a module specifies any overrides, it cannot"
-              + " be used as a dependency by others.",
+              + " certain location, instead of from a registry. This"
+              + " directive only takes effect in the root module; in other words, if a module"
+              + " is used as a dependency by others, its own overrides are ignored.",
       parameters = {
         @Param(
             name = "module_name",
@@ -840,8 +840,8 @@ public class ModuleFileGlobals {
       name = "git_override",
       doc =
           "Specifies that a dependency should come from a certain commit of a Git repository. This"
-              + " directive can only be used by the root module; in other words, if a module"
-              + " specifies any overrides, it cannot be used as a dependency by others.",
+              + " directive only takes effect in the root module; in other words, if a module"
+              + " is used as a dependency by others, its own overrides are ignored.",
       parameters = {
         @Param(
             name = "module_name",
@@ -907,8 +907,8 @@ public class ModuleFileGlobals {
       name = "local_path_override",
       doc =
           "Specifies that a dependency should come from a certain directory on local disk. This"
-              + " directive can only be used by the root module; in other words, if a module"
-              + " specifies any overrides, it cannot be used as a dependency by others.",
+              + " directive only takes effect in the root module; in other words, if a module"
+              + " is used as a dependency by others, its own overrides are ignored.",
       parameters = {
         @Param(
             name = "module_name",

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -215,7 +215,10 @@ public class DiscoveryTest extends FoundationTestCase {
             .addModule(
                 createModuleKey("ccc", "2.0"),
                 "module(name='ccc', version='2.0');bazel_dep(name='ddd',version='3.0')")
-            .addModule(createModuleKey("ddd", "3.0"), "module(name='ddd', version='3.0')");
+            .addModule(
+                createModuleKey("ddd", "3.0"),
+                // Add a random override here; it should be ignored
+                "module(name='ddd', version='3.0');local_path_override(module_name='ff',path='f')");
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of(registry.getUrl()));
 
     EvaluationResult<DiscoveryValue> result =


### PR DESCRIPTION
They're simply ignored.

RELNOTES: Overrides specified by non-root modules no longer cause an error, and are silently ignored instead. They were originally treated as an error to allow for the future possibility of overrides in the transitive dependency graph working together; but we've deemed that infeasible (and even if it was, it'd be so complicated and confusing to users that it would not be a good addition). PiperOrigin-RevId: 529095596
Change-Id: I8b9b7b570b405ee757554accf791d8e4c1ff6528

(cherry picked from commit 78cb7d5b652ee155a0d1ad5cef3a3131e9705152)