### PR TITLE
Include name in `repr` of exported `rule`s

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -982,7 +982,11 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
 
     @Override
     public void repr(Printer printer) {
-      printer.append("<rule>");
+      if (isExported()) {
+        printer.append("<rule ").append(getRuleClass().getName()).append(">");
+      } else {
+        printer.append("<rule>");
+      }
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkStringRepresentationsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkStringRepresentationsTest.java
@@ -268,7 +268,7 @@ public class StarlarkStringRepresentationsTest extends BuildViewTestCase {
   @Test
   public void testStringRepresentations_rules() throws Exception {
     setBuildLanguageOptions("--experimental_builtins_injection_override=+cc_library");
-    assertStringRepresentation("native.cc_library", "<rule>");
+    assertStringRepresentation("native.cc_library", "<rule cc_library>");
     assertStringRepresentation("def f(): pass", "rule(implementation=f)", "<rule>");
   }
 


### PR DESCRIPTION
For an exported rule `foo_library`, `repr(foo_library)` now evaluates to `<rule foo_library>`, not `<rule>`, matching the behavior of native rules more closely.

Fixes #17483