### PR TITLE
Fix cquery example text by using a cc_binary as tool

### DIFF
--- a/site/en/query/cquery.md
+++ b/site/en/query/cquery.md
@@ -209,8 +209,9 @@ genrule(
      cmd = "$(locations :tool) $&lt; >$@",
      tools = [":tool"],
 )
-cc_library(
+cc_binary(
     name = "tool",
+    srcs = ["tool.cpp"],
 )
 </pre>
 


### PR DESCRIPTION
The previous example used a `cc_library` as the `tool` in a `genrule` which is odd. Improve the docs by using a `cc_binary` here.