### PR TITLE
[6.3.0] Pass version to java_runtimes created by local_java_repository

### DIFF
--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -62,6 +62,7 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
             name = runtime_name,
             java_home = java_home,
             visibility = visibility,
+            version = int(version) if version.isdigit() else 0,
         )
 
     native.config_setting(


### PR DESCRIPTION
Work towards #17281

Closes #18344.

Commit https://github.com/bazelbuild/bazel/commit/1c1584b4081972c69d7746243f023257387d8121

PiperOrigin-RevId: 530662071
Change-Id: I9376cbc7117d9c8370cf50d42988cca44dad9785