### PR TITLE
[6.3.0] Disable ImpossibleNullComparison

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -59,6 +59,7 @@ DEFAULT_JAVACOPTS = [
     "-Xep:EmptyTopLevelDeclaration:OFF",
     "-Xep:LenientFormatStringValidation:OFF",
     "-Xep:ReturnMissingNullable:OFF",
+    "-Xep:ImpossibleNullComparison:OFF",
 ]
 
 # java_toolchain parameters without specifying javac, java.compiler,


### PR DESCRIPTION
Disable ImpossibleNullComparison to fix failing presubmits in 6.3

E.g. https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/15828#01881e5d-4e13-458d-adbf-c1d0659f4198

Commit https://github.com/bazelbuild/bazel/commit/f4b35a2df7f4e0fccec93c901a7ffc3ce96e17e6

PiperOrigin-RevId: 532157602
Change-Id: I8e64b9774a83d55894bf63661a10a7faf1ca69cf