### PR TITLE
cc_library: propagate data dependencies via implementation_deps.

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -277,6 +277,9 @@ def _cc_library_impl(ctx):
     for dep in ctx.attr.deps:
         runfiles_list.append(dep[DefaultInfo].default_runfiles)
 
+    for dep in ctx.attr.implementation_deps:
+        runfiles_list.append(dep[DefaultInfo].default_runfiles)
+
     runfiles = ctx.runfiles().merge_all(runfiles_list)
 
     default_runfiles = ctx.runfiles(files = cc_helper.get_dynamic_libraries_for_runtime(linking_context_for_runfiles, True))


### PR DESCRIPTION
Sources from `implementation_deps` aren't propagated for compilation, but their runfiles may still be needed in runtime; they currently aren't provided, which seems like a bug (reproduction in [gist](https://gist.github.com/quval/2cc5b2cd323a10ae6a9375f326a296c2)).