### PR TITLE
[6.3.0] Automatic code cleanup.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/cmdline/ParallelVisitorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/ParallelVisitorTest.java
@@ -23,7 +23,6 @@ import com.google.devtools.build.lib.cmdline.BatchCallback.SafeBatchCallback;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.testutil.TestThread;
 import java.util.ArrayList;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -153,12 +152,7 @@ public class ParallelVisitorTest {
       synchronized (this) {
         visits.add(values);
       }
-      return new Visit(
-          values,
-          Iterables.concat(
-              Iterables.transform(
-                  values,
-                  v -> Optional.ofNullable(successorMap.get(v)).orElse(ImmutableList.of()))));
+      return new Visit(values, Iterables.concat(Iterables.transform(values, successorMap::get)));
     }
 
     @Override


### PR DESCRIPTION
Fix failing presubmits in 6.3 (see comment https://github.com/bazelbuild/bazel/pull/18405#issuecomment-1549196375)

PiperOrigin-RevId: 488722109
Change-Id: Ia0422938fd88d4260b39b1e3a54a548766c91ef9