### PR TITLE
Support symlinks for Android SDK build-tools directories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
@@ -373,7 +373,7 @@ public class AndroidSdkRepositoryFunction extends AndroidRepositoryFunction {
     String newestBuildToolsDirectory = null;
     AndroidRevision newestBuildToolsRevision = null;
     for (Dirent buildToolsDirectory : buildToolsDirectories) {
-      if (buildToolsDirectory.getType() != Dirent.Type.DIRECTORY) {
+      if (buildToolsDirectory.getType() != Dirent.Type.DIRECTORY && buildToolsDirectory.getType() != Dirent.Type.SYMLINK) {
         continue;
       }
       try {


### PR DESCRIPTION
I made the changes proposed in this feature request issue https://github.com/bazelbuild/bazel/issues/18345