### PR TITLE
bes: add retry attempt to build tool stream request

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceProtoUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceProtoUtil.java
@@ -118,19 +118,31 @@ public final class BuildEventServiceProtoUtil {
   /** Creates a PublishBuildToolEventStreamRequest from a packed bazel event. */
   public PublishBuildToolEventStreamRequest bazelEvent(
       long sequenceNumber, Timestamp timestamp, Any packedEvent) {
+    return bazelEvent(sequenceNumber, timestamp, /* streamAttempt */ 1, packedEvent);
+  }
+
+  public PublishBuildToolEventStreamRequest bazelEvent(
+      long sequenceNumber, Timestamp timestamp, int streamAttempt, Any packedEvent) {
     return publishBuildToolEventStreamRequest(
         projectId,
         sequenceNumber,
         timestamp,
+        streamAttempt,
         com.google.devtools.build.v1.BuildEvent.newBuilder().setBazelEvent(packedEvent));
   }
 
   public PublishBuildToolEventStreamRequest streamFinished(
       long sequenceNumber, Timestamp timestamp) {
+    return streamFinished(sequenceNumber, timestamp, /* streamAttempt */ 1);
+  }
+
+  public PublishBuildToolEventStreamRequest streamFinished(
+      long sequenceNumber, Timestamp timestamp, int streamAttempt) {
     return publishBuildToolEventStreamRequest(
         projectId,
         sequenceNumber,
         timestamp,
+        streamAttempt,
         BuildEvent.newBuilder()
             .setComponentStreamFinished(
                 BuildComponentStreamFinished.newBuilder().setType(FINISHED)));
@@ -141,9 +153,11 @@ public final class BuildEventServiceProtoUtil {
       @Nullable String projectId,
       long sequenceNumber,
       Timestamp timestamp,
+      int streamAttempt,
       BuildEvent.Builder besEvent) {
     PublishBuildToolEventStreamRequest.Builder builder =
         PublishBuildToolEventStreamRequest.newBuilder()
+            .setRetryAttemptNumber(streamAttempt)
             .setOrderedBuildEvent(
                 OrderedBuildEvent.newBuilder()
                     .setSequenceNumber(sequenceNumber)

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploader.java
@@ -400,6 +400,11 @@ public final class BuildEventServiceUploader implements Runnable {
     Deque<SendBuildEventCommand> ackQueue = new ArrayDeque<>();
     boolean lastEventSent = false;
     int acksReceived = 0;
+    // Tracks the actual open stream attempt.
+    // Correspond to PublishBuildToolEventStreamRequest.retry_attempt_number.
+    int streamAttempt = 1;
+    // Tracks the stream status to determine sleep duration between retries.
+    // Reset to zero when sever successfully ACK an event.
     int retryAttempt = 0;
 
     try {
@@ -448,6 +453,7 @@ public final class BuildEventServiceUploader implements Runnable {
                   besProtoUtil.bazelEvent(
                       buildEvent.getSequenceNumber(),
                       buildEvent.getCreationTime(),
+                      streamAttempt,
                       Any.pack(serializedRegularBuildEvent));
 
               streamContext.sendOverStream(request);
@@ -462,7 +468,7 @@ public final class BuildEventServiceUploader implements Runnable {
               lastEventSent = true;
               PublishBuildToolEventStreamRequest request =
                   besProtoUtil.streamFinished(
-                      lastEvent.getSequenceNumber(), lastEvent.getCreationTime());
+                      lastEvent.getSequenceNumber(), lastEvent.getCreationTime(), streamAttempt);
               streamContext.sendOverStream(request);
               streamContext.halfCloseStream();
               halfCloseFuture.set(null);
@@ -564,6 +570,8 @@ public final class BuildEventServiceUploader implements Runnable {
                   "Retrying stream: status='%s', sleepMillis=%d", streamStatus, sleepMillis);
               sleeper.sleepMillis(sleepMillis);
 
+              // About to open a new stream, increase attempt count.
+              streamAttempt++;
               // If we made progress, meaning the server ACKed events that we sent, then reset
               // the retry counter to 0.
               if (acksReceived > 0) {

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/AbstractBuildEventServiceTransportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/AbstractBuildEventServiceTransportTest.java
@@ -304,11 +304,13 @@ public abstract class AbstractBuildEventServiceTransportTest extends FoundationT
     Timestamp timestamp = Timestamps.fromMillis(clock.advanceMillis(1000L));
     // Send UNAVAILABLE on streamFinished event
     fakeBesServer.setStreamEventPredicateAndResponseStatus(
-        (req) -> Objects.equals(req, BES_PROTO_UTIL.streamFinished(4, timestamp)),
+        (req) ->
+            Objects.equals(
+                req, BES_PROTO_UTIL.streamFinished(4, timestamp, req.getRetryAttemptNumber())),
         Status.UNAVAILABLE);
 
     BuildEventServiceTransport transport =
-        newBuildEventServiceTransport(/*publishLifecycleEvents=*/ false);
+        newBuildEventServiceTransport(/* publishLifecycleEvents= */ false);
     transport.sendBuildEvent(started);
     transport.sendBuildEvent(progress);
     transport.sendBuildEvent(success);
@@ -323,14 +325,14 @@ public abstract class AbstractBuildEventServiceTransportTest extends FoundationT
     assertThat(fakeBesServer.getStreamEvents(BES_PROTO_UTIL.streamId(BAZEL_EVENT)))
         .containsAtLeast(
             BES_PROTO_UTIL.bazelEvent(
-                1, timestamp, Any.pack(started.asStreamProto(buildEventContext))),
+                1, timestamp, 1, Any.pack(started.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(progress.asStreamProto(buildEventContext))),
+                2, timestamp, 1, Any.pack(progress.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                3, timestamp, Any.pack(success.asStreamProto(buildEventContext))),
-            BES_PROTO_UTIL.streamFinished(4, timestamp),
+                3, timestamp, 1, Any.pack(success.asStreamProto(buildEventContext))),
+            BES_PROTO_UTIL.streamFinished(4, timestamp, 1),
             // Verify retry on streamFinished message
-            BES_PROTO_UTIL.streamFinished(4, timestamp))
+            BES_PROTO_UTIL.streamFinished(4, timestamp, 2))
         .inOrder();
   }
 
@@ -373,11 +375,15 @@ public abstract class AbstractBuildEventServiceTransportTest extends FoundationT
 
     Any expectedPackedEvent = Any.pack(progress.asStreamProto(buildEventContext));
     fakeBesServer.setStreamEventPredicateAndResponseStatus(
-        (req) -> Objects.equals(req, BES_PROTO_UTIL.bazelEvent(2, timestamp, expectedPackedEvent)),
+        (req) ->
+            Objects.equals(
+                req,
+                BES_PROTO_UTIL.bazelEvent(
+                    2, timestamp, req.getRetryAttemptNumber(), expectedPackedEvent)),
         Status.CANCELLED);
 
     BuildEventServiceTransport transport =
-        newBuildEventServiceTransport(/*publishLifecycleEvents=*/ false);
+        newBuildEventServiceTransport(/* publishLifecycleEvents= */ false);
     transport.sendBuildEvent(started);
     transport.sendBuildEvent(progress);
     transport.sendBuildEvent(success);
@@ -392,30 +398,30 @@ public abstract class AbstractBuildEventServiceTransportTest extends FoundationT
     assertThat(fakeBesServer.getSuccessfulStreamEvents(BES_PROTO_UTIL.streamId(BAZEL_EVENT)))
         .contains(
             BES_PROTO_UTIL.bazelEvent(
-                1, timestamp, Any.pack(started.asStreamProto(buildEventContext))));
+                1, timestamp, 1, Any.pack(started.asStreamProto(buildEventContext))));
 
     assertThat(fakeBesServer.getStreamEvents(BES_PROTO_UTIL.streamId(BAZEL_EVENT)))
         .containsAtLeast(
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(progress.asStreamProto(buildEventContext))),
+                2, timestamp, 1, Any.pack(progress.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(progress.asStreamProto(buildEventContext))),
+                2, timestamp, 2, Any.pack(progress.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(progress.asStreamProto(buildEventContext))),
+                2, timestamp, 3, Any.pack(progress.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(progress.asStreamProto(buildEventContext))),
+                2, timestamp, 4, Any.pack(progress.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(progress.asStreamProto(buildEventContext))));
+                2, timestamp, 5, Any.pack(progress.asStreamProto(buildEventContext))));
   }
 
   @Test(timeout = TIMEOUT_MILLIS)
   public void testRetriesForBuildEvents_everyEventFailsOnce() throws Exception {
     Timestamp timestamp = Timestamps.fromMillis(clock.advanceMillis(1000L));
     fakeBesServer.setStreamEventPredicateAndResponseStatus(
-        everyEventFailsOnce(), Status.UNAVAILABLE);
+        everyToolEventFailsOnce(), Status.UNAVAILABLE);
 
     BuildEventServiceTransport transport =
-        newBuildEventServiceTransport(/*publishLifecycleEvents=*/ false);
+        newBuildEventServiceTransport(/* publishLifecycleEvents= */ false);
     transport.sendBuildEvent(started);
     transport.sendBuildEvent(success);
     transport.close().get();
@@ -423,23 +429,23 @@ public abstract class AbstractBuildEventServiceTransportTest extends FoundationT
     assertThat(fakeBesServer.getSuccessfulStreamEvents(BES_PROTO_UTIL.streamId(BAZEL_EVENT)))
         .containsAtLeast(
             BES_PROTO_UTIL.bazelEvent(
-                1, timestamp, Any.pack(started.asStreamProto(buildEventContext))),
+                1, timestamp, 2, Any.pack(started.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(success.asStreamProto(buildEventContext))),
-            BES_PROTO_UTIL.streamFinished(3, timestamp));
+                2, timestamp, 3, Any.pack(success.asStreamProto(buildEventContext))),
+            BES_PROTO_UTIL.streamFinished(3, timestamp, 4));
 
     assertThat(fakeBesServer.getStreamEvents(BES_PROTO_UTIL.streamId(BAZEL_EVENT)))
         .containsAtLeast(
             BES_PROTO_UTIL.bazelEvent(
-                1, timestamp, Any.pack(started.asStreamProto(buildEventContext))),
+                1, timestamp, 1, Any.pack(started.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                1, timestamp, Any.pack(started.asStreamProto(buildEventContext))),
+                1, timestamp, 2, Any.pack(started.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(success.asStreamProto(buildEventContext))),
+                2, timestamp, 2, Any.pack(success.asStreamProto(buildEventContext))),
             BES_PROTO_UTIL.bazelEvent(
-                2, timestamp, Any.pack(success.asStreamProto(buildEventContext))),
-            BES_PROTO_UTIL.streamFinished(3, timestamp),
-            BES_PROTO_UTIL.streamFinished(3, timestamp));
+                2, timestamp, 3, Any.pack(success.asStreamProto(buildEventContext))),
+            BES_PROTO_UTIL.streamFinished(3, timestamp, 3),
+            BES_PROTO_UTIL.streamFinished(3, timestamp, 4));
   }
 
   /** Tests that a successfully transmitted build event resets the retry counter. */
@@ -938,6 +944,28 @@ public abstract class AbstractBuildEventServiceTransportTest extends FoundationT
       @Override
       public boolean test(@Nullable T o) {
         return alreadyMatched.add(o);
+      }
+    };
+  }
+
+  /**
+   * Similar to everyEventFailsOnce, except we discard retry_attempt_number when comparing events.
+   */
+  private static Predicate<PublishBuildToolEventStreamRequest> everyToolEventFailsOnce() {
+    return new Predicate<PublishBuildToolEventStreamRequest>() {
+
+      private final Set<PublishBuildToolEventStreamRequest> alreadyMatched = new HashSet<>();
+
+      @Override
+      public boolean test(@Nullable PublishBuildToolEventStreamRequest req) {
+        var obEvent = req.getOrderedBuildEvent();
+        var event =
+            BES_PROTO_UTIL.bazelEvent(
+                obEvent.getSequenceNumber(),
+                obEvent.getEvent().getEventTime(),
+                0,
+                Any.pack(obEvent.getEvent()));
+        return alreadyMatched.add(event);
       }
     };
   }

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceProtoUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceProtoUtilTest.java
@@ -221,6 +221,7 @@ public class BuildEventServiceProtoUtilTest {
                                 .setEventTime(firstEventTimestamp)
                                 .setBazelEvent(anything))
                         .build())
+                .setRetryAttemptNumber(1)
                 .build());
 
     Timestamp secondEventTimestamp = Timestamps.fromMillis(clock.advanceMillis(100));
@@ -241,6 +242,7 @@ public class BuildEventServiceProtoUtilTest {
                                 .setEventTime(secondEventTimestamp)
                                 .setBazelEvent(anything))
                         .build())
+                .setRetryAttemptNumber(1)
                 .build());
 
     Timestamp thirdEventTimestamp = Timestamps.fromMillis(clock.advanceMillis(100));
@@ -263,6 +265,7 @@ public class BuildEventServiceProtoUtilTest {
                                     BuildComponentStreamFinished.newBuilder()
                                         .setType(FinishType.FINISHED)))
                         .build())
+                .setRetryAttemptNumber(1)
                 .build());
   }
 

--- a/third_party/googleapis/google/devtools/build/v1/publish_build_event.proto
+++ b/third_party/googleapis/google/devtools/build/v1/publish_build_event.proto
@@ -184,4 +184,9 @@ message PublishBuildToolEventStreamRequest {
   // request. BES only performs this check for events with sequence_number 1
   // i.e. the first event in the stream.
   bool check_preceding_lifecycle_events_present = 7;
+
+  // Number of streaming RPCs initiated (including this one) to upload the
+  // entire tool stream. Starts at 1 to differentiate with the default unset
+  // value.
+  int32 retry_attempt_number = 8;
 }


### PR DESCRIPTION
Today, all build events sent from Bazel should be delivered reliably
and ack-ed by BES service, otherwise, Bazel will attempt to re-uploads
the missing events.

Currently, bazel and BES service communicate using a bi-directional
GRPC stream, which is subjected to network failures. Especially in the
case where (1) BES service received an event and sent ACK to Bazel, but
(2) the ACK message is lost in transit, subsequently causing (3) Bazel
to retry sending the same event, it would be hard for BES service to
tell why an event is being sent out of the expected sequence (i.e. not
receiving BuildStarted event).

To help BES service differentiate between original events and events
sent because of retry attempts, add a new `retry_attempt` field to
PublishBuildToolEventStreamRequest in publish_build_event.proto.
A value of zero for `retry_attempt` should signify a fresh new event
while a value greater than zero should signify an event being sent
in a retry attempt.
