### PR TITLE
Improve error message if `select` references non-existent package

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ViewCreationFailedException.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ViewCreationFailedException.java
@@ -32,7 +32,7 @@ public class ViewCreationFailedException extends Exception {
   }
 
   public ViewCreationFailedException(String message, FailureDetail failureDetail, Throwable cause) {
-    super(message + ": " + cause.getMessage(), cause);
+    super(combineMessages(message, cause), cause);
     this.failureDetail = checkNotNull(failureDetail);
   }
 
@@ -43,5 +43,13 @@ public class ViewCreationFailedException extends Exception {
 
   public FailureDetail getFailureDetail() {
     return failureDetail;
+  }
+
+  private static String combineMessages(String message, Throwable cause) {
+    if (cause.getMessage().isEmpty()) {
+      return message;
+    } else {
+      return message + ": " + cause.getMessage();
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/DependencyEvaluationException.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/DependencyEvaluationException.java
@@ -37,13 +37,13 @@ import net.starlark.java.syntax.Location;
 public class DependencyEvaluationException extends Exception {
   /* Null denotes whatever default exit code callers choose. */
   @Nullable private final DetailedExitCode detailedExitCode;
-  private final Location location;
+  @Nullable private final Location location;
   private final boolean depReportedOwnError;
 
   private DependencyEvaluationException(
       Exception cause,
       @Nullable DetailedExitCode detailedExitCode,
-      Location location,
+      @Nullable Location location,
       boolean depReportedOwnError) {
     super(cause.getMessage(), cause);
     this.detailedExitCode = detailedExitCode;
@@ -68,6 +68,7 @@ public class DependencyEvaluationException extends Exception {
     return detailedExitCode;
   }
 
+  @Nullable
   public Location getLocation() {
     return location;
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredValueCreationException.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredValueCreationException.java
@@ -34,7 +34,7 @@ import net.starlark.java.syntax.Location;
 public final class ConfiguredValueCreationException extends Exception
     implements SaneAnalysisException {
 
-  private final Location location;
+  @Nullable private final Location location;
   @Nullable private final BuildEventId configuration;
   private final NestedSet<Cause> rootCauses;
   // TODO(b/138456686): if warranted by a need for finer-grained details, replace the constructors
@@ -42,7 +42,7 @@ public final class ConfiguredValueCreationException extends Exception
   private final DetailedExitCode detailedExitCode;
 
   public ConfiguredValueCreationException(
-      Location location,
+      @Nullable Location location,
       String message,
       Label label,
       @Nullable BuildEventId configuration,
@@ -83,6 +83,7 @@ public final class ConfiguredValueCreationException extends Exception
     this(ctgValue, message, /*rootCauses=*/ null, /*detailedExitCode=*/ null);
   }
 
+  @Nullable
   public Location getLocation() {
     return location;
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/constraints/ConstraintsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/constraints/ConstraintsTest.java
@@ -1401,4 +1401,26 @@ public class ConstraintsTest extends AbstractConstraintsTest {
     assertContainsEvent("//hello:lib: the current command line flags disqualify all supported "
         + "environments because of incompatible select() paths");
   }
+
+  @Test
+  public void invalidSelectKeyError() throws Exception {
+    scratch.file(
+        "hello/a/BUILD",
+        "java_library(",
+        "    name = 'a',",
+        "    runtime_deps = ['//hello/b'],",
+        ")");
+    scratch.file(
+        "hello/b/BUILD",
+        "java_library(",
+        "    name = 'b',",
+        "    runtime_deps = select({'//hello/c': []}),",
+        ")");
+    reporter.removeHandler(failFastHandler);
+    assertThat(getConfiguredTarget("//hello/a")).isNull();
+    assertContainsEvent(
+        "no such package 'hello/c': BUILD file not found in any of the following directories. Add"
+            + " a BUILD file to a directory to mark it as a package");
+    assertContainsEvent("errors encountered resolving select() keys for //hello/b:b");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ConstraintValueLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ConstraintValueLookupUtilTest.java
@@ -127,6 +127,7 @@ public class ConstraintValueLookupUtilTest extends ToolchainTestCase {
             .build();
     GetConstraintValueInfoKey key = GetConstraintValueInfoKey.create(ImmutableList.of(targetKey));
 
+    reporter.removeHandler(failFastHandler);
     EvaluationResult<GetConstraintValueInfoValue> result = getConstraintValueInfo(key);
 
     assertThatEvaluationResult(result).hasError();
@@ -137,8 +138,10 @@ public class ConstraintValueLookupUtilTest extends ToolchainTestCase {
     assertThatEvaluationResult(result)
         .hasErrorEntryForKeyThat(key)
         .hasExceptionThat()
-        .hasMessageThat()
-        .contains("no such package 'fake': BUILD file not found");
+        .hasCauseThat()
+        .isInstanceOf(ConfiguredValueCreationException.class);
+
+    assertContainsEvent("no such package 'fake': BUILD file not found");
   }
 
   // Calls ConstraintValueLookupUtil.getConstraintValueInfo.

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainTypeLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainTypeLookupUtilTest.java
@@ -150,6 +150,7 @@ public class ToolchainTypeLookupUtilTest extends ToolchainTestCase {
             .build();
     GetToolchainTypeInfoKey key = GetToolchainTypeInfoKey.create(ImmutableList.of(targetKey));
 
+    reporter.removeHandler(failFastHandler);
     EvaluationResult<GetToolchainTypeInfoValue> result = getToolchainTypeInfo(key);
 
     assertThatEvaluationResult(result).hasError();
@@ -160,8 +161,10 @@ public class ToolchainTypeLookupUtilTest extends ToolchainTestCase {
     assertThatEvaluationResult(result)
         .hasErrorEntryForKeyThat(key)
         .hasExceptionThat()
-        .hasMessageThat()
-        .contains("no such package 'fake': BUILD file not found");
+        .hasCauseThat()
+        .isInstanceOf(ConfiguredValueCreationException.class);
+
+    assertContainsEvent("no such package 'fake': BUILD file not found");
   }
 
   // Calls ToolchainTypeLookupUtil.getToolchainTypeInfo.


### PR DESCRIPTION
If a key in a `select` references a package that does not exist, the error message now includes a reference to the target with the `select`:

```
ERROR: no such package 'hello/c': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /tmp/bazel-crash/hello/c
ERROR: /tmp/bazel-crash/hello/b/BUILD:1:13: errors encountered resolving select() keys for //hello/b:b
ERROR: Analysis of target '//hello/a:a' failed; build aborted
```

Previously, it didn't:
```
ERROR: Analysis of target '//hello/a:a' failed; build aborted: no such package 'hello/c': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /tmp/bazel-crash/hello/c
```

Fixes #17689