### PR TITLE
[6.3.0] Enrich local BEP upload errors with file path and digest possible.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -333,7 +333,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
 
     assertThat(eventHandler.getEvents()).isNotEmpty();
     assertThat(eventHandler.getEvents().get(0).getMessage())
-        .contains("Uploading BEP referenced local files: ");
+        .contains("Uploading BEP referenced local file /file");
 
     artifactUploader.release();
 


### PR DESCRIPTION
Closes #18461.

Commit https://github.com/bazelbuild/bazel/commit/997be1ea6fa289d350230ce4fdfbcb240efaf0e0

PiperOrigin-RevId: 534006853
Change-Id: I256297fe494393f13e178bf74f967b9b691db281