### PR TITLE
Silence noise from download() when allow_fail=True

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -35,7 +35,9 @@ import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpUtils;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.FetchProgress;
+import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.packages.StarlarkInfo;
 import com.google.devtools.build.lib.packages.StructImpl;
 import com.google.devtools.build.lib.packages.StructProvider;
@@ -488,7 +490,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
               canonicalId,
               Optional.<String>absent(),
               outputPath.getPath(),
-              env.getListener(),
+              allowFail ? NullEventHandler.INSTANCE : env.getListener(),
               envVariables,
               getIdentifyingStringForLogging());
       if (executable) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -412,8 +412,8 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
             defaultValue = "False",
             named = true,
             doc =
-                "If set, indicate the error in the return value"
-                    + " instead of raising an error for failed downloads"),
+                "If set, indicate the error in the return value instead of raising an error for"
+                    + " failed downloads. This silences errors and warnings."),
         @Param(
             name = "canonical_id",
             defaultValue = "''",
@@ -586,8 +586,8 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
             defaultValue = "False",
             named = true,
             doc =
-                "If set, indicate the error in the return value"
-                    + " instead of raising an error for failed downloads"),
+                "If set, indicate the error in the return value instead of raising an error for"
+                    + " failed downloads. This silences errors and warnings."),
         @Param(
             name = "canonical_id",
             defaultValue = "''",
@@ -691,7 +691,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
               canonicalId,
               Optional.of(type),
               downloadDirectory,
-              env.getListener(),
+              allowFail ? NullEventHandler.INSTANCE : env.getListener(),
               envVariables,
               getIdentifyingStringForLogging());
     } catch (InterruptedException e) {


### PR DESCRIPTION
We have a custom repository rule that uses download(..., allow_fail=True) to first check if an artifact is already in the repository cache.  Obviously, this test is expected to fail when it is not, but Bazel is incredibly loud by printing a WARNING message for each attempt of the form:

WARNING: Download from file:/mnt/jenkins/home/jenkins/.cache/bazel/_bazel_jenkins/5d6e21225a0f8eb93bf6c0ff841144e1/external/anaconda-python_3.10_x86_64/python-3.10.9-h7a1cb2a_2.tar.bz2 failed: class java.io.FileNotFoundException /mnt/jenkins/home/jenkins/.cache/bazel/_bazel_jenkins/5d6e21225a0f8eb93bf6c0ff841144e1/external/anaconda-python_3.10_x86_64/python-3.10.9-h7a1cb2a_2.tar.bz2 (No such file or directory)

Given that allow_fail=True is meant to let the caller check for failures, warnings should be suppressed.  This change makes this happen.