### PR TITLE
[6.3.0] Fix Xcode 14.3 compatibility

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,7 +25,7 @@ build:ubuntu1804_java11 --config=remote_shared
 # Alias
 build:remote --config=ubuntu1804_java11
 
-build:macos --macos_minimum_os=10.10
+build:macos --macos_minimum_os=10.11
 
 # Enable Bzlmod
 build:bzlmod --experimental_enable_bzlmod

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -188,7 +188,7 @@ public class AppleCommandLineOptions extends FragmentOptions {
 
   @VisibleForTesting public static final String DEFAULT_IOS_SDK_VERSION = "8.4";
   @VisibleForTesting public static final String DEFAULT_WATCHOS_SDK_VERSION = "2.0";
-  @VisibleForTesting public static final String DEFAULT_MACOS_SDK_VERSION = "10.10";
+  @VisibleForTesting public static final String DEFAULT_MACOS_SDK_VERSION = "10.11";
   @VisibleForTesting public static final String DEFAULT_TVOS_SDK_VERSION = "9.0";
   @VisibleForTesting static final String DEFAULT_IOS_CPU = "x86_64";
 

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionProperties.java
@@ -37,7 +37,7 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
 
   @VisibleForTesting public static final String DEFAULT_IOS_SDK_VERSION = "8.4";
   @VisibleForTesting public static final String DEFAULT_WATCHOS_SDK_VERSION = "2.0";
-  @VisibleForTesting public static final String DEFAULT_MACOS_SDK_VERSION = "10.10";
+  @VisibleForTesting public static final String DEFAULT_MACOS_SDK_VERSION = "10.11";
   @VisibleForTesting public static final String DEFAULT_TVOS_SDK_VERSION = "9.0";
 
   private final Optional<DottedVersion> xcodeVersion;


### PR DESCRIPTION
With Xcode 14.3+ on x86_64 machines there is an opaque error when linking binaries on macOS because Apple removed an old support library. That library is only linked if the macOS target is < 10.11, so this bumps the default versions past that. This macOS version was released in September 2015.

Fixes https://github.com/bazelbuild/bazel/issues/18278

Closes #18460.

Commit https://github.com/bazelbuild/bazel/commit/86ef4f4cc2b8f7fd58101eb49c266be63f6e923c

PiperOrigin-RevId: 534743568
Change-Id: I131880096c941df0097fe3b1faabd5a6afada4f3