### PR TITLE
support persistent worker for aar extractors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -825,6 +825,16 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     public boolean oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest;
 
     @Option(
+        name = "experimental_persistent_aar_extractor",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+        effectTags = {
+          OptionEffectTag.EXECUTION,
+        },
+        help = "Enable persistent aar extractor by using workers.")
+    public boolean persistentAarExtractor;
+
+    @Option(
         name = "persistent_android_resource_processor",
         defaultValue = "null",
         documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
@@ -1129,6 +1139,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
       exec.manifestMergerOrder = manifestMergerOrder;
       exec.oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest =
           oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest;
+      exec.persistentAarExtractor = persistentAarExtractor;
       exec.persistentBusyboxTools = persistentBusyboxTools;
       exec.persistentMultiplexBusyboxTools = persistentMultiplexBusyboxTools;
       exec.disableNativeAndroidRules = disableNativeAndroidRules;
@@ -1174,6 +1185,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final boolean dataBindingV2;
   private final boolean dataBindingUpdatedArgs;
   private final boolean dataBindingAndroidX;
+  private final boolean persistentAarExtractor;
   private final boolean persistentBusyboxTools;
   private final boolean persistentMultiplexBusyboxTools;
   private final boolean persistentDexDesugar;
@@ -1236,6 +1248,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     this.dataBindingV2 = options.dataBindingV2;
     this.dataBindingUpdatedArgs = options.dataBindingUpdatedArgs;
     this.dataBindingAndroidX = options.dataBindingAndroidX;
+    this.persistentAarExtractor = options.persistentAarExtractor;
     this.persistentBusyboxTools = options.persistentBusyboxTools;
     this.persistentMultiplexBusyboxTools = options.persistentMultiplexBusyboxTools;
     this.persistentDexDesugar = options.persistentDexDesugar;
@@ -1476,6 +1489,11 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   @Override
   public boolean useDataBindingAndroidX() {
     return dataBindingAndroidX;
+  }
+
+  @Override
+  public boolean persistentAarExtractor() {
+    return persistentAarExtractor;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
@@ -232,6 +232,13 @@ public interface AndroidConfigurationApi extends StarlarkValue {
   boolean useDataBindingAndroidX();
 
   @StarlarkMethod(
+     name = "persistent_aar_extractor",
+     structField = true,
+     doc = "",
+     documented = false)
+  boolean persistentAarExtractor();
+
+  @StarlarkMethod(
       name = "persistent_busybox_tools",
       structField = true,
       doc = "",

--- a/src/test/shell/bazel/android/aar_integration_test.sh
+++ b/src/test/shell/bazel/android/aar_integration_test.sh
@@ -147,4 +147,38 @@ EOF
   assert_one_of $apk_contents "lib/armeabi-v7a/libapp.so"
 }
 
+function test_aar_extractor_worker() {
+  create_new_workspace
+  setup_android_sdk_support
+  cat > AndroidManifest.xml <<EOF
+<manifest package="com.example"/>
+EOF
+  mkdir -p res/layout
+  cat > res/layout/mylayout.xml <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" />
+EOF
+  mkdir assets
+  echo "some asset" > assets/a
+  zip example.aar AndroidManifest.xml res/layout/mylayout.xml assets/a
+  cat > BUILD <<EOF
+aar_import(
+  name = "example",
+  aar = "example.aar",
+)
+android_binary(
+  name = "app",
+  custom_package = "com.example",
+  manifest = "AndroidManifest.xml",
+  deps = [":example"],
+)
+EOF
+
+  bazel clean
+  bazel build --experimental_persistent_aar_extractor :app || fail "build failed"
+  apk_contents="$(zipinfo -1 bazel-bin/app.apk)"
+  assert_one_of $apk_contents "assets/a"
+  assert_one_of $apk_contents "res/layout/mylayout.xml"
+}
+
 run_suite "aar_import integration tests"

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -88,6 +88,7 @@ py_binary(
     deps = [
         ":junction_lib",
         "//third_party/py/abseil",
+        ":json_worker_wrapper",
     ],
 )
 
@@ -123,6 +124,7 @@ py_binary(
     deps = [
         ":junction_lib",
         "//third_party/py/abseil",
+        ":json_worker_wrapper",
     ],
 )
 
@@ -138,6 +140,7 @@ py_binary(
     deps = [
         ":junction_lib",
         "//third_party/py/abseil",
+        ":json_worker_wrapper",
     ],
 )
 
@@ -153,6 +156,7 @@ py_binary(
     deps = [
         ":junction_lib",
         "//third_party/py/abseil",
+        ":json_worker_wrapper",
     ],
 )
 
@@ -191,6 +195,13 @@ py_library(
     name = "junction_lib",
     srcs = ["junction.py"],
     visibility = ["//visibility:private"],
+)
+
+py_library(
+    name = "json_worker_wrapper",
+    srcs = ["json_worker_wrapper.py"],
+    visibility = ["//visibility:private"],
+    srcs_version = "PY3",
 )
 
 py_test(

--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -352,6 +352,7 @@ py_binary(
     deps = [
         ":junction_lib",
         "//third_party/py/abseil",
+        ":json_worker_wrapper",
     ],
 )
 
@@ -371,6 +372,7 @@ py_binary(
     deps = [
         ":junction_lib",
         "//third_party/py/abseil",
+        ":json_worker_wrapper",
     ],
 )
 
@@ -381,6 +383,7 @@ py_binary(
     deps = [
         ":junction_lib",
         "//third_party/py/abseil",
+        ":json_worker_wrapper",
     ],
 )
 
@@ -391,6 +394,7 @@ py_binary(
     deps = [
         ":junction_lib",
         "//third_party/py/abseil",
+        ":json_worker_wrapper",
     ],
 )
 
@@ -406,6 +410,13 @@ py_library(
     # TODO(bazel-team): remove srcs_version = "PY2AND3" while fixing https://github.com/bazelbuild/bazel/issues/10127.
     srcs_version = "PY2AND3",
     visibility = ["//visibility:private"],
+)
+
+py_library(
+    name = "json_worker_wrapper",
+    srcs = ["json_worker_wrapper.py"],
+    visibility = ["//visibility:private"],
+    srcs_version = "PY3",
 )
 
 alias(

--- a/tools/android/aar_embedded_jars_extractor.py
+++ b/tools/android/aar_embedded_jars_extractor.py
@@ -29,6 +29,7 @@ from absl import app
 from absl import flags
 
 from tools.android import junction
+from tools.android import json_worker_wrapper
 
 FLAGS = flags.FLAGS
 
@@ -100,5 +101,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-  FLAGS(sys.argv)
-  app.run(main)
+  json_worker_wrapper.wrap_worker(FLAGS, main, app.run)

--- a/tools/android/aar_embedded_proguard_extractor.py
+++ b/tools/android/aar_embedded_proguard_extractor.py
@@ -27,6 +27,7 @@ from absl import app
 from absl import flags
 
 from tools.android import junction
+from tools.android import json_worker_wrapper
 
 FLAGS = flags.FLAGS
 
@@ -71,5 +72,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-  FLAGS(sys.argv)
-  app.run(main)
+  json_worker_wrapper.wrap_worker(FLAGS, main, app.run)

--- a/tools/android/aar_native_libs_zip_creator.py
+++ b/tools/android/aar_native_libs_zip_creator.py
@@ -30,6 +30,7 @@ from absl import app
 from absl import flags
 
 from tools.android import junction
+from tools.android import json_worker_wrapper
 
 FLAGS = flags.FLAGS
 
@@ -104,5 +105,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-  FLAGS(sys.argv)
-  app.run(main)
+  json_worker_wrapper.wrap_worker(FLAGS, main, app.run)

--- a/tools/android/aar_resources_extractor.py
+++ b/tools/android/aar_resources_extractor.py
@@ -31,6 +31,7 @@ from absl import app
 from absl import flags
 
 from tools.android import junction
+from tools.android import json_worker_wrapper
 
 FLAGS = flags.FLAGS
 
@@ -145,5 +146,4 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-  FLAGS(sys.argv)
-  app.run(main)
+  json_worker_wrapper.wrap_worker(FLAGS, main, app.run)

--- a/tools/android/json_worker_wrapper.py
+++ b/tools/android/json_worker_wrapper.py
@@ -1,0 +1,60 @@
+# pylint: disable=g-direct-third-party-import
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A wrapper for AAR extractors to support persistent worker."""
+
+import json
+import sys
+import traceback
+
+
+def wrap_worker(flags, main, app_run):
+  """When the --persistent_worker flag is set, it runs in worker mode, otherwise it runs the main method directly.
+
+  Args:
+    flags: The FlagValues instance to parse command line arguments.
+    main: The main function to execute.
+    app_run: app.run() function in Abseil.
+  """
+  if sys.argv[1] == "--persistent_worker":
+    if "--run_with_pdb" in sys.argv or "--run_with_profiling" in sys.argv:
+      sys.stderr.write("pdb and profiling are not supported in worker mode.\n")
+      sys.exit(1)
+    while True:
+      # parse work requests from stdin
+      request_str = sys.stdin.readline()
+      work_request = json.loads(request_str)
+
+      args = [sys.argv[0]] + work_request["arguments"]
+      flags(args)
+      _wrap_result(main, args)
+  else:
+    flags(sys.argv)
+    app_run(main)
+
+
+def _wrap_result(main, args):
+  """Execute main function and return worker response.
+
+  Args:
+    main: The main function to execute.
+    args: A non-empty list of the command line arguments including program name.
+  """
+  response = {
+    "exitCode": 0,
+    "output": "",
+  }
+  main(args)
+  sys.stdout.write(json.dumps(response))
+  sys.stdout.flush()


### PR DESCRIPTION
This PR supports persistent worker for Android aar extractors, it'll significantly improve the aar extractors performance especially in the first time compilation without cache.
It's not enable by default, can use flag `build --experimental_persistent_aar_extractor=true` to enable it.

using worker:
![image](https://github.com/bazelbuild/bazel/assets/10076965/804f8167-4a52-4321-ba4a-9d1f1dd57644)
not using worker:
![image](https://github.com/bazelbuild/bazel/assets/10076965/26ef4047-4ff7-45f3-9767-ce48418aa089)
