### PR TITLE
Fix https://github.com/bazelbuild/bazel/issues/18493.

### DIFF
--- a/src/test/shell/bazel/run_test.sh
+++ b/src/test/shell/bazel/run_test.sh
@@ -172,4 +172,43 @@ EOF
      ./script.bat || fail "Run should succeed"
 }
 
+function test_run_test_exit_code() {
+  # EXPERIMENTAL_SPLIT_XML_GENERATION is set by the outer bazel and influences
+  # the test setup of the inner bazel. To make sure we hit the codepath we want
+  # to test here, unset the variable.
+  unset EXPERIMENTAL_SPLIT_XML_GENERATION
+
+  mkdir -p foo
+  cat > foo/BUILD <<'EOF'
+sh_test(
+  name = "exit0",
+  srcs = ["exit0.sh"],
+)
+
+sh_test(
+  name = "exit1",
+  srcs = ["exit1.sh"],
+)
+EOF
+
+  cat > foo/exit0.sh <<'EOF'
+set -x
+exit 0
+EOF
+  chmod +x foo/exit0.sh
+  bazel run //foo:exit0 &>"$TEST_log" \
+    || fail "Expected exit code 0, received $?"
+
+  cat > foo/exit1.sh <<'EOF'
+set -x
+exit 1
+EOF
+  chmod +x foo/exit1.sh
+  bazel run --noexperimental_split_xml_generation //foo:exit1 &>"$TEST_log" \
+    && fail "Expected exit code 1, received $?"
+
+  # Avoid failing the test because of the last non-zero exit-code.
+  true
+}
+
 run_suite "run_under_tests"

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -323,11 +323,13 @@ if [[ "${EXPERIMENTAL_SPLIT_XML_GENERATION}" == "1" ]]; then
     ("$1" "$TEST_PATH" "${@:3}" 2>&1) <&0 &
   fi
 else
+  set -o pipefail
   if [ -z "$COVERAGE_DIR" ]; then
     ("${TEST_PATH}" "$@" 2>&1 | tee -a "${XML_OUTPUT_FILE}.log") <&0 &
   else
     ("$1" "$TEST_PATH" "${@:3}" 2>&1 | tee -a "${XML_OUTPUT_FILE}.log") <&0 &
   fi
+  set +o pipefail
 fi
 childPid=$!
 


### PR DESCRIPTION
The use of the pipe in
https://github.com/bazelbuild/bazel/commit/b8e92cc55378fb7b80f5abe0abf59d41f53ba483 made it swallow the exit code, so we need to set pipefail.

Fix https://github.com/bazelbuild/bazel/issues/18493