### PR TITLE
[6.2.1] Fix https://github.com/bazelbuild/bazel/issues/18493.

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -322,11 +322,13 @@ if [[ "${EXPERIMENTAL_SPLIT_XML_GENERATION}" == "1" ]]; then
     ("$1" "$TEST_PATH" "${@:3}" 2>&1) <&0 &
   fi
 else
+  set -o pipefail
   if [ -z "$COVERAGE_DIR" ]; then
     ("${TEST_PATH}" "$@" 2>&1 | tee -a "${XML_OUTPUT_FILE}.log") <&0 &
   else
     ("$1" "$TEST_PATH" "${@:3}" 2>&1 | tee -a "${XML_OUTPUT_FILE}.log") <&0 &
   fi
+  set +o pipefail
 fi
 childPid=$!
 


### PR DESCRIPTION
The use of the pipe in https://github.com/bazelbuild/bazel/commit/b8e92cc55378fb7b80f5abe0abf59d41f53ba483 made it swallow the exit code, so we need to set pipefail.

Fix https://github.com/bazelbuild/bazel/issues/18493

Closes #18498.

Commit https://github.com/bazelbuild/bazel/commit/9cdc003fd37191ebcb02e0ad6b28c0d8fb18c09a

PiperOrigin-RevId: 535520323
Change-Id: Idf1a5c39bf5b7deec29b76c10ece2825b568ebf2