### PR TITLE
Add new NDK rules to the NDK docs

### DIFF
--- a/site/en/docs/android-ndk.md
+++ b/site/en/docs/android-ndk.md
@@ -37,6 +37,8 @@ android_ndk_repository(
 For more information on the `android_ndk_repository` rule, see the [Build
 Encyclopedia entry](/reference/be/android#android_ndk_repository).
 
+If you're using a recent version of the Android NDK (r22 and beyond), you'll need to use the Starlark implementation of `android_ndk_repository` instead. Follow the instructions in [its README](https://github.com/bazelbuild/rules_android_ndk).
+
 ## Quick start {:#quick-start}
 
 To build C++ for Android, simply add `cc_library` dependencies to your


### PR DESCRIPTION
Hi wonderful Bazelers,

I'd happened to notice that the new NDK rules weren't referenced from the NDK docs, so I thought I'd toss up a quick change to help new users find their way.

Thanks for your consideration! Feel free (of course) to edit or push a different change if you'd prefer something else. (Was trying to strike a balance between the new rule being in their early stages and the old rule no longer being updated and not working for the past few years of NDKs. See https://github.com/bazelbuild/bazel/issues/12889 for more context.) 

Thanks,
Chris
(ex-Googler, [compile_commands_extractor](https://github.com/hedronvision/bazel-compile-commands-extractor/issues) author, rules_boost collaborator, etc.) 