### PR TITLE
[6.3.0] Extend the credential helper default timeout to 10s.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -161,7 +161,7 @@ public class AuthAndTLSOptions extends OptionsBase {
 
   @Option(
       name = "experimental_credential_helper_timeout",
-      defaultValue = "5s",
+      defaultValue = "10s",
       converter = DurationConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},


### PR DESCRIPTION
The default timeout makes the integration tests 1% flaky on RBE.

PiperOrigin-RevId: 535255555
Change-Id: I8270ffbfcbd00ec7c38a92a546d5726f1b10b68d