### PR TITLE
[6.2.1] Use extension rather than local names in ModuleExtensionMetadata

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionMetadata.java
@@ -188,7 +188,7 @@ public class ModuleExtensionMetadata implements StarlarkValue {
             .collect(toImmutableSet());
     var actualImports =
         rootUsages.stream()
-            .flatMap(usage -> usage.getImports().keySet().stream())
+            .flatMap(usage -> usage.getImports().values().stream())
             .filter(repo -> !actualDevImports.contains(repo))
             .collect(toImmutableSet());
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -1599,13 +1599,23 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "bazel_dep(name='ext', version='1.0')",
         "bazel_dep(name='data_repo',version='1.0')",
         "ext = use_extension('@ext//:defs.bzl', 'ext')",
-        "use_repo(ext, 'direct_dep', 'indirect_dep', 'invalid_dep')",
+        "use_repo(",
+        "  ext,",
+        "  'indirect_dep',",
+        "  'invalid_dep',",
+        "  my_direct_dep = 'direct_dep',",
+        ")",
         "ext_dev = use_extension('@ext//:defs.bzl', 'ext', dev_dependency = True)",
-        "use_repo(ext_dev, 'direct_dev_dep', 'indirect_dev_dep', 'invalid_dev_dep')");
+        "use_repo(",
+        "  ext_dev,",
+        "  'indirect_dev_dep',",
+        "  'invalid_dev_dep',",
+        "  my_direct_dev_dep = 'direct_dev_dep',",
+        ")");
     scratch.file(workspaceRoot.getRelative("BUILD").getPathString());
     scratch.file(
         workspaceRoot.getRelative("data.bzl").getPathString(),
-        "load('@direct_dep//:data.bzl', direct_dep_data='data')",
+        "load('@my_direct_dep//:data.bzl', direct_dep_data='data')",
         "data = direct_dep_data");
 
     registry.addModule(


### PR DESCRIPTION
ModuleExtensionMetadata incorrectly identified repos by their local names rather than the names used by the generating extension, which resulted in incorrect fixup warnings when supplying keyword arguments to `use_repo`.

Closes #18528.
commit https://github.com/bazelbuild/bazel/commit/0af70cd16b3589079ba0b7f1f68a3351e0252454

PiperOrigin-RevId: 536386347
Change-Id: I4368b0dcdc28d6b2827b74b3b0b73c31a0215c0f