### PR TITLE
[6.3.0] [credentialhelper] Ignore all errors when writing stdin

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialHelper.java
@@ -82,12 +82,8 @@ public final class CredentialHelper {
           GSON.toJson(GetCredentialsRequest.newBuilder().setUri(uri).build(), stdin);
         } catch (IOException e) {
           // This can happen if the helper prints a static set of credentials without reading from
-          // stdin (e.g., with a simple shell script running `echo "{...}"`). If the process is
-          // already finished even though we failed to write to its stdin, ignore the error and
-          // assume the process did not need the request payload.
-          if (!process.finished()) {
-            throw e;
-          }
+          // stdin (e.g., with a simple shell script running `echo "{...}"`). This is fine to
+          // ignore.
         }
 
         try {


### PR DESCRIPTION
It's totally fine for helpers to not care about the request on stdin and close stdin early.

```
ERROR: java.io.IOException: Broken pipe
	at java.base/java.io.FileOutputStream.writeBytes(Native Method)
	at java.base/java.io.FileOutputStream.write(Unknown Source)
	at java.base/java.io.BufferedOutputStream.flushBuffer(Unknown Source)
	at java.base/java.io.BufferedOutputStream.flush(Unknown Source)
	at java.base/java.io.FilterOutputStream.close(Unknown Source)
	at java.base/sun.nio.cs.StreamEncoder.implClose(Unknown Source)
	at java.base/sun.nio.cs.StreamEncoder.close(Unknown Source)
	at java.base/java.io.OutputStreamWriter.close(Unknown Source)
	at com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelper.getCredentials(CredentialHelper.java:83)
	at com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperCredentials.getCredentialsFromHelper(CredentialHelperCredentials.java:108)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$13(BoundedLocalCache.java:2451)
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(Unknown Source)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2449)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2432)
	at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:107)
	at com.github.benmanes.caffeine.cache.LocalManualCache.get(LocalManualCache.java:62)
	at com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperCredentials.getRequestMetadata(CredentialHelperCredentials.java:80)
	at com.google.auth.Credentials.blockingGetToCallback(Credentials.java:112)
	at com.google.auth.Credentials$1.run(Credentials.java:98)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

Follow-up on https://github.com/bazelbuild/bazel/commit/7c235ff15190b1eefdbd34696a55272bbb221435

Closes #18501.

Commit https://github.com/bazelbuild/bazel/commit/845fc89e503c0ec84ba03b29dafa7c65e6051c9b

PiperOrigin-RevId: 536403312
Change-Id: I837bae70978e29f748c0fcc398c8f64de2b7b7c6