### PR TITLE
[6.3.0] Make cpp file extensions case sensitive again

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -30,9 +30,44 @@ public final class CppFileTypes {
   // .cu and .cl are CUDA and OpenCL source extensions, respectively. They are expected to only be
   // supported with clang. Bazel is not officially supporting these targets, and the extensions are
   // listed only as long as they work with the existing C++ actions.
+  // FileType is extended to use case-sensitive comparison also on Windows
   public static final FileType CPP_SOURCE =
-      FileType.of(".cc", ".cpp", ".cxx", ".c++", ".C", ".cu", ".cl");
-  public static final FileType C_SOURCE = FileType.of(".c");
+      new FileType() {
+        final ImmutableList<String> extensions =
+            ImmutableList.of(".cc", ".cpp", ".cxx", ".c++", ".C", ".cu", ".cl");
+
+        @Override
+        public boolean apply(String path) {
+          for (String ext : extensions) {
+            if (path.endsWith(ext)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        @Override
+        public ImmutableList<String> getExtensions() {
+          return extensions;
+        }
+      };
+
+  // FileType is extended to use case-sensitive comparison also on Windows
+  public static final FileType C_SOURCE =
+      new FileType() {
+        final String ext = ".c";
+
+        @Override
+        public boolean apply(String path) {
+          return path.endsWith(ext);
+        }
+
+        @Override
+        public ImmutableList<String> getExtensions() {
+          return ImmutableList.of(ext);
+        }
+      };
+
   public static final FileType OBJC_SOURCE = FileType.of(".m");
   public static final FileType OBJCPP_SOURCE = FileType.of(".mm");
   public static final FileType CLIF_INPUT_PROTO = FileType.of(".ipb");

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppFileTypesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppFileTypesTest.java
@@ -77,4 +77,12 @@ public class CppFileTypesTest {
     assertThat(Link.ARCHIVE_LIBRARY_FILETYPES.matches("someframework")).isTrue();
     assertThat(Link.ARCHIVE_FILETYPES.matches("someframework")).isTrue();
   }
+
+  @Test
+  public void testCaseSensitiveCFiles() {
+    assertThat(CppFileTypes.C_SOURCE.matches("foo.c")).isTrue();
+    assertThat(CppFileTypes.CPP_SOURCE.matches("foo.c")).isFalse();
+    assertThat(CppFileTypes.C_SOURCE.matches("foo.C")).isFalse();
+    assertThat(CppFileTypes.CPP_SOURCE.matches("foo.C")).isTrue();
+  }
 }


### PR DESCRIPTION
This fixes an issue introduced by PR #14005 where .c and .C extensions were handled case-insensitive on Windows so the cxxopt will be passed to C source files.

Closes #15073 .

Closes #18119.

PiperOrigin-RevId: 526001251
Change-Id: I464e5feae397bdac443ddd159309f77071629e01