### PR TITLE
Use output directory naming scheme `diff_against_dynamic_baseline`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -579,7 +579,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
   @Option(
       name = "experimental_output_directory_naming_scheme",
-      defaultValue = "diff_against_baseline",
+      defaultValue = "diff_against_dynamic_baseline",
       converter = OutputDirectoryNamingSchemeConverter.class,
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
@@ -40,7 +40,6 @@ import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.BuildOptionsView;
 import com.google.devtools.build.lib.analysis.config.CompilationMode;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
-import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputDirectoryNamingScheme;
 import com.google.devtools.build.lib.analysis.config.InvalidConfigurationException;
 import com.google.devtools.build.lib.analysis.config.transitions.SplitTransition;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
@@ -183,8 +182,10 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
     String modeSegment = compilationModeFlag(compilationMode);
 
     String hash = "";
-    if (targetConfig.getOptions().get(CoreOptions.class).outputDirectoryNamingScheme
-        == OutputDirectoryNamingScheme.DIFF_AGAINST_BASELINE) {
+    if (targetConfig
+        .getOptions()
+        .get(CoreOptions.class)
+        .useBaselineForOutputDirectoryNamingScheme()) {
       PlatformType platformType = null;
       switch (configurationDistinguisher) {
         case APPLEBIN_IOS:


### PR DESCRIPTION
Compared to `diff_against_baseline`, this mode improves caching when top-level flags change that are reset in the exec configuration.

Fixes #18480