### PR TITLE
Document precedence of JAVABIN on java_binary rule

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaBinaryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaBinaryRule.java
@@ -120,7 +120,9 @@ public final class BazelJavaBinaryRule implements RuleDefinition {
 <p>
   Builds a Java archive ("jar file"), plus a wrapper shell script with the same name as the rule.
   The wrapper shell script uses a classpath that includes, among other things, a jar file for each
-  library on which the binary depends.
+  library on which the binary depends. When running the wrapper shell script, any nonempty
+  <code>JAVABIN</code> environment variable will take precedence over the version specified via
+  Bazel's configured <code>--java_runtime_version</code>.
 </p>
 <p>
   The wrapper script accepts several unique flags. Refer to

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaBinaryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaBinaryRule.java
@@ -122,7 +122,7 @@ public final class BazelJavaBinaryRule implements RuleDefinition {
   The wrapper shell script uses a classpath that includes, among other things, a jar file for each
   library on which the binary depends. When running the wrapper shell script, any nonempty
   <code>JAVABIN</code> environment variable will take precedence over the version specified via
-  Bazel's configured <code>--java_runtime_version</code>.
+  Bazel's <code>--java_runtime_version</code> flag.
 </p>
 <p>
   The wrapper script accepts several unique flags. Refer to


### PR DESCRIPTION
Ran into some confusion around this at work. We recently changed our Bazel repo so that everything was compiling/running with Java 17, but some folks would get issues when `bazel run`ing `java_binary` targets. Error messages indicated they were still running on a Java 8 VM despite the `--java_runtime_version` flag.

Looking at where the stub template is filled in, I noticed that JAVABIN environment variable takes precedence over the java_executable: https://cs.opensource.google/bazel/bazel/+/master:src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl;l=183?q=javabin&ss=bazel%2Fbazel&start=11

The folks running into issues set their `JAVABIN` in `.zshrc` files, so that was taking precedence over the Bazel flags and incorrectly running the Java 17 compiled code on a Java 8 VM. Seems reasonable that `JAVABIN` take precedence, but I figure this should probably be documented somewhere to save other folks the trouble of digging into the guts to figure out what was going on.