### PR TITLE
Deprecate examples inside bazelbuild/bazel

### DIFF
--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -1,0 +1,3 @@
+# Bazel examples (Deprecated)
+
+This folder example is deprecated. In the future this folder will be deleted and all examples will be available in <https://github.com/bazelbuild/examples>.


### PR DESCRIPTION
See: https://github.com/bazelbuild/examples/issues/201