### PR TITLE
Properly implement diretiness check for unresolved symlink

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -735,8 +735,12 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
 
     @Override
     public boolean wasModifiedSinceDigest(Path path) {
-      // We could store an mtime but I have no clue where to get one from createFromMetadata
-      return true;
+      try {
+        var newMetadata = FileArtifactValue.createForUnresolvedSymlink(path);
+        return !Arrays.equals(digest, newMetadata.getDigest());
+      } catch (IOException e) {
+        return true;
+      }
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
@@ -253,6 +253,23 @@ public final class FileArtifactValueTest {
   }
 
   @Test
+  public void testUptodateUnresolvedSymlink() throws Exception {
+    Path path = fs.getPath("/dir/symlink");
+    path.getParentDirectory().createDirectoryAndParents();
+    path.createSymbolicLink(PathFragment.create("target_path"));
+    FileArtifactValue value = FileArtifactValue.createForUnresolvedSymlink(path);
+
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+
+    path.delete();
+    path.createSymbolicLink(PathFragment.create("modified_target_path"));
+
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+  }
+
+  @Test
   public void addToFingerprint_equalByDigest() throws Exception {
     FileArtifactValue value1 =
         FileArtifactValue.createForTesting(scratchFile("/dir/file1", /*mtime=*/ 1, "content"));


### PR DESCRIPTION
This will fix warning when using `--experimental_guard_against_concurrent_changes` with unresolved symlink.

See https://github.com/bazelbuild/bazel/issues/17162.