### PR TITLE
Use the execution platform to determine which genrule.cmd* to run.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -2181,6 +2181,12 @@ java_library(
 java_library(
     name = "constraints/constraint_constants",
     srcs = ["constraints/ConstraintConstants.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/analysis/platform",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//third_party:guava",
+    ],
 )
 
 java_library(

--- a/src/main/java/com/google/devtools/build/lib/analysis/ShToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ShToolchain.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.analysis;
 
+import static com.google.devtools.build.lib.analysis.constraints.ConstraintConstants.OS_TO_CONSTRAINTS;
+
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
@@ -21,7 +23,9 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import javax.annotation.Nullable;
 
-/** Class to work with the shell toolchain, e.g. get the shell interpreter's path. */
+/**
+ * Class to work with the shell toolchain, e.g. get the shell interpreter's path.
+ */
 public final class ShToolchain {
 
   private static PathFragment getHostOrDefaultPath() {
@@ -65,7 +69,7 @@ public final class ShToolchain {
       for (OS os : ShellConfiguration.getShellExecutables().keySet()) {
         if (platformInfo
             .constraints()
-            .hasConstraintValue(ShellConfiguration.OS_TO_CONSTRAINTS.get(os))) {
+            .hasConstraintValue(OS_TO_CONSTRAINTS.get(os))) {
           return ShellConfiguration.getShellExecutables().get(os);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
@@ -13,14 +13,10 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.Fragment;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.analysis.config.RequiresOptions;
-import com.google.devtools.build.lib.analysis.platform.ConstraintSettingInfo;
-import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
-import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.OptionsUtils.PathFragmentConverter;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -36,10 +32,6 @@ import java.util.function.Function;
 public class ShellConfiguration extends Fragment {
 
   private static Map<OS, PathFragment> shellExecutables;
-
-  private static final ConstraintSettingInfo OS_CONSTRAINT_SETTING =
-      ConstraintSettingInfo.create(
-          Label.parseCanonicalUnchecked("@platforms//os:os"));
 
   private static Function<Options, PathFragment> optionsBasedDefault;
 
@@ -65,35 +57,7 @@ public class ShellConfiguration extends Fragment {
     optionsBasedDefault = (options) -> null;
     shellExecutables = osToShellMap;
   }
-  // Standard mapping between OS and the corresponding platform constraints.
-  static final ImmutableMap<OS, ConstraintValueInfo> OS_TO_CONSTRAINTS =
-      ImmutableMap.<OS, ConstraintValueInfo>builder()
-          .put(
-              OS.DARWIN,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:osx")))
-          .put(
-              OS.WINDOWS,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:windows")))
-          .put(
-              OS.FREEBSD,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:freebsd")))
-          .put(
-              OS.OPENBSD,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:openbsd")))
-          .put(
-              OS.UNKNOWN,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:none")))
-          .buildOrThrow();
+
 
   private final boolean useShBinaryStubScript;
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/ConstraintConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/ConstraintConstants.java
@@ -13,11 +13,54 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis.constraints;
 
-/** Constants needed for use of the constraints system. */
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.platform.ConstraintSettingInfo;
+import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.util.OS;
+
+/**
+ * Constants needed for use of the constraints system.
+ */
 public final class ConstraintConstants {
 
   public static final String ENVIRONMENT_RULE = "environment";
 
+  private static final ConstraintSettingInfo OS_CONSTRAINT_SETTING =
+      ConstraintSettingInfo.create(
+          Label.parseCanonicalUnchecked("@platforms//os:os"));
+
+  // Standard mapping between OS and the corresponding platform constraints.
+  public static final ImmutableMap<OS, ConstraintValueInfo> OS_TO_CONSTRAINTS =
+      ImmutableMap.<OS, ConstraintValueInfo>builder()
+          .put(
+              OS.DARWIN,
+              ConstraintValueInfo.create(
+                  OS_CONSTRAINT_SETTING,
+                  Label.parseCanonicalUnchecked("@platforms//os:osx")))
+          .put(
+              OS.WINDOWS,
+              ConstraintValueInfo.create(
+                  OS_CONSTRAINT_SETTING,
+                  Label.parseCanonicalUnchecked("@platforms//os:windows")))
+          .put(
+              OS.FREEBSD,
+              ConstraintValueInfo.create(
+                  OS_CONSTRAINT_SETTING,
+                  Label.parseCanonicalUnchecked("@platforms//os:freebsd")))
+          .put(
+              OS.OPENBSD,
+              ConstraintValueInfo.create(
+                  OS_CONSTRAINT_SETTING,
+                  Label.parseCanonicalUnchecked("@platforms//os:openbsd")))
+          .put(
+              OS.UNKNOWN,
+              ConstraintValueInfo.create(
+                  OS_CONSTRAINT_SETTING,
+                  Label.parseCanonicalUnchecked("@platforms//os:none")))
+          .buildOrThrow();
+
   // No-op constructor to keep this from being instantiated.
-  private ConstraintConstants() {}
+  private ConstraintConstants() {
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/BUILD
@@ -22,6 +22,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/execution_transition_factory",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/analysis:constraints/constraint_constants",
         "//src/main/java/com/google/devtools/build/lib/analysis:file_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis:make_variable_supplier",
         "//src/main/java/com/google/devtools/build/lib/analysis:rule_definition_environment",

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.rules.genrule;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.devtools.build.lib.analysis.constraints.ConstraintConstants.OS_TO_CONSTRAINTS;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -94,8 +95,8 @@ public abstract class GenRuleBase implements RuleConfiguredTargetFactory {
   private static Pair<CommandType, String> determineCommandTypeAndAttribute(
       RuleContext ruleContext) {
     AttributeMap attributeMap = ruleContext.attributes();
-    // TODO(pcloudy): This should match the execution platform instead of using OS.getCurrent()
-    if (OS.getCurrent() == OS.WINDOWS) {
+    if (ruleContext.getExecutionPlatform().constraints()
+        .hasConstraintValue(OS_TO_CONSTRAINTS.get(OS.WINDOWS))) {
       if (attributeMap.isAttributeValueExplicitlySpecified("cmd_ps")) {
         return Pair.of(CommandType.WINDOWS_POWERSHELL, "cmd_ps");
       }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/BUILD
@@ -15,15 +15,7 @@ filegroup(
 
 java_library(
     name = "GenruleTests_lib",
-    srcs = glob(
-               ["*.java"],
-               exclude = ["GenRuleWindowsConfiguredTargetTest.java"],
-           ) +
-           # If we are on windows add back the test
-           select({
-               "//conditions:default": [],
-               "//src/conditions:windows": ["GenRuleWindowsConfiguredTargetTest.java"],
-           }),
+    srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",


### PR DESCRIPTION
Currently the host platform is used, which fails when using a Windows remote executor from a non-Windows host.

Also change GenRuleWindowsConfiguredTargetTest to run on every host platform.

Fixes #18584.