### PR TITLE
[6.3.0] Fix dangling string literal in `extension_metadata` docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
@@ -158,7 +158,7 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
                     + " repositories or does not import all of these repositories via <a"
                     + " href=\"../globals/module.html#use_repo\"><code>use_repo</code></a> on an"
                     + " extension proxy created with <code><a"
-                    + " href=\"../globals/module.html#use_extension>use_extension</a>(...,"
+                    + " href=\"../globals/module.html#use_extension\">use_extension</a>(...,"
                     + " dev_dependency = True)</code>, Bazel will print a warning and a fixup"
                     + " command when the extension is evaluated.<p>If one of"
                     + " <code>root_module_direct_deps</code> and"


### PR DESCRIPTION
Closes #18587.

Commit https://github.com/bazelbuild/bazel/commit/5a89879d5745bc83010122c7755d90c0d497ff74

PiperOrigin-RevId: 538171456
Change-Id: Idd8300c73beb60b101aaf28c4f04843051bae292