### PR TITLE
Add changes to cc_shared_library from head to 6.3

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -93,6 +93,18 @@ import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Structure;
 import net.starlark.java.eval.Tuple;
+import com.google.devtools.build.docgen.annot.DocCategory;
+import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.ParamType;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.packages.BuiltinProvider;
+import com.google.devtools.build.lib.packages.NativeInfo;
+import com.google.devtools.build.docgen.annot.StarlarkConstructor;
+import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
+import net.starlark.java.eval.Starlark;
 
 /**
  * A module that contains Starlark utilities for C++ support.
@@ -139,10 +151,119 @@ public abstract class CcModule
 
   public abstract CppSemantics getSemantics(Language language);
 
+  /**
+   * This class exists only for a 6.3 cherrypick. For 7.0 this will be in Starlark.
+   */
+  @StarlarkBuiltin(
+    name = "CcSharedLibraryHintInfo",
+    category = DocCategory.PROVIDER,
+    documented = false
+  )
+  @Immutable
+  private static final class CcSharedLibraryHintInfo extends NativeInfo implements StructApi {
+    private static final Provider PROVIDER = new Provider();
+
+    private final List<String> attributes;
+    private final List<Label> owners;
+
+    public CcSharedLibraryHintInfo(
+        List<String> attributes,
+        List<Label> owners) {
+      this.attributes = attributes;
+      this.owners = owners;
+    }
+
+    @StarlarkMethod(
+      name = "attributes",
+      structField = true,
+      allowReturnNones = true,
+      documented = false)
+    @Nullable
+    public Sequence<String> getAttributes() {
+      return attributes == null ? null : StarlarkList.immutableCopyOf(attributes);
+    }
+
+    @StarlarkMethod(
+      name = "owners",
+      structField = true,
+      allowReturnNones = true,
+      documented = false)
+    @Nullable
+    public Sequence<Label> getOwners() {
+      return owners == null ? null : StarlarkList.immutableCopyOf(owners);
+    }
+
+    @Override
+    public Provider getProvider() {
+      return PROVIDER;
+    }
+
+    public static class Provider extends BuiltinProvider<CcSharedLibraryHintInfo>
+          implements ProviderApi {
+        private Provider() {
+          super("CcSharedLibraryHintInfo", CcSharedLibraryHintInfo.class);
+        }
+    }
+  }
+
+  @StarlarkMethod(
+    name = "CcSharedLibraryHintInfo_6_X_constructor_do_not_use",
+    documented = false,
+    parameters = {
+      @Param(
+          name = "attributes",
+          documented = false,
+          positional = false,
+          named = true,
+          defaultValue = "None",
+          allowedTypes = {
+            @ParamType(type = Sequence.class),
+            @ParamType(type = NoneType.class)
+          }),
+      @Param(
+          name = "owners",
+          documented = false,
+          positional = false,
+          named = true,
+          defaultValue = "None",
+          allowedTypes = {
+            @ParamType(type = Sequence.class),
+            @ParamType(type = NoneType.class)
+          }),
+    }
+  )
+  public CcSharedLibraryHintInfo ccSharedLibraryHintInfoConstructor(
+        Object starlarkAttributesObject,
+        Object starlarkOwnersObject) throws EvalException {
+      List<String> attributes = null;
+      if (starlarkAttributesObject != Starlark.NONE) {
+        attributes = convertFromNoneable(
+            starlarkAttributesObject, /* defaultValue= */ (Sequence<String>) null).getImmutableList();
+      }
+      List<Label> owners = null;
+      if (starlarkOwnersObject != Starlark.NONE) {
+        owners = convertFromNoneable(
+            starlarkOwnersObject, /* defaultValue= */ (Sequence<Label>) null).getImmutableList();
+      }
+      return new CcSharedLibraryHintInfo(
+          attributes,
+          owners
+      );
+  }
+
+  @StarlarkMethod(
+    name = "CcSharedLibraryHintInfo_6_X_getter_do_not_use",
+    documented = false,
+    structField = true)
+  public Provider getCcSharedLibraryHintInfo() {
+    return CcSharedLibraryHintInfo.PROVIDER;
+  }
+
   @Override
   public Provider getCcToolchainProvider() {
     return CcToolchainProvider.PROVIDER;
   }
+
 
   @Override
   public FeatureConfigurationForStarlark configureFeatures(

--- a/src/main/starlark/builtins_bzl/common/exports.bzl
+++ b/src/main/starlark/builtins_bzl/common/exports.bzl
@@ -17,7 +17,7 @@
 load("@_builtins//:common/cc/cc_import.bzl", "cc_import")
 load("@_builtins//:common/cc/cc_binary_wrapper.bzl", "cc_binary")
 load("@_builtins//:common/cc/cc_test_wrapper.bzl", cc_test = "cc_test_wrapper")
-load("@_builtins//:common/cc/experimental_cc_shared_library.bzl", "CcSharedLibraryInfo", "cc_shared_library", "cc_shared_library_permissions")
+load("@_builtins//:common/cc/experimental_cc_shared_library.bzl", "CcSharedLibraryInfo", "cc_shared_library")
 load("@_builtins//:common/objc/objc_import.bzl", "objc_import")
 load("@_builtins//:common/objc/objc_library.bzl", "objc_library")
 load("@_builtins//:common/objc/compilation_support.bzl", "compilation_support")
@@ -54,7 +54,6 @@ exported_rules = {
     "objc_library": objc_library,
     "proto_library": proto_library,
     "+cc_shared_library": cc_shared_library,
-    "+cc_shared_library_permissions": cc_shared_library_permissions,
     "+cc_binary": cc_binary,
     "+cc_test": cc_test,
     "+cc_library": cc_library,

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
@@ -2,15 +2,22 @@ load(
     ":starlark_tests.bzl",
     "additional_inputs_test",
     "build_failure_test",
-    "debug_files_test",
     "interface_library_output_group_test",
-    "linking_suffix_test",
+    "linking_order_test",
     "paths_test",
     "runfiles_test",
-    "no_exporting_static_lib_test",
+    "check_linking_action_lib_parameters_test",
+    "forwarding_cc_lib",
+    "nocode_cc_lib",
+    "wrapped_cc_lib",
 )
 
 LINKABLE_MORE_THAN_ONCE = "LINKABLE_MORE_THAN_ONCE"
+
+NO_BUILD_TAGS = [
+    "manual",
+    "nobuilder",
+]
 
 licenses(["notice"])
 
@@ -36,8 +43,14 @@ cc_binary(
     name = "binary",
     srcs = ["main.cc"],
     dynamic_deps = ["foo_so"],
-    deps = ["foo"],
+    deps = [
+        ":foo",
+    ],
 )
+
+# TODO(bazel-team): Add a test for proto dependencies once these tests are run
+# directly from a BUILD file and not from within a shell test. Right now
+# mocking what's needed to have a single proto dependency makes it impractical.
 
 cc_binary(
     name = "binary_with_bar_so_twice",
@@ -73,7 +86,7 @@ cc_shared_library(
     name = "diamond2_so",
     dynamic_deps = [":a_so"],
     features = ["windows_export_all_symbols"],
-    deps = [":qux2"],
+    deps = [":bar"],
 )
 
 cc_binary(
@@ -103,10 +116,12 @@ cc_shared_library(
         "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3:diff_pkg_so"
     ],
     features = ["windows_export_all_symbols"],
-    preloaded_deps = ["preloaded_dep"],
     deps = [
         "baz",
         "foo",
+        "cc_lib_with_no_srcs",
+        "nocode_cc_lib",
+        "should_not_be_linked_cc_lib",
         "a_suffix",
     ],
     user_link_flags = select({
@@ -117,12 +132,6 @@ cc_shared_library(
         ],
         "//conditions:default": [],
     }),
-)
-
-cc_library(
-    name = "preloaded_dep",
-    srcs = ["preloaded_dep.cc"],
-    hdrs = ["preloaded_dep.h"],
 )
 
 cc_library(
@@ -140,15 +149,69 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        "preloaded_dep",
         "bar",
         "baz",
         # Not exported.
         "qux",
-        "qux2",
         "prebuilt",
         "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3:diff_pkg"
+    ] + select({
+        ":is_bazel": ["qux2"],
+        "//conditions:default": [],
+    }),
+)
+
+wrapped_cc_lib(
+    name = "wrapped_cc_lib",
+    deps = [
+        "indirect_dep",
     ],
+)
+
+forwarding_cc_lib(
+    name = "cc_lib_with_no_srcs",
+    deps = [
+        "wrapped_cc_lib",
+    ],
+)
+
+wrapped_cc_lib(
+    name = "should_not_be_linked_wrapped",
+    deps = [
+        "indirect_dep3",
+    ],
+)
+
+forwarding_cc_lib(
+    name = "should_not_be_linked_cc_lib",
+    do_not_follow_deps = [
+        "should_not_be_linked_wrapped",
+    ],
+)
+
+nocode_cc_lib(
+    name = "nocode_cc_lib",
+    additional_inputs = [
+        ":additional_script.txt",
+    ],
+    deps = [
+        "indirect_dep2",
+    ],
+)
+
+cc_library(
+    name = "indirect_dep",
+    srcs = ["indirect_dep.cc"],
+)
+
+cc_library(
+    name = "indirect_dep2",
+    srcs = ["indirect_dep2.cc"],
+)
+
+cc_library(
+    name = "indirect_dep3",
+    srcs = ["indirect_dep3.cc"],
 )
 
 cc_library(
@@ -175,7 +238,7 @@ cc_library(
     name = "qux2",
     srcs = ["qux2.cc"],
     hdrs = ["qux2.h"],
-    tags = [LINKABLE_MORE_THAN_ONCE],
+    tags = [LINKABLE_MORE_THAN_ONCE] + NO_BUILD_TAGS,
 )
 
 config_setting(
@@ -196,9 +259,6 @@ cc_shared_library(
         "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3:bar",
     ],
     features = ["windows_export_all_symbols"],
-    permissions = [
-        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3:permissions",
-    ],
     deps = [
         "bar",
         "bar2",
@@ -230,8 +290,10 @@ cc_library(
     hdrs = ["bar.h"],
     deps = [
         "barX",
-        "qux2",
-    ],
+    ] + select({
+        ":is_bazel": ["qux2"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -281,7 +343,7 @@ filegroup(
     output_group = "rule_impl_debug_files",
 )
 
-linking_suffix_test(
+linking_order_test(
     name = "linking_action_test",
     # TODO(bazel-team): Support this test on Windows and Mac.
     is_linux = select({
@@ -321,22 +383,10 @@ paths_test(
     name = "path_matching_test",
 )
 
-build_failure_test(
-    name = "export_without_permissions_test",
-    message = "doesn't have the necessary permissions",
-    target_under_test = "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/failing_targets:permissions_fail_so",
-)
-
-build_failure_test(
-    name = "forbidden_target_permissions_test",
-    message = "can only list targets that are in the same package or a sub-package",
-    target_under_test = "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/failing_targets:permissions_fail",
-)
-
 cc_library(
     name = "prebuilt",
+    hdrs = ["direct_so_file_cc_lib.h"],
     srcs = [
-        "direct_so_file_cc_lib.h",
         ":just_main_output",
     ],
 )
@@ -393,60 +443,6 @@ cc_library(
     ],
 )
 
-cc_shared_library_permissions(
-    name = "permissions",
-    targets = [
-        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library:a_suffix",
-        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library:qux",
-        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library:qux2",
-    ],
-)
-
-cc_library(
-    name = "static_lib_no_exporting",
-    srcs = [
-        "bar.cc",
-        "bar.h",
-    ],
-    tags = ["NO_EXPORTING"],
-)
-
-cc_library(
-    name = "static_lib_exporting",
-    srcs = [
-        "bar2.cc",
-        "bar2.h",
-    ],
-)
-
-cc_shared_library(
-    name = "lib_with_no_exporting_roots_1",
-    deps = [":static_lib_no_exporting"],
-)
-
-cc_shared_library(
-    name = "lib_with_no_exporting_roots_2",
-    deps = [":static_lib_no_exporting"],
-    dynamic_deps = [":lib_with_no_exporting_roots_3"],
-)
-
-cc_shared_library(
-    name = "lib_with_no_exporting_roots_3",
-    deps = [":static_lib_no_exporting"],
-)
-
-cc_shared_library(
-    name = "lib_with_no_exporting_roots",
-    deps = [
-        ":static_lib_no_exporting",
-        ":static_lib_exporting",
-    ],
-    dynamic_deps = [
-        ":lib_with_no_exporting_roots_1",
-        ":lib_with_no_exporting_roots_2",
-    ],
-)
-
 build_failure_test(
     name = "two_dynamic_deps_same_export_in_so_test",
     message = "Two shared libraries in dependencies export the same symbols",
@@ -457,11 +453,6 @@ build_failure_test(
     name = "two_dynamic_deps_same_export_in_binary_test",
     message = "Two shared libraries in dependencies link the same  library statically",
     target_under_test = "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/failing_targets:two_dynamic_deps_same_export_in_binary",
-)
-
-debug_files_test(
-    name = "debug_files_test",
-    target_under_test = ":binary",
 )
 
 interface_library_output_group_test(
@@ -482,7 +473,26 @@ runfiles_test(
     target_under_test = ":python_test",
 )
 
-no_exporting_static_lib_test(
-    name = "no_exporting_static_lib_test",
-    target_under_test = ":lib_with_no_exporting_roots",
+check_linking_action_lib_parameters_test(
+    name = "check_binary_doesnt_take_already_linked_in_libs",
+    target_under_test = ":binary",
+    libs_that_shouldnt_be_present = ["foo", "bar"],
+)
+
+check_linking_action_lib_parameters_test(
+    name = "check_shared_lib_doesnt_take_already_linked_in_libs",
+    target_under_test = ":foo_so",
+    libs_that_shouldnt_be_present = ["bar"],
+)
+
+build_failure_test(
+    name = "shared_library_without_deps",
+    message = "'cc_shared_library' must have at least one dependency in 'deps' (or 'roots')",
+    target_under_test = "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/failing_targets:failing_with_no_deps_so",
+)
+
+build_failure_test(
+    name = "direct_dep_with_only_shared_lib_file",
+    message = "Do not place libraries which only contain a precompiled dynamic library",
+    target_under_test = "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/failing_targets:failing_only_dynamic_lib",
 )

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/cc_shared_library_integration_test.sh
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/cc_shared_library_integration_test.sh
@@ -38,16 +38,16 @@ function check_symbol_absent() {
 
 function test_shared_library_symbols() {
   foo_so=$(find . -name libfoo_so.so)
-  symbols=$(nm -D $foo_so)
+  symbols=$(nm $foo_so)
   check_symbol_present "$symbols" "U _Z3barv"
   check_symbol_present "$symbols" "T _Z3bazv"
   check_symbol_present "$symbols" "T _Z3foov"
-  # Check that the preloaded dep symbol is not present
-  check_symbol_present "$symbols" "U _Z13preloaded_depv"
-
-  check_symbol_absent "$symbols" "_Z3quxv"
+  check_symbol_present "$symbols" "T _Z3foov"
+  check_symbol_present "$symbols" "t _Z3quxv"
+  check_symbol_present "$symbols" "t _Z12indirect_depv"
+  check_symbol_present "$symbols" "t _Z13indirect_dep2v"
+  check_symbol_absent "$symbols" "_Z13indirect_dep3v"
   check_symbol_absent "$symbols" "_Z4bar3v"
-  check_symbol_absent "$symbols" "_Z4bar4v"
 }
 
 function test_shared_library_user_link_flags() {
@@ -66,14 +66,11 @@ function do_test_binary() {
 function test_binary() {
   binary=$(find . -name binary)
   do_test_binary $binary
-  check_symbol_present "$symbols" "T _Z13preloaded_depv"
 }
 
 function test_cc_test() {
   cc_test=$(find . -name cc_test)
   do_test_binary $cc_test
-  check_symbol_absent "$symbols" "_Z13preloaded_depv"
-  $LDD_BINARY $cc_test | (grep -q "preloaded_Udep.so" || (echo "Expected '"preloaded_Udep.so"'" && exit 1))
 }
 
 test_shared_library_user_link_flags

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/failing_targets/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/failing_targets/BUILD.builtin_test
@@ -32,22 +32,6 @@ cc_library(
     ],
 )
 
-cc_shared_library(
-    name = "permissions_fail_so",
-    deps = [
-        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3:bar",
-    ],
-    tags = TAGS,
-)
-
-cc_shared_library_permissions(
-    name = "permissions_fail",
-    tags = TAGS,
-    targets = [
-        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library:foo",
-    ],
-)
-
 cc_library(
     name = "a",
     srcs = ["a.cc"],
@@ -100,3 +84,32 @@ cc_shared_library(
     ],
     tags = TAGS,
 )
+
+cc_shared_library(
+    name = "failing_with_no_deps_so",
+    tags = TAGS,
+)
+
+
+cc_shared_library(
+    name = "failing_only_dynamic_lib",
+    deps = [
+        "dynamic_only",
+    ],
+    tags = TAGS,
+)
+
+cc_library(
+    name = "dynamic_only",
+    srcs = [
+        "libabc.so",
+    ],
+)
+
+genrule(
+    name = "abc_lib",
+    srcs = [],
+    outs = ["libabc.so"],
+    cmd = "touch \"$@\"",
+)
+

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/foo.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/foo.cc
@@ -15,7 +15,6 @@
 #include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/baz.h"
 #include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/direct_so_file_cc_lib.h"
 #include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/direct_so_file_cc_lib2.h"
-#include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/preloaded_dep.h"
 #include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/qux.h"
 #include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3/diff_pkg.h"
 
@@ -27,7 +26,6 @@ int foo() {
 #ifdef IS_LINUX
   direct_so_file_cc_lib();
   direct_so_file_cc_lib2();
-  preloaded_dep();
 #endif
   return 42;
 }

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/indirect_dep.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/indirect_dep.cc
@@ -1,0 +1,15 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int indirect_dep() { return 0; }

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/indirect_dep2.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/indirect_dep2.cc
@@ -1,4 +1,4 @@
-// Copyright 2016 The Bazel Authors. All rights reserved.
+// Copyright 2023 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,5 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef EXAMPLES_TEST_CC_SHARED_LIBRARY_PRELOADED_DEP_H_
-#define EXAMPLES_TEST_CC_SHARED_LIBRARY_PRELOADED_DEP_H_
 
-int preloaded_dep();
-
-#endif  // EXAMPLES_TEST_CC_SHARED_LIBRARY_PRELOADED_DEP_H_
+int indirect_dep2() { return 0; }

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/indirect_dep3.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/indirect_dep3.cc
@@ -1,4 +1,4 @@
-// Copyright 2016 The Bazel Authors. All rights reserved.
+// Copyright 2023 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,5 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/preloaded_dep.h"
 
-int preloaded_dep() { return 42; }
+int indirect_dep3() { return 0; }

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3/BUILD.builtin_test
@@ -21,10 +21,3 @@ cc_shared_library(
         ":diff_pkg",
     ],
 )
-
-cc_shared_library_permissions(
-    name = "permissions",
-    targets = [
-        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library3:bar",
-    ],
-)


### PR DESCRIPTION
Tensorflow is blocked on updating its grpc version due to the old implementation dropping objects from upb_proto_libraries.

This contains that fix from head and others. The whole difference with head is the name of the CcSharedLibraryHintInfo and also the fact that the experimental flag is still present together with experimental_link_static_libraries_once still being false by default. In 7.0 the experimental flag will be gone and experimental_link_static_libraries_once will be true by default. This wasn't done for 6.3 because it'd be a breaking change.