### PR TITLE
Update ignored_error logic for circuit_breaker

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
@@ -13,16 +13,11 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.circuitbreaker;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.remote.Retrier;
-import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 
 /** Factory for {@link Retrier.CircuitBreaker} */
 public class CircuitBreakerFactory {
-
-  public static final ImmutableSet<Class<? extends Exception>> DEFAULT_IGNORED_ERRORS =
-      ImmutableSet.of(CacheNotFoundException.class);
   public static final int DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE = 100;
 
   private CircuitBreakerFactory() {}

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.circuitbreaker;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.remote.Retrier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -33,12 +32,10 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   private State state;
   private final AtomicInteger successes;
   private final AtomicInteger failures;
-  private final AtomicInteger ignoredFailures;
   private final int failureRateThreshold;
   private final int slidingWindowSize;
   private final int minCallCountToComputeFailureRate;
   private final ScheduledExecutorService scheduledExecutor;
-  private final ImmutableSet<Class<? extends Exception>> ignoredErrors;
 
   /**
    * Creates a {@link FailureCircuitBreaker}.
@@ -51,7 +48,6 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   public FailureCircuitBreaker(int failureRateThreshold, int slidingWindowSize) {
     this.failures = new AtomicInteger(0);
     this.successes = new AtomicInteger(0);
-    this.ignoredFailures = new AtomicInteger(0);
     this.failureRateThreshold = failureRateThreshold;
     this.slidingWindowSize = slidingWindowSize;
     this.minCallCountToComputeFailureRate =
@@ -59,7 +55,6 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
     this.state = State.ACCEPT_CALLS;
     this.scheduledExecutor =
         slidingWindowSize > 0 ? Executors.newSingleThreadScheduledExecutor() : null;
-    this.ignoredErrors = CircuitBreakerFactory.DEFAULT_IGNORED_ERRORS;
   }
 
   @Override
@@ -68,33 +63,22 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   }
 
   @Override
-  public void recordFailure(Exception e) {
-    if (!ignoredErrors.contains(e.getClass())) {
-      int failureCount = failures.incrementAndGet();
-      int totalCallCount = successes.get() + failureCount + ignoredFailures.get();
-      if (slidingWindowSize > 0) {
-        var unused =
-            scheduledExecutor.schedule(
-                failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
-      }
+  public void recordFailure() {
+    int failureCount = failures.incrementAndGet();
+    int totalCallCount = successes.get() + failureCount;
+    if (slidingWindowSize > 0) {
+      var unused = scheduledExecutor.schedule(failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
+    }
 
-      if (totalCallCount < minCallCountToComputeFailureRate) {
-        // The remote call count is below the threshold required to calculate the failure rate.
-        return;
-      }
-      double failureRate = (failureCount * 100.0) / totalCallCount;
+    if (totalCallCount < minCallCountToComputeFailureRate) {
+      // The remote call count is below the threshold required to calculate the failure rate.
+      return;
+    }
+    double failureRate = (failureCount * 100.0) / totalCallCount;
 
-      // Since the state can only be changed to the open state, synchronization is not required.
-      if (failureRate > this.failureRateThreshold) {
-        this.state = State.REJECT_CALLS;
-      }
-    } else {
-      ignoredFailures.incrementAndGet();
-      if (slidingWindowSize > 0) {
-        var unused =
-            scheduledExecutor.schedule(
-                ignoredFailures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
-      }
+    // Since the state can only be changed to the open state, synchronization is not required.
+    if (failureRate > this.failureRateThreshold) {
+      this.state = State.REJECT_CALLS;
     }
   }
 
@@ -102,9 +86,7 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   public void recordSuccess() {
     successes.incrementAndGet();
     if (slidingWindowSize > 0) {
-      var unused =
-          scheduledExecutor.schedule(
-              successes::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
+      var unused = scheduledExecutor.schedule(successes::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -67,7 +67,9 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
     int failureCount = failures.incrementAndGet();
     int totalCallCount = successes.get() + failureCount;
     if (slidingWindowSize > 0) {
-      var unused = scheduledExecutor.schedule(failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
+      var unused =
+          scheduledExecutor.schedule(
+              failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
     }
 
     if (totalCallCount < minCallCountToComputeFailureRate) {
@@ -86,7 +88,9 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   public void recordSuccess() {
     successes.incrementAndGet();
     if (slidingWindowSize > 0) {
-      var unused = scheduledExecutor.schedule(successes::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
+      var unused =
+          scheduledExecutor.schedule(
+              successes::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
@@ -344,7 +344,7 @@ public class RetrierTest {
     Supplier<Backoff> s = () -> new ZeroBackoff(maxRetries);
     List<Status> retriableGrpcError = Arrays.asList(Status.ABORTED, Status.UNKNOWN, Status.DEADLINE_EXCEEDED);
     List<Status> nonRetriableGrpcError = Arrays.asList(Status.NOT_FOUND, Status.OUT_OF_RANGE, Status.ALREADY_EXISTS);
-    TripAfterNCircuitBreaker cb = new TripAfterNCircuitBreaker(retriableGrpcError.size() * 2);
+    TripAfterNCircuitBreaker cb = new TripAfterNCircuitBreaker(retriableGrpcError.size() * (maxRetries + 1));
     Retrier r = new Retrier(s, RemoteRetrier.RETRIABLE_GRPC_ERRORS, retryService, cb);
 
 
@@ -356,7 +356,7 @@ public class RetrierTest {
               () -> {
                 throw new StatusRuntimeException(status);
               });
-      expectedConsecutiveFailures += maxRetries;
+      expectedConsecutiveFailures += maxRetries + 1;
       assertThrows(ExecutionException.class, res::get);
       assertThat(cb.consecutiveFailures).isEqualTo(expectedConsecutiveFailures);
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
@@ -357,8 +357,8 @@ public class RetrierTest {
                 throw new StatusRuntimeException(status);
               });
       expectedConsecutiveFailures += maxRetries;
-      assertThat(cb.consecutiveFailures).isEqualTo(expectedConsecutiveFailures);
       assertThrows(ExecutionException.class, res::get);
+      assertThat(cb.consecutiveFailures).isEqualTo(expectedConsecutiveFailures);
     }
 
     assertThat(cb.state).isEqualTo(State.REJECT_CALLS);

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -15,12 +15,11 @@ package com.google.devtools.build.lib.remote.circuitbreaker;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import build.bazel.remote.execution.v2.Digest;
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
-import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import java.util.stream.IntStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,40 +29,41 @@ import org.junit.runners.JUnit4;
 public class FailureCircuitBreakerTest {
 
   @Test
-  public void testRecordFailure_withIgnoredErrors() throws InterruptedException {
+  public void testRecordFailure_circuitTrips() throws InterruptedException {
     final int failureRateThreshold = 10;
     final int windowInterval = 100;
     FailureCircuitBreaker failureCircuitBreaker =
         new FailureCircuitBreaker(failureRateThreshold, windowInterval);
 
-    List<Exception> listOfExceptionThrownOnFailure = new ArrayList<>();
+    List<Runnable> listOfSuccessAndFailureCalls = new ArrayList<>();
     for (int index = 0; index < failureRateThreshold; index++) {
-      listOfExceptionThrownOnFailure.add(new Exception());
-    }
-    for (int index = 0; index < failureRateThreshold * 9; index++) {
-      listOfExceptionThrownOnFailure.add(new CacheNotFoundException(Digest.newBuilder().build()));
+      listOfSuccessAndFailureCalls.add(failureCircuitBreaker::recordFailure);
     }
 
-    Collections.shuffle(listOfExceptionThrownOnFailure);
+    for (int index = 0; index < failureRateThreshold * 9; index++) {
+      listOfSuccessAndFailureCalls.add(failureCircuitBreaker::recordSuccess);
+    }
+
+    Collections.shuffle(listOfSuccessAndFailureCalls);
 
     // make calls equals to threshold number of not ignored failure calls in parallel.
-    listOfExceptionThrownOnFailure.stream()
+    listOfSuccessAndFailureCalls.stream()
         .parallel()
-        .forEach(failureCircuitBreaker::recordFailure);
+        .forEach(Runnable::run);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
     // Sleep for windowInterval + 1ms.
     Thread.sleep(windowInterval + 1 /*to compensate any delay*/);
 
     // make calls equals to threshold number of not ignored failure calls in parallel.
-    listOfExceptionThrownOnFailure.stream()
+    listOfSuccessAndFailureCalls.stream()
         .parallel()
-        .forEach(failureCircuitBreaker::recordFailure);
+        .forEach(Runnable::run);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
     // Sleep for less than windowInterval.
     Thread.sleep(windowInterval - 5);
-    failureCircuitBreaker.recordFailure(new Exception());
+    failureCircuitBreaker.recordFailure();
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 
@@ -80,15 +80,15 @@ public class FailureCircuitBreakerTest {
     // minCallToComputeFailure.
     IntStream.range(0, minCallToComputeFailure >> 1)
         .parallel()
-        .forEach(i -> failureCircuitBreaker.recordFailure(new Exception()));
+        .forEach(i -> failureCircuitBreaker.recordFailure());
     IntStream.range(0, minCallToComputeFailure >> 1)
         .parallel()
         .forEach(i -> failureCircuitBreaker.recordSuccess());
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
     // Sleep for less than windowInterval.
-    Thread.sleep(windowInterval - 20);
-    failureCircuitBreaker.recordFailure(new Exception());
+    Thread.sleep(windowInterval - 50);
+    failureCircuitBreaker.recordFailure();
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }


### PR DESCRIPTION
When the digest size exceeds the max configured digest size by remote-cache, an "out_of_range" error is returned. These errors should not be considered as API failures for the circuit breaker logic, as they do not indicate any issues with the remote-cache service.
Similarly there are other non-retriable errors that should not be treated as server failure such as ALREADY_EXISTS.

This change considers non-retriable errors as user/client error and logs them as success. While retriable errors such `DEADLINE_EXCEEDED`, `UNKNOWN` etc are logged as failure.

Related PRs
#18359
#18539
