### PR TITLE
Remove unnecessary Java runtime dependency of non-binary rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaRuleClasses.java
@@ -107,7 +107,7 @@ public class BazelJavaRuleClasses {
       return RuleDefinition.Metadata.builder()
           .name("$java_base_rule")
           .type(RuleClassType.ABSTRACT)
-          .ancestors(JavaToolchainBaseRule.class, JavaRuntimeBaseRule.class)
+          .ancestors(JavaToolchainBaseRule.class)
           .build();
     }
   }
@@ -461,6 +461,7 @@ public class BazelJavaRuleClasses {
           .type(RuleClassType.ABSTRACT)
           .ancestors(
               JavaRule.class,
+              JavaRuntimeBaseRule.class,
               // java_binary and java_test require the crosstool C++ runtime
               // libraries (libstdc++.so, libgcc_s.so).
               // TODO(bazel-team): Add tests for Java+dynamic runtime.


### PR DESCRIPTION
Work towards #17085
Work towards https://github.com/bazelbuild/rules_java/issues/64 
Split off from #18262