### PR TITLE
Remove runtime dependency of non-executable java_binary

### DIFF
--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl
@@ -258,7 +258,9 @@ def _make_binary_rule(implementation, attrs, executable = False, test = False):
         test = test,
         fragments = ["cpp", "java"],
         provides = [JavaInfo],
-        toolchains = [semantics.JAVA_TOOLCHAIN, semantics.JAVA_RUNTIME_TOOLCHAIN] + cc_helper.use_cpp_toolchain(),
+        toolchains = [semantics.JAVA_TOOLCHAIN] + cc_helper.use_cpp_toolchain() + (
+            [semantics.JAVA_RUNTIME_TOOLCHAIN] if executable or test else []
+        ),
         # TODO(hvd): replace with filegroups?
         outputs = {
             "classjar": "%{name}.jar",
@@ -306,6 +308,7 @@ def make_java_binary(executable, resolve_launcher_flag, has_launcher = False):
                 "args": attr.string_list(),
                 "output_licenses": attr.license() if hasattr(attr, "license") else attr.string_list(),
             }),
+            remove_attrs = [] if executable else ["_java_runtime_toolchain_type"],
         ),
         executable = executable,
     )

--- a/src/main/starlark/builtins_bzl/common/java/blaze_java_semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/blaze_java_semantics.bzl
@@ -1,0 +1,29 @@
+# TODO: Remove on import. This file only exists to indicate the changes that have to be made to the
+#       internal version of java_semantics.bzl.
+
+def _get_java_runtime_dependent_runfiles_and_symlinks(
+        ctx,
+        *,
+        executable,
+        feature_config,
+        is_absolute_path):
+    java_runtime_toolchain = semantics.find_java_runtime_toolchain(ctx)
+
+    # Add symlinks to the C++ runtime libraries under a path that can be built
+    # into the Java binary without having to embed the crosstool, gcc, and grte
+    # version information contained within the libraries' package paths.
+    runfiles_symlinks = {}
+
+    if not is_absolute_path(ctx, java_runtime_toolchain.java_home):
+        runfiles_symlinks = {
+            ("_cpp_runtimes/%s" % lib.basename): lib
+            for lib in cc_helper.find_cpp_toolchain(ctx).dynamic_runtime_lib(
+                feature_configuration = feature_config,
+            ).to_list()
+        }
+
+    return [java_runtime_toolchain.files], runfiles_symlinks
+
+semantics = struct(
+    get_java_runtime_dependent_runfiles_and_symlinks = _get_java_runtime_dependent_runfiles_and_symlinks,
+)

--- a/src/main/starlark/builtins_bzl/common/java/java_semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_semantics.bzl
@@ -53,6 +53,17 @@ def _stamping_enabled(ctx, stamp):
 def _get_build_info(ctx, stamp):
     return java_common.get_build_info(ctx, _stamping_enabled(ctx, stamp))
 
+def _get_java_runtime_dependent_runfiles_and_symlinks(
+        ctx,
+        *,
+        executable,
+        feature_config,
+        is_absolute_path):
+    if not executable:
+        return [], {}
+    java_runtime_toolchain = semantics.find_java_runtime_toolchain(ctx)
+    return [java_runtime_toolchain.files], {}
+
 semantics = struct(
     JAVA_TOOLCHAIN_LABEL = "@bazel_tools//tools/jdk:current_java_toolchain",
     JAVA_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:toolchain_type",
@@ -62,6 +73,7 @@ semantics = struct(
     JAVA_RUNTIME_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:runtime_toolchain_type",
     JAVA_RUNTIME_TOOLCHAIN = _builtins.toplevel.config_common.toolchain_type("@bazel_tools//tools/jdk:runtime_toolchain_type", mandatory = True),
     find_java_runtime_toolchain = _find_java_runtime_toolchain,
+    get_java_runtime_dependent_runfiles_and_symlinks = _get_java_runtime_dependent_runfiles_and_symlinks,
     JAVA_PLUGINS_FLAG_ALIAS_LABEL = "@bazel_tools//tools/jdk:java_plugins_flag_alias",
     EXTRA_SRCS_TYPES = [],
     ALLOWED_RULES_IN_DEPS = [


### PR DESCRIPTION
The `java_binary` Starlark implementation now only directly depends on a Java runtime toolchain when it is used as an executable rule.

This work will eventually allow `java_binary` with `create_executable = False` to be compiled for platforms that do not provide a regular JDK, such as Android.

Work towards #17085
Work towards https://github.com/bazelbuild/rules_java/issues/64 
Split off from #18262