### PR TITLE
Set actionId when download outputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionInputPrefetcher.java
@@ -36,6 +36,7 @@ public interface ActionInputPrefetcher {
         public ListenableFuture<Void> prefetchFiles(
             Iterable<? extends ActionInput> inputs,
             MetadataSupplier metadataSupplier,
+            String actionId,
             Priority priority) {
           // Do nothing.
           return immediateVoidFuture();
@@ -79,7 +80,10 @@ public interface ActionInputPrefetcher {
    * @return future success if prefetch is finished or {@link IOException}.
    */
   ListenableFuture<Void> prefetchFiles(
-      Iterable<? extends ActionInput> inputs, MetadataSupplier metadataSupplier, Priority priority);
+      Iterable<? extends ActionInput> inputs,
+      MetadataSupplier metadataSupplier,
+      String actionId,
+      Priority priority);
 
   /**
    * Whether the prefetcher requires the metadata for a tree artifact to be available whenever one

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -211,7 +211,7 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
               ? resultMessage
               : CommandFailureUtils.describeCommandFailure(
                   executionOptions.verboseFailures, cwd, spawn);
-      throw new SpawnExecException(message, spawnResult, /*forciblyRunRemotely=*/ false);
+      throw new SpawnExecException(message, spawnResult, /* forciblyRunRemotely= */ false);
     }
     return ImmutableList.of(spawnResult);
   }
@@ -245,7 +245,7 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
     }
 
     @Override
-    public ListenableFuture<Void> prefetchInputs()
+    public ListenableFuture<Void> prefetchInputs(String actionId)
         throws IOException, ForbiddenActionInputException {
       if (Spawns.shouldPrefetchInputsForLocalExecution(spawn)) {
         return Futures.catchingAsync(
@@ -255,6 +255,7 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
                     getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true)
                         .values(),
                     getInputMetadataProvider()::getInputMetadata,
+                    actionId,
                     Priority.MEDIUM),
             BulkTransferException.class,
             (BulkTransferException e) -> {
@@ -284,6 +285,7 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
     public InputMetadataProvider getInputMetadataProvider() {
       return actionExecutionContext.getInputMetadataProvider();
     }
+
     @Override
     public <T extends ActionContext> T getContext(Class<T> identifyingType) {
       return actionExecutionContext.getContext(identifyingType);

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -152,16 +152,17 @@ public interface SpawnRunner {
      * again. I suppose we could require implementations to memoize getInputMapping (but not compute
      * it eagerly), and that may change in the future.
      */
-    ListenableFuture<Void> prefetchInputs() throws IOException, ForbiddenActionInputException;
+    ListenableFuture<Void> prefetchInputs(String actionId)
+        throws IOException, ForbiddenActionInputException;
 
     /**
      * Prefetches the Spawns input files to the local machine and wait to finish.
      *
      * @see #prefetchInputs()
      */
-    default void prefetchInputsAndWait()
+    default void prefetchInputsAndWait(String actionId)
         throws IOException, ExecException, InterruptedException, ForbiddenActionInputException {
-      ListenableFuture<Void> future = prefetchInputs();
+      ListenableFuture<Void> future = prefetchInputs(actionId);
       try (SilentCloseable s =
           Profiler.instance().profile(ProfilerTask.REMOTE_DOWNLOAD, "stage remote inputs")) {
         future.get();
@@ -175,7 +176,7 @@ public interface SpawnRunner {
         }
         throw new IOException(e);
       } catch (InterruptedException e) {
-        future.cancel(/*mayInterruptIfRunning=*/ true);
+        future.cancel(/* mayInterruptIfRunning= */ true);
         throw e;
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -142,7 +142,7 @@ public class LocalSpawnRunner implements SpawnRunner {
         context.getFileOutErr(),
         xattrProvider);
     if (Spawns.shouldPrefetchInputsForLocalExecution(spawn)) {
-      context.prefetchInputsAndWait();
+      context.prefetchInputsAndWait(context.getId());
     }
     spawnMetrics.addSetupTimeInMs((int) setupTimeStopwatch.elapsed().toMillis());
 
@@ -289,7 +289,7 @@ public class LocalSpawnRunner implements SpawnRunner {
 
     @FormatMethod
     private void stepLog(Level level, @FormatString String fmt, Object... args) {
-      stepLog(level, /*cause=*/ null, fmt, args);
+      stepLog(level, /* cause= */ null, fmt, args);
     }
 
     @FormatMethod

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -625,7 +625,10 @@ public class RemoteActionFileSystem extends DelegateFileSystem {
       }
       getFromFuture(
           inputFetcher.prefetchFiles(
-              ImmutableList.of(input), this::getInputMetadata, Priority.CRITICAL));
+              ImmutableList.of(input),
+              this::getInputMetadata,
+              "RemoteActionFSPrefetch",
+              Priority.CRITICAL));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException(String.format("Received interrupt while fetching file '%s'", path), e);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -46,6 +46,7 @@ class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
   private final String buildRequestId;
   private final String commandId;
   private final RemoteCache remoteCache;
+  private final DigestUtil digestUtil;
 
   RemoteActionInputFetcher(
       Reporter reporter,
@@ -55,8 +56,10 @@ class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
       Path execRoot,
       TempPathGenerator tempPathGenerator,
       RemoteOutputChecker remoteOutputChecker,
-      OutputPermissions outputPermissions) {
-    super(reporter, execRoot, tempPathGenerator, remoteOutputChecker, outputPermissions);
+      OutputPermissions outputPermissions,
+      DigestUtil digestUtil) {
+    super(
+        reporter, execRoot, tempPathGenerator, remoteOutputChecker, outputPermissions, digestUtil);
     this.buildRequestId = Preconditions.checkNotNull(buildRequestId);
     this.commandId = Preconditions.checkNotNull(commandId);
     this.remoteCache = Preconditions.checkNotNull(remoteCache);
@@ -83,11 +86,12 @@ class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
       Path tempPath,
       PathFragment execPath,
       FileArtifactValue metadata,
+      String actionId,
       Priority priority)
       throws IOException {
     checkArgument(metadata.isRemote(), "Cannot download file that is not a remote file.");
     RequestMetadata requestMetadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "prefetcher", null);
+        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, actionId, null);
     RemoteActionExecutionContext context = RemoteActionExecutionContext.create(requestMetadata);
 
     Digest digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -203,7 +203,7 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(prefetcher.prefetchFiles(metadata.keySet(), metadata::get, Priority.MEDIUM));
 
-    verify(prefetcher, never()).doDownloadFile(any(), any(), any(), any(), any());
+    verify(prefetcher, never()).doDownloadFile(any(), any(), any(), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
   }
@@ -219,7 +219,7 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(prefetcher.prefetchFiles(metadata.keySet(), metadata::get, Priority.MEDIUM));
 
-    verify(prefetcher).doDownloadFile(any(), any(), eq(a.getExecPath()), any(), any());
+    verify(prefetcher).doDownloadFile(any(), any(), eq(a.getExecPath()), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
     assertThat(FileSystemUtils.readContent(a.getPath(), UTF_8)).isEqualTo("hello world remote");
@@ -666,7 +666,7 @@ public abstract class ActionInputPrefetcherTestBase {
               return resultSupplier.get();
             })
         .when(prefetcher)
-        .doDownloadFile(any(), any(), any(), any(), any());
+        .doDownloadFile(any(), any(), any(), any(), any(), any());
   }
 
   private void assertReadableNonWritableAndExecutable(Path path) throws IOException {


### PR DESCRIPTION
In f62a8b9f6a7e840c648f44f094390c3b85b236df, we remove the actionId when
prefetching inputs from remote cache to execute action locally.

However, this does affect the scenario when we execute action
remotely and want to download the outputs after.
