### PR TITLE
[6.3.0] Fix issue with release notes script

### DIFF
--- a/scripts/release/relnotes.py
+++ b/scripts/release/relnotes.py
@@ -171,13 +171,13 @@ if __name__ == "__main__":
   is_major = bool(re.fullmatch(r"\d+.0.0", current_release))
 
   tags = [tag for tag in git("tag", "--sort=refname") if "pre" not in tag]
+
+  # Get the baseline for RCs (before release tag is created)
   if current_release not in tags:
     tags.append(current_release)
-    tags.sort()
-    last_release = tags[tags.index(current_release) - 1]
-  else:
-    print("Error: release tag already exists")
-    sys.exit(1)
+
+  tags.sort()
+  last_release = tags[tags.index(current_release) - 1]
 
   # Assuming HEAD is on the current (to-be-released) release, find the merge
   # base with the last release so that we know which commits to generate notes


### PR DESCRIPTION
This release notes script is run at different points in the release process, including once after the tag is created to update the final release index page and GitHub release page.

Commit https://github.com/bazelbuild/bazel/commit/4e7e8bf8c2ebadb97776530c81f95457a2be0f2e

PiperOrigin-RevId: 537860711
Change-Id: I6bf129c82eb2c83b37993d4ef691d4783c5735b6