### PR TITLE
ApiVersion: switch to use ClientApiVersion

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ApiVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ApiVersion.java
@@ -14,21 +14,21 @@
 
 package com.google.devtools.build.lib.remote;
 
-import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.semver.SemVer;
 
-/**
- * Represents a version of the Remote Execution API.
- */
+// Represents a version of the Remote Execution API.
 public class ApiVersion implements Comparable<ApiVersion> {
   public final int major;
   public final int minor;
   public final int patch;
   public final String prerelease;
 
-  // The current version of the Remote Execution API. This field will need to be updated
-  // together with all version changes.
-  public static final ApiVersion current = new ApiVersion(SemVer.newBuilder().setMajor(2).build());
+  // The current lowest/highest versions (inclusive) of the Remote Execution API that Bazel
+  // supports. These fields will need to be updated together with all version changes.
+  public static final ApiVersion low =
+      new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build());
+  public static final ApiVersion high =
+      new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build());
 
   public ApiVersion(int major, int minor, int patch, String prerelease) {
     this.major = major;
@@ -92,74 +92,5 @@ public class ApiVersion implements Comparable<ApiVersion> {
       return Integer.compare(minor, other.minor);
     }
     return Integer.compare(patch, other.patch);
-  }
-
-  static class ServerSupportedStatus {
-    private enum State {
-      SUPPORTED,
-      UNSUPPORTED,
-      DEPRECATED,
-    }
-    private final String message;
-    private final State state;
-
-    private ServerSupportedStatus(State state, String message) {
-      this.state = state;
-      this.message = message;
-    }
-
-    public static ServerSupportedStatus supported() {
-      return new ServerSupportedStatus(State.SUPPORTED, "");
-    }
-
-    public static ServerSupportedStatus unsupported(
-        ApiVersion curr, ApiVersion lowApiVersion, ApiVersion highApiVersion) {
-      return new ServerSupportedStatus(
-          State.UNSUPPORTED,
-          String.format(
-              "The API version %s is not supported by the server. "
-                  + "Please switch to a supported version: %s to %s.",
-              curr, lowApiVersion, highApiVersion));
-    }
-
-    public static ServerSupportedStatus deprecated(
-        ApiVersion curr, ApiVersion lowApiVersion, ApiVersion highApiVersion) {
-      return new ServerSupportedStatus(
-          State.DEPRECATED,
-          String.format(
-              "The API version %s is deprecated by the server. "
-                  + "Please upgrade to a recommended version: %s to %s.",
-              curr, lowApiVersion, highApiVersion));
-    }
-
-    public String getMessage() {
-      return message;
-    }
-
-    public boolean isSupported() {
-      return state == State.SUPPORTED;
-    }
-
-    public boolean isDeprecated() {
-      return state == State.DEPRECATED;
-    }
-
-    public boolean isUnsupported() {
-      return state == State.UNSUPPORTED;
-    }
-  }
-
-  public ServerSupportedStatus checkServerSupportedVersions(ServerCapabilities cap) {
-    ApiVersion deprecated =
-        cap.hasDeprecatedApiVersion() ? new ApiVersion(cap.getDeprecatedApiVersion()) : null;
-    ApiVersion low = new ApiVersion(cap.getLowApiVersion());
-    ApiVersion high = new ApiVersion(cap.getHighApiVersion());
-    if (deprecated != null && compareTo(deprecated) >= 0 && compareTo(low) < 0) {
-      return ServerSupportedStatus.deprecated(this, low, high);
-    }
-    if (compareTo(low) < 0 || compareTo(high) > 0) {
-      return ServerSupportedStatus.unsupported(this, low, high);
-    }
-    return ServerSupportedStatus.supported();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/ClientApiVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ClientApiVersion.java
@@ -1,0 +1,142 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import build.bazel.remote.execution.v2.ServerCapabilities;
+import javax.annotation.Nullable;
+
+// Represents a range of the Remote Execution API that client supports.
+public class ClientApiVersion {
+  private final ApiVersion low;
+  private final ApiVersion high;
+
+  public static final ClientApiVersion current =
+      new ClientApiVersion(ApiVersion.low, ApiVersion.high);
+
+  public ClientApiVersion(ApiVersion low, ApiVersion high) {
+    this.low = low;
+    this.high = high;
+  }
+
+  public ApiVersion getLow() {
+    return low;
+  }
+
+  public ApiVersion getHigh() {
+    return high;
+  }
+
+  public boolean isSupported(ApiVersion version) {
+    return low.compareTo(version) <= 0 && high.compareTo(version) >= 0;
+  }
+
+  static class ServerSupportedStatus {
+    private enum State {
+      SUPPORTED,
+      UNSUPPORTED,
+      DEPRECATED,
+    }
+
+    private final String message;
+    private final State state;
+    private final ApiVersion highestSupportedVersion;
+
+    private ServerSupportedStatus(State state, String message, ApiVersion highestSupportedVersion) {
+      this.state = state;
+      this.message = message;
+      this.highestSupportedVersion = highestSupportedVersion;
+    }
+
+    public static ServerSupportedStatus supported(ApiVersion highestSupportedVersion) {
+      return new ServerSupportedStatus(State.SUPPORTED, "", highestSupportedVersion);
+    }
+
+    public static ServerSupportedStatus unsupported(
+        ApiVersion clientLow, ApiVersion clientHigh, ApiVersion serverLow, ApiVersion serverHigh) {
+      return new ServerSupportedStatus(
+          State.UNSUPPORTED,
+          String.format(
+              "The client supported API versions, %s to %s, is not supported by the server, %s to"
+                  + " %s. Please switch to a different server or upgrade Bazel.",
+              clientLow, clientHigh, serverLow, serverHigh),
+          null);
+    }
+
+    public static ServerSupportedStatus deprecated(
+        ApiVersion clientHigh, ApiVersion serverLow, ApiVersion serverHigh) {
+      return new ServerSupportedStatus(
+          State.DEPRECATED,
+          String.format(
+              "The highest API version Bazel support %s is deprecated by the server. "
+                  + "Please upgrade to server's recommended version: %s to %s.",
+              clientHigh, serverLow, serverHigh),
+          clientHigh);
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public ApiVersion getHighestSupportedVersion() {
+      return highestSupportedVersion;
+    }
+
+    public boolean isSupported() {
+      return state == State.SUPPORTED;
+    }
+
+    public boolean isDeprecated() {
+      return state == State.DEPRECATED;
+    }
+
+    public boolean isUnsupported() {
+      return state == State.UNSUPPORTED;
+    }
+  }
+
+  // highestSupportedVersion compares the client's supported versions against the input low and high
+  // versions and returns the highest supported version. If the client's supported versions are not
+  // supported
+  // by the server, it returns null.
+  @Nullable
+  private ApiVersion highestSupportedVersion(ApiVersion serverLow, ApiVersion serverHigh) {
+    var higestLow = this.low.compareTo(serverLow) >= 0 ? this.low : serverLow;
+    var lowestHigh = this.high.compareTo(serverHigh) <= 0 ? this.high : serverHigh;
+
+    return higestLow.compareTo(lowestHigh) <= 0 ? lowestHigh : null;
+  }
+
+  public ServerSupportedStatus checkServerSupportedVersions(ServerCapabilities cap) {
+    var serverLow = new ApiVersion(cap.getLowApiVersion());
+    var serverHigh = new ApiVersion(cap.getHighApiVersion());
+
+    var highest = highestSupportedVersion(serverLow, serverHigh);
+    if (highest != null) {
+      return ServerSupportedStatus.supported(highest);
+    }
+
+    var deprecated =
+        cap.hasDeprecatedApiVersion() ? new ApiVersion(cap.getDeprecatedApiVersion()) : null;
+    if (deprecated == null) {
+      return ServerSupportedStatus.unsupported(this.low, this.high, serverLow, serverHigh);
+    }
+
+    highest = highestSupportedVersion(deprecated, serverHigh);
+    if (highest != null) {
+      return ServerSupportedStatus.deprecated(highest, serverLow, serverHigh);
+    }
+
+    return ServerSupportedStatus.unsupported(this.low, this.high, serverLow, serverHigh);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/ClientApiVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ClientApiVersion.java
@@ -107,8 +107,7 @@ public class ClientApiVersion {
 
   // highestSupportedVersion compares the client's supported versions against the input low and high
   // versions and returns the highest supported version. If the client's supported versions are not
-  // supported
-  // by the server, it returns null.
+  // supported by the server, it returns null.
   @Nullable
   private ApiVersion highestSupportedVersion(ApiVersion serverLow, ApiVersion serverHigh) {
     var higestLow = this.low.compareTo(serverLow) >= 0 ? this.low : serverLow;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -182,8 +182,8 @@ class RemoteServerCapabilities {
     }
 
     // Check API version.
-    ApiVersion.ServerSupportedStatus st =
-        ApiVersion.current.checkServerSupportedVersions(capabilities);
+    ClientApiVersion.ServerSupportedStatus st =
+        ClientApiVersion.current.checkServerSupportedVersions(capabilities);
     if (st.isUnsupported()) {
       result.addError(st.getMessage());
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/ApiVersionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ApiVersionTest.java
@@ -16,18 +16,14 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.semver.SemVer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Tests for {@link ApiVersion}.
- */
+// Tests for {@link ApiVersion}.
 @RunWith(JUnit4.class)
 public class ApiVersionTest {
-
   @Test
   public void testToString() throws Exception {
     assertThat(new ApiVersion(0, 0, 0, "v1test").toString()).isEqualTo("v1test");
@@ -45,81 +41,25 @@ public class ApiVersionTest {
         .isLessThan(0);
     assertThat(new ApiVersion(0, 0, 1, "").compareTo(new ApiVersion(1, 0, 0, "v1test")))
         .isGreaterThan(0);
-    assertThat(new ApiVersion(1, 0, 0, "").compareTo(new ApiVersion(2, 0, 0, "")))
-        .isLessThan(0);
-    assertThat(new ApiVersion(2, 0, 0, "").compareTo(new ApiVersion(1, 0, 0, "")))
-        .isGreaterThan(0);
-    assertThat(new ApiVersion(2, 1, 0, "").compareTo(new ApiVersion(2, 2, 0, "")))
-        .isLessThan(0);
-    assertThat(new ApiVersion(2, 2, 0, "").compareTo(new ApiVersion(2, 1, 0, "")))
-        .isGreaterThan(0);
-    assertThat(new ApiVersion(2, 2, 1, "").compareTo(new ApiVersion(2, 2, 2, "")))
-        .isLessThan(0);
-    assertThat(new ApiVersion(2, 2, 2, "").compareTo(new ApiVersion(2, 1, 1, "")))
-        .isGreaterThan(0);
-    assertThat(new ApiVersion(2, 2, 2, "").compareTo(new ApiVersion(2, 2, 2, "")))
-        .isEqualTo(0);
+    assertThat(new ApiVersion(1, 0, 0, "").compareTo(new ApiVersion(2, 0, 0, ""))).isLessThan(0);
+    assertThat(new ApiVersion(2, 0, 0, "").compareTo(new ApiVersion(1, 0, 0, ""))).isGreaterThan(0);
+    assertThat(new ApiVersion(2, 1, 0, "").compareTo(new ApiVersion(2, 2, 0, ""))).isLessThan(0);
+    assertThat(new ApiVersion(2, 2, 0, "").compareTo(new ApiVersion(2, 1, 0, ""))).isGreaterThan(0);
+    assertThat(new ApiVersion(2, 2, 1, "").compareTo(new ApiVersion(2, 2, 2, ""))).isLessThan(0);
+    assertThat(new ApiVersion(2, 2, 2, "").compareTo(new ApiVersion(2, 1, 1, ""))).isGreaterThan(0);
+    assertThat(new ApiVersion(2, 2, 2, "").compareTo(new ApiVersion(2, 2, 2, ""))).isEqualTo(0);
   }
 
   @Test
   public void testFromToSemver() throws Exception {
-    SemVer[] semvers = new SemVer[] {
-      SemVer.newBuilder().setMajor(2).build(),
-      SemVer.newBuilder().setMajor(2).setMinor(1).setPatch(3).build(),
-      SemVer.newBuilder().setPrerelease("v1test").build(),
-    };
+    SemVer[] semvers =
+        new SemVer[] {
+          SemVer.newBuilder().setMajor(2).build(),
+          SemVer.newBuilder().setMajor(2).setMinor(1).setPatch(3).build(),
+          SemVer.newBuilder().setPrerelease("v1test").build(),
+        };
     for (SemVer sm : semvers) {
       assertThat(new ApiVersion(sm).toSemVer()).isEqualTo(sm);
-    }
-  }
-
-  @Test
-  public void testCheckServerSupportedVersions_isSupported() throws Exception {
-    assertThat(
-            new ApiVersion(2, 1, 1, "")
-                .checkServerSupportedVersions(
-                    ServerCapabilities.newBuilder()
-                        .setLowApiVersion(SemVer.newBuilder().setMajor(2).build())
-                        .setHighApiVersion(SemVer.newBuilder().setMajor(3).build())
-                        .build())
-                .isSupported())
-        .isTrue();
-  }
-
-  @Test
-  public void testCheckServerSupportedVersions_isDeprecated() throws Exception {
-    for (ApiVersion v :
-        new ApiVersion[] {
-          new ApiVersion(0, 0, 0, "v1test"),
-          new ApiVersion(0, 0, 0, "v2test"),
-          new ApiVersion(1, 0, 0, "")
-        }) {
-      ApiVersion.ServerSupportedStatus st =
-          v.checkServerSupportedVersions(
-              ServerCapabilities.newBuilder()
-                  .setDeprecatedApiVersion(SemVer.newBuilder().setPrerelease("v1test").build())
-                  .setLowApiVersion(SemVer.newBuilder().setMajor(2).build())
-                  .setHighApiVersion(SemVer.newBuilder().setMajor(3).build())
-                  .build());
-      assertThat(st.isDeprecated()).isTrue();
-      assertThat(st.getMessage()).contains("deprecated");
-      assertThat(st.getMessage()).contains("2.0 to 3.0");
-    }
-  }
-
-  @Test
-  public void testCheckServerSupportedVersions_isUnsupported() throws Exception {
-    for (ApiVersion v :
-        new ApiVersion[] {new ApiVersion(0, 0, 0, "v1test"), new ApiVersion(3, 1, 0, "")}) {
-      ApiVersion.ServerSupportedStatus st =
-          v.checkServerSupportedVersions(
-              ServerCapabilities.newBuilder()
-                  .setLowApiVersion(SemVer.newBuilder().setMajor(2).build())
-                  .setHighApiVersion(SemVer.newBuilder().setMajor(3).build())
-                  .build());
-      assertThat(st.isUnsupported()).isTrue();
-      assertThat(st.getMessage()).contains("not supported");
-      assertThat(st.getMessage()).contains("2.0 to 3.0");
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/ClientApiVersionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ClientApiVersionTest.java
@@ -1,0 +1,139 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.bazel.remote.execution.v2.ServerCapabilities;
+import build.bazel.semver.SemVer;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+// Tests for {@link ApiVersion}.
+@RunWith(Parameterized.class)
+public class ClientApiVersionTest {
+  @Parameters(name = "{0}")
+  public static List<Object[]> testCases() {
+    return Arrays.asList(
+        new Object[][] {
+          {
+            "noSupportedVersion",
+            new ClientApiVersion(
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build())),
+            ServerCapabilities.newBuilder()
+                .setLowApiVersion(SemVer.newBuilder().setMajor(2).setMinor(1).build())
+                .setHighApiVersion(SemVer.newBuilder().setMajor(2).setMinor(2).build())
+                .build(),
+            ClientApiVersion.ServerSupportedStatus.unsupported(
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(1).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(2).build())),
+            Arrays.asList("not supported", "2.0 to 2.0", "2.1 to 2.2")
+          },
+          {
+            "deprecated",
+            new ClientApiVersion(
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build())),
+            ServerCapabilities.newBuilder()
+                .setDeprecatedApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build())
+                .setLowApiVersion(SemVer.newBuilder().setMajor(2).setMinor(1).build())
+                .setHighApiVersion(SemVer.newBuilder().setMajor(2).setMinor(2).build())
+                .build(),
+            ClientApiVersion.ServerSupportedStatus.deprecated(
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(1).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(2).build())),
+            Arrays.asList("2.0 is deprecated", "2.1 to 2.2")
+          },
+          {
+            "clientHigh",
+            new ClientApiVersion(
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(3).build())),
+            ServerCapabilities.newBuilder()
+                .setLowApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build())
+                .setHighApiVersion(SemVer.newBuilder().setMajor(2).setMinor(4).build())
+                .build(),
+            ClientApiVersion.ServerSupportedStatus.supported(
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(3).build())),
+            Arrays.asList()
+          },
+          {
+            "serverHigh",
+            new ClientApiVersion(
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build()),
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(3).build())),
+            ServerCapabilities.newBuilder()
+                .setLowApiVersion(SemVer.newBuilder().setMajor(2).setMinor(0).build())
+                .setHighApiVersion(SemVer.newBuilder().setMajor(2).setMinor(1).build())
+                .build(),
+            ClientApiVersion.ServerSupportedStatus.supported(
+                new ApiVersion(SemVer.newBuilder().setMajor(2).setMinor(1).build())),
+            Arrays.asList()
+          },
+        });
+  }
+
+  private final ClientApiVersion clientApiVersion;
+  private final ServerCapabilities serverCapabilities;
+  private final ClientApiVersion.ServerSupportedStatus expectedHighestSupportedVersion;
+  private final List<String> expectedMessages;
+
+  public ClientApiVersionTest(
+      String name,
+      ClientApiVersion clientApiVersion,
+      ServerCapabilities serverCapabilities,
+      ClientApiVersion.ServerSupportedStatus expectedHighestSupportedVersion,
+      List<String> expectedMessages) {
+    this.clientApiVersion = clientApiVersion;
+    this.serverCapabilities = serverCapabilities;
+    this.expectedHighestSupportedVersion = expectedHighestSupportedVersion;
+    this.expectedMessages = expectedMessages;
+  }
+
+  @Test
+  public void testClientApiVersion() {
+    var serverSupportedStatus = clientApiVersion.checkServerSupportedVersions(serverCapabilities);
+    assertThat(serverSupportedStatus.isSupported())
+        .isEqualTo(expectedHighestSupportedVersion.isSupported());
+    assertThat(serverSupportedStatus.isUnsupported())
+        .isEqualTo(expectedHighestSupportedVersion.isUnsupported());
+    assertThat(serverSupportedStatus.isDeprecated())
+        .isEqualTo(expectedHighestSupportedVersion.isDeprecated());
+    assertThat(serverSupportedStatus.getMessage())
+        .isEqualTo(expectedHighestSupportedVersion.getMessage());
+
+    for (var expectedMessage : expectedMessages) {
+      assertThat(serverSupportedStatus.getMessage()).contains(expectedMessage);
+    }
+    if (expectedMessages.size() == 0) {
+      assertThat(serverSupportedStatus.getMessage()).isEmpty();
+    }
+
+    var expectedHigh = expectedHighestSupportedVersion.getHighestSupportedVersion();
+    if (expectedHigh != null) {
+      var high = serverSupportedStatus.getHighestSupportedVersion();
+
+      assertThat(high).isNotNull();
+      assertThat(high.compareTo(expectedHigh)).isEqualTo(0);
+    }
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -85,8 +85,8 @@ public final class RemoteModuleTest {
   private static final String CACHE_SERVER_NAME = "cache-server";
   private static final ServerCapabilities CACHE_ONLY_CAPS =
       ServerCapabilities.newBuilder()
-          .setLowApiVersion(ApiVersion.current.toSemVer())
-          .setHighApiVersion(ApiVersion.current.toSemVer())
+          .setLowApiVersion(ApiVersion.low.toSemVer())
+          .setHighApiVersion(ApiVersion.high.toSemVer())
           .setCacheCapabilities(
               CacheCapabilities.newBuilder()
                   .addDigestFunctions(Value.SHA256)
@@ -98,8 +98,8 @@ public final class RemoteModuleTest {
 
   private static final ServerCapabilities EXEC_AND_CACHE_CAPS =
       ServerCapabilities.newBuilder()
-          .setLowApiVersion(ApiVersion.current.toSemVer())
-          .setHighApiVersion(ApiVersion.current.toSemVer())
+          .setLowApiVersion(ApiVersion.low.toSemVer())
+          .setHighApiVersion(ApiVersion.high.toSemVer())
           .setExecutionCapabilities(
               ExecutionCapabilities.newBuilder()
                   .setExecEnabled(true)
@@ -111,8 +111,8 @@ public final class RemoteModuleTest {
 
   private static final ServerCapabilities EXEC_ONLY_CAPS =
       ServerCapabilities.newBuilder()
-          .setLowApiVersion(ApiVersion.current.toSemVer())
-          .setHighApiVersion(ApiVersion.current.toSemVer())
+          .setLowApiVersion(ApiVersion.low.toSemVer())
+          .setHighApiVersion(ApiVersion.high.toSemVer())
           .setExecutionCapabilities(
               ExecutionCapabilities.newBuilder()
                   .setExecEnabled(true)
@@ -122,8 +122,8 @@ public final class RemoteModuleTest {
 
   private static final ServerCapabilities NONE_CAPS =
       ServerCapabilities.newBuilder()
-          .setLowApiVersion(ApiVersion.current.toSemVer())
-          .setHighApiVersion(ApiVersion.current.toSemVer())
+          .setLowApiVersion(ApiVersion.low.toSemVer())
+          .setHighApiVersion(ApiVersion.high.toSemVer())
           .build();
 
   private static final CapabilitiesImpl INACCESSIBLE_GRPC_REMOTE =

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteServerCapabilitiesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteServerCapabilitiesTest.java
@@ -242,7 +242,7 @@ public class RemoteServerCapabilitiesTest {
   public void testCheckClientServerCompatibility_apiVersionDeprecated() throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setDeprecatedApiVersion(ApiVersion.current.toSemVer())
+            .setDeprecatedApiVersion(ApiVersion.low.toSemVer())
             .setLowApiVersion(new ApiVersion(100, 0, 0, "").toSemVer())
             .setHighApiVersion(new ApiVersion(100, 0, 0, "").toSemVer())
             .setCacheCapabilities(
@@ -289,8 +289,8 @@ public class RemoteServerCapabilitiesTest {
       throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.MD5)
@@ -311,8 +311,8 @@ public class RemoteServerCapabilitiesTest {
   public void testCheckClientServerCompatibility_remoteCacheDoesNotSupportUpdate() {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.SHA256)
@@ -340,8 +340,8 @@ public class RemoteServerCapabilitiesTest {
   public void testCheckClientServerCompatibility_remoteExecutionIsDisabled() throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.SHA256)
@@ -371,8 +371,8 @@ public class RemoteServerCapabilitiesTest {
       throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.SHA256)
@@ -401,8 +401,8 @@ public class RemoteServerCapabilitiesTest {
   public void testCheckClientServerCompatibility_localFallbackNoRemoteCacheUpdate() {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.SHA256)
@@ -456,8 +456,8 @@ public class RemoteServerCapabilitiesTest {
   public void testCheckClientServerCompatibility_cachePriority() throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.SHA256)
@@ -498,8 +498,8 @@ public class RemoteServerCapabilitiesTest {
   public void testCheckClientServerCompatibility_executionPriority() throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.SHA256)
@@ -563,8 +563,8 @@ public class RemoteServerCapabilitiesTest {
   public void testCheckClientServerCompatibility_executionCapsOnly() throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setExecutionCapabilities(
                 ExecutionCapabilities.newBuilder()
                     .setDigestFunction(DigestFunction.Value.SHA256)
@@ -587,8 +587,8 @@ public class RemoteServerCapabilitiesTest {
       throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setExecutionCapabilities(
                 ExecutionCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.MD5)
@@ -611,8 +611,8 @@ public class RemoteServerCapabilitiesTest {
   public void testCheckClientServerCompatibility_cacheCapsOnly() throws Exception {
     ServerCapabilities caps =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(ApiVersion.current.toSemVer())
-            .setHighApiVersion(ApiVersion.current.toSemVer())
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(DigestFunction.Value.SHA256)

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CapabilitiesServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CapabilitiesServer.java
@@ -40,12 +40,11 @@ final class CapabilitiesServer extends CapabilitiesImplBase {
   @Override
   public void getCapabilities(
       GetCapabilitiesRequest request, StreamObserver<ServerCapabilities> responseObserver) {
-    SemVer current = ApiVersion.current.toSemVer();
     DigestFunction.Value df = digestUtil.getDigestFunction();
     ServerCapabilities.Builder response =
         ServerCapabilities.newBuilder()
-            .setLowApiVersion(current)
-            .setHighApiVersion(current)
+            .setLowApiVersion(ApiVersion.low.toSemVer())
+            .setHighApiVersion(ApiVersion.high.toSemVer())
             .setCacheCapabilities(
                 CacheCapabilities.newBuilder()
                     .addDigestFunctions(df)


### PR DESCRIPTION
ApiVersion is a class that wrap around RemoteApi's SemVer proto.
We have been relying on ApiVersion.current to determine the current
version of RemoteApi that Bazel supports.

However, to start supporting newer versions of RemoteApi while providing
backward compatibility with different server implementations, we don't
want to reduce our support to a single version. Instead, we need a range
of versions that Bazel (client-side) supports to match with the range of
versions the server supports, which is provided via RemoteApi's
ServerCapabilities.

Create ClientApiVersion to supply this version range logic and move
support status check from ApiVersion to the new class.

Enhance ServerSupportedStatus with the inclusion of the highest
supported version, which could either be "null", in case of Unsupported
status, or is the highest supported version in case of Supported or
Deprecated status.

This work should enable #18270 in a future change. Previously, #18270
was reverted because backward incompatible with older RemoteApi
versions.
