### PR TITLE
singlejar: fixes to build with msys2 on Windows

### DIFF
--- a/src/main/cpp/util/numbers.h
+++ b/src/main/cpp/util/numbers.h
@@ -15,6 +15,7 @@
 #define BAZEL_SRC_MAIN_CPP_UTIL_NUMBERS_H_
 
 #include <string>
+#include <cstdint>
 
 namespace blaze_util {
 

--- a/src/tools/singlejar/diag.h
+++ b/src/tools/singlejar/diag.h
@@ -38,18 +38,18 @@
 #include <stdio.h>
 #include <string.h>
 #define _diag_msg(prefix, msg, ...) \
-  { fprintf(stderr, prefix msg "\n", __VA_ARGS__); }
+  { fprintf(stderr, prefix msg "\n", ##__VA_ARGS__); }
 #define _diag_msgx(exit_value, prefix, msg, ...) \
   { \
-    _diag_msg(prefix, msg, __VA_ARGS__); \
+    _diag_msg(prefix, msg, ##__VA_ARGS__); \
     ::ExitProcess(exit_value); \
   }
 #define diag_err(exit_value, fmt, ...) \
-  _diag_msgx(exit_value, "ERROR: ", fmt, __VA_ARGS__)
+  _diag_msgx(exit_value, "ERROR: ", fmt, ##__VA_ARGS__)
 #define diag_errx(exit_value, fmt, ...) \
-  _diag_msgx(exit_value, "ERROR: ", fmt, __VA_ARGS__)
-#define diag_warn(fmt, ...) _diag_msg("WARNING: ", fmt, __VA_ARGS__)
-#define diag_warnx(fmt, ...) _diag_msg("WARNING: ", fmt, __VA_ARGS__)
+  _diag_msgx(exit_value, "ERROR: ", fmt, ##__VA_ARGS__)
+#define diag_warn(fmt, ...) _diag_msg("WARNING: ", fmt, ##__VA_ARGS__)
+#define diag_warnx(fmt, ...) _diag_msg("WARNING: ", fmt, ##__VA_ARGS__)
 
 #else
 #error Unknown platform


### PR DESCRIPTION
singlejar is a C++ tool that Bazel builds for the executor platform. This change resolves some compile-time errors on Windows with msys2.

In src/tools/singlejar/diag.h, use ##__VA_ARGS__ instead of __VA_ARGS__. This uses a language extension implemented in MSVC, GCC, and Clang that elides the leading comma when there are no arguments. MSVC did this implicitly without ##, which is why this compiles now.

In src/main/util/numbers.h, include <cstdint> for int32_t.

Fixes #18632