### PR TITLE
[6.3.0] Update ignored_error logic for circuit_breaker

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -100,7 +101,7 @@ public class Retrier {
     State state();
 
     /** Called after an execution failed. */
-    void recordFailure(Exception e);
+    void recordFailure();
 
     /** Called after an execution succeeded. */
     void recordSuccess();
@@ -130,7 +131,7 @@ public class Retrier {
         }
 
         @Override
-        public void recordFailure(Exception e) {}
+        public void recordFailure() {}
 
         @Override
         public void recordSuccess() {}
@@ -245,12 +246,14 @@ public class Retrier {
         circuitBreaker.recordSuccess();
         return r;
       } catch (Exception e) {
-        circuitBreaker.recordFailure(e);
         Throwables.throwIfInstanceOf(e, InterruptedException.class);
-        if (State.TRIAL_CALL.equals(circuitState)) {
+        if (!shouldRetry.test(e)) {
+          // A non-retriable error doesn't represent server failure.
+          circuitBreaker.recordSuccess();
           throw e;
         }
-        if (!shouldRetry.test(e)) {
+        circuitBreaker.recordFailure();
+        if (Objects.equals(circuitState, State.TRIAL_CALL)) {
           throw e;
         }
         final long delayMillis = backoff.nextDelayMillis(e);
@@ -297,11 +300,11 @@ public class Retrier {
 
   private <T> ListenableFuture<T> onExecuteAsyncFailure(
       Exception t, AsyncCallable<T> call, Backoff backoff, State circuitState) {
-    circuitBreaker.recordFailure(t);
-    if (circuitState.equals(State.TRIAL_CALL)) {
-      return Futures.immediateFailedFuture(t);
-    }
     if (isRetriable(t)) {
+      circuitBreaker.recordFailure();
+      if (circuitState.equals(State.TRIAL_CALL)) {
+        return Futures.immediateFailedFuture(t);
+      }
       long waitMillis = backoff.nextDelayMillis(t);
       if (waitMillis >= 0) {
         try {
@@ -315,6 +318,10 @@ public class Retrier {
         return Futures.immediateFailedFuture(t);
       }
     } else {
+      // gRPC Errors NOT_FOUND, OUT_OF_RANGE, ALREADY_EXISTS etc. are non-retriable error, and they
+      // don't represent an
+      // issue in Server. So treating these errors as successful api call.
+      circuitBreaker.recordSuccess();
       return Futures.immediateFailedFuture(t);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
@@ -13,16 +13,11 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.circuitbreaker;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.remote.Retrier;
-import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 
 /** Factory for {@link Retrier.CircuitBreaker} */
 public class CircuitBreakerFactory {
-
-  public static final ImmutableSet<Class<? extends Exception>> DEFAULT_IGNORED_ERRORS =
-      ImmutableSet.of(CacheNotFoundException.class);
   public static final int DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE = 100;
 
   private CircuitBreakerFactory() {}

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.circuitbreaker;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.remote.Retrier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -32,12 +31,10 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   private State state;
   private final AtomicInteger successes;
   private final AtomicInteger failures;
-  private final AtomicInteger ignoredFailures;
   private final int failureRateThreshold;
   private final int slidingWindowSize;
   private final int minCallCountToComputeFailureRate;
   private final ScheduledExecutorService scheduledExecutor;
-  private final ImmutableSet<Class<? extends Exception>> ignoredErrors;
 
   /**
    * Creates a {@link FailureCircuitBreaker}.
@@ -49,14 +46,12 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   public FailureCircuitBreaker(int failureRateThreshold, int slidingWindowSize) {
     this.failures = new AtomicInteger(0);
     this.successes = new AtomicInteger(0);
-    this.ignoredFailures = new AtomicInteger(0);
     this.failureRateThreshold = failureRateThreshold;
     this.slidingWindowSize = slidingWindowSize;
     this.minCallCountToComputeFailureRate = CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE;
     this.state = State.ACCEPT_CALLS;
     this.scheduledExecutor =
         slidingWindowSize > 0 ? Executors.newSingleThreadScheduledExecutor() : null;
-    this.ignoredErrors = CircuitBreakerFactory.DEFAULT_IGNORED_ERRORS;
   }
 
   @Override
@@ -65,31 +60,24 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   }
 
   @Override
-  public void recordFailure(Exception e) {
-    if (!ignoredErrors.contains(e.getClass())) {
-      int failureCount = failures.incrementAndGet();
-      int totalCallCount = successes.get() + failureCount + ignoredFailures.get();
-      if (slidingWindowSize > 0) {
-        var unused =
-            scheduledExecutor.schedule(
-                failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
-      }
+  public void recordFailure() {
+    int failureCount = failures.incrementAndGet();
+    int totalCallCount = successes.get() + failureCount;
+    if (slidingWindowSize > 0) {
+      var unused =
+          scheduledExecutor.schedule(
+              failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
+    }
 
-      if (totalCallCount < minCallCountToComputeFailureRate) {
-        // The remote call count is below the threshold required to calculate the failure rate.
-        return;
-      }
-      double failureRate = (failureCount * 100.0) / totalCallCount;
+    if (totalCallCount < minCallCountToComputeFailureRate) {
+      // The remote call count is below the threshold required to calculate the failure rate.
+      return;
+    }
+    double failureRate = (failureCount * 100.0) / totalCallCount;
 
-      // Since the state can only be changed to the open state, synchronization is not required.
-      if (failureRate > this.failureRateThreshold) {
-        this.state = State.REJECT_CALLS;
-      }
-    } else {
-      ignoredFailures.incrementAndGet();
-      if (slidingWindowSize > 0) {
-        scheduledExecutor.schedule(ignoredFailures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
-      }
+    // Since the state can only be changed to the open state, synchronization is not required.
+    if (failureRate > this.failureRateThreshold) {
+      this.state = State.REJECT_CALLS;
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -15,10 +15,7 @@ package com.google.devtools.build.lib.remote.circuitbreaker;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import build.bazel.remote.execution.v2.Digest;
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
-import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -33,36 +30,37 @@ import java.util.stream.IntStream;
 public class FailureCircuitBreakerTest {
 
   @Test
-  public void testRecordFailure_withIgnoredErrors() throws InterruptedException {
+  public void testRecordFailure_circuitTrips() throws InterruptedException {
     final int failureRateThreshold = 10;
     final int windowInterval = 100;
     FailureCircuitBreaker failureCircuitBreaker =
         new FailureCircuitBreaker(failureRateThreshold, windowInterval);
 
-    List<Exception> listOfExceptionThrownOnFailure = new ArrayList<>();
+    List<Runnable> listOfSuccessAndFailureCalls = new ArrayList<>();
     for (int index = 0; index < failureRateThreshold; index++) {
-      listOfExceptionThrownOnFailure.add(new Exception());
-    }
-    for (int index = 0; index < failureRateThreshold * 9; index++) {
-      listOfExceptionThrownOnFailure.add(new CacheNotFoundException(Digest.newBuilder().build()));
+      listOfSuccessAndFailureCalls.add(failureCircuitBreaker::recordFailure);
     }
 
-    Collections.shuffle(listOfExceptionThrownOnFailure);
+    for (int index = 0; index < failureRateThreshold * 9; index++) {
+      listOfSuccessAndFailureCalls.add(failureCircuitBreaker::recordSuccess);
+    }
+
+    Collections.shuffle(listOfSuccessAndFailureCalls);
 
     // make calls equals to threshold number of not ignored failure calls in parallel.
-    listOfExceptionThrownOnFailure.stream().parallel().forEach(failureCircuitBreaker::recordFailure);
+    listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
     // Sleep for windowInterval + 1ms.
     Thread.sleep(windowInterval + 1 /*to compensate any delay*/);
 
     // make calls equals to threshold number of not ignored failure calls in parallel.
-    listOfExceptionThrownOnFailure.stream().parallel().forEach(failureCircuitBreaker::recordFailure);
+    listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
     // Sleep for less than windowInterval.
     Thread.sleep(windowInterval - 5);
-    failureCircuitBreaker.recordFailure(new Exception());
+    failureCircuitBreaker.recordFailure();
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 
@@ -74,15 +72,19 @@ public class FailureCircuitBreakerTest {
     FailureCircuitBreaker failureCircuitBreaker =
         new FailureCircuitBreaker(failureRateThreshold, windowInterval);
 
-    // make half failure call, half success call and number of total call less than minCallToComputeFailure.
-    IntStream.range(0, minCallToComputeFailure >> 1).parallel()
-        .forEach(i -> failureCircuitBreaker.recordFailure(new Exception()));
-    IntStream.range(0, minCallToComputeFailure >> 1).parallel().forEach(i -> failureCircuitBreaker.recordSuccess());
+    // make half failure call, half success call and number of total call less than
+    // minCallToComputeFailure.
+    IntStream.range(0, minCallToComputeFailure >> 1)
+        .parallel()
+        .forEach(i -> failureCircuitBreaker.recordFailure());
+    IntStream.range(0, minCallToComputeFailure >> 1)
+        .parallel()
+        .forEach(i -> failureCircuitBreaker.recordSuccess());
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
     // Sleep for less than windowInterval.
-    Thread.sleep(windowInterval - 20);
-    failureCircuitBreaker.recordFailure(new Exception());
+    Thread.sleep(windowInterval - 50);
+    failureCircuitBreaker.recordFailure();
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
   }
 }


### PR DESCRIPTION
When the digest size exceeds the max configured digest size by remote-cache, an "out_of_range" error is returned. These errors should not be considered as API failures for the circuit breaker logic, as they do not indicate any issues with the remote-cache service.
Similarly there are other non-retriable errors that should not be treated as server failure such as ALREADY_EXISTS.

This change considers non-retriable errors as user/client error and logs them as success. While retriable errors such `DEADLINE_EXCEEDED`, `UNKNOWN` etc are logged as failure.

Related PRs

Closes #18613.

PiperOrigin-RevId: 539948823
Change-Id: I5b51f6a3aecab7c17d73f78b8234d9a6da49fe6c
