### PR TITLE
[6.3.0] Adds a flag to enable coverage for generated source files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -536,6 +536,11 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
     return options.instrumentTestTargets;
   }
 
+  /** Returns a boolean of whether to collect code coverage for generated files or not. */
+  public boolean shouldCollectCodeCoverageForGeneratedFiles() {
+    return options.collectCodeCoverageForGeneratedFiles;
+  }
+
   /**
    * Returns a new, unordered mapping of names to values of "Make" variables defined by this
    * configuration.

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -426,6 +426,16 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public boolean collectCodeCoverage;
 
   @Option(
+      name = "experimental_collect_code_coverage_for_generated_files",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      help =
+          "If specified, Bazel will also generate collect coverage information for generated"
+              + " files.")
+  public boolean collectCodeCoverageForGeneratedFiles;
+
+  @Option(
       name = "build_runfile_manifests",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
@@ -213,8 +213,8 @@ public final class InstrumentedFilesCollector {
       for (TransitiveInfoCollection dep :
           getPrerequisitesForAttributes(ruleContext, spec.sourceAttributes)) {
         for (Artifact artifact : dep.getProvider(FileProvider.class).getFilesToBuild().toList()) {
-          if (artifact.isSourceArtifact() &&
-              spec.instrumentedFileTypes.matches(artifact.getFilename())) {
+          if (shouldIncludeArtifact(ruleContext.getConfiguration(), artifact)
+              && spec.instrumentedFileTypes.matches(artifact.getFilename())) {
             localSourcesBuilder.add(artifact);
           }
         }
@@ -260,6 +260,14 @@ public final class InstrumentedFilesCollector {
       BuildConfigurationValue config, Label label, boolean isTest) {
     return ((config.shouldInstrumentTestTargets() || !isTest)
         && config.getInstrumentationFilter().isIncluded(label.toString()));
+  }
+
+  /**
+   * Return whether the artifact should be collected based on the origin of the artifact and the
+   * --experimental_collect_code_coverage_for_generated_files config setting.
+   */
+  public static boolean shouldIncludeArtifact(BuildConfigurationValue config, Artifact artifact) {
+    return artifact.isSourceArtifact() || config.shouldCollectCodeCoverageForGeneratedFiles();
   }
 
   /**


### PR DESCRIPTION
Closes #11350.

Commit https://github.com/bazelbuild/bazel/commit/9c83049a707a761db8bb2450f105e9e9c66a87be

RELNOTES: Add flag --experimental_collect_code_coverage_for_generated_files.
PiperOrigin-RevId: 539648731
Change-Id: I352de7a74c522db6fbe5e10a21268914d1e39d58