### PR TITLE
Fix OOM in `Runfiles#describeKey`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetFingerprintCache.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetFingerprintCache.java
@@ -84,7 +84,7 @@ public class NestedSetFingerprintCache {
     sb.append("size: ").append(list.size()).append('\n');
     for (T item : list) {
       sb.append("  ");
-      mapFn.expandToCommandLine(item, s -> sb.append(sb).append(", "));
+      mapFn.expandToCommandLine(item, s -> sb.append(s).append(", "));
       sb.append('\n');
     }
     return sb.toString();


### PR DESCRIPTION
`describedNestedSetFingerprint` appended a `StringBuilder` to itself in a loop instead of the actual item from the nested set.