### PR TITLE
Fix OOM in `describeNestedSetFingerprint`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetFingerprintCache.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetFingerprintCache.java
@@ -60,6 +60,23 @@ public class NestedSetFingerprintCache {
     addToFingerprint(mapFn, fingerprint, digestMap, children);
   }
 
+  public static <T> String describedNestedSetFingerprint(
+      CommandLineItem.ExceptionlessMapFn<? super T> mapFn, NestedSet<T> nestedSet) {
+    if (nestedSet.isEmpty()) {
+      return "<empty>";
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append("order: ").append(nestedSet.getOrder()).append('\n');
+    ImmutableList<T> list = nestedSet.toList();
+    sb.append("size: ").append(list.size()).append('\n');
+    for (T item : list) {
+      sb.append("  ");
+      mapFn.expandToCommandLine(item, s -> sb.append(s).append(", "));
+      sb.append('\n');
+    }
+    return sb.toString();
+  }
+
   private <T> void addNestedSetToFingerprintSlow(
       MapFn<? super T> mapFn, Fingerprint fingerprint, NestedSet<T> nestedSet)
       throws CommandLineExpansionException, InterruptedException {


### PR DESCRIPTION
`describedNestedSetFingerprint` appended a `StringBuilder` to itself in a loop instead of the actual item from the nested set, resulting in OOMs in `Runfiles#describeKey` and `RepoMappingManifestAction#describeKey`.

Work towards #18666

Closes #18668.

Commit https://github.com/bazelbuild/bazel/commit/a6a874ba098a3df5cf53aaf38d77352d8e087796

PiperOrigin-RevId: 540270874
Change-Id: Id408ab4c2438bea264b586f8ae5567dc41260242