### PR TITLE
Fixed links to types in language.md

### DIFF
--- a/site/en/rules/language.md
+++ b/site/en/rules/language.md
@@ -41,8 +41,8 @@ types are supported:
 * [None](lib/globals#None)
 * [bool](lib/bool)
 * [dict](lib/dict)
-* [tuple](lib/globals#tuple)
-* function
+* [tuple](lib/tuple)
+* [function](lib/function)
 * [int](lib/int)
 * [list](lib/list)
 * [string](lib/string)


### PR DESCRIPTION
The "tuple" and "function" links were inconsistent.

I'm not entirely sure how to test this.