### PR TITLE
Add BLAKE3 digest function to remote_execution.proto

### DIFF
--- a/third_party/remoteapis/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/third_party/remoteapis/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1885,6 +1885,10 @@ message DigestFunction {
     // Test vectors of this digest function can be found in the
     // accompanying sha256tree_test_vectors.txt file.
     SHA256TREE = 8;
+
+    // The BLAKE3 hash function.
+    // See https://github.com/BLAKE3-team/BLAKE3.
+    BLAKE3 = 9;
   }
 }
 


### PR DESCRIPTION
Add BLAKE3 digest function to remote_execution.proto

In https://github.com/bazelbuild/remote-apis/pull/248, BLAKE3 support was added
to remote-apis.

This PR mirrors that change in bazel's local copy of remote_execution.proto.

This is a partial commit for #18658.
