### PR TITLE
Add BLAKE3 source code to third_party

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -194,6 +194,14 @@ dist_http_archive(
     strip_prefix = "zstd-jni-1.5.2-3",
 )
 
+dist_http_archive(
+    name = "blake3",
+    build_file = "//third_party:blake3/blake3.BUILD",
+    patch_cmds = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE,
+    patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE_WIN,
+    strip_prefix = "BLAKE3-1.3.3",
+)
+
 http_archive(
     name = "org_snakeyaml",
     build_file_content = """

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -270,6 +270,21 @@ DIST_DEPS = {
         "license_text": "LICENSE",
         "package_version": "1.5.2-3",
     },
+    "blake3": {
+        "archive": "v1.3.3.zip",
+        "sha256": "bb529ba133c0256df49139bd403c17835edbf60d2ecd6463549c6a5fe279364d",
+        "urls": [
+            "https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/1.3.3.zip",
+        ],
+        "used_in": [
+            "additional_distfiles",
+        ],
+        "license_kinds": [
+            "@rules_license//licenses/spdx:Apache-2.0",
+        ],
+        "license_text": "LICENSE",
+        "package_version": "1.3.3",
+    },
     ###################################################
     #
     # Build time dependencies for testing and packaging

--- a/third_party/blake3/blake3.BUILD
+++ b/third_party/blake3/blake3.BUILD
@@ -1,0 +1,83 @@
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+licenses(["notice"])  #  BSD/MIT-like license
+
+exports_files(["LICENSE"])
+
+license(
+    name = "license",
+    package_name = "blake3",
+    license_kinds = [
+        "@rules_license//licenses/spdx:Apache-2.0",
+    ],
+    license_text = "LICENSE",
+    package_version = "1.3.3",
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//third_party:__pkg__"],
+)
+
+cc_library(
+    name = "blake3",
+    srcs = [
+        "c/blake3.c",
+        "c/blake3_dispatch.c",
+        "c/blake3_portable.c",
+    ] + select({
+        "@bazel_tools//src/conditions:linux_x86_64": [
+            "c/blake3_avx2_x86-64_unix.S",
+            "c/blake3_avx512_x86-64_unix.S",
+            "c/blake3_sse2_x86-64_unix.S",
+            "c/blake3_sse41_x86-64_unix.S",
+        ],
+        "@bazel_tools//src/conditions:windows_x64": [
+            "c/blake3_avx2_x86-64_windows_msvc.asm",
+            "c/blake3_avx512_x86-64_windows_msvc.asm",
+            "c/blake3_sse2_x86-64_windows_msvc.asm",
+            "c/blake3_sse41_x86-64_windows_msvc.asm",
+        ],
+        "@bazel_tools//src/conditions:darwin_arm64": [
+            "c/blake3_neon.c",
+        ],
+        "//conditions:default": [],
+    }),
+    hdrs = [
+        "c/blake3.h",
+        "c/blake3_impl.h",
+    ],
+    copts = select({
+        "@bazel_tools//src/conditions:linux_x86_64": [],
+        "@bazel_tools//src/conditions:windows_x64": [],
+        "@bazel_tools//src/conditions:darwin_arm64": [
+            "-DBLAKE3_USE_NEON=1",
+        ],
+        "//conditions:default": [
+            "-DBLAKE3_NO_SSE2",
+            "-DBLAKE3_NO_SSE41",
+            "-DBLAKE3_NO_AVX2",
+            "-DBLAKE3_NO_AVX512",
+        ],
+    }),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "example",
+    srcs = [
+        "c/example.c",
+    ],
+    copts = [
+        "-w",
+        "-O3",
+    ],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":blake3",
+    ],
+)


### PR DESCRIPTION
Add BLAKE3 source code to third_party

This PR adds the BLAKE3 C and asm sources to third_party, and includes a BUILD
file to build them.

This is a partial commit for #18658.
