### PR TITLE
Prevent most side effects of yanked modules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -48,6 +48,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.RegistryFactoryImpl;
 import com.google.devtools.build.lib.bazel.bzlmod.RepoSpec;
 import com.google.devtools.build.lib.bazel.bzlmod.SingleExtensionEvalFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.SingleExtensionUsagesFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.commands.FetchCommand;
 import com.google.devtools.build.lib.bazel.commands.ModqueryCommand;
 import com.google.devtools.build.lib.bazel.commands.SyncCommand;
@@ -590,7 +591,7 @@ public class BazelRepositoryModule extends BlazeModule {
             BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE, bazelCompatibilityMode),
         PrecomputedValue.injected(BazelLockFileFunction.LOCKFILE_MODE, bazelLockfileMode),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, allowedYankedVersions));
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, allowedYankedVersions));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -168,6 +168,7 @@ java_library(
         "SingleExtensionUsagesFunction.java",
         "StarlarkBazelModule.java",
         "TypeCheckedTag.java",
+        "YankedVersionsUtil.java",
     ],
     deps = [
         ":common",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -168,7 +168,7 @@ public class BazelDepGraphFunction implements SkyFunction {
         (ClientEnvironmentValue)
             env.getValue(
                 ClientEnvironmentFunction.key(
-                    BazelModuleResolutionFunction.BZLMOD_ALLOWED_YANKED_VERSIONS_ENV));
+                    YankedVersionsUtil.BZLMOD_ALLOWED_YANKED_VERSIONS_ENV));
     if (allowedYankedVersionsFromEnv == null) {
       return null;
     }
@@ -180,7 +180,7 @@ public class BazelDepGraphFunction implements SkyFunction {
                 toImmutableMap(e -> e.getKey(), e -> ((LocalPathOverride) e.getValue()).getPath()));
 
     ImmutableList<String> yankedVersions =
-        ImmutableList.copyOf(BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.get(env));
+        ImmutableList.copyOf(YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.get(env));
     Boolean ignoreDevDeps = ModuleFileFunction.IGNORE_DEV_DEPS.get(env);
     String compatabilityMode =
         BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.get(env).name();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
@@ -15,21 +15,17 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
-import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.bazel.BazelVersion;
 import com.google.devtools.build.lib.bazel.bzlmod.InterimModule.DepSpec;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
-import com.google.devtools.build.lib.bazel.bzlmod.Version.ParseException;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
-import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -43,10 +39,8 @@ import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -59,10 +53,6 @@ public class BazelModuleResolutionFunction implements SkyFunction {
       new Precomputed<>("check_direct_dependency");
   public static final Precomputed<BazelCompatibilityMode> BAZEL_COMPATIBILITY_MODE =
       new Precomputed<>("bazel_compatibility_mode");
-  public static final Precomputed<List<String>> ALLOWED_YANKED_VERSIONS =
-      new Precomputed<>("allowed_yanked_versions");
-
-  public static final String BZLMOD_ALLOWED_YANKED_VERSIONS_ENV = "BZLMOD_ALLOW_YANKED_VERSIONS";
 
   @Override
   @Nullable
@@ -71,7 +61,9 @@ public class BazelModuleResolutionFunction implements SkyFunction {
 
     ClientEnvironmentValue allowedYankedVersionsFromEnv =
         (ClientEnvironmentValue)
-            env.getValue(ClientEnvironmentFunction.key(BZLMOD_ALLOWED_YANKED_VERSIONS_ENV));
+            env.getValue(
+                ClientEnvironmentFunction.key(
+                    YankedVersionsUtil.BZLMOD_ALLOWED_YANKED_VERSIONS_ENV));
     if (allowedYankedVersionsFromEnv == null) {
       return null;
     }
@@ -104,12 +96,7 @@ public class BazelModuleResolutionFunction implements SkyFunction {
         Objects.requireNonNull(BAZEL_COMPATIBILITY_MODE.get(env)),
         env.getListener());
 
-    verifyYankedVersions(
-        resolvedDepGraph,
-        parseYankedVersions(
-            allowedYankedVersionsFromEnv.getValue(),
-            Objects.requireNonNull(ALLOWED_YANKED_VERSIONS.get(env))),
-        env.getListener());
+    verifyYankedVersions(resolvedDepGraph);
 
     ImmutableMap<ModuleKey, Module> finalDepGraph =
         computeFinalDepGraph(resolvedDepGraph, root.getOverrides(), env.getListener());
@@ -194,125 +181,15 @@ public class BazelModuleResolutionFunction implements SkyFunction {
     }
   }
 
-  /**
-   * Parse a set of allowed yanked version from command line flag (--allowed_yanked_versions) and
-   * environment variable (ALLOWED_YANKED_VERSIONS). If `all` is specified, return Optional.empty();
-   * otherwise returns the set of parsed modulel key.
-   */
-  private Optional<ImmutableSet<ModuleKey>> parseYankedVersions(
-      String allowedYankedVersionsFromEnv, List<String> allowedYankedVersionsFromFlag)
+  private static void verifyYankedVersions(ImmutableMap<ModuleKey, InterimModule> depGraph)
       throws BazelModuleResolutionFunctionException {
-    ImmutableSet.Builder<ModuleKey> allowedYankedVersionBuilder = new ImmutableSet.Builder<>();
-    if (allowedYankedVersionsFromEnv != null) {
-      if (parseModuleKeysFromString(
-          allowedYankedVersionsFromEnv,
-          allowedYankedVersionBuilder,
-          String.format(
-              "envirnoment variable %s=%s",
-              BZLMOD_ALLOWED_YANKED_VERSIONS_ENV, allowedYankedVersionsFromEnv))) {
-        return Optional.empty();
-      }
-    }
-    for (String allowedYankedVersions : allowedYankedVersionsFromFlag) {
-      if (parseModuleKeysFromString(
-          allowedYankedVersions,
-          allowedYankedVersionBuilder,
-          String.format("command line flag --allow_yanked_versions=%s", allowedYankedVersions))) {
-        return Optional.empty();
-      }
-    }
-    return Optional.of(allowedYankedVersionBuilder.build());
-  }
-
-  /**
-   * Parse of a comma-separated list of module version(s) of the form '<module name>@<version>' or
-   * 'all' from the string. Returns true if 'all' is present, otherwise returns false.
-   */
-  private boolean parseModuleKeysFromString(
-      String input, ImmutableSet.Builder<ModuleKey> allowedYankedVersionBuilder, String context)
-      throws BazelModuleResolutionFunctionException {
-    ImmutableList<String> moduleStrs = ImmutableList.copyOf(Splitter.on(',').split(input));
-
-    for (String moduleStr : moduleStrs) {
-      if (moduleStr.equals("all")) {
-        return true;
-      }
-
-      if (moduleStr.isEmpty()) {
-        continue;
-      }
-
-      String[] pieces = moduleStr.split("@", 2);
-
-      if (pieces.length != 2) {
-        throw new BazelModuleResolutionFunctionException(
-            ExternalDepsException.withMessage(
-                Code.VERSION_RESOLUTION_ERROR,
-                "Parsing %s failed, module versions must be of the form '<module name>@<version>'",
-                context),
-            Transience.PERSISTENT);
-      }
-
-      if (!RepositoryName.VALID_MODULE_NAME.matcher(pieces[0]).matches()) {
-        throw new BazelModuleResolutionFunctionException(
-            ExternalDepsException.withMessage(
-                Code.VERSION_RESOLUTION_ERROR,
-                "Parsing %s failed, invalid module name '%s': valid names must 1) only contain"
-                    + " lowercase letters (a-z), digits (0-9), dots (.), hyphens (-), and"
-                    + " underscores (_); 2) begin with a lowercase letter; 3) end with a lowercase"
-                    + " letter or digit.",
-                context,
-                pieces[0]),
-            Transience.PERSISTENT);
-      }
-
-      Version version;
-      try {
-        version = Version.parse(pieces[1]);
-      } catch (ParseException e) {
-        throw new BazelModuleResolutionFunctionException(
-            ExternalDepsException.withCauseAndMessage(
-                Code.VERSION_RESOLUTION_ERROR,
-                e,
-                "Parsing %s failed, invalid version specified for module: %s",
-                context,
-                pieces[1]),
-            Transience.PERSISTENT);
-      }
-
-      allowedYankedVersionBuilder.add(ModuleKey.create(pieces[0], version));
-    }
-    return false;
-  }
-
-  private static void verifyYankedVersions(
-      ImmutableMap<ModuleKey, InterimModule> depGraph,
-      Optional<ImmutableSet<ModuleKey>> allowedYankedVersions,
-      ExtendedEventHandler eventHandler)
-      throws BazelModuleResolutionFunctionException, InterruptedException {
     // Check whether all resolved modules are either not yanked or allowed. Modules with a
     // NonRegistryOverride are ignored as their metadata is not available whatsoever.
     for (InterimModule m : depGraph.values()) {
       if (m.getKey().equals(ModuleKey.ROOT) || m.getRegistry() == null) {
         continue;
       }
-      Optional<ImmutableMap<Version, String>> yankedVersions;
-      try {
-        yankedVersions = m.getRegistry().getYankedVersions(m.getKey().getName(), eventHandler);
-      } catch (IOException e) {
-        eventHandler.handle(
-            Event.warn(
-                String.format(
-                    "Could not read metadata file for module %s: %s", m.getKey(), e.getMessage())));
-        continue;
-      }
-      if (yankedVersions.isEmpty()) {
-        continue;
-      }
-      String yankedInfo = yankedVersions.get().get(m.getVersion());
-      if (yankedInfo != null
-          && allowedYankedVersions.isPresent()
-          && !allowedYankedVersions.get().contains(m.getKey())) {
+      if (m.getYankedInfo().isPresent()) {
         throw new BazelModuleResolutionFunctionException(
             ExternalDepsException.withMessage(
                 Code.VERSION_RESOLUTION_ERROR,
@@ -322,7 +199,7 @@ public class BazelModuleResolutionFunction implements SkyFunction {
                     + "continue using this version, allow it using the --allow_yanked_versions "
                     + "flag or the BZLMOD_ALLOW_YANKED_VERSIONS env variable.",
                 m.getKey(),
-                yankedInfo),
+                m.getYankedInfo().get()),
             Transience.PERSISTENT);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -50,6 +50,9 @@ public abstract class InterimModule extends ModuleBase {
   /** List of bazel compatible versions that would run/fail this module */
   public abstract ImmutableList<String> getBazelCompatibility();
 
+  /** The reason why this module was yanked or empty if it hasn't been yanked. */
+  public abstract Optional<String> getYankedInfo();
+
   /** The specification of a dependency. */
   @AutoValue
   public abstract static class DepSpec {
@@ -102,7 +105,8 @@ public abstract class InterimModule extends ModuleBase {
         .setName("")
         .setVersion(Version.EMPTY)
         .setKey(ModuleKey.ROOT)
-        .setCompatibilityLevel(0);
+        .setCompatibilityLevel(0)
+        .setYankedInfo(Optional.empty());
   }
 
   /**
@@ -132,6 +136,9 @@ public abstract class InterimModule extends ModuleBase {
 
     /** Optional; defaults to {@link #setName}. */
     public abstract Builder setRepoName(String value);
+
+    /** Optional; defaults to {@link Optional#empty()}. */
+    public abstract Builder setYankedInfo(Optional<String> value);
 
     public abstract Builder setBazelCompatibility(ImmutableList<String> value);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.NonRootModuleFileValue;
@@ -28,6 +29,8 @@ import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps.Code;
+import com.google.devtools.build.lib.skyframe.ClientEnvironmentFunction;
+import com.google.devtools.build.lib.skyframe.ClientEnvironmentValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue.Precomputed;
 import com.google.devtools.build.lib.util.Fingerprint;
@@ -102,10 +105,29 @@ public class ModuleFileFunction implements SkyFunction {
       return computeForRootModule(starlarkSemantics, env);
     }
 
+    ClientEnvironmentValue allowedYankedVersionsFromEnv =
+        (ClientEnvironmentValue)
+            env.getValue(
+                ClientEnvironmentFunction.key(
+                    YankedVersionsUtil.BZLMOD_ALLOWED_YANKED_VERSIONS_ENV));
+    if (allowedYankedVersionsFromEnv == null) {
+      return null;
+    }
+
+    Optional<ImmutableSet<ModuleKey>> allowedYankedVersions;
+    try {
+      allowedYankedVersions =
+          YankedVersionsUtil.parseYankedVersions(
+              allowedYankedVersionsFromEnv.getValue(),
+              Objects.requireNonNull(YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.get(env)));
+    } catch (ExternalDepsException e) {
+      throw new ModuleFileFunctionException(e, SkyFunctionException.Transience.PERSISTENT);
+    }
+
     ModuleFileValue.Key moduleFileKey = (ModuleFileValue.Key) skyKey;
     ModuleKey moduleKey = moduleFileKey.getModuleKey();
     GetModuleFileResult getModuleFileResult =
-        getModuleFile(moduleKey, moduleFileKey.getOverride(), env);
+        getModuleFile(moduleKey, moduleFileKey.getOverride(), allowedYankedVersions, env);
     if (getModuleFileResult == null) {
       return null;
     }
@@ -119,6 +141,8 @@ public class ModuleFileFunction implements SkyFunction {
             moduleKey,
             // Dev dependencies should always be ignored if the current module isn't the root module
             /* ignoreDevDeps= */ true,
+            // We try to prevent most side effects of yanked modules, in particular print().
+            /* printIsNoop= */ getModuleFileResult.yankedInfo != null,
             starlarkSemantics,
             env);
 
@@ -137,6 +161,23 @@ public class ModuleFileFunction implements SkyFunction {
           "the MODULE.bazel file of %s declares a different version (%s)",
           moduleKey,
           module.getVersion());
+    }
+
+    if (getModuleFileResult.yankedInfo != null) {
+      // Yanked modules should not have observable side effects such as adding dependency
+      // requirements, so we drop those from the constructed module. We do have to preserve the
+      // compatibility level as it influences the set of versions the yanked version can be updated
+      // to during selection.
+      return NonRootModuleFileValue.create(
+          InterimModule.builder()
+              .setKey(module.getKey())
+              .setName(module.getName())
+              .setVersion(module.getVersion())
+              .setCompatibilityLevel(module.getCompatibilityLevel())
+              .setRegistry(module.getRegistry())
+              .setYankedInfo(Optional.of(getModuleFileResult.yankedInfo))
+              .build(),
+          moduleFileHash);
     }
 
     return NonRootModuleFileValue.create(module, moduleFileHash);
@@ -159,6 +200,7 @@ public class ModuleFileFunction implements SkyFunction {
             /* registry= */ null,
             ModuleKey.ROOT,
             /* ignoreDevDeps= */ Objects.requireNonNull(IGNORE_DEV_DEPS.get(env)),
+            /* printIsNoop=*/ false,
             starlarkSemantics,
             env);
     InterimModule module = moduleFileGlobals.buildModule();
@@ -193,6 +235,7 @@ public class ModuleFileFunction implements SkyFunction {
       @Nullable Registry registry,
       ModuleKey moduleKey,
       boolean ignoreDevDeps,
+      boolean printIsNoop,
       StarlarkSemantics starlarkSemantics,
       Environment env)
       throws ModuleFileFunctionException, InterruptedException {
@@ -211,7 +254,11 @@ public class ModuleFileFunction implements SkyFunction {
       Program program = Program.compileFile(starlarkFile, predeclaredEnv);
       // TODO(wyv): check that `program` has no `def`, `if`, etc
       StarlarkThread thread = new StarlarkThread(mu, starlarkSemantics);
-      thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
+      if (printIsNoop) {
+        thread.setPrintHandler((t, msg) -> {});
+      } else {
+        thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
+      }
       Starlark.execFileProgram(program, predeclaredEnv, thread);
     } catch (SyntaxError.Exception e) {
       Event.replayEventsOn(env.getListener(), e.errors());
@@ -225,13 +272,19 @@ public class ModuleFileFunction implements SkyFunction {
 
   private static class GetModuleFileResult {
     ModuleFile moduleFile;
+    // `yankedInfo` is non-null if and only if the module has been yanked and hasn't been
+    // allowlisted.
+    @Nullable String yankedInfo;
     // `registry` can be null if this module has a non-registry override.
     @Nullable Registry registry;
   }
 
   @Nullable
   private GetModuleFileResult getModuleFile(
-      ModuleKey key, @Nullable ModuleOverride override, Environment env)
+      ModuleKey key,
+      @Nullable ModuleOverride override,
+      Optional<ImmutableSet<ModuleKey>> allowedYankedVersions,
+      Environment env)
       throws ModuleFileFunctionException, InterruptedException {
     // If there is a non-registry override for this module, we need to fetch the corresponding repo
     // first and read the module file from there.
@@ -291,6 +344,8 @@ public class ModuleFileFunction implements SkyFunction {
         }
         result.moduleFile = moduleFile.get();
         result.registry = registry;
+        YankedVersionsUtil.getYankedInfo(registry, key, allowedYankedVersions, env.getListener())
+            .ifPresent(yankedInfo -> result.yankedInfo = yankedInfo);
         return result;
       } catch (IOException e) {
         throw errorf(
@@ -333,6 +388,10 @@ public class ModuleFileFunction implements SkyFunction {
 
     ModuleFileFunctionException(ExternalDepsException cause) {
       super(cause, Transience.TRANSIENT);
+    }
+
+    ModuleFileFunctionException(ExternalDepsException cause, Transience transience) {
+      super(cause, transience);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -117,7 +117,7 @@ public class ModuleFileFunction implements SkyFunction {
     Optional<ImmutableSet<ModuleKey>> allowedYankedVersions;
     try {
       allowedYankedVersions =
-          YankedVersionsUtil.parseYankedVersions(
+          YankedVersionsUtil.parseAllowedYankedVersions(
               allowedYankedVersionsFromEnv.getValue(),
               Objects.requireNonNull(YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.get(env)));
     } catch (ExternalDepsException e) {
@@ -344,8 +344,10 @@ public class ModuleFileFunction implements SkyFunction {
         }
         result.moduleFile = moduleFile.get();
         result.registry = registry;
-        YankedVersionsUtil.getYankedInfo(registry, key, allowedYankedVersions, env.getListener())
-            .ifPresent(yankedInfo -> result.yankedInfo = yankedInfo);
+        result.yankedInfo =
+            YankedVersionsUtil.getYankedInfo(
+                    registry, key, allowedYankedVersions, env.getListener())
+                .orElse(null);
         return result;
       } catch (IOException e) {
         throw errorf(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsUtil.java
@@ -1,0 +1,144 @@
+package com.google.devtools.build.lib.bazel.bzlmod;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.server.FailureDetails;
+import com.google.devtools.build.lib.skyframe.PrecomputedValue;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/** Utility class to parse and evaluate yanked version specifications and exceptions. */
+public final class YankedVersionsUtil {
+
+  public static final PrecomputedValue.Precomputed<List<String>> ALLOWED_YANKED_VERSIONS =
+      new PrecomputedValue.Precomputed<>("allowed_yanked_versions");
+  public static final String BZLMOD_ALLOWED_YANKED_VERSIONS_ENV = "BZLMOD_ALLOW_YANKED_VERSIONS";
+
+  /**
+   * Parse a set of allowed yanked version from command line flag (--allowed_yanked_versions) and
+   * environment variable (ALLOWED_YANKED_VERSIONS). If `all` is specified, return Optional.empty();
+   * otherwise returns the set of parsed modulel key.
+   */
+  static Optional<ImmutableSet<ModuleKey>> parseYankedVersions(
+      String allowedYankedVersionsFromEnv, List<String> allowedYankedVersionsFromFlag)
+      throws ExternalDepsException {
+    ImmutableSet.Builder<ModuleKey> allowedYankedVersionBuilder = new ImmutableSet.Builder<>();
+    if (allowedYankedVersionsFromEnv != null) {
+      if (parseModuleKeysFromString(
+          allowedYankedVersionsFromEnv,
+          allowedYankedVersionBuilder,
+          String.format(
+              "environment variable %s=%s",
+              BZLMOD_ALLOWED_YANKED_VERSIONS_ENV, allowedYankedVersionsFromEnv))) {
+        return Optional.empty();
+      }
+    }
+    for (String allowedYankedVersions : allowedYankedVersionsFromFlag) {
+      if (parseModuleKeysFromString(
+          allowedYankedVersions,
+          allowedYankedVersionBuilder,
+          String.format("command line flag --allow_yanked_versions=%s", allowedYankedVersions))) {
+        return Optional.empty();
+      }
+    }
+    return Optional.of(allowedYankedVersionBuilder.build());
+  }
+
+  /**
+   * Returns the reason for the given module being yanked, or {@code Optional.empty()} if the module
+   * is not yanked or explicitly allowed despite being yanked.
+   */
+  static Optional<String> getYankedInfo(
+      Registry registry,
+      ModuleKey key,
+      Optional<ImmutableSet<ModuleKey>> allowedYankedVersions,
+      ExtendedEventHandler eventHandler)
+      throws InterruptedException {
+    Optional<ImmutableMap<Version, String>> yankedVersions;
+    try {
+      yankedVersions = registry.getYankedVersions(key.getName(), eventHandler);
+    } catch (IOException e) {
+      eventHandler.handle(
+          Event.warn(
+              String.format(
+                  "Could not read metadata file for module %s: %s", key, e.getMessage())));
+      // This is failing open: If we can't read the metadata file, we allow yanked modules to be
+      // fetched.
+      return Optional.empty();
+    }
+    if (yankedVersions.isEmpty()) {
+      return Optional.empty();
+    }
+    String yankedInfo = yankedVersions.get().get(key.getVersion());
+    if (yankedInfo != null
+        && allowedYankedVersions.isPresent()
+        && !allowedYankedVersions.get().contains(key)) {
+      return Optional.of(yankedInfo);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Parse of a comma-separated list of module version(s) of the form '<module name>@<version>' or
+   * 'all' from the string. Returns true if 'all' is present, otherwise returns false.
+   */
+  private static boolean parseModuleKeysFromString(
+      String input, ImmutableSet.Builder<ModuleKey> allowedYankedVersionBuilder, String context)
+      throws ExternalDepsException {
+    ImmutableList<String> moduleStrs = ImmutableList.copyOf(Splitter.on(',').split(input));
+
+    for (String moduleStr : moduleStrs) {
+      if (moduleStr.equals("all")) {
+        return true;
+      }
+
+      if (moduleStr.isEmpty()) {
+        continue;
+      }
+
+      String[] pieces = moduleStr.split("@", 2);
+
+      if (pieces.length != 2) {
+        throw ExternalDepsException.withMessage(
+            FailureDetails.ExternalDeps.Code.VERSION_RESOLUTION_ERROR,
+            "Parsing %s failed, module versions must be of the form '<module name>@<version>'",
+            context);
+      }
+
+      if (!RepositoryName.VALID_MODULE_NAME.matcher(pieces[0]).matches()) {
+        throw ExternalDepsException.withMessage(
+            FailureDetails.ExternalDeps.Code.VERSION_RESOLUTION_ERROR,
+            "Parsing %s failed, invalid module name '%s': valid names must 1) only contain"
+                + " lowercase letters (a-z), digits (0-9), dots (.), hyphens (-), and"
+                + " underscores (_); 2) begin with a lowercase letter; 3) end with a lowercase"
+                + " letter or digit.",
+            context,
+            pieces[0]);
+      }
+
+      Version version;
+      try {
+        version = Version.parse(pieces[1]);
+      } catch (Version.ParseException e) {
+        throw ExternalDepsException.withCauseAndMessage(
+            FailureDetails.ExternalDeps.Code.VERSION_RESOLUTION_ERROR,
+            e,
+            "Parsing %s failed, invalid version specified for module: %s",
+            context,
+            pieces[1]);
+      }
+
+      allowedYankedVersionBuilder.add(ModuleKey.create(pieces[0], version));
+    }
+    return false;
+  }
+
+  private YankedVersionsUtil() {}
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsUtil.java
@@ -25,7 +25,7 @@ public final class YankedVersionsUtil {
    * environment variable (ALLOWED_YANKED_VERSIONS). If `all` is specified, return Optional.empty();
    * otherwise returns the set of parsed modulel key.
    */
-  static Optional<ImmutableSet<ModuleKey>> parseYankedVersions(
+  static Optional<ImmutableSet<ModuleKey>> parseAllowedYankedVersions(
       String allowedYankedVersionsFromEnv, List<String> allowedYankedVersionsFromFlag)
       throws ExternalDepsException {
     ImmutableSet.Builder<ModuleKey> allowedYankedVersionBuilder = new ImmutableSet.Builder<>();

--- a/src/test/java/com/google/devtools/build/lib/analysis/RunfilesRepoMappingManifestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/RunfilesRepoMappingManifestTest.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -63,7 +64,7 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
             BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE, BazelCompatibilityMode.ERROR),
         PrecomputedValue.injected(BazelLockFileFunction.LOCKFILE_MODE, LockfileMode.OFF),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()));
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()));
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -72,7 +73,7 @@ public final class StarlarkRuleTransitionProviderTest extends BuildViewTestCase 
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING),
         PrecomputedValue.injected(

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisTestCase.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -250,7 +251,7 @@ public abstract class AnalysisTestCase extends FoundationTestCase {
                         BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES,
                         CheckDirectDepsMode.WARNING),
                     PrecomputedValue.injected(
-                        BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+                        YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
                     PrecomputedValue.injected(
                         BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE,
                         BazelCompatibilityMode.ERROR),
@@ -301,7 +302,7 @@ public abstract class AnalysisTestCase extends FoundationTestCase {
                 BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES,
                 CheckDirectDepsMode.WARNING),
             PrecomputedValue.injected(
-                BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+                YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
             PrecomputedValue.injected(
                 BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE,
                 BazelCompatibilityMode.WARNING),

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -147,7 +147,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.set(
         differencer, BazelCompatibilityMode.ERROR);
     BazelLockFileFunction.LOCKFILE_MODE.set(differencer, LockfileMode.OFF);
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunctionTest.java
@@ -197,7 +197,7 @@ public class BazelLockFileFunctionTest extends FoundationTestCase {
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, true);
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.set(
         differencer, BazelCompatibilityMode.ERROR);
     BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES.set(
@@ -277,7 +277,7 @@ public class BazelLockFileFunctionTest extends FoundationTestCase {
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, true);
     ModuleFileFunction.REGISTRIES.set(differencer, registries);
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of("my_dep_1", override));
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, yankedVersions);
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, yankedVersions);
     BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES.set(
         differencer, CheckDirectDepsMode.ERROR);
     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.set(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
@@ -131,7 +131,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.set(
         differencer, BazelCompatibilityMode.ERROR);
     BazelLockFileFunction.LOCKFILE_MODE.set(differencer, LockfileMode.OFF);
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
   }
 
   @Test
@@ -282,7 +282,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
   @Test
   public void testYankedVersionCheckIgnoredByAll() throws Exception {
     setupModulesForYankedVersion();
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of("all"));
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of("all"));
     EvaluationResult<BazelModuleResolutionValue> result =
         evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
     assertThat(result.hasError()).isFalse();
@@ -291,8 +291,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
   @Test
   public void testYankedVersionCheckIgnoredBySpecific() throws Exception {
     setupModulesForYankedVersion();
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(
-        differencer, ImmutableList.of("b@1.0"));
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of("b@1.0"));
     EvaluationResult<BazelModuleResolutionValue> result =
         evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
     assertThat(result.hasError()).isFalse();
@@ -301,8 +300,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
   @Test
   public void testBadYankedVersionFormat() throws Exception {
     setupModulesForYankedVersion();
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(
-        differencer, ImmutableList.of("b~1.0"));
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of("b~1.0"));
     EvaluationResult<BazelModuleResolutionValue> result =
         evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
     assertThat(result.hasError()).isTrue();
@@ -328,5 +326,86 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
             .addModule(createModuleKey("b", "1.0"), "module(name='b', version='1.0');")
             .addYankedVersion("b", ImmutableMap.of(Version.parse("1.0"), "1.0 is a bad version!"));
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of(registry.getUrl()));
+  }
+
+  @Test
+  public void testYankedVersionSideEffects_equalCompatibilityLevel() throws Exception {
+    scratch.file(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='mod', version='1.0')",
+        "bazel_dep(name = 'a', version = '1.0')",
+        "bazel_dep(name = 'b', version = '1.1')");
+
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/bar")
+            .addModule(
+                createModuleKey("a", "1.0"),
+                "module(name='a', version='1.0')",
+                "bazel_dep(name='b', version='1.0')")
+            .addModule(createModuleKey("c", "1.0"), "module(name='c', version='1.0')")
+            .addModule(createModuleKey("c", "1.1"), "module(name='c', version='1.1')")
+            .addModule(
+                createModuleKey("b", "1.0"),
+                "module(name='b', version='1.0', compatibility_level = 2)",
+                "bazel_dep(name='c', version='1.1')",
+                "print('hello from yanked version')")
+            .addModule(
+                createModuleKey("b", "1.1"),
+                "module(name='b', version='1.1', compatibility_level = 2)",
+                "bazel_dep(name='c', version='1.0')")
+            .addYankedVersion("b", ImmutableMap.of(Version.parse("1.0"), "1.0 is a bad version!"));
+
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of(registry.getUrl()));
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    assertThat(result.hasError()).isFalse();
+    assertThat(result.get(BazelModuleResolutionValue.KEY).getResolvedDepGraph().keySet())
+        .containsExactly(
+            ModuleKey.ROOT,
+            createModuleKey("a", "1.0"),
+            createModuleKey("b", "1.1"),
+            createModuleKey("c", "1.0"));
+    assertDoesNotContainEvent("hello from yanked version");
+  }
+
+  @Test
+  public void testYankedVersionSideEffects_differentCompatibilityLevel() throws Exception {
+    scratch.file(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='mod', version='1.0')",
+        "bazel_dep(name = 'a', version = '1.0')",
+        "bazel_dep(name = 'b', version = '1.1')");
+
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/bar")
+            .addModule(
+                createModuleKey("a", "1.0"),
+                "module(name='a', version='1.0')",
+                "bazel_dep(name='b', version='1.0')")
+            .addModule(createModuleKey("c", "1.0"), "module(name='c', version='1.0')")
+            .addModule(createModuleKey("c", "1.1"), "module(name='c', version='1.1')")
+            .addModule(
+                createModuleKey("b", "1.0"),
+                "module(name='b', version='1.0', compatibility_level = 2)",
+                "bazel_dep(name='c', version='1.1')",
+                "print('hello from yanked version')")
+            .addModule(
+                createModuleKey("b", "1.1"),
+                "module(name='b', version='1.1', compatibility_level = 3)",
+                "bazel_dep(name='c', version='1.0')")
+            .addYankedVersion("b", ImmutableMap.of(Version.parse("1.0"), "1.0 is a bad version!"));
+
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of(registry.getUrl()));
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    assertThat(result.hasError()).isTrue();
+    assertThat(result.getError().toString())
+        .contains(
+            "a@1.0 depends on b@1.0 with compatibility level 2, but <root> depends on b@1.1 with compatibility level 3 which is different");
+    assertDoesNotContainEvent("hello from yanked version");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleFunctionTest.java
@@ -140,7 +140,7 @@ public final class BzlmodRepoRuleFunctionTest extends FoundationTestCase {
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
     BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES.set(
         differencer, CheckDirectDepsMode.WARNING);
     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.set(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.rules.repository.RepositoryDelegatorFunctio
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction;
 import com.google.devtools.build.lib.skyframe.BazelSkyframeExecutorConstants;
 import com.google.devtools.build.lib.skyframe.BzlmodRepoRuleFunction;
+import com.google.devtools.build.lib.skyframe.ClientEnvironmentFunction;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.ExternalFileAction;
 import com.google.devtools.build.lib.skyframe.FileFunction;
@@ -178,6 +179,9 @@ public class DiscoveryTest extends FoundationTestCase {
                 .put(
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))
+                .put(
+                    SkyFunctions.CLIENT_ENVIRONMENT_VARIABLE,
+                    new ClientEnvironmentFunction(new AtomicReference<>(ImmutableMap.of())))
                 .buildOrThrow(),
             differencer);
 
@@ -196,7 +200,7 @@ public class DiscoveryTest extends FoundationTestCase {
     RepositoryDelegatorFunction.RESOLVED_FILE_FOR_VERIFICATION.set(differencer, Optional.empty());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -284,7 +284,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     RepositoryDelegatorFunction.RESOLVED_FILE_FOR_VERIFICATION.set(differencer, Optional.empty());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of(registry.getUrl()));
     BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES.set(
         differencer, CheckDirectDepsMode.WARNING);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.rules.repository.RepositoryDelegatorFunctio
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction;
 import com.google.devtools.build.lib.skyframe.BazelSkyframeExecutorConstants;
 import com.google.devtools.build.lib.skyframe.BzlmodRepoRuleFunction;
+import com.google.devtools.build.lib.skyframe.ClientEnvironmentFunction;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.ExternalFileAction;
 import com.google.devtools.build.lib.skyframe.FileFunction;
@@ -152,6 +153,9 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 .put(
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))
+                .put(
+                    SkyFunctions.CLIENT_ENVIRONMENT_VARIABLE,
+                    new ClientEnvironmentFunction(new AtomicReference<>(ImmutableMap.of())))
                 .buildOrThrow(),
             differencer);
 
@@ -170,7 +174,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     RepositoryDelegatorFunction.RESOLVED_FILE_FOR_VERIFICATION.set(differencer, Optional.empty());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/SkyframeQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/SkyframeQueryHelper.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleKey;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -374,7 +375,7 @@ public abstract class SkyframeQueryHelper extends AbstractQueryHelper<Target> {
                         BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES,
                         CheckDirectDepsMode.WARNING),
                     PrecomputedValue.injected(
-                        BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+                        YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
                     PrecomputedValue.injected(
                         BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE,
                         BazelCompatibilityMode.ERROR),
@@ -416,7 +417,7 @@ public abstract class SkyframeQueryHelper extends AbstractQueryHelper<Target> {
                     CheckDirectDepsMode.WARNING))
             .add(
                 PrecomputedValue.injected(
-                    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()))
+                    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()))
             .add(
                 PrecomputedValue.injected(
                     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE,

--- a/src/test/java/com/google/devtools/build/lib/rules/LabelBuildSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/LabelBuildSettingTest.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -55,7 +56,7 @@ public class LabelBuildSettingTest extends BuildViewTestCase {
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING),
         PrecomputedValue.injected(

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -36,6 +36,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -273,7 +274,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     RepositoryDelegatorFunction.RESOLVED_FILE_FOR_VERIFICATION.set(differencer, Optional.empty());
     ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, false);
     ModuleFileFunction.MODULE_OVERRIDES.set(differencer, ImmutableMap.of());
-    BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
+    YankedVersionsUtil.ALLOWED_YANKED_VERSIONS.set(differencer, ImmutableList.of());
     BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES.set(
         differencer, CheckDirectDepsMode.WARNING);
     BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE.set(

--- a/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -75,8 +76,7 @@ public final class StarlarkDocExtractTest extends BuildViewTestCase {
             ModuleFileFunction.REGISTRIES, ImmutableList.of(registry.getUrl())),
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
-        PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+        PrecomputedValue.injected(YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING),
         PrecomputedValue.injected(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -110,7 +111,7 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING),
         PrecomputedValue.injected(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternsFunctionTest.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleKey;
 import com.google.devtools.build.lib.bazel.bzlmod.Version;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -244,7 +245,7 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.BAZEL_COMPATIBILITY_MODE, BazelCompatibilityMode.ERROR),
         PrecomputedValue.injected(BazelLockFileFunction.LOCKFILE_MODE, LockfileMode.OFF));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunctionTest.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.Version;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -83,7 +84,7 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING),
         PrecomputedValue.injected(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunctionTest.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -110,7 +111,7 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING),
         PrecomputedValue.injected(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.BazelLockFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -65,7 +66,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
         PrecomputedValue.injected(ModuleFileFunction.IGNORE_DEV_DEPS, false),
         PrecomputedValue.injected(ModuleFileFunction.MODULE_OVERRIDES, ImmutableMap.of()),
         PrecomputedValue.injected(
-            BazelModuleResolutionFunction.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
+            YankedVersionsUtil.ALLOWED_YANKED_VERSIONS, ImmutableList.of()),
         PrecomputedValue.injected(
             BazelModuleResolutionFunction.CHECK_DIRECT_DEPENDENCIES, CheckDirectDepsMode.WARNING),
         PrecomputedValue.injected(


### PR DESCRIPTION
Yanked module versions no longer contribute dependency requirements or emit `DEBUG` messages for `print()` statements.

Since the module files of yanked modules are still evaluated to learn their compatibility levels, they can still fail to execute.