### PR TITLE
Valid json when using jsonproto output in queries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/JSONProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/JSONProtoOutputFormatter.java
@@ -20,6 +20,8 @@ import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * An output formatter that outputs a protocol buffer json representation of a query result and
@@ -40,10 +42,13 @@ public class JSONProtoOutputFormatter extends ProtoOutputFormatter {
       @Override
       public void processOutput(Iterable<Target> partialResult)
           throws IOException, InterruptedException {
+        List<String> jsonProtoBuffers = new ArrayList<>();
         for (Target target : partialResult) {
-          out.write(
-              jsonPrinter.print(toTargetProtoBuffer(target)).getBytes(StandardCharsets.UTF_8));
+          jsonProtoBuffers.add(jsonPrinter.print(toTargetProtoBuffer(target)));
         }
+        out.write("[".getBytes(StandardCharsets.UTF_8));
+        out.write(String.join(",", jsonProtoBuffers).getBytes(StandardCharsets.UTF_8));
+        out.write("]".getBytes(StandardCharsets.UTF_8));
       }
     };
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/OutputFormatters.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/OutputFormatters.java
@@ -37,9 +37,9 @@ public class OutputFormatters {
         new PackageOutputFormatter(),
         new LocationOutputFormatter(),
         new GraphOutputFormatter(),
-        new JSONProtoOutputFormatter(),
         new XmlOutputFormatter(),
         new ProtoOutputFormatter(),
+        new StreamedJSONProtoOutputFormatter(),
         new StreamedProtoOutputFormatter());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
@@ -40,7 +40,7 @@ public class QueryOptions extends CommonQueryOptions {
       effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
       help =
           "The format in which the query results should be printed. Allowed values for query are:"
-              + " build, graph, jsonproto, label, label_kind, location, maxrank, minrank, package,"
+              + " build, graph, streamed_jsonproto, label, label_kind, location, maxrank, minrank, package,"
               + " proto, xml.")
   public String outputFormat;
 

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedJSONProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedJSONProtoOutputFormatter.java
@@ -20,12 +20,9 @@ import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
- * An output formatter that outputs a protocol buffer json representation of a query result and
- * outputs the json to the output print stream.
+ * An output formatter that prints a list of targets according to ndjson spec to the output print stream.
  */
 public class StreamedJSONProtoOutputFormatter extends ProtoOutputFormatter {
   @Override

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedJSONProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedJSONProtoOutputFormatter.java
@@ -27,10 +27,10 @@ import java.util.List;
  * An output formatter that outputs a protocol buffer json representation of a query result and
  * outputs the json to the output print stream.
  */
-public class JSONProtoOutputFormatter extends ProtoOutputFormatter {
+public class StreamedJSONProtoOutputFormatter extends ProtoOutputFormatter {
   @Override
   public String getName() {
-    return "jsonproto";
+    return "streamed_jsonproto";
   }
 
   private final JsonFormat.Printer jsonPrinter = JsonFormat.printer();
@@ -42,13 +42,11 @@ public class JSONProtoOutputFormatter extends ProtoOutputFormatter {
       @Override
       public void processOutput(Iterable<Target> partialResult)
           throws IOException, InterruptedException {
-        List<String> jsonProtoBuffers = new ArrayList<>();
         for (Target target : partialResult) {
-          jsonProtoBuffers.add(jsonPrinter.print(toTargetProtoBuffer(target)));
+          out.write(
+              jsonPrinter.omittingInsignificantWhitespace().print(toTargetProtoBuffer(target)).getBytes(StandardCharsets.UTF_8));
+          out.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
         }
-        out.write("[".getBytes(StandardCharsets.UTF_8));
-        out.write(String.join(",", jsonProtoBuffers).getBytes(StandardCharsets.UTF_8));
-        out.write("]".getBytes(StandardCharsets.UTF_8));
       }
     };
   }

--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -668,7 +668,7 @@ genquery(name='q',
          opts = ["--output=blargh"],)
 EOF
 
-  local expected_error_msg="in genquery rule //starfruit:q: Invalid output format 'blargh'. Valid values are: label, label_kind, build, minrank, maxrank, package, location, graph, jsonproto, xml, proto"
+  local expected_error_msg="in genquery rule //starfruit:q: Invalid output format 'blargh'. Valid values are: label, label_kind, build, minrank, maxrank, package, location, graph, xml, proto, streamed_jsonproto, "
   bazel build //starfruit:q >& $TEST_log && fail "Expected failure"
   expect_log "$expected_error_msg"
 }
@@ -1098,7 +1098,7 @@ EOF
   expect_log "//pkg3:t4"
 }
 
-function test_basic_query_jsonproto() {
+function test_basic_query_streamed_jsonproto() {
   local pkg="${FUNCNAME[0]}"
   mkdir -p "$pkg" || fail "mkdir -p $pkg"
   cat > "$pkg/BUILD" <<'EOF'
@@ -1109,15 +1109,15 @@ genrule(
     cmd = "echo unused > $(OUTS)",
 )
 EOF
-  bazel query --output=jsonproto --noimplicit_deps "//$pkg:bar" > output 2> "$TEST_log" \
+  bazel query --output=streamed_jsonproto --noimplicit_deps "//$pkg:bar" > output 2> "$TEST_log" \
     || fail "Expected success"
   cat output >> "$TEST_log"
 
   # Verify that the appropriate attributes were included.
-  assert_contains "\"ruleClass\": \"genrule\"" output
-  assert_contains "\"name\": \"//$pkg:bar\"" output
-  assert_contains "\"ruleInput\": \[\"//$pkg:dummy.txt\"\]" output
-  assert_contains "\"ruleOutput\": \[\"//$pkg:bar_out.txt\"\]" output
+  assert_contains "\"ruleClass\":\"genrule\"" output
+  assert_contains "\"name\":\"//$pkg:bar\"" output
+  assert_contains "\"ruleInput\":\[\"//$pkg:dummy.txt\"\]" output
+  assert_contains "\"ruleOutput\":\[\"//$pkg:bar_out.txt\"\]" output
   assert_contains "echo unused" output
 }
 

--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -1108,17 +1108,39 @@ genrule(
     outs = ["bar_out.txt"],
     cmd = "echo unused > $(OUTS)",
 )
+genrule(
+    name = "foo",
+    srcs = ["dummy.txt"],
+    outs = ["foo_out.txt"],
+    cmd = "echo unused > $(OUTS)",
+)
 EOF
-  bazel query --output=streamed_jsonproto --noimplicit_deps "//$pkg:bar" > output 2> "$TEST_log" \
+  bazel query --output=streamed_jsonproto --noimplicit_deps "//$pkg/..." > output 2> "$TEST_log" \
     || fail "Expected success"
   cat output >> "$TEST_log"
 
   # Verify that the appropriate attributes were included.
-  assert_contains "\"ruleClass\":\"genrule\"" output
-  assert_contains "\"name\":\"//$pkg:bar\"" output
-  assert_contains "\"ruleInput\":\[\"//$pkg:dummy.txt\"\]" output
-  assert_contains "\"ruleOutput\":\[\"//$pkg:bar_out.txt\"\]" output
-  assert_contains "echo unused" output
+
+  foo_line_number=$(grep -n "foo" output | cut -d':' -f1)
+  bar_line_number=$(grep -n "bar" output | cut -d':' -f1)
+
+  foo_ndjson_line=$(sed -n "${foo_line_number}p" output) 
+  bar_ndjson_line=$(sed -n "${bar_line_number}p" output)
+ 
+  echo "$foo_ndjson_line" > foo_ndjson_file
+  echo "$bar_ndjson_line" > bar_ndjson_file
+
+  assert_contains "\"ruleClass\":\"genrule\"" foo_ndjson_file
+  assert_contains "\"name\":\"//$pkg:foo\"" foo_ndjson_file
+  assert_contains "\"ruleInput\":\[\"//$pkg:dummy.txt\"\]" foo_ndjson_file
+  assert_contains "\"ruleOutput\":\[\"//$pkg:foo_out.txt\"\]" foo_ndjson_file
+  assert_contains "echo unused" foo_ndjson_file
+
+  assert_contains "\"ruleClass\":\"genrule\"" bar_ndjson_file
+  assert_contains "\"name\":\"//$pkg:bar\"" bar_ndjson_file
+  assert_contains "\"ruleInput\":\[\"//$pkg:dummy.txt\"\]" bar_ndjson_file
+  assert_contains "\"ruleOutput\":\[\"//$pkg:bar_out.txt\"\]" bar_ndjson_file
+  assert_contains "echo unused" bar_ndjson_file
 }
 
 run_suite "${PRODUCT_NAME} query tests"


### PR DESCRIPTION
When using `bazel query ... --output=jsonproto `, the output JSON is not valid as
1. elements are not comma separated. 
2. the outer containers don't have "[", "]".

This PR fixes the above issue.

