### PR TITLE
RemoteCache: keep ServerCapabilities instead of CacheCapabilities

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -22,6 +22,7 @@ import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -84,24 +85,28 @@ public class RemoteCache extends AbstractReferenceCounted {
   private final CountDownLatch closeCountDownLatch = new CountDownLatch(1);
   protected final AsyncTaskCache.NoResult<Digest> casUploadCache = AsyncTaskCache.NoResult.create();
 
-  protected final CacheCapabilities cacheCapabilities;
+  protected final ServerCapabilities serverCapabilities;
   protected final RemoteCacheClient cacheProtocol;
   protected final RemoteOptions options;
   protected final DigestUtil digestUtil;
 
   public RemoteCache(
-      CacheCapabilities cacheCapabilities,
+      ServerCapabilities serverCapabilities,
       RemoteCacheClient cacheProtocol,
       RemoteOptions options,
       DigestUtil digestUtil) {
-    this.cacheCapabilities = cacheCapabilities;
+    this.serverCapabilities = serverCapabilities;
     this.cacheProtocol = cacheProtocol;
     this.options = options;
     this.digestUtil = digestUtil;
   }
 
+  public ServerCapabilities getServerCapabilities() {
+    return serverCapabilities;
+  }
+
   public CacheCapabilities getCacheCapabilities() {
-    return cacheCapabilities;
+    return serverCapabilities.getCacheCapabilities();
   }
 
   public CachedActionResult downloadActionResult(
@@ -124,7 +129,10 @@ public class RemoteCache extends AbstractReferenceCounted {
 
   /** Returns whether the action cache supports updating action results. */
   public boolean actionCacheSupportsUpdate() {
-    return cacheCapabilities.getActionCacheUpdateCapabilities().getUpdateEnabled();
+    return serverCapabilities
+        .getCacheCapabilities()
+        .getActionCacheUpdateCapabilities()
+        .getUpdateEnabled();
   }
 
   /** Upload the action result to the remote cache. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -23,9 +23,9 @@ import static com.google.devtools.build.lib.remote.util.RxUtils.mergeBulkTransfe
 import static com.google.devtools.build.lib.remote.util.RxUtils.toTransferResult;
 import static java.lang.String.format;
 
-import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -60,7 +60,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class RemoteExecutionCache extends RemoteCache {
 
   public RemoteExecutionCache(
-      CacheCapabilities cacheCapabilities,
+      ServerCapabilities cacheCapabilities,
       RemoteCacheClient protocolImpl,
       RemoteOptions options,
       DigestUtil digestUtil) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -124,11 +124,14 @@ import javax.annotation.Nullable;
 
 /** RemoteModule provides distributed cache and remote execution for Bazel. */
 public final class RemoteModule extends BlazeModule {
-  private static final CacheCapabilities HTTP_AND_DISK_CACHE_CAPABILITIES =
-      CacheCapabilities.newBuilder()
-          .setActionCacheUpdateCapabilities(
-              ActionCacheUpdateCapabilities.newBuilder().setUpdateEnabled(true).build())
-          .setSymlinkAbsolutePathStrategy(SymlinkAbsolutePathStrategy.Value.ALLOWED)
+  private static final ServerCapabilities HTTP_AND_DISK_CACHE_CAPABILITIES =
+      ServerCapabilities.newBuilder()
+          .setCacheCapabilities(
+              CacheCapabilities.newBuilder()
+                  .setActionCacheUpdateCapabilities(
+                      ActionCacheUpdateCapabilities.newBuilder().setUpdateEnabled(true).build())
+                  .setSymlinkAbsolutePathStrategy(SymlinkAbsolutePathStrategy.Value.ALLOWED)
+                  .build())
           .build();
 
   private final ListeningScheduledExecutorService retryScheduler =
@@ -663,8 +666,7 @@ public final class RemoteModule extends BlazeModule {
       }
       execChannel.release();
       RemoteExecutionCache remoteCache =
-          new RemoteExecutionCache(
-              cacheCapabilities.getCacheCapabilities(), cacheClient, remoteOptions, digestUtil);
+          new RemoteExecutionCache(cacheCapabilities, cacheClient, remoteOptions, digestUtil);
       actionContextProvider =
           RemoteActionContextProvider.createForRemoteExecution(
               executorService,
@@ -701,8 +703,7 @@ public final class RemoteModule extends BlazeModule {
       }
 
       RemoteCache remoteCache =
-          new RemoteCache(
-              cacheCapabilities.getCacheCapabilities(), cacheClient, remoteOptions, digestUtil);
+          new RemoteCache(cacheCapabilities, cacheClient, remoteOptions, digestUtil);
       actionContextProvider =
           RemoteActionContextProvider.createForRemoteCaching(
               executorService, env, remoteCache, retryScheduler, digestUtil, remoteOutputChecker);

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -22,8 +22,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
 import com.google.common.collect.ImmutableList;
@@ -177,7 +177,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
       filesToUpload.put(
           file,
           new LocalFile(
-              file, LocalFileType.OUTPUT, /*artifact=*/ null, /*artifactMetadata=*/ null));
+              file, LocalFileType.OUTPUT, /* artifact= */ null, /* artifactMetadata= */ null));
     }
     serviceRegistry.addService(new MaybeFailOnceUploadService(blobsByHash));
 
@@ -220,7 +220,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
       filesToUpload.put(
           file,
           new LocalFile(
-              file, LocalFileType.OUTPUT, /*artifact=*/ null, /*artifactMetadata=*/ null));
+              file, LocalFileType.OUTPUT, /* artifact= */ null, /* artifactMetadata= */ null));
     }
     serviceRegistry.addService(new MaybeFailOnceUploadService(blobsByHash));
 
@@ -352,7 +352,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
       filesToUpload.put(
           file,
           new LocalFile(
-              file, LocalFileType.OUTPUT, /*artifact=*/ null, /*artifactMetadata=*/ null));
+              file, LocalFileType.OUTPUT, /* artifact= */ null, /* artifactMetadata= */ null));
     }
     String hashOfBlobThatShouldFail = blobsByHash.keySet().iterator().next().toString();
     serviceRegistry.addService(
@@ -437,7 +437,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     assertThat(remotePath.getFileSystem()).isEqualTo(remoteFs);
     LocalFile file =
         new LocalFile(
-            remotePath, LocalFileType.OUTPUT, /*artifact=*/ null, /*artifactMetadata=*/ null);
+            remotePath, LocalFileType.OUTPUT, /* artifact= */ null, /* artifactMetadata= */ null);
 
     // act
 
@@ -488,10 +488,16 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         ImmutableMap.of(
             remoteFile,
             new LocalFile(
-                remoteFile, LocalFileType.OUTPUT, /*artifact=*/ null, /*artifactMetadata=*/ null),
+                remoteFile,
+                LocalFileType.OUTPUT,
+                /* artifact= */ null,
+                /* artifactMetadata= */ null),
             localFile,
             new LocalFile(
-                localFile, LocalFileType.OUTPUT, /*artifact=*/ null, /*artifactMetadata=*/ null));
+                localFile,
+                LocalFileType.OUTPUT,
+                /* artifact= */ null,
+                /* artifactMetadata= */ null));
     PathConverter pathConverter = artifactUploader.upload(files).get();
 
     // assert
@@ -541,7 +547,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         .findMissingDigests(any(), any());
 
     return new RemoteCache(
-        CacheCapabilities.getDefaultInstance(), cacheClient, remoteOptions, DIGEST_UTIL);
+        ServerCapabilities.getDefaultInstance(), cacheClient, remoteOptions, DIGEST_UTIL);
   }
 
   private ByteStreamBuildEventArtifactUploader newArtifactUploader(RemoteCache remoteCache) {
@@ -549,11 +555,11 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     return new ByteStreamBuildEventArtifactUploader(
         MoreExecutors.directExecutor(),
         reporter,
-        /*verboseFailures=*/ true,
+        /* verboseFailures= */ true,
         remoteCache,
-        /*remoteServerInstanceName=*/ "localhost/instance",
-        /*buildRequestId=*/ "none",
-        /*commandId=*/ "none",
+        /* remoteServerInstanceName= */ "localhost/instance",
+        /* buildRequestId= */ "none",
+        /* commandId= */ "none",
         SyscallCache.NO_CACHE,
         RemoteBuildEventUploadMode.ALL);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionCacheGrpc.ActionCacheImplBase;
 import build.bazel.remote.execution.v2.ActionResult;
-import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.ContentAddressableStorageGrpc.ContentAddressableStorageImplBase;
 import build.bazel.remote.execution.v2.Digest;
@@ -37,6 +36,7 @@ import build.bazel.remote.execution.v2.FileNode;
 import build.bazel.remote.execution.v2.FindMissingBlobsRequest;
 import build.bazel.remote.execution.v2.FindMissingBlobsResponse;
 import build.bazel.remote.execution.v2.GetActionResultRequest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.Tree;
 import build.bazel.remote.execution.v2.UpdateActionResultRequest;
 import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
@@ -101,7 +101,7 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
     RemoteExecutionCache client =
         new RemoteExecutionCache(
-            CacheCapabilities.getDefaultInstance(), newClient(options), options, DIGEST_UTIL);
+            ServerCapabilities.getDefaultInstance(), newClient(options), options, DIGEST_UTIL);
     PathFragment execPath = PathFragment.create("my/exec/path");
     VirtualActionInput virtualActionInput =
         ActionsTestUtil.createVirtualActionInput(execPath, "hello");
@@ -158,7 +158,7 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
         });
 
     // Upload all missing inputs (that is, the virtual action input from above)
-    client.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), /*force=*/ true);
+    client.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), /* force= */ true);
   }
 
   @Test
@@ -291,7 +291,8 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     GrpcCacheClient client = newClient(remoteOptions);
     RemoteCache remoteCache =
-        new RemoteCache(CacheCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
+        new RemoteCache(
+            ServerCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
 
     Digest fooDigest = DIGEST_UTIL.computeAsUtf8("foo-contents");
     Digest barDigest = DIGEST_UTIL.computeAsUtf8("bar-contents");
@@ -315,7 +316,8 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     GrpcCacheClient client = newClient(remoteOptions);
     RemoteCache remoteCache =
-        new RemoteCache(CacheCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
+        new RemoteCache(
+            ServerCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
 
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");
@@ -384,7 +386,8 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     GrpcCacheClient client = newClient(remoteOptions);
     RemoteCache remoteCache =
-        new RemoteCache(CacheCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
+        new RemoteCache(
+            ServerCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
 
     final Digest barDigest =
         fakeFileCache.createScratchInputDirectory(
@@ -428,7 +431,8 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     GrpcCacheClient client = newClient(remoteOptions);
     RemoteCache remoteCache =
-        new RemoteCache(CacheCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
+        new RemoteCache(
+            ServerCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
 
     final Digest wobbleDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("bar/test/wobble"), "xyz");
@@ -500,7 +504,7 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     UploadManifest uploadManifest =
         UploadManifest.create(
             remoteCache.options,
-            remoteCache.cacheCapabilities,
+            remoteCache.getCacheCapabilities(),
             remoteCache.digestUtil,
             remotePathResolver,
             actionKey,
@@ -587,7 +591,8 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
 
     GrpcCacheClient client = newClient(remoteOptions);
     RemoteCache remoteCache =
-        new RemoteCache(CacheCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
+        new RemoteCache(
+            ServerCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
     remoteCache.downloadActionResult(
         context,
         DIGEST_UTIL.asActionKey(DIGEST_UTIL.computeAsUtf8("key")),
@@ -599,7 +604,8 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     GrpcCacheClient client = newClient(remoteOptions);
     RemoteCache remoteCache =
-        new RemoteCache(CacheCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
+        new RemoteCache(
+            ServerCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
 
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");
@@ -676,7 +682,8 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     remoteOptions.maxOutboundMessageSize = 80; // Enough for one digest, but not two.
     GrpcCacheClient client = newClient(remoteOptions);
     RemoteCache remoteCache =
-        new RemoteCache(CacheCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
+        new RemoteCache(
+            ServerCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
 
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");
@@ -742,7 +749,8 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     GrpcCacheClient client = newClient(remoteOptions);
     RemoteCache remoteCache =
-        new RemoteCache(CacheCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
+        new RemoteCache(
+            ServerCapabilities.getDefaultInstance(), client, remoteOptions, DIGEST_UTIL);
 
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");

--- a/src/test/java/com/google/devtools/build/lib/remote/InMemoryRemoteCache.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/InMemoryRemoteCache.java
@@ -15,8 +15,8 @@ package com.google.devtools.build.lib.remote;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -33,19 +33,19 @@ class InMemoryRemoteCache extends RemoteExecutionCache {
   InMemoryRemoteCache(
       Map<Digest, byte[]> casEntries, RemoteOptions options, DigestUtil digestUtil) {
     super(
-        CacheCapabilities.getDefaultInstance(),
+        ServerCapabilities.getDefaultInstance(),
         new InMemoryCacheClient(casEntries),
         options,
         digestUtil);
   }
 
   InMemoryRemoteCache(RemoteOptions options, DigestUtil digestUtil) {
-    super(CacheCapabilities.getDefaultInstance(), new InMemoryCacheClient(), options, digestUtil);
+    super(ServerCapabilities.getDefaultInstance(), new InMemoryCacheClient(), options, digestUtil);
   }
 
   InMemoryRemoteCache(
       RemoteCacheClient cacheProtocol, RemoteOptions options, DigestUtil digestUtil) {
-    super(CacheCapabilities.getDefaultInstance(), cacheProtocol, options, digestUtil);
+    super(ServerCapabilities.getDefaultInstance(), cacheProtocol, options, digestUtil);
   }
 
   Digest addContents(RemoteActionExecutionContext context, String txt)

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -16,8 +16,8 @@ package com.google.devtools.build.lib.remote;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
@@ -171,7 +171,7 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
           entry.getValue());
     }
     return new RemoteCache(
-        CacheCapabilities.getDefaultInstance(),
+        ServerCapabilities.getDefaultInstance(),
         new InMemoryCacheClient(cacheEntries),
         options,
         digestUtil);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
@@ -22,9 +22,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import build.bazel.remote.execution.v2.ActionResult;
-import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -111,11 +111,11 @@ public class RemoteCacheTest {
     Spawn spawn =
         new SimpleSpawn(
             new FakeOwner("foo", "bar", "//dummy:label"),
-            /*arguments=*/ ImmutableList.of(),
-            /*environment=*/ ImmutableMap.of(),
-            /*executionInfo=*/ ImmutableMap.of(),
-            /*inputs=*/ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
-            /*outputs=*/ ImmutableSet.of(),
+            /* arguments= */ ImmutableList.of(),
+            /* environment= */ ImmutableMap.of(),
+            /* executionInfo= */ ImmutableMap.of(),
+            /* inputs= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            /* outputs= */ ImmutableSet.of(),
             ResourceSet.ZERO);
     context = RemoteActionExecutionContext.create(spawn, metadata);
     fs = new InMemoryFileSystem(new JavaClock(), DigestHashFunction.SHA256);
@@ -615,7 +615,7 @@ public class RemoteCacheTest {
 
   private RemoteCache newRemoteCache(RemoteCacheClient remoteCacheClient) {
     return new RemoteCache(
-        CacheCapabilities.getDefaultInstance(),
+        ServerCapabilities.getDefaultInstance(),
         remoteCacheClient,
         Options.getDefaults(RemoteOptions.class),
         digestUtil);
@@ -623,7 +623,7 @@ public class RemoteCacheTest {
 
   private RemoteExecutionCache newRemoteExecutionCache(RemoteCacheClient remoteCacheClient) {
     return new RemoteExecutionCache(
-        CacheCapabilities.getDefaultInstance(),
+        ServerCapabilities.getDefaultInstance(),
         remoteCacheClient,
         Options.getDefaults(RemoteOptions.class),
         digestUtil);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 
 import build.bazel.remote.execution.v2.ActionCacheGrpc.ActionCacheImplBase;
 import build.bazel.remote.execution.v2.ActionResult;
-import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.ContentAddressableStorageGrpc.ContentAddressableStorageImplBase;
 import build.bazel.remote.execution.v2.Digest;
@@ -331,7 +330,7 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             channel.retain(), callCredentialsProvider, remoteOptions, retrier, DIGEST_UTIL);
     remoteCache =
         new RemoteExecutionCache(
-            CacheCapabilities.getDefaultInstance(), cacheProtocol, remoteOptions, DIGEST_UTIL);
+            ServerCapabilities.getDefaultInstance(), cacheProtocol, remoteOptions, DIGEST_UTIL);
     RemoteExecutionService remoteExecutionService =
         new RemoteExecutionService(
             directExecutor(),

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.FileNode;
+import build.bazel.remote.execution.v2.ServerCapabilities;
 import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import build.bazel.remote.execution.v2.SymlinkNode;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -36,11 +37,14 @@ import java.io.IOException;
 
 /** A {@link RemoteCache} backed by an {@link DiskCacheClient}. */
 class OnDiskBlobStoreCache extends RemoteCache {
-  private static final CacheCapabilities CAPABILITIES =
-      CacheCapabilities.newBuilder()
-          .setActionCacheUpdateCapabilities(
-              ActionCacheUpdateCapabilities.newBuilder().setUpdateEnabled(true).build())
-          .setSymlinkAbsolutePathStrategy(SymlinkAbsolutePathStrategy.Value.ALLOWED)
+  private static final ServerCapabilities CAPABILITIES =
+      ServerCapabilities.newBuilder()
+          .setCacheCapabilities(
+              CacheCapabilities.newBuilder()
+                  .setActionCacheUpdateCapabilities(
+                      ActionCacheUpdateCapabilities.newBuilder().setUpdateEnabled(true).build())
+                  .setSymlinkAbsolutePathStrategy(SymlinkAbsolutePathStrategy.Value.ALLOWED)
+                  .build())
           .build();
 
   public OnDiskBlobStoreCache(RemoteOptions options, Path cacheDir, DigestUtil digestUtil) {


### PR DESCRIPTION
In Remote Execution Api, ServerCapabilities includes CacheCapabilities
and ExecutionCapabilities and the Api Version metadata for version
compatibility check.

To helps check Bazel compatibility with Remote Cache implementations
that are using Remote Execution API, we would need access to the Api
Version metadata in ServerCapabilities.
So instead of storing just a subset of ServerCapabilities, expand
RemoteCache to store the whole ServerCapabilities instead.

This is a part of #18270.
