### PR TITLE
[6.3.0] Declare credential helpers to be a stable feature.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -141,7 +141,8 @@ public class AuthAndTLSOptions extends OptionsBase {
   public Duration grpcKeepaliveTimeout;
 
   @Option(
-      name = "experimental_credential_helper",
+      name = "credential_helper",
+      oldName = "experimental_credential_helper",
       defaultValue = "null",
       allowMultiple = true,
       converter = UnresolvedScopedCredentialHelperConverter.class,
@@ -160,7 +161,8 @@ public class AuthAndTLSOptions extends OptionsBase {
   public List<UnresolvedScopedCredentialHelper> credentialHelpers;
 
   @Option(
-      name = "experimental_credential_helper_timeout",
+      name = "credential_helper_timeout",
+      oldName = "experimental_credential_helper_timeout",
       defaultValue = "10s",
       converter = DurationConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
@@ -172,7 +174,8 @@ public class AuthAndTLSOptions extends OptionsBase {
   public Duration credentialHelperTimeout;
 
   @Option(
-      name = "experimental_credential_helper_cache_duration",
+      name = "credential_helper_cache_duration",
+      oldName = "experimental_credential_helper_cache_duration",
       defaultValue = "30m",
       converter = DurationConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
@@ -184,7 +187,7 @@ public class AuthAndTLSOptions extends OptionsBase {
               + " of this flag.")
   public Duration credentialHelperCacheTimeout;
 
-  /** One of the values of the `--experimental_credential_helper` flag. */
+  /** One of the values of the `--credential_helper` flag. */
   @AutoValue
   public abstract static class UnresolvedScopedCredentialHelper {
     /** Returns the scope of the credential helper (if any). */
@@ -194,7 +197,7 @@ public class AuthAndTLSOptions extends OptionsBase {
     public abstract String getPath();
   }
 
-  /** A {@link Converter} for the `--experimental_credential_helper` flag. */
+  /** A {@link Converter} for the `--credential_helper` flag. */
   public static final class UnresolvedScopedCredentialHelperConverter
       extends Converter.Contextless<UnresolvedScopedCredentialHelper> {
     public static final UnresolvedScopedCredentialHelperConverter INSTANCE =

--- a/src/test/py/bazel/bzlmod/bzlmod_credentials_test.py
+++ b/src/test/py/bazel/bzlmod/bzlmod_credentials_test.py
@@ -125,7 +125,7 @@ class BzlmodCredentialsTest(test_base.TestBase):
     ) as static_server:
       _, stdout, _ = self.RunBazel([
           'run',
-          '--experimental_credential_helper=%workspace%/credhelper',
+          '--credential_helper=%workspace%/credhelper',
           '--registry=' + static_server.getURL(),
           '--registry=https://bcr.bazel.build',
           '//:main',
@@ -156,7 +156,7 @@ class BzlmodCredentialsTest(test_base.TestBase):
       _, stdout, _ = self.RunBazel(
           [
               'run',
-              '--experimental_credential_helper=%workspace%/credhelper',
+              '--credential_helper=%workspace%/credhelper',
               '--registry=' + static_server.getURL(),
               '--registry=https://bcr.bazel.build',
               '//:main',

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -108,7 +108,7 @@ function test_credential_helper_remote_cache() {
 
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --experimental_credential_helper="${TEST_TMPDIR}/credhelper" \
+      --credential_helper="${TEST_TMPDIR}/credhelper" \
       //a:a >& $TEST_log || fail "Build with credentials should have succeeded"
 
   # First build should have called helper for 4 distinct URIs.
@@ -116,7 +116,7 @@ function test_credential_helper_remote_cache() {
 
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --experimental_credential_helper="${TEST_TMPDIR}/credhelper" \
+      --credential_helper="${TEST_TMPDIR}/credhelper" \
       //a:b >& $TEST_log || fail "Build with credentials should have succeeded"
 
   # Second build should have hit the credentials cache.
@@ -138,7 +138,7 @@ function test_credential_helper_remote_execution() {
   bazel build \
       --spawn_strategy=remote \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_credential_helper="${TEST_TMPDIR}/credhelper" \
+      --credential_helper="${TEST_TMPDIR}/credhelper" \
       //a:a >& $TEST_log || fail "Build with credentials should have succeeded"
 
   # First build should have called helper for 5 distinct URIs.
@@ -147,7 +147,7 @@ function test_credential_helper_remote_execution() {
   bazel build \
       --spawn_strategy=remote \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_credential_helper="${TEST_TMPDIR}/credhelper" \
+      --credential_helper="${TEST_TMPDIR}/credhelper" \
       //a:b >& $TEST_log || fail "Build with credentials should have succeeded"
 
   # Second build should have hit the credentials cache.
@@ -160,7 +160,7 @@ function test_credential_helper_clear_cache() {
   bazel build \
       --spawn_strategy=remote \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_credential_helper="${TEST_TMPDIR}/credhelper" \
+      --credential_helper="${TEST_TMPDIR}/credhelper" \
       //a:a >& $TEST_log || fail "Build with credentials should have succeeded"
 
   expect_credential_helper_calls 5
@@ -170,7 +170,7 @@ function test_credential_helper_clear_cache() {
   bazel build \
       --spawn_strategy=remote \
       --remote_executor=grpc://localhost:${worker_port} \
-      --experimental_credential_helper="${TEST_TMPDIR}/credhelper" \
+      --credential_helper="${TEST_TMPDIR}/credhelper" \
       //a:b >& $TEST_log || fail "Build with credentials should have succeeded"
 
   # Build after clean should have called helper again.

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -1801,12 +1801,12 @@ function test_auth_from_credential_helper() {
   bazel build //:it \
       && fail "Expected failure when downloading repo without credential helper"
 
-  bazel build --experimental_credential_helper="${TEST_TMPDIR}/credhelper" //:it \
+  bazel build --credential_helper="${TEST_TMPDIR}/credhelper" //:it \
       || fail "Expected success when downloading repo with credential helper"
 
   expect_credential_helper_calls 1
 
-  bazel build --experimental_credential_helper="${TEST_TMPDIR}/credhelper" //:it \
+  bazel build --credential_helper="${TEST_TMPDIR}/credhelper" //:it \
       || fail "Expected success when downloading repo with credential helper"
 
   expect_credential_helper_calls 1 # expect credentials to have been cached
@@ -1822,7 +1822,7 @@ function test_auth_from_credential_helper_overrides_starlark() {
 
   setup_auth baduser badpass
 
-  bazel build --experimental_credential_helper="${TEST_TMPDIR}/credhelper" //:it \
+  bazel build --credential_helper="${TEST_TMPDIR}/credhelper" //:it \
       || fail "Expected success when downloading repo with credential helper overriding basic auth"
 }
 
@@ -2217,7 +2217,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel build --experimental_credential_helper="${TEST_TMPDIR}/credhelper" //:it \
+  bazel build --credential_helper="${TEST_TMPDIR}/credhelper" //:it \
       || fail "Expected success despite needing a file behind credential helper"
 }
 
@@ -2264,7 +2264,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel build --experimental_credential_helper="${TEST_TMPDIR}/credhelper" //:it \
+  bazel build --credential_helper="${TEST_TMPDIR}/credhelper" //:it \
       || fail "Expected success despite needing a file behind credential helper"
 }
 


### PR DESCRIPTION
Closes #18615.

Commit https://github.com/bazelbuild/bazel/commit/0573eee38d7d3b695267dfd125ab8e08d83a2640

PiperOrigin-RevId: 539607278
Change-Id: I250250452db923ba132f1445c46b0112b175e505