### PR TITLE
[6.3.0] Add a new provider for injecting native libs in android_binary

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -63,6 +63,7 @@ import com.google.devtools.build.lib.rules.android.AarImportBaseRule;
 import com.google.devtools.build.lib.rules.android.AndroidApplicationResourceInfo;
 import com.google.devtools.build.lib.rules.android.AndroidAssetsInfo;
 import com.google.devtools.build.lib.rules.android.AndroidBinaryDataInfo;
+import com.google.devtools.build.lib.rules.android.AndroidBinaryNativeLibsInfo;
 import com.google.devtools.build.lib.rules.android.AndroidCcLinkParamsProvider;
 import com.google.devtools.build.lib.rules.android.AndroidConfiguration;
 import com.google.devtools.build.lib.rules.android.AndroidDeviceBrokerInfo;
@@ -421,6 +422,7 @@ public class BazelRuleClassProvider {
                   AndroidFeatureFlagSetProvider.PROVIDER,
                   ProguardMappingProvider.PROVIDER,
                   AndroidBinaryDataInfo.PROVIDER,
+                  AndroidBinaryNativeLibsInfo.PROVIDER,
                   BaselineProfileProvider.PROVIDER);
           builder.addStarlarkBootstrap(bootstrap);
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidApplicationResourceInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidApplicationResourceInfo.java
@@ -15,16 +15,11 @@ package com.google.devtools.build.lib.rules.android;
 
 import static com.google.devtools.build.lib.rules.android.AndroidStarlarkData.fromNoneable;
 
-import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.collect.nestedset.Depset;
-import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidApplicationResourceInfoApi;
-import javax.annotation.Nullable;
-import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 
 /** A provider for Android resource APKs (".ap_") and related info. */
@@ -47,8 +42,6 @@ public class AndroidApplicationResourceInfo extends NativeInfo
   private final Artifact databindingLayoutInfoZip;
   private final Artifact buildStampJar;
   private final boolean shouldCompileJavaSrcs;
-  private final NativeLibs nativeLibs;
-  private final NestedSet<Artifact> transitiveNativeLibs;
 
   AndroidApplicationResourceInfo(
       Artifact resourceApk,
@@ -61,9 +54,7 @@ public class AndroidApplicationResourceInfo extends NativeInfo
       Artifact resourcesZip,
       Artifact databindingLayoutInfoZip,
       Artifact buildStampJar,
-      boolean shouldCompileJavaSrcs,
-      NativeLibs nativeLibs,
-      NestedSet<Artifact> transitiveNativeLibs) {
+      boolean shouldCompileJavaSrcs) {
     this.resourceApk = resourceApk;
     this.resourceJavaSrcJar = resourceJavaSrcJar;
     this.resourceJavaClassJar = resourceJavaClassJar;
@@ -75,8 +66,6 @@ public class AndroidApplicationResourceInfo extends NativeInfo
     this.databindingLayoutInfoZip = databindingLayoutInfoZip;
     this.buildStampJar = buildStampJar;
     this.shouldCompileJavaSrcs = shouldCompileJavaSrcs;
-    this.nativeLibs = nativeLibs;
-    this.transitiveNativeLibs = transitiveNativeLibs;
   }
 
   @Override
@@ -145,44 +134,6 @@ public class AndroidApplicationResourceInfo extends NativeInfo
     return shouldCompileJavaSrcs;
   }
 
-  @Nullable
-  @Override
-  public Dict<String, Depset> getNativeLibsStarlark() {
-    if (nativeLibs == null) {
-      return null;
-    }
-    return Dict.immutableCopyOf(
-        Maps.transformValues(nativeLibs.getMap(), set -> Depset.of(Artifact.TYPE, set)));
-  }
-
-  @Nullable
-  @Override
-  public Artifact getNativeLibsNameStarlark() {
-    if (nativeLibs == null) {
-      return null;
-    }
-    return nativeLibs.getName();
-  }
-
-  @Nullable
-  @Override
-  public Depset getTransitiveNativeLibsStarlark() {
-    if (transitiveNativeLibs == null) {
-      return null;
-    }
-    return Depset.of(Artifact.TYPE, transitiveNativeLibs);
-  }
-
-  @Nullable
-  public NativeLibs getNativeLibs() {
-    return nativeLibs;
-  }
-
-  @Nullable
-  public NestedSet<Artifact> getTransitiveNativeLibs() {
-    return transitiveNativeLibs;
-  }
-
   /** Provider for {@link AndroidApplicationResourceInfo}. */
   public static class AndroidApplicationResourceInfoProvider
       extends BuiltinProvider<AndroidApplicationResourceInfo>
@@ -204,9 +155,7 @@ public class AndroidApplicationResourceInfo extends NativeInfo
         Object resourcesZip,
         Object databindingLayoutInfoZip,
         Object buildStampJar,
-        boolean shouldCompileJavaSrcs,
-        Object nativeLibs,
-        Object transitiveNativeLibs)
+        boolean shouldCompileJavaSrcs)
         throws EvalException {
 
       return new AndroidApplicationResourceInfo(
@@ -220,9 +169,7 @@ public class AndroidApplicationResourceInfo extends NativeInfo
           fromNoneable(resourcesZip, Artifact.class),
           fromNoneable(databindingLayoutInfoZip, Artifact.class),
           fromNoneable(buildStampJar, Artifact.class),
-          shouldCompileJavaSrcs,
-          AndroidStarlarkData.getNativeLibs(nativeLibs),
-          AndroidStarlarkData.fromNoneableDepset(transitiveNativeLibs, "transitive_native_libs"));
+          shouldCompileJavaSrcs);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
@@ -408,10 +408,12 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
               .build(ruleContext));
     }
 
+    AndroidBinaryNativeLibsInfo nativeLibsInfo =
+        ruleContext.getPrerequisite("application_resources", AndroidBinaryNativeLibsInfo.PROVIDER);
+
     NativeLibs nativeLibs;
-    if (androidApplicationResourceInfo != null
-        && androidApplicationResourceInfo.getNativeLibs() != null) {
-      nativeLibs = androidApplicationResourceInfo.getNativeLibs();
+    if (nativeLibsInfo != null && nativeLibsInfo.getNativeLibs() != null) {
+      nativeLibs = nativeLibsInfo.getNativeLibs();
     } else {
       nativeLibs =
           NativeLibs.fromLinkedNativeDeps(
@@ -422,9 +424,8 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
     }
 
     final NestedSet<Artifact> nativeLibsAar;
-    if (androidApplicationResourceInfo != null
-        && androidApplicationResourceInfo.getTransitiveNativeLibs() != null) {
-      nativeLibsAar = androidApplicationResourceInfo.getTransitiveNativeLibs();
+    if (nativeLibsInfo != null && nativeLibsInfo.getTransitiveNativeLibs() != null) {
+      nativeLibsAar = nativeLibsInfo.getTransitiveNativeLibs();
     } else {
       nativeLibsAar = getTransitiveNativeLibs(ruleContext);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinaryNativeLibsInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinaryNativeLibsInfo.java
@@ -1,0 +1,119 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.rules.android;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.collect.nestedset.Depset;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.packages.BuiltinProvider;
+import com.google.devtools.build.lib.packages.NativeInfo;
+import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidApplicationResourceInfoApi;
+import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidBinaryNativeLibsInfoApi;
+import java.util.Map.Entry;
+import javax.annotation.Nullable;
+import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.EvalException;
+
+/** A provider for native libs for android_binary. */
+@Immutable
+public class AndroidBinaryNativeLibsInfo extends NativeInfo
+    implements AndroidBinaryNativeLibsInfoApi<Artifact> {
+
+  /** Singleton instance of the provider type for {@link AndroidBinaryNativeLibsInfo}. */
+  public static final AndroidBinaryNativeLibsInfoProvider PROVIDER =
+      new AndroidBinaryNativeLibsInfoProvider();
+
+  private final NativeLibs nativeLibs;
+  private final NestedSet<Artifact> transitiveNativeLibs;
+
+  AndroidBinaryNativeLibsInfo(NativeLibs nativeLibs, NestedSet<Artifact> transitiveNativeLibs) {
+    this.nativeLibs = nativeLibs;
+    this.transitiveNativeLibs = transitiveNativeLibs;
+  }
+
+  @Override
+  public AndroidBinaryNativeLibsInfoProvider getProvider() {
+    return PROVIDER;
+  }
+
+  @Nullable
+  @Override
+  public Dict<String, Depset> getNativeLibsStarlark() {
+    if (nativeLibs == null) {
+      return null;
+    }
+    return Dict.immutableCopyOf(
+        Maps.transformValues(nativeLibs.getMap(), set -> Depset.of(Artifact.TYPE, set)));
+  }
+
+  @Nullable
+  @Override
+  public Artifact getNativeLibsNameStarlark() {
+    if (nativeLibs == null) {
+      return null;
+    }
+    return nativeLibs.getName();
+  }
+
+  @Nullable
+  @Override
+  public Depset getTransitiveNativeLibsStarlark() {
+    if (transitiveNativeLibs == null) {
+      return null;
+    }
+    return Depset.of(Artifact.TYPE, transitiveNativeLibs);
+  }
+
+  @Nullable
+  public NativeLibs getNativeLibs() {
+    return nativeLibs;
+  }
+
+  @Nullable
+  public NestedSet<Artifact> getTransitiveNativeLibs() {
+    return transitiveNativeLibs;
+  }
+
+  /** Provider for {@link AndroidBinaryNativeLibsInfo}. */
+  public static class AndroidBinaryNativeLibsInfoProvider
+      extends BuiltinProvider<AndroidBinaryNativeLibsInfo>
+      implements AndroidBinaryNativeLibsInfoApi.Provider<Artifact> {
+
+    private AndroidBinaryNativeLibsInfoProvider() {
+      super(AndroidApplicationResourceInfoApi.NAME, AndroidBinaryNativeLibsInfo.class);
+    }
+
+    @Override
+    public AndroidBinaryNativeLibsInfoApi<Artifact> createInfo(
+        Dict<?, ?> nativeLibs, Object nativeLibsName, Object transitiveNativeLibs)
+        throws EvalException {
+      Dict<String, Depset> nativeLibsDict =
+          Dict.cast(nativeLibs, String.class, Depset.class, "native_libs");
+      ImmutableMap.Builder<String, NestedSet<Artifact>> nativeLibsMapBuilder =
+          ImmutableMap.builder();
+      for (Entry<String, Depset> entry : nativeLibsDict.entrySet()) {
+        nativeLibsMapBuilder.put(
+            entry.getKey(), Depset.cast(entry.getValue(), Artifact.class, "native_libs"));
+      }
+      return new AndroidBinaryNativeLibsInfo(
+          NativeLibs.of(
+              nativeLibsMapBuilder.buildOrThrow(),
+              AndroidStarlarkData.fromNoneable(nativeLibsName, Artifact.class)),
+          AndroidStarlarkData.fromNoneableDepset(transitiveNativeLibs, "transitive_native_libs"));
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkData.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkData.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.rules.android;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -31,7 +30,6 @@ import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.packages.Provider;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
-import com.google.devtools.build.lib.packages.StructImpl;
 import com.google.devtools.build.lib.rules.android.AndroidLibraryAarInfo.Aar;
 import com.google.devtools.build.lib.rules.android.databinding.DataBinding;
 import com.google.devtools.build.lib.rules.java.JavaCompilationArgsProvider;
@@ -46,7 +44,6 @@ import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidDataProcess
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -70,26 +67,6 @@ public abstract class AndroidStarlarkData
         AndroidLibraryAarInfo,
         AndroidBinaryDataInfo,
         ValidatedAndroidResources> {
-
-  @Nullable
-  public static NativeLibs getNativeLibs(Object struct) throws EvalException {
-    if (struct != Starlark.NONE) {
-      StructImpl s = (StructImpl) struct;
-      Dict<String, Depset> dict =
-          Dict.cast(s.getValue("libs", Dict.class), String.class, Depset.class, "libs");
-      ImmutableMap.Builder<String, NestedSet<Artifact>> nativeLibsMapBuilder =
-          ImmutableMap.builder();
-      for (Entry<String, Depset> entry : dict.entrySet()) {
-        nativeLibsMapBuilder.put(
-            entry.getKey(), Depset.cast(entry.getValue(), Artifact.class, "libs"));
-      }
-      return NativeLibs.of(
-          nativeLibsMapBuilder.buildOrThrow(),
-          fromNoneable(s.getValue("libs_name"), Artifact.class));
-    } else {
-      return null;
-    }
-  }
 
   public abstract AndroidSemantics getAndroidSemantics();
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidApplicationResourceInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidApplicationResourceInfoApi.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.starlarkbuildapi.android;
 
 import com.google.devtools.build.docgen.annot.StarlarkConstructor;
-import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
@@ -23,7 +22,6 @@ import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
-import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.NoneType;
 
@@ -146,30 +144,6 @@ public interface AndroidApplicationResourceInfoApi<FileT extends FileApi> extend
       structField = true)
   boolean shouldCompileJavaSrcs();
 
-  @Nullable
-  @StarlarkMethod(
-      name = "native_libs",
-      documented = false,
-      allowReturnNones = true,
-      structField = true)
-  Dict<String, Depset> getNativeLibsStarlark();
-
-  @Nullable
-  @StarlarkMethod(
-      name = "native_libs_name",
-      documented = false,
-      allowReturnNones = true,
-      structField = true)
-  FileApi getNativeLibsNameStarlark();
-
-  @Nullable
-  @StarlarkMethod(
-      name = "transitive_native_libs",
-      documented = false,
-      allowReturnNones = true,
-      structField = true)
-  Depset getTransitiveNativeLibsStarlark();
-
   /** Provider for {@link AndroidApplicationResourceInfoApi}. */
   @StarlarkBuiltin(
       name = "Provider",
@@ -262,24 +236,6 @@ public interface AndroidApplicationResourceInfoApi<FileT extends FileApi> extend
               doc = "",
               defaultValue = "None"),
           @Param(name = "should_compile_java_srcs", named = true, doc = "", defaultValue = "True"),
-          @Param(
-              name = "native_libs",
-              allowedTypes = {
-                @ParamType(type = StructApi.class),
-                @ParamType(type = NoneType.class),
-              },
-              named = true,
-              doc = "",
-              defaultValue = "None"),
-          @Param(
-              name = "transitive_native_libs",
-              allowedTypes = {
-                @ParamType(type = Depset.class),
-                @ParamType(type = NoneType.class),
-              },
-              named = true,
-              doc = "",
-              defaultValue = "None"),
         },
         selfCall = true)
     @StarlarkConstructor
@@ -294,9 +250,7 @@ public interface AndroidApplicationResourceInfoApi<FileT extends FileApi> extend
         Object resourcesZip,
         Object databindingLayoutInfoZip,
         Object buildStampJar,
-        boolean shouldCompileJava,
-        Object nativeLibs,
-        Object transitiveNativeLibs)
+        boolean shouldCompileJava)
         throws EvalException;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidBinaryNativeLibsInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidBinaryNativeLibsInfoApi.java
@@ -1,0 +1,112 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.starlarkbuildapi.android;
+
+import com.google.devtools.build.docgen.annot.StarlarkConstructor;
+import com.google.devtools.build.lib.collect.nestedset.Depset;
+import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
+import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
+import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
+import javax.annotation.Nullable;
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.ParamType;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.NoneType;
+
+/** A provider for native libs for android_binary. */
+@StarlarkBuiltin(
+    name = "AndroidBinaryNativeLibsInfoApi",
+    doc =
+        "Do not use this module. It is intended for migration purposes only. If you depend on it, "
+            + "you will be broken when it is removed.",
+    documented = false)
+public interface AndroidBinaryNativeLibsInfoApi<FileT extends FileApi> extends StructApi {
+
+  /** Name of this info object. */
+  String NAME = "AndroidBinaryNativeLibsInfo";
+
+  @Nullable
+  @StarlarkMethod(
+      name = "native_libs",
+      documented = false,
+      allowReturnNones = true,
+      structField = true)
+  Dict<String, Depset> getNativeLibsStarlark();
+
+  @Nullable
+  @StarlarkMethod(
+      name = "native_libs_name",
+      documented = false,
+      allowReturnNones = true,
+      structField = true)
+  FileApi getNativeLibsNameStarlark();
+
+  @Nullable
+  @StarlarkMethod(
+      name = "transitive_native_libs",
+      documented = false,
+      allowReturnNones = true,
+      structField = true)
+  Depset getTransitiveNativeLibsStarlark();
+
+  /** Provider for {@link AndroidBinaryNativeLibsInfoApi}. */
+  @StarlarkBuiltin(
+      name = "Provider",
+      doc =
+          "Do not use this module. It is intended for migration purposes only. If you depend on "
+              + "it, you will be broken when it is removed.",
+      documented = false)
+  interface Provider<FileT extends FileApi> extends ProviderApi {
+
+    @StarlarkMethod(
+        name = NAME,
+        doc = "The <code>AndroidBinaryNativeLibsInfo</code> constructor.",
+        documented = false,
+        parameters = {
+          @Param(
+              name = "native_libs",
+              allowedTypes = {
+                @ParamType(type = Dict.class),
+              },
+              named = true,
+              doc = ""),
+          @Param(
+              name = "native_libs_name",
+              allowedTypes = {
+                @ParamType(type = FileApi.class),
+                @ParamType(type = NoneType.class),
+              },
+              named = true,
+              doc = "",
+              defaultValue = "None"),
+          @Param(
+              name = "transitive_native_libs",
+              allowedTypes = {
+                @ParamType(type = Depset.class),
+                @ParamType(type = NoneType.class),
+              },
+              named = true,
+              doc = "",
+              defaultValue = "None"),
+        },
+        selfCall = true)
+    @StarlarkConstructor
+    AndroidBinaryNativeLibsInfoApi<FileT> createInfo(
+        Dict<?, ?> nativeLibs, Object nativeLibsName, Object transitiveNativeLibs)
+        throws EvalException;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidBootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidBootstrap.java
@@ -63,6 +63,7 @@ public class AndroidBootstrap implements Bootstrap {
       AndroidFeatureFlagSetProviderApi.Provider androidFeatureFlagSetProviderApiProvider,
       ProguardMappingProviderApi.Provider<?> proguardMappingProviderApiProvider,
       AndroidBinaryDataInfoApi.Provider<?, ?, ?, ?> androidBinaryDataInfoProvider,
+      AndroidBinaryNativeLibsInfoApi.Provider<?> androidBinaryInternalNativeLibsInfoApiProvider,
       BaselineProfileProviderApi.Provider<?> baselineProfileProvider) {
 
     this.androidCommon = androidCommon;
@@ -73,6 +74,8 @@ public class AndroidBootstrap implements Bootstrap {
     builder.put(AndroidResourcesInfoApi.NAME, androidResourcesInfoProvider);
     builder.put(AndroidNativeLibsInfoApi.NAME, androidNativeLibsInfoProvider);
     builder.put(AndroidApplicationResourceInfoApi.NAME, androidApplicationResourceInfoApiProvider);
+    builder.put(
+        AndroidBinaryNativeLibsInfoApi.NAME, androidBinaryInternalNativeLibsInfoApiProvider);
     builder.put(AndroidSdkProviderApi.NAME, androidSdkProviderApi);
     builder.put(AndroidManifestInfoApi.NAME, androidManifestInfo);
     builder.put(AndroidAssetsInfoApi.NAME, androidAssetsInfoProvider);


### PR DESCRIPTION
Cherrypicking to support the Starlark android_binary rule 

This reverts the changes made recently to AndroidApplicationResourceInfo and moves them to a separate provider. This helps keep the native libs related processing in Starlark separate from resources processing.

PiperOrigin-RevId: 485555064
Change-Id: I78725fe022f1e0089f063681b42c857d001165cf (cherry picked from commit e3fae33312b4a6dd230f441b6764f373d0f1f83e)