### PR TITLE
WindowsSubprocess: fix potential null pointer exception

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/shell/WindowsSubprocess.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/WindowsSubprocess.java
@@ -247,8 +247,12 @@ public class WindowsSubprocess implements Subprocess {
   @Override
   public synchronized void close() {
     if (nativeProcess != WindowsProcesses.INVALID) {
-      stdoutStream.close();
-      stderrStream.close();
+      if (stdoutStream != null) {
+        stdoutStream.close();
+      }
+      if (stderrStream != null) {
+        stderrStream.close();
+      }
       long process = nativeProcess;
       nativeProcess = WindowsProcesses.INVALID;
       WindowsProcesses.deleteProcess(process);

--- a/src/main/java/com/google/devtools/build/lib/shell/WindowsSubprocess.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/WindowsSubprocess.java
@@ -247,6 +247,7 @@ public class WindowsSubprocess implements Subprocess {
   @Override
   public synchronized void close() {
     if (nativeProcess != WindowsProcesses.INVALID) {
+      // stdoutStream and stderrStream are null if they are redirected to files.
       if (stdoutStream != null) {
         stdoutStream.close();
       }


### PR DESCRIPTION
WindowsSubprocess sets its stdoutStream and stderrStream fields to null when output is redirected to a file.
WindowsSubprocess.close should check whether those fields are null before calling ProcessInputStream.close.