### PR TITLE
[6.3.0] Properly handle invalid credential files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -330,7 +330,7 @@ public final class GoogleAuthUtils {
         creds = creds.createScoped(authScopes);
       }
       return creds;
-    } catch (IOException e) {
+    } catch (Exception e) {
       String message = "Failed to init auth credentials: " + e.getMessage();
       throw new IOException(message, e);
     }


### PR DESCRIPTION
to prevent Bazel sever from crashing.

The functions used to construct credentials could throw runtime exception which will crash Bazel server in which case the Bazel client will just exit silently.

Fixes #18755.

Closes #18770.

PiperOrigin-RevId: 543413376
Change-Id: I71238345f350caaac51f9cc9f654661a90cf6737