### PR TITLE
Create the initial version of the packages_used rule

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -50,6 +50,7 @@ tasks:
       - "//third_party/ijar/..."
       - "//tools/android/..."
       - "//tools/aquery_differ/..."
+      - "//tools/compliance/..."
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/buildjar/..."

--- a/tools/compliance/BUILD
+++ b/tools/compliance/BUILD
@@ -18,3 +18,15 @@ packages_used(
     target = "//src:bazel_nojdk",
     out = "bazel_packages.json",
 )
+
+py_test(
+    name = "packages_used_test",
+    size = "medium",
+    srcs = ["packages_used_test.py"],
+    python_version = "PY3",
+    data = [
+        ":bazel_packages.json",
+    ],
+    deps = [
+    ],
+)

--- a/tools/compliance/BUILD
+++ b/tools/compliance/BUILD
@@ -1,5 +1,7 @@
 # Tools for gathering OSS licenses
 
+load(":gather_packages.bzl", "packages_used")
+
 licenses(["notice"])  # Apache 2.0
 
 filegroup(
@@ -9,4 +11,10 @@ filegroup(
         "//tools:__subpackages__",
         "@bazel_tools//tools:__subpackages__",
     ],
+)
+
+packages_used(
+    name = "bazel_packages",
+    target = "//src:bazel_nojdk",
+    out = "bazel_packages.json",
 )

--- a/tools/compliance/gather_packages.bzl
+++ b/tools/compliance/gather_packages.bzl
@@ -222,11 +222,12 @@ def _packages_used_impl(ctx):
     package_info_json = package_infos_to_json(tpi.package_info)
     packages = labels_to_json(tpi.packages.to_list())
 
+    # Create a single dict of all the info.
     main_template = """{{
     "top_level_target": "{top_level_target}",
     "licenses": {licenses},
     "package_info": {package_info},
-    "packages": {packages},
+    "packages": {packages}
     \n}}"""
 
     content = main_template.format(
@@ -235,7 +236,6 @@ def _packages_used_impl(ctx):
         package_info = package_info_json,
         packages = packages,
     )
-    print(content)
     ctx.actions.write(
         output = ctx.outputs.out,
         content = content,

--- a/tools/compliance/gather_packages.bzl
+++ b/tools/compliance/gather_packages.bzl
@@ -21,6 +21,7 @@ load(
 )
 load("@rules_license//rules_gathering:trace.bzl", "TraceInfo")
 load(":user_filtered_rule_kinds.bzl", "user_aspect_filters")
+load(":to_json.bzl", "licenses_to_json", "package_infos_to_json", "labels_to_json")
 
 TransitivePackageInfo = provider(
     """Transitive list of all SBOM relevant dependencies.""",
@@ -98,9 +99,10 @@ def _get_transitive_metadata(ctx, trans_license_info, trans_package_info, trans_
                 if info.packages:
                     trans_packages.append(info.packages)
 
-                if info.traces:
-                    for trace in info.traces:
-                        traces.append("(" + ", ".join([str(ctx.label), ctx.rule.kind, name]) + ") -> " + trace)
+                if hasattr(info, "traces"):
+                    if info.traces:
+                        for trace in info.traces:
+                            traces.append("(" + ", ".join([str(ctx.label), ctx.rule.kind, name]) + ") -> " + trace)
 
 def gather_package_common(target, ctx, provider_factory, metadata_providers, filter_func):
     """Collect license and other metadata info from myself and my deps.
@@ -211,4 +213,42 @@ gather_package_info = aspect(
     },
     provides = [TransitivePackageInfo],
     apply_to_generating_rules = True,
+)
+
+def _packages_used_impl(ctx):
+    """Write the TransitivePackageInfo as JSON."""
+    tpi = ctx.attr.target[TransitivePackageInfo]
+    licenses_json = licenses_to_json(tpi.license_info)
+    package_info_json = package_infos_to_json(tpi.package_info)
+    packages = labels_to_json(tpi.packages.to_list())
+
+    main_template = """{{
+    "top_level_target": "{top_level_target}",
+    "licenses": {licenses},
+    "package_info": {package_info},
+    "packages": {packages},
+    \n}}"""
+
+    content = main_template.format(
+        top_level_target = ctx.attr.target.label,
+        licenses = licenses_json,
+        package_info = package_info_json,
+        packages = packages,
+    )
+    print(content)
+    ctx.actions.write(
+        output = ctx.outputs.out,
+        content = content,
+    )
+
+packages_used = rule(
+    doc = """Gather transitive package information for a target and write as JSON.""",
+    implementation = _packages_used_impl,
+    attrs = {
+        "target": attr.label(
+            aspects = [gather_package_info],
+            allow_files = True,
+        ),
+        "out": attr.output(mandatory = True),
+    },
 )

--- a/tools/compliance/packages_used_test.py
+++ b/tools/compliance/packages_used_test.py
@@ -1,0 +1,42 @@
+"""Smoke test for packages_used."""
+
+import json
+import os
+import unittest
+
+
+def read_data_file(basename):
+  path = os.path.join(
+      os.getenv("TEST_SRCDIR"),
+      "io_bazel/tools/compliance",
+      basename)
+  with open(path, "rt", encoding="utf-8") as f:
+    return f.read()
+
+
+class PackagesUsedTest(unittest.TestCase):
+
+  def test_found_key_licenses(self):
+    raw_json = read_data_file("bazel_packages.json")
+    content = json.loads(raw_json)
+    found_top_level_license = False
+    found_zlib = False
+    for l in content["licenses"]:
+      if l["label"] == "//:license":
+        found_top_level_license = True
+      if l["label"] == "//third_party/zlib:license":
+        found_zlib = True
+    self.assertTrue(found_top_level_license)
+    self.assertTrue(found_zlib)
+
+  def test_found_remote_packages(self):
+    raw_json = read_data_file("bazel_packages.json")
+    content = json.loads(raw_json)
+    self.assertIn(
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_proto",
+        content["packages"])
+
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tools/compliance/to_json.bzl
+++ b/tools/compliance/to_json.bzl
@@ -39,25 +39,22 @@ def _bazel_package(label):
     clean_label = _strip_null_repo(label)
     return clean_label[0:-(len(label.name) + 1)]
 
-_license_template = """
-      {{
-        "label": "{label}",
-        "bazel_package": "{bazel_package}",
-        "license_kinds": [{kinds}
-        ],
-        "copyright_notice": "{copyright_notice}",
-        "package_name": "{package_name}",
-        "package_url": "{package_url}",
-        "package_version": "{package_version}",
-        "license_text": "{license_text}"
-      }}"""
+_license_template = """{{
+  "label": "{label}",
+  "bazel_package": "{bazel_package}",
+  "license_kinds": [{kinds}],
+  "copyright_notice": "{copyright_notice}",
+  "package_name": "{package_name}",
+  "package_url": "{package_url}",
+  "package_version": "{package_version}",
+  "license_text": "{license_text}"
+}}"""
 
-_kind_template = """
-          {{
-            "target": "{kind_path}",
-            "name": "{kind_name}",
-            "conditions": {kind_conditions}
-          }}"""
+_kind_template = """{{
+  "target": "{kind_path}",
+  "name": "{kind_name}",
+  "conditions": {kind_conditions}
+}}"""
 
 def license_info_to_json(license):
     """Converts a LicenseInfo to JSON.
@@ -102,14 +99,13 @@ def licenses_to_json(licenses):
     return "[" + ",".join(all_licenses) + "]"
 
 
-_package_info_template = """
-          {{
-            "target": "{label}",
-            "bazel_package": "{bazel_package}",
-            "package_name": "{package_name}",
-            "package_url": "{package_url}",
-            "package_version": "{package_version}"
-          }}"""
+_package_info_template = """{{
+  "target": "{label}",
+  "bazel_package": "{bazel_package}",
+  "package_name": "{package_name}",
+  "package_url": "{package_url}",
+  "package_version": "{package_version}"
+}}"""
 
 def package_info_to_json(package_info):
     """Converts a PackageInfo to json.

--- a/tools/compliance/to_json.bzl
+++ b/tools/compliance/to_json.bzl
@@ -49,7 +49,7 @@ _license_template = """
         "package_name": "{package_name}",
         "package_url": "{package_url}",
         "package_version": "{package_version}",
-        "license_text": "{license_text}",
+        "license_text": "{license_text}"
       }}"""
 
 _kind_template = """

--- a/tools/compliance/to_json.bzl
+++ b/tools/compliance/to_json.bzl
@@ -1,0 +1,157 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility methods for turning package metadata to JSON.
+
+These should eventually be part of rules_license.
+"""
+
+load(
+    "@rules_license//rules:providers.bzl",
+    "LicenseInfo",
+    "PackageInfo",
+)
+
+def _strip_null_repo(label):
+    """Removes the null repo name (e.g. @//) from a string.
+
+    The is to make str(label) compatible between bazel 5.x and 6.x
+    """
+    s = str(label)
+    if s.startswith('@//'):
+        return s[1:]
+    elif s.startswith('@@//'):
+        return s[2:]
+    return s
+
+def _bazel_package(label):
+    """Returns the package containing a label."""
+    clean_label = _strip_null_repo(label)
+    return clean_label[0:-(len(label.name) + 1)]
+
+_license_template = """
+      {{
+        "label": "{label}",
+        "bazel_package": "{bazel_package}",
+        "license_kinds": [{kinds}
+        ],
+        "copyright_notice": "{copyright_notice}",
+        "package_name": "{package_name}",
+        "package_url": "{package_url}",
+        "package_version": "{package_version}",
+        "license_text": "{license_text}",
+      }}"""
+
+_kind_template = """
+          {{
+            "target": "{kind_path}",
+            "name": "{kind_name}",
+            "conditions": {kind_conditions}
+          }}"""
+
+def license_info_to_json(license):
+    """Converts a LicenseInfo to JSON.
+
+    Args:
+        license: a LicenseInfo
+    Returns:
+        JSON representation of license.
+    """
+    kinds = []
+    for kind in sorted(license.license_kinds, key = lambda x: x.name):
+        kinds.append(_kind_template.format(
+            kind_name = kind.name,
+            kind_path = kind.label,
+            kind_conditions = kind.conditions,
+        ))
+
+    return _license_template.format(
+        copyright_notice = license.copyright_notice,
+        kinds = ",".join(kinds),
+        license_text = license.license_text.path,
+        package_name = license.package_name,
+        package_url = license.package_url,
+        package_version = license.package_version,
+        label = _strip_null_repo(license.label),
+        bazel_package =  _bazel_package(license.label),
+    )
+
+def licenses_to_json(licenses):
+    """Converts a list of LicenseInfo to JSON.
+
+    This list is sorted by label for stability.
+
+    Args:
+        licenses: list(LicenseInfo)
+    Returns:
+        JSON representation of licenses
+    """
+    all_licenses = []
+    for license in sorted(licenses.to_list(), key = lambda x: x.label):
+        all_licenses.append(license_info_to_json(license))
+    return "[" + ",".join(all_licenses) + "]"
+
+
+_package_info_template = """
+          {{
+            "target": "{label}",
+            "bazel_package": "{bazel_package}",
+            "package_name": "{package_name}",
+            "package_url": "{package_url}",
+            "package_version": "{package_version}"
+          }}"""
+
+def package_info_to_json(package_info):
+    """Converts a PackageInfo to json.
+
+    Args:
+        package_info: a PackageInfo
+    Returns:
+        JSON representation of package_info.
+    """
+    return _package_info_template.format(
+        label = _strip_null_repo(package_info.label),
+        bazel_package =  _bazel_package(package_info.label),
+        package_name = package_info.package_name,
+        package_url = package_info.package_url,
+        package_version = package_info.package_version,
+    )
+
+
+def package_infos_to_json(packages):
+    """Converts a list of PackageInfo to JSON.
+
+    This list is sorted by label for stability.
+
+    Args:
+        packages: list(PackageInfo)
+    Returns:
+        JSON representation of packages.
+    """
+    all_packages = []
+    for package in sorted(packages.to_list(), key = lambda x: x.label):
+         all_packages.append(package_info_to_json(package))
+    return "[" + ",".join(all_packages) + "]"
+
+
+def labels_to_json(labels):
+    """Converts a list of Labels to JSON.
+
+    This list is sorted for stability.
+
+    Args:
+        labels: list(Label)
+    Returns:
+        JSON representation of the labels.
+    """
+    return "[%s]" % ",".join(['"%s"' % _strip_null_repo(l) for l in sorted(labels)])


### PR DESCRIPTION
`packages_used` writes transitive SBOM data to a file for future processing.  By itself, the rule is not useful. It produces input for an SBOM generator (TBD in a future PR). That generator will take the output from packages_used, and merge with the maven lock file to produce a richer SBOM.

Most of this will be moved to rules_license after we finish this proof-of-concept within the Bazel sources.

```
bazel build //tools/compliance:all
more bazel-bin/tools/compliance/bazel_packages.json
```

