### PR TITLE
[6.3.0] Add REPO.bazel and MODULE.bazel as workspace boundary markers

### DIFF
--- a/src/main/cpp/workspace_layout.cc
+++ b/src/main/cpp/workspace_layout.cc
@@ -27,21 +27,19 @@ namespace blaze {
 using std::string;
 using std::vector;
 
-static const char kWorkspaceDotBazelMarker[] = "WORKSPACE.bazel";
-static const char kWorkspaceMarker[] = "WORKSPACE";
-
 string WorkspaceLayout::GetOutputRoot() const {
   return blaze::GetOutputRoot();
 }
 
 bool WorkspaceLayout::InWorkspace(const string &workspace) const {
-  auto workspaceDotBazelPath =
-      blaze_util::JoinPath(workspace, kWorkspaceDotBazelMarker);
-  auto workspacePath = blaze_util::JoinPath(workspace, kWorkspaceMarker);
-  return (blaze_util::PathExists(workspaceDotBazelPath) &&
-          !blaze_util::IsDirectory(workspaceDotBazelPath)) ||
-         (blaze_util::PathExists(workspacePath) &&
-          !blaze_util::IsDirectory(workspacePath));
+  for (auto boundaryFileName :
+       {"MODULE.bazel", "REPO.bazel", "WORKSPACE.bazel", "WORKSPACE"}) {
+    auto boundaryFilePath = blaze_util::JoinPath(workspace, boundaryFileName);
+    if (blaze_util::PathExists(boundaryFilePath) &&
+        !blaze_util::IsDirectory(boundaryFilePath))
+      return true;
+  }
+  return false;
 }
 
 string WorkspaceLayout::GetWorkspace(const string &cwd) const {

--- a/src/main/cpp/workspace_layout.h
+++ b/src/main/cpp/workspace_layout.h
@@ -29,7 +29,8 @@ class WorkspaceLayout {
   virtual std::string GetOutputRoot() const;
 
   // Given the working directory, returns the nearest enclosing directory with a
-  // WORKSPACE file in it.  If there is no such enclosing directory, returns "".
+  // workspace boundary file in it.  If there is no such enclosing directory,
+  // returns "".
   //
   // E.g., if there was a WORKSPACE file in foo/bar/build_root:
   // GetWorkspace('foo/bar') --> ''
@@ -41,7 +42,7 @@ class WorkspaceLayout {
   virtual std::string GetWorkspace(const std::string& cwd) const;
 
   // Given a result returned from GetWorkspace, returns a pretty workspace name
-  // than can e.g. be used in the process title of the Bazel server.
+  // that can e.g. be used in the process title of the Bazel server.
   virtual std::string GetPrettyWorkspaceName(
       const std::string& workspace) const;
 

--- a/src/test/cpp/workspace_layout_test.cc
+++ b/src/test/cpp/workspace_layout_test.cc
@@ -22,6 +22,7 @@
 #include "src/main/cpp/util/file.h"
 #include "src/main/cpp/util/path.h"
 #include "googletest/include/gtest/gtest.h"
+#include "src/main/cpp/util/file_platform.h"
 
 namespace blaze {
 
@@ -34,8 +35,6 @@ class WorkspaceLayoutTest : public ::testing::Test {
 
   void SetUp() override {
     ASSERT_TRUE(blaze_util::MakeDirectories(build_root_, 0755));
-    ASSERT_TRUE(blaze_util::WriteFile(
-        "", blaze_util::JoinPath(build_root_, "WORKSPACE"), 0755));
   }
 
   void TearDown() override {
@@ -55,17 +54,26 @@ class WorkspaceLayoutTest : public ::testing::Test {
 };
 
 TEST_F(WorkspaceLayoutTest, GetWorkspace) {
-  // "" is returned when there's no workspace path.
-  std::string cwd = "foo/bar";
-  ASSERT_EQ("", workspace_layout_->GetWorkspace(cwd));
-  ASSERT_FALSE(workspace_layout_->InWorkspace(cwd));
+  ASSERT_TRUE(blaze_util::WriteFile(
+      "", blaze_util::JoinPath(build_root_, "WORKSPACE"), 0755));
+  const auto foobar = blaze_util::JoinPath(build_root_, "foo/bar");
+  ASSERT_TRUE(blaze_util::MakeDirectories(foobar, 0755));
 
-  cwd = build_root_;
-  ASSERT_EQ(build_root_, workspace_layout_->GetWorkspace(cwd));
+  // "" is returned when there's no workspace path.
+  ASSERT_EQ("", workspace_layout_->GetWorkspace("foo/bar"));
+  ASSERT_FALSE(workspace_layout_->InWorkspace("foo/bar"));
+
+  ASSERT_EQ(build_root_, workspace_layout_->GetWorkspace(build_root_));
   ASSERT_TRUE(workspace_layout_->InWorkspace(build_root_));
 
-  cwd = blaze_util::JoinPath(build_root_, cwd);
-  ASSERT_EQ(build_root_, workspace_layout_->GetWorkspace(cwd));
+  ASSERT_EQ(build_root_, workspace_layout_->GetWorkspace(foobar));
+  ASSERT_FALSE(workspace_layout_->InWorkspace(foobar));
+
+  // Now write a REPO.bazel file in foo/bar. It becomes the new workspace root.
+  ASSERT_TRUE(blaze_util::WriteFile(
+      "", blaze_util::JoinPath(foobar, "REPO.bazel"), 0755));
+  ASSERT_EQ(foobar, workspace_layout_->GetWorkspace(foobar));
+  ASSERT_TRUE(workspace_layout_->InWorkspace(foobar));
 }
 
 }  // namespace blaze


### PR DESCRIPTION
Work towards https://github.com/bazelbuild/bazel/issues/18077

RELNOTES: The REPO.bazel and MODULE.bazel files are now also considered workspace boundary markers.
PiperOrigin-RevId: 523979135
Change-Id: I0cbc9964742a0e5efa8afac8b8dfb84c6235a2f0