### PR TITLE
Delay connecting to the remote executor until executorInit

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
@@ -169,7 +169,7 @@ public class RemoteOutputService implements OutputService {
 
   @Override
   public RemoteArtifactChecker getRemoteArtifactChecker() {
-    return checkNotNull(remoteOutputChecker, "remoteOutputChecker must not be null");
+    return remoteOutputChecker != null ? remoteOutputChecker : RemoteArtifactChecker.IGNORE_ALL;
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorFactory.java
@@ -13,49 +13,23 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
-import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
-import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutorFactory;
+import com.google.devtools.build.lib.util.AbruptExitException;
 
 /** Factory for {@link RemoteRepositoryRemoteExecutor}. */
 class RemoteRepositoryRemoteExecutorFactory implements RepositoryRemoteExecutorFactory {
+  private final RemoteModule remoteModule;
+  private final CommandEnvironment env;
 
-  private final RemoteExecutionCache remoteExecutionCache;
-  private final RemoteExecutionClient remoteExecutor;
-  private final DigestUtil digestUtil;
-  private final String buildRequestId;
-  private final String commandId;
-
-  private final String remoteInstanceName;
-  private final boolean acceptCached;
-
-  RemoteRepositoryRemoteExecutorFactory(
-      RemoteExecutionCache remoteExecutionCache,
-      RemoteExecutionClient remoteExecutor,
-      DigestUtil digestUtil,
-      String buildRequestId,
-      String commandId,
-      String remoteInstanceName,
-      boolean acceptCached) {
-    this.remoteExecutionCache = remoteExecutionCache;
-    this.remoteExecutor = remoteExecutor;
-    this.digestUtil = digestUtil;
-    this.buildRequestId = buildRequestId;
-    this.commandId = commandId;
-    this.remoteInstanceName = remoteInstanceName;
-    this.acceptCached = acceptCached;
+  RemoteRepositoryRemoteExecutorFactory(RemoteModule remoteModule, CommandEnvironment env) {
+    this.remoteModule = remoteModule;
+    this.env = env;
   }
 
   @Override
-  public RepositoryRemoteExecutor create() {
-    return new RemoteRepositoryRemoteExecutor(
-        remoteExecutionCache,
-        remoteExecutor,
-        digestUtil,
-        buildRequestId,
-        commandId,
-        remoteInstanceName,
-        acceptCached);
+  public RepositoryRemoteExecutor create() throws AbruptExitException {
+    return remoteModule.getRemoteRepositoryRemoteExecutor(env);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteExecutorFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteExecutorFactory.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.runtime;
 
+import com.google.devtools.build.lib.util.AbruptExitException;
 import javax.annotation.Nullable;
 
 /** Factory for {@link RepositoryRemoteExecutor}. */
@@ -20,5 +21,5 @@ public interface RepositoryRemoteExecutorFactory {
 
   /** Returns a new {@link RepositoryRemoteExecutor} or {@code null}. */
   @Nullable
-  RepositoryRemoteExecutor create();
+  RepositoryRemoteExecutor create() throws AbruptExitException;
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -242,6 +242,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       assertThat(executionServerCapabilitiesImpl.getRequestCount()).isEqualTo(1);
@@ -264,6 +265,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       assertThat(cacheServerCapabilitiesImpl.getRequestCount()).isEqualTo(1);
@@ -292,6 +294,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       assertThat(executionServerCapabilitiesImpl.getRequestCount()).isEqualTo(1);
@@ -324,6 +327,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       assertThat(executionServerCapabilitiesImpl.getRequestCount()).isEqualTo(1);
@@ -351,7 +355,8 @@ public final class RemoteModuleTest {
 
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
-      assertThrows(AbruptExitException.class, () -> remoteModule.beforeCommand(env));
+      remoteModule.beforeCommand(env);
+      assertThrows(AbruptExitException.class, () -> remoteModule.initializeRemoteExecution(env));
     } finally {
       cacheServer.shutdownNow();
       cacheServer.awaitTermination();
@@ -370,7 +375,8 @@ public final class RemoteModuleTest {
 
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
-      assertThrows(AbruptExitException.class, () -> remoteModule.beforeCommand(env));
+      remoteModule.beforeCommand(env);
+      assertThrows(AbruptExitException.class, () -> remoteModule.initializeRemoteExecution(env));
     } finally {
       cacheServer.shutdownNow();
       cacheServer.awaitTermination();
@@ -389,6 +395,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       RemoteActionContextProvider actionContextProvider = remoteModule.getActionContextProvider();
@@ -414,6 +421,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       RemoteActionContextProvider actionContextProvider = remoteModule.getActionContextProvider();
@@ -468,6 +476,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       RemoteActionContextProvider actionContextProvider = remoteModule.getActionContextProvider();
@@ -494,6 +503,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       RemoteActionContextProvider actionContextProvider = remoteModule.getActionContextProvider();
@@ -522,6 +532,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       assertThat(executionServerCapabilitiesImpl.getRequestCount()).isEqualTo(1);
@@ -545,6 +556,7 @@ public final class RemoteModuleTest {
       CommandEnvironment env = createTestCommandEnvironment(remoteModule, remoteOptions);
 
       remoteModule.beforeCommand(env);
+      remoteModule.initializeRemoteExecution(env);
 
       assertThat(Thread.interrupted()).isFalse();
       assertThat(cacheServerCapabilitiesImpl.getRequestCount()).isEqualTo(1);


### PR DESCRIPTION
This change moves the majority of the code in the beforeCommand hook of the RemoteModule to executorInit.  This makes the former validate the configuration flags only, and postpones any attempts to connect to the remote executor until it's actually needed.

The reason for delaying the connection to the executor is to ensure that commands that do /not/ require it can run through completion without errors nor pauses.

To make the diff of this change small, I've tried to leave the code where it was by wrapping it in a new function that gets called from executorInit.  The indirection is not necessary for anything else though.

Fixes #18760.