### PR TITLE
Avoid losing transitive packages in PrerequisiteProducer.computeDepedencies.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AspectResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AspectResolver.java
@@ -16,13 +16,10 @@ package com.google.devtools.build.lib.analysis;
 import static com.google.devtools.build.lib.analysis.AspectCollection.buildAspectKey;
 import static com.google.devtools.build.lib.analysis.AspectResolutionHelpers.aspectMatchesConfiguredTarget;
 
-import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.analysis.configuredtargets.MergedConfiguredTarget;
 import com.google.devtools.build.lib.causes.LabelCause;
-import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.packages.AspectDescriptor;
 import com.google.devtools.build.lib.packages.NoSuchThingException;
-import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.skyframe.AspectCreationException;
 import com.google.devtools.build.lib.skyframe.AspectKeyCreator.AspectKey;
 import com.google.devtools.build.lib.skyframe.BuildConfigurationKey;
@@ -53,7 +50,7 @@ public final class AspectResolver {
       SkyFunction.LookupEnvironment env,
       Map<ConfiguredTargetKey, ConfiguredTargetAndData> configuredTargetMap,
       Iterable<Dependency> deps,
-      @Nullable NestedSetBuilder<Package> transitivePackages)
+      TransitiveDependencyState transitiveState)
       throws AspectCreationException, InterruptedException {
     OrderedSetMultimap<Dependency, ConfiguredAspect> result = OrderedSetMultimap.create();
     Set<SkyKey> allAspectKeys = new HashSet<>();
@@ -98,10 +95,7 @@ public final class AspectResolver {
         }
 
         result.put(dep, aspectValue.getConfiguredAspect());
-        if (transitivePackages != null) {
-          transitivePackages.addTransitive(
-              Preconditions.checkNotNull(aspectValue.getTransitivePackages()));
-        }
+        transitiveState.updateTransitivePackages(aspectKey, aspectValue.getTransitivePackages());
       }
     }
     return result;

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -374,6 +374,7 @@ java_library(
         ":toolchain_collection",
         ":toolchain_context",
         ":top_level_artifact_context",
+        ":transitive_dependency_state",
         ":transitive_info_collection",
         ":transitive_info_provider",
         ":transitive_info_provider_effective_class_helper",

--- a/src/main/java/com/google/devtools/build/lib/analysis/TransitiveDependencyState.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/TransitiveDependencyState.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Comparators.lexicographical;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
@@ -128,7 +129,7 @@ public final class TransitiveDependencyState {
     if (packageCollector == null) {
       return;
     }
-    packageCollector.configuredTargetPackages.put(key, packages);
+    packageCollector.configuredTargetPackages.put(key, checkNotNull(packages));
   }
 
   /** Adds to the set of transitive packages if {@link #storeTransitivePackages} is true. */
@@ -136,15 +137,7 @@ public final class TransitiveDependencyState {
     if (packageCollector == null) {
       return;
     }
-    packageCollector.aspectPackages.put(key, packages);
-  }
-
-  /** Sets a batch of transitive packages to be added. */
-  public void setTransitivePackagesBatch(NestedSet<Package> packages) {
-    if (packageCollector == null) {
-      return;
-    }
-    packageCollector.transitivePackagesBatch = packages;
+    packageCollector.aspectPackages.put(key, checkNotNull(packages));
   }
 
   @Nullable
@@ -192,13 +185,6 @@ public final class TransitiveDependencyState {
         new TreeMap<>(ASPECT_KEY_ORDERING);
 
     /**
-     * Stores a single batch of packages computed by {@link
-     * PrerequisiteProducer#resolveConfiguredTargetDependencies}.
-     */
-    // TODO(b/261521010): delete this when the corresponding method is deleted.
-    private NestedSet<Package> transitivePackagesBatch;
-
-    /**
      * Constructs the deterministically ordered result.
      *
      * <p>It's safe to call this multiple times.
@@ -214,10 +200,6 @@ public final class TransitiveDependencyState {
       }
       for (NestedSet<Package> packageSet : aspectPackages.values()) {
         result.addTransitive(packageSet);
-      }
-
-      if (transitivePackagesBatch != null) {
-        result.addTransitive(transitivePackagesBatch);
       }
 
       return result.build();

--- a/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py
@@ -91,9 +91,10 @@ class BazelRepoMappingTest(test_base.TestBase):
                 '  return DefaultInfo(files=depset(direct=[exe]),'
                 ' executable=exe, runfiles=runfiles)'
             ),
+            'noop_aspect=aspect(lambda target, ctx: [])',
             'bare_test=rule(',
             '  implementation=_bare_test_impl,',
-            '  attrs={"data":attr.label_list(allow_files=True)},',
+            '  attrs={"data":attr.label_list(allow_files=True, aspects = [noop_aspect])},',
             '  test=True,',
             ')',
         ],


### PR DESCRIPTION
The computeDependencies method always started with an empty transitive package set. If resolveConfiguredTargetDependencies had already been called and cached in the skyframe state on a previous restart, the transitive package set would not be properly filled. Resolve this by replacing the "transitive packages batch" with TransitiveDependencyState's incremental updateTransitivePackages method.

This bug appears to have been introduced by https://github.com/bazelbuild/bazel/commit/bd9eb4f3b505ca81622984e87df1c44829e04555.