### PR TITLE
Start to incorporate data from the maven lock into our SBOM

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -180,6 +180,11 @@ pkg_tar(
     visibility = ["//:__subpackages__"],
 )
 
+exports_files(
+    ["maven_install.json"],
+    visibility = ["//tools/compliance:__pkg__"],
+)
+
 py_binary(
     name = "combine_distfiles",
     srcs = ["combine_distfiles.py"],

--- a/tools/compliance/gather_packages.bzl
+++ b/tools/compliance/gather_packages.bzl
@@ -160,7 +160,6 @@ def gather_package_common(target, ctx, provider_factory, metadata_providers, fil
     elif hasattr(ctx.rule.attr, "tags"):
         for tag in ctx.rule.attr.tags:
             if tag.startswith("maven_coordinates="):
-                print(tag)
                 packages.append(target.label)
 
     # Now gather transitive collection of providers from the targets

--- a/tools/compliance/gather_packages.bzl
+++ b/tools/compliance/gather_packages.bzl
@@ -139,7 +139,6 @@ def gather_package_common(target, ctx, provider_factory, metadata_providers, fil
     # First we gather my direct license attachments
     licenses = []
     package_info = []
-    packages = None
     if ctx.rule.kind == "_license":
         # Don't try to gather licenses from the license rule itself. We'll just
         # blunder into the text file of the license and pick up the default
@@ -154,9 +153,15 @@ def gather_package_common(target, ctx, provider_factory, metadata_providers, fil
 
     # Record all the external repos anyway.
     target_name = str(target.label)
+    packages = None
     if target_name.startswith("@") and target_name[1] != "/":
         packages = [target.label]
         # DBG print(str(target.label))
+    elif hasattr(ctx.rule.attr, "tags"):
+        for tag in ctx.rule.attr.tags:
+            if tag.startswith("maven_coordinates="):
+                print(tag)
+                packages.append(target.label)
 
     # Now gather transitive collection of providers from the targets
     # this target depends upon.
@@ -168,6 +173,7 @@ def gather_package_common(target, ctx, provider_factory, metadata_providers, fil
 
     if (not licenses and
         not package_info and
+        not packages and
         not trans_license_info and
         not trans_package_info and
         not trans_packages):

--- a/tools/compliance/sbom.bzl
+++ b/tools/compliance/sbom.bzl
@@ -47,7 +47,6 @@ _sbom = rule(
     implementation = _sbom_impl,
     attrs = {
         "packages_used": attr.label(
-            #allow_files = True,
             allow_single_file = True,
             mandatory = True,
         ),

--- a/tools/compliance/sbom.bzl
+++ b/tools/compliance/sbom.bzl
@@ -27,6 +27,12 @@ def _sbom_impl(ctx):
     inputs = [inps[0]]
     args.add("--packages_used", inps[0].path)
     args.add("--out", ctx.outputs.out.path)
+    if ctx.attr._maven_install:
+        files = ctx.attr._maven_install.files.to_list()
+        if len(files) != 1:
+            fail("maven_install must be a single file")
+        args.add("--maven_install", files[0].path)
+        inputs.append(files[0])
     ctx.actions.run(
         mnemonic = "CreateSBOM",
         progress_message = "Creating SBOM for %s" % ctx.label,
@@ -41,7 +47,8 @@ _sbom = rule(
     implementation = _sbom_impl,
     attrs = {
         "packages_used": attr.label(
-            allow_files = True,
+            #allow_files = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "out": attr.output(mandatory = True),
@@ -50,6 +57,10 @@ _sbom = rule(
             executable = True,
             allow_files = True,
             cfg = "exec",
+        ),
+        "_maven_install": attr.label(
+            default = Label("//:maven_install.json"),
+            allow_single_file = True,
         ),
     },
 )

--- a/tools/compliance/write_sbom.py
+++ b/tools/compliance/write_sbom.py
@@ -18,7 +18,7 @@ This tool takes input from several sources and weaves together an SBOM.
 Inputs:
   - the output of packages_used. This is a JSON block of license, package_info
     and other declarations, plus a list of all remote packages referenced.
-  - TODO: the maven lock file
+  - the maven lock file (maven_install.json)
   - FUTURE: other packgage lock files
   - FUTURE: a user provided override of package URL to corrected information
 
@@ -28,13 +28,16 @@ This tool is private to the sbom() rule.
 import argparse
 import datetime
 import json
+import hashlib
 
 
-def create_sbom(package_info: dict) -> dict:  # pylint: disable=g-bare-generic
+# pylint: disable=g-bare-generic
+def create_sbom(package_info: dict, maven_packages: dict) -> dict:
   """Creates a dict representing an SBOM.
 
   Args:
-    package_info: dict of data from packages_used output
+    package_info: dict of data from packages_used output.
+    maven_packages: packages gleaned from Maven lock file.
   Returns:
     dict of SBOM data
   """
@@ -67,27 +70,115 @@ def create_sbom(package_info: dict) -> dict:  # pylint: disable=g-bare-generic
   })
 
   for pkg in package_info["packages"]:
-    packages.append(
-        {
-            "name": pkg,
-            # TODO(aiuto): Fill in the rest
-            # "SPDXID": "SPDXRef-GooglePackage-4c7dc29872b9c418",
-            # "supplier": "Organization: Google LLC",
-            # "downloadLocation": "NOASSERTION",
-            # "licenseConcluded": "License-da09db95a268defe",
-            # "copyrightText": ""
-        }
-    )
+    id = hashlib.md5()
+    id.update(pkg.encode('utf-8'))
+    spdxid = 'SPDXRef-GooglePackage-%s' % id.hexdigest()
+    pi = {
+        "name": pkg,
+        "downloadLocation": "NOASSERTION",
+        "SPDXID": spdxid,
+        # TODO(aiuto): Fill in the rest
+        # "supplier": "Organization: Google LLC",
+        # "licenseConcluded": "License-da09db95a268defe",
+        # "copyrightText": ""
+    }
+
+    have_maven = None
+    if pkg.startswith('@maven//:'):
+      have_maven = maven_packages.get(pkg[9:])
+    elif pkg.endswith("//file:file"):
+      # Bazel hacks jvm_external to add //file:file as a target, then we depend
+      # on that rather than the correct thing.
+      # Example: @org_apache_tomcat_tomcat_annotations_api_8_0_5//file:file
+      # Check for just the versioned root
+      have_maven = maven_packages.get(pkg[1:-11])
+
+    if have_maven:
+        pi["downloadLocation"] = have_maven['url']
+    else:
+        print("MISSING ", pkg)
+
+    packages.append(pi)
     relationships.append(
         {
             "spdxElementId": "SPDXRef-Package-main",
-            # "relatedSpdxElement": "SPDXRef-GooglePackage-4c7dc29872b9c418",
+            "relatedSpdxElement": spdxid,
             "relationshipType": "CONTAINS",
         }
     )
 
   ret["packages"] = packages
   ret["relationships"] = relationships
+  return ret
+
+
+def maven_to_bazel(s):
+  """Returns a string with maven separators mapped to what we use in Bazel.
+
+  Essentially '.', '-', ':' => '_'.
+
+  Args:
+    s: a string
+  Returns:
+    a string
+  """
+  return s.replace('.', '_').replace('-', '_').replace(':', '_')
+
+# pylint: disable=g-bare-generic
+def maven_install_to_packages(maven_install: dict) -> dict:
+  """Convert raw maven lock file into a dict keyed by bazel package names.
+
+  Args:
+    maven_install: raw maven lock file data
+  Returns:
+    dict keyed by names created by rules_jvm_external
+  """
+
+  # Map repo coordinate back to the download repository.
+  # The input dict is of the form
+  # "https//repo1.maven.org/": [ com.google.foo:some.package, ...]
+  # But.... sometimes the artifact is
+  #    com.google.foo:some.package.jar.arch
+  # and then  that means the artifact table has an entry
+  # in their shasums table keyed by arch.
+
+  repo_to_url = {}
+  for url, repos in maven_install["repositories"].items():
+    for repo in repos:
+      if repo in repo_to_url:
+        print('WARNING: Duplicate download path for <%s>. Using %s' % 
+              (repo, repo_to_url[repo]))
+        continue
+      repo_to_url[repo] = url
+
+  ret = {}
+  for name, info in maven_install["artifacts"].items():
+    repo, artifact = name.split(':')
+    version = info["version"]
+    bazel_version = maven_to_bazel(version)
+
+    for arch in info['shasums'].keys():
+      # build the download URL
+      sub_version = version
+      repo_name = name
+      if arch != 'jar':
+        sub_version = version + '-' + arch
+        repo_name = '%s:jar:%s' % (name, arch)
+
+      url = '{mirror}{repo}/{artifact}/{version}/{artifact}-{version}.jar'.format(
+          mirror = repo_to_url[repo_name],
+          repo = repo.replace('.', '/'),
+          artifact = artifact,
+          version = version,
+      )
+      # print(name, url)
+      tmp = info.copy()
+      tmp["maven_name"] = name
+      tmp["url"] = url
+      bazel_name = maven_to_bazel(name) + '_' + maven_to_bazel(sub_version)
+      ret[bazel_name] = tmp
+      if arch == 'jar':
+        ret[bazel_name] = tmp
   return ret
 
 
@@ -103,12 +194,28 @@ def main() -> None:
       required=True,
       help="JSON list of transitive package data for a target",
   )
+  parser.add_argument(
+      "--maven_install",
+      required=False,
+      default = "",
+      help="Maven lock file",
+  )
   opts = parser.parse_args()
 
   with open(opts.packages_used, "rt", encoding="utf-8") as inp:
     package_info = json.loads(inp.read())
+
+  maven_packages = None
+  if opts.maven_install:
+    with open(opts.maven_install, "rt", encoding="utf-8") as inp:
+      maven_install = json.loads(inp.read())
+      maven_packages = maven_install_to_packages(maven_install)
+
+      print(json.dumps(maven_packages, indent=2))
+
+  sbom = create_sbom(package_info, maven_packages)
   with open(opts.out, "w", encoding="utf-8") as out:
-    out.write(json.dumps(create_sbom(package_info), indent=2))
+    out.write(json.dumps(sbom, indent=2))
 
 
 if __name__ == "__main__":

--- a/tools/compliance/write_sbom.py
+++ b/tools/compliance/write_sbom.py
@@ -96,6 +96,7 @@ def create_sbom(package_info: dict, maven_packages: dict) -> dict:
     if have_maven:
         pi["downloadLocation"] = have_maven['url']
     else:
+        # TODO(aiuto): Do something better for this case.
         print("MISSING ", pkg)
 
     packages.append(pi)
@@ -171,7 +172,6 @@ def maven_install_to_packages(maven_install: dict) -> dict:
           artifact = artifact,
           version = version,
       )
-      # print(name, url)
       tmp = info.copy()
       tmp["maven_name"] = name
       tmp["url"] = url
@@ -210,8 +210,8 @@ def main() -> None:
     with open(opts.maven_install, "rt", encoding="utf-8") as inp:
       maven_install = json.loads(inp.read())
       maven_packages = maven_install_to_packages(maven_install)
-
-      print(json.dumps(maven_packages, indent=2))
+      # Useful for debugging
+      # print(json.dumps(maven_packages, indent=2))
 
   sbom = create_sbom(package_info, maven_packages)
   with open(opts.out, "w", encoding="utf-8") as out:


### PR DESCRIPTION
This works so far, but oh what hackery. Bazel uses a non-standard way of referencing maven artifacts, so the external references we see don't map back to the lock file directly. And the lock file is a tricky beast to understand.

I am happy I have a few elements in place.  I will come back for more in the next pass.