### PR TITLE
[6.3.0] Fix non-declared symlink issue for local actions when BwoB.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -490,7 +490,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       Priority priority) {
     if (path.isSymbolicLink()) {
       try {
-        path = path.getRelative(path.readSymbolicLink());
+        path = path.resolveSymbolicLinks();
       } catch (IOException e) {
         return Completable.error(e);
       }

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -885,6 +885,36 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
         /* isLocal= */ true);
   }
 
+  @Test
+  public void nonDeclaredSymlinksFromLocalActions() throws Exception {
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  srcs = [],",
+        "  outs = ['foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'foo-link',",
+        "  srcs = [':foo'],",
+        "  outs = ['foo.link'],",
+        "  cmd = 'ln -s foo.txt $@',",
+        "  local = True,",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo-link'],",
+        "  outs = ['foobar.txt'],",
+        "  cmd = 'cat $(location :foo-link) > $@ && echo bar >> $@',",
+        "  local = True,",
+        ")");
+
+    buildTarget("//:foobar");
+
+    assertValidOutputFile("foobar.txt", "foo\nbar\n");
+  }
+
   protected void assertOutputsDoNotExist(String target) throws Exception {
     for (Artifact output : getArtifacts(target)) {
       assertWithMessage(


### PR DESCRIPTION
When prefetching non-declared symlink for local actions, we want to download the target artifact if they haven't been downloaded.

Currently, the code use `path.getRelativePath(path.readSymbolicLink())` to mimic resolving relative symlink which is not correct. Replacing it with `path.readSymbolicLink()`.

Fixes #18772.

Commit https://github.com/bazelbuild/bazel/commit/5c4cf47a131c84506aad9ce0e014c6643c31a4ac

PiperOrigin-RevId: 544331900
Change-Id: Ie2a6bac298ab9f81e44d5f505f1b3d83519ba3ca