### PR TITLE
fix: toolchain doesn't contain cpu mips64

### DIFF
--- a/tools/cpp/lib_cc_configure.bzl
+++ b/tools/cpp/lib_cc_configure.bzl
@@ -198,7 +198,7 @@ def get_cpu_value(repository_ctx):
         return "ppc"
     if arch in ["s390x"]:
         return "s390x"
-    if arch in ["mips64"]:
+    if arch in ["mips64", "mips64el"]:
         return "mips64"
     if arch in ["riscv64"]:
         return "riscv64"


### PR DESCRIPTION
This commit fix local_config_cc in cc_toolchain_suite can't match mips64 arch.