### PR TITLE
[6.3.0] Expose metadata_files parameter in coverage_common.instrumented_files_info

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/CoverageCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/CoverageCommon.java
@@ -76,9 +76,6 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
     if (!supportFilesBuilder.isEmpty() || !environmentPairs.isEmpty()) {
       BuiltinRestriction.throwIfNotBuiltinUsage(thread);
     }
-    if (!metadataFiles.isEmpty()) {
-      BuiltinRestriction.throwIfNotBuiltinUsage(thread);
-    }
     return createInstrumentedFilesInfo(
         starlarkRuleContext.getRuleContext(),
         Sequence.cast(sourceAttributes, String.class, "source_attributes"),

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/CoverageCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/CoverageCommonApi.java
@@ -95,9 +95,11 @@ public interface CoverageCommonApi<
             defaultValue = "None"),
         @Param(
             name = "metadata_files",
+            doc =
+                "Additional files required to generate coverage LCOV files after code execution."
+                    + " e.g. .gcno files for C++.",
             named = true,
             positional = false,
-            documented = false,
             defaultValue = "[]",
             allowedTypes = {
               @ParamType(type = Sequence.class, generic1 = FileApi.class),

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/CoverageCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/CoverageCommonApi.java
@@ -93,6 +93,15 @@ public interface CoverageCommonApi<
             positional = false,
             named = true,
             defaultValue = "None"),
+        @Param(
+            name = "metadata_files",
+            named = true,
+            positional = false,
+            documented = false,
+            defaultValue = "[]",
+            allowedTypes = {
+              @ParamType(type = Sequence.class, generic1 = FileApi.class),
+            })
       },
       useStarlarkThread = true)
   InstrumentedFilesInfoApi instrumentedFilesInfo(
@@ -102,6 +111,7 @@ public interface CoverageCommonApi<
       Object supportFiles, // Sequence or Depset of <FileApi> expected
       Dict<?, ?> environment, // <String, String>
       Object extensions,
+      Sequence<?> metadataFiles,
       StarlarkThread thread)
       throws EvalException, TypeException;
 }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
@@ -947,6 +947,8 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
         "load('//myinfo:myinfo.bzl', 'MyInfo')",
         "",
         "def custom_rule_impl(ctx):",
+        "    metadata = ctx.actions.declare_file(ctx.label.name + '.metadata')",
+        "    ctx.actions.write(metadata, '')",
         "    return [",
         "        coverage_common.instrumented_files_info(",
         "            ctx,",
@@ -966,6 +968,7 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
         // Missing attrs are ignored
         "                'missing_dep_attr',",
         "            ],",
+        "            metadata_files = [metadata],",
         "        ),",
         "    ]",
         "",
@@ -1032,7 +1035,7 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
     assertThat(
             ActionsTestUtil.baseArtifactNames(
                 ((Depset) myInfo.getValue("metadata_files")).getSet(Artifact.class)))
-        .containsExactly("label_dep.gcno", "label_list_dep.gcno", "dict_dep.gcno");
+        .containsExactly("label_dep.gcno", "label_list_dep.gcno", "dict_dep.gcno", "cr.metadata");
     ConfiguredTarget customRule = getConfiguredTarget("//test/starlark:cr");
     assertThat(
             ActionsTestUtil.baseArtifactNames(


### PR DESCRIPTION
Cherry-picks changes required to add an expose this parameter to coverage_common.

Specifically, parts of c449a821 and ef54ef5d are picked onto 6.3.0.