### PR TITLE
[Skymeld] Remove the left over symlinks from sibling repositories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
@@ -293,15 +293,7 @@ public class SymlinkForest {
    */
   public ImmutableList<Path> plantSymlinkForest() throws IOException, AbruptExitException {
     deleteTreesBelowNotPrefixed(execroot, prefix);
-
-    if (siblingRepositoryLayout) {
-      // Delete execroot/../<symlinks> to directories representing external repositories.
-      for (Path p : execroot.getParentDirectory().getDirectoryEntries()) {
-        if (p.isSymbolicLink()) {
-          p.deleteTree();
-        }
-      }
-    }
+    deleteSiblingRepositorySymlinks(siblingRepositoryLayout, execroot);
 
     boolean shouldLinkAllTopLevelItems = false;
     Map<Path, Path> mainRepoLinks = Maps.newLinkedHashMap();
@@ -367,6 +359,18 @@ public class SymlinkForest {
     return plantedSymlinks.build();
   }
 
+  private static void deleteSiblingRepositorySymlinks(boolean siblingRepositoryLayout, Path execroot)
+      throws IOException {
+    if (siblingRepositoryLayout) {
+      // Delete execroot/../<symlinks> to directories representing external repositories.
+      for (Path p : execroot.getParentDirectory().getDirectoryEntries()) {
+        if (p.isSymbolicLink()) {
+          p.deleteTree();
+        }
+      }
+    }
+  }
+
   /**
    * Eagerly plant the symlinks from execroot to the source root provided by the single package path
    * of the current build. Only works with a single package path. Before planting the new symlinks,
@@ -379,6 +383,7 @@ public class SymlinkForest {
       boolean siblingRepositoryLayout)
       throws IOException {
     deleteTreesBelowNotPrefixed(execroot, prefix);
+    deleteSiblingRepositorySymlinks(siblingRepositoryLayout, execroot);
 
     // Plant everything under the single source root.
     for (Path target : sourceRoot.getDirectoryEntries()) {


### PR DESCRIPTION
This was a missing behavior in Skymeld, which caused some integration tests to fail when we tried turning on Skymeld by default for Bazel. Example failure:  https://storage.googleapis.com/bazel-untrusted-buildkite-artifacts/01890719-efb9-428c-80bb-5449e92383e8/src/test/shell/bazel/bazel_proto_library_test/test_attempts/attempt_1.log

This PR fixes this bug by adding this missing behavior.

Verified that the test passed afterwards.