### PR TITLE
Adjust --top_level_targets_for_symlinks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -766,16 +766,35 @@ public class ExecutionTool {
     Reporter reporter = env.getReporter();
 
     // Gather configurations to consider.
-    Set<BuildConfigurationValue> targetConfigurations =
-        buildRequestOptions.useTopLevelTargetsForSymlinks() && !targetsToBuild.isEmpty()
-            ? targetsToBuild.stream()
-                .map(ConfiguredTarget::getActual)
-                .map(ConfiguredTarget::getConfigurationKey)
-                .filter(Objects::nonNull)
-                .distinct()
-                .map((key) -> executor.getConfiguration(reporter, key))
-                .collect(toImmutableSet())
-            : ImmutableSet.of(configuration);
+    ImmutableSet<BuildConfigurationValue> targetConfigs;
+    if (buildRequestOptions.useTopLevelTargetsForSymlinks() && !targetsToBuild.isEmpty()) {
+      // Collect the configuration of each top-level requested target. These may be different than
+      // the build's top-level configuration because of self-transitions.
+      ImmutableSet<BuildConfigurationValue> requestedTargetConfigs =
+          targetsToBuild.stream()
+              .map(ConfiguredTarget::getActual)
+              .map(ConfiguredTarget::getConfigurationKey)
+              .filter(Objects::nonNull)
+              .distinct()
+              .map((key) -> executor.getConfiguration(reporter, key))
+              .collect(toImmutableSet());
+      if (requestedTargetConfigs.size() == 1) {
+        // All top-level targets have the same configuration, so use that one.
+        targetConfigs = requestedTargetConfigs;
+      } else if (requestedTargetConfigs.contains(configuration)) {
+        // Mixed configs but at least one of them includes the top-level config. Set symlinks to the
+        // top-level config so at least non-transitioned targets resolve. See
+        // https://github.com/bazelbuild/bazel/issues/17081.
+        targetConfigs = ImmutableSet.of(configuration);
+      } else {
+        // Mixed configs, none of which include the top-level config. Delete the symlinks because
+        // they won't contain any relevant data. This is handled in the
+        // createOutputDirectorySymlinks call below.
+        targetConfigs = requestedTargetConfigs;
+      }
+    } else {
+      targetConfigs = ImmutableSet.of(configuration);
+    }
 
     String productName = runtime.getProductName();
     try (SilentCloseable c =
@@ -787,7 +806,7 @@ public class ExecutionTool {
           env.getWorkspace(),
           env.getDirectories(),
           getReporter(),
-          targetConfigurations,
+          targetConfigs,
           options -> getConfiguration(executor, reporter, options),
           productName);
     }

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -781,9 +781,19 @@ public class ExecutionTool {
       if (requestedTargetConfigs.size() == 1) {
         // All top-level targets have the same configuration, so use that one.
         targetConfigs = requestedTargetConfigs;
+<<<<<<< HEAD
       } else if (requestedTargetConfigs.contains(configuration)) {
         // Mixed configs but at least one of them includes the top-level config. Set symlinks to the
         // top-level config so at least non-transitioned targets resolve. See
+=======
+      } else if (requestedTargetConfigs.stream()
+          .anyMatch(
+              c -> c.getOutputDirectoryName().equals(configuration.getOutputDirectoryName()))) {
+        // Mixed configs but at least one matches the top-level config's output path (this doesn't
+        // mean it's the same as the top-level config: --trim_test_configuration means non-test
+        // targets use the default output path but lack the top-level config's TestOptions). Set
+        // symlinks to the top-level config so at least non-transitioned targets resolve. See
+>>>>>>> ea02ba53fc (Adjust --top_level_targets_for_symlinks.)
         // https://github.com/bazelbuild/bazel/issues/17081.
         targetConfigs = ImmutableSet.of(configuration);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -781,11 +781,6 @@ public class ExecutionTool {
       if (requestedTargetConfigs.size() == 1) {
         // All top-level targets have the same configuration, so use that one.
         targetConfigs = requestedTargetConfigs;
-<<<<<<< HEAD
-      } else if (requestedTargetConfigs.contains(configuration)) {
-        // Mixed configs but at least one of them includes the top-level config. Set symlinks to the
-        // top-level config so at least non-transitioned targets resolve. See
-=======
       } else if (requestedTargetConfigs.stream()
           .anyMatch(
               c -> c.getOutputDirectoryName().equals(configuration.getOutputDirectoryName()))) {
@@ -793,7 +788,6 @@ public class ExecutionTool {
         // mean it's the same as the top-level config: --trim_test_configuration means non-test
         // targets use the default output path but lack the top-level config's TestOptions). Set
         // symlinks to the top-level config so at least non-transitioned targets resolve. See
->>>>>>> ea02ba53fc (Adjust --top_level_targets_for_symlinks.)
         // https://github.com/bazelbuild/bazel/issues/17081.
         targetConfigs = ImmutableSet.of(configuration);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
@@ -169,7 +169,7 @@ public final class OutputDirectoryLinksUtils {
       eventHandler.handle(
           Event.warn(
               String.format(
-                  "cleared convenience symlink(s) %s because they wouldn't contain 0 "
+                  "cleared convenience symlink(s) %s because they wouldn't contain "
                       + "requested targets' outputs. Those targets self-transition to multiple "
                       + "distinct configurations",
                   Joiner.on(", ").join(ambiguousLinks))));

--- a/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/OutputDirectoryLinksUtils.java
@@ -169,7 +169,9 @@ public final class OutputDirectoryLinksUtils {
       eventHandler.handle(
           Event.warn(
               String.format(
-                  "cleared convenience symlink(s) %s because their destinations would be ambiguous",
+                  "cleared convenience symlink(s) %s because they wouldn't contain 0 "
+                      + "requested targets' outputs. Those targets self-transition to multiple "
+                      + "distinct configurations",
                   Joiner.on(", ").join(ambiguousLinks))));
     }
     return convenienceSymlinksBuilder.build();


### PR DESCRIPTION
Adjust `--top_level_targets_for_symlinks`.

#### Old semantics:

- If all targets in `$ bazel build //...` have the top-level config, `bazel-bin`, etc. point to that config
- If all targets in `$ bazel build //...` have the same transitioned config, `bazel-bin`, etc. point to that config
- If targets in `$ bazel build //...` have mixed configs, `bazel-bin`, etc. are deleted

#### New semantics:

- If all targets in `$ bazel build //...` have the top-level config, `bazel-bin`, etc. point to that config
- If all targets in `$ bazel build //...` have the same transitioned config, `bazel-bin`, etc. point to that config
- If targets in `$ bazel build //...` have mixed configs and at least one of them is the top-level config, `bazel-bin`, etc. point to the top-level config
- If targets in `$ bazel build //...` have mixed configs and none are the top-level config, `bazel-bin`, etc. are deleted


Fixes https://github.com/bazelbuild/bazel/issues/17081.


