### PR TITLE
Add helper for Markdown inline code escaping

### DIFF
--- a/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownUtil.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.skydoc.rendering;
 
+import static java.util.Comparator.naturalOrder;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.skydoc.rendering.proto.StardocOutputProtos.AspectInfo;
@@ -25,14 +27,11 @@ import com.google.devtools.build.skydoc.rendering.proto.StardocOutputProtos.Prov
 import com.google.devtools.build.skydoc.rendering.proto.StardocOutputProtos.RuleInfo;
 import com.google.devtools.build.skydoc.rendering.proto.StardocOutputProtos.StarlarkFunctionInfo;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-/**
- * Contains a number of utility methods for markdown rendering.
- */
+/** Contains a number of utility methods for markdown rendering. */
 public final class MarkdownUtil {
   private static final int MAX_LINE_LENGTH = 100;
 
@@ -89,25 +88,25 @@ public final class MarkdownUtil {
   private static final Pattern CONSECUTIVE_BACKTICKS = Pattern.compile("`+");
 
   /**
-   * Returns a Markdown code span (e.g. <code>`return foo;`</code>) that contains the given literal
-   * text, which may itself contain backticks.
+   * Returns a Markdown code span (e.g. {@code `return foo;`}) that contains the given literal text,
+   * which may itself contain backticks.
    *
    * <p>For example:
    *
    * <ul>
-   *   <li><code>foo</code> becomes <code>`foo`</code>
-   *   <li><code>fo`o</code> becomes <code>``fo`o``</code>
-   *   <li><code>`foo`</code> becomes <code>`` `foo` ``</code>
+   *   <li>{@code markdownCodeSpan("foo")} returns {@code "`foo`"}
+   *   <li>{@code markdownCodeSpan("fo`o")} returns {@code "``fo`o``"}
+   *   <li>{@code markdownCodeSpan("`foo`")} returns {@code "`` foo` ``""}
    * </ul>
    */
-  public String markdownCodeSpan(String code) {
+  public static String markdownCodeSpan(String code) {
     // https://github.github.com/gfm/#code-span
     int numConsecutiveBackticks =
         CONSECUTIVE_BACKTICKS
             .matcher(code)
             .results()
             .map(match -> match.end() - match.start())
-            .max(Comparator.naturalOrder())
+            .max(naturalOrder())
             .orElse(0);
     String padding = code.startsWith("`") || code.endsWith("`") ? " " : "";
     return String.format(

--- a/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownUtil.java
@@ -25,7 +25,9 @@ import com.google.devtools.build.skydoc.rendering.proto.StardocOutputProtos.Prov
 import com.google.devtools.build.skydoc.rendering.proto.StardocOutputProtos.RuleInfo;
 import com.google.devtools.build.skydoc.rendering.proto.StardocOutputProtos.StarlarkFunctionInfo;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -82,6 +84,34 @@ public final class MarkdownUtil {
    */
   public String htmlEscape(String docString) {
     return docString.replace("<", "&lt;").replace(">", "&gt;");
+  }
+
+  private static final Pattern CONSECUTIVE_BACKTICKS = Pattern.compile("`+");
+
+  /**
+   * Returns a string that escapes the given string so that it can be used in a markdown inline code segment, delimited
+   * by backticks (not included in the returned string).
+   *
+   * <p>For example:
+   * <ul>
+   *     <li><code>foo</code> becomes <code>foo</code>
+   *     <li><code>`foo`</code> becomes <code>` `foo` `</code>
+   *     <li><code>``foo``</code> becomes <code>`` `foo` ``</code>
+   * </ul>
+   */
+  public String markdownInlineCodeEscape(String code) {
+    int numConsecutiveBackticks =
+        CONSECUTIVE_BACKTICKS
+            .matcher(code)
+            .results()
+            .map(match -> match.end() - match.start())
+            .max(Comparator.naturalOrder())
+            .orElse(0);
+    if (numConsecutiveBackticks == 0) {
+      return code;
+    } else {
+      return String.format("%1$s %2$s %1$s", "`".repeat(numConsecutiveBackticks), code);
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownUtil.java
@@ -89,17 +89,19 @@ public final class MarkdownUtil {
   private static final Pattern CONSECUTIVE_BACKTICKS = Pattern.compile("`+");
 
   /**
-   * Returns a string that escapes the given string so that it can be used in a markdown inline code segment, delimited
-   * by backticks (not included in the returned string).
+   * Returns a Markdown code span (e.g. <code>`return foo;`</code>) that contains the given literal
+   * text, which may itself contain backticks.
    *
    * <p>For example:
+   *
    * <ul>
-   *     <li><code>foo</code> becomes <code>foo</code>
-   *     <li><code>`foo`</code> becomes <code>` `foo` `</code>
-   *     <li><code>``foo``</code> becomes <code>`` `foo` ``</code>
+   *   <li><code>foo</code> becomes <code>`foo`</code>
+   *   <li><code>fo`o</code> becomes <code>``fo`o``</code>
+   *   <li><code>`foo`</code> becomes <code>`` `foo` ``</code>
    * </ul>
    */
-  public String markdownInlineCodeEscape(String code) {
+  public String markdownCodeSpan(String code) {
+    // https://github.github.com/gfm/#code-span
     int numConsecutiveBackticks =
         CONSECUTIVE_BACKTICKS
             .matcher(code)
@@ -107,11 +109,9 @@ public final class MarkdownUtil {
             .map(match -> match.end() - match.start())
             .max(Comparator.naturalOrder())
             .orElse(0);
-    if (numConsecutiveBackticks == 0) {
-      return code;
-    } else {
-      return String.format("%1$s %2$s %1$s", "`".repeat(numConsecutiveBackticks), code);
-    }
+    String padding = code.startsWith("`") || code.endsWith("`") ? " " : "";
+    return String.format(
+        "%1$s%2$s%3$s%2$s%1$s", "`".repeat(numConsecutiveBackticks + 1), padding, code);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/skydoc/BUILD
+++ b/src/test/java/com/google/devtools/build/skydoc/BUILD
@@ -11,6 +11,7 @@ filegroup(
     testonly = 0,
     srcs = glob(["**"]) + [
         "//src/test/java/com/google/devtools/build/skydoc/private:srcs",
+        "//src/test/java/com/google/devtools/build/skydoc/rendering:srcs",
         "//src/test/java/com/google/devtools/build/skydoc/testdata/same_level_file_test:srcs",
     ],
     visibility = ["//src:__pkg__"],

--- a/src/test/java/com/google/devtools/build/skydoc/rendering/BUILD
+++ b/src/test/java/com/google/devtools/build/skydoc/rendering/BUILD
@@ -1,7 +1,20 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
+package(
+    default_testonly = 1,
+    default_visibility = ["//src:__subpackages__"],
+)
+
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["*"]),
+    visibility = ["//src/main/java/com/google/devtools/build/skydoc:__pkg__"],
+)
+
 java_test(
     name = "MarkdownUtilTest",
+    size = "small",
     srcs = ["MarkdownUtilTest.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/skydoc/rendering",

--- a/src/test/java/com/google/devtools/build/skydoc/rendering/BUILD
+++ b/src/test/java/com/google/devtools/build/skydoc/rendering/BUILD
@@ -1,0 +1,11 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+java_test(
+    name = "MarkdownUtilTest",
+    srcs = ["MarkdownUtilTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/skydoc/rendering",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/skydoc/rendering/BUILD
+++ b/src/test/java/com/google/devtools/build/skydoc/rendering/BUILD
@@ -9,7 +9,7 @@ filegroup(
     name = "srcs",
     testonly = 0,
     srcs = glob(["*"]),
-    visibility = ["//src/main/java/com/google/devtools/build/skydoc:__pkg__"],
+    visibility = ["//src/test/java/com/google/devtools/build/skydoc:__pkg__"],
 )
 
 java_test(

--- a/src/test/java/com/google/devtools/build/skydoc/rendering/MarkdownUtilTest.java
+++ b/src/test/java/com/google/devtools/build/skydoc/rendering/MarkdownUtilTest.java
@@ -1,3 +1,17 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.devtools.build.skydoc.rendering;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -10,22 +24,23 @@ public class MarkdownUtilTest {
 
   @Test
   public void markdownCodeSpan() {
-    assertThat(util.markdownCodeSpan("")).isEqualTo("``");
-    assertThat(util.markdownCodeSpan("foo bar ")).isEqualTo("`foo bar `");
+    assertThat(MarkdownUtil.markdownCodeSpan("")).isEqualTo("``");
+    assertThat(MarkdownUtil.markdownCodeSpan("foo bar ")).isEqualTo("`foo bar `");
   }
 
   @Test
   public void markdownCodeSpan_backticks() {
-    assertThat(util.markdownCodeSpan("foo`bar")).isEqualTo("``foo`bar``");
-    assertThat(util.markdownCodeSpan("foo``bar")).isEqualTo("```foo``bar```");
-    assertThat(util.markdownCodeSpan("foo`bar```baz``quz")).isEqualTo("````foo`bar```baz``quz````");
+    assertThat(MarkdownUtil.markdownCodeSpan("foo`bar")).isEqualTo("``foo`bar``");
+    assertThat(MarkdownUtil.markdownCodeSpan("foo``bar")).isEqualTo("```foo``bar```");
+    assertThat(MarkdownUtil.markdownCodeSpan("foo`bar```baz``quz"))
+        .isEqualTo("````foo`bar```baz``quz````");
   }
 
   @Test
   public void markdownCodeSpan_backticksPadding() {
-    assertThat(util.markdownCodeSpan("`foo")).isEqualTo("`` `foo ``");
-    assertThat(util.markdownCodeSpan("``foo")).isEqualTo("``` ``foo ```");
-    assertThat(util.markdownCodeSpan("foo`")).isEqualTo("`` foo` ``");
-    assertThat(util.markdownCodeSpan("foo``")).isEqualTo("``` foo`` ```");
+    assertThat(MarkdownUtil.markdownCodeSpan("`foo")).isEqualTo("`` `foo ``");
+    assertThat(MarkdownUtil.markdownCodeSpan("``foo")).isEqualTo("``` ``foo ```");
+    assertThat(MarkdownUtil.markdownCodeSpan("foo`")).isEqualTo("`` foo` ``");
+    assertThat(MarkdownUtil.markdownCodeSpan("foo``")).isEqualTo("``` foo`` ```");
   }
 }

--- a/src/test/java/com/google/devtools/build/skydoc/rendering/MarkdownUtilTest.java
+++ b/src/test/java/com/google/devtools/build/skydoc/rendering/MarkdownUtilTest.java
@@ -1,0 +1,31 @@
+package com.google.devtools.build.skydoc.rendering;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public class MarkdownUtilTest {
+
+  MarkdownUtil util = new MarkdownUtil();
+
+  @Test
+  public void markdownCodeSpan() {
+    assertThat(util.markdownCodeSpan("")).isEqualTo("``");
+    assertThat(util.markdownCodeSpan("foo bar ")).isEqualTo("`foo bar `");
+  }
+
+  @Test
+  public void markdownCodeSpan_backticks() {
+    assertThat(util.markdownCodeSpan("foo`bar")).isEqualTo("``foo`bar``");
+    assertThat(util.markdownCodeSpan("foo``bar")).isEqualTo("```foo``bar```");
+    assertThat(util.markdownCodeSpan("foo`bar```baz``quz")).isEqualTo("````foo`bar```baz``quz````");
+  }
+
+  @Test
+  public void markdownCodeSpan_backticksPadding() {
+    assertThat(util.markdownCodeSpan("`foo")).isEqualTo("`` `foo ``");
+    assertThat(util.markdownCodeSpan("``foo")).isEqualTo("``` ``foo ```");
+    assertThat(util.markdownCodeSpan("foo`")).isEqualTo("`` foo` ``");
+    assertThat(util.markdownCodeSpan("foo``")).isEqualTo("``` foo`` ```");
+  }
+}


### PR DESCRIPTION
The helper adds escaping to a string so that it can be embedded in a Markdown inline code segment delimited by backticks.