### PR TITLE
Flip `--incompatible_hermetic_sandbox_tmp` for Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,9 @@ build --tool_java_language_version=11
 # Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
 build --incompatible_disallow_empty_glob
 
+# Fix non-deterministic Java compilation failures (https://github.com/bazelbuild/bazel/issues/3236)
+build --incompatible_sandbox_hermetic_tmp
+
 # User-specific .bazelrc
 try-import %workspace%/user.bazelrc
 


### PR DESCRIPTION
Fixes spurious Java compile action failures when the action is sandboxed.

Work towards #3236