### PR TITLE
[6.3.0] Add a new provider for passing dex related artifacts in android_binary

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -69,6 +69,7 @@ import com.google.devtools.build.lib.rules.android.AndroidConfiguration;
 import com.google.devtools.build.lib.rules.android.AndroidDeviceBrokerInfo;
 import com.google.devtools.build.lib.rules.android.AndroidDeviceRule;
 import com.google.devtools.build.lib.rules.android.AndroidDeviceScriptFixtureRule;
+import com.google.devtools.build.lib.rules.android.AndroidDexInfo;
 import com.google.devtools.build.lib.rules.android.AndroidFeatureFlagSetProvider;
 import com.google.devtools.build.lib.rules.android.AndroidHostServiceFixtureRule;
 import com.google.devtools.build.lib.rules.android.AndroidIdeInfoProvider;
@@ -423,7 +424,8 @@ public class BazelRuleClassProvider {
                   ProguardMappingProvider.PROVIDER,
                   AndroidBinaryDataInfo.PROVIDER,
                   AndroidBinaryNativeLibsInfo.PROVIDER,
-                  BaselineProfileProvider.PROVIDER);
+                  BaselineProfileProvider.PROVIDER,
+                  AndroidDexInfo.PROVIDER);
           builder.addStarlarkBootstrap(bootstrap);
 
           try {

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDexInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDexInfo.java
@@ -1,0 +1,80 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.rules.android;
+
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.packages.BuiltinProvider;
+import com.google.devtools.build.lib.packages.NativeInfo;
+import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidDexInfoApi;
+import net.starlark.java.eval.EvalException;
+
+/** A provider for Android Dex artifacts */
+@Immutable
+public class AndroidDexInfo extends NativeInfo implements AndroidDexInfoApi<Artifact> {
+
+  public static final String PROVIDER_NAME = "AndroidDexInfo";
+  public static final Provider PROVIDER = new Provider();
+
+  private final Artifact deployJar;
+  private final Artifact finalClassesDexZip;
+  private final Artifact javaResourceJar;
+
+  public AndroidDexInfo(Artifact deployJar, Artifact finalClassesDexZip, Artifact javaResourceJar) {
+    this.deployJar = deployJar;
+    this.finalClassesDexZip = finalClassesDexZip;
+    this.javaResourceJar = javaResourceJar;
+  }
+
+  @Override
+  public Provider getProvider() {
+    return PROVIDER;
+  }
+
+  @Override
+  public Artifact getDeployJar() {
+    return deployJar;
+  }
+
+  @Override
+  public Artifact getFinalClassesDexZip() {
+    return finalClassesDexZip;
+  }
+
+  @Override
+  public Artifact getJavaResourceJar() {
+    return javaResourceJar;
+  }
+
+  /** Provider for {@link AndroidDexInfo}. */
+  public static class Provider extends BuiltinProvider<AndroidDexInfo>
+      implements AndroidDexInfoApi.Provider<Artifact> {
+
+    private Provider() {
+      super(PROVIDER_NAME, AndroidDexInfo.class);
+    }
+
+    public String getName() {
+      return PROVIDER_NAME;
+    }
+
+    @Override
+    public AndroidDexInfo createInfo(
+        Artifact deployJar, Artifact finalClassesDexZip, Artifact javaResourceJar)
+        throws EvalException {
+
+      return new AndroidDexInfo(deployJar, finalClassesDexZip, javaResourceJar);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDexInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDexInfo.java
@@ -13,11 +13,14 @@
 // limitations under the License.
 package com.google.devtools.build.lib.rules.android;
 
+import static com.google.devtools.build.lib.rules.android.AndroidStarlarkData.fromNoneable;
+
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidDexInfoApi;
+import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 
 /** A provider for Android Dex artifacts */
@@ -53,6 +56,7 @@ public class AndroidDexInfo extends NativeInfo implements AndroidDexInfoApi<Arti
   }
 
   @Override
+  @Nullable
   public Artifact getJavaResourceJar() {
     return javaResourceJar;
   }
@@ -71,10 +75,11 @@ public class AndroidDexInfo extends NativeInfo implements AndroidDexInfoApi<Arti
 
     @Override
     public AndroidDexInfo createInfo(
-        Artifact deployJar, Artifact finalClassesDexZip, Artifact javaResourceJar)
+        Artifact deployJar, Artifact finalClassesDexZip, Object javaResourceJar)
         throws EvalException {
 
-      return new AndroidDexInfo(deployJar, finalClassesDexZip, javaResourceJar);
+      return new AndroidDexInfo(
+          deployJar, finalClassesDexZip, fromNoneable(javaResourceJar, Artifact.class));
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidBootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidBootstrap.java
@@ -64,7 +64,8 @@ public class AndroidBootstrap implements Bootstrap {
       ProguardMappingProviderApi.Provider<?> proguardMappingProviderApiProvider,
       AndroidBinaryDataInfoApi.Provider<?, ?, ?, ?> androidBinaryDataInfoProvider,
       AndroidBinaryNativeLibsInfoApi.Provider<?> androidBinaryInternalNativeLibsInfoApiProvider,
-      BaselineProfileProviderApi.Provider<?> baselineProfileProvider) {
+      BaselineProfileProviderApi.Provider<?> baselineProfileProvider,
+      AndroidDexInfoApi.Provider<?> androidDexInfoApiProvider) {
 
     this.androidCommon = androidCommon;
     ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
@@ -93,6 +94,7 @@ public class AndroidBootstrap implements Bootstrap {
     builder.put(ProguardMappingProviderApi.NAME, proguardMappingProviderApiProvider);
     builder.put(AndroidBinaryDataInfoApi.NAME, androidBinaryDataInfoProvider);
     builder.put(BaselineProfileProviderApi.NAME, baselineProfileProvider);
+    builder.put(AndroidDexInfoApi.NAME, androidDexInfoApiProvider);
     providers = builder.build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidDexInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidDexInfoApi.java
@@ -1,0 +1,100 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.starlarkbuildapi.android;
+
+import com.google.devtools.build.docgen.annot.StarlarkConstructor;
+import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
+import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
+import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.ParamType;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.EvalException;
+
+/** An Info that can provides dex artifacts. */
+@StarlarkBuiltin(
+    name = "AndroidDexInfo",
+    doc =
+        "Do not use this module. It is intended for migration purposes only. If you depend on it, "
+            + "you will be broken when it is removed.",
+    documented = false)
+public interface AndroidDexInfoApi<FileT extends FileApi> extends StructApi {
+
+  /** Name of this info object. */
+  String NAME = "AndroidDexInfo";
+
+  @StarlarkMethod(
+      name = "deploy_jar",
+      doc = "The deploy jar.",
+      documented = false,
+      structField = true)
+  FileT getDeployJar();
+
+  @StarlarkMethod(
+      name = "final_classes_dex_zip",
+      doc = "The zip file containing the final dex classes.",
+      documented = false,
+      structField = true)
+  FileT getFinalClassesDexZip();
+
+  @StarlarkMethod(
+      name = "java_resource_jar",
+      doc = "The final Java resource jar.",
+      documented = false,
+      structField = true)
+  FileT getJavaResourceJar();
+
+  /** Provider for {@link AndroidDexInfoApi}. */
+  @StarlarkBuiltin(
+      name = "Provider",
+      doc =
+          "Do not use this module. It is intended for migration purposes only. If you depend on "
+              + "it, you will be broken when it is removed.",
+      documented = false)
+  interface Provider<FileT extends FileApi> extends ProviderApi {
+
+    @StarlarkMethod(
+        name = NAME,
+        doc = "The <code>AndroidDexInfo</code> constructor.",
+        documented = false,
+        parameters = {
+          @Param(
+              name = "deploy_jar",
+              allowedTypes = {
+                @ParamType(type = FileApi.class),
+              },
+              named = true,
+              doc = "The \"_deploy\" jar suitable for deployment."),
+          @Param(
+              name = "final_classes_dex_zip",
+              allowedTypes = {
+                @ParamType(type = FileApi.class),
+              },
+              named = true,
+              doc = "The zip file containing the final dex classes."),
+          @Param(
+              name = "java_resource_jar",
+              allowedTypes = {
+                @ParamType(type = FileApi.class),
+              },
+              named = true,
+              doc = "The final Java resource jar."),
+        },
+        selfCall = true)
+    @StarlarkConstructor
+    AndroidDexInfoApi<FileT> createInfo(
+        FileT deployJar, FileT finalClassesDexZip, FileT javaResourceJar) throws EvalException;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidDexInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidDexInfoApi.java
@@ -17,11 +17,13 @@ import com.google.devtools.build.docgen.annot.StarlarkConstructor;
 import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
+import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.NoneType;
 
 /** An Info that can provides dex artifacts. */
 @StarlarkBuiltin(
@@ -49,11 +51,13 @@ public interface AndroidDexInfoApi<FileT extends FileApi> extends StructApi {
       structField = true)
   FileT getFinalClassesDexZip();
 
+  @Nullable
   @StarlarkMethod(
       name = "java_resource_jar",
       doc = "The final Java resource jar.",
       documented = false,
-      structField = true)
+      structField = true,
+      allowReturnNones = true)
   FileT getJavaResourceJar();
 
   /** Provider for {@link AndroidDexInfoApi}. */
@@ -88,6 +92,7 @@ public interface AndroidDexInfoApi<FileT extends FileApi> extends StructApi {
               name = "java_resource_jar",
               allowedTypes = {
                 @ParamType(type = FileApi.class),
+                @ParamType(type = NoneType.class),
               },
               named = true,
               doc = "The final Java resource jar."),
@@ -95,6 +100,6 @@ public interface AndroidDexInfoApi<FileT extends FileApi> extends StructApi {
         selfCall = true)
     @StarlarkConstructor
     AndroidDexInfoApi<FileT> createInfo(
-        FileT deployJar, FileT finalClassesDexZip, FileT javaResourceJar) throws EvalException;
+        FileT deployJar, FileT finalClassesDexZip, Object javaResourceJar) throws EvalException;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBuildViewTestCase.java
@@ -189,6 +189,11 @@ public abstract class AndroidBuildViewTestCase extends BuildViewTestCase {
         target.getProvider(FileProvider.class).getFilesToBuild(), "_unsigned.apk");
   }
 
+  protected Artifact getDeployJar(ConfiguredTarget target) {
+    return getFirstArtifactEndingWith(
+        target.getProvider(FileProvider.class).getFilesToBuild(), "_deploy.jar");
+  }
+
   protected Artifact getResourceApk(ConfiguredTarget target) {
     Artifact resourceApk =
         getFirstArtifactEndingWith(


### PR DESCRIPTION
Cherrypicking 2 commits to support the Starlark android_binary rule


- First commit
    PiperOrigin-RevId: 515061110
    Change-Id: Ieefe430582c01264fb510de3ac1017d3332f51aa

- Second commit
    PiperOrigin-RevId: 531000013
    Change-Id: I67c3457d131041aa4bab5db0892cdc0f0584f2dc

