### PR TITLE
Print $TEST_UNDECLARED_OUTPUTS_ZIP failure reason

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -427,8 +427,9 @@ if [[ -n "$TEST_UNDECLARED_OUTPUTS_ZIP" ]] && cd "$TEST_UNDECLARED_OUTPUTS_DIR";
     # Otherwise echo printed the top-level files and directories.
     # Pass files to zip with *, so paths with spaces aren't broken up.
     # Remove original files after zipping them.
-    zip -qrm "$TEST_UNDECLARED_OUTPUTS_ZIP" -- * 2>/dev/null || \
-        echo >&2 "Could not create \"$TEST_UNDECLARED_OUTPUTS_ZIP\": zip not found or failed"
+    if ! zip_output="$(zip -qrm "$TEST_UNDECLARED_OUTPUTS_ZIP" -- * 2>&1)"; then
+        echo >&2 "Could not create \"$TEST_UNDECLARED_OUTPUTS_ZIP\": $zip_output"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Zipping up the `$TEST_UNDECLARED_OUTPUTS_DIR` can fail -- for example if `zip` is not installed. This PR improves the printed message to include the actual failure reason.

It's easy to test this manually with a brutal `sudo mv /bin/zip /bin/zip.backup`:

The old message looked like
`Could not create /home/user/.cache/bazel/_bazel_laltenmueller/5f48ff965103b174f3c248651ebad24d/sandbox/linux-sandbox/1/execroot/repo/bazel-out/k8-fastbuild/testlogs/path/to/package/test/run_2_of_2/test.outputs/outputs.zip": zip not found or failed`

The new message looks like
`Could not create "/home/user/.cache/bazel/_bazel_laltenmueller/5f48ff965103b174f3c248651ebad24d/sandbox/linux-sandbox/1/execroot/repo/bazel-out/k8-fastbuild/testlogs/path/to/package/test/run_1_of_2/test.outputs/outputs.zip": external/bazel_tools/tools/test/test-setup.sh: line 430: zip: command not found`
