### PR TITLE
[6.3.0] Ignore broken classic desugar tests on Windows

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -274,6 +274,12 @@ tasks:
       - "//tools/test/..."
       # Re-enable the following tests on Windows:
       # https://github.com/bazelbuild/bazel/issues/4292
+      - "-//src/test/java/com/google/devtools/build/android/desugar/nest/..."
+      - "-//src/test/java/com/google/devtools/build/android/desugar/stringconcat/..."
+      - "-//src/test/java/com/google/devtools/build/android/desugar/testing/junit/..."
+      - "-//src/test/java/com/google/devtools/build/android/desugar/covariantreturn/..."
+      - "-//src/test/java/com/google/devtools/build/android/desugar/scan/..."
+      - "-//src/test/java/com/google/devtools/build/android/desugar/typeannotation/..."
       - "-//src/test/java/com/google/devtools/build/android/r8/..."
       - "-//src/test/java/com/google/devtools/build/lib/query2/cquery/..."
       - "-//src/test/java/com/google/devtools/build/lib/query2/engine/..."


### PR DESCRIPTION
presubmit.yml already ignored these, but postsubmit.yml should ignore them too.