### PR TITLE
[6.3.0] Disable UseCorrectAssertInTests by default

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -59,6 +59,7 @@ DEFAULT_JAVACOPTS = [
     "-Xep:EmptyTopLevelDeclaration:OFF",
     "-Xep:LenientFormatStringValidation:OFF",
     "-Xep:ReturnMissingNullable:OFF",
+    "-Xep:UseCorrectAssertInTests:OFF",
 ]
 
 # java_toolchain parameters without specifying javac, java.compiler,


### PR DESCRIPTION
Original commit in rules_java: https://github.com/bazelbuild/rules_java/commit/63c6c73dba2aa97823fe4695c1a7668cb62e8fd0

Note: Cannot be cherry-picked due to the recent changes to java_tools/rules_java. The same change has been made to the old file.