### PR TITLE
Add `additional_linker_inputs` option to `cc_library` rule

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
@@ -310,6 +310,18 @@ public class BazelCppRuleClasses {
           </p>
           <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
           .add(attr("linkopts", STRING_LIST))
+           /*<!-- #BLAZE_RULE($cc_rule).ATTRIBUTE(additional_linker_inputs) -->
+           Pass these files to the C++ linker command.
+           <p>
+             For example, compiled Windows .res files can be provided here to be embedded in
+             the binary target.
+           </p>
+          <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+          .add(
+              attr("additional_linker_inputs", LABEL_LIST)
+                  .orderIndependent()
+                  .direct_compile_time_input()
+                  .allowedFileTypes(FileTypeSet.ANY_FILE))
           /*<!-- #BLAZE_RULE($cc_rule).ATTRIBUTE(nocopts) -->
           Remove matching options from the C++ compilation command.
           Subject to <a href="${link make-variables}">"Make" variable</a> substitution.
@@ -487,18 +499,6 @@ public class BazelCppRuleClasses {
     @Override
     public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
       return builder
-          /*<!-- #BLAZE_RULE($cc_binary_base).ATTRIBUTE(additional_linker_inputs) -->
-           Pass these files to the C++ linker command.
-           <p>
-           For example, compiled Windows .res files can be provided here to be embedded in
-           the binary target.
-           </p>
-          <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
-          .add(
-              attr("additional_linker_inputs", LABEL_LIST)
-                  .orderIndependent()
-                  .direct_compile_time_input()
-                  .allowedFileTypes(FileTypeSet.ANY_FILE))
           .override(
               attr("deps", LABEL_LIST)
                   .allowedRuleClasses(DEPS_ALLOWED_RULES)

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -148,7 +148,7 @@ def _cc_library_impl(ctx):
             compilation_outputs = compilation_outputs,
             cc_toolchain = cc_toolchain,
             feature_configuration = feature_configuration,
-            additional_inputs = _filter_linker_scripts(ctx.files.deps),
+            additional_inputs = _filter_linker_scripts(ctx.files.deps) + ctx.files.additional_linker_inputs,
             linking_contexts = linking_contexts,
             grep_includes = ctx.executable._grep_includes,
             user_link_flags = cc_helper.linkopts(ctx, additional_make_variable_substitutions, cc_toolchain),
@@ -206,11 +206,12 @@ def _cc_library_impl(ctx):
     else:
         user_link_flags = cc_helper.linkopts(ctx, additional_make_variable_substitutions, cc_toolchain)
         linker_scripts = _filter_linker_scripts(ctx.files.deps)
-        if len(user_link_flags) > 0 or len(linker_scripts) > 0 or not semantics.should_create_empty_archive():
+        additional_linker_inputs = ctx.files.additional_linker_inputs
+        if len(user_link_flags) > 0 or len(linker_scripts) > 0 or len(additional_linker_inputs) > 0 or not semantics.should_create_empty_archive():
             linker_input = cc_common.create_linker_input(
                 owner = ctx.label,
                 user_link_flags = user_link_flags,
-                additional_inputs = depset(linker_scripts),
+                additional_inputs = depset(linker_scripts + additional_linker_inputs),
             )
             contexts_to_merge.append(cc_common.create_linking_context(linker_inputs = depset([linker_input])))
 
@@ -575,6 +576,10 @@ attrs = {
     ),
     "linkstamp": attr.label(allow_single_file = True),
     "linkopts": attr.string_list(),
+    "additional_linker_inputs": attr.label_list(
+        allow_files = True,
+        flags = ["ORDER_INDEPENDENT", "DIRECT_COMPILE_TIME_INPUT"],
+    ),
     "includes": attr.string_list(),
     "defines": attr.string_list(),
     "copts": attr.string_list(),


### PR DESCRIPTION
This is achieved by the following related changes:

1) Moving the `additional_linker_inputs` attribute up from the `cc_binary_base` rule to the `cc_rule`. The rationale here is that any rule that allows `linkopts` to be set should also support `additional_linker_inputs`.

2) Adding the `additional_linker_inputs` attr to the `cc_library` rule context. This was copied verbatim from the existing `cc_binary` attribute list.

3) Appending the `ctx.files.additional_linker_inputs` list to the list of linker scripts wherever they are passed as `additional_inputs` in the `cc_library.bzl` builtin file corresponding to the `cc_library` rule.

----------------------

For context on this PR, see issue #17788 as well as the original [Google group discussion](https://groups.google.com/g/bazel-discuss/c/1VFvNBDqzVU/m/F5UmYO-RAAAJ), which inspired the feature request.

Resolves #17788.