### PR TITLE
[6.3.0] Print timestamp at the start of test execution.

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -19,7 +19,7 @@ exec 2>&1
 
 # Executing the test log will page it.
 echo 'exec ${PAGER:-/usr/bin/less} "$0" || exit 1'
-echo "Executing tests from ${TEST_TARGET}"
+echo "Executing tests from ${TEST_TARGET} at $(date +"%F %T %Z")"
 
 function is_absolute {
   [[ "$1" = /* ]] || [[ "$1" =~ ^[a-zA-Z]:[/\\].* ]]


### PR DESCRIPTION
The intent is to simplify debugging of timeouts and pre-test latency: this way for timeouts there will be a clear measured interval between `Executing tests...` to `Test timed out at...` lines.

One side-effect of this will be to guarantee all test logs are unique, rather than just the ones that contain a timestamped log entry or timeout. I don't expect this to be an issue, as the vast majority of logs should already be unique for some reason or another.

Commit https://github.com/bazelbuild/bazel/commit/ed4872a3fab99f9e51dcbf91418504795b533438

RELNOTES: Print timestamp at the start of test execution logs.
PiperOrigin-RevId: 549006113
Change-Id: Iae7441a60bd7f6cbca8e96369618a44f68273039