### PR TITLE
Convert Starlark options with `Starlark#fromJava` in `build_config`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -107,7 +107,7 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
 
       // Add Starlark options.
       for (Map.Entry<Label, Object> e : buildOptions.getStarlarkOptions().entrySet()) {
-        result.put(e.getKey().toString(), e.getValue());
+        result.put(e.getKey().toString(), Starlark.fromJava(e.getValue(), null));
       }
       return result.buildOrThrow();
     }


### PR DESCRIPTION
`cquery`'s `build_config` function now ensures that Starlark option values are converted to Starlark types before being added to the `dict` of all options, fixing a crash observed for list-typed build settings specified on the command line.