### PR TITLE
Add support for isolated extension usages to the lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
@@ -19,8 +19,10 @@ import static com.google.common.collect.Comparators.emptiesFirst;
 import static java.util.Comparator.comparing;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Splitter;
 import com.google.devtools.build.lib.cmdline.Label;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 
 /** A unique identifier for a {@link ModuleExtension}. */
@@ -48,6 +50,17 @@ public abstract class ModuleExtensionId {
 
     public static IsolationKey create(ModuleKey module, String usageExportedName) {
       return new AutoValue_ModuleExtensionId_IsolationKey(module, usageExportedName);
+    }
+
+    @Override
+    public String toString() {
+      return getModule() + "~" + getUsageExportedName();
+    }
+
+    public static IsolationKey fromString(String s) throws Version.ParseException {
+      List<String> isolationKeyParts = Splitter.on("~").splitToList(s);
+      return ModuleExtensionId.IsolationKey.create(
+          ModuleKey.fromString(isolationKeyParts.get(0)), isolationKeyParts.get(1));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
@@ -16,9 +16,11 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import java.util.Comparator;
+import java.util.List;
 
 /** A module name, version pair that identifies a module in the external dependency graph. */
 @AutoValue
@@ -78,5 +80,18 @@ public abstract class ModuleKey {
     }
     return RepositoryName.createUnvalidated(
         String.format("%s~%s", getName(), getVersion().isEmpty() ? "override" : getVersion()));
+  }
+
+  public static ModuleKey fromString(String s) throws Version.ParseException {
+    if (s.equals("<root>")) {
+      return ModuleKey.ROOT;
+    }
+    List<String> parts = Splitter.on('@').splitToList(s);
+    if (parts.get(1).equals("_")) {
+      return ModuleKey.create(parts.get(0), Version.EMPTY);
+    }
+
+    Version version = Version.parse(parts.get(1));
+    return ModuleKey.create(parts.get(0), version);
   }
 }

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -299,6 +299,55 @@ class BazelLockfileTest(test_base.TestBase):
     )
     self.assertNotIn('Hello from the other side!', ''.join(stderr))
 
+  def testIsolatedModuleExtension(self):
+    self.ScratchFile(
+      'MODULE.bazel',
+      [
+        'lockfile_ext = use_extension("extension.bzl", "lockfile_ext", isolate = True)',
+        'lockfile_ext.dep(name = "bmbm", versions = ["v1", "v2"])',
+        'use_repo(lockfile_ext, "hello")',
+      ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+      'extension.bzl',
+      [
+        'def _repo_rule_impl(ctx):',
+        '    ctx.file("WORKSPACE")',
+        '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
+        '',
+        'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+        '',
+        'def _module_ext_impl(ctx):',
+        '    print("Hello from the other side!")',
+        '    repo_rule(name="hello")',
+        '    for mod in ctx.modules:',
+        '        for dep in mod.tags.dep:',
+        '            print("Name:", dep.name, ", Versions:", dep.versions)',
+        '',
+        '_dep = tag_class(attrs={"name": attr.string(), "versions":',
+        ' attr.string_list()})',
+        'lockfile_ext = module_extension(',
+        '    implementation=_module_ext_impl,',
+        '    tag_classes={"dep": _dep},',
+        '    environ=["GREEN_TREES", "NOT_SET"],',
+        ')',
+      ],
+    )
+
+    # Only set one env var, to make sure null variables don't crash
+    _, _, stderr = self.RunBazel(
+      ['build', '@hello//:all'], env_add={'GREEN_TREES': 'In the city'}
+    )
+    self.assertIn('Hello from the other side!', ''.join(stderr))
+    self.assertIn('Name: bmbm , Versions: ["v1", "v2"]', ''.join(stderr))
+
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+      ['build', '@hello//:all'], env_add={'GREEN_TREES': 'In the city'}
+    )
+    self.assertNotIn('Hello from the other side!', ''.join(stderr))
+
   def testModuleExtensionsInDifferentBuilds(self):
     # Test that the module extension stays in the lockfile (as long as it's
     # used in the module) even if it is not in the current build


### PR DESCRIPTION
Previously, Bazel would crash if a module declares an isolated extension usage and the lockfile is used.