### PR TITLE
Add `default_repo_name` attribute to `starlark_doc_extract`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtract.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtract.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.devtools.build.lib.packages.ImplicitOutputsFunction.fromTemplates;
+import static com.google.devtools.build.lib.packages.Type.STRING;
 import static com.google.devtools.build.lib.packages.Type.STRING_LIST;
 import static java.util.stream.Collectors.partitioningBy;
 
@@ -67,6 +68,7 @@ public class StarlarkDocExtract implements RuleConfiguredTargetFactory {
   static final String SRC_ATTR = "src";
   static final String DEPS_ATTR = "deps";
   static final String SYMBOL_NAMES_ATTR = "symbol_names";
+  static final String DEFAULT_REPO_NAME_ATTR = "default_repo_name";
   static final SafeImplicitOutputsFunction BINARYPROTO_OUT = fromTemplates("%{name}.binaryproto");
   static final SafeImplicitOutputsFunction TEXTPROTO_OUT = fromTemplates("%{name}.textproto");
 
@@ -295,7 +297,10 @@ public class StarlarkDocExtract implements RuleConfiguredTargetFactory {
     ModuleInfo moduleInfo;
     try {
       moduleInfo =
-          new ModuleInfoExtractor(getWantedSymbolPredicate(ruleContext), repositoryMapping)
+          new ModuleInfoExtractor(
+                  getWantedSymbolPredicate(ruleContext),
+                  repositoryMapping,
+                  (String) ruleContext.getRule().getAttr(DEFAULT_REPO_NAME_ATTR, STRING))
               .extractFrom(module);
     } catch (ModuleInfoExtractor.ExtractionException e) {
       ruleContext.ruleError(e.getMessage());

--- a/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractRule.java
@@ -18,6 +18,7 @@ import static com.google.devtools.build.lib.packages.Attribute.attr;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 import static com.google.devtools.build.lib.packages.ImplicitOutputsFunction.fromFunctions;
+import static com.google.devtools.build.lib.packages.Type.STRING;
 import static com.google.devtools.build.lib.packages.Type.STRING_LIST;
 
 import com.google.common.collect.ImmutableList;
@@ -93,6 +94,12 @@ public final class StarlarkDocExtractRule implements RuleDefinition {
         .add(
             attr(StarlarkDocExtract.SYMBOL_NAMES_ATTR, STRING_LIST)
                 .value(ImmutableList.<String>of()))
+        /*<!-- #BLAZE_RULE(starlark_doc_extract).ATTRIBUTE(symbol_names) -->
+        The repository name to emit for labels that reference targets in the same repository as this
+        rule. If set to the empty string (the default), such labels are rendered in
+        repository-relative form.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+        .add(attr(StarlarkDocExtract.DEFAULT_REPO_NAME_ATTR, STRING).value(""))
         /*<!-- #BLAZE_RULE(starlark_doc_extract).IMPLICIT_OUTPUTS -->
         <ul>
           <li><code><var>name</var>.binaryproto</code> (the default output): A

--- a/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -73,15 +73,16 @@ public final class ModuleInfoExtractorTest {
   }
 
   private static ModuleInfoExtractor getExtractor() {
-    return new ModuleInfoExtractor(name -> true, RepositoryMapping.ALWAYS_FALLBACK);
+    return new ModuleInfoExtractor(name -> true, RepositoryMapping.ALWAYS_FALLBACK, "");
   }
 
   private static ModuleInfoExtractor getExtractor(Predicate<String> isWantedQualifiedName) {
-    return new ModuleInfoExtractor(isWantedQualifiedName, RepositoryMapping.ALWAYS_FALLBACK);
+    return new ModuleInfoExtractor(isWantedQualifiedName, RepositoryMapping.ALWAYS_FALLBACK, "");
   }
 
-  private static ModuleInfoExtractor getExtractor(RepositoryMapping repositoryMapping) {
-    return new ModuleInfoExtractor(name -> true, repositoryMapping);
+  private static ModuleInfoExtractor getExtractor(
+      RepositoryMapping repositoryMapping, String defaultRepoName) {
+    return new ModuleInfoExtractor(name -> true, repositoryMapping, defaultRepoName);
   }
 
   @Test
@@ -681,7 +682,7 @@ public final class ModuleInfoExtractorTest {
     RepositoryName canonicalName = RepositoryName.create("canonical");
     RepositoryMapping repositoryMapping =
         RepositoryMapping.create(ImmutableMap.of("local", canonicalName), RepositoryName.MAIN);
-    ModuleInfo moduleInfo = getExtractor(repositoryMapping).extractFrom(module);
+    ModuleInfo moduleInfo = getExtractor(repositoryMapping, "").extractFrom(module);
     assertThat(
             moduleInfo.getRuleInfoList().get(0).getAttributeList().stream()
                 .filter(attr -> !attr.equals(ModuleInfoExtractor.IMPLICIT_NAME_ATTRIBUTE_INFO))
@@ -690,6 +691,38 @@ public final class ModuleInfoExtractorTest {
             "\"//test:foo\"",
             "[\"//x\", \"@local//y\", \"@local//y:z\"]",
             "{\"//x\": \"label_in_main\", \"@local//y\": \"label_in_dep\"}");
+  }
+
+  @Test
+  public void labelStringification_defaultRepoName() throws Exception {
+    Module module =
+        exec(
+            "def _my_impl(ctx):",
+            "    pass",
+            "my_lib = rule(",
+            "    implementation = _my_impl,",
+            "    attrs = {",
+            "        'label': attr.label(default = '//test:foo'),",
+            "        'label_list': attr.label_list(",
+            "            default = ['//x', '@canonical//y', '@canonical//y:z'],",
+            "        ),",
+            "        'label_keyed_string_dict': attr.label_keyed_string_dict(",
+            "           default = {'//x': 'label_in_main', '@canonical//y': 'label_in_dep'}",
+            "         ),",
+            "    }",
+            ")");
+    RepositoryName canonicalName = RepositoryName.create("canonical");
+    RepositoryMapping repositoryMapping =
+        RepositoryMapping.create(ImmutableMap.of("local", canonicalName), RepositoryName.MAIN);
+    ModuleInfo moduleInfo = getExtractor(repositoryMapping, "my_repo").extractFrom(module);
+    assertThat(
+            moduleInfo.getRuleInfoList().get(0).getAttributeList().stream()
+                .filter(attr -> !attr.equals(ModuleInfoExtractor.IMPLICIT_NAME_ATTRIBUTE_INFO))
+                .map(AttributeInfo::getDefaultValue))
+        .containsExactly(
+            "\"@my_repo//test:foo\"",
+            "[\"@my_repo//x\", \"@local//y\", \"@local//y:z\"]",
+            "{\"@my_repo//x\": \"label_in_main\", \"@local//y\": \"label_in_dep\"}");
   }
 
   @Test


### PR DESCRIPTION
The specified repository name is used to make repo-relative labels repo-absolute. This applies to default values that are labels as well as the locations of `.bzl` files.