### PR TITLE
Check invariant during Starlark options parsing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -17,6 +17,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -418,9 +419,10 @@ public final class BlazeOptionHandler {
       return DetailedExitCode.success();
     }
     try {
-      StarlarkOptionsParser.newStarlarkOptionsParser(
-              new SkyframeExecutorTargetLoader(env), optionsParser)
-          .parse();
+      Preconditions.checkState(
+          StarlarkOptionsParser.newStarlarkOptionsParser(
+                  new SkyframeExecutorTargetLoader(env), optionsParser)
+              .parse());
     } catch (OptionsParsingException e) {
       String logMessage = "Error parsing Starlark options";
       logger.atInfo().withCause(e).log("%s", logMessage);

--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -34,7 +34,6 @@ import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -103,7 +102,6 @@ public class StarlarkOptionsParser {
   // OptionsParserImpl.identifyOptionAndPossibleArgument. Consider combining. This would probably
   // require multiple rounds of parsing to fit starlark-defined options into native option format.
   @VisibleForTesting
-  @CanIgnoreReturnValue
   public boolean parse() throws OptionsParsingException {
     return parseGivenArgs(nativeOptionsParser.getSkippedArgs());
   }
@@ -115,7 +113,6 @@ public class StarlarkOptionsParser {
    *     work to retrieve build setting targets (after which it'll call this method again)
    */
   @VisibleForTesting
-  @CanIgnoreReturnValue
   public boolean parseGivenArgs(List<String> args) throws OptionsParsingException {
     // Map of <option name (label), <unparsed option value, loaded option>>.
     Multimap<String, Pair<String, Target>> unparsedOptions = LinkedListMultimap.create();

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CanonicalizeCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CanonicalizeCommand.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.runtime.commands;
 import static com.google.devtools.common.options.Converters.BLAZE_ALIASING_FLAG;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.Event;
@@ -200,7 +201,7 @@ public final class CanonicalizeCommand implements BlazeCommand {
         StarlarkOptionsParser.newStarlarkOptionsParser(
             new SkyframeExecutorTargetLoader(env), parser);
     try {
-      starlarkOptionsParser.parse();
+      Preconditions.checkState(starlarkOptionsParser.parse());
     } catch (OptionsParsingException e) {
       return reportAndCreateCommandFailure(
           env, e.getMessage(), FailureDetails.Command.Code.STARLARK_OPTIONS_PARSE_FAILURE);

--- a/src/test/java/com/google/devtools/build/lib/starlark/util/StarlarkOptionsTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/util/StarlarkOptionsTestCase.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.starlark.util;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
@@ -76,7 +78,7 @@ public class StarlarkOptionsTestCase extends BuildViewTestCase {
     if (!onlyStarlarkParser) {
       optionsParser.parse(asList);
     }
-    starlarkOptionsParser.parseGivenArgs(asList);
+    assertThat(starlarkOptionsParser.parseGivenArgs(asList)).isTrue();
     return starlarkOptionsParser.getNativeOptionsParserFortesting();
   }
 
@@ -86,11 +88,11 @@ public class StarlarkOptionsTestCase extends BuildViewTestCase {
     List<String> bazelrcOptionsList = Arrays.asList(bazelrcOptions.split(" "));
     optionsParser.parse(PriorityCategory.COMMAND_LINE, /* source= */ null, commandLineOptionsList);
     optionsParser.parse(PriorityCategory.RC_FILE, "fake.bazelrc", bazelrcOptionsList);
-    starlarkOptionsParser.parseGivenArgs(
+    assertThat(starlarkOptionsParser.parseGivenArgs(
         ImmutableList.<String>builder()
             .addAll(commandLineOptionsList)
             .addAll(bazelrcOptionsList)
-            .build());
+            .build())).isTrue();
     return starlarkOptionsParser.getNativeOptionsParserFortesting();
   }
 


### PR DESCRIPTION
The particular implementation of `BuildSettingLoader` always loads targets synchronously without every returning `null`, so the return value of `parse` is expected to be `true`. Check this invariant to make these calls easier to understand.