### PR TITLE
Add `render_main_repo_name` attribute to `starlark_doc_extract`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
@@ -68,9 +68,16 @@ public abstract class RepositoryMapping {
    * additional mappings. If there are conflicts, existing mappings will take precedence.
    */
   public RepositoryMapping withAdditionalMappings(Map<String, RepositoryName> additionalMappings) {
-    HashMap<String, RepositoryName> allMappings = new HashMap<>(additionalMappings);
+    // We want to preserve the existing sort order of entries, adding new ones only if they do
+    // not override an existing entry.
+    ImmutableMap.Builder<String, RepositoryName> allMappings = ImmutableMap.builder();
     allMappings.putAll(entries());
-    return createInternal(allMappings, ownerRepo());
+    for (Map.Entry<String, RepositoryName> entry : additionalMappings.entrySet()) {
+      if (!entries().containsKey(entry.getKey())) {
+        allMappings.put(entry);
+      }
+    }
+    return createInternal(allMappings.buildOrThrow(), ownerRepo());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/ModuleInfoExtractor.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/ModuleInfoExtractor.java
@@ -65,7 +65,6 @@ import net.starlark.java.eval.Structure;
 /** API documentation extractor for a compiled, loaded Starlark module. */
 final class ModuleInfoExtractor {
   private final Predicate<String> isWantedQualifiedName;
-  private final RepositoryMapping repositoryMapping;
   private final Function<Label, String> labelRenderer;
 
   @VisibleForTesting
@@ -120,7 +119,6 @@ final class ModuleInfoExtractor {
       RepositoryMapping repositoryMapping,
       boolean renderMainRepoName) {
     this.isWantedQualifiedName = isWantedQualifiedName;
-    this.repositoryMapping = repositoryMapping;
     this.labelRenderer = new LabelRenderer(repositoryMapping, renderMainRepoName);
   }
 
@@ -169,8 +167,8 @@ final class ModuleInfoExtractor {
         mainRepoName =
             repositoryMapping.entries().entrySet().stream()
                 .filter(entry -> entry.getValue().isMain() && isPublicName(entry.getKey()))
-                .findFirst()
                 .map(Map.Entry::getKey)
+                .findFirst()
                 .orElse("");
       } else {
         mainRepoName = "";

--- a/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractRule.java
@@ -95,9 +95,15 @@ public final class StarlarkDocExtractRule implements RuleDefinition {
             attr(StarlarkDocExtract.SYMBOL_NAMES_ATTR, STRING_LIST)
                 .value(ImmutableList.<String>of()))
         /*<!-- #BLAZE_RULE(starlark_doc_extract).ATTRIBUTE(render_main_repo_name) -->
-        If true, render the name of the main repository (as specified in <code>WORKSPACE</code> or
-        <code>MODULE.bazel</code>) in labels in emitted documentation. In other words, labels like
-        <code>//foo:bar.bzl</code> will be emitted as <code>@my_repo//foo:bar.bzl</code>.
+        If true, render main repo labels in emitted documentation with a repo component (in other
+        words, <code>//foo:bar.bzl</code> will be emitted as <code>@my_repo//foo:bar.bzl</code>).
+        <p>The name of the main repo is obtained from <code>module(name = ...)<code> in
+        <code>MODULE.bazel</code> (if it is available and Bzlmod is enabled), or from
+        <code>workspace(name = ...)</code> in <code>WORKSPACE</code>.
+        <p>This attribute should be set to <code>False</code> when generating documentation for
+        Starlark files which are intended to be used only within the same repository, and to
+        <code>True</code> when generating documentation for Starlark files which are intended to be
+        used from other repositories.
         <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
         .add(attr(StarlarkDocExtract.RENDER_MAIN_REPO_NAME, BOOLEAN).value(false))
         /*<!-- #BLAZE_RULE(starlark_doc_extract).IMPLICIT_OUTPUTS -->

--- a/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractRule.java
@@ -18,6 +18,7 @@ import static com.google.devtools.build.lib.packages.Attribute.attr;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 import static com.google.devtools.build.lib.packages.ImplicitOutputsFunction.fromFunctions;
+import static com.google.devtools.build.lib.packages.Type.BOOLEAN;
 import static com.google.devtools.build.lib.packages.Type.STRING_LIST;
 
 import com.google.common.collect.ImmutableList;
@@ -93,6 +94,12 @@ public final class StarlarkDocExtractRule implements RuleDefinition {
         .add(
             attr(StarlarkDocExtract.SYMBOL_NAMES_ATTR, STRING_LIST)
                 .value(ImmutableList.<String>of()))
+        /*<!-- #BLAZE_RULE(starlark_doc_extract).ATTRIBUTE(render_main_repo_name) -->
+        If true, render the name of the main repository (as specified in <code>WORKSPACE</code> or
+        <code>MODULE.bazel</code>) in labels in emitted documentation. In other words, labels like
+        <code>//foo:bar.bzl</code> will be emitted as <code>@my_repo//foo:bar.bzl</code>.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+        .add(attr(StarlarkDocExtract.RENDER_MAIN_REPO_NAME, BOOLEAN).value(false))
         /*<!-- #BLAZE_RULE(starlark_doc_extract).IMPLICIT_OUTPUTS -->
         <ul>
           <li><code><var>name</var>.binaryproto</code> (the default output): A

--- a/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryMappingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryMappingTest.java
@@ -69,6 +69,19 @@ public final class RepositoryMappingTest {
   }
 
   @Test
+  public void additionalMappings_iterationOrder() throws Exception {
+    RepositoryMapping mapping =
+        RepositoryMapping.createAllowingFallback(
+                ImmutableMap.of(
+                    "B",
+                    RepositoryName.create("com_foo_bar_b"),
+                    "C",
+                    RepositoryName.create("com_foo_bar_c")))
+            .withAdditionalMappings(ImmutableMap.of("A", RepositoryName.create("com_foo_bar_a")));
+    assertThat(mapping.entries().keySet()).containsExactly("B", "C", "A").inOrder();
+  }
+
+  @Test
   public void composeWith() throws Exception {
     RepositoryMapping mapping =
         RepositoryMapping.createAllowingFallback(

--- a/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
@@ -38,7 +38,6 @@ import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDir
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.cmdline.Label;
-import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue.Injected;
 import com.google.devtools.build.lib.starlarkbuildapi.repository.RepositoryBootstrap;
@@ -122,7 +121,7 @@ public final class StarlarkDocExtractTest extends BuildViewTestCase {
     ConfiguredTarget target = getConfiguredTarget(targetName);
     Label targetLabel = Label.parseCanonicalUnchecked(targetName);
     String outputName = targetLabel.toPathFragment().getPathString() + ".binaryproto";
-    if (targetLabel.getRepository() != RepositoryName.MAIN) {
+    if (!targetLabel.getRepository().isMain()) {
       outputName =
           String.format("external/%s/%s", targetLabel.getRepository().getName(), outputName);
     }
@@ -1081,7 +1080,7 @@ public final class StarlarkDocExtractTest extends BuildViewTestCase {
 
   @Test
   public void labels_whenStarlarkDocExtractInWorkspaceDep_renderRepoName() throws Exception {
-    rewriteWorkspace("local_repository(name = 'dep', path = 'my_dep_path'");
+    rewriteWorkspace("local_repository(name = 'dep', path = 'dep_path')");
     scratch.file("dep_path/WORKSPACE", "workspace(name = 'dep')");
     scratch.file(
         "dep_path/foo.bzl", //


### PR DESCRIPTION
For labels in the main repo, users may wish one of 2 behaviors:

* render labels in display form (without the repo component) - when documenting rules intended for other users of the same repo. (This is the expected use case in an organization's internal monorepo).
* render labels with the @repo component included - when documenting rules intended for use from other repos. (This is the expected use case for public rule sets.)

Formerly, starlark_doc_extract only supported case 1. We add support for case 2 via the new `render_main_repo_name` attribute. Supporting it means we can't simply use Label.getDisplayForm() any more - we need to post-process the string via a new label renderer.

It also turned out that Label.getDisplayForm() fails an assert when using a repo map owned by the non-main repo. This means we always have to use the main repo's repo map for rendering, which in turn means that starlark_doc_extract's label stringification is different depending on whether the starlark_doc_extract target lives in the main repo or a dependency. Arguably, this is the correct thing to do: the owner of the main repo presumably wants to generate documentation with consistent repo names regardless of whether the target lives in the main repo or in a dep.

Inspired by @fmeum's work in https://github.com/bazelbuild/bazel/pull/19002