### PR TITLE
remote: document remote download regex

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/CommonRemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/CommonRemoteOptions.java
@@ -30,13 +30,13 @@ public class CommonRemoteOptions extends OptionsBase {
       name = "experimental_remote_download_regex",
       defaultValue = "null",
       allowMultiple = true,
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
           "Force Bazel to download the artifacts that match the given regexp. To be used in"
               + " conjunction with Build without the Bytes (or the internal equivalent) to allow"
               + " the client to request certain artifacts that might be needed locally (e.g. IDE"
-              + " support)")
+              + " support). Multiple regexes can be specified by repeating this flag.")
   public List<String> remoteDownloadRegex;
 
   @Option(


### PR DESCRIPTION
As we are switching to a default Build without Bytes, it would be useful
for users to be able to look up usage of remote_download_regex flag in
Bazel's reference documentation.

Also add a small note about accumulative usage of the flag.
