### PR TITLE
[6.4.0] Move BazelFileSystemModule into bazel package

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -132,9 +132,29 @@ java_library(
 )
 
 java_library(
+    name = "bazel_filesystem_module",
+    srcs = ["BazelFileSystemModule.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/jni",
+        "//src/main/java/com/google/devtools/build/lib/unix",
+        "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
+        "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/main/java/com/google/devtools/build/lib/windows",
+        "//src/main/java/com/google/devtools/common/options",
+        "//src/main/protobuf:failure_details_java_proto",
+        "//third_party:guava",
+    ],
+)
+
+java_library(
     name = "main",
     srcs = ["Bazel.java"],
     deps = [
+        ":bazel_filesystem_module",
         ":builtin_command_module",
         ":modules",
         ":repository_module",

--- a/src/main/java/com/google/devtools/build/lib/bazel/Bazel.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/Bazel.java
@@ -49,7 +49,7 @@ public final class Bazel {
           com.google.devtools.build.lib.runtime.MemoryPressureModule.class,
           com.google.devtools.build.lib.platform.SleepPreventionModule.class,
           com.google.devtools.build.lib.platform.SystemSuspensionModule.class,
-          com.google.devtools.build.lib.runtime.BazelFileSystemModule.class,
+          BazelFileSystemModule.class,
           com.google.devtools.build.lib.runtime.mobileinstall.MobileInstallModule.class,
           com.google.devtools.build.lib.bazel.BazelWorkspaceStatusModule.class,
           com.google.devtools.build.lib.bazel.BazelDiffAwarenessModule.class,

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelFileSystemModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelFileSystemModule.java
@@ -11,12 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package com.google.devtools.build.lib.runtime;
+package com.google.devtools.build.lib.bazel;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Strings;
 import com.google.devtools.build.lib.jni.JniLoader;
+import com.google.devtools.build.lib.runtime.BlazeModule;
+import com.google.devtools.build.lib.runtime.BlazeServerStartupOptions;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.Filesystem;
 import com.google.devtools.build.lib.server.FailureDetails.Filesystem.Code;


### PR DESCRIPTION
Currently, it is included in runtime library with glob which is shared between bazel and blaze. Moving it to bazel package to prevent from packaging it when building blaze.

An upcoming change (in https://github.com/bazelbuild/bazel/pull/18784) will package BLAKE3 to this module and we don't want it in blaze.

PiperOrigin-RevId: 547516042
Change-Id: I673fa3d6824d56c85e85b02d13b4eb56571edda9

(cherry picked from commit 6d6bbdcd7ac7e8130741417d891e641495b046b2)