### PR TITLE
Fix visibility issue of googleapis and remoteapis with Bzlmod enabled

### DIFF
--- a/third_party/googleapis/BUILD.bazel
+++ b/third_party/googleapis/BUILD.bazel
@@ -60,7 +60,7 @@ filegroup(
         ":google_devtools_remoteexecution_v1test_remote_execution_java_grpc_srcs",
         ":google_watch_v1_java_grpc_srcs",
     ],
-    visibility = ["@//src:__pkg__"],
+    visibility = ["@io_bazel//src:__pkg__"],
 )
 
 java_proto_library(

--- a/third_party/remoteapis/BUILD.bazel
+++ b/third_party/remoteapis/BUILD.bazel
@@ -34,7 +34,7 @@ filegroup(
         ":build_bazel_remote_asset_v1_remote_asset_java_grpc_srcs",
         ":build_bazel_remote_execution_v2_remote_execution_java_grpc_srcs",
     ],
-    visibility = ["@//src:__pkg__"],
+    visibility = ["@io_bazel//src:__pkg__"],
 )
 
 proto_library(


### PR DESCRIPTION
`@//` won't work with Bzlmod enabled.

Working towards https://github.com/bazelbuild/bazel/issues/18957