### PR TITLE
[6.4.0] Advertise CcInfo from cc_import (#19086)

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
@@ -220,6 +220,7 @@ cc_import = rule(
         ),
         "_cc_toolchain": attr.label(default = "@" + semantics.get_repo() + "//tools/cpp:current_cc_toolchain"),
     },
+    provides = [CcInfo],    
     toolchains = cc_helper.use_cpp_toolchain(),
     fragments = ["cpp"],
     incompatible_use_toolchain_transition = True,

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
@@ -405,12 +405,10 @@ paths_test(
     name = "path_matching_test",
 )
 
-cc_library(
+cc_import(
     name = "prebuilt",
     hdrs = ["direct_so_file_cc_lib.h"],
-    srcs = [
-        ":just_main_output",
-    ],
+    shared_library = ":just_main_output",
 )
 
 filegroup(


### PR DESCRIPTION
* Advertise CcInfo from cc_import

Commit https://github.com/bazelbuild/bazel/commit/2e3c5d0acef5f904143126908cc9edafae014636

Fixes #19056

* Update BUILD.builtin_test