### PR TITLE
Update `test_summary` doc to include information on its effects to BES

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -281,14 +281,15 @@ public class ExecutionOptions extends OptionsBase {
       defaultValue = "short",
       converter = TestSummaryFormat.Converter.class,
       documentationCategory = OptionDocumentationCategory.LOGGING,
-      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+      effectTags = {OptionEffectTag.TERMINAL_OUTPUT, OptionEffectTag.AFFECTS_OUTPUTS},
       help =
           "Specifies the desired format of the test summary. Valid values are 'short' to print"
               + " information only about tests executed, 'terse', to print information only about"
               + " unsuccessful tests that were run, 'detailed' to print detailed information about"
               + " failed test cases, 'testcase' to print summary in test case resolution, do not"
               + " print detailed information about failed test cases and 'none' to omit the"
-              + " summary.")
+              + " summary. When set to 'detailed' or 'testcase', the test details are added to BES"
+              + " outputs.")
   public TestSummaryFormat testSummary;
 
   @Option(


### PR DESCRIPTION
This PR seeks to clarify documentation around `test_summary`. We spent several hours debugging changes to the input in our BES processor. After digging through commits and [Bazel source](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java#L351-L352), we found that `--test_summary={detailed,testcase}` adds the test details to the BES event, when we expected this to only impact terminal output.