### PR TITLE
[6.3.1] Disable lockfiles by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -278,7 +278,7 @@ public class RepositoryOptions extends OptionsBase {
   @Option(
       name = "lockfile_mode",
       converter = LockfileMode.Converter.class,
-      defaultValue = "update",
+      defaultValue = "off",
       documentationCategory = OptionDocumentationCategory.BZLMOD,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       help =


### PR DESCRIPTION
We're seeing too many lockfile issues in 6.3.0. Let's disable this in 6.3.1 so that we have time to properly fix them, and re-enable it in 6.4.0.

cc @meteorcloudy @SalmaSamy 