### PR TITLE
Merge `use_repo` buildifier fixups into a single command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionMetadata.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -285,7 +286,7 @@ public class ModuleExtensionMetadata implements StarlarkValue {
               String.join(", ", indirectDepImports));
     }
 
-    var fixupCommands =
+    var fixupCommand =
         Stream.of(
                 makeUseRepoCommand(
                     "use_repo_add",
@@ -315,19 +316,18 @@ public class ModuleExtensionMetadata implements StarlarkValue {
                     extensionBzlFile,
                     extensionName,
                     rootUsage.getIsolationKey()))
-            .flatMap(Optional::stream);
+            .flatMap(Optional::stream)
+            .collect(joining(" ", "buildozer ", " //MODULE.bazel:all"));
 
     return Optional.of(
         Event.warn(
             location,
             message
                 + String.format(
-                    "%s ** You can use the following buildozer command(s) to fix these"
+                    "%s ** You can use the following buildozer command to fix these"
                         + " issues:%s\n\n"
                         + "%s",
-                    "\033[35m\033[1m",
-                    "\033[0m",
-                    fixupCommands.collect(Collectors.joining("\n")))));
+                    "\033[35m\033[1m", "\033[0m", fixupCommand)));
   }
 
   private static Optional<String> makeUseRepoCommand(
@@ -354,8 +354,7 @@ public class ModuleExtensionMetadata implements StarlarkValue {
       commandParts.add(extensionName);
     }
     commandParts.addAll(repos);
-    return Optional.of(
-        String.format("buildozer '%s' //MODULE.bazel:all", String.join(" ", commandParts)));
+    return Optional.of(commandParts.stream().collect(joining(" ", "'", "'")));
   }
 
   private Optional<ImmutableSet<String>> getRootModuleDirectDeps(Set<String> allRepos)

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -1845,16 +1845,13 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             + "Imported, but reported as indirect dependencies by the extension:\n"
             + "    indirect_dep, indirect_dev_dep\n"
             + "\n"
-            + "\033[35m\033[1m ** You can use the following buildozer command(s) to fix these"
+            + "\033[35m\033[1m ** You can use the following buildozer command to fix these"
             + " issues:\033[0m\n"
             + "\n"
             + "buildozer 'use_repo_add @ext//:defs.bzl ext missing_direct_dep non_dev_as_dev_dep'"
-            + " //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_remove @ext//:defs.bzl ext dev_as_non_dev_dep"
-            + " indirect_dep invalid_dep' //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_add dev @ext//:defs.bzl ext dev_as_non_dev_dep"
-            + " missing_direct_dev_dep' //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_remove dev @ext//:defs.bzl ext indirect_dev_dep invalid_dev_dep"
+            + " 'use_repo_remove @ext//:defs.bzl ext dev_as_non_dev_dep indirect_dep invalid_dep'"
+            + " 'use_repo_add dev @ext//:defs.bzl ext dev_as_non_dev_dep missing_direct_dev_dep'"
+            + " 'use_repo_remove dev @ext//:defs.bzl ext indirect_dev_dep invalid_dev_dep"
             + " non_dev_as_dev_dep' //MODULE.bazel:all",
         ImmutableSet.of(EventKind.WARNING));
   }
@@ -1929,14 +1926,13 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             + " extension (may cause the build to fail when used by other modules):\n"
             + "    direct_dev_dep, indirect_dev_dep\n"
             + "\n"
-            + "\033[35m\033[1m ** You can use the following buildozer command(s) to fix these"
+            + "\033[35m\033[1m ** You can use the following buildozer command to fix these"
             + " issues:\033[0m\n"
             + "\n"
             + "buildozer 'use_repo_add @ext//:defs.bzl ext direct_dev_dep indirect_dev_dep"
-            + " missing_direct_dep missing_direct_dev_dep' //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_remove @ext//:defs.bzl ext invalid_dep' //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_remove dev @ext//:defs.bzl ext direct_dev_dep indirect_dev_dep"
-            + " invalid_dev_dep' //MODULE.bazel:all",
+            + " missing_direct_dep missing_direct_dev_dep' 'use_repo_remove @ext//:defs.bzl ext"
+            + " invalid_dep' 'use_repo_remove dev @ext//:defs.bzl ext direct_dev_dep"
+            + " indirect_dev_dep invalid_dev_dep' //MODULE.bazel:all",
         ImmutableSet.of(EventKind.WARNING));
   }
 
@@ -2012,14 +2008,12 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             + " extension (may cause the build to fail when used by other modules):\n"
             + "    direct_dep, indirect_dep\n"
             + "\n"
-            + "\033[35m\033[1m ** You can use the following buildozer command(s) to fix these"
+            + "\033[35m\033[1m ** You can use the following buildozer command to fix these"
             + " issues:\033[0m\n"
             + "\n"
             + "buildozer 'use_repo_remove @ext//:defs.bzl ext direct_dep indirect_dep invalid_dep'"
-            + " //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_add dev @ext//:defs.bzl ext direct_dep indirect_dep"
-            + " missing_direct_dep missing_direct_dev_dep' //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_remove dev @ext//:defs.bzl ext invalid_dev_dep'"
+            + " 'use_repo_add dev @ext//:defs.bzl ext direct_dep indirect_dep missing_direct_dep"
+            + " missing_direct_dev_dep' 'use_repo_remove dev @ext//:defs.bzl ext invalid_dev_dep'"
             + " //MODULE.bazel:all",
         ImmutableSet.of(EventKind.WARNING));
   }
@@ -2133,11 +2127,11 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             + "Imported, but reported as indirect dependencies by the extension:\n"
             + "    indirect_dep\n"
             + "\n"
-            + "\033[35m\033[1m ** You can use the following buildozer command(s) to fix these"
+            + "\033[35m\033[1m ** You can use the following buildozer command to fix these"
             + " issues:\033[0m\n"
             + "\n"
-            + "buildozer 'use_repo_add ext1 direct_dep missing_direct_dep' //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_remove ext1 indirect_dep' //MODULE.bazel:all",
+            + "buildozer 'use_repo_add ext1 direct_dep missing_direct_dep' 'use_repo_remove ext1"
+            + " indirect_dep' //MODULE.bazel:all",
         ImmutableSet.of(EventKind.WARNING));
     assertContainsEvent(
         "WARNING /ws/MODULE.bazel:8:21: The module extension ext defined in @ext//:defs.bzl"
@@ -2147,7 +2141,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             + " build to fail):\n"
             + "    missing_direct_dep\n"
             + "\n"
-            + "\033[35m\033[1m ** You can use the following buildozer command(s) to fix these"
+            + "\033[35m\033[1m ** You can use the following buildozer command to fix these"
             + " issues:\033[0m\n"
             + "\n"
             + "buildozer 'use_repo_add ext2 missing_direct_dep' //MODULE.bazel:all",
@@ -2217,11 +2211,11 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             + "Imported, but reported as indirect dependencies by the extension:\n"
             + "    indirect_dep\n"
             + "\n"
-            + "\033[35m\033[1m ** You can use the following buildozer command(s) to fix these"
+            + "\033[35m\033[1m ** You can use the following buildozer command to fix these"
             + " issues:\033[0m\n"
             + "\n"
-            + "buildozer 'use_repo_add ext1 direct_dep missing_direct_dep' //MODULE.bazel:all\n"
-            + "buildozer 'use_repo_remove ext1 indirect_dep' //MODULE.bazel:all",
+            + "buildozer 'use_repo_add ext1 direct_dep missing_direct_dep' 'use_repo_remove ext1"
+            + " indirect_dep' //MODULE.bazel:all",
         ImmutableSet.of(EventKind.WARNING));
     assertContainsEvent(
         "WARNING /ws/MODULE.bazel:8:21: The module extension ext defined in @ext//:defs.bzl"
@@ -2231,7 +2225,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             + " build to fail):\n"
             + "    missing_direct_dep\n"
             + "\n"
-            + "\033[35m\033[1m ** You can use the following buildozer command(s) to fix these"
+            + "\033[35m\033[1m ** You can use the following buildozer command to fix these"
             + " issues:\033[0m\n"
             + "\n"
             + "buildozer 'use_repo_add ext2 missing_direct_dep' //MODULE.bazel:all",


### PR DESCRIPTION
Users only have to copy&paste a single command this way.