### PR TITLE
Switch xcode_autoconf to use 'configure = True'

### DIFF
--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -293,7 +293,7 @@ def _impl(repository_ctx):
 
 xcode_autoconf = repository_rule(
     implementation = _impl,
-    local = True,
+    configure = True,
     attrs = {
         "xcode_locator": attr.string(),
         "remote_xcode": attr.string(),


### PR DESCRIPTION
Using 'local = True' seems to run this too frequently. Realistically the user's installed Xcode versions don't change very often so similar to cc_autoconf this should be ok.