### PR TITLE
Replace rules_docker with rules_oci on recommended rules page

### DIFF
--- a/site/en/rules/index.md
+++ b/site/en/rules/index.md
@@ -18,7 +18,7 @@ Here is a selection of recommended rules:
 
 * [Android](/docs/bazel-and-android)
 * [C / C++](/docs/bazel-and-cpp)
-* [Docker](https://github.com/bazel-contrib/rules_oci){: .external}
+* [Docker/OCI](https://github.com/bazel-contrib/rules_oci){: .external}
 * [Go](https://github.com/bazelbuild/rules_go){: .external}
 * [Haskell](https://github.com/tweag/rules_haskell){: .external}
 * [Java](/docs/bazel-and-java)

--- a/site/en/rules/index.md
+++ b/site/en/rules/index.md
@@ -18,7 +18,7 @@ Here is a selection of recommended rules:
 
 * [Android](/docs/bazel-and-android)
 * [C / C++](/docs/bazel-and-cpp)
-* [Docker](https://github.com/bazelbuild/rules_docker){: .external}
+* [Docker](https://github.com/bazel-contrib/rules_oci){: .external}
 * [Go](https://github.com/bazelbuild/rules_go){: .external}
 * [Haskell](https://github.com/tweag/rules_haskell){: .external}
 * [Java](/docs/bazel-and-java)


### PR DESCRIPTION
I believe it is no longer maintained, so I'm following the process outlined in the Bazel documentation: https://bazel.build/community/recommended-rules#demotion

Here's some data on rules_docker:
- Maintenance signals have gone down significantly in the last year: https://oss-compass.org/analyze/snbnfub0?range=1Y
- Hasn't been released in a year
- Second-most-recent commit was mine from about five months ago, adding the "minimal maintenance mode" https://github.com/bazelbuild/rules_docker/pull/2236 - there's more context in that PR.
- Never reached 1.0

rules_oci seems like the replacement.
- It has strong adoption testimonials https://github.com/bazel-contrib/rules_oci/discussions/299
- Version is 1.2 with semver guarantees
