### PR TITLE
Add path to patched file to invalid chunk error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -300,7 +300,13 @@ public class PatchUtil {
       }
     }
 
-    List<String> newContent = applyOffsetPatchTo(patch, oldContent);
+    List<String> newContent;
+    try {
+      newContent = applyOffsetPatchTo(patch, oldContent);
+    } catch (PatchFailedException e) {
+      throw new PatchFailedException(
+          String.format("in patch applied to %s: %s", oldFile, e.getMessage()));
+    }
 
     // The file we should write newContent to.
     Path outputFile;

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/PatchUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/PatchUtilTest.java
@@ -512,7 +512,8 @@ public final class PatchUtilTest {
     assertThat(expected)
         .hasMessageThat()
         .contains(
-            "Incorrect Chunk: the chunk content doesn't match the target\n"
+            "in patch applied to /root/foo.cc: Incorrect Chunk: the chunk content doesn't match "
+                + "the target\n"
                 + "**Original Position**: 2\n"
                 + "\n"
                 + "**Original Content**:\n"

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -375,8 +375,8 @@ public final class StarlarkRepositoryContextTest {
           .hasCauseThat()
           .hasMessageThat()
           .isEqualTo(
-              "Error applying patch /outputDir/my.patch: Incorrect Chunk: the chunk content "
-                  + "doesn't match the target\n"
+              "Error applying patch /outputDir/my.patch: in patch applied to "
+                  + "/outputDir/foo: Incorrect Chunk: the chunk content doesn't match the target\n"
                   + "**Original Position**: 1\n"
                   + "\n"
                   + "**Original Content**:\n"


### PR DESCRIPTION
When a chunk in a patch fails to apply, it now also prints the path to the file that the patch is applied to.