### PR TITLE
Remove deploy jar Java runtime dependency for non-executable targets 

### DIFF
--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_deploy_jar.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_deploy_jar.bzl
@@ -59,4 +59,12 @@ def _bazel_deploy_jars_impl(ctx):
 
     return []
 
-deploy_jars = make_deploy_jars_rule(implementation = _bazel_deploy_jars_impl)
+executable_deploy_jars = make_deploy_jars_rule(
+    implementation = _bazel_deploy_jars_impl,
+    create_executable = True,
+)
+
+nonexecutable_deploy_jars = make_deploy_jars_rule(
+    implementation = _bazel_deploy_jars_impl,
+    create_executable = False,
+)

--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_wrapper.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_wrapper.bzl
@@ -22,7 +22,7 @@ load(":bazel/java/bazel_java_binary.bzl", _java_test = "java_test", java_bin_exe
 load(":bazel/java/bazel_java_binary_nolauncher.bzl", java_bin_exec_no_launcher_flag = "java_binary", java_test_no_launcher = "java_test")
 load(":bazel/java/bazel_java_binary_custom_launcher.bzl", java_bin_exec_custom_launcher = "java_binary", java_test_custom_launcher = "java_test")
 load(":bazel/java/bazel_java_binary_nonexec.bzl", java_bin_nonexec = "java_binary")
-load(":bazel/java/bazel_java_binary_deploy_jar.bzl", "deploy_jars")
+load(":bazel/java/bazel_java_binary_deploy_jar.bzl", "executable_deploy_jars", "nonexecutable_deploy_jars")
 load(":common/java/java_binary_wrapper.bzl", "register_java_binary_rules")
 
 def java_binary(**kwargs):
@@ -31,7 +31,8 @@ def java_binary(**kwargs):
         java_bin_nonexec,
         java_bin_exec_no_launcher_flag,
         java_bin_exec_custom_launcher,
-        rule_deploy_jars = deploy_jars,
+        rule_executable_deploy_jars = executable_deploy_jars,
+        rule_nonexecutable_deploy_jars = nonexecutable_deploy_jars,
         **kwargs
     )
 
@@ -41,7 +42,8 @@ def java_test(**kwargs):
         java_test_no_launcher,
         java_test_no_launcher,
         java_test_custom_launcher,
-        rule_deploy_jars = deploy_jars,
+        rule_executable_deploy_jars = executable_deploy_jars,
+        rule_nonexecutable_deploy_jars = nonexecutable_deploy_jars,
         is_test_rule_class = True,
         **kwargs
     )

--- a/src/main/starlark/builtins_bzl/common/java/java_binary_deploy_jar.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary_deploy_jar.bzl
@@ -144,6 +144,8 @@ def create_deploy_archive(
         extra_args = []):
     """ Creates a deploy jar
 
+    Requires a Java runtime toolchain if and only if hermetic is True.
+
     Args:
         ctx: (RuleContext) The rule context
         launcher: (File) the launcher artifact
@@ -167,8 +169,6 @@ def create_deploy_archive(
         add_opens: (depset)
         extra_args: (list[Args]) Optional arguments for the deploy jar action
     """
-    runtime = semantics.find_java_runtime_toolchain(ctx)
-
     input_files = []
     input_files.extend(build_info_files)
 
@@ -216,18 +216,20 @@ def create_deploy_archive(
     if multi_release:
         args.add("--multi_release")
 
-    if hermetic and runtime.lib_modules != None and runtime.hermetic_files != None:
-        java_home = runtime.java_home
-        lib_modules = runtime.lib_modules
-        hermetic_files = runtime.hermetic_files
-        args.add("--hermetic_java_home", java_home)
-        args.add("--jdk_lib_modules", lib_modules)
-        args.add_all("--resources", hermetic_files)
-        input_files.append(lib_modules)
-        transitive_input_files.append(hermetic_files)
+    if hermetic:
+        runtime = semantics.find_java_runtime_toolchain(ctx)
+        if runtime.lib_modules != None:
+            java_home = runtime.java_home
+            lib_modules = runtime.lib_modules
+            hermetic_files = runtime.hermetic_files
+            args.add("--hermetic_java_home", java_home)
+            args.add("--jdk_lib_modules", lib_modules)
+            args.add_all("--resources", hermetic_files)
+            input_files.append(lib_modules)
+            transitive_input_files.append(hermetic_files)
 
-        if shared_archive == None:
-            shared_archive = runtime.default_cds
+            if shared_archive == None:
+                shared_archive = runtime.default_cds
 
     if shared_archive:
         input_files.append(shared_archive)
@@ -256,11 +258,12 @@ def _implicit_outputs(binary):
         "unstrippeddeployjar": "%s_deploy.jar.unstripped" % binary_name,
     }
 
-def make_deploy_jars_rule(implementation):
+def make_deploy_jars_rule(implementation, *, create_executable):
     """Creates the deploy jar auxiliary rule for java_binary
 
     Args:
         implementation: (Function) The rule implementation function
+        create_executable: (bool) The value of the create_executable attribute of java_binary
 
     Returns:
         The deploy jar rule class
@@ -276,12 +279,19 @@ def make_deploy_jars_rule(implementation):
             ),
             "_cc_toolchain": attr.label(default = "@" + cc_semantics.get_repo() + "//tools/cpp:current_cc_toolchain"),
             "_java_toolchain_type": attr.label(default = semantics.JAVA_TOOLCHAIN_TYPE),
-            "_java_runtime_toolchain_type": attr.label(default = semantics.JAVA_RUNTIME_TOOLCHAIN_TYPE),
             "_build_info_translator": attr.label(
                 default = semantics.BUILD_INFO_TRANSLATOR_LABEL,
             ),
-        },
+        } | (
+            {
+                "_java_runtime_toolchain_type": attr.label(
+                    default = semantics.JAVA_RUNTIME_TOOLCHAIN_TYPE,
+                ),
+            } if create_executable else {}
+        ),
         outputs = _implicit_outputs,
         fragments = ["java"],
-        toolchains = [semantics.JAVA_TOOLCHAIN, semantics.JAVA_RUNTIME_TOOLCHAIN] + cc_helper.use_cpp_toolchain(),
+        toolchains = [semantics.JAVA_TOOLCHAIN] + cc_helper.use_cpp_toolchain() + (
+            [semantics.JAVA_RUNTIME_TOOLCHAIN] if create_executable else []
+        ),
     )

--- a/src/main/starlark/builtins_bzl/common/java/java_binary_deploy_jar.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary_deploy_jar.bzl
@@ -258,7 +258,7 @@ def _implicit_outputs(binary):
         "unstrippeddeployjar": "%s_deploy.jar.unstripped" % binary_name,
     }
 
-def make_deploy_jars_rule(implementation, *, create_executable):
+def make_deploy_jars_rule(implementation, *, create_executable = True):
     """Creates the deploy jar auxiliary rule for java_binary
 
     Args:
@@ -268,6 +268,9 @@ def make_deploy_jars_rule(implementation, *, create_executable):
     Returns:
         The deploy jar rule class
     """
+    toolchains = [semantics.JAVA_TOOLCHAIN] + cc_helper.use_cpp_toolchain()
+    if create_executable:
+        toolchains.append(semantics.JAVA_RUNTIME_TOOLCHAIN)
     return rule(
         implementation = implementation,
         attrs = {
@@ -282,16 +285,8 @@ def make_deploy_jars_rule(implementation, *, create_executable):
             "_build_info_translator": attr.label(
                 default = semantics.BUILD_INFO_TRANSLATOR_LABEL,
             ),
-        } | (
-            {
-                "_java_runtime_toolchain_type": attr.label(
-                    default = semantics.JAVA_RUNTIME_TOOLCHAIN_TYPE,
-                ),
-            } if create_executable else {}
-        ),
+        },
         outputs = _implicit_outputs,
         fragments = ["java"],
-        toolchains = [semantics.JAVA_TOOLCHAIN] + cc_helper.use_cpp_toolchain() + (
-            [semantics.JAVA_RUNTIME_TOOLCHAIN] if create_executable else []
-        ),
+        toolchains = toolchains,
     )

--- a/src/main/starlark/builtins_bzl/common/java/java_binary_wrapper.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary_wrapper.bzl
@@ -20,7 +20,15 @@ the supplied value of the `create_executable` attribute.
 
 _DEPLOY_JAR_RULE_NAME_SUFFIX = "_deployjars_internal_rule"
 
-def register_java_binary_rules(rule_exec, rule_nonexec, rule_nolauncher, rule_customlauncher, rule_deploy_jars = None, is_test_rule_class = False, **kwargs):
+def register_java_binary_rules(
+        rule_exec,
+        rule_nonexec,
+        rule_nolauncher,
+        rule_customlauncher,
+        rule_executable_deploy_jars = None,
+        rule_nonexecutable_deploy_jars = None,
+        is_test_rule_class = False,
+        **kwargs):
     """Registers the correct java_binary rule and deploy jar rule
 
     Args:
@@ -28,15 +36,18 @@ def register_java_binary_rules(rule_exec, rule_nonexec, rule_nolauncher, rule_cu
         rule_nonexec: (Rule) The non-executable java_binary rule
         rule_nolauncher: (Rule) The executable java_binary rule without launcher flag resolution
         rule_customlauncher: (Rule) The executable java_binary rule with a custom launcher attr set
-        rule_deploy_jars: (Rule) The auxiliary deploy jars rule
+        rule_executable_deploy_jars: (Rule) The auxiliary deploy jars rule for create_executable = True
+        rule_nonexecutable_deploy_jars: (Rule) The auxiliary deploy jars rule for create_executable = False
         is_test_rule_class: (bool) If this is a test rule
         **kwargs: Actual args to instantiate the rule
     """
 
+    create_executable = "create_executable" not in kwargs or kwargs["create_executable"]
+
     # TODO(hvd): migrate depot to integers / maybe use decompose_select_list()
     if "stamp" in kwargs and type(kwargs["stamp"]) == type(True):
         kwargs["stamp"] = 1 if kwargs["stamp"] else 0
-    if "create_executable" in kwargs and not kwargs["create_executable"]:
+    if not create_executable:
         rule_nonexec(**kwargs)
     elif "use_launcher" in kwargs and not kwargs["use_launcher"]:
         rule_nolauncher(**kwargs)
@@ -45,6 +56,7 @@ def register_java_binary_rules(rule_exec, rule_nonexec, rule_nolauncher, rule_cu
     else:
         rule_exec(**kwargs)
 
+    rule_deploy_jars = rule_executable_deploy_jars if create_executable else rule_nonexecutable_deploy_jars
     if rule_deploy_jars and (
         not kwargs.get("tags", []) or "nodeployjar" not in kwargs.get("tags", [])
     ):


### PR DESCRIPTION
This allows deploy jars for `java_binary` targets with `create_executable = False` to compile for target platforms for which no standalone Java runtime is available (e.g. Android).

Along the way, this removes a redundant check (`runtime.hermetic_files` is never `None`) and ensures that files coming from the hermetic runtime are only added if `hermetic` is set to `True`.

Work towards #17085