### PR TITLE
Remove the obsolete `exec_tools` attribute from `genrule`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRule.java
@@ -31,14 +31,4 @@ public class BazelGenRule extends GenRuleBase {
     }
     return ruleContext.attributes().get("stamp", Type.BOOLEAN);
   }
-
-  // TODO(https://github.com/bazelbuild/bazel/issues/19132): Remove this override once downstream
-  // projects are migrated.
-  @Override
-  protected CommandHelper.Builder commandHelperBuilder(RuleContext ruleContext) {
-    return CommandHelper.builder(ruleContext)
-        .addToolDependencies("tools")
-        .addToolDependencies("exec_tools")
-        .addToolDependencies("toolchains");
-  }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRuleRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRuleRule.java
@@ -46,23 +46,6 @@ public final class BazelGenRuleRule implements RuleDefinition {
                 .cfg(ExecutionTransitionFactory.createFactory())
                 .value(env.getToolsLabel(GENRULE_SETUP_LABEL)))
 
-        // TODO(https://github.com/bazelbuild/bazel/issues/19132): Remove this once downstream
-        // projects are migrated.
-        /* <!-- #BLAZE_RULE(genrule).ATTRIBUTE(exec_tools) -->
-        <b>Deprecated. Use <a href="#genrule.tools"><code>tools</code></a> instead.</b>
-
-        <p>
-          There was a period of time when <code>exec_tools</code> and <code>tools</code> behaved
-          differently, but they are now equivalent and the Blaze team will be migrating all uses of
-          <code>exec_tools</code> to <code>tools</code>.
-        </p>
-        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
-        .add(
-            attr("exec_tools", LABEL_LIST)
-                .cfg(ExecutionTransitionFactory.createFactory())
-                .allowedFileTypes(FileTypeSet.ANY_FILE)
-                .dontCheckConstraints())
-
         // TODO(bazel-team): stamping doesn't seem to work. Fix it or remove attribute.
         .add(attr("stamp", BOOLEAN).value(false))
         .build();


### PR DESCRIPTION

Part of #19132.