### PR TITLE
Include the full absolute paths of runfiles in action keys

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
@@ -215,7 +215,7 @@ public final class SymlinkTreeAction extends AbstractAction {
     // safe to add more fields in the future.
     fp.addBoolean(runfiles != null);
     if (runfiles != null) {
-      runfiles.fingerprint(actionKeyContext, fp);
+      runfiles.fingerprint(actionKeyContext, fp, /* digestAbsolutePaths= */ true);
     }
     fp.addBoolean(repoMappingManifest != null);
     if (repoMappingManifest != null) {

--- a/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
@@ -155,6 +155,11 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
     public boolean isRemotable() {
       return false;
     }
+
+    @Override
+    public boolean emitsAbsolutePaths() {
+      return false;
+    }
   }
 
   /**

--- a/src/test/shell/integration/runfiles_test.sh
+++ b/src/test/shell/integration/runfiles_test.sh
@@ -427,5 +427,54 @@ EOF
   expect_log_once "Runfiles must not contain middleman artifacts"
 }
 
+function test_manifest_action_reruns_on_output_base_change() {
+  CURRENT_DIRECTORY=$(pwd)
+
+  OUTPUT_BASE="${CURRENT_DIRECTORY}/test/outputs/__main__"
+  TEST_FOLDER_1="${CURRENT_DIRECTORY}/test/test1"
+  TEST_FOLDER_2="${CURRENT_DIRECTORY}/test/test2"
+
+  mkdir -p "${OUTPUT_BASE}"
+  mkdir -p "${TEST_FOLDER_1}"
+  mkdir -p "${TEST_FOLDER_2}"
+
+  cd "${TEST_FOLDER_1}"
+  touch WORKSPACE
+  cat > BUILD <<EOF
+sh_binary(
+    name = "hello_world",
+    srcs = ["hello_world.sh"],
+)
+EOF
+  cat > hello_world.sh <<EOF
+echo "Hello World"
+EOF
+  chmod +x hello_world.sh
+
+  cd "${TEST_FOLDER_2}"
+  touch WORKSPACE
+  cat > BUILD <<EOF
+sh_binary(
+    name = "hello_world",
+    srcs = ["hello_world.sh"],
+)
+EOF
+  cat > hello_world.sh <<EOF
+echo "Hello World"
+EOF
+  chmod +x hello_world.sh
+
+  cd "${TEST_FOLDER_1}"
+  bazel --output_base="${OUTPUT_BASE}" build //...
+
+  assert_contains "${TEST_FOLDER_1}" bazel-bin/hello_world.runfiles_manifest
+  assert_not_contains "${TEST_FOLDER_2}" bazel-bin/hello_world.runfiles_manifest
+
+  cd "${TEST_FOLDER_2}"
+  bazel --output_base="${OUTPUT_BASE}" build //...
+
+  assert_not_contains "${TEST_FOLDER_1}" bazel-bin/hello_world.runfiles_manifest
+  assert_contains "${TEST_FOLDER_2}" bazel-bin/hello_world.runfiles_manifest
+}
 
 run_suite "runfiles"


### PR DESCRIPTION
Both `SourceManifestAction` and `SymlinkTreeAction`, the only users of `Runfiles#fingerprint`, emit absolute paths to runfiles artifacts in their output. This requires also including these paths in the action key computation to prevent incorrect incremental builds if `--output_base` changes.

Fixes #17267