### PR TITLE
Add gitignore for VS Code / Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@
 /.project
 /.settings
 /.vscode/
+.eclipse/
+.settings/
+.classpath
+.project
+eclipse-*bin/
 /bazel.iml
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.


### PR DESCRIPTION
Add files to gitignore when using Bazel with VS Code Java / Eclipse plug-in.