### PR TITLE
Add header missing when compiling with mingw-gcc

### DIFF
--- a/src/tools/launcher/launcher_maker.cc
+++ b/src/tools/launcher/launcher_maker.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
Fixes this failure:

```
external/bazel_tools/src/tools/launcher/launcher_maker.cc:77:3: error: 'int64_t' was not declared in this scope
   77 |   int64_t bytes = 0;
      |   ^~~~~~~
external/bazel_tools/src/tools/launcher/launcher_maker.cc:22:1: note: 'int64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   21 | #include "src/main/cpp/util/path_platform.h"
  +++ |+#include <cstdint>
   22 |
external/bazel_tools/src/tools/launcher/launcher_maker.cc:81:5: error: 'bytes' was not declared in this scope
   81 |     bytes += line.length();
      |     ^~~~~
external/bazel_tools/src/tools/launcher/launcher_maker.cc:86:44: error: 'bytes' was not declared in this scope
   86 |   dst.write(reinterpret_cast<const char*>(&bytes), sizeof(bytes));
      |                                            ^~~~~

```

Fixes bazelbuild/rules_go#3642