### PR TITLE
[6.4.0] bazel_dep allows missing version with poor error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -351,6 +351,15 @@ public class ModuleFileFunction implements SkyFunction {
     }
 
     // Otherwise, we should get the module file from a registry.
+    if (key.getVersion().isEmpty()) {
+      // Print a friendlier error message if the user forgets to specify a version *and* doesn't
+      // have a non-registry override.
+      throw errorf(
+          Code.MODULE_NOT_FOUND,
+          "bad bazel_dep on module '%s' with no version. Did you forget to specify a version, or a"
+              + " non-registry override?",
+          key.getName());
+    }
     // TODO(wyv): Move registry object creation to BazelRepositoryModule so we don't repeatedly
     //   create them, and we can better report the error (is it a flag error or override error?).
     List<String> registries = Objects.requireNonNull(REGISTRIES.get(env));
@@ -361,6 +370,7 @@ public class ModuleFileFunction implements SkyFunction {
       }
     } else if (override != null) {
       // This should never happen.
+      // TODO(wyv): make ModuleOverride a sealed interface so this is checked at compile time.
       throw new IllegalStateException(
           String.format(
               "unrecognized override type %s for module %s",

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -279,6 +279,19 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
   }
 
   @Test
+  public void forgotVersion() throws Exception {
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of(registry.getUrl()));
+
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bbb", ""), null);
+    EvaluationResult<ModuleFileValue> result =
+        evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertThat(result.getError().toString())
+        .contains("bad bazel_dep on module 'bbb' with no version");
+  }
+
+  @Test
   public void testRegistriesCascade() throws Exception {
     // Registry1 has no module B@1.0; registry2 and registry3 both have it. We should be using the
     // B@1.0 from registry2.


### PR DESCRIPTION
Ideally we would also include the location of the offending bazel_dep, but that requires a (slightly?) bigger change to record the locations of all bazel_deps.

Fixes https://github.com/bazelbuild/bazel/issues/17126

Commit https://github.com/bazelbuild/bazel/commit/d664fb7a97f8171bd69a3726ef8075e37994352e

PiperOrigin-RevId: 554406088
Change-Id: I46865c31dc983de18ac64a37e8ee15ebec624937