### PR TITLE
[6.4.0] Always check `$config_dependencies` visibility at use

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.packages.PackageGroup;
 import com.google.devtools.build.lib.packages.RawAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Target;
+import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
@@ -89,6 +90,7 @@ public abstract class CommonPrerequisiteValidator implements PrerequisiteValidat
 
       if (!toolCheckAtDefinition
           || !attribute.isImplicit()
+          || attribute.getName().equals(RuleClass.CONFIG_SETTING_DEPS_ATTRIBUTE)
           || rule.getRuleClassObject().getRuleDefinitionEnvironmentLabel() == null) {
         // Default check: The attribute must be visible from the target.
         if (!context.isVisible(prerequisite.getConfiguredTarget())) {


### PR DESCRIPTION
All dependencies for `select` expressions are collected in an implicit `$config_dependencies` attribute. Even with `--incompatible_visibility_private_attributes_at_definition`, visibility for this attribute is now checked relative to the use rather than the definition of the rule.

Fixes #19126

Closes #19139.

Commit https://github.com/bazelbuild/bazel/commit/5ca89d43ce965ae0884f53161b3bfa74966c7923

PiperOrigin-RevId: 553830083
Change-Id: Ic4af0f5ad9a0c627c973cd5ce88dd1e1bf51474e