### PR TITLE
[6.4.0] Enable cc toolchain resolution when cross compiling to windows arm64.

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -56,6 +56,7 @@ platforms:
       - "-c"
       - "opt"
       - "--cpu=x64_arm64_windows"
+      - "--incompatible_enable_cc_toolchain_resolution"
     build_targets:
       - "//src:bazel.exe"
       - "//src:bazel_nojdk.exe"


### PR DESCRIPTION
Otherwise, the config settings will not be correctly resolved resulting in build error when compiling blake3.

PiperOrigin-RevId: 550568252
Change-Id: I8323f7f89aae6ca47db20fa8d177c027c754e1fb

(cherry picked from commit 12ac28cc50be5080a569c6542b316497581ee562)