### PR TITLE
Ensure disk cache root exists

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -142,9 +142,6 @@ public final class RemoteCacheClientFactory {
       throws IOException {
     Path cacheDir =
         workingDirectory.getRelative(Preconditions.checkNotNull(diskCachePath, "diskCachePath"));
-    if (!cacheDir.exists()) {
-      cacheDir.createDirectoryAndParents();
-    }
     return new DiskCacheClient(cacheDir, verifyDownloads, digestUtil);
   }
 
@@ -159,9 +156,6 @@ public final class RemoteCacheClientFactory {
       throws IOException {
     Path cacheDir =
         workingDirectory.getRelative(Preconditions.checkNotNull(diskCachePath, "diskCachePath"));
-    if (!cacheDir.exists()) {
-      cacheDir.createDirectoryAndParents();
-    }
 
     RemoteCacheClient httpCache = createHttp(options, cred, authAndTlsOptions, digestUtil, retrier);
     return createDiskAndRemoteClient(

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -55,7 +55,7 @@ public class DiskCacheClient implements RemoteCacheClient {
    * @param verifyDownloads whether verify the digest of downloaded content are the same as the
    *     digest used to index that file.
    */
-  public DiskCacheClient(Path root, boolean verifyDownloads, DigestUtil digestUtil) {
+  public DiskCacheClient(Path root, boolean verifyDownloads, DigestUtil digestUtil) throws IOException {
     this.verifyDownloads = verifyDownloads;
     this.digestUtil = digestUtil;
 
@@ -65,6 +65,10 @@ public class DiskCacheClient implements RemoteCacheClient {
       this.root =
           root.getChild(
               Ascii.toLowerCase(digestUtil.getDigestFunction().getValueDescriptor().getName()));
+    }
+
+    if (!this.root.exists()) {
+      this.root.createDirectoryAndParents();
     }
   }
 

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -43,7 +43,8 @@ class OnDiskBlobStoreCache extends RemoteCache {
           .setSymlinkAbsolutePathStrategy(SymlinkAbsolutePathStrategy.Value.ALLOWED)
           .build();
 
-  public OnDiskBlobStoreCache(RemoteOptions options, Path cacheDir, DigestUtil digestUtil) {
+  public OnDiskBlobStoreCache(RemoteOptions options, Path cacheDir, DigestUtil digestUtil)
+      throws IOException {
     super(
         CAPABILITIES,
         new DiskCacheClient(cacheDir, /* verifyDownloads= */ true, digestUtil),


### PR DESCRIPTION
The disk cache root directory was previously being manually created in two places before creating the disk cache client. This CL instead ensures that the disk cache root directory is created when createDiskCache() is called, and simplifies the other callsites.

This fixes an issue where the disk cache directory might not exist if using --digest_function=BLAKE3.