### PR TITLE
Allow CppLinkAction to inspect input sizes in resource estimation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -123,6 +123,7 @@ java_library(
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:auto_value",
         "//third_party:caffeine",
+        "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/protobuf:protobuf_java",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -38,6 +38,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
         "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
         "//src/main/java/com/google/devtools/build/lib/actions:middleman_type",
         "//src/main/java/com/google/devtools/build/lib/actions:runfiles_supplier",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
@@ -66,6 +66,7 @@ import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.ShellEscaper;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -531,10 +532,11 @@ public final class CppLinkAction extends AbstractAction implements CommandAction
           if (value != null) {
             inputsBytes += value.getSize();
           } else {
-            logger.atWarning().log(
-                "Linker metrics: failed to get size of %s: no metadata", input.getExecPath());
+            throw new IOException("no metadata");
           }
-        } catch (Exception e) {
+        } catch (IOException e) {
+          // TODO(https://github.com/bazelbuild/bazel/issues/17368): Propagate as ExecException when
+          // input sizes are used in the model.
           logger.atWarning().log(
               "Linker metrics: failed to get size of %s: %s (ignored)", input.getExecPath(), e);
         }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -451,6 +451,7 @@ java_test(
         "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
         "//third_party:guava",
         "//third_party:junit4",
+        "//third_party:mockito",
         "//third_party:truth",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.analysis.util.ActionTester;
 import com.google.devtools.build.lib.analysis.util.ActionTester.ActionCombinationFactory;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
@@ -49,6 +50,7 @@ import com.google.devtools.build.lib.packages.util.MockCcSupport;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.FeatureConfiguration;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.VariableValue;
 import com.google.devtools.build.lib.rules.cpp.CppActionConfigs.CppPlatform;
+import com.google.devtools.build.lib.rules.cpp.CppLinkAction.LocalResourcesEstimator;
 import com.google.devtools.build.lib.rules.cpp.Link.LinkTargetType;
 import com.google.devtools.build.lib.rules.cpp.Link.LinkingMode;
 import com.google.devtools.build.lib.rules.cpp.LinkerInputs.LibraryToLink;
@@ -770,24 +772,50 @@ public final class CppLinkActionTest extends BuildViewTestCase {
     assertThat(builder.canSplitCommandLine()).isTrue();
   }
 
+  private static NestedSet<Artifact> createInputs(RuleContext ruleContext, int count) {
+    NestedSetBuilder<Artifact> builder = new NestedSetBuilder<>(Order.LINK_ORDER);
+    for (int i = 0; i < count; i++) {
+      Artifact artifact =
+          ActionsTestUtil.createArtifact(
+              ruleContext.getBinDirectory(), String.format("input-%d", i));
+      builder.add(artifact);
+    }
+    return builder.build();
+  }
+
+  private ResourceSet estimateResourceConsumptionLocal(
+      RuleContext ruleContext, OS os, int inputsCount) throws Exception {
+    NestedSet<Artifact> inputs = createInputs(ruleContext, inputsCount);
+    try {
+      LocalResourcesEstimator estimator = new LocalResourcesEstimator(os, inputs);
+      return estimator.get();
+    } finally {
+      for (Artifact input : inputs.toList()) {
+        input.getPath().delete();
+      }
+    }
+  }
+
   @Test
-  public void tesLocalLinkResourceEstimate() {
-    assertThat(CppLinkAction.estimateResourceConsumptionLocal(OS.DARWIN, 100))
+  public void testLocalLinkResourceEstimate() throws Exception {
+    RuleContext ruleContext = createDummyRuleContext();
+
+    assertThat(estimateResourceConsumptionLocal(ruleContext, OS.DARWIN, 100))
         .isEqualTo(ResourceSet.createWithRamCpu(20, 1));
 
-    assertThat(CppLinkAction.estimateResourceConsumptionLocal(OS.DARWIN, 1000))
+    assertThat(estimateResourceConsumptionLocal(ruleContext, OS.DARWIN, 1000))
         .isEqualTo(ResourceSet.createWithRamCpu(65, 1));
 
-    assertThat(CppLinkAction.estimateResourceConsumptionLocal(OS.LINUX, 100))
+    assertThat(estimateResourceConsumptionLocal(ruleContext, OS.LINUX, 100))
         .isEqualTo(ResourceSet.createWithRamCpu(50, 1));
 
-    assertThat(CppLinkAction.estimateResourceConsumptionLocal(OS.LINUX, 10000))
+    assertThat(estimateResourceConsumptionLocal(ruleContext, OS.LINUX, 10000))
         .isEqualTo(ResourceSet.createWithRamCpu(900, 1));
 
-    assertThat(CppLinkAction.estimateResourceConsumptionLocal(OS.WINDOWS, 0))
+    assertThat(estimateResourceConsumptionLocal(ruleContext, OS.WINDOWS, 0))
         .isEqualTo(ResourceSet.createWithRamCpu(1500, 1));
 
-    assertThat(CppLinkAction.estimateResourceConsumptionLocal(OS.WINDOWS, 1000))
+    assertThat(estimateResourceConsumptionLocal(ruleContext, OS.WINDOWS, 1000))
         .isEqualTo(ResourceSet.createWithRamCpu(2500, 1));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.rules.cpp;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
+import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
@@ -785,9 +787,12 @@ public final class CppLinkActionTest extends BuildViewTestCase {
 
   private ResourceSet estimateResourceConsumptionLocal(
       RuleContext ruleContext, OS os, int inputsCount) throws Exception {
+    ActionExecutionContext actionExecutionContext = mock(ActionExecutionContext.class);
+
     NestedSet<Artifact> inputs = createInputs(ruleContext, inputsCount);
     try {
-      LocalResourcesEstimator estimator = new LocalResourcesEstimator(os, inputs);
+      LocalResourcesEstimator estimator =
+          new LocalResourcesEstimator(actionExecutionContext, os, inputs);
       return estimator.get();
     } finally {
       for (Artifact input : inputs.toList()) {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.rules.cpp;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -33,6 +34,7 @@ import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -787,7 +789,10 @@ public final class CppLinkActionTest extends BuildViewTestCase {
 
   private ResourceSet estimateResourceConsumptionLocal(
       RuleContext ruleContext, OS os, int inputsCount) throws Exception {
+    InputMetadataProvider inputMetadataProvider = mock(InputMetadataProvider.class);
+
     ActionExecutionContext actionExecutionContext = mock(ActionExecutionContext.class);
+    when(actionExecutionContext.getInputMetadataProvider()).thenReturn(inputMetadataProvider);
 
     NestedSet<Artifact> inputs = createInputs(ruleContext, inputsCount);
     try {


### PR DESCRIPTION
This PR instrumets the CppLinkAction to print log lines for every link operation and dumps the number of inputs, the aggregate size of the inputs, the predicted memory usage, and the actual consumed memory.

Calculating the aggregate size of the inputs is a costly operation because we need to expand a nested set and stat all of its files, which explains why this PR is complex.  I've modified the local memory estimator to compute the inputs size exactly once per link as we need this information both to predict memory consumption _and_ to emit the log line after the spawn completes.

This is meant to aid in assessing the local resources prediction for linking with the goal of adjusting the model, but that should be done in a separate change.

Helps address #17368.