### PR TITLE
[Duplicate] Fix valid json when using jsonproto output in queries  with new `--output=streamed_jsonproto` implementation.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/OutputFormatters.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/OutputFormatters.java
@@ -37,9 +37,9 @@ public class OutputFormatters {
         new PackageOutputFormatter(),
         new LocationOutputFormatter(),
         new GraphOutputFormatter(),
-        new JSONProtoOutputFormatter(),
         new XmlOutputFormatter(),
         new ProtoOutputFormatter(),
+        new StreamedJSONProtoOutputFormatter(),
         new StreamedProtoOutputFormatter());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
@@ -40,8 +40,8 @@ public class QueryOptions extends CommonQueryOptions {
       effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
       help =
           "The format in which the query results should be printed. Allowed values for query are:"
-              + " build, graph, jsonproto, label, label_kind, location, maxrank, minrank, package,"
-              + " proto, xml.")
+              + " build, graph, streamed_jsonproto, label, label_kind, location, maxrank, minrank,"
+              + " package, proto, xml.")
   public String outputFormat;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedJSONProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedJSONProtoOutputFormatter.java
@@ -22,13 +22,13 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 /**
- * An output formatter that outputs a protocol buffer json representation of a query result and
- * outputs the json to the output print stream.
+ * An output formatter that prints a list of targets according to ndjson spec to the output print
+ * stream.
  */
-public class JSONProtoOutputFormatter extends ProtoOutputFormatter {
+public class StreamedJSONProtoOutputFormatter extends ProtoOutputFormatter {
   @Override
   public String getName() {
-    return "jsonproto";
+    return "streamed_jsonproto";
   }
 
   private final JsonFormat.Printer jsonPrinter = JsonFormat.printer();
@@ -42,7 +42,11 @@ public class JSONProtoOutputFormatter extends ProtoOutputFormatter {
           throws IOException, InterruptedException {
         for (Target target : partialResult) {
           out.write(
-              jsonPrinter.print(toTargetProtoBuffer(target)).getBytes(StandardCharsets.UTF_8));
+              jsonPrinter
+                  .omittingInsignificantWhitespace()
+                  .print(toTargetProtoBuffer(target))
+                  .getBytes(StandardCharsets.UTF_8));
+          out.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
         }
       }
     };

--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -668,7 +668,7 @@ genquery(name='q',
          opts = ["--output=blargh"],)
 EOF
 
-  local expected_error_msg="in genquery rule //starfruit:q: Invalid output format 'blargh'. Valid values are: label, label_kind, build, minrank, maxrank, package, location, graph, jsonproto, xml, proto"
+  local expected_error_msg="in genquery rule //starfruit:q: Invalid output format 'blargh'. Valid values are: label, label_kind, build, minrank, maxrank, package, location, graph, xml, proto, streamed_jsonproto, "
   bazel build //starfruit:q >& $TEST_log && fail "Expected failure"
   expect_log "$expected_error_msg"
 }
@@ -1064,7 +1064,41 @@ EOF
   expect_log "//${package}:hint"
 }
 
-function test_basic_query_jsonproto() {
+function test_same_pkg_direct_rdeps_loads_only_inputs_packages() {
+  mkdir -p "pkg1"
+  mkdir -p "pkg2"
+  mkdir -p "pkg3"
+
+  cat > "pkg1/BUILD" <<EOF
+sh_library(name = "t1", deps = [":t2", "//pkg2:t3"])
+sh_library(name = "t2")
+EOF
+
+  cat > "pkg2/BUILD" <<EOF
+sh_library(name = "t3")
+EOF
+
+  cat > "pkg3/BUILD" <<EOF
+sh_library(name = "t4", deps = [":t5"])
+sh_library(name = "t5")
+EOF
+
+  bazel query --experimental_ui_debug_all_events \
+     "same_pkg_direct_rdeps(//pkg1:t2+//pkg3:t5)"  >& $TEST_log \
+    || fail "Expected success"
+
+  expect_log "Loading package: pkg1"
+  expect_log "Loading package: pkg3"
+  # For graphless query mode, pkg2 should not be loaded because
+  # same_pkg_direct_rdeps only cares about the targets in the same package
+  # as its inputs.
+  expect_not_log "Loading package: pkg2"
+  # the result of "same_pkg_direct_rdeps(//pkg1:t2+//pkg3:t5)"
+  expect_log "//pkg1:t1"
+  expect_log "//pkg3:t4"
+}
+
+function test_basic_query_streamed_jsonproto() {
   local pkg="${FUNCNAME[0]}"
   mkdir -p "$pkg" || fail "mkdir -p $pkg"
   cat > "$pkg/BUILD" <<'EOF'
@@ -1074,17 +1108,39 @@ genrule(
     outs = ["bar_out.txt"],
     cmd = "echo unused > $(OUTS)",
 )
+genrule(
+    name = "foo",
+    srcs = ["dummy.txt"],
+    outs = ["foo_out.txt"],
+    cmd = "echo unused > $(OUTS)",
+)
 EOF
-  bazel query --output=jsonproto --noimplicit_deps "//$pkg:bar" > output 2> "$TEST_log" \
+  bazel query --output=streamed_jsonproto --noimplicit_deps "//$pkg/..." > output 2> "$TEST_log" \
     || fail "Expected success"
   cat output >> "$TEST_log"
 
   # Verify that the appropriate attributes were included.
-  assert_contains "\"ruleClass\": \"genrule\"" output
-  assert_contains "\"name\": \"//$pkg:bar\"" output
-  assert_contains "\"ruleInput\": \[\"//$pkg:dummy.txt\"\]" output
-  assert_contains "\"ruleOutput\": \[\"//$pkg:bar_out.txt\"\]" output
-  assert_contains "echo unused" output
+
+  foo_line_number=$(grep -n "foo" output | cut -d':' -f1)
+  bar_line_number=$(grep -n "bar" output | cut -d':' -f1)
+
+  foo_ndjson_line=$(sed -n "${foo_line_number}p" output)
+  bar_ndjson_line=$(sed -n "${bar_line_number}p" output)
+
+  echo "$foo_ndjson_line" > foo_ndjson_file
+  echo "$bar_ndjson_line" > bar_ndjson_file
+
+  assert_contains "\"ruleClass\":\"genrule\"" foo_ndjson_file
+  assert_contains "\"name\":\"//$pkg:foo\"" foo_ndjson_file
+  assert_contains "\"ruleInput\":\[\"//$pkg:dummy.txt\"\]" foo_ndjson_file
+  assert_contains "\"ruleOutput\":\[\"//$pkg:foo_out.txt\"\]" foo_ndjson_file
+  assert_contains "echo unused" foo_ndjson_file
+
+  assert_contains "\"ruleClass\":\"genrule\"" bar_ndjson_file
+  assert_contains "\"name\":\"//$pkg:bar\"" bar_ndjson_file
+  assert_contains "\"ruleInput\":\[\"//$pkg:dummy.txt\"\]" bar_ndjson_file
+  assert_contains "\"ruleOutput\":\[\"//$pkg:bar_out.txt\"\]" bar_ndjson_file
+  assert_contains "echo unused" bar_ndjson_file
 }
 
 run_suite "${PRODUCT_NAME} query tests"


### PR DESCRIPTION
Fix valid json when using jsonproto output in queries  with new `--output=streamed_jsonproto` implementation.

Closes #18701.

Commit https://github.com/bazelbuild/bazel/commit/2cd583a4868354c2198fbb63f124136ad1c0d29b

PiperOrigin-RevId: 555417403
Change-Id: I30eb06f734188f8511884954f43c5f5b3c0091a3