### PR TITLE
[6.4.0] Ensure disk cache root exists

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -139,9 +139,6 @@ public final class RemoteCacheClientFactory {
       throws IOException {
     Path cacheDir =
         workingDirectory.getRelative(Preconditions.checkNotNull(diskCachePath, "diskCachePath"));
-    if (!cacheDir.exists()) {
-      cacheDir.createDirectoryAndParents();
-    }
     return new DiskCacheClient(cacheDir, verifyDownloads, checkActionResult, digestUtil);
   }
 
@@ -153,12 +150,6 @@ public final class RemoteCacheClientFactory {
       AuthAndTLSOptions authAndTlsOptions,
       DigestUtil digestUtil)
       throws IOException {
-    Path cacheDir =
-        workingDirectory.getRelative(Preconditions.checkNotNull(diskCachePath, "diskCachePath"));
-    if (!cacheDir.exists()) {
-      cacheDir.createDirectoryAndParents();
-    }
-
     RemoteCacheClient httpCache = createHttp(options, cred, authAndTlsOptions, digestUtil);
     return createDiskAndRemoteClient(
         workingDirectory,

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -59,7 +59,7 @@ public class DiskCacheClient implements RemoteCacheClient {
    *     is {@code true} and blobs referenced by the AC are missing, ignore the AC.
    */
   public DiskCacheClient(
-      Path root, boolean verifyDownloads, boolean checkActionResult, DigestUtil digestUtil) {
+      Path root, boolean verifyDownloads, boolean checkActionResult, DigestUtil digestUtil) throws IOException {
     this.verifyDownloads = verifyDownloads;
     this.checkActionResult = checkActionResult;
     this.digestUtil = digestUtil;
@@ -71,6 +71,8 @@ public class DiskCacheClient implements RemoteCacheClient {
           root.getChild(
               Ascii.toLowerCase(digestUtil.getDigestFunction().getValueDescriptor().getName()));
     }
+
+    this.root.createDirectoryAndParents();
   }
 
   /** Returns {@code true} if the provided {@code key} is stored in the CAS. */

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -43,7 +43,8 @@ class OnDiskBlobStoreCache extends RemoteCache {
           .setSymlinkAbsolutePathStrategy(SymlinkAbsolutePathStrategy.Value.ALLOWED)
           .build();
 
-  public OnDiskBlobStoreCache(RemoteOptions options, Path cacheDir, DigestUtil digestUtil) {
+  public OnDiskBlobStoreCache(RemoteOptions options, Path cacheDir, DigestUtil digestUtil)
+      throws IOException {
     super(
         CAPABILITIES,
         new DiskCacheClient(


### PR DESCRIPTION
The disk cache root directory was previously being manually created in two places before creating the disk cache client. This CL instead ensures that the disk cache root directory is created when createDiskCache() is called, and simplifies the other callsites.

This fixes an issue where the disk cache directory might not exist if using --digest_function=BLAKE3.

PiperOrigin-RevId: 555429326
Change-Id: Ifcfa8c686df30c03c9fca24be860b2db780a6374

(cherry picked from commit 00dfa2ee8cce6722847c60bfb0626458503741af)