### PR TITLE
[Duplicate] Rename `cc_test_wrapper` to `cc_test`

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_test_wrapper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_test_wrapper.bzl
@@ -20,7 +20,7 @@ load(":common/cc/cc_test_with_linkstatic.bzl", _cc_test_with_linkstatic = "cc_te
 load(":common/cc/cc_test_no_linkstatic_aspects.bzl", _cc_test_no_linkstatic_aspects = "cc_test")
 load(":common/cc/cc_test_with_linkstatic_aspects.bzl", _cc_test_with_linkstatic_aspects = "cc_test")
 
-def cc_test_wrapper(**kwargs):
+def cc_test(**kwargs):
     """Entry point for cc_test rules.
 
     This avoids propagating aspects on certain attributes if dynamic_deps attribute is unset.

--- a/src/main/starlark/builtins_bzl/common/exports.bzl
+++ b/src/main/starlark/builtins_bzl/common/exports.bzl
@@ -16,8 +16,10 @@
 
 load("@_builtins//:common/cc/cc_import.bzl", "cc_import")
 load("@_builtins//:common/cc/cc_binary_wrapper.bzl", "cc_binary")
-load("@_builtins//:common/cc/cc_test_wrapper.bzl", cc_test = "cc_test_wrapper")
-load("@_builtins//:common/cc/experimental_cc_shared_library.bzl", "CcSharedLibraryInfo", "cc_shared_library")
+load("@_builtins//:common/cc/cc_toolchain_provider_helper.bzl", "get_cc_toolchain_provider")
+load("@_builtins//:common/cc/cc_test_wrapper.bzl", "cc_test")
+load("@_builtins//:common/cc/cc_shared_library.bzl", "CcSharedLibraryInfo", "cc_shared_library")
+load("@_builtins//:common/cc/cc_shared_library_hint_info.bzl", "CcSharedLibraryHintInfo")
 load("@_builtins//:common/objc/objc_import.bzl", "objc_import")
 load("@_builtins//:common/objc/objc_library.bzl", "objc_library")
 load("@_builtins//:common/objc/compilation_support.bzl", "compilation_support")


### PR DESCRIPTION
Previously, `str(native.cc_test)` included `cc_test_wrapper`, which is an implementation detail of `cc_test`.

Closes #18871.

Commit https://github.com/bazelbuild/bazel/commit/70e31daf933181d188433a604163d4b935ffebd6

PiperOrigin-RevId: 546836622
Change-Id: I80e02a2be80ab01610c5848ab1cd506df11c9557