### PR TITLE
Fix objc transition for cc_binary -- smallest change

### DIFF
--- a/src/main/starlark/builtins_bzl/common/objc/transitions.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/transitions.bzl
@@ -56,12 +56,12 @@ def _determine_single_architecture(platform_type, settings):
             return DEFAULT_TVOS_CPU
         return tvos_cpus[0]
     if platform_type == MACOS:
-        macos_cpus = settings["//command_line_option:macos_cpus"]
-        if macos_cpus:
-            return macos_cpus[0]
         cpu_value = settings["//command_line_option:cpu"]
         if cpu_value.startswith(DARWIN_CPU_PREFIX):
             return cpu_value[len(DARWIN_CPU_PREFIX):]
+        macos_cpus = settings["//command_line_option:macos_cpus"]
+        if macos_cpus:
+            return macos_cpus[0]
         return DEFAULT_MACOS_CPU
     if platform_type == CATALYST:
         catalyst_cpus = settings["//command_line_option:catalyst_cpus"]


### PR DESCRIPTION
A quick cut at the smallest change that would fix #19204.
Please see that issue for context.

https://github.com/bazelbuild/bazel/pull/19236 is an alternative that attempts to simplify. It's a slightly larger--and much redder--CL.