### PR TITLE
build-runfiles: remove temporary file prior to creating it

### DIFF
--- a/src/main/tools/build-runfiles.cc
+++ b/src/main/tools/build-runfiles.cc
@@ -117,6 +117,12 @@ class RunfilesCreator {
 
   void ReadManifest(const std::string &manifest_file, bool allow_relative,
                     bool use_metadata) {
+    // Remove file left over from previous invocation. This ensures that
+    // opening succeeds if the existing file is read-only.
+    if (unlink(temp_filename_.c_str()) != 0 && errno != ENOENT) {
+      PDIE("removing temporary file at '%s/%s'", output_base_.c_str(),
+           temp_filename_.c_str());
+    }
     FILE *outfile = fopen(temp_filename_.c_str(), "w");
     if (!outfile) {
       PDIE("opening '%s/%s' for writing", output_base_.c_str(),


### PR DESCRIPTION
When building with Remote Output Service, bb_clientd has the ability to restore snapshots of previous bazel-out/ directories. Though the file contents of these snapshots are identical to what's created in the past, the files will be read-only. This is because the files may be shared by multiple snapshots.

We have noticed that most of Bazel is fine with that. Most of the times Bazel is a good citizen, where it removes any files before recreating them. We did notice a very rare case where build-runfiles tries to make in-place modifications to a temporary file that it maintains. This change ensures that build-runfiles stops doing this.