### PR TITLE
atomicallyWriteTo: remove temporary file prior to creating it

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/VirtualActionInput.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/VirtualActionInput.java
@@ -67,6 +67,7 @@ public abstract class VirtualActionInput implements ActionInput, StreamWriter {
   protected byte[] atomicallyWriteTo(Path outputPath, String uniqueSuffix) throws IOException {
     Path tmpPath = outputPath.getFileSystem().getPath(outputPath.getPathString() + uniqueSuffix);
     tmpPath.getParentDirectory().createDirectoryAndParents();
+    tmpPath.delete();
     try {
       byte[] digest = writeTo(tmpPath);
       // We expect the following to replace the params file atomically in case we are using

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -230,6 +230,11 @@ public class SandboxHelpersTest {
   public void atomicallyWriteVirtualInput_writesArbitraryVirtualInput() throws Exception {
     VirtualActionInput input = ActionsTestUtil.createVirtualActionInput("file", "hello");
 
+    // Store an existing directory at the location where atomicallyWriteTo()
+    // writes its temporary file. It should be removed prior to the creation of
+    // the temporary file.
+    scratch.resolve("/outputs/file-1234").createDirectoryAndParents();
+
     input.atomicallyWriteRelativeTo(scratch.resolve("/outputs"), "-1234");
 
     assertThat(scratch.resolve("/outputs").readdir(Symlinks.NOFOLLOW))


### PR DESCRIPTION
This change is the same in spirit to #19241. When using Bazel in combination with bb_clientd, bb_clientd may restore a copy of bazel-out/ from a snapshot. Files restored from the snapshot are not mutable, as they may be backed by other snapshots, a remote CAS, etc. etc. etc..

This change extends atomicallyWriteTo() to always write contents into a new file that is guaranteed to be writable. The logic that's added here is merely copy-pasted from what's already present at the bottom of the same function.