### PR TITLE
[7.0] Revert "Make --incompatible_remote_results_ignore_disk a no-op."

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -286,13 +286,23 @@ public class RemoteExecutionService {
     if (useRemoteCache(remoteOptions)) {
       allowRemoteCache = remoteOptions.remoteAcceptCached && Spawns.mayBeCachedRemotely(spawn);
       if (useDiskCache(remoteOptions)) {
-        // Combined cache. Disk cache is treated as local cache. Actions which are tagged with
-        // `no-remote-cache` can still hit the disk cache.
-        allowDiskCache = Spawns.mayBeCached(spawn);
+        // Combined cache
+        if (remoteOptions.incompatibleRemoteResultsIgnoreDisk) {
+          // --incompatible_remote_results_ignore_disk is set. Disk cache is treated as local cache.
+          // Actions which are tagged with `no-remote-cache` can still hit the disk cache.
+          allowDiskCache = Spawns.mayBeCached(spawn);
+        } else {
+          // Disk cache is treated as a remote cache and disabled for `no-remote-cache`.
+          allowDiskCache = allowRemoteCache;
+        }
       }
     } else {
       // Disk cache only
-      allowDiskCache = Spawns.mayBeCached(spawn);
+      if (remoteOptions.incompatibleRemoteResultsIgnoreDisk) {
+        allowDiskCache = Spawns.mayBeCached(spawn);
+      } else {
+        allowDiskCache = remoteOptions.remoteAcceptCached && Spawns.mayBeCached(spawn);
+      }
     }
 
     return CachePolicy.create(allowRemoteCache, allowDiskCache);
@@ -311,13 +321,24 @@ public class RemoteExecutionService {
           shouldUploadLocalResultsToRemoteCache(remoteOptions, spawn.getExecutionInfo())
               && remoteCache.actionCacheSupportsUpdate();
       if (useDiskCache(remoteOptions)) {
-        // Combined cache. Treat the disk cache part as local cache. Actions which are tagged with
-        // `no-remote-cache` can still hit the disk cache.
-        allowDiskCache = Spawns.mayBeCached(spawn);
+        // Combined cache
+        if (remoteOptions.incompatibleRemoteResultsIgnoreDisk) {
+          // If --incompatible_remote_results_ignore_disk is set, we treat the disk cache part as
+          // local cache. Actions which are tagged with `no-remote-cache` can still hit the disk
+          // cache.
+          allowDiskCache = Spawns.mayBeCached(spawn);
+        } else {
+          // Otherwise, it's treated as a remote cache and disabled for `no-remote-cache`.
+          allowDiskCache = allowRemoteCache;
+        }
       }
     } else {
       // Disk cache only
-      allowDiskCache = Spawns.mayBeCached(spawn);
+      if (remoteOptions.incompatibleRemoteResultsIgnoreDisk) {
+        allowDiskCache = Spawns.mayBeCached(spawn);
+      } else {
+        allowDiskCache = remoteOptions.remoteUploadLocalResults && Spawns.mayBeCached(spawn);
+      }
     }
 
     return CachePolicy.create(allowRemoteCache, allowDiskCache);

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -312,7 +312,16 @@ public final class RemoteOptions extends CommonRemoteOptions {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help = "No-op")
+      help =
+          "If set to true, --noremote_upload_local_results and --noremote_accept_cached will not"
+              + " apply to the disk cache. If both --disk_cache and --remote_cache are set"
+              + " (combined cache):\n"
+              + "\t--noremote_upload_local_results will cause results to be written to the disk"
+              + " cache, but not uploaded to the remote cache.\n"
+              + "\t--noremote_accept_cached will result in Bazel checking for results in the disk"
+              + " cache, but not in the remote cache.\n"
+              + "\tno-remote-exec actions can hit the disk cache.\n"
+              + "See #8216 for details.")
   public boolean incompatibleRemoteResultsIgnoreDisk;
 
   @Option(

--- a/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
+++ b/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
@@ -236,6 +236,7 @@ EOF
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
       --disk_cache=$cache_dir \
+      --incompatible_remote_results_ignore_disk \
       --remote_upload_local_results=false \
       --remote_build_event_upload=minimal \
       --build_event_json_file=$BEP_JSON \
@@ -265,6 +266,7 @@ EOF
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
       --disk_cache=$cache_dir \
+      --incompatible_remote_results_ignore_disk \
       --remote_upload_local_results=false \
       --remote_build_event_upload=all \
       --build_event_json_file=$BEP_JSON \

--- a/src/test/shell/bazel/remote/remote_execution_http_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_http_test.sh
@@ -349,13 +349,13 @@ EOF
   mkdir $cache
 
   # Build and push to disk cache but not http cache
-  bazel build $disk_flags $http_flags --noremote_upload_local_results //a:test \
+  bazel build $disk_flags $http_flags --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results //a:test \
     || fail "Failed to build //a:test with combined disk http cache"
   cp -f bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected
 
   # Fetch from disk cache
   bazel clean
-  bazel build $disk_flags //a:test --noremote_upload_local_results &> $TEST_log \
+  bazel build $disk_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results &> $TEST_log \
     || fail "Failed to fetch //a:test from disk cache"
   expect_log "1 disk cache hit" "Fetch from disk cache failed"
   diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
@@ -363,7 +363,7 @@ EOF
 
   # No cache result from http cache, rebuild target
   bazel clean
-  bazel build $http_flags //a:test --noremote_upload_local_results &> $TEST_log \
+  bazel build $http_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_not_log "1 remote cache hit" "Should not get cache hit from http cache"
   expect_log "1 .*-sandbox" "Rebuild target failed"
@@ -375,7 +375,7 @@ EOF
 
   # No cache result from http cache, rebuild target, and upload result to http cache
   bazel clean
-  bazel build $http_flags //a:test --noremote_accept_cached &> $TEST_log \
+  bazel build $http_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_not_log "1 remote cache hit" "Should not get cache hit from http cache"
   expect_log "1 .*-sandbox" "Rebuild target failed"
@@ -384,7 +384,7 @@ EOF
 
   # No cache result from http cache, rebuild target, and upload result to disk cache
   bazel clean
-  bazel build $disk_flags $http_flags //a:test --noremote_accept_cached &> $TEST_log \
+  bazel build $disk_flags $http_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_not_log "1 remote cache hit" "Should not get cache hit from http cache"
   expect_log "1 .*-sandbox" "Rebuild target failed"
@@ -393,7 +393,7 @@ EOF
 
   # Fetch from disk cache
   bazel clean
-  bazel build $disk_flags $http_flags //a:test --noremote_accept_cached &> $TEST_log \
+  bazel build $disk_flags $http_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_log "1 disk cache hit" "Fetch from disk cache failed"
   diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1398,8 +1398,10 @@ function test_combined_disk_remote_exec_with_flag_combinations() {
      # ensure CAS entries get uploaded even when action entries don't.
      "--noremote_upload_local_results"
      "--remote_upload_local_results"
-     # Should be some disk cache hits, just not remote.
+     # we should see no cache hits  [incompatible_remote_results_ignore_disk=false is default]
      "--noremote_accept_cached"
+     # Should be some disk cache hits, just not remote.
+     "--noremote_accept_cached --incompatible_remote_results_ignore_disk"
   )
 
   for flags in "${testcases[@]}"; do
@@ -1612,13 +1614,13 @@ EOF
   mkdir $cache
 
   # Build and push to disk cache but not grpc cache
-  bazel build $disk_flags $grpc_flags --noremote_upload_local_results //a:test \
+  bazel build $disk_flags $grpc_flags --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results //a:test \
     || fail "Failed to build //a:test with combined disk grpc cache"
   cp -f bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected
 
   # Fetch from disk cache
   bazel clean
-  bazel build $disk_flags //a:test --noremote_upload_local_results &> $TEST_log \
+  bazel build $disk_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results &> $TEST_log \
     || fail "Failed to fetch //a:test from disk cache"
   expect_log "1 disk cache hit" "Fetch from disk cache failed"
   diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
@@ -1626,7 +1628,7 @@ EOF
 
   # No cache result from grpc cache, rebuild target
   bazel clean
-  bazel build $grpc_flags //a:test --noremote_upload_local_results &> $TEST_log \
+  bazel build $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_not_log "1 remote cache hit" "Should not get cache hit from grpc cache"
   expect_log "1 .*-sandbox" "Rebuild target failed"
@@ -1638,7 +1640,7 @@ EOF
 
   # No cache result from grpc cache, rebuild target, and upload result to grpc cache
   bazel clean
-  bazel build $grpc_flags //a:test --noremote_accept_cached &> $TEST_log \
+  bazel build $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_not_log "1 remote cache hit" "Should not get cache hit from grpc cache"
   expect_log "1 .*-sandbox" "Rebuild target failed"
@@ -1647,7 +1649,7 @@ EOF
 
   # No cache result from grpc cache, rebuild target, and upload result to disk cache
   bazel clean
-  bazel build $disk_flags $grpc_flags //a:test --noremote_accept_cached &> $TEST_log \
+  bazel build $disk_flags $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_not_log "1 remote cache hit" "Should not get cache hit from grpc cache"
   expect_log "1 .*-sandbox" "Rebuild target failed"
@@ -1656,7 +1658,7 @@ EOF
 
   # Fetch from disk cache
   bazel clean
-  bazel build $disk_flags $grpc_flags //a:test --noremote_accept_cached &> $TEST_log \
+  bazel build $disk_flags $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_log "1 disk cache hit" "Fetch from disk cache failed"
   diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
@@ -1771,13 +1773,13 @@ EOF
   mkdir $cache
 
   # Build and push to disk cache but not remote cache
-  bazel build $disk_flags $grpc_flags //a:test \
+  bazel build $disk_flags $grpc_flags --incompatible_remote_results_ignore_disk=true //a:test \
     || fail "Failed to build //a:test with combined cache"
   cp -f bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected
 
   # Fetch from disk cache
   bazel clean
-  bazel build $disk_flags //a:test &> $TEST_log \
+  bazel build $disk_flags //a:test --incompatible_remote_results_ignore_disk=true &> $TEST_log \
     || fail "Failed to fetch //a:test from disk cache"
   expect_log "1 disk cache hit" "Fetch from disk cache failed"
   diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
@@ -1785,7 +1787,7 @@ EOF
 
   # No cache result from grpc cache, rebuild target
   bazel clean
-  bazel build $grpc_flags //a:test &> $TEST_log \
+  bazel build $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true &> $TEST_log \
     || fail "Failed to build //a:test"
   expect_not_log "1 remote cache hit" "Should not get cache hit from grpc cache"
   diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
@@ -1811,6 +1813,7 @@ EOF
   bazel build \
     --disk_cache=${cache_dir} \
     --remote_executor=grpc://localhost:${worker_port} \
+    --incompatible_remote_results_ignore_disk=true \
     //a:test &> $TEST_log \
     || fail "Failed to build //a:test"
 


### PR DESCRIPTION
We'd like to use Bazel 7.0 but we still rely on this feature for a number of repos.

This issue has a summary of the problems: https://github.com/bazelbuild/bazel/issues/17428

The main changes we'd need are:

1. to filter out several hundreds of GB from the disk cache - doing this many writes caused disk corruption on macOS. #17428 has more info about it

2. When we use this feature with RBE it prevents from uploading artifacts that are tagged as `no-remote-cache`. https://github.com/bazelbuild/bazel-buildfarm/issues/1402 has the issue for buildfarm

*Setting `--incompatible_remote_results_ignore_disk=true` on 6.0, breaks RBE on 6.x.x for us too, because we set many mnemonics which are RBE inputs to `no-remote-cache`. The `no-remote-cache` actions are dependencies of RBE  test actions - but fail to be uploaded to the execution service.

For instance, we have remotely executed `TestRunner a` who depends on `Bundle b`:
```
TestRunner "a" -> Bundle "b"

TestRunner remote
Bundle no-remote-cache
```
`--incompatible_remote_results_ignore_disk=true` causes `Bundle b` to not be uploaded to to the execution service 

This reverts commit c88f374246c0a7b3a87c58553d3b9ad0ef4e9ad4.