### PR TITLE
Include dependency edge info in transition errors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/DependencyProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/DependencyProducer.java
@@ -189,12 +189,22 @@ final class DependencyProducer
 
   @Override
   public void acceptTransitionError(TransitionException e) {
-    sink.acceptDependencyError(DependencyError.of(e));
+    sink.acceptDependencyError(
+        DependencyError.of(new TransitionException(getMessageWithEdgeTransitionInfo(e), e)));
   }
 
   @Override
   public void acceptTransitionError(OptionsParsingException e) {
-    sink.acceptDependencyError(DependencyError.of(e));
+    sink.acceptDependencyError(
+        DependencyError.of(
+            new OptionsParsingException(
+                getMessageWithEdgeTransitionInfo(e), e.getInvalidArgument(), e)));
+  }
+
+  private String getMessageWithEdgeTransitionInfo(Throwable e) {
+    return String.format(
+        "On dependency edge %s -|%s|-> %s: %s",
+        parameters.target().getLabel(), kind.getAttribute().getName(), toLabel, e.getMessage());
   }
 
   private StateMachine processTransitionResult(Tasks tasks) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/DependencyProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/DependencyProducer.java
@@ -203,8 +203,12 @@ final class DependencyProducer
 
   private String getMessageWithEdgeTransitionInfo(Throwable e) {
     return String.format(
-        "On dependency edge %s -|%s|-> %s: %s",
-        parameters.target().getLabel(), kind.getAttribute().getName(), toLabel, e.getMessage());
+        "On dependency edge %s (%s) -|%s|-> %s: %s",
+        parameters.target().getLabel(),
+        parameters.configurationKey().getOptions().shortId(),
+        kind.getAttribute().getName(),
+        toLabel,
+        e.getMessage());
   }
 
   private StateMachine processTransitionResult(Tasks tasks) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransition.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransition.java
@@ -87,20 +87,16 @@ public abstract class StarlarkTransition implements ConfigurationTransition {
   // TODO(blaze-configurability): add more information to this exception e.g. originating target of
   // transition.
   public static class TransitionException extends Exception {
-    private final String message;
-
     public TransitionException(String message) {
-      this.message = message;
+      super(message);
     }
 
     public TransitionException(Throwable cause) {
-      this.message = cause.getMessage();
+      super(cause);
     }
 
-    /** Returns the error message. */
-    @Override
-    public String getMessage() {
-      return message;
+    public TransitionException(String message, Throwable cause) {
+      super(message, cause);
     }
   }
 


### PR DESCRIPTION
When a Starlark transition implementation function fails, it now prints an error such as:

```
ERROR: /home/user/example/BUILD.bazel:3:11: On dependency edge //pkg:wrapper (ed19e2b) -|exports|-> //pkg:real_target: Errors encountered while applying Starlark transition
```

Previously, the generated error messages would only point to the BUILD file location of the target with the outgoing edge as well as a stack trace of the transition function (the latter only for Starlark errors, not those encountered during option conversion).