### PR TITLE
Remove incompatible_use_toolchain_transition = True

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -934,7 +934,6 @@ def make_cc_binary(cc_binary_attrs, **kwargs):
         },
         toolchains = cc_helper.use_cpp_toolchain() +
                      semantics.get_runtimes_toolchain(),
-        incompatible_use_toolchain_transition = True,
         executable = True,
         **kwargs
     )

--- a/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
@@ -212,5 +212,4 @@ cc_import = rule(
     provides = [CcInfo],
     toolchains = cc_helper.use_cpp_toolchain(),
     fragments = ["cpp"],
-    incompatible_use_toolchain_transition = True,
 )

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -619,7 +619,6 @@ cc_library = rule(
     toolchains = cc_helper.use_cpp_toolchain() +
                  semantics.get_runtimes_toolchain(),
     fragments = ["cpp"] + semantics.additional_fragments(),
-    incompatible_use_toolchain_transition = True,
     provides = [CcInfo],
     exec_groups = {
         "cpp_link": exec_group(toolchains = cc_helper.use_cpp_toolchain()),

--- a/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
@@ -842,7 +842,6 @@ cc_shared_library = rule(
     },
     toolchains = cc_helper.use_cpp_toolchain(),
     fragments = ["cpp"] + semantics.additional_fragments(),
-    incompatible_use_toolchain_transition = True,
 )
 
 for_testing_dont_use_check_if_target_under_path = _check_if_target_under_path

--- a/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl
@@ -140,6 +140,5 @@ def make_cc_test(with_linkstatic = False, with_aspects = False):
         toolchains = [] +
                      cc_helper.use_cpp_toolchain() +
                      semantics.get_runtimes_toolchain(),
-        incompatible_use_toolchain_transition = True,
         test = True,
     )

--- a/src/main/starlark/builtins_bzl/common/objc/objc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/objc_import.bzl
@@ -91,5 +91,4 @@ objc_import = rule(
     ),
     fragments = ["objc", "apple", "cpp"],
     toolchains = cc_helper.use_cpp_toolchain(),
-    incompatible_use_toolchain_transition = True,
 )

--- a/src/main/starlark/builtins_bzl/common/objc/objc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/objc_library.bzl
@@ -135,5 +135,4 @@ objc_library = rule(
     fragments = ["objc", "apple", "cpp"],
     cfg = apple_crosstool_transition,
     toolchains = cc_helper.use_cpp_toolchain(),
-    incompatible_use_toolchain_transition = True,
 )

--- a/src/test/java/com/google/devtools/build/lib/rules/python/PythonToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/PythonToolchainTest.java
@@ -72,7 +72,6 @@ public class PythonToolchainTest extends BuildViewTestCase {
         "myrule = rule(",
         "    implementation = _myrule_impl,",
         "    toolchains = ['" + TOOLCHAIN_TYPE + "'],",
-        "    incompatible_use_toolchain_transition = True,",
         ")");
     // A toolchain implementation and an instance of the rule that will use it.
     scratch.file(

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -3463,7 +3463,6 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
         "      exec_compatible_with = ['//something:extra'],",
         "    ),",
         "  },",
-        "  incompatible_use_toolchain_transition = True,",
         ")");
     scratch.file(
         "something/BUILD",

--- a/src/test/shell/bazel/cc_api_rules.bzl
+++ b/src/test/shell/bazel/cc_api_rules.bzl
@@ -101,7 +101,6 @@ cc_lib = rule(
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
     fragments = ["cpp"],
-    incompatible_use_toolchain_transition = True,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )
 
@@ -200,6 +199,5 @@ cc_bin = rule(
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
     fragments = ["cpp"],
-    incompatible_use_toolchain_transition = True,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -268,7 +268,6 @@ def _compiler_flag_impl(ctx):
 compiler_flag = rule(
     implementation = _compiler_flag_impl,
     toolchains = ["//target_skipping/custom_tools:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 EOF
 }

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -2464,7 +2464,6 @@ def _impl(ctx):
 outer_toolchain = rule(
     implementation = _impl,
     toolchains = ["//${pkg}/inner:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 EOF
   cat > "${pkg}/outer/BUILD" <<EOF
@@ -2499,7 +2498,6 @@ def _impl(ctx):
 demo_rule = rule(
     implementation = _impl,
     toolchains = ["//${pkg}/outer:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 EOF
   cat > "${pkg}/rule/BUILD" <<EOF

--- a/src/test/shell/integration/toolchain_transition_test.sh
+++ b/src/test/shell/integration/toolchain_transition_test.sh
@@ -355,7 +355,6 @@ sample = rule(
         "log": "%{name}.log",
     },
     toolchains = ["//${pkg}/toolchain:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 
 def _sample_test_impl(ctx):
@@ -389,7 +388,6 @@ sample_test = rule(
         "log": "%{name}.log",
     },
     toolchains = ["//${pkg}/toolchain:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     test = True,
 )
 EOF

--- a/tools/cpp/cc_flags_supplier.bzl
+++ b/tools/cpp/cc_flags_supplier.bzl
@@ -31,6 +31,5 @@ cc_flags_supplier = rule(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = use_cpp_toolchain(),
-    incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )

--- a/tools/cpp/compiler_flag.bzl
+++ b/tools/cpp/compiler_flag.bzl
@@ -26,5 +26,4 @@ compiler_flag = rule(
         "_cc_toolchain": attr.label(default = Label("//tools/cpp:current_cc_toolchain")),
     },
     toolchains = use_cpp_toolchain(),
-    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
This has been a no-op since the flag was flipped

https://github.com/bazelbuild/bazel/issues/11584