### PR TITLE
Add --incompatible_disable_objc_library_transition

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -701,6 +701,17 @@ public final class BuildLanguageOptions extends OptionsBase {
       help = "If set to true, the ObjcProvider's APIs for linking info will be removed.")
   public boolean incompatibleObjcProviderRemoveLinkingInfo;
 
+  @Option(
+      name = "incompatible_disable_objc_library_transition",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+        "Disable objc_library's custom transition and inherit "
+            + "from the top level target instead")
+  public boolean incompatibleDisableObjcLibraryTransition;
+
   /**
    * An interner to reduce the number of StarlarkSemantics instances. A single Blaze instance should
    * never accumulate a large number of these and being able to shortcut on object identity makes a
@@ -800,6 +811,9 @@ public final class BuildLanguageOptions extends OptionsBase {
             .setBool(
                 INCOMPATIBLE_OBJC_PROVIDER_REMOVE_LINKING_INFO,
                 incompatibleObjcProviderRemoveLinkingInfo)
+            .setBool(
+                INCOMPATIBLE_DISABLE_OBJC_LIBRARY_TRANSITION,
+                incompatibleDisableObjcLibraryTransition)
             .build();
     return INTERNER.intern(semantics);
   }
@@ -890,6 +904,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       "-experimental_merge_fixed_and_default_shell_env";
   public static final String INCOMPATIBLE_OBJC_PROVIDER_REMOVE_LINKING_INFO =
       "-incompatible_objc_provider_remove_linking_info";
+  public static final String INCOMPATIBLE_DISABLE_OBJC_LIBRARY_TRANSITION =
+      "-incompatible_disable_objc_library_transition";
 
   // non-booleans
   public static final StarlarkSemantics.Key<String> EXPERIMENTAL_BUILTINS_BZL_PATH =

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1162,6 +1162,12 @@ public abstract class CcModule
   }
 
   @Override
+  public boolean getIncompatibleDisableObjcLibraryTransition(StarlarkThread thread) throws EvalException {
+    isCalledFromStarlarkCcCommon(thread);
+    return thread.getSemantics().getBool(BuildLanguageOptions.INCOMPATIBLE_DISABLE_OBJC_LIBRARY_TRANSITION);
+  }
+
+  @Override
   public CcLinkingContext createCcLinkingInfo(
       Object linkerInputs,
       Object librariesToLinkObject,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
@@ -1103,6 +1103,12 @@ public interface CcModuleApi<
   boolean checkExperimentalCcSharedLibrary(StarlarkThread thread) throws EvalException;
 
   @StarlarkMethod(
+      name = "incompatible_disable_objc_library_transition",
+      useStarlarkThread = true,
+      documented = false)
+  boolean getIncompatibleDisableObjcLibraryTransition(StarlarkThread thread) throws EvalException;
+
+  @StarlarkMethod(
       name = "create_linking_context",
       doc = "Creates a <code>LinkingContext</code>.",
       useStarlarkThread = true,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
@@ -631,6 +631,10 @@ def _check_experimental_cc_shared_library():
     cc_common_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
     return cc_common_internal.check_experimental_cc_shared_library()
 
+def _incompatible_disable_objc_library_transition():
+    cc_common_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
+    return cc_common_internal.incompatible_disable_objc_library_transition()
+
 def _create_module_map(*, file, name, umbrella_header = None):
     cc_common_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
     return cc_common_internal.create_module_map(
@@ -914,6 +918,7 @@ cc_common = struct(
     merge_cc_infos = _merge_cc_infos,
     create_compilation_context = _create_compilation_context,
     legacy_cc_flags_make_variable_do_not_use = _legacy_cc_flags_make_variable_do_not_use,
+    incompatible_disable_objc_library_transition = _incompatible_disable_objc_library_transition,
     is_cc_toolchain_resolution_enabled_do_not_use = _is_cc_toolchain_resolution_enabled_do_not_use,
     create_cc_toolchain_config_info = _create_cc_toolchain_config_info,
     create_linking_context_from_compilation_outputs = _create_linking_context_from_compilation_outputs,

--- a/src/main/starlark/builtins_bzl/common/objc/objc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/objc_library.bzl
@@ -21,6 +21,7 @@ load("@_builtins//:common/objc/objc_common.bzl", "extensions", "objc_common")
 load("@_builtins//:common/objc/semantics.bzl", "semantics")
 load("@_builtins//:common/objc/transitions.bzl", "apple_crosstool_transition")
 load(":common/objc/providers.bzl", "J2ObjcEntryClassInfo", "J2ObjcMappingFileInfo")
+load(":common/cc/cc_common.bzl", "cc_common")
 load(":common/cc/cc_info.bzl", "CcInfo")
 
 objc_internal = _builtins.internal.objc_internal
@@ -133,6 +134,6 @@ objc_library = rule(
         common_attrs.SDK_FRAMEWORK_DEPENDER_RULE,
     ),
     fragments = ["objc", "apple", "cpp"],
-    cfg = apple_crosstool_transition,
+    cfg = None if cc_common.incompatible_disable_objc_library_transition() else apple_crosstool_transition,
     toolchains = cc_helper.use_cpp_toolchain(),
 )

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -99,6 +99,30 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   }
 
   @Test
+  public void testNoTransition() throws Exception {
+    scratch.file(
+        "bin/BUILD",
+        "objc_library(",
+        "    name = 'objc',",
+        "    srcs = ['objc.m'],",
+        ")",
+        "cc_binary(",
+        "    name = 'cc',",
+        "    srcs = ['cc.cc'],",
+        "    deps = [':objc'],",
+        ")");
+
+    setBuildLanguageOptions("--incompatible_disable_objc_library_transition");
+    useConfiguration("--macos_cpus=arm64,x86_64");
+
+    ConfiguredTarget cc = getConfiguredTarget("//bin:cc");
+    Artifact objcObject =
+        ActionsTestUtil.getFirstArtifactEndingWith(
+            actionsTestUtil().artifactClosureOf(getFilesToBuild(cc)), "objc.o");
+    assertThat(objcObject.getExecPathString()).contains("k8-fastbuild");
+  }
+
+  @Test
   public void testFilesToBuild() throws Exception {
     ConfiguredTarget target =
         createLibraryTargetWriter("//objc:One")


### PR DESCRIPTION
This is a migration for https://github.com/bazelbuild/bazel/issues/16870

Users who rely on the current behavior should instead wrap their library in a target from [rules_apple](https://github.com/bazelbuild/rules_apple).

Fixes https://github.com/bazelbuild/bazel/issues/19204