### PR TITLE
Add support for more workspace boundary files to bash completion

### DIFF
--- a/scripts/bash_completion_test.sh
+++ b/scripts/bash_completion_test.sh
@@ -768,4 +768,27 @@ test_info() {
                      'info --show_make_env '
 }
 
+test_workspace_boundary() {
+    # "Test that workspace boundary files are recognized"
+    mkdir -p sub_repo/some/pkg
+    touch sub_repo/some/pkg/BUILD
+    cd sub_repo 2>/dev/null
+
+    touch WORKSPACE.bazel
+    assert_expansion 'build //s' \
+                     'build //some/'
+
+    mv WORKSPACE.bazel MODULE.bazel
+    assert_expansion 'build //s' \
+                     'build //some/'
+
+    mv MODULE.bazel REPO.bazel
+    assert_expansion 'build //s' \
+                     'build //some/'
+
+    rm REPO.bazel
+    assert_expansion 'build //s' \
+                     'build //sub_repo/'
+}
+
 run_suite "Tests of bash completion of 'blaze' command."

--- a/scripts/bazel-complete-template.bash
+++ b/scripts/bazel-complete-template.bash
@@ -79,13 +79,17 @@ _bazel__get_rule_match_pattern() {
 }
 
 # Compute workspace directory. Search for the innermost
-# enclosing directory with a WORKSPACE file.
+# enclosing directory with a boundary file (see
+# src/main/cpp/workspace_layout.cc).
 _bazel__get_workspace_path() {
   local workspace=$PWD
   while true; do
-    if [ -f "${workspace}/WORKSPACE" ]; then
+    if [ -f "${workspace}/WORKSPACE" ] || \
+       [ -f "${workspace}/WORKSPACE.bazel" ] || \
+       [ -f "${workspace}/MODULE.bazel" ] || \
+       [ -f "${workspace}/REPO.bazel" ]; then
       break
-    elif [ -z "$workspace" -o "$workspace" = "/" ]; then
+    elif [ -z "$workspace" ] || [ "$workspace" = "/" ]; then
       workspace=$PWD
       break;
     fi


### PR DESCRIPTION
Bash completion now also recognized `WORKSPACE.bazel`, `MODULE.bazel` and `REPO.bazel`.

Also fixes a shellcheck finding.