### PR TITLE
[6.4.0] Download `BazelRegistryJson` only once per registry

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -82,6 +82,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//third_party:caffeine",
         "//third_party:gson",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -49,6 +49,7 @@ public class IndexRegistry implements Registry {
   private final DownloadManager downloadManager;
   private final Map<String, String> clientEnv;
   private final Gson gson;
+  private volatile Optional<BazelRegistryJson> bazelRegistryJson;
 
   public IndexRegistry(URI uri, DownloadManager downloadManager, Map<String, String> clientEnv) {
     this.uri = uri;
@@ -140,9 +141,6 @@ public class IndexRegistry implements Registry {
   public RepoSpec getRepoSpec(
       ModuleKey key, RepositoryName repoName, ExtendedEventHandler eventHandler)
       throws IOException, InterruptedException {
-    Optional<BazelRegistryJson> bazelRegistryJson =
-        grabJson(
-            constructUrl(getUrl(), "bazel_registry.json"), BazelRegistryJson.class, eventHandler);
     Optional<SourceJson> sourceJson =
         grabJson(
             constructUrl(
@@ -157,12 +155,30 @@ public class IndexRegistry implements Registry {
     String type = sourceJson.get().type;
     switch (type) {
       case "archive":
-        return createArchiveRepoSpec(sourceJson, bazelRegistryJson, key, repoName);
+        return createArchiveRepoSpec(sourceJson, getBazelRegistryJson(eventHandler), key, repoName);
       case "local_path":
-        return createLocalPathRepoSpec(sourceJson, bazelRegistryJson, key, repoName);
+        return createLocalPathRepoSpec(
+            sourceJson, getBazelRegistryJson(eventHandler), key, repoName);
       default:
         throw new IOException(String.format("Invalid source type for module %s", key));
     }
+  }
+
+  @SuppressWarnings("OptionalAssignedToNull")
+  private Optional<BazelRegistryJson> getBazelRegistryJson(ExtendedEventHandler eventHandler)
+      throws IOException, InterruptedException {
+    if (bazelRegistryJson == null) {
+      synchronized (this) {
+        if (bazelRegistryJson == null) {
+          bazelRegistryJson =
+              grabJson(
+                  constructUrl(getUrl(), "bazel_registry.json"),
+                  BazelRegistryJson.class,
+                  eventHandler);
+        }
+      }
+    }
+    return bazelRegistryJson;
   }
 
   private RepoSpec createLocalPathRepoSpec(


### PR DESCRIPTION
By caching `BazelRegistryJson` in `IndexRegistry` and caching `IndexRegistry` instances per registry URL, `bazel_registry.json` is only downloaded once per registry instead of once for each module in the final dependency graph in `computeFinalDepGraph`.

On my local machine, this shaves 4s off of the time spent on module resolution for Bazel itself.

Closes #19292.

Commit https://github.com/bazelbuild/bazel/commit/8337dd704237d2d21fd999c9484a23174b6074d5

PiperOrigin-RevId: 558940780
Change-Id: I89b03a4c246b10f39b89a79852c922a6504f00bf