### PR TITLE
Allow customizing errors during remote connections

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -582,9 +582,8 @@ public final class RemoteModule extends BlazeModule {
     } catch (AbruptExitException e) {
       throw e; // prevent abrupt interception
     } catch (Exception e) {
-      String errorMessage =
-          "Failed to query remote execution capabilities: "
-              + Utils.grpcAwareErrorMessage(e, verboseFailures);
+      String errorMessage = remoteOptions.remoteInitFailureMessage.replace("{message}",
+          Utils.grpcAwareErrorMessage(e, verboseFailures));
       if (remoteOptions.remoteLocalFallback) {
         if (verboseFailures) {
           errorMessage += System.lineSeparator() + Throwables.getStackTraceAsString(e);

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.util.OptionsUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Converters.AssignmentConverter;
+import com.google.devtools.common.options.Converters.StringConverter;
 import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -614,6 +615,21 @@ public final class RemoteOptions extends CommonRemoteOptions {
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help = "Maximum number of open files allowed during BEP artifact upload.")
   public int maximumOpenFiles;
+
+  @Option(
+      name = "experimental_remote_init_failure_message",
+      defaultValue = "Failed to query remote execution capabilities: {message}",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+      converter = StringConverter.class,
+      help =
+          "Message to print when the connection to the remote cache or executor fails. The "
+              + "{message} placeholder is replaced with the actual error. This can be used to "
+              + "provide additional details on how to resolve the connection problem because the "
+              + "action that a user can take depends on the specific deployment of the remote "
+              + "build services."
+  )
+  public String remoteInitFailureMessage;
 
   @Option(
       name = "remote_print_execution_messages",


### PR DESCRIPTION
Almost all remote caching and execution services are protected by some kind of authentication or networking requirements (like VPN).  These vary from deployment to deployment so Bazel cannot print useful error messages on its own to guide users to a solution when they experience a connectivity problem.

To resolve this, add a new --experimental_remote_init_failure_message flag that provides a template for the error messages that Bazel prints when the connection to the build farm fails.  The default value respects the existing messages to not change behavior, but users can tweak its value to provide guidance to users.

The idea is that the .bazelrc of a repo will customize this flag to provide a useful message in the context of that repo.