### PR TITLE
Remove redundant line break in user-manual

### DIFF
--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -926,7 +926,6 @@ possible in the edit/build/test cycle. This argument affects the way all
 non-flag arguments are interpreted: each argument must be a
 file target label or a plain filename relative to the current working
 directory, and one rule that depends on each source filename is built. For
-
 C++ and Java
 sources, rules in the same language space are preferentially chosen. For
 multiple rules with the same preference, the one that appears first in the


### PR DESCRIPTION
<img width="659" alt="image" src="https://github.com/bazelbuild/bazel/assets/46747123/4e6864e2-42ee-47b1-acfd-33bdd26e381d">

The new paragraph caused by extra line break looks strange.