### PR TITLE
Flip `--incompatible_merge_fixed_and_default_shell_env`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -681,7 +681,7 @@ public final class BuildLanguageOptions extends OptionsBase {
 
   @Option(
       name = "incompatible_merge_fixed_and_default_shell_env",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
@@ -887,7 +887,7 @@ public final class BuildLanguageOptions extends OptionsBase {
   public static final String EXPERIMENTAL_GET_FIXED_CONFIGURED_ACTION_ENV =
       "-experimental_get_fixed_configured_action_env";
   public static final String INCOMPATIBLE_MERGE_FIXED_AND_DEFAULT_SHELL_ENV =
-      "-experimental_merge_fixed_and_default_shell_env";
+      "+experimental_merge_fixed_and_default_shell_env";
   public static final String INCOMPATIBLE_OBJC_PROVIDER_REMOVE_LINKING_INFO =
       "-incompatible_objc_provider_remove_linking_info";
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -417,7 +417,18 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
             defaultValue = "False",
             named = true,
             positional = false,
-            doc = "Whether the action should use the built in shell environment or not."),
+            doc =
+                "Whether the action should use the default shell environment, which consists of a"
+                    + " few OS-dependent variables as well as variables set via <a"
+                    + " href=\"/reference/command-line-reference#flag--action_env\"><code>"
+                    + "--action_env</code></a>."
+                    + "<p>If both <code>use_default_shell_env</code> and <code>env</code> are set"
+                    + " to <code>True</code>, values set in <code>env</code> will overwrite the"
+                    + " default shell environment if <a "
+                    + "href=\"/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env\">"
+                    + "<code>--incompatible_merge_fixed_and_default_shell_env</code></a> is"
+                    + " enabled (default). If the flag is not enabled, <code>env</code> is"
+                    + " ignored."),
         @Param(
             name = "env",
             allowedTypes = {
@@ -427,7 +438,15 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
             defaultValue = "None",
             named = true,
             positional = false,
-            doc = "Sets the dictionary of environment variables."),
+            doc =
+                "Sets the dictionary of environment variables."
+                    + "<p>If both <code>use_default_shell_env</code> and <code>env</code> are set"
+                    + " to <code>True</code>, values set in <code>env</code> will overwrite the"
+                    + " default shell environment if <a "
+                    + "href=\"/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env\">"
+                    + "<code>--incompatible_merge_fixed_and_default_shell_env</code></a> is"
+                    + " enabled (default). If the flag is not enabled, <code>env</code> is"
+                    + " ignored."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {
@@ -664,7 +683,18 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
             defaultValue = "False",
             named = true,
             positional = false,
-            doc = "Whether the action should use the built in shell environment or not."),
+            doc =
+                "Whether the action should use the default shell environment, which consists of a"
+                    + " few OS-dependent variables as well as variables set via <a"
+                    + " href=\"/reference/command-line-reference#flag--action_env\"><code>"
+                    + "--action_env</code></a>."
+                    + "<p>If both <code>use_default_shell_env</code> and <code>env</code> are set"
+                    + " to <code>True</code>, values set in <code>env</code> will overwrite the"
+                    + " default shell environment if <a "
+                    + "href=\"/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env\">"
+                    + "<code>--incompatible_merge_fixed_and_default_shell_env</code></a> is"
+                    + " enabled (default). If the flag is not enabled, <code>env</code> is"
+                    + " ignored."),
         @Param(
             name = "env",
             allowedTypes = {
@@ -674,7 +704,15 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
             defaultValue = "None",
             named = true,
             positional = false,
-            doc = "Sets the dictionary of environment variables."),
+            doc =
+                "Sets the dictionary of environment variables."
+                    + "<p>If both <code>use_default_shell_env</code> and <code>env</code> are set"
+                    + " to <code>True</code>, values set in <code>env</code> will overwrite the"
+                    + " default shell environment if <a "
+                    + "href=\"/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env\">"
+                    + "<code>--incompatible_merge_fixed_and_default_shell_env</code></a> is"
+                    + " enabled (default). If the flag is not enabled, <code>env</code> is"
+                    + " ignored."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -142,6 +142,7 @@ public class ConsistencyTest {
         "--incompatible_disallow_struct_provider_syntax=" + rand.nextBoolean(),
         "--incompatible_do_not_split_linking_cmdline=" + rand.nextBoolean(),
         "--incompatible_java_common_parameters=" + rand.nextBoolean(),
+        "--incompatible_merge_fixed_and_default_shell_env=" + rand.nextBoolean(),
         "--incompatible_new_actions_api=" + rand.nextBoolean(),
         "--incompatible_no_attr_license=" + rand.nextBoolean(),
         "--incompatible_no_implicit_file_export=" + rand.nextBoolean(),
@@ -190,6 +191,8 @@ public class ConsistencyTest {
             BuildLanguageOptions.INCOMPATIBLE_DISALLOW_STRUCT_PROVIDER_SYNTAX, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_DO_NOT_SPLIT_LINKING_CMDLINE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_JAVA_COMMON_PARAMETERS, rand.nextBoolean())
+        .setBool(
+            BuildLanguageOptions.INCOMPATIBLE_MERGE_FIXED_AND_DEFAULT_SHELL_ENV, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NEW_ACTIONS_API, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_ATTR_LICENSE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_IMPLICIT_FILE_EXPORT, rand.nextBoolean())

--- a/src/test/shell/integration/action_env_test.sh
+++ b/src/test/shell/integration/action_env_test.sh
@@ -253,7 +253,6 @@ function test_use_default_shell_env_and_fixed_env {
 
     ACTION_AND_CLIENT_INHERITED=client CLIENT_INHERITED=client \
         bazel build \
-        --incompatible_merge_fixed_and_default_shell_env \
         --action_env=ACTION_AND_CLIENT_FIXED=client \
         --action_env=ACTION_AND_CLIENT_INHERITED \
         --action_env=CLIENT_FIXED=client \


### PR DESCRIPTION
Fixes #5980 
Closes #19317 

RELNOTES[INC]: --incompatible_merge_fixed_and_default_shell_env is flipped to true. See #19317 for details.