### PR TITLE
Wait for local build event file to complete without the implicit requirement on --bes_upload_mode.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceTransport.java
@@ -191,4 +191,9 @@ public class BuildEventServiceTransport implements BuildEventTransport {
           checkNotNull(commandStartTime));
     }
   }
+
+  @Override
+  public boolean shouldWaitForUploadComplete() {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventTransport.java
@@ -87,6 +87,13 @@ public interface BuildEventTransport {
    */
   boolean mayBeSlow();
 
+  /**
+   * Returns true if Bazel should wait for the transport upload to complete. Example of this type of
+   * transports includes JSON/Binary BEP file which is often read by tools after the invocation.
+   * Bazel should complete writing them before turns the control back to command line.
+   */
+  boolean shouldWaitForUploadComplete();
+
   @VisibleForTesting
   @Nullable
   BuildEventArtifactUploader getUploader();

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BinaryFormatFileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BinaryFormatFileTransport.java
@@ -56,4 +56,9 @@ public final class BinaryFormatFileTransport extends FileTransport {
     }
     return bos.toByteArray();
   }
+
+  @Override
+  public boolean shouldWaitForUploadComplete() {
+    return true;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
@@ -46,7 +46,6 @@ public class BuildEventStreamOptions extends OptionsBase {
       name = "build_event_binary_file",
       oldName = "experimental_build_event_binary_file",
       defaultValue = "",
-      implicitRequirements = {"--bes_upload_mode=wait_for_upload_complete"},
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
@@ -59,7 +58,6 @@ public class BuildEventStreamOptions extends OptionsBase {
       name = "build_event_json_file",
       oldName = "experimental_build_event_json_file",
       defaultValue = "",
-      implicitRequirements = {"--bes_upload_mode=wait_for_upload_complete"},
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/JsonFormatFileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/JsonFormatFileTransport.java
@@ -57,4 +57,9 @@ public final class JsonFormatFileTransport extends FileTransport {
     }
     return protoJsonRepresentation.getBytes(UTF_8);
   }
+
+  @Override
+  public boolean shouldWaitForUploadComplete() {
+    return true;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransport.java
@@ -49,4 +49,9 @@ public final class TextFormatFileTransport extends FileTransport {
     String protoTextRepresentation = TextFormat.printer().printToString(buildEvent);
     return ("event {\n" + protoTextRepresentation + "}\n\n").getBytes(UTF_8);
   }
+
+  @Override
+  public boolean shouldWaitForUploadComplete() {
+    return false;
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -74,6 +74,7 @@ java_test(
         "@googleapis//:google_devtools_build_v1_build_events_java_proto",
         "@googleapis//:google_devtools_build_v1_publish_build_event_java_grpc",
         "@googleapis//:google_devtools_build_v1_publish_build_event_java_proto",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.bugreport.BugReport;
 import com.google.devtools.build.lib.bugreport.Crash;
 import com.google.devtools.build.lib.bugreport.CrashContext;
 import com.google.devtools.build.lib.buildeventservice.BazelBuildEventServiceModule.BackendConfig;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceModule.BuildEventOutputStreamFactory;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.Aborted;
@@ -74,6 +75,8 @@ import com.google.devtools.build.v1.PublishBuildToolEventStreamResponse;
 import com.google.devtools.build.v1.PublishLifecycleEventRequest;
 import com.google.devtools.build.v1.StreamId;
 import com.google.protobuf.Empty;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Server;
@@ -84,11 +87,15 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.MutableHandlerRegistry;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -102,6 +109,7 @@ import java.util.SortedSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.junit.After;
@@ -111,10 +119,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Tests for {@link BazelBuildEventServiceModule}. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTestCase {
 
   private static final Duration WAIT_FOR_LAST_INVOCATION_TIMEOUT = Duration.ofSeconds(2);
@@ -127,6 +134,9 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
 
   private BazelBuildEventServiceModule besModule;
   private BlazeModule connectivityModule = new NoOpConnectivityModule();
+
+  @Nullable
+  private BuildEventOutputStreamFactory buildEventOutputStreamFactory;
 
   @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
@@ -167,6 +177,9 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
   private void runBuildWithOptions(String... options) throws Exception {
     addOptions(options);
     besModule = runtimeWrapper.getRuntime().getBlazeModule(BazelBuildEventServiceModule.class);
+    if (buildEventOutputStreamFactory != null) {
+      besModule.setBuildEventOutputStreamFactory(buildEventOutputStreamFactory);
+    }
     runtimeWrapper.newCommand();
     buildTarget();
   }
@@ -440,6 +453,43 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
   public void testAfterCommand_fullyAsync() throws Exception {
     runBuildWithOptions("--bes_backend=inprocess", "--bes_upload_mode=FULLY_ASYNC");
     afterBuildCommand();
+    events.assertNoWarningsOrErrors();
+  }
+
+  enum LocalBepFileTestParam {
+    JSON,
+    BINARY;
+
+    String getBesFlag(String file) {
+      switch (this) {
+        case JSON:
+          return "--build_event_json_file=" + file;
+        case BINARY:
+          return "--build_event_binary_file=" + file;
+      }
+      throw new IllegalStateException();
+    }
+  }
+
+  @Test
+  public void testAfterCommand_fullyAsync_waitLocalBEPFile(
+      @TestParameter LocalBepFileTestParam localBepFile) throws Exception {
+    AtomicReference<DelayingCloseBufferedOutputStream> outRef = new AtomicReference<>(null);
+    buildEventOutputStreamFactory = (file) -> {
+      var out = new DelayingCloseBufferedOutputStream(
+          Files.newOutputStream(Paths.get(file)), Duration.ofSeconds(1));
+      outRef.set(out);
+      return out;
+    };
+    buildEventService.setDelayBeforeClosingStream(Duration.ofSeconds(10));
+    var file = tmpFolder.newFile();
+
+    runBuildWithOptions("--bes_backend=inprocess", "--bes_upload_mode=FULLY_ASYNC",
+        "--bes_timeout=1s", localBepFile.getBesFlag(file.getAbsolutePath()));
+    afterBuildCommand();
+
+    assertThat(outRef.get().isClosed()).isTrue();
+    // Expect Bazel doesn't wait for uploading to bes_backend, otherwise there will be a timeout error.
     events.assertNoWarningsOrErrors();
   }
 
@@ -1053,6 +1103,29 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
     public void onCompleted() {
       responseObserver.onError(
           new StatusRuntimeException(Status.DATA_LOSS.withDescription(errorMessage)));
+    }
+  }
+
+
+  private static final class DelayingCloseBufferedOutputStream extends BufferedOutputStream {
+    private final Duration delay;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    DelayingCloseBufferedOutputStream(OutputStream out, Duration delay) {
+      super(out);
+      this.delay = delay;
+      this.out = out;
+    }
+
+    @Override
+    public void close() throws IOException {
+      Uninterruptibles.sleepUninterruptibly(delay);
+      super.close();
+      closed.set(true);
+    }
+
+    public boolean isClosed() {
+      return closed.get();
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
@@ -171,6 +171,11 @@ public final class BuildEventStreamerTest extends FoundationTestCase {
     }
 
     @Override
+    public boolean shouldWaitForUploadComplete() {
+      return true;
+    }
+
+    @Override
     public synchronized void sendBuildEvent(BuildEvent event) {
       events.add(event);
       try {


### PR DESCRIPTION
In 62060ba and 232d848, we added implicit requirement to `--bes_upload_mode=wait_for_upload_complete` when using flags `--build_event_binary_file` or `--build_event_json_file`. The motivation was to make sure these files are completely written to disk before Bazel completes the invocation, since most of the cases, these files are read by tools immediately after the invocation assuming the file is complete.

However, when an invocation has `--bes_backend`, `--bes_upload_mode=fully_async` and `build_event_[binary|json]_file` flags, the implicit requirement on `--bes_upload_mode=wait_for_upload_complete` overrides `--bes_upload_mode=fully_async` resulting in Bazel operates in `wait_for_upload_complete` mode, despite of  `fully_async` being requested. This implicitly forces tools that need to read local build event files to wait for BES upload.

This PR introduces `shouldWaitForUploadComplete()` method to `BuildEventTransport` so that the requirement is decoupled from `--bes_upload_mode`. Both `BinaryFormatFileTransport` and `JsonFormatFileTransport` return `true` while others remain `false`.

We also add `BuildEventOutputStreamFactory` to make it possible to assert the output stream is properly closed after invocation in the tests.

Fixes #19117.