### PR TITLE
Use effective `StarlarkSemantics` with `cquery --output=starlark`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.lib.analysis.ViewCreationFailedException;
 import com.google.devtools.build.lib.buildtool.BuildTool.ExitException;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.query2.NamedThreadSafeOutputFormatterCallback;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
@@ -160,7 +161,10 @@ public abstract class PostAnalysisQueryProcessor<T> implements BuildTool.Analysi
             queryRuntimeHelper.getOutputStreamForQueryOutput(),
             env.getSkyframeExecutor(),
             runtime.getRuleClassProvider(),
-            env.getPackageManager());
+            env.getPackageManager(),
+            env.getSkyframeExecutor()
+                .getEffectiveStarlarkSemantics(
+                    env.getOptions().getOptions(BuildLanguageOptions.class)));
     String outputFormat = postAnalysisQueryEnvironment.getOutputFormat();
     NamedThreadSafeOutputFormatterCallback<T> callback =
         NamedThreadSafeOutputFormatterCallback.selectCallback(outputFormat, callbacks);

--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -89,6 +89,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkSemantics;
 
 /**
  * {@link QueryEnvironment} that runs queries based on results from the analysis phase.
@@ -136,7 +137,8 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
           OutputStream outputStream,
           SkyframeExecutor skyframeExecutor,
           RuleClassProvider ruleClassProvider,
-          PackageManager packageManager)
+          PackageManager packageManager,
+          StarlarkSemantics starlarkSemantics)
           throws QueryException, InterruptedException;
 
   public abstract String getOutputFormat();

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkSemantics;
 
 /**
  * {@link QueryEnvironment} that is specialized for running action graph queries over the configured
@@ -138,7 +139,8 @@ public class ActionGraphQueryEnvironment
           OutputStream out,
           SkyframeExecutor skyframeExecutor,
           RuleClassProvider ruleClassProvider,
-          PackageManager packageManager) {
+          PackageManager packageManager,
+          StarlarkSemantics starlarkSemantics) {
     return ImmutableList.of(
         new ActionGraphProtoOutputFormatterCallback(
             eventHandler,

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -64,6 +64,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkSemantics;
 
 /**
  * {@link QueryEnvironment} that runs queries over the configured target (analysis) graph.
@@ -193,7 +194,8 @@ public class ConfiguredTargetQueryEnvironment
           OutputStream out,
           SkyframeExecutor skyframeExecutor,
           RuleClassProvider ruleClassProvider,
-          PackageManager packageManager)
+          PackageManager packageManager,
+          StarlarkSemantics starlarkSemantics)
           throws QueryException, InterruptedException {
     AspectResolver aspectResolver =
         cqueryOptions.aspectDeps.createResolver(packageManager, eventHandler);
@@ -269,7 +271,7 @@ public class ConfiguredTargetQueryEnvironment
             kct -> getFwdDeps(ImmutableList.of(kct)),
             getMainRepoMapping()),
         new StarlarkOutputFormatterCallback(
-            eventHandler, cqueryOptions, out, skyframeExecutor, accessor),
+            eventHandler, cqueryOptions, out, skyframeExecutor, accessor, starlarkSemantics),
         new FilesOutputFormatterCallback(
             eventHandler, cqueryOptions, out, skyframeExecutor, accessor, topLevelArtifactContext));
   }

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -893,8 +893,17 @@ EOF
     --starlark:expr="str(target.label) + '%foo'" > output \
     2>"$TEST_log" || fail "Expected success"
 
-  assert_contains "//$pkg:pylib%foo" output
-  assert_contains "//$pkg:pylibtwo%foo" output
+  assert_contains "^@//$pkg:pylib%foo$" output
+  assert_contains "^@//$pkg:pylibtwo%foo$" output
+
+  bazel cquery "//$pkg:all" --output=starlark \
+    --noincompatible_unambiguous_label_stringification \
+    --starlark:expr="str(target.label) + '%foo'" > output \
+    2>"$TEST_log" || fail "Expected success"
+
+  # Verify use of the effective rather than default Starlark semantics.
+  assert_contains "^//$pkg:pylib%foo$" output
+  assert_contains "^//$pkg:pylibtwo%foo$" output
 
   # Test that the default for --starlark:expr str(target.label)
   bazel cquery "//$pkg:all" --output=starlark >output \


### PR DESCRIPTION
Previously, `BuildLanguageOption`s had no effect as the default semantics were used.

Work towards #17864