### PR TITLE
build: bump abseil-cpp to 20230802.0

### DIFF
--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -235,16 +235,15 @@ DIST_DEPS = {
         ],
     },
     "com_google_absl": {
-        "archive": "20220623.1.tar.gz",
-        "sha256": "91ac87d30cc6d79f9ab974c51874a704de9c2647c40f6932597329a282217ba8",
+        "archive": "20230802.0",
+        "sha256": "59d2976af9d6ecf001a81a35749a6e551a335b949d34918cfade07737b9d93c5",
         "urls": [
-            "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/refs/tags/20220623.1.tar.gz",
-            "https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.1.tar.gz",
+            "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz",
         ],
         "used_in": [
             "additional_distfiles",
         ],
-        "strip_prefix": "abseil-cpp-20220623.1",
+        "strip_prefix": "abseil-cpp-20230802.0",
         "license_kinds": [
             "@rules_license//licenses/generic:notice",
         ],


### PR DESCRIPTION
refer [bazel-6.2.1 fails to build with gcc-13 · Issue #18642 · bazelbuild/bazel](https://github.com/bazelbuild/bazel/issues/18642)

I use only GitHub because `20230802.0.tar.gz` not found in the mirror. Should be test on abseil-cpp by latest.
Because this version is LTS.

This version build on bazel v6, use `BAZEL_CXXOPTS='-std=c++14' bazel build //src:bazel-dev`. Because bazel v6 use `-std=c++0x` by default.