### PR TITLE
[6.4.0] Ensure lockfile is updated after reset to pre-build state

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionEvent.java
@@ -36,4 +36,9 @@ public abstract class BazelModuleResolutionEvent implements Postable {
 
   public abstract ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage>
       getExtensionUsagesById();
+
+  @Override
+  public boolean storeForReplay() {
+    return true;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionEvent.java
@@ -33,4 +33,9 @@ public abstract class ModuleExtensionResolutionEvent implements Postable {
   public abstract ModuleExtensionId getExtensionId();
 
   public abstract LockFileModuleExtension getModuleExtension();
+
+  @Override
+  public boolean storeForReplay() {
+    return true;
+  }
 }

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -861,5 +861,47 @@ class BazelLockfileTest(test_base.TestBase):
         stderr,
     )
 
+  def testLockfileRecreatedAfterDeletion(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'lockfile_ext = use_extension("extension.bzl", "lockfile_ext")',
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def _repo_rule_impl(ctx):',
+            '    ctx.file("WORKSPACE")',
+            '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
+            '',
+            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            '',
+            'def _module_ext_impl(ctx):',
+            '    repo_rule(name="hello")',
+            '',
+            'lockfile_ext = module_extension(',
+            '    implementation=_module_ext_impl,',
+            ')',
+        ],
+    )
+
+    self.RunBazel(['build', '@hello//:all'])
+
+    # Return the lockfile to the state it had before the
+    # previous build: it didn't exist.
+    with open('MODULE.bazel.lock', 'r') as lock_file:
+      old_data = lock_file.read()
+    os.remove('MODULE.bazel.lock')
+
+    self.RunBazel(['build', '@hello//:all'])
+
+    with open('MODULE.bazel.lock', 'r') as lock_file:
+      new_data = lock_file.read()
+
+    self.assertEqual(old_data, new_data)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
The events that update the lockfile are important for incremental correctness and thus need to return `true` from `storeForReplay`.

Before this change, if a build creates the lockfile because it didn't exist and the lockfile is then deleted, subsequent builds did not regenerate it as the relevant SkyFunctions wouldn't rerun and the events were not replayed.

Closes #19343.

Commit https://github.com/bazelbuild/bazel/commit/19c0c809abbe4bc70d3d6b493ff966dd41c54768

PiperOrigin-RevId: 561287438
Change-Id: I549f99b896a0095e8ffc35b7bacc8a841a44219a