### PR TITLE
Fix precompiled lib symlinks missing in runfiles of cc_shared_library

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
@@ -733,7 +733,10 @@ def _cc_shared_library_impl(ctx):
         # precompiled_dynamic_library.dynamic_library could be None if the library to link just contains
         # an interface library which is valid if the actual library is obtained from the system.
         if precompiled_dynamic_library.dynamic_library != None:
-            precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.dynamic_library)
+            if precompiled_dynamic_library.resolved_symlink_dynamic_library != None:
+                precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.resolved_symlink_dynamic_library)
+            else:
+                precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.dynamic_library)
 
     runfiles = runfiles.merge(ctx.runfiles(files = precompiled_only_dynamic_libraries_runfiles))
 

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/starlark_tests.bzl
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/starlark_tests.bzl
@@ -186,27 +186,51 @@ def _runfiles_test_impl(env, target):
         "libfoo_so.so",
         "libbar_so.so",
         "libdiff_pkg_so.so",
+        "libdirect_so_file.so",
         "libprivate_lib_so.so",
+        "renamed_so_file_copy.so",
         "Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary_Slibfoo_Uso.so",
         "Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary_Slibbar_Uso.so",
         "Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary3_Slibdiff_Upkg_Uso.so",
-        "Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary/renamed_so_file_copy.so",
-        "Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary/libdirect_so_file.so",
     ]
-    for runfile in target[DefaultInfo].default_runfiles.files.to_list():
+    runfiles = [file.path for file in target[DefaultInfo].default_runfiles.files.to_list()]
+    for runfile in runfiles:
         # Ignore Python runfiles
-        if "python" in runfile.path:
+        if "python" in runfile:
             continue
 
         found_basename = False
         for expected_basename in expected_basenames:
-            if runfile.path.endswith(expected_basename):
+            if runfile.endswith(expected_basename):
                 found_basename = True
                 break
 
         env.expect.where(
-            detail = runfile.path + " not found in expected basenames:\n" + "\n".join(expected_basenames),
+            detail = runfile + " not found in expected basenames:\n" + "\n".join(expected_basenames),
         ).that_bool(found_basename).equals(True)
+
+    # Match e.g. bazel-out/k8-fastbuild/bin/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/libdirect_so_file.so
+    path_suffix = "/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library"
+    expected_files = [
+        "libbar_so.so",
+        "libdirect_so_file.so",
+        "libfoo_so.so",
+        "libprivate_lib_so.so",
+        "python_test",
+        "renamed_so_file_copy.so",
+    ]
+    for file in expected_files:
+        path = path_suffix + "/" + file
+
+        found = False
+        for runfile in runfiles:
+            if runfile.endswith(path):
+                found = True
+                break
+
+        env.expect.where(
+            detail = file + " not found in runfiles:\n" + "\n".join(runfiles),
+        ).that_bool(found).equals(True)
 
 def _runfiles_test_macro(name, target):
     analysis_test(


### PR DESCRIPTION
26d882f92943587d39460320694b17865ea74f91 was intended to remove unnecessary files from runfiles However it also removes (some?) required symlinks from runfiles. E.g. libtensorflow_cc.so.2.13.0 is present in the runfiles but `libtensorflow_cc.so.2` is not leading to failures as programs are linked to the latter. See https://github.com/tensorflow/tensorflow/issues/60326

Use the same logic used in other places preferring `resolved_symlink_dynamic_library` over `dynamic_library`.