### PR TITLE
Also apply `NestedSet` optimizations to `Depset`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/Depset.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/Depset.java
@@ -377,7 +377,16 @@ public final class Depset implements StarlarkValue, Debug.ValueWithDebugAttribut
     if (builder.isEmpty()) {
       return builder.getOrder().emptyDepset();
     }
-    return new Depset(type, builder.build());
+    NestedSet<Object> set = builder.build();
+    // If the nested set was optimized to one of the transitive elements, reuse the corresponding
+    // depset.
+    for (Depset x : transitive) {
+      if (x.getSet() == set) {
+        return x;
+      }
+    }
+
+    return new Depset(type, set);
   }
 
   /** An exception thrown when validation fails on the type of elements of a nested set. */

--- a/src/test/java/com/google/devtools/build/lib/collect/nestedset/DepsetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/collect/nestedset/DepsetTest.java
@@ -419,4 +419,20 @@ public final class DepsetTest {
     assertThat(ev.lookup("stable1")).isNotSameInstanceAs(ev.lookup("preorder1"));
     assertThat(ev.lookup("stable2")).isNotSameInstanceAs(ev.lookup("preorder2"));
   }
+
+  @Test
+  public void testSingleNonEmptyTransitiveAndNoDirectsUnwrapped() throws Exception {
+    ev.exec(
+        "inner = depset([1, 2, 3])",
+        "outer = depset(transitive = [depset(), inner, depset()])");
+    assertThat(ev.lookup("outer")).isSameInstanceAs(ev.lookup("inner"));
+  }
+
+  @Test
+  public void testSingleNonEmptyTransitiveAndMatchingDirectUnwrapped() throws Exception {
+    ev.exec(
+        "inner = depset([1])",
+        "outer = depset([1], transitive = [depset(), inner, depset()])");
+    assertThat(ev.lookup("outer")).isSameInstanceAs(ev.lookup("inner"));
+  }
 }


### PR DESCRIPTION
If the construction of a `NestedSet` involves only a single non-empty transitive set, this set may be returned directly as an optimization. This commit checks for this case when constructing a `Depset` and reuses the corresponding `Depset` if possible.

Since `Depset`s that are direct elements of providers are usually unwrapped into their `NestedSet`, this optimization only applies to instances stored in `struct`s as well as reduces allocations.

Realizes an optimization proposed by @brentleyjones in https://bazelbuild.slack.com/archives/CA31HN1T3/p1693487067454409?thread_ts=1693484609.534579&cid=CA31HN1T3.