### PR TITLE
Ensure DirectoryContext.createOrSetWritable() always creates directories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -54,6 +54,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -144,9 +145,13 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                         // Otherwise, it must belong to a tree artifact, since the directory for a
                         // tree is created in a non-writable state before prefetching begins, and
                         // this is the first time the prefetcher is seeing it.
-                        state.mustSetOutputPermissions = !dir.isWritable();
-                        if (state.mustSetOutputPermissions) {
-                          dir.setWritable(true);
+                        try {
+                          state.mustSetOutputPermissions = !dir.isWritable();
+                          if (state.mustSetOutputPermissions) {
+                            dir.setWritable(true);
+                          }
+                        } catch (FileNotFoundException e) {
+                          dir.createDirectoryAndParents();
                         }
                       }
                     } catch (IOException e) {


### PR DESCRIPTION
In case DirectoryContext.createOrSetWritable() is called on a directory inside of a Tree, it already does a nice forward sweep along the path to create missing intermediate directories. When creating a bare output file in a nested directory, it does not. It implicitly assumes that the output directory was already created at a previous point in time.

This doesn't cause issues whenever we do a fully clean build, as some earlier phase (the analysis phase?) creates the missing parent directories for us. However, if we remove the nested directory structure from bazel-bin/ manually and rerun the test, this causes failures along the lines:

    java.io.FileNotFoundException: /REDACTED/execroot/main/bazel-out/darwin_x86_64-fastbuild/bin/some/very/very/very/deeply/nested (No such file or directory)

Solve this issue by properly catching FileNotFoundExceptions that are generated when we call Path.isWritable() on the parent directory of the output file. In that case we resort to calling
Path.createDirectoryAndParents().

I think this is likely the most efficient strategy, as it means we don't need to do a full forward scan of the path in the common case where the parent directory does exist.

This issue can be noticed in practice when switching from --remote_output_service (PR #12823) to --remote_download_minimal.