### PR TITLE
Add blake3 NEON instructions on linux arm64

### DIFF
--- a/third_party/blake3/blake3.BUILD
+++ b/third_party/blake3/blake3.BUILD
@@ -57,6 +57,9 @@ cc_library(
             # lacking the headers to compile AVX512.
 	    "-DBLAKE3_NO_AVX512",
 	],
+	"@bazel_tools//src/conditions:linux_arm64": [
+            "-DBLAKE3_USE_NEON=0",
+        ],
         "@bazel_tools//src/conditions:windows_x64": [],
         "@bazel_tools//src/conditions:windows_arm64": [
             "-DBLAKE3_USE_NEON=0",

--- a/third_party/blake3/blake3.BUILD
+++ b/third_party/blake3/blake3.BUILD
@@ -57,7 +57,7 @@ cc_library(
             # lacking the headers to compile AVX512.
 	    "-DBLAKE3_NO_AVX512",
 	],
-	"@bazel_tools//src/conditions:linux_arm64": [
+	"@bazel_tools//src/conditions:linux_aarch64": [
             "-DBLAKE3_USE_NEON=0",
         ],
         "@bazel_tools//src/conditions:windows_x64": [],

--- a/third_party/blake3/blake3.BUILD
+++ b/third_party/blake3/blake3.BUILD
@@ -45,6 +45,9 @@ cc_library(
             "c/blake3_sse2_x86-64_windows_msvc.asm",
             "c/blake3_sse41_x86-64_windows_msvc.asm",
         ],
+        "@bazel_tools//src/conditions:windows_arm64": [
+            "c/blake3_neon.c",
+        ],
         "@bazel_tools//src/conditions:darwin_arm64": [
             "c/blake3_neon.c",
         ],
@@ -65,7 +68,7 @@ cc_library(
         ],
         "@bazel_tools//src/conditions:windows_x64": [],
         "@bazel_tools//src/conditions:windows_arm64": [
-            "-DBLAKE3_USE_NEON=0",
+            "-DBLAKE3_USE_NEON=1",
         ],
         "@bazel_tools//src/conditions:darwin_arm64": [
             "-DBLAKE3_USE_NEON=1",

--- a/third_party/blake3/blake3.BUILD
+++ b/third_party/blake3/blake3.BUILD
@@ -36,6 +36,9 @@ cc_library(
             "c/blake3_sse2_x86-64_unix.S",
             "c/blake3_sse41_x86-64_unix.S",
         ],
+        "@bazel_tools//src/conditions:linux_aarch64": [
+            "c/blake3_neon.c",
+        ],
         "@bazel_tools//src/conditions:windows_x64": [
             "c/blake3_avx2_x86-64_windows_msvc.asm",
             "c/blake3_avx512_x86-64_windows_msvc.asm",
@@ -57,8 +60,8 @@ cc_library(
             # lacking the headers to compile AVX512.
 	    "-DBLAKE3_NO_AVX512",
 	],
-	"@bazel_tools//src/conditions:linux_aarch64": [
-            "-DBLAKE3_USE_NEON=0",
+        "@bazel_tools//src/conditions:linux_aarch64": [
+            "-DBLAKE3_USE_NEON=1",
         ],
         "@bazel_tools//src/conditions:windows_x64": [],
         "@bazel_tools//src/conditions:windows_arm64": [


### PR DESCRIPTION
otherwise getting libunix_jni.so: undefined symbol: blake3_hash_many_neon

see https://github.com/bazelbuild/bazel/commit/d0de5e044c65fe7c5e414f860887be20087732da