### PR TITLE
[6.4.0] Add --incompatible_disable_objc_library_transition

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -662,6 +662,17 @@ public final class BuildLanguageOptions extends OptionsBase {
       help = "If enabled, targets that have unknown attributes set to None fail.")
   public boolean incompatibleFailOnUnknownAttributes;
 
+  @Option(
+      name = "incompatible_disable_objc_library_transition",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "Disable objc_library's custom transition and inherit "
+              + "from the top level target instead")
+  public boolean incompatibleDisableObjcLibraryTransition;
+
   /**
    * An interner to reduce the number of StarlarkSemantics instances. A single Blaze instance should
    * never accumulate a large number of these and being able to shortcut on object identity makes a
@@ -754,6 +765,9 @@ public final class BuildLanguageOptions extends OptionsBase {
                 EXPERIMENTAL_GET_FIXED_CONFIGURED_ACTION_ENV,
                 experimentalGetFixedConfiguredEnvironment)
             .setBool(INCOMPATIBLE_FAIL_ON_UNKNOWN_ATTRIBUTES, incompatibleFailOnUnknownAttributes)
+            .setBool(
+                INCOMPATIBLE_DISABLE_OBJC_LIBRARY_TRANSITION,
+                incompatibleDisableObjcLibraryTransition)
             .build();
     return INTERNER.intern(semantics);
   }
@@ -844,6 +858,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       "-experimental_get_fixed_configured_action_env";
   public static final String INCOMPATIBLE_FAIL_ON_UNKNOWN_ATTRIBUTES =
       "-incompatible_fail_on_unknown_attributes";
+  public static final String INCOMPATIBLE_DISABLE_OBJC_LIBRARY_TRANSITION =
+      "-incompatible_disable_objc_library_transition";
 
   // non-booleans
   public static final StarlarkSemantics.Key<String> EXPERIMENTAL_BUILTINS_BZL_PATH =

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1114,6 +1114,14 @@ public abstract class CcModule
   }
 
   @Override
+  public boolean getIncompatibleDisableObjcLibraryTransition(StarlarkThread thread)
+      throws EvalException {
+    return thread
+        .getSemantics()
+        .getBool(BuildLanguageOptions.INCOMPATIBLE_DISABLE_OBJC_LIBRARY_TRANSITION);
+  }
+
+  @Override
   public CcLinkingContext createCcLinkingInfo(
       Object linkerInputs,
       Object librariesToLinkObject,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
@@ -778,6 +778,12 @@ public interface CcModuleApi<
       throws EvalException;
 
   @StarlarkMethod(
+      name = "incompatible_disable_objc_library_transition",
+      useStarlarkThread = true,
+      documented = false)
+  boolean getIncompatibleDisableObjcLibraryTransition(StarlarkThread thread) throws EvalException;
+
+  @StarlarkMethod(
       name = "create_linking_context",
       doc = "Creates a <code>LinkingContext</code>.",
       useStarlarkThread = true,

--- a/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
@@ -144,6 +144,9 @@ def _check_experimental_cc_shared_library(ctx):
     if not cc_common.check_experimental_cc_shared_library():
         fail("Pass --experimental_cc_shared_library to use cc_shared_library")
 
+def _incompatible_disable_objc_library_transition():
+    return cc_common.incompatible_disable_objc_library_transition()
+
 def _get_linkstatic_default(ctx):
     if ctx.attr._is_test:
         # By default Tests do not link statically. Except on Windows.
@@ -194,4 +197,5 @@ semantics = struct(
     get_coverage_attrs = _get_coverage_attrs,
     get_coverage_env = _get_coverage_env,
     get_proto_aspects = _get_proto_aspects,
+    incompatible_disable_objc_library_transition = _incompatible_disable_objc_library_transition,
 )

--- a/src/main/starlark/builtins_bzl/common/objc/objc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/objc_library.bzl
@@ -18,6 +18,7 @@ load("@_builtins//:common/objc/compilation_support.bzl", "compilation_support")
 load("@_builtins//:common/objc/attrs.bzl", "common_attrs")
 load("@_builtins//:common/objc/transitions.bzl", "apple_crosstool_transition")
 load("@_builtins//:common/cc/cc_helper.bzl", "cc_helper")
+load("@_builtins//:common/cc/semantics.bzl", "semantics")
 
 objc_internal = _builtins.internal.objc_internal
 CcInfo = _builtins.toplevel.CcInfo
@@ -102,7 +103,7 @@ objc_library = rule(
         common_attrs.XCRUN_RULE,
     ),
     fragments = ["objc", "apple", "cpp"],
-    cfg = apple_crosstool_transition,
+    cfg = None if semantics.incompatible_disable_objc_library_transition() else apple_crosstool_transition,
     toolchains = cc_helper.use_cpp_toolchain(),
     incompatible_use_toolchain_transition = True,
 )

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -110,6 +110,30 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   }
 
   @Test
+  public void testNoTransition() throws Exception {
+    scratch.file(
+        "bin/BUILD",
+        "objc_library(",
+        "    name = 'objc',",
+        "    srcs = ['objc.m'],",
+        ")",
+        "cc_binary(",
+        "    name = 'cc',",
+        "    srcs = ['cc.cc'],",
+        "    deps = [':objc'],",
+        ")");
+
+    setBuildLanguageOptions("--incompatible_disable_objc_library_transition");
+    useConfiguration("--macos_cpus=arm64,x86_64");
+
+    ConfiguredTarget cc = getConfiguredTarget("//bin:cc");
+    Artifact objcObject =
+        ActionsTestUtil.getFirstArtifactEndingWith(
+            actionsTestUtil().artifactClosureOf(getFilesToBuild(cc)), "objc.o");
+    assertThat(objcObject.getExecPathString()).contains("k8-fastbuild");
+  }
+
+  @Test
   public void testFilesToBuild() throws Exception {
     ConfiguredTarget target =
         createLibraryTargetWriter("//objc:One")


### PR DESCRIPTION
This is a migration for https://github.com/bazelbuild/bazel/issues/16870

Users who rely on the current behavior should instead wrap their library in a target from [rules_apple](https://github.com/bazelbuild/rules_apple).

Closes https://github.com/bazelbuild/bazel/issues/19383.

PiperOrigin-RevId: 561253613
Change-Id: I1b1b24a08caa33e86881bfe376a525060c9887a9 (cherry picked from commit 0f34e76f45a2d9a6407431ea3a371a9d62814527)