### PR TITLE
sandbox: directory inputs are crated not symlinked

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -88,7 +88,11 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
 
   @Override
   protected void copyFile(Path source, Path target) throws IOException {
-    target.createSymbolicLink(source);
+    if (source.isDirectory()) {
+      target.createDirectory();
+    } else {
+      target.createSymbolicLink(source);
+    }
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
@@ -73,10 +73,11 @@ public class AbstractContainerizingSandboxedSpawnTest {
     Path execRoot = testRoot.getRelative("execroot");
     execRoot.createDirectory();
 
-    Path outputFile = execRoot.getRelative("very/output.txt");
-    Path outputLink = execRoot.getRelative("very/output.link");
-    Path outputDangling = execRoot.getRelative("very/output.dangling");
-    Path outputDir = execRoot.getRelative("very/output.dir");
+    Path veryDir = execRoot.getRelative("very");
+    Path outputFile = veryDir.getRelative("very/output.txt");
+    Path outputLink = veryDir.getRelative("output.link");
+    Path outputDangling = veryDir.getRelative("very/output.dangling");
+    Path outputDir = veryDir.getRelative("output.dir");
     Path outputInUncreatedTargetDir = execRoot.getRelative("uncreated/output.txt");
 
     ImmutableSet<PathFragment> outputs =


### PR DESCRIPTION
This allows for a pattern like:

```starlark
genrule(
    name = "compile_external",
    srcs = [
        "//some/dir/with:headers",
        "//some/dir/with:header_files",
    ],
    cmd = "some_compiler -I$(execpath //some/dir/with:headers)",
)
```

with `//some/dir/with:BUILD.bazel` looking like:
```starlark
filegroup(
    name = "header_files",
    srcs = ["headers/foo.h", "headers/bar.h"],
)

exports_files(["headers"])
```

Without this patch, this construct fails when using a symlinking sandbox because the sandbox tries to create symlinks for both `headers` and `headers/foo.h`, and gets an IOException because these can't both be created.