### PR TITLE
fix bug of zip file larger than 2G with zipper tool

### DIFF
--- a/third_party/ijar/platform_utils.h
+++ b/third_party/ijar/platform_utils.h
@@ -28,7 +28,7 @@ namespace devtools_ijar {
 // Platform-independent stat data.
 struct Stat {
   // Total size of the file in bytes.
-  int total_size;
+  u8 total_size;
   // The Unix file mode from the stat.st_mode field.
   mode_t file_mode;
   // True if this is a directory.

--- a/third_party/ijar/test/zip_test.sh
+++ b/third_party/ijar/test/zip_test.sh
@@ -233,4 +233,9 @@ function test_unzipper_zip64_archive() {
   diff -r unzipped source
 }
 
+function test_zipper_file_large_than_2G() {
+  dd if=/dev/zero of=${TEST_TMPDIR}/file_2064M.bin bs=16M count=129
+  $ZIPPER c ${TEST_TMPDIR}/output.zip ${TEST_TMPDIR}/file_2064M.bin
+}
+
 run_suite "zipper tests"


### PR DESCRIPTION
Replace file size data type (`int` to `u8`) to support file larger than 2G.

See #19407 