### PR TITLE
[6.4.0] Ignore Starlark options on commands with `allowResidue = False`

### DIFF
--- a/src/main/java/com/google/devtools/common/options/OptionsParser.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParser.java
@@ -758,10 +758,8 @@ public class OptionsParser implements OptionsParsingResult {
   private void addResidueFromResult(OptionsParserImplResult result) throws OptionsParsingException {
     residue.addAll(result.getResidue());
     postDoubleDashResidue.addAll(result.postDoubleDashResidue);
-    if (!allowResidue && (!getSkippedArgs().isEmpty() || !residue.isEmpty())) {
-      String errorMsg =
-          "Unrecognized arguments: "
-              + Joiner.on(' ').join(Iterables.concat(getSkippedArgs(), residue));
+    if (!allowResidue && !residue.isEmpty()) {
+      String errorMsg = "Unrecognized arguments: " + Joiner.on(' ').join(residue);
       throw new OptionsParsingException(errorMsg);
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -438,24 +438,6 @@ public class BlazeOptionHandlerTest {
   }
 
   @Test
-  public void testParseOptions_disallowResidue_skippedArgsLeadToFailure() throws Exception {
-    ImmutableList<Class<? extends OptionsBase>> optionsClasses =
-        ImmutableList.of(TestOptions.class, CommonCommandOptions.class, ClientOptions.class);
-
-    BlazeOptionHandlerTestHelper helper =
-        new BlazeOptionHandlerTestHelper(
-            optionsClasses,
-            /* allowResidue= */ false,
-            /* aliasFlag= */ null,
-            /* skipStarlarkPrefixes= */ true);
-    OptionsParser parser = helper.getOptionsParser();
-
-    OptionsParsingException e =
-        assertThrows(OptionsParsingException.class, () -> parser.parse("--//f=1"));
-    assertThat(e).hasMessageThat().isEqualTo("Unrecognized arguments: --//f=1");
-  }
-
-  @Test
   public void testParseOptions_explicitOption() {
     optionHandler.parseOptions(
         ImmutableList.of("c0", "--test_multiple_string=explicit"), eventHandler);

--- a/src/test/py/bazel/options_test.py
+++ b/src/test/py/bazel/options_test.py
@@ -269,6 +269,20 @@ class OptionsTest(test_base.TestBase):
         stderr,
     )
 
+  def testCommonPseudoCommand_allowResidueFalseCommandIgnoresStarlarkOptions(
+      self,
+  ):
+    self.ScratchFile("WORKSPACE.bazel")
+    self.ScratchFile(
+        ".bazelrc",
+        [
+            "common --@foo//bar:flag",
+        ],
+    )
+
+    # Check that version doesn't fail.
+    self.RunBazel(["version"])
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Ensures that `bazel version` does not fail when a `common` line in `.bazelrc` contains a Starlark option (similar for `sync` and `shutdown`). There is very little chance for users being confused about these commands accepting and silently ignoring Starlark flags.

Fixes https://github.com/bazelbuild/bazel/pull/18130#issuecomment-1697620075

Closes #19363.

Commit https://github.com/bazelbuild/bazel/commit/954b4d9b1e7fd9b0a09cd9eed2a057e43ce3f8eb

PiperOrigin-RevId: 562959337
Change-Id: Ifb4f44d63f1801f6c5a8c2f421138b4014c49a06