### PR TITLE
Update zlib build file

### DIFF
--- a/third_party/zlib/BUILD
+++ b/third_party/zlib/BUILD
@@ -68,11 +68,14 @@ distrib_cc_library(
         "zlib.h",
         "zutil.h",
     ],
-    # Use -Dverbose=-1 to turn off zlib's trace logging. (#3280)
-    copts = [
-        "-w",
-        "-Dverbose=-1",
-    ],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-Wno-deprecated-non-prototype",
+            "-Wno-unused-variable",
+            "-Wno-implicit-function-declaration",
+        ],
+    }),
     enable_distributions = ["debian"],
     includes = ["."],
     visibility = ["//visibility:public"],

--- a/third_party/zlib/BUILD.tools
+++ b/third_party/zlib/BUILD.tools
@@ -12,18 +12,21 @@ license(
         "@rules_license//licenses/spdx:0BSD",
     ],
     license_text = "LICENSE",
-    package_version = "1.2.12",
+    package_version = "1.3",
 )
 
 cc_library(
     name = "zlib",
     srcs = glob(["*.c"]),
     hdrs = glob(["*.h"]),
-    # Use -Dverbose=-1 to turn off zlib's trace logging. (#3280)
-    copts = [
-        "-w",
-        "-Dverbose=-1",
-    ],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-Wno-deprecated-non-prototype",
+            "-Wno-unused-variable",
+            "-Wno-implicit-function-declaration",
+        ],
+    }),
     includes = ["."],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fix https://github.com/bazelbuild/bazel/issues/17956 again after https://github.com/bazelbuild/bazel/pull/19352

Eventually we should remove zlib from third_party and use the BCR module.