### PR TITLE
[6.4.0] Expose PackageSpecificationInfo provider as a top level symbol

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/PackageSpecificationProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PackageSpecificationProvider.java
@@ -24,13 +24,15 @@ import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.packages.PackageGroup;
 import com.google.devtools.build.lib.packages.PackageSpecification.PackageGroupContents;
 import com.google.devtools.build.lib.packages.Provider;
+import com.google.devtools.build.lib.starlarkbuildapi.PackageSpecificationProviderApi;
 import java.util.Optional;
 
 /**
  * A {@link TransitiveInfoProvider} that describes a set of transitive package specifications used
  * in package groups.
  */
-public class PackageSpecificationProvider extends NativeInfo implements TransitiveInfoProvider {
+public class PackageSpecificationProvider extends NativeInfo
+    implements TransitiveInfoProvider, PackageSpecificationProviderApi {
 
   private static final String STARLARK_NAME = "PackageSpecificationInfo";
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider.RuleSet;
+import com.google.devtools.build.lib.analysis.PackageSpecificationProvider;
 import com.google.devtools.build.lib.analysis.PlatformConfiguration;
 import com.google.devtools.build.lib.analysis.ShellConfiguration;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
@@ -509,6 +510,14 @@ public class BazelRuleClassProvider {
         }
       };
 
+  static final RuleSet PACKAGING_RULES =
+      new RuleSet() {
+        @Override
+        public void init(ConfiguredRuleClassProvider.Builder builder) {
+          builder.addStarlarkAccessibleTopLevels("PackageSpecificationInfo", PackageSpecificationProvider.PROVIDER);
+        }
+      };
+
   private static final ImmutableSet<RuleSet> RULE_SETS =
       ImmutableSet.of(
           BAZEL_SETUP,
@@ -529,6 +538,7 @@ public class BazelRuleClassProvider {
           J2ObjcRules.INSTANCE,
           TestingSupportRules.INSTANCE,
           VARIOUS_WORKSPACE_RULES,
+          PACKAGING_RULES,
           // This rule set is a little special: it needs to depend on every configuration fragment
           // that has Make variables, so we put it last.
           ToolchainRules.INSTANCE);

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.bazel.rules;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider.RuleSet;
-import com.google.devtools.build.lib.analysis.PackageSpecificationProvider;
 import com.google.devtools.build.lib.analysis.StaticallyLinkedMarkerProvider;
 import com.google.devtools.build.lib.bazel.rules.cpp.BazelCcBinaryRule;
 import com.google.devtools.build.lib.bazel.rules.cpp.BazelCcImportRule;
@@ -94,8 +93,6 @@ public class CcRules implements RuleSet {
     builder.addStarlarkBuiltinsInternal(
         "StaticallyLinkedMarkerProvider", StaticallyLinkedMarkerProvider.PROVIDER);
     builder.addStarlarkBuiltinsInternal("CcNativeLibraryInfo", CcNativeLibraryInfo.PROVIDER);
-    builder.addStarlarkBuiltinsInternal(
-        "PackageSpecificationInfo", PackageSpecificationProvider.PROVIDER);
     builder.addStarlarkBootstrap(
         new CcBootstrap(
             new BazelCcModule(),

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/PackageSpecificationProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/PackageSpecificationProviderApi.java
@@ -1,0 +1,25 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.starlarkbuildapi;
+
+import com.google.devtools.build.docgen.annot.DocCategory;
+import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
+import net.starlark.java.annot.StarlarkBuiltin;
+
+/** Provider which describes a set of transitive package specifications used in package groups. */
+@StarlarkBuiltin(
+    name = "PackageSpecificationInfo",
+    doc = "Information about transitive package specifications used in package groups.",
+    category = DocCategory.PROVIDER)
+public interface PackageSpecificationProviderApi extends StructApi {}


### PR DESCRIPTION
This is one more step towards implementing a public Starlark API for checking if a target exists in an allowlist.

Cherry picking d1d35b2. 