### PR TITLE
Do not force linking of default link libs in Unix toolchain

### DIFF
--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/cc_shared_library_integration_test.sh
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/cc_shared_library_integration_test.sh
@@ -76,10 +76,10 @@ function test_cc_test() {
 
 function test_number_of_linked_libs() {
   binary=$(find . -name binary)
-  expected_num_libs="6"
+  expected_num_libs="5"
   num_libs=$(readelf -d  $binary | grep NEEDED | wc -l)
   echo "$num_libs" | (grep -q  "$expected_num_libs" \
-    || (echo "Expected no more than "$expected_num_libs" linked libraries but was $num_libs" && exit 1))
+    || (echo "Expected $expected_num_libs linked libraries but was $num_libs" && exit 1))
 }
 
 test_shared_library_user_link_flags


### PR DESCRIPTION
`libstdc++` (`libc++` on macOS) and `libm` are no longer linked in if none of their symbols are referenced, e.g., in a pure C target.

Fixes #6221