### PR TITLE
[6.4.0] Remove PackageGroupConfiguredTarget.isAvailableFor function

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/PackageGroupConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/PackageGroupConfiguredTarget.java
@@ -14,15 +14,11 @@
 
 package com.google.devtools.build.lib.analysis.configuredtargets;
 
-import static net.starlark.java.eval.Module.ofInnermostEnclosingStarlarkFunction;
-
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.analysis.Allowlist;
 import com.google.devtools.build.lib.analysis.FileProvider;
 import com.google.devtools.build.lib.analysis.PackageSpecificationProvider;
 import com.google.devtools.build.lib.analysis.TargetContext;
 import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
-import com.google.devtools.build.lib.cmdline.BazelModuleContext;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -32,12 +28,6 @@ import com.google.devtools.build.lib.packages.PackageGroup;
 import com.google.devtools.build.lib.packages.PackageSpecification.PackageGroupContents;
 import com.google.devtools.build.lib.packages.Provider;
 import javax.annotation.Nullable;
-import net.starlark.java.annot.Param;
-import net.starlark.java.annot.ParamType;
-import net.starlark.java.annot.StarlarkMethod;
-import net.starlark.java.eval.EvalException;
-import net.starlark.java.eval.Starlark;
-import net.starlark.java.eval.StarlarkThread;
 
 /**
  * Dummy ConfiguredTarget for package groups. Contains no functionality, since package groups are
@@ -85,25 +75,5 @@ public class PackageGroupConfiguredTarget extends AbstractConfiguredTarget {
   @Override
   protected Object rawGetStarlarkProvider(String providerKey) {
     return null;
-  }
-
-  @StarlarkMethod(
-      name = "isAvailableFor",
-      documented = false,
-      parameters = {
-        @Param(
-            name = "label",
-            allowedTypes = {@ParamType(type = Label.class)})
-      },
-      useStarlarkThread = true)
-  public boolean starlarkMatches(Label label, StarlarkThread starlarkThread) throws EvalException {
-    RepositoryName repository =
-        BazelModuleContext.of(ofInnermostEnclosingStarlarkFunction(starlarkThread))
-            .label()
-            .getRepository();
-    if (!"@_builtins".equals(repository.getNameWithAt())) {
-      throw Starlark.errorf("private API only for use by builtins");
-    }
-    return Allowlist.isAvailableFor(packageSpecificationProvider.getPackageSpecifications(), label);
   }
 }


### PR DESCRIPTION
Support for checking if a target exists inside an allowlist was added inside PackageSpecificationProvider as a `contains` function (c4d5fdb). `PackageGroupConfiguredTarget.isAvailableFor` can be removed.

Cherrypicking beb6ea8.
