### PR TITLE
Fix type checking for colliding aspect-on-aspect attributes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolutionHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolutionHelpers.java
@@ -475,7 +475,10 @@ public final class DependencyResolutionHelpers {
       Iterable<Aspect> aspects,
       Set<String> aspectProcessedAttributes,
       ImmutableList.Builder<AttributeDependencyKind> attributes) {
-    for (Aspect aspect : aspects) {
+    // In case of multiple aspects applying on top of each other, the ones later in the list (i.e.
+    // closer to the outermost, main aspect) take precedence. In particular, the main aspect always
+    // sees its own attributes.
+    for (Aspect aspect : ImmutableList.copyOf(aspects).reverse()) {
       for (Attribute attribute : aspect.getDefinition().getAttributes().values()) {
         if (aspectProcessedAttributes.add(attribute.getName())) {
           attributes.add(AttributeDependencyKind.forAspect(attribute, aspect.getAspectClass()));

--- a/src/test/java/com/google/devtools/build/lib/analysis/AspectTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/AspectTest.java
@@ -1031,7 +1031,7 @@ public class AspectTest extends AnalysisTestCase {
   }
 
   @Test
-  public void aspectWithExtraAttributeDependsOnNotApplicable_usesAttributeFromDependentAspect()
+  public void aspectWithExtraAttributeDependsOnNotApplicable_usesOwnAttribute()
       throws Exception {
     ExtraAttributeAspect aspectApplies =
         new ExtraAttributeAspect(
@@ -1055,7 +1055,7 @@ public class AspectTest extends AnalysisTestCase {
     ExtraAttributeAspect.Provider provider =
         getAspectByName(analysisResult.getAspectsMap(), aspectApplies.getName())
             .getProvider(ExtraAttributeAspect.Provider.class);
-    assertThat(provider.label()).isEqualTo("//extra:extra2");
+    assertThat(provider.label()).isEqualTo("//extra:extra");
     assertThat(
             getAspectByName(analysisResult.getAspectsMap(), aspectDoesNotApply.getName())
                 .getProviders()


### PR DESCRIPTION
Previously, Starlark-defined aspects-on-aspects saw their own attribute values but the type declared by the underlying aspect in case of an attribute name collision.

As a side effect of this change, native aspects-on-aspects now see their own attribute values instead of those of the underlying aspect.