### PR TITLE
[6.4.0] Remove default -s flag from macOS libtool invocation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -631,7 +631,7 @@ public class CppActionConfigs {
                         "    action: 'c++-link-static-library'",
                         "    flag_group {",
                         ifLinux(platform, "flag: 'rcsD'"),
-                        ifMac(platform, "flag: '-static'", "flag: '-s'"),
+                        ifMac(platform, "flag: '-static'"),
                         "    }",
                         "    flag_group {",
                         "      expand_if_all_available: 'output_execpath'",


### PR DESCRIPTION
-s is the default but it's not supported by llvm's libtool replacement which results in failed links. I don't think we really care about the specifics here, so since it's the default for most folks we can drop it.

Closes #17489.

Commit https://github.com/bazelbuild/bazel/commit/ae7cfa59461b2c694226be689662d387e9c38427

PiperOrigin-RevId: 511121405
Change-Id: Id0b52f960072100d232fdbf5461dec068c8e3edf