### PR TITLE
mkdir before calling unzip

### DIFF
--- a/src/package-bazel.sh
+++ b/src/package-bazel.sh
@@ -47,6 +47,7 @@ cp $* ${PACKAGE_DIR}
 if [[ $DEV_BUILD -eq 0 ]]; then
   # Unpack the deploy jar for postprocessing and for "re-compressing" to save
   # ~10% of final binary size.
+  mkdir -p $RECOMP
   unzip -q -d $RECOMP ${DEPLOY_JAR}
   cd $RECOMP
 


### PR DESCRIPTION
Busybox's unzip implementation doesn't create directories passed with `-d`, and instead assumes they exist and errors if they don't.