### PR TITLE
[6.4.0] Turn off lockfile feature by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -278,7 +278,7 @@ public class RepositoryOptions extends OptionsBase {
   @Option(
       name = "lockfile_mode",
       converter = LockfileMode.Converter.class,
-      defaultValue = "update",
+      defaultValue = "off",
       documentationCategory = OptionDocumentationCategory.BZLMOD,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       help =


### PR DESCRIPTION
Turn on the lockfile feature by default in bazel 7. But until then, we are turning it off.