### PR TITLE
Optimize classpath pre-processing in java_stub_template.txt

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -309,18 +309,20 @@ function create_and_run_classpath_jar() {
   for path in ${CLASSPATH}; do
     # Loop through the characters of the path and convert characters that are
     # not alphanumeric nor -_.~/ to their 2-digit hexadecimal representation
-    local i c buff
-    local converted_path=""
+    if [[ ! $path =~ ^[-_.~/a-zA-Z0-9]*$ ]]; then
+      local i c buff
+      local converted_path=""
 
-    for ((i=0; i<${#path}; i++)); do
-      c=${path:$i:1}
-      case ${c} in
-            [-_.~/a-zA-Z0-9] ) buff=${c} ;;
-            * )               printf -v buff '%%%02x' "'$c'"
-      esac
-      converted_path+="${buff}"
-    done
-    path=${converted_path}
+      for ((i=0; i<${#path}; i++)); do
+        c=${path:$i:1}
+        case ${c} in
+              [-_.~/a-zA-Z0-9] ) buff=${c} ;;
+              * )               printf -v buff '%%%02x' "'$c'"
+        esac
+        converted_path+="${buff}"
+      done
+      path=${converted_path}
+    fi
 
     if is_windows; then
       path="file:/${path}" # e.g. "file:/C:/temp/foo.jar"

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -306,6 +306,7 @@ function create_and_run_classpath_jar() {
 
   OLDIFS="$IFS"
   IFS="${CLASSPATH_SEPARATOR}" # Use a custom separator for the loop.
+  current_dir=$(pwd)
   for path in ${CLASSPATH}; do
     # Loop through the characters of the path and convert characters that are
     # not alphanumeric nor -_.~/ to their 2-digit hexadecimal representation
@@ -330,7 +331,7 @@ function create_and_run_classpath_jar() {
       # If not absolute, qualify the path
       case "${path}" in
         /*) ;; # Already an absolute path
-        *) path="$(pwd)/${path}";; # Now qualified
+        *) path="${current_dir}/${path}";; # Now qualified
       esac
       path="file:${path}" # e.g. "file:/usr/local/foo.jar"
     fi


### PR DESCRIPTION
The classpath pre-processing in this `java_stub_template.txt` loop: https://github.com/bazelbuild/bazel/blob/fcfcb929366dd3faac9643302b19c88bcf871ec6/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt#L309 is slow for long classpaths. For example for classpaths with ~250,000 and ~700,000 entries the loop takes 28 and 50 seconds, respectively, on an intel MacBook. This change reduce the times to 1 second or less.

Fixes #19480