### PR TITLE
[6.4.0] Improve error when a label is provided in `config_setting`'s `values`

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -2317,4 +2317,20 @@ public class ConfigSettingTest extends BuildViewTestCase {
     assertThat(getConfiguredTarget("//test:fg")).isNotNull();
     assertNoEvents();
   }
+
+  @Test
+  public void labelInValuesError() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        "config_setting(",
+        "    name = 'match',",
+        "    values = {'//foo:bar': 'value'},",
+        ")");
+    reporter.removeHandler(failFastHandler); // expect errors
+    assertThat(getConfiguredTarget("//test:match")).isNull();
+    assertContainsEvent(
+        "in values attribute of config_setting rule //test:match: '//foo:bar' is"
+            + " not a valid setting name, but appears to be a label. Did you mean to place it in"
+            + " flag_values instead?");
+  }
 }


### PR DESCRIPTION
Suggest to use `flag_values` instead. Previously, this only resulted in an ambiguous "Unrecognized option" error.

Closes #19464.

Commit https://github.com/bazelbuild/bazel/commit/bd5dbc5a4fb890758115cce60a8ef8e5b09c6cf1

PiperOrigin-RevId: 564367170
Change-Id: Ibe9397be4300783ab6e5b5de9e08e40142de0b4c