### PR TITLE
Remove visionOS support from cc_test

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl
@@ -102,7 +102,6 @@ def make_cc_test(with_aspects = False):
                 "@" + paths.join(semantics.get_platforms_root(), "os:ios"),
                 "@" + paths.join(semantics.get_platforms_root(), "os:macos"),
                 "@" + paths.join(semantics.get_platforms_root(), "os:tvos"),
-                "@" + paths.join(semantics.get_platforms_root(), "os:visionos"),
                 "@" + paths.join(semantics.get_platforms_root(), "os:watchos"),
             ],
         ),


### PR DESCRIPTION
Having this here requires folks to update platforms which can be annoying until you're using bzlmod since it's a dependency of everything. This also isn't very important since in general when testing visionOS code you should be using a rule from rules_apple.