### PR TITLE
[6.4.0] Optimize classpath pre-processing in java_stub_template.txt

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -306,21 +306,24 @@ function create_and_run_classpath_jar() {
 
   OLDIFS="$IFS"
   IFS="${CLASSPATH_SEPARATOR}" # Use a custom separator for the loop.
+  current_dir=$(pwd)
   for path in ${CLASSPATH}; do
     # Loop through the characters of the path and convert characters that are
     # not alphanumeric nor -_.~/ to their 2-digit hexadecimal representation
-    local i c buff
-    local converted_path=""
+    if [[ ! $path =~ ^[-_.~/a-zA-Z0-9]*$ ]]; then
+      local i c buff
+      local converted_path=""
 
-    for ((i=0; i<${#path}; i++)); do
-      c=${path:$i:1}
-      case ${c} in
-            [-_.~/a-zA-Z0-9] ) buff=${c} ;;
-            * )               printf -v buff '%%%02x' "'$c'"
-      esac
-      converted_path+="${buff}"
-    done
-    path=${converted_path}
+      for ((i=0; i<${#path}; i++)); do
+        c=${path:$i:1}
+        case ${c} in
+              [-_.~/a-zA-Z0-9] ) buff=${c} ;;
+              * )               printf -v buff '%%%02x' "'$c'"
+        esac
+        converted_path+="${buff}"
+      done
+      path=${converted_path}
+    fi
 
     if is_windows; then
       path="file:/${path}" # e.g. "file:/C:/temp/foo.jar"
@@ -328,7 +331,7 @@ function create_and_run_classpath_jar() {
       # If not absolute, qualify the path
       case "${path}" in
         /*) ;; # Already an absolute path
-        *) path="$(pwd)/${path}";; # Now qualified
+        *) path="${current_dir}/${path}";; # Now qualified
       esac
       path="file:${path}" # e.g. "file:/usr/local/foo.jar"
     fi


### PR DESCRIPTION
The classpath pre-processing in this `java_stub_template.txt` loop: https://github.com/bazelbuild/bazel/blob/fcfcb929366dd3faac9643302b19c88bcf871ec6/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt#L309 is slow for long classpaths. For example for classpaths with ~250,000 and ~700,000 entries the loop takes 28 and 50 seconds, respectively, on an intel MacBook. This change reduce the times to 1 second or less.

Fixes #19480

Closes #19481.

Commit https://github.com/bazelbuild/bazel/commit/4e8f0bdb4eca04844a86e3c7affc8aa85245e75a

PiperOrigin-RevId: 564491123
Change-Id: Id4be898c3f800d5390dd8bf997535a5e71a76ba3