### PR TITLE
Only use `/showIncludes` if supported

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -458,7 +458,9 @@ public final class CppCompileActionBuilder {
   }
 
   public boolean dotdFilesEnabled() {
-    return cppSemantics.needsDotdInputPruning(configuration) && !shouldParseShowIncludes();
+    return cppSemantics.needsDotdInputPruning(configuration)
+        && !shouldParseShowIncludes()
+        && !featureConfiguration.isEnabled(CppRuleClasses.NO_DOTD_FILE);
   }
 
   public boolean serializedDiagnosticsFilesEnabled() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
@@ -404,6 +404,9 @@ public class CppRuleClasses {
   /** A string constant for /showIncludes parsing feature, should only be used for MSVC toolchain */
   public static final String PARSE_SHOWINCLUDES = "parse_showincludes";
 
+  /** A string constant for a feature that, if enabled, disables .d file handling. */
+  public static final String NO_DOTD_FILE = "no_dotd_file";
+
   /*
    * A string constant for the fdo_instrument feature.
    */

--- a/tools/cpp/BUILD.windows.tpl
+++ b/tools/cpp/BUILD.windows.tpl
@@ -229,6 +229,7 @@ cc_toolchain_config(
     default_link_flags = ["/MACHINE:X64"],
     dbg_mode_debug_flag = "%{dbg_mode_debug_flag_x64}",
     fastbuild_mode_debug_flag = "%{fastbuild_mode_debug_flag_x64}",
+    supports_parse_showincludes = %{msvc_parse_showincludes_x64},
 )
 
 toolchain(
@@ -295,6 +296,7 @@ cc_toolchain_config(
     default_link_flags = ["/MACHINE:X86"],
     dbg_mode_debug_flag = "%{dbg_mode_debug_flag_x86}",
     fastbuild_mode_debug_flag = "%{fastbuild_mode_debug_flag_x86}",
+    supports_parse_showincludes = %{msvc_parse_showincludes_x86},
 )
 
 toolchain(
@@ -361,6 +363,7 @@ cc_toolchain_config(
     default_link_flags = ["/MACHINE:ARM"],
     dbg_mode_debug_flag = "%{dbg_mode_debug_flag_arm}",
     fastbuild_mode_debug_flag = "%{fastbuild_mode_debug_flag_arm}",
+    supports_parse_showincludes = %{msvc_parse_showincludes_arm},
 )
 
 toolchain(
@@ -427,6 +430,7 @@ cc_toolchain_config(
     default_link_flags = ["/MACHINE:ARM64"],
     dbg_mode_debug_flag = "%{dbg_mode_debug_flag_arm64}",
     fastbuild_mode_debug_flag = "%{fastbuild_mode_debug_flag_arm64}",
+    supports_parse_showincludes = %{msvc_parse_showincludes_arm64},
 )
 
 toolchain(
@@ -493,6 +497,7 @@ cc_toolchain_config(
     default_link_flags = ["/MACHINE:X64"],
     dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_x64}",
     fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_x64}",
+    supports_parse_showincludes = %{clang_cl_parse_showincludes_x64},
 )
 
 toolchain(
@@ -560,6 +565,7 @@ cc_toolchain_config(
     default_link_flags = ["/MACHINE:ARM64"],
     dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_arm64}",
     fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_arm64}",
+    supports_parse_showincludes = %{clang_cl_parse_showincludes_arm64},
 )
 
 toolchain(

--- a/tools/cpp/lib_cc_configure.bzl
+++ b/tools/cpp/lib_cc_configure.bzl
@@ -148,7 +148,8 @@ def execute(
         repository_ctx,
         command,
         environment = None,
-        expect_failure = False):
+        expect_failure = False,
+        expect_empty_output = False):
     """Execute a command, return stdout if succeed and throw an error if it fails. Doesn't %-escape the result!"""
     if environment:
         result = repository_ctx.execute(command, environment = environment)
@@ -171,10 +172,15 @@ def execute(
                 ),
             )
     stripped_stdout = result.stdout.strip()
-    if not stripped_stdout:
-        auto_configure_fail(
-            "empty output from command %s, stderr: (%s)" % (command, result.stderr),
-        )
+    if expect_empty_output != (not stripped_stdout):
+        if expect_empty_output:
+            auto_configure_fail(
+                "non-empty output from command %s, stdout: (%s), stderr: (%s)" % (command, result.stdout, result.stderr),
+            )
+        else:
+            auto_configure_fail(
+                "empty output from command %s, stderr: (%s)" % (command, result.stderr),
+            )
     return stripped_stdout
 
 def get_cpu_value(repository_ctx):

--- a/tools/cpp/windows_cc_toolchain_config.bzl
+++ b/tools/cpp/windows_cc_toolchain_config.bzl
@@ -187,7 +187,6 @@ def _impl(ctx):
                 "compiler_output_flags",
                 "nologo",
                 "msvc_env",
-                "parse_showincludes",
                 "user_compile_flags",
                 "sysroot",
             ],
@@ -202,7 +201,6 @@ def _impl(ctx):
                 "default_compile_flags",
                 "nologo",
                 "msvc_env",
-                "parse_showincludes",
                 "user_compile_flags",
                 "sysroot",
                 "unfiltered_compile_flags",
@@ -217,7 +215,6 @@ def _impl(ctx):
                 "compiler_output_flags",
                 "nologo",
                 "msvc_env",
-                "parse_showincludes",
                 "user_compile_flags",
                 "sysroot",
             ],
@@ -789,6 +786,7 @@ def _impl(ctx):
 
         parse_showincludes_feature = feature(
             name = "parse_showincludes",
+            enabled = ctx.attr.supports_parse_showincludes,
             flag_sets = [
                 flag_set(
                     actions = [
@@ -802,6 +800,27 @@ def _impl(ctx):
                     flag_groups = [flag_group(flags = ["/showIncludes"])],
                 ),
             ],
+            env_sets = [
+                env_set(
+                    actions = [
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                    ],
+                    # Force English (and thus a consistent locale) output so that Bazel can parse
+                    # the /showIncludes output without having to guess the encoding.
+                    env_entries = [env_entry(key = "VSLANG", value = "1033")],
+                ),
+            ],
+        )
+
+        # MSVC does not emit .d files.
+        no_dotd_file_feature = feature(
+            name = "no_dotd_file",
+            enabled = True,
         )
 
         treat_warnings_as_errors_feature = feature(
@@ -1101,6 +1120,7 @@ def _impl(ctx):
             external_include_paths_feature,
             preprocessor_defines_feature,
             parse_showincludes_feature,
+            no_dotd_file_feature,
             generate_pdb_file_feature,
             shared_flag_feature,
             linkstamps_feature,
@@ -1417,6 +1437,7 @@ cc_toolchain_config = rule(
         "dbg_mode_debug_flag": attr.string(),
         "fastbuild_mode_debug_flag": attr.string(),
         "tool_bin_path": attr.string(default = "not_found"),
+        "supports_parse_showincludes": attr.bool(),
     },
     provides = [CcToolchainConfigInfo],
 )


### PR DESCRIPTION
The auto-configured Windows toolchain now only enables `/showIncludes` if the English language pack for VS is installed and the compiler language can thus be forced to be English. Other languages may use encodings other than ASCII or UTF-8 and thus fail to be recognized by Bazel's `ShowInputFilter`. A warning with a suggested fix is shown if this fails.

See #19451
Fixes #19439

RELNOTES: Compilation actions using the auto-configured MSVC toolchain are forced to emit error messages in English if the English language pack for Visual Studio is installed.