### PR TITLE
Update unknown Xcode version error message and provide an environment variable to force re-evaluation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfig.java
@@ -388,11 +388,11 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
       } else if (specifiedVersionFromRemote != null) {
         ruleContext.ruleWarning(
             String.format(
-                "--xcode_version=%1$s specified, but it is not available locally. Your build"
-                    + " will fail if any actions require a local Xcode. If you believe you have"
-                    + " '%1$s' installed, try running \"blaze shutdown\", and then re-run your"
-                    + " command.  localy available versions: [%2$s]. remotely available"
-                    + " versions: [%3$s]",
+                "--xcode_version=%1$s specified, but it is not available locally. Your build will"
+                    + " fail if any actions require a local Xcode. If you believe you have '%1$s'"
+                    + " installed, try running \"blaze sync --configure\", and then re-run your"
+                    + " command.  localy available versions: [%2$s]. remotely available versions:"
+                    + " [%3$s]",
                 versionOverrideFlag,
                 printableXcodeVersions(localVersions.getAvailableVersions()),
                 printableXcodeVersions(remoteVersions.getAvailableVersions())));
@@ -403,7 +403,7 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
                 "--xcode_version=%1$s specified, but '%1$s' is not an available Xcode version."
                     + " localy available versions: [%2$s]. remotely available versions:"
                     + " [%3$s]. If you believe you have '%1$s' installed, try running \"blaze"
-                    + " shutdown\", and then re-run your command.",
+                    + " sync --configure\", and then re-run your command.",
                 versionOverrideFlag,
                 printableXcodeVersions(localVersions.getAvailableVersions()),
                 printableXcodeVersions(remoteVersions.getAvailableVersions())));
@@ -457,10 +457,10 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
       checkState(defaultVersion != null);
       return Maps.immutableEntry(defaultVersion, Availability.BOTH);
     } else { // Use the local default.
-        ruleContext.ruleWarning(
-            "You passed --experimental_prefer_mutual_xcode=false, which prevents Bazel from"
-                + " selecting an Xcode version that optimizes your performance. Please consider"
-                + " using --experimental_prefer_mutual_xcode=true.");
+      ruleContext.ruleWarning(
+          "You passed --experimental_prefer_mutual_xcode=false, which prevents Bazel from"
+              + " selecting an Xcode version that optimizes your performance. Please consider"
+              + " using --experimental_prefer_mutual_xcode=true.");
       return Maps.immutableEntry(localVersions.getDefaultVersion(), Availability.LOCAL);
     }
   }

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -296,6 +296,7 @@ def _impl(repository_ctx):
 
 xcode_autoconf = repository_rule(
     environ = [
+        "DEVELOPER_DIR",
         "XCODE_VERSION",
     ],
     implementation = _impl,

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -295,6 +295,9 @@ def _impl(repository_ctx):
     repository_ctx.file("BUILD", build_contents)
 
 xcode_autoconf = repository_rule(
+    environ = [
+        "XCODE_VERSION",
+    ],
     implementation = _impl,
     configure = True,
     attrs = {


### PR DESCRIPTION
As of c747ae7aab077227099409f2f0774b485d42eaa4, you need to run `bazel sync --configure` instead of `bazel shutdown`, to force re-finding of Xcode versions.

Certain setups have a hard time running that new command, versus previously only having to cause Bazel to restart. To accommodate that, I’ve also added the `XCODE_VERSION` variable to `environ` (to match a similar use defined here: https://github.com/bazelbuild/apple_support/commit/ddf25c260162b01ec639739aad41ad6008343d22), which allows those setups to force the re-evaluation by using `--repo_env`. And since the `default` attribute is influenced by `DEVELOPER_DIR`, I've included that in `environ` as well.