### PR TITLE
[6.4.0] Write an explicit line ending to the lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -187,11 +187,12 @@ public class BazelLockFileModule extends BlazeModule {
           lockfilePath.asPath(),
           UTF_8,
           GsonTypeAdapterUtil.createLockFileGson(
-                  lockfilePath
-                      .asPath()
-                      .getParentDirectory()
-                      .getRelative(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME))
-              .toJson(updatedLockfile));
+                      lockfilePath
+                          .asPath()
+                          .getParentDirectory()
+                          .getRelative(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME))
+                  .toJson(updatedLockfile)
+              + "\n");
     } catch (IOException e) {
       logger.atSevere().withCause(e).log(
           "Error while updating MODULE.bazel.lock file: %s", e.getMessage());


### PR DESCRIPTION
Otherwise, we get the following change on Linux after generating the lockfile on Windows.

```
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4098,4 +4098,4 @@
       }
     }
   }
-}
+}
\ No newline at end of file
```

RELNOTES: None
PiperOrigin-RevId: 565042838
Change-Id: I5b93d155d7f1baf3a11b5d5aaf199e67b99af973