### PR TITLE
Advertise CcInfo from cc_proto_library

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_proto_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_proto_library.bzl
@@ -282,4 +282,5 @@ cc_proto_library = rule(
             allow_files = False,
         ),
     },
+    provides = [CcInfo],
 )


### PR DESCRIPTION
This should have been in 6.3 but I didn't backport it.