### PR TITLE
Print dep chain leading to a module that is in error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
@@ -112,6 +112,8 @@ public class BazelModuleResolutionFunction implements SkyFunction {
     ImmutableMap<ModuleKey, InterimModule> initialDepGraph;
     try (SilentCloseable c = Profiler.instance().profile(ProfilerTask.BZLMOD, "discovery")) {
       initialDepGraph = Discovery.run(env, root);
+    } catch (ExternalDepsException e) {
+      throw new BazelModuleResolutionFunctionException(e, Transience.PERSISTENT);
     }
     if (initialDepGraph == null) {
       return null;

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
@@ -15,15 +15,22 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import static java.util.stream.Collectors.joining;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.bzlmod.InterimModule.DepSpec;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
+import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
+import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyframeLookupResult;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -43,12 +50,14 @@ final class Discovery {
    */
   @Nullable
   public static ImmutableMap<ModuleKey, InterimModule> run(
-      Environment env, RootModuleFileValue root) throws InterruptedException {
+      Environment env, RootModuleFileValue root)
+      throws InterruptedException, ExternalDepsException {
     String rootModuleName = root.getModule().getName();
     ImmutableMap<String, ModuleOverride> overrides = root.getOverrides();
     Map<ModuleKey, InterimModule> depGraph = new HashMap<>();
     depGraph.put(ModuleKey.ROOT, rewriteDepSpecs(root.getModule(), overrides, rootModuleName));
     Queue<ModuleKey> unexpanded = new ArrayDeque<>();
+    Map<ModuleKey, ModuleKey> predecessors = new HashMap<>();
     unexpanded.add(ModuleKey.ROOT);
     while (!unexpanded.isEmpty()) {
       Set<SkyKey> unexpandedSkyKeys = new HashSet<>();
@@ -58,6 +67,7 @@ final class Discovery {
           if (depGraph.containsKey(depSpec.toModuleKey())) {
             continue;
           }
+          predecessors.putIfAbsent(depSpec.toModuleKey(), module.getKey());
           unexpandedSkyKeys.add(
               ModuleFileValue.key(depSpec.toModuleKey(), overrides.get(depSpec.getName())));
         }
@@ -65,7 +75,28 @@ final class Discovery {
       SkyframeLookupResult result = env.getValuesAndExceptions(unexpandedSkyKeys);
       for (SkyKey skyKey : unexpandedSkyKeys) {
         ModuleKey depKey = ((ModuleFileValue.Key) skyKey).getModuleKey();
-        ModuleFileValue moduleFileValue = (ModuleFileValue) result.get(skyKey);
+        ModuleFileValue moduleFileValue;
+        try {
+          moduleFileValue =
+              (ModuleFileValue) result.getOrThrow(skyKey, ExternalDepsException.class);
+        } catch (ExternalDepsException e) {
+          // Trace back a dependency chain to the root module. There can be multiple paths to the
+          // failing module, but any of those is useful for debugging.
+          List<ModuleKey> depChain = new ArrayList<>();
+          depChain.add(depKey);
+          ModuleKey predecessor = depKey;
+          while ((predecessor = predecessors.get(predecessor)) != null) {
+            depChain.add(predecessor);
+          }
+          Collections.reverse(depChain);
+          String depChainString =
+              depChain.stream().map(ModuleKey::toString).collect(joining(" -> "));
+          throw ExternalDepsException.withCauseAndMessage(
+              FailureDetails.ExternalDeps.Code.BAD_MODULE,
+              e,
+              "in module dependency chain %s",
+              depChainString);
+        }
         if (moduleFileValue == null) {
           // Don't return yet. Try to expand any other unexpanded nodes before returning.
           depGraph.put(depKey, null);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -108,7 +108,13 @@ public class DiscoveryTest extends FoundationTestCase {
       if (root == null) {
         return null;
       }
-      ImmutableMap<ModuleKey, InterimModule> depGraph = Discovery.run(env, root);
+      ImmutableMap<ModuleKey, InterimModule> depGraph;
+      try {
+        depGraph = Discovery.run(env, root);
+      } catch (ExternalDepsException e) {
+        throw new BazelModuleResolutionFunction.BazelModuleResolutionFunctionException(
+            e, SkyFunctionException.Transience.PERSISTENT);
+      }
       return depGraph == null ? null : DiscoveryValue.create(depGraph);
     }
   }

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -101,8 +101,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 48, stderr)
     self.assertIn(
         (
-            'ERROR: Error computing the main repository mapping: error parsing'
-            ' MODULE.bazel file for sss@1.3'
+             'ERROR: Error computing the main repository mapping: in module '
+             'dependency chain <root> -> sss@1.3: error parsing MODULE.bazel '
+             'file for sss@1.3'
         ),
         stderr,
     )


### PR DESCRIPTION
When a module file has an error, this now results in an error such as:

```
ERROR: Error computing the main repository mapping: in module dependency chain <root> -> grpc@1.48.1.bcr.1 -> re2@2021-09-01: the MODULE.bazel file of re2@2021-09-01 declares a different version (2021-09-02)
```