### PR TITLE
[6.4.0] Show fetch progress for the `mod` command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -607,6 +607,9 @@ public final class UiEventHandler implements EventHandler {
         return;
       }
       buildRunning = false;
+      // Have to set this, otherwise there's a lingering "checking cached actions" message for the
+      // `mod` command, which doesn't even run any actions.
+      stateTracker.setBuildComplete();
     }
     stopUpdateThread();
     synchronized (this) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -71,7 +71,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy; 
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /** Tracks state for the UI. */
@@ -465,8 +465,7 @@ class UiStateTracker {
   }
 
   void buildComplete(BuildCompleteEvent event) {
-    buildComplete = true;
-    buildCompleteAt = Instant.ofEpochMilli(clock.currentTimeMillis());
+    setBuildComplete();
 
     if (event.getResult().getSuccess()) {
       status = "INFO";
@@ -498,6 +497,11 @@ class UiStateTracker {
 
   protected boolean buildCompleted() {
     return buildComplete;
+  }
+
+  public void setBuildComplete() {
+    buildComplete = true;
+    buildCompleteAt = Instant.ofEpochMilli(clock.currentTimeMillis());
   }
 
   synchronized void downloadProgress(FetchProgress event) {


### PR DESCRIPTION
By sending out the proper events to let the UiEventHandler know that we want progress displayed.

Fixes https://github.com/bazelbuild/bazel/issues/19252

PiperOrigin-RevId: 565701083
Change-Id: If4853cc70c0fad2e0b0bebd2378dddab05e37ce1