### PR TITLE
[6.4.0] Print dep chain leading to a module that is in error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
@@ -120,6 +120,8 @@ public class BazelModuleResolutionFunction implements SkyFunction {
     ImmutableMap<ModuleKey, InterimModule> initialDepGraph;
     try (SilentCloseable c = Profiler.instance().profile(ProfilerTask.BZLMOD, "discovery")) {
       initialDepGraph = Discovery.run(env, root);
+    } catch (ExternalDepsException e) {
+      throw new BazelModuleResolutionFunctionException(e, Transience.PERSISTENT);
     }
     if (initialDepGraph == null) {
       return null;

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -108,7 +108,13 @@ public class DiscoveryTest extends FoundationTestCase {
       if (root == null) {
         return null;
       }
-      ImmutableMap<ModuleKey, InterimModule> depGraph = Discovery.run(env, root);
+      ImmutableMap<ModuleKey, InterimModule> depGraph;
+      try {
+        depGraph = Discovery.run(env, root);
+      } catch (ExternalDepsException e) {
+        throw new BazelModuleResolutionFunction.BazelModuleResolutionFunctionException(
+            e, SkyFunctionException.Transience.PERSISTENT);
+      }
       return depGraph == null ? null : DiscoveryValue.create(depGraph);
     }
   }

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -102,8 +102,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 48, stderr)
     self.assertIn(
         (
-            'ERROR: Error computing the main repository mapping: error parsing'
-            ' MODULE.bazel file for sss@1.3'
+            'ERROR: Error computing the main repository mapping: in module '
+            'dependency chain <root> -> sss@1.3: error parsing MODULE.bazel '
+            'file for sss@1.3'
         ),
         stderr,
     )


### PR DESCRIPTION
When a module file has an error, this now results in an error such as:

```
ERROR: Error computing the main repository mapping: in module dependency chain <root> -> grpc@1.48.1.bcr.1 -> re2@2021-09-01: the MODULE.bazel file of re2@2021-09-01 declares a different version (2021-09-02)
```

Closes #19535.

Commit https://github.com/bazelbuild/bazel/commit/184796da1b5f8e23cefe4f3375d5b107fa871300

PiperOrigin-RevId: 565759770
Change-Id: I8ec788de4e83f59cc5ff5dc6f9fac19322181c08