### PR TITLE
[6.4.0] Revert "Switch xcode_autoconf to use 'configure = True' (#19174)"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfig.java
@@ -403,11 +403,11 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
       } else if (specifiedVersionFromRemote != null) {
         ruleContext.ruleWarning(
             String.format(
-                "--xcode_version=%1$s specified, but it is not available locally. Your build will"
-                    + " fail if any actions require a local Xcode. If you believe you have '%1$s'"
-                    + " installed, try running \"blaze sync --configure\", and then re-run your"
-                    + " command.  localy available versions: [%2$s]. remotely available versions:"
-                    + " [%3$s]",
+                "--xcode_version=%1$s specified, but it is not available locally. Your build"
+                    + " will fail if any actions require a local Xcode. If you believe you have"
+                    + " '%1$s' installed, try running \"blaze shutdown\", and then re-run your"
+                    + " command.  localy available versions: [%2$s]. remotely available"
+                    + " versions: [%3$s]",
                 versionOverrideFlag,
                 printableXcodeVersions(localVersions.getAvailableVersions()),
                 printableXcodeVersions(remoteVersions.getAvailableVersions())));
@@ -418,7 +418,7 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
                 "--xcode_version=%1$s specified, but '%1$s' is not an available Xcode version."
                     + " localy available versions: [%2$s]. remotely available versions:"
                     + " [%3$s]. If you believe you have '%1$s' installed, try running \"blaze"
-                    + " sync --configure\", and then re-run your command.",
+                    + " shutdown\", and then re-run your command.",
                 versionOverrideFlag,
                 printableXcodeVersions(localVersions.getAvailableVersions()),
                 printableXcodeVersions(remoteVersions.getAvailableVersions())));
@@ -472,10 +472,10 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
       checkState(defaultVersion != null);
       return Maps.immutableEntry(defaultVersion, Availability.BOTH);
     } else { // Use the local default.
-      ruleContext.ruleWarning(
-          "You passed --experimental_prefer_mutual_xcode=false, which prevents Bazel from"
-              + " selecting an Xcode version that optimizes your performance. Please consider"
-              + " using --experimental_prefer_mutual_xcode=true.");
+        ruleContext.ruleWarning(
+            "You passed --experimental_prefer_mutual_xcode=false, which prevents Bazel from"
+                + " selecting an Xcode version that optimizes your performance. Please consider"
+                + " using --experimental_prefer_mutual_xcode=true.");
       return Maps.immutableEntry(localVersions.getDefaultVersion(), Availability.LOCAL);
     }
   }

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -300,7 +300,7 @@ xcode_autoconf = repository_rule(
         "XCODE_VERSION",
     ],
     implementation = _impl,
-    configure = True,
+    local = True,
     attrs = {
         "xcode_locator": attr.string(),
         "remote_xcode": attr.string(),


### PR DESCRIPTION
This reverts commit 1b2732f465405c35e18a8ee0afbe1929a2aa5a51 and part of d17f5e9bd0eb8f653b21477b41ee3954b9066635.

Bzlmod doesn’t support `bazel sync --configure`, making using `xcode_autoconf` with `configure = True` hard to work with. Until Bzlmod supports that, we shouldn’t make this change in an LTS release.