### PR TITLE
[6.4.0] Explain the use of `str(Label(...))` in the docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -53,7 +53,14 @@ import net.starlark.java.eval.StarlarkValue;
  *
  * <p>Parsing is robust against bad input, for example, from the command line.
  */
-@StarlarkBuiltin(name = "Label", category = DocCategory.BUILTIN, doc = "A BUILD target identifier.")
+@StarlarkBuiltin(
+    name = "Label",
+    category = DocCategory.BUILTIN,
+    doc =
+        "A BUILD target identifier."
+            + "<p>For every <code>Label<code> instance <code>l</code>, the string representation"
+            + " <code>str(l)</code> has the property that <code>Label(str(l)) == l</code>,"
+            + " regardless of where the <code>Label()</code> call occurs.")
 @AutoCodec
 @Immutable
 @ThreadSafe


### PR DESCRIPTION
Closes #19509.

Commit https://github.com/bazelbuild/bazel/commit/d9beda5b4f6ce8d2b8d574da5d4362c7b211f243

PiperOrigin-RevId: 565763282
Change-Id: I0a8ede20b6bda5140a83c03a44577c034a54dd5f