### PR TITLE
Update bzlmod migration to mention enable_bzlmod

### DIFF
--- a/site/en/external/migration.md
+++ b/site/en/external/migration.md
@@ -32,6 +32,19 @@ your workspace root, maybe with comments like:
     # See MODULE.bazel for external dependencies setup.
     ```
 
+### Enable Blzmod in your bazelrc {:#enable-bzldmod}
+
+`.bazelrc` lets you set flags that apply every time your run Bazel.  To enable
+Bzlmod we use the `--enable_bzlmod` flag, and apply it to the `common` command so
+it applies to every command:
+
+* **.bazelrc**
+
+    ```
+    # Enable bzlmod for every bazel command
+    common --enable_bzlmod
+    ```
+
 ### Specify repository name for your workspace {:#specify-repo-name}
 
 *   **WORKSPACE**

--- a/site/en/external/migration.md
+++ b/site/en/external/migration.md
@@ -35,13 +35,13 @@ your workspace root, maybe with comments like:
 ### Enable Blzmod in your bazelrc {:#enable-bzldmod}
 
 `.bazelrc` lets you set flags that apply every time your run Bazel.  To enable
-Bzlmod we use the `--enable_bzlmod` flag, and apply it to the `common` command so
+Bzlmod, use the `--enable_bzlmod` flag, and apply it to the `common` command so
 it applies to every command:
 
 * **.bazelrc**
 
     ```
-    # Enable bzlmod for every bazel command
+    # Enable Bzlmod for every Bazel command
     common --enable_bzlmod
     ```
 


### PR DESCRIPTION
It the migration guide make sure to explicitly tell the user to update their `.bazelrc` with the `--enable_bzlmod` so that Bzlmod will be active.  This resolves #19561