### PR TITLE
Fix genquery documentation around the default ordering.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryRule.java
@@ -114,8 +114,9 @@ public final class GenQueryRule implements RuleDefinition {
     is not allowed).
   </p>
   <p>
-    The genquery's output is ordered using <code>--order_output=full</code> in
-    order to enforce deterministic output.
+    The genquery's output is ordered lexicographically in order to enforce deterministic output,
+    with the exception of <code>--output=graph|minrank|maxrank</code> or when <code>somepath</code>
+    is used as the top-level function.
   <p>
     The name of the output file is the name of the rule.
   </p>


### PR DESCRIPTION
Genquery's default output order has been changed to lexicographical ordering since a while, the documentation needs to be updated. 

Fixes #16234.