### PR TITLE
Error on potential unsupported `/showIncludes` lines

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1710,6 +1710,22 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       throws ActionExecutionException {
     Collection<Path> stdoutDeps = showIncludesFilterForStdout.getDependencies(execRoot);
     Collection<Path> stderrDeps = showIncludesFilterForStderr.getDependencies(execRoot);
+    if (stdoutDeps.isEmpty()
+        && stderrDeps.isEmpty()
+        && (showIncludesFilterForStdout.sawPotentialUnsupportedShowIncludesLine()
+            || showIncludesFilterForStderr.sawPotentialUnsupportedShowIncludesLine())) {
+      // /showIncludes parsing didn't result in any headers being found (unusual) *and* also
+      // encountered a line that looked like /showIncludes output in an unsupported encoding.
+      String message =
+          "While parsing the C++ compiler output for information about included headers, Bazel "
+              + "failed to find any headers but encountered a line that appears to be "
+              + "/showIncludes output in an unsupported encoding. This can result in incorrect "
+              + "incremental builds. If you are using the default Windows MSVC toolchain that "
+              + "ships with Bazel, ensure that the English language pack for Visual Studio is "
+              + "installed and then run 'bazel clean --expunge'.";
+      DetailedExitCode code = createDetailedExitCode(message, Code.FIND_USED_HEADERS_IO_EXCEPTION);
+      throw new ActionExecutionException(message, this, /* catastrophe= */ false, code);
+    }
     return HeaderDiscovery.discoverInputsFromDependencies(
         this,
         getSourceFile(),

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilterTest.java
@@ -55,6 +55,7 @@ public class ShowIncludesFilterTest {
     // Normal output message with newline
     filterOutputStream.write(getBytes("I am compiling\n"));
     assertThat(output.toString()).isEqualTo("I am compiling\n");
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
   }
 
   @Test
@@ -65,6 +66,7 @@ public class ShowIncludesFilterTest {
     filterOutputStream.flush();
     // flush to output should succeed
     assertThat(output.toString()).isEqualTo("Still compiling");
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
   }
 
   @Test
@@ -78,6 +80,7 @@ public class ShowIncludesFilterTest {
     filterOutputStream.write(getBytes("other info"));
     filterOutputStream.flush();
     assertThat(output.toString()).isEqualTo("Note: other info");
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
   }
 
   @Test
@@ -91,6 +94,7 @@ public class ShowIncludesFilterTest {
     // It's a match, output should be filtered, dependency on bar.h should be found.
     assertThat(output.toString()).isEmpty();
     assertThat(showIncludesFilter.getDependencies()).contains("bar.h");
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
   }
 
   @Test
@@ -106,6 +110,7 @@ public class ShowIncludesFilterTest {
     // It's a match, output should be filtered, dependency on bar.h should be found.
     assertThat(output.toString()).isEmpty();
     assertThat(showIncludesFilter.getDependencies()).contains("..\\__main__\\foo\\bar\\bar.h");
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
   }
 
   @Test
@@ -119,6 +124,7 @@ public class ShowIncludesFilterTest {
     // It's a match, output should be filtered, dependency on bar.h should be found.
     assertThat(output.toString()).isEmpty();
     assertThat(showIncludesFilter.getDependencies()).contains("C:\\system\\foo\\bar\\bar.h");
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
   }
 
   @Test
@@ -127,6 +133,7 @@ public class ShowIncludesFilterTest {
     // It's a match, output should be filtered, no dependency found.
     assertThat(output.toString()).isEmpty();
     assertThat(showIncludesFilter.getDependencies()).isEmpty();
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
   }
 
   @Test
@@ -138,5 +145,36 @@ public class ShowIncludesFilterTest {
     filterOutputStream.write(getBytes(".h"));
     filterOutputStream.flush();
     assertThat(output.toString()).isEqualTo("foo.h");
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
+  }
+
+  @Test
+  public void testSawPotentialUnsupportedShowIncludesLine() throws IOException {
+    // MSVC output with French non-UTF-8 locale.
+    filterOutputStream.write(getBytes("Remarque"));
+    filterOutputStream.write(0xFF);
+    filterOutputStream.write(getBytes(": inclusion du fichier"));
+    filterOutputStream.write(0xFF);
+    filterOutputStream.write(getBytes(":  C:\\bazel\\execroot\\foo\n"));
+    filterOutputStream.flush();
+
+    assertThat(output.toString()).isNotEmpty();
+    assertThat(showIncludesFilter.getDependencies()).isEmpty();
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isTrue();
+  }
+
+  @Test
+  public void testSawPotentialUnsupportedShowIncludesLine_nearMatches() throws IOException {
+    filterOutputStream.write(getBytes("foo: bar: C:\\bazel\\foo\n"));
+    filterOutputStream.write(getBytes("foo: C:\\bazel\\execroot\\foo\n"));
+    filterOutputStream.write(getBytes("foo: bar: baz: C:\\bazel\\execroot\\foo\n"));
+    filterOutputStream.write(getBytes("foo: bar(123): C:\\bazel\\execroot\\foo\n"));
+    filterOutputStream.write(getBytes("foo: bar: C:\\bazel\\execroot\\foo: baz\n"));
+    filterOutputStream.write(getBytes("foo: bar: bazel\\execroot\\foo\n"));
+    filterOutputStream.flush();
+
+    assertThat(output.toString()).isNotEmpty();
+    assertThat(showIncludesFilter.getDependencies()).isEmpty();
+    assertThat(showIncludesFilter.sawPotentialUnsupportedShowIncludesLine()).isFalse();
   }
 }


### PR DESCRIPTION
This error ensures that removing the English language pack for MSVC
without also refetching `@local_config_cc` doesn't result in silently
incorrect incremental builds.

I considered making this a warning instead, but that would either result
in warning spam (if a false positive) or drown in the unfiltered MSVC
output (if a true positive). Making this an error is better for
correctness and will lead users to report any false positive matches.

Fixes https://github.com/bazelbuild/bazel/issues/19439#issuecomment-1728701937