### PR TITLE
[6.4.0] Disable bzlmod_query_test for RBE build

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -344,6 +344,7 @@ tasks:
       - "-//src/test/py/bazel:bazel_overrides_test"
       - "-//src/test/py/bazel:bazel_repo_mapping_test"
       - "-//src/test/py/bazel:bazel_yanked_versions_test"
+      - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/shell/bazel:verify_workspace"
     include_json_profile:
       - build

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -334,6 +334,7 @@ tasks:
       - "-//src/test/py/bazel:bazel_overrides_test"
       - "-//src/test/py/bazel:bazel_repo_mapping_test"
       - "-//src/test/py/bazel:bazel_yanked_versions_test"
+      - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/shell/bazel:verify_workspace"
   kythe_ubuntu2004:
     shell_commands:


### PR DESCRIPTION
Due to an issue on RBE worker (b/217865760), accessing multiple URLs at the same time may cause timeout.

https://buildkite.com/bazel/google-bazel-presubmit/builds/71669#018aafe9-d1c9-4a95-8741-8062ce5f12e3

Commit https://github.com/bazelbuild/bazel/commit/ae99c1f3a303b2993ce6dbab32ff3bd067fb296d

RELNOTES: None
PiperOrigin-RevId: 566895027
Change-Id: Icf5a243d22b0ae64c9c64e038feee69eefdcfc19