### PR TITLE
fix /tmp has no writable permission if it is symbolic link

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -427,7 +427,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     }
     FileSystem fs = sandboxExecRoot.getFileSystem();
     writableDirs.add(fs.getPath("/dev/shm").resolveSymbolicLinks());
-    writableDirs.add(fs.getPath("/tmp"));
+    writableDirs.add(fs.getPath("/tmp").resolveSymbolicLinks());
 
     return writableDirs.build();
   }


### PR DESCRIPTION
fix #19438 