### PR TITLE
[6.4.0] Clear runfiles environment variables for `bazel run`

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -2151,6 +2151,12 @@ unsigned int BlazeServer::Communicate(
       return blaze_exit_code::INTERNAL_ERROR;
     }
 
+    // Clear environment variables before setting the requested ones so that
+    // users can still explicitly override the clearing.
+    for (const auto &variable_name : request.environment_variable_to_clear()) {
+      UnsetEnv(variable_name);
+    }
+
     vector<string> argv(request.argv().begin(), request.argv().end());
     for (const auto &variable : request.environment_variable()) {
       SetEnv(variable.name(), variable.value());

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -339,6 +339,7 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
             showSubcommands.prettyPrintArgs,
             spawn.getArguments(),
             spawn.getEnvironment(),
+            /* environmentVariablesToClear= */ null,
             getExecRoot().getPathString(),
             spawn.getConfigurationChecksum(),
             spawn.getExecutionPlatformLabelString());

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -280,6 +280,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
                           .map(a -> escapeBytestringUtf8(a))
                           .collect(toImmutableList()),
                   /* environment= */ null,
+                  /* environmentVariablesToClear= */ null,
                   /* cwd= */ null,
                   action.getOwner().getConfigurationChecksum(),
                   action.getExecutionPlatform() == null

--- a/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Ordering;
 import java.io.File;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -41,6 +42,8 @@ public class CommandFailureUtils {
     void describeCommandCwd(String cwd, StringBuilder message);
     void describeCommandEnvPrefix(StringBuilder message, boolean isolated);
     void describeCommandEnvVar(StringBuilder message, Map.Entry<String, String> entry);
+
+    void describeCommandUnsetEnvVar(StringBuilder message, String name);
     /**
      * Formats the command element and adds it to the message.
      *
@@ -84,6 +87,12 @@ public class CommandFailureUtils {
     }
 
     @Override
+    public void describeCommandUnsetEnvVar(StringBuilder message, String name) {
+      // Only the short form of --unset is supported on macOS.
+      message.append("-u ").append(ShellEscaper.escapeString(name)).append(" \\\n  ");
+    }
+
+    @Override
     public void describeCommandElement(
         StringBuilder message, String commandElement, boolean isBinary) {
       message.append(ShellEscaper.escapeString(commandElement));
@@ -124,6 +133,11 @@ public class CommandFailureUtils {
     }
 
     @Override
+    public void describeCommandUnsetEnvVar(StringBuilder message, String name) {
+      message.append("SET ").append(name).append('=').append("\n  ");
+    }
+
+    @Override
     public void describeCommandElement(
         StringBuilder message, String commandElement, boolean isBinary) {
       // Replace the forward slashes with back slashes if the `commandElement` is the binary path
@@ -156,6 +170,7 @@ public class CommandFailureUtils {
       boolean prettyPrintArgs,
       Collection<String> commandLineElements,
       @Nullable Map<String, String> environment,
+      @Nullable List<String> environmentVariablesToClear,
       @Nullable String cwd,
       @Nullable String configurationChecksum,
       @Nullable String executionPlatformAsLabelString) {
@@ -205,6 +220,12 @@ public class CommandFailureUtils {
       if (environment != null) {
         describeCommandImpl.describeCommandEnvPrefix(
             message, form != CommandDescriptionForm.COMPLETE_UNISOLATED);
+        if (environmentVariablesToClear != null) {
+          for (String name : Ordering.natural().sortedCopy(environmentVariablesToClear)) {
+            message.append("  ");
+            describeCommandImpl.describeCommandUnsetEnvVar(message, name);
+          }
+        }
         // A map can never have two keys with the same value, so we only need to compare the keys.
         Comparator<Map.Entry<String, String>> mapEntryComparator = comparingByKey();
         for (Map.Entry<String, String> entry :
@@ -291,6 +312,7 @@ public class CommandFailureUtils {
             /* prettyPrintArgs= */ false,
             commandLineElements,
             env,
+            null,
             cwd,
             configurationChecksum,
             executionPlatformAsLabelString));

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
@@ -211,11 +211,12 @@ public final class WorkerKey {
     // debugging.
     return CommandFailureUtils.describeCommand(
         CommandDescriptionForm.COMPLETE,
-        /*prettyPrintArgs=*/ false,
+        /* prettyPrintArgs= */ false,
         args,
         env,
+        /* environmentVariablesToClear= */ null,
         execRoot.getPathString(),
-        /*configurationChecksum=*/ null,
-        /*executionPlatformAsLabelString=*/ null);
+        /* configurationChecksum= */ null,
+        /* executionPlatformAsLabelString= */ null);
   }
 }

--- a/src/main/protobuf/command_server.proto
+++ b/src/main/protobuf/command_server.proto
@@ -92,6 +92,7 @@ message ExecRequest {
   bytes working_directory = 1;
   repeated bytes argv = 2;
   repeated EnvironmentVariable environment_variable = 3;
+  repeated bytes environment_variable_to_clear = 4;
 }
 
 // Contains metadata and result data for a command execution.

--- a/src/test/java/com/google/devtools/build/lib/util/CommandFailureUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/CommandFailureUtilsTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.util;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import java.util.Arrays;
@@ -210,6 +211,8 @@ public class CommandFailureUtilsTest {
     env.put("FOO", "foo");
     env.put("PATH", "/usr/bin:/bin:/sbin");
 
+    ImmutableList<String> envToClear = ImmutableList.of("CLEAR", "THIS");
+
     String cwd = "/my/working/directory";
     PlatformInfo executionPlatform =
         PlatformInfo.builder().setLabel(Label.parseAbsoluteUnchecked("//platform:exec")).build();
@@ -219,6 +222,7 @@ public class CommandFailureUtilsTest {
             true,
             Arrays.asList(args),
             env,
+            envToClear,
             cwd,
             "cfg12345",
             executionPlatform.label().toString());
@@ -227,6 +231,8 @@ public class CommandFailureUtilsTest {
         .isEqualTo(
             "(cd /my/working/directory && \\\n"
                 + "  exec env - \\\n"
+                + "    -u CLEAR \\\n"
+                + "    -u THIS \\\n"
                 + "    FOO=foo \\\n"
                 + "    PATH=/usr/bin:/bin:/sbin \\\n"
                 + "  some_command \\\n"

--- a/src/test/shell/bazel/run_test.sh
+++ b/src/test/shell/bazel/run_test.sh
@@ -164,4 +164,51 @@ EOF
   true
 }
 
+function test_run_with_runfiles_env() {
+  mkdir -p b
+  cat > b/BUILD <<'EOF'
+sh_binary(
+  name = "binary",
+  srcs = ["binary.sh"],
+  deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+EOF
+  cat > b/binary.sh <<'EOF'
+#!/usr/bin/env bash
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+own_path=$(rlocation main/b/binary.sh)
+echo "own path: $own_path"
+test -f "$own_path"
+EOF
+  chmod +x b/binary.sh
+
+  bazel run //b:binary --script_path=script.bat &>"$TEST_log" \
+    || fail "Script generation should succeed"
+
+  cat ./script.bat &>"$TEST_log"
+
+  # Make it so that the runfiles variables point to an incorrect but valid
+  # runfiles directory/manifest, simulating a left over one from a different
+  # test to which RUNFILES_DIR and RUNFILES_MANIFEST_FILE point in the client
+  # env.
+  BOGUS_RUNFILES_DIR="$(pwd)/bogus_runfiles/bazel_tools/tools/bash/runfiles"
+  mkdir -p "$BOGUS_RUNFILES_DIR"
+  touch "$BOGUS_RUNFILES_DIR/runfiles.bash"
+  BOGUS_RUNFILES_MANIFEST_FILE="$(pwd)/bogus_manifest"
+  echo "bazel_tools/tools/bash/runfiles/runfiles.bash bogus/path" > "$BOGUS_RUNFILES_MANIFEST_FILE"
+
+  RUNFILES_DIR="$BOGUS_RUNFILES_DIR" RUNFILES_MANIFEST_FILE="$BOGUS_RUNFILES_MANIFEST_FILE" \
+     ./script.bat || fail "Run should succeed"
+}
+
 run_suite "run_under_tests"


### PR DESCRIPTION
When an environment variable such as `RUNFILES_DIR` is set in the client environment when a target using runfiles libraries is run via `bazel run`, the libraries can't look up the runfiles directory or manifest.

This is fixed by clearing the runfiles-related environment variables from the env in which the target is executed.

Fixes #17571

Closes #17690.

PiperOrigin-RevId: 516474822
Change-Id: Ia5201d4334b286b36ba2e476e850b98992ca0ffa

Closes #19596