### PR TITLE
Add missing googletest directory to cpp usecase doc to reflect actual structure

### DIFF
--- a/site/en/tutorials/cpp-use-cases.md
+++ b/site/en/tutorials/cpp-use-cases.md
@@ -126,12 +126,12 @@ Then create `gtest.BUILD`, a `BUILD` file used to compile Google Test.
 Google Test has several "special" requirements that make its `cc_library` rule
 more complicated:
 
-*  `googletest-release-1.10.0/src/gtest-all.cc` `#include`s all other
-   files in `googletest-release-1.10.0/src/`: exclude it from the
+*  `googletest-release-1.10.0/googletest/src/gtest-all.cc` `#include`s all other
+   files in `googletest-release-1.10.0/googletest/src/`: exclude it from the
    compile to prevent link errors for duplicate symbols.
 
 *  It uses header files that are relative to the
-`googletest-release-1.10.0/include/` directory  (`"gtest/gtest.h"`), so you must
+`googletest-release-1.10.0/googletest/include/` directory  (`"gtest/gtest.h"`), so you must
 add that directory to the include paths.
 
 *  It needs to link in `pthread`, so add that as a `linkopt`.
@@ -142,16 +142,16 @@ The final rule therefore looks like this:
 cc_library(
     name = "main",
     srcs = glob(
-        ["googletest-release-1.10.0/src/*.cc"],
-        exclude = ["googletest-release-1.10.0/src/gtest-all.cc"]
+        ["googletest-release-1.10.0/googletest/src/*.cc"],
+        exclude = ["googletest-release-1.10.0/googletest/src/gtest-all.cc"]
     ),
     hdrs = glob([
-        "googletest-release-1.10.0/include/**/*.h",
-        "googletest-release-1.10.0/src/*.h"
+        "googletest-release-1.10.0/googletest/include/**/*.h",
+        "googletest-release-1.10.0/googletest/src/*.h"
     ]),
     copts = [
-        "-Iexternal/gtest/googletest-release-1.10.0/include",
-        "-Iexternal/gtest/googletest-release-1.10.0"
+        "-Iexternal/gtest/googletest-release-1.10.0/googletest/include",
+        "-Iexternal/gtest/googletest-release-1.10.0/googletest"
     ],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
@@ -180,14 +180,17 @@ Then `gtest.BUILD` would look like this:
 cc_library(
     name = "main",
     srcs = glob(
-        ["src/*.cc"],
-        exclude = ["src/gtest-all.cc"]
+        ["googletest/src/*.cc"],
+        exclude = ["googletest/src/gtest-all.cc"]
     ),
     hdrs = glob([
-        "include/**/*.h",
-        "src/*.h"
+        "googletest/include/**/*.h",
+        "googletest/src/*.h"
     ]),
-    copts = ["-Iexternal/gtest/include"],
+    copts = [
+      "-Iexternal/gtest/googletest/include",
+      "-Iexternal/gtest/googletest",
+    ],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
 )
@@ -214,7 +217,10 @@ Then create `./test/BUILD` file for your tests:
 cc_test(
     name = "hello-test",
     srcs = ["hello-test.cc"],
-    copts = ["-Iexternal/gtest/include"],
+    copts = [
+      "-Iexternal/gtest/googletest/include",
+      "-Iexternal/gtest/googletest",
+    ],
     deps = [
         "@gtest//:main",
         "//main:hello-greet",


### PR DESCRIPTION
The use-case doc assumes that `googletest`'s directories such as `src`/`include` are located at the top, but if we see the contents of https://github.com/google/googletest/archive/release-1.10.0.zip, there is an intermediate directory `googletest`.

![Screenshot 2023-09-26 at 0 05 51](https://github.com/bazelbuild/bazel/assets/1391330/02d56fdb-272c-4a25-ad9c-2f36dece2c1c)

So if we want to have `strip_prefix = "googletest-release-1.10.0"` with the custom `BUILD` file, we need to append `googletest` as a prefix (just like the repository's [`BUILD` file](https://github.com/google/googletest/blob/release-1.10.0/BUILD.bazel)). And so fixing the doc.