### PR TITLE
[6.4.0] Show test labels in summaries in display form

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifier.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifier.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.analysis.test.TestResult;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.ExecutionOptions.TestOutputFormat;
 import com.google.devtools.build.lib.exec.ExecutionOptions.TestSummaryFormat;
@@ -108,6 +109,7 @@ public class TerminalTestResultNotifier implements TestResultNotifier {
   private final TestLogPathFormatter testLogPathFormatter;
   private final OptionsParsingResult options;
   private final TestSummaryOptions summaryOptions;
+  private final RepositoryMapping mainRepoMapping;
 
   /**
    * @param printer The terminal to print to
@@ -115,11 +117,13 @@ public class TerminalTestResultNotifier implements TestResultNotifier {
   public TerminalTestResultNotifier(
       AnsiTerminalPrinter printer,
       TestLogPathFormatter testLogPathFormatter,
-      OptionsParsingResult options) {
+      OptionsParsingResult options,
+      RepositoryMapping mainRepoMapping) {
     this.printer = printer;
     this.testLogPathFormatter = testLogPathFormatter;
     this.options = options;
     this.summaryOptions = options.getOptions(TestSummaryOptions.class);
+    this.mainRepoMapping = mainRepoMapping;
   }
 
   /**
@@ -172,7 +176,8 @@ public class TerminalTestResultNotifier implements TestResultNotifier {
           testLogPathFormatter,
           summaryOptions.verboseSummary,
           showAllTestCases,
-          withConfig);
+          withConfig,
+          mainRepoMapping);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/TestSummaryPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TestSummaryPrinter.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.runtime;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.exec.ExecutionOptions.TestOutputFormat;
 import com.google.devtools.build.lib.exec.TestLogHelper;
 import com.google.devtools.build.lib.util.LoggingUtil;
@@ -119,7 +120,14 @@ public class TestSummaryPrinter {
       TestLogPathFormatter testLogPathFormatter,
       boolean verboseSummary,
       boolean showAllTestCases) {
-    print(summary, terminalPrinter, testLogPathFormatter, verboseSummary, showAllTestCases, false);
+    print(
+        summary,
+        terminalPrinter,
+        testLogPathFormatter,
+        verboseSummary,
+        showAllTestCases,
+        false,
+        RepositoryMapping.ALWAYS_FALLBACK);
   }
 
   /**
@@ -133,7 +141,8 @@ public class TestSummaryPrinter {
       TestLogPathFormatter testLogPathFormatter,
       boolean verboseSummary,
       boolean showAllTestCases,
-      boolean withConfigurationName) {
+      boolean withConfigurationName,
+      RepositoryMapping mainRepoMapping) {
     BlazeTestStatus status = summary.getStatus();
     // Skip output for tests that failed to build.
     if ((!verboseSummary && status == BlazeTestStatus.FAILED_TO_BUILD)
@@ -141,7 +150,7 @@ public class TestSummaryPrinter {
       return;
     }
     String message = getCacheMessage(summary) + statusString(summary);
-    String targetName = summary.getLabel().toString();
+    String targetName = summary.getLabel().getDisplayForm(mainRepoMapping);
     if (withConfigurationName) {
       targetName += " (" + summary.getConfiguration().getMnemonic() + ")";
     }

--- a/src/test/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifierTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.ExecutionOptions.TestSummaryFormat;
 import com.google.devtools.build.lib.runtime.TerminalTestResultNotifier.TestSummaryOptions;
@@ -293,7 +294,10 @@ public final class TerminalTestResultNotifierTest {
 
     TerminalTestResultNotifier terminalTestResultNotifier =
         new TerminalTestResultNotifier(
-            ansiTerminalPrinter, Path::getPathString, optionsParsingResult);
+            ansiTerminalPrinter,
+            Path::getPathString,
+            optionsParsingResult,
+            RepositoryMapping.ALWAYS_FALLBACK);
     terminalTestResultNotifier.notify(builder.build(), 0);
   }
 
@@ -318,7 +322,10 @@ public final class TerminalTestResultNotifierTest {
 
     TerminalTestResultNotifier terminalTestResultNotifier =
         new TerminalTestResultNotifier(
-            ansiTerminalPrinter, Path::getPathString, optionsParsingResult);
+            ansiTerminalPrinter,
+            Path::getPathString,
+            optionsParsingResult,
+            RepositoryMapping.ALWAYS_FALLBACK);
     terminalTestResultNotifier.notify(ImmutableSet.of(testSummary), 1);
   }
 


### PR DESCRIPTION
When running external tests with Bzlmod, this results in apparent labels instead of canonical ones.

Closes #19593.

Commit https://github.com/bazelbuild/bazel/commit/4c154346c76250d2c0287e202ee0dc3eb07a28c7

PiperOrigin-RevId: 568312090
Change-Id: Ice4c48d9ae7e313b33ad41fe954ce57d5a1e2b12