### PR TITLE
Add support for `use_repo_rule` in MODULE.bazel files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -25,6 +25,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/net/starlark/java/eval",
         "//third_party:auto_value",
@@ -192,6 +193,7 @@ java_library(
         ":module_extension",
         ":module_extension_metadata",
         ":registry",
+        ":repo_rule_creator",
         ":resolution",
         "//src/main/java/com/google/devtools/build/docgen/annot",
         "//src/main/java/com/google/devtools/build/lib:runtime",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
@@ -35,6 +35,12 @@ public abstract class ModuleExtensionId {
               ModuleExtensionId::getIsolationKey,
               emptiesFirst(IsolationKey.LEXICOGRAPHIC_COMPARATOR));
 
+  /**
+   * The "magical" name of innate extensions, which are fabricated extensions that modules with
+   * usages of {@code use_repo_rule} have.
+   */
+  public static final String INNATE_EXTENSION_NAME = "_repo_rules";
+
   /** A unique identifier for a single isolated usage of a fixed module extension. */
   @AutoValue
   abstract static class IsolationKey {
@@ -73,6 +79,10 @@ public abstract class ModuleExtensionId {
   public static ModuleExtensionId create(
       Label bzlFileLabel, String extensionName, Optional<IsolationKey> isolationKey) {
     return new AutoValue_ModuleExtensionId(bzlFileLabel, extensionName, isolationKey);
+  }
+
+  public final boolean isInnate() {
+    return getExtensionName().equals(INNATE_EXTENSION_NAME);
   }
 
   public String asTargetString() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -24,9 +24,7 @@ import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.NonRootModuleFileValue;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
-import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
-import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.DotBazelFileSyntaxChecker;
@@ -43,7 +41,6 @@ import com.google.devtools.build.lib.skyframe.PrecomputedValue.Precomputed;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.SkyFunction;
@@ -350,15 +347,11 @@ public class ModuleFileFunction implements SkyFunction {
       if (env.getValue(FileValue.key(moduleFilePath)) == null) {
         return null;
       }
-      Label moduleFileLabel =
-          Label.createUnvalidated(
-              PackageIdentifier.create(key.getCanonicalRepoName(), PathFragment.EMPTY_FRAGMENT),
-              LabelConstants.MODULE_DOT_BAZEL_FILE_NAME.getBaseName());
       GetModuleFileResult result = new GetModuleFileResult();
       result.moduleFile =
           ModuleFile.create(
               readModuleFile(moduleFilePath.asPath()),
-              moduleFileLabel.getUnambiguousCanonicalForm());
+              key.moduleFileLabel().getUnambiguousCanonicalForm());
       return result;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
@@ -18,7 +18,11 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
+import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Comparator;
 import java.util.List;
 
@@ -61,6 +65,13 @@ public abstract class ModuleKey {
 
   /** The version of the module. Must be empty iff the module has a {@link NonRegistryOverride}. */
   public abstract Version getVersion();
+
+  /** Returns the label that points to the MODULE.bazel file of this module. */
+  public final Label moduleFileLabel() {
+    return Label.createUnvalidated(
+        PackageIdentifier.create(getCanonicalRepoName(), PathFragment.EMPTY_FRAGMENT),
+        LabelConstants.MODULE_DOT_BAZEL_FILE_NAME.getBaseName());
+  }
 
   @Override
   public final String toString() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -17,25 +17,34 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.base.StandardSystemProperty.OS_ARCH;
 import static com.google.common.collect.ImmutableBiMap.toImmutableBiMap;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
+import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule.RepositoryRuleFunction;
 import com.google.devtools.build.lib.cmdline.BazelModuleContext;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.packages.NoSuchPackageException;
+import com.google.devtools.build.lib.packages.Rule;
+import com.google.devtools.build.lib.packages.RuleFactory.InvalidRuleException;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -49,6 +58,7 @@ import com.google.devtools.build.lib.skyframe.BzlLoadFunction;
 import com.google.devtools.build.lib.skyframe.BzlLoadFunction.BzlLoadFailedException;
 import com.google.devtools.build.lib.skyframe.BzlLoadValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.RootedPath;
@@ -62,14 +72,16 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
-import net.starlark.java.eval.Module;
 import net.starlark.java.eval.Mutability;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkList;
@@ -128,52 +140,18 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     if (usagesValue == null) {
       return null;
     }
-    Location sampleUsageLocation =
-        usagesValue.getExtensionUsages().values().iterator().next().getLocation();
-    BzlLoadValue bzlLoadValue =
-        loadBzlFile(extensionId.getBzlFileLabel(), sampleUsageLocation, starlarkSemantics, env);
-    if (bzlLoadValue == null) {
+    RunnableExtension extension;
+    if (extensionId.isInnate()) {
+      extension = loadInnateRunnableExtension(extensionId, usagesValue, starlarkSemantics, env);
+    } else {
+      extension = loadRegularRunnableExtension(extensionId, usagesValue, starlarkSemantics, env);
+    }
+    if (extension == null) {
       return null;
     }
-    // TODO(wyv): Consider whether there's a need to check .bzl load visibility
-    // (BzlLoadFunction#checkLoadVisibilities).
-    // TODO(wyv): Consider refactoring to use PackageFunction#loadBzlModules, or the simpler API
-    // that may be created by b/237658764.
-
-    // Check that the .bzl file actually exports a module extension by our name.
-    Object exported = bzlLoadValue.getModule().getGlobal(extensionId.getExtensionName());
-    if (!(exported instanceof ModuleExtension)) {
-      ImmutableSet<String> exportedExtensions =
-          bzlLoadValue.getModule().getGlobals().entrySet().stream()
-              .filter(e -> e.getValue() instanceof ModuleExtension)
-              .map(Entry::getKey)
-              .collect(toImmutableSet());
-      throw new SingleExtensionEvalFunctionException(
-          ExternalDepsException.withMessage(
-              ExternalDeps.Code.BAD_MODULE,
-              "%s does not export a module extension called %s, yet its use is requested at %s%s",
-              extensionId.getBzlFileLabel(),
-              extensionId.getExtensionName(),
-              sampleUsageLocation,
-              SpellChecker.didYouMean(extensionId.getExtensionName(), exportedExtensions)),
-          Transience.PERSISTENT);
-    }
-
-    ModuleExtension extension = (ModuleExtension) exported;
-    ImmutableMap<String, String> extensionEnvVars =
-        RepositoryFunction.getEnvVarValues(env, ImmutableSet.copyOf(extension.getEnvVariables()));
-    if (extensionEnvVars == null) {
-      return null;
-    }
-    byte[] bzlTransitiveDigest =
-        BazelModuleContext.of(bzlLoadValue.getModule()).bzlTransitiveDigest();
 
     // Check the lockfile first for that module extension
     LockfileMode lockfileMode = BazelLockFileFunction.LOCKFILE_MODE.get(env);
-    ModuleExtensionEvalFactors extensionFactors =
-        ModuleExtensionEvalFactors.create(
-            extension.getOsDependent() ? OS.getCurrent().toString() : "",
-            extension.getArchDependent() ? OS_ARCH.value() : "");
     if (!lockfileMode.equals(LockfileMode.OFF)) {
       BazelLockFileValue lockfile = (BazelLockFileValue) env.getValue(BazelLockFileValue.KEY);
       if (lockfile == null) {
@@ -183,10 +161,10 @@ public class SingleExtensionEvalFunction implements SkyFunction {
           tryGettingValueFromLockFile(
               env,
               extensionId,
-              extensionFactors,
-              extensionEnvVars,
+              extension.getEvalFactors(),
+              extension.getEnvVars(),
               usagesValue,
-              bzlTransitiveDigest,
+              extension.getBzlTransitiveDigest(),
               lockfile);
       if (singleExtensionEvalValue != null) {
         return singleExtensionEvalValue;
@@ -195,8 +173,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
 
     // Run that extension!
     RunModuleExtensionResult moduleExtensionResult =
-        runModuleExtension(
-            extensionId, extension, usagesValue, bzlLoadValue.getModule(), starlarkSemantics, env);
+        extension.run(env, usagesValue, starlarkSemantics, extensionId);
     if (moduleExtensionResult == null) {
       return null;
     }
@@ -215,11 +192,11 @@ public class SingleExtensionEvalFunction implements SkyFunction {
           .post(
               ModuleExtensionResolutionEvent.create(
                   extensionId,
-                  extensionFactors,
+                  extension.getEvalFactors(),
                   LockFileModuleExtension.builder()
-                      .setBzlTransitiveDigest(bzlTransitiveDigest)
+                      .setBzlTransitiveDigest(extension.getBzlTransitiveDigest())
                       .setAccumulatedFileDigests(moduleExtensionResult.getAccumulatedFileDigests())
-                      .setEnvVariables(extensionEnvVars)
+                      .setEnvVariables(extension.getEnvVars())
                       .setGeneratedRepoSpecs(generatedRepoSpecs)
                       .setModuleExtensionMetadata(moduleExtensionMetadata)
                       .build()));
@@ -248,7 +225,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
         throw new SingleExtensionEvalFunctionException(
             ExternalDepsException.withMessage(
                 Code.BAD_MODULE,
-                "The module extension '%s''%s' does not exist in the lockfile",
+                "The module extension '%s'%s does not exist in the lockfile",
                 extensionId,
                 extensionFactors.isEmpty() ? "" : " for platform " + extensionFactors),
             Transience.PERSISTENT);
@@ -478,127 +455,455 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     return bzlLoadValue;
   }
 
+  /**
+   * An internal abstraction to support the two "flavors" of module extensions: the "regular", which
+   * is declared using {@code module_extension} in a .bzl file; and the "innate", which is
+   * fabricated from usages of {@code use_repo_rule} in MODULE.bazel files.
+   *
+   * <p>The general idiom is to "load" such a {@link RunnableExtension} object by getting as much
+   * information about it as needed to determine whether it can be reused from the lockfile (hence
+   * methods such as {@link #getEvalFactors()}, {@link #getBzlTransitiveDigest()}, {@link
+   * #getEnvVars()}). Then the {@link #run} method can be called if it's determined that we can't
+   * reuse the cached results in the lockfile and have to re-run this extension.
+   */
+  private interface RunnableExtension {
+    ModuleExtensionEvalFactors getEvalFactors();
+
+    byte[] getBzlTransitiveDigest();
+
+    ImmutableMap<String, String> getEnvVars();
+
+    @Nullable
+    RunModuleExtensionResult run(
+        Environment env,
+        SingleExtensionUsagesValue usagesValue,
+        StarlarkSemantics starlarkSemantics,
+        ModuleExtensionId extensionId)
+        throws InterruptedException, SingleExtensionEvalFunctionException;
+  }
+
+  /** Information about a single repo to be created by an innate extension. */
+  @AutoValue
+  abstract static class InnateExtensionRepo {
+    abstract Label bzlLabel();
+
+    abstract String ruleName();
+
+    abstract Tag tag();
+
+    abstract BzlLoadValue loadedBzl();
+
+    static Builder builder() {
+      return new AutoValue_SingleExtensionEvalFunction_InnateExtensionRepo.Builder();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+
+      abstract Builder setBzlLabel(Label value);
+
+      abstract Label bzlLabel();
+
+      abstract Builder setRuleName(String value);
+
+      abstract Builder setTag(Tag value);
+
+      abstract Tag tag();
+
+      abstract Builder setLoadedBzl(BzlLoadValue value);
+
+      abstract InnateExtensionRepo build();
+    }
+  }
+
   @Nullable
-  private RunModuleExtensionResult runModuleExtension(
+  private InnateRunnableExtension loadInnateRunnableExtension(
       ModuleExtensionId extensionId,
-      ModuleExtension extension,
       SingleExtensionUsagesValue usagesValue,
-      Module module,
       StarlarkSemantics starlarkSemantics,
       Environment env)
-      throws SingleExtensionEvalFunctionException, InterruptedException {
-    ModuleExtensionEvalStarlarkThreadContext threadContext =
-        new ModuleExtensionEvalStarlarkThreadContext(
-            usagesValue.getExtensionUniqueName() + "~",
-            extensionId.getBzlFileLabel().getPackageIdentifier(),
-            BazelModuleContext.of(module).repoMapping(),
-            directories,
-            env.getListener());
-    ModuleExtensionContext moduleContext;
-    Optional<ModuleExtensionMetadata> moduleExtensionMetadata;
-    try (Mutability mu =
-        Mutability.create("module extension", usagesValue.getExtensionUniqueName())) {
-      StarlarkThread thread = new StarlarkThread(mu, starlarkSemantics);
-      thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
-      moduleContext = createContext(env, usagesValue, starlarkSemantics, extensionId, extension);
-      threadContext.storeInThread(thread);
-      try (SilentCloseable c =
-          Profiler.instance()
-              .profile(
-                  ProfilerTask.BZLMOD,
-                  () -> "evaluate module extension: " + extensionId.asTargetString())) {
-        Object returnValue =
-            Starlark.fastcall(
-                thread, extension.getImplementation(), new Object[] {moduleContext}, new Object[0]);
-        if (returnValue != Starlark.NONE && !(returnValue instanceof ModuleExtensionMetadata)) {
+      throws InterruptedException, SingleExtensionEvalFunctionException {
+    // An innate extension should have a singular usage.
+    if (usagesValue.getExtensionUsages().size() > 1) {
+      throw new SingleExtensionEvalFunctionException(
+          ExternalDepsException.withMessage(
+              Code.BAD_MODULE,
+              "innate module extension %s is used by multiple modules: %s",
+              extensionId,
+              usagesValue.getExtensionUsages().keySet()),
+          Transience.PERSISTENT);
+    }
+    ModuleKey moduleKey = Iterables.getOnlyElement(usagesValue.getExtensionUsages().keySet());
+    Preconditions.checkState(moduleKey.moduleFileLabel().equals(extensionId.getBzlFileLabel()));
+    ImmutableList<Tag> tags =
+        Iterables.getOnlyElement(usagesValue.getExtensionUsages().values()).getTags();
+    RepositoryMapping repoMapping = usagesValue.getRepoMappings().get(moduleKey);
+
+    // Each tag of this usage defines a repo. The name of the tag is of the form
+    // "<bzl_file_label>%<rule_name>". Collect the .bzl files referenced and load them.
+    Label.RepoContext repoContext =
+        Label.RepoContext.of(moduleKey.getCanonicalRepoName(), repoMapping);
+    ArrayList<InnateExtensionRepo.Builder> repoBuilders = new ArrayList<>(tags.size());
+    for (Tag tag : tags) {
+      Iterator<String> parts = Splitter.on('%').split(tag.getTagName()).iterator();
+      InnateExtensionRepo.Builder repoBuilder = InnateExtensionRepo.builder().setTag(tag);
+      repoBuilders.add(repoBuilder);
+      try {
+        Label label = Label.parseWithRepoContext(parts.next(), repoContext);
+        BzlLoadFunction.checkValidLoadLabel(label, starlarkSemantics);
+        repoBuilder.setBzlLabel(label).setRuleName(parts.next());
+      } catch (LabelSyntaxException e) {
+        throw new SingleExtensionEvalFunctionException(
+            ExternalDepsException.withCauseAndMessage(
+                Code.BAD_MODULE, e, "bad repo rule .bzl file label at %s", tag.getLocation()),
+            Transience.PERSISTENT);
+      }
+    }
+    ImmutableSet<BzlLoadValue.Key> loadKeys =
+        repoBuilders.stream()
+            .map(r -> BzlLoadValue.keyForBzlmod(r.bzlLabel()))
+            .collect(toImmutableSet());
+    HashSet<Label> digestedLabels = new HashSet<>();
+    Fingerprint transitiveBzlDigest = new Fingerprint();
+    SkyframeLookupResult loadResult = env.getValuesAndExceptions(loadKeys);
+    for (InnateExtensionRepo.Builder repoBuilder : repoBuilders) {
+      BzlLoadValue loadedBzl;
+      try {
+        loadedBzl =
+            (BzlLoadValue)
+                loadResult.getOrThrow(
+                    BzlLoadValue.keyForBzlmod(repoBuilder.bzlLabel()),
+                    BzlLoadFailedException.class);
+      } catch (BzlLoadFailedException e) {
+        throw new SingleExtensionEvalFunctionException(
+            ExternalDepsException.withCauseAndMessage(
+                Code.BAD_MODULE,
+                e,
+                "error loading '%s' for repo rules, requested by %s",
+                repoBuilder.bzlLabel(),
+                repoBuilder.tag().getLocation()),
+            Transience.PERSISTENT);
+      }
+      if (loadedBzl == null) {
+        return null;
+      }
+      repoBuilder.setLoadedBzl(loadedBzl);
+      if (digestedLabels.add(repoBuilder.bzlLabel())) {
+        // Only digest this BzlLoadValue if we haven't seen this bzl label before.
+        transitiveBzlDigest.addBytes(loadedBzl.getTransitiveDigest());
+      }
+    }
+
+    return new InnateRunnableExtension(
+        moduleKey,
+        repoBuilders.stream().map(InnateExtensionRepo.Builder::build).collect(toImmutableList()),
+        transitiveBzlDigest.digestAndReset());
+  }
+
+  private final class InnateRunnableExtension implements RunnableExtension {
+    private final ModuleKey moduleKey;
+    private final ImmutableList<InnateExtensionRepo> repos;
+    private final byte[] transitiveBzlDigest;
+
+    InnateRunnableExtension(
+        ModuleKey moduleKey, ImmutableList<InnateExtensionRepo> repos, byte[] transitiveBzlDigest) {
+      this.moduleKey = moduleKey;
+      this.repos = repos;
+      this.transitiveBzlDigest = transitiveBzlDigest;
+    }
+
+    @Override
+    public ModuleExtensionEvalFactors getEvalFactors() {
+      return ModuleExtensionEvalFactors.create("", "");
+    }
+
+    @Override
+    public byte[] getBzlTransitiveDigest() {
+      return transitiveBzlDigest;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getEnvVars() {
+      return ImmutableMap.of();
+    }
+
+    @Override
+    public RunModuleExtensionResult run(
+        Environment env,
+        SingleExtensionUsagesValue usagesValue,
+        StarlarkSemantics starlarkSemantics,
+        ModuleExtensionId extensionId)
+        throws InterruptedException, SingleExtensionEvalFunctionException {
+      var generatedRepoSpecs = ImmutableMap.<String, RepoSpec>builderWithExpectedSize(repos.size());
+      // Instiantiate the repos one by one.
+      for (InnateExtensionRepo repo : repos) {
+        Object exported = repo.loadedBzl().getModule().getGlobal(repo.ruleName());
+        if (!(exported instanceof RepositoryRuleFunction)) {
+          ImmutableSet<String> exportedRepoRules =
+              repo.loadedBzl().getModule().getGlobals().entrySet().stream()
+                  .filter(e -> e.getValue() instanceof RepositoryRuleFunction)
+                  .map(Entry::getKey)
+                  .collect(toImmutableSet());
+          throw new SingleExtensionEvalFunctionException(
+              ExternalDepsException.withMessage(
+                  Code.BAD_MODULE,
+                  "%s does not export a repository_rule called %s, yet its use is requested at"
+                      + " %s%s",
+                  repo.bzlLabel(),
+                  repo.ruleName(),
+                  repo.tag().getLocation(),
+                  SpellChecker.didYouMean(repo.ruleName(), exportedRepoRules)),
+              Transience.PERSISTENT);
+        }
+        RepositoryRuleFunction repoRule = (RepositoryRuleFunction) exported;
+        Dict<String, Object> kwargs = repo.tag().getAttributeValues().attributes();
+        // This cast should be safe since it should have been verified at tag creation time.
+        String name = (String) kwargs.get("name");
+        String prefixedName = usagesValue.getExtensionUniqueName() + "~" + name;
+        Rule ruleInstance;
+        try {
+          ruleInstance =
+              BzlmodRepoRuleCreator.createRule(
+                  extensionId.getBzlFileLabel().getPackageIdentifier(),
+                  usagesValue.getRepoMappings().get(moduleKey),
+                  directories,
+                  starlarkSemantics,
+                  env.getListener(),
+                  "SingleExtensionEval.createInnateExtensionRepoRule",
+                  repoRule.getRuleClass(),
+                  Maps.transformEntries(kwargs, (k, v) -> k.equals("name") ? prefixedName : v));
+        } catch (InvalidRuleException | NoSuchPackageException | EvalException e) {
+          throw new SingleExtensionEvalFunctionException(
+              ExternalDepsException.withCauseAndMessage(
+                  Code.BAD_MODULE,
+                  e,
+                  "error creating repo %s requested at %s",
+                  name,
+                  repo.tag().getLocation()),
+              Transience.PERSISTENT);
+        }
+        RepoSpec repoSpec =
+            RepoSpec.builder()
+                .setBzlFile(
+                    repoRule
+                        .getRuleClass()
+                        .getRuleDefinitionEnvironmentLabel()
+                        .getUnambiguousCanonicalForm())
+                .setRuleClassName(repoRule.getRuleClass().getName())
+                .setAttributes(
+                    AttributeValues.create(
+                        Maps.transformEntries(kwargs, (k, v) -> ruleInstance.getAttr(k))))
+                .build();
+        generatedRepoSpecs.put(name, repoSpec);
+      }
+      return RunModuleExtensionResult.create(
+          ImmutableMap.of(), generatedRepoSpecs.buildOrThrow(), Optional.empty());
+    }
+  }
+
+  @Nullable
+  private RegularRunnableExtension loadRegularRunnableExtension(
+      ModuleExtensionId extensionId,
+      SingleExtensionUsagesValue usagesValue,
+      StarlarkSemantics starlarkSemantics,
+      Environment env)
+      throws InterruptedException, SingleExtensionEvalFunctionException {
+    Location sampleUsageLocation =
+        usagesValue.getExtensionUsages().values().iterator().next().getLocation();
+    BzlLoadValue bzlLoadValue =
+        loadBzlFile(extensionId.getBzlFileLabel(), sampleUsageLocation, starlarkSemantics, env);
+    if (bzlLoadValue == null) {
+      return null;
+    }
+    // TODO(wyv): Consider whether there's a need to check .bzl load visibility
+    // (BzlLoadFunction#checkLoadVisibilities).
+    // TODO(wyv): Consider refactoring to use PackageFunction#loadBzlModules, or the simpler API
+    // that may be created by b/237658764.
+
+    // Check that the .bzl file actually exports a module extension by our name.
+    Object exported = bzlLoadValue.getModule().getGlobal(extensionId.getExtensionName());
+    if (!(exported instanceof ModuleExtension)) {
+      ImmutableSet<String> exportedExtensions =
+          bzlLoadValue.getModule().getGlobals().entrySet().stream()
+              .filter(e -> e.getValue() instanceof ModuleExtension)
+              .map(Entry::getKey)
+              .collect(toImmutableSet());
+      throw new SingleExtensionEvalFunctionException(
+          ExternalDepsException.withMessage(
+              ExternalDeps.Code.BAD_MODULE,
+              "%s does not export a module extension called %s, yet its use is requested at %s%s",
+              extensionId.getBzlFileLabel(),
+              extensionId.getExtensionName(),
+              sampleUsageLocation,
+              SpellChecker.didYouMean(extensionId.getExtensionName(), exportedExtensions)),
+          Transience.PERSISTENT);
+    }
+
+    ModuleExtension extension = (ModuleExtension) exported;
+    ImmutableMap<String, String> envVars =
+        RepositoryFunction.getEnvVarValues(env, ImmutableSet.copyOf(extension.getEnvVariables()));
+    if (envVars == null) {
+      return null;
+    }
+    return new RegularRunnableExtension(
+        BazelModuleContext.of(bzlLoadValue.getModule()), extension, envVars);
+  }
+
+  private final class RegularRunnableExtension implements RunnableExtension {
+    private final BazelModuleContext bazelModuleContext;
+    private final ModuleExtension extension;
+    private final ImmutableMap<String, String> envVars;
+
+    RegularRunnableExtension(
+        BazelModuleContext bazelModuleContext,
+        ModuleExtension extension,
+        ImmutableMap<String, String> envVars) {
+      this.bazelModuleContext = bazelModuleContext;
+      this.extension = extension;
+      this.envVars = envVars;
+    }
+
+    @Override
+    public ModuleExtensionEvalFactors getEvalFactors() {
+      return ModuleExtensionEvalFactors.create(
+          extension.getOsDependent() ? OS.getCurrent().toString() : "",
+          extension.getArchDependent() ? OS_ARCH.value() : "");
+    }
+
+    @Override
+    public ImmutableMap<String, String> getEnvVars() {
+      return envVars;
+    }
+
+    @Override
+    public byte[] getBzlTransitiveDigest() {
+      return bazelModuleContext.bzlTransitiveDigest();
+    }
+
+    @Nullable
+    @Override
+    public RunModuleExtensionResult run(
+        Environment env,
+        SingleExtensionUsagesValue usagesValue,
+        StarlarkSemantics starlarkSemantics,
+        ModuleExtensionId extensionId)
+        throws InterruptedException, SingleExtensionEvalFunctionException {
+      ModuleExtensionEvalStarlarkThreadContext threadContext =
+          new ModuleExtensionEvalStarlarkThreadContext(
+              usagesValue.getExtensionUniqueName() + "~",
+              extensionId.getBzlFileLabel().getPackageIdentifier(),
+              bazelModuleContext.repoMapping(),
+              directories,
+              env.getListener());
+      ModuleExtensionContext moduleContext;
+      Optional<ModuleExtensionMetadata> moduleExtensionMetadata;
+      try (Mutability mu =
+          Mutability.create("module extension", usagesValue.getExtensionUniqueName())) {
+        StarlarkThread thread = new StarlarkThread(mu, starlarkSemantics);
+        thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
+        moduleContext = createContext(env, usagesValue, starlarkSemantics, extensionId);
+        threadContext.storeInThread(thread);
+        try (SilentCloseable c =
+            Profiler.instance()
+                .profile(
+                    ProfilerTask.BZLMOD,
+                    () -> "evaluate module extension: " + extensionId.asTargetString())) {
+          Object returnValue =
+              Starlark.fastcall(
+                  thread,
+                  extension.getImplementation(),
+                  new Object[] {moduleContext},
+                  new Object[0]);
+          if (returnValue != Starlark.NONE && !(returnValue instanceof ModuleExtensionMetadata)) {
+            throw new SingleExtensionEvalFunctionException(
+                ExternalDepsException.withMessage(
+                    ExternalDeps.Code.BAD_MODULE,
+                    "expected module extension %s in %s to return None or extension_metadata, got"
+                        + " %s",
+                    extensionId.getExtensionName(),
+                    extensionId.getBzlFileLabel(),
+                    Starlark.type(returnValue)),
+                Transience.PERSISTENT);
+          }
+          if (returnValue instanceof ModuleExtensionMetadata) {
+            moduleExtensionMetadata = Optional.of((ModuleExtensionMetadata) returnValue);
+          } else {
+            moduleExtensionMetadata = Optional.empty();
+          }
+        } catch (NeedsSkyframeRestartException e) {
+          // Clean up and restart by returning null.
+          try {
+            if (moduleContext.getWorkingDirectory().exists()) {
+              moduleContext.getWorkingDirectory().deleteTree();
+            }
+          } catch (IOException e1) {
+            ExternalDepsException externalDepsException =
+                ExternalDepsException.withCauseAndMessage(
+                    ExternalDeps.Code.UNRECOGNIZED,
+                    e1,
+                    "Failed to clean up module context directory");
+            throw new SingleExtensionEvalFunctionException(
+                externalDepsException, Transience.TRANSIENT);
+          }
+          return null;
+        } catch (EvalException e) {
+          env.getListener().handle(Event.error(e.getMessageWithStack()));
           throw new SingleExtensionEvalFunctionException(
               ExternalDepsException.withMessage(
                   ExternalDeps.Code.BAD_MODULE,
-                  "expected module extension %s in %s to return None or extension_metadata, got %s",
+                  "error evaluating module extension %s in %s",
                   extensionId.getExtensionName(),
-                  extensionId.getBzlFileLabel(),
-                  Starlark.type(returnValue)),
-              Transience.PERSISTENT);
+                  extensionId.getBzlFileLabel()),
+              Transience.TRANSIENT);
         }
-        if (returnValue instanceof ModuleExtensionMetadata) {
-          moduleExtensionMetadata = Optional.of((ModuleExtensionMetadata) returnValue);
-        } else {
-          moduleExtensionMetadata = Optional.empty();
-        }
-      } catch (NeedsSkyframeRestartException e) {
-        // Clean up and restart by returning null.
-        try {
-          if (moduleContext.getWorkingDirectory().exists()) {
-            moduleContext.getWorkingDirectory().deleteTree();
-          }
-        } catch (IOException e1) {
-          ExternalDepsException externalDepsException =
-              ExternalDepsException.withCauseAndMessage(
-                  ExternalDeps.Code.UNRECOGNIZED,
-                  e1,
-                  "Failed to clean up module context directory");
-          throw new SingleExtensionEvalFunctionException(
-              externalDepsException, Transience.TRANSIENT);
-        }
-        return null;
-      } catch (EvalException e) {
-        env.getListener().handle(Event.error(e.getMessageWithStack()));
-        throw new SingleExtensionEvalFunctionException(
-            ExternalDepsException.withMessage(
-                ExternalDeps.Code.BAD_MODULE,
-                "error evaluating module extension %s in %s",
-                extensionId.getExtensionName(),
-                extensionId.getBzlFileLabel()),
-            Transience.TRANSIENT);
       }
+      return RunModuleExtensionResult.create(
+          moduleContext.getAccumulatedFileDigests(),
+          threadContext.getGeneratedRepoSpecs(),
+          moduleExtensionMetadata);
     }
-    return RunModuleExtensionResult.create(
-        moduleContext.getAccumulatedFileDigests(),
-        threadContext.getGeneratedRepoSpecs(),
-        moduleExtensionMetadata);
-  }
 
-  private ModuleExtensionContext createContext(
-      Environment env,
-      SingleExtensionUsagesValue usagesValue,
-      StarlarkSemantics starlarkSemantics,
-      ModuleExtensionId extensionId,
-      ModuleExtension extension)
-      throws SingleExtensionEvalFunctionException {
-    Path workingDirectory =
-        directories
-            .getOutputBase()
-            .getRelative(LabelConstants.MODULE_EXTENSION_WORKING_DIRECTORY_LOCATION)
-            .getRelative(usagesValue.getExtensionUniqueName());
-    ArrayList<StarlarkBazelModule> modules = new ArrayList<>();
-    for (AbridgedModule abridgedModule : usagesValue.getAbridgedModules()) {
-      ModuleKey moduleKey = abridgedModule.getKey();
-      try {
-        modules.add(
-            StarlarkBazelModule.create(
-                abridgedModule,
-                extension,
-                usagesValue.getRepoMappings().get(moduleKey),
-                usagesValue.getExtensionUsages().get(moduleKey)));
-      } catch (ExternalDepsException e) {
-        throw new SingleExtensionEvalFunctionException(e, Transience.PERSISTENT);
+    private ModuleExtensionContext createContext(
+        Environment env,
+        SingleExtensionUsagesValue usagesValue,
+        StarlarkSemantics starlarkSemantics,
+        ModuleExtensionId extensionId)
+        throws SingleExtensionEvalFunctionException {
+      Path workingDirectory =
+          directories
+              .getOutputBase()
+              .getRelative(LabelConstants.MODULE_EXTENSION_WORKING_DIRECTORY_LOCATION)
+              .getRelative(usagesValue.getExtensionUniqueName());
+      ArrayList<StarlarkBazelModule> modules = new ArrayList<>();
+      for (AbridgedModule abridgedModule : usagesValue.getAbridgedModules()) {
+        ModuleKey moduleKey = abridgedModule.getKey();
+        try {
+          modules.add(
+              StarlarkBazelModule.create(
+                  abridgedModule,
+                  extension,
+                  usagesValue.getRepoMappings().get(moduleKey),
+                  usagesValue.getExtensionUsages().get(moduleKey)));
+        } catch (ExternalDepsException e) {
+          throw new SingleExtensionEvalFunctionException(e, Transience.PERSISTENT);
+        }
       }
+      ModuleExtensionUsage rootUsage = usagesValue.getExtensionUsages().get(ModuleKey.ROOT);
+      boolean rootModuleHasNonDevDependency =
+          rootUsage != null && rootUsage.getHasNonDevUseExtension();
+      return new ModuleExtensionContext(
+          workingDirectory,
+          env,
+          clientEnvironmentSupplier.get(),
+          downloadManager,
+          timeoutScaling,
+          processWrapper,
+          starlarkSemantics,
+          repositoryRemoteExecutor,
+          extensionId,
+          StarlarkList.immutableCopyOf(modules),
+          rootModuleHasNonDevDependency);
     }
-    ModuleExtensionUsage rootUsage = usagesValue.getExtensionUsages().get(ModuleKey.ROOT);
-    boolean rootModuleHasNonDevDependency =
-        rootUsage != null && rootUsage.getHasNonDevUseExtension();
-    return new ModuleExtensionContext(
-        workingDirectory,
-        env,
-        clientEnvironmentSupplier.get(),
-        downloadManager,
-        timeoutScaling,
-        processWrapper,
-        starlarkSemantics,
-        repositoryRemoteExecutor,
-        extensionId,
-        StarlarkList.immutableCopyOf(modules),
-        rootModuleHasNonDevDependency);
   }
 
   static final class SingleExtensionEvalFunctionException extends SkyFunctionException {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionUsagesValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionUsagesValue.java
@@ -33,7 +33,7 @@ public abstract class SingleExtensionUsagesValue implements SkyValue {
   public abstract ImmutableMap<ModuleKey, ModuleExtensionUsage> getExtensionUsages();
 
   /**
-   * The "unique name" (see {@link BazelDepGraphValue#getExtensionUniqueNames} of this extension.
+   * The "unique name" (see {@link BazelDepGraphValue#getExtensionUniqueNames}) of this extension.
    */
   public abstract String getExtensionUniqueName();
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2392,4 +2392,73 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "Conflict between 'foo' tag at /ws/MODULE.bazel:2:8 and 'foo' tag at /ws/MODULE.bazel:3:8",
         ImmutableSet.of(EventKind.DEBUG));
   }
+
+  @Test
+  public void innate() throws Exception {
+    scratch.file(
+        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "bazel_dep(name='foo',version='1.0')",
+        "data_repo = use_repo_rule('@foo//:repo.bzl', 'data_repo')",
+        "data_repo(name='data', data='get up at 6am.')");
+    scratch.file(workspaceRoot.getRelative("BUILD").getPathString());
+    scratch.file(
+        workspaceRoot.getRelative("data.bzl").getPathString(),
+        "load('@data//:data.bzl', self_data='data')",
+        "load('@foo//:data.bzl', foo_data='data')",
+        "data=self_data+' '+foo_data");
+
+    registry.addModule(
+        createModuleKey("foo", "1.0"),
+        "module(name='foo',version='1.0')",
+        "data_repo = use_repo_rule('//:repo.bzl', 'data_repo')",
+        "data_repo(name='data', data='go to bed at 11pm.')");
+    scratch.file(modulesRoot.getRelative("foo~1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~1.0/BUILD").getPathString());
+    scratch.file(
+        modulesRoot.getRelative("foo~1.0/data.bzl").getPathString(),
+        "load('@data//:data.bzl',repo_data='data')",
+        "data=repo_data");
+    scratch.file(
+        modulesRoot.getRelative("foo~1.0/repo.bzl").getPathString(),
+        "def _data_repo_impl(ctx):",
+        "  ctx.file('BUILD.bazel')",
+        "  ctx.file('data.bzl', 'data='+json.encode(ctx.attr.data))",
+        "data_repo = repository_rule(",
+        "  implementation=_data_repo_impl, attrs={'data':attr.string()})");
+
+    SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
+    EvaluationResult<BzlLoadValue> result =
+        evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
+    if (result.hasError()) {
+      throw result.getError().getException();
+    }
+    assertThat(result.get(skyKey).getModule().getGlobal("data"))
+        .isEqualTo("get up at 6am. go to bed at 11pm.");
+  }
+
+  @Test
+  public void innate_noSuchRepoRule() throws Exception {
+    scratch.file(
+        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "data_repo = use_repo_rule('//:repo.bzl', 'data_repo')",
+        "data_repo(name='data', data='get up at 6am.')");
+    scratch.file(workspaceRoot.getRelative("BUILD").getPathString());
+    scratch.file(
+        workspaceRoot.getRelative("data.bzl").getPathString(),
+        "load('@data//:data.bzl', self_data='data')",
+        "data=self_data");
+    scratch.file(
+        workspaceRoot.getRelative("repo.bzl").getPathString(), "data_repo = 3  # not a repo rule");
+
+    SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
+    reporter.removeHandler(failFastHandler);
+    EvaluationResult<BzlLoadValue> result =
+        evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertThat(result.getError().getException())
+        .hasMessageThat()
+        .contains(
+            "//:repo.bzl does not export a repository_rule called data_repo, yet its use is"
+                + " requested at /ws/MODULE.bazel");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -838,6 +838,84 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
   }
 
   @Test
+  public void testModuleExtensions_innate() throws Exception {
+    scratch.file(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "repo = use_repo_rule('//:repo.bzl','repo')",
+        "repo(name='repo_name', value='something')",
+        "http_archive = use_repo_rule('@bazel_tools//:http.bzl','http_archive')",
+        "http_archive(name='guava',url='guava.com')",
+        "http_archive(name='vuaga',url='vuaga.com',dev_dependency=True)");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of());
+
+    SkyKey skyKey = ModuleFileValue.KEY_FOR_ROOT_MODULE;
+    EvaluationResult<ModuleFileValue> result =
+        evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
+    if (result.hasError()) {
+      throw result.getError().getException();
+    }
+    ModuleFileValue moduleFileValue = result.get(skyKey);
+    assertThat(moduleFileValue.getModule())
+        .isEqualTo(
+            InterimModuleBuilder.create("", "")
+                .setKey(ModuleKey.ROOT)
+                .addExtensionUsage(
+                    ModuleExtensionUsage.builder()
+                        .setExtensionBzlFile("//:MODULE.bazel")
+                        .setExtensionName("_repo_rules")
+                        .setIsolationKey(Optional.empty())
+                        .setUsingModule(ModuleKey.ROOT)
+                        .setLocation(Location.fromFile("/workspace/MODULE.bazel"))
+                        .setImports(
+                            ImmutableBiMap.of(
+                                "repo_name", "repo_name", "guava", "guava", "vuaga", "vuaga"))
+                        .setDevImports(ImmutableSet.of("vuaga"))
+                        .setHasDevUseExtension(true)
+                        .setHasNonDevUseExtension(true)
+                        .addTag(
+                            Tag.builder()
+                                .setTagName("//:repo.bzl%repo")
+                                .setAttributeValues(
+                                    AttributeValues.create(
+                                        Dict.<String, Object>builder()
+                                            .put("name", "repo_name")
+                                            .put("value", "something")
+                                            .buildImmutable()))
+                                .setDevDependency(false)
+                                .setLocation(
+                                    Location.fromFileLineColumn("/workspace/MODULE.bazel", 2, 5))
+                                .build())
+                        .addTag(
+                            Tag.builder()
+                                .setTagName("@bazel_tools//:http.bzl%http_archive")
+                                .setAttributeValues(
+                                    AttributeValues.create(
+                                        Dict.<String, Object>builder()
+                                            .put("name", "guava")
+                                            .put("url", "guava.com")
+                                            .buildImmutable()))
+                                .setDevDependency(false)
+                                .setLocation(
+                                    Location.fromFileLineColumn("/workspace/MODULE.bazel", 4, 13))
+                                .build())
+                        .addTag(
+                            Tag.builder()
+                                .setTagName("@bazel_tools//:http.bzl%http_archive")
+                                .setAttributeValues(
+                                    AttributeValues.create(
+                                        Dict.<String, Object>builder()
+                                            .put("name", "vuaga")
+                                            .put("url", "vuaga.com")
+                                            .buildImmutable()))
+                                .setDevDependency(true)
+                                .setLocation(
+                                    Location.fromFileLineColumn("/workspace/MODULE.bazel", 5, 13))
+                                .build())
+                        .build())
+                .build());
+  }
+
+  @Test
   public void testModuleFileExecute_syntaxError() throws Exception {
     scratch.file(
         rootDirectory.getRelative("MODULE.bazel").getPathString(),


### PR DESCRIPTION
This CL introduces a new directive in the MDOULE.bazel file, `use_repo_rule`, which is a convenient way to declare repos that are only visible to the current module. See https://github.com/bazelbuild/bazel/issues/17141#issuecomment-1622343142 for example usage.

Under the hood, this is implemented as an "innate" module extension for each module that uses `use_repo_rule`. The ID of this extension is a fake one: with the bzl file label of `@@name~version//:MODULE.bazel` and name of `__innate`. Each tag of this extension corresponds to a repo. The name of the tag is the string `${repo_rule_bzl_label}%${repo_rule_name}`, and the attributes of the tag are the attributes of the repo.

Fixes https://github.com/bazelbuild/bazel/issues/17141.