### PR TITLE
Correct documentation about `--coverage_output_generator` and `--coverage_report_generator`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/CoverageConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/CoverageConfiguration.java
@@ -49,8 +49,7 @@ public class CoverageConfiguration extends Fragment implements CoverageConfigura
         },
         help =
             "Location of the binary that is used to postprocess raw coverage reports. This must "
-                + "currently be a filegroup that contains a single file, the binary. Defaults to "
-                + "'//tools/test:lcov_merger'.")
+                + "be a binary target. Defaults to '//tools/test:lcov_merger'.")
     public Label coverageOutputGenerator;
 
     @Option(
@@ -65,8 +64,7 @@ public class CoverageConfiguration extends Fragment implements CoverageConfigura
         },
         help =
             "Location of the binary that is used to generate coverage reports. This must "
-                + "currently be a filegroup that contains a single file, the binary. Defaults to "
-                + "'//tools/test:coverage_report_generator'.")
+                + "be a binary target. Defaults to '//tools/test:coverage_report_generator'.")
     public Label coverageReportGenerator;
   }
 


### PR DESCRIPTION
The documentation said that each of these must be a `filegroup` with a single binary file, but they actual accept any binary target. This avoids a misconception that they aren't able to take data dependencies (because `filegroup` ignores `data`) while they do (e.g. with an `sh_binary`).