### PR TITLE
Make sure the default Android SDK API is the first registered SDK

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryRule.java
@@ -46,7 +46,9 @@ public class AndroidSdkRepositoryRule implements RuleDefinition {
   }
 
   private static final ImmutableList<String> calculateToolchainsToRegister(Rule rule) {
-    return ImmutableList.of(String.format("@%s//:all", rule.getName()));
+    return ImmutableList.of(
+        String.format("@%s//:sdk-toolchain", rule.getName()), // Register the default SDK first.
+        String.format("@%s//:all", rule.getName()));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_empty_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_empty_template.txt
@@ -20,6 +20,12 @@ filegroup(
     srcs = [":error_message"],
 )
 
+toolchain(
+    name = "sdk-toolchain",
+    toolchain_type = "@bazel_tools//tools/android:sdk_toolchain_type",
+    toolchain = ":error_message",
+)
+
 filegroup(
     name = "d8_jar_import",
     srcs = [":error_message"],

--- a/tools/android/android_sdk_repository_template.bzl
+++ b/tools/android/android_sdk_repository_template.bzl
@@ -217,6 +217,11 @@ def create_android_sdk_rules(
         name = "sdk",
         actual = ":sdk-%d" % default_api_level,
     )
+    native.alias(
+        name = "sdk-toolchain",
+        actual = ":sdk-%d-toolchain" % default_api_level,
+    )
+
     java_binary(
         name = "apksigner",
         main_class = "com.android.apksigner.ApkSignerTool",


### PR DESCRIPTION
toolchain.

Otherwise the lowest API value is instead registered.