### PR TITLE
Remove non-executable mode and deploy jars from Bazel java_test

### DIFF
--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_wrapper.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_wrapper.bzl
@@ -22,6 +22,7 @@ load(":bazel/java/bazel_java_binary.bzl", _java_test = "java_test", java_bin_exe
 load(":bazel/java/bazel_java_binary_nonexec.bzl", java_bin_nonexec = "java_binary")
 load(":bazel/java/bazel_java_binary_deploy_jar.bzl", "deploy_jars", "deploy_jars_nonexec")
 load(":common/java/java_binary_wrapper.bzl", "register_java_binary_rules")
+load(":common/java/java_semantics.bzl", "semantics")
 
 def java_binary(**kwargs):
     register_java_binary_rules(
@@ -33,11 +34,12 @@ def java_binary(**kwargs):
     )
 
 def java_test(**kwargs):
-    register_java_binary_rules(
-        _java_test,
-        _java_test,
-        rule_deploy_jars = deploy_jars,
-        rule_deploy_jars_nonexec = deploy_jars_nonexec,
-        is_test_rule_class = True,
-        **kwargs
-    )
+    if "stamp" in kwargs and type(kwargs["stamp"]) == type(True):
+        kwargs["stamp"] = 1 if kwargs["stamp"] else 0
+    if "use_launcher" in kwargs and not kwargs["use_launcher"]:
+        kwargs["launcher"] = None
+    else:
+        # If launcher is not set or None, set it to config flag
+        if "launcher" not in kwargs or not kwargs["launcher"]:
+            kwargs["launcher"] = semantics.LAUNCHER_FLAG_LABEL
+    _java_test(**kwargs)

--- a/src/main/starlark/builtins_bzl/common/java/java_binary_wrapper.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary_wrapper.bzl
@@ -27,14 +27,12 @@ def register_java_binary_rules(
         rule_nonexec,
         rule_deploy_jars = None,
         rule_deploy_jars_nonexec = None,
-        is_test_rule_class = False,
         **kwargs):
     """Registers the correct java_binary rule and deploy jar rule
 
     Args:
         rule_exec: (Rule) The executable java_binary rule
         rule_nonexec: (Rule) The non-executable java_binary rule
-        is_test_rule_class: (bool) If this is a test rule
         **kwargs: Actual args to instantiate the rule
     """
 
@@ -60,8 +58,6 @@ def register_java_binary_rules(
         not kwargs.get("tags", []) or "nodeployjar" not in kwargs.get("tags", [])
     ):
         deploy_jar_args = _filtered_dict(kwargs, _DEPLOY_JAR_RULE_ATTRS)
-        if is_test_rule_class:
-            deploy_jar_args["testonly"] = True
 
         # Do not let the deploy jar be matched by wildcard target patterns.
         if "tags" not in deploy_jar_args or not deploy_jar_args["tags"]:


### PR DESCRIPTION
This makes java_test a simple rule with a macro wrapper, and thus extendable.

Stop producing deploy jars for tests in Bazel. That was a misfeature.

Stop producing non-executable deploy jars in Bazel java_test.

RELNOTES[INC]: java_test doesn't produce deploy jars anymore

PiperOrigin-RevId: 568507588
Change-Id: Id219736b71b36f37e0722d13055dd6ac0a796e74