### PR TITLE
Update AndroidInstrumentationTestTest to get prerequisites for the

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidInstrumentationTestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidInstrumentationTestTest.java
@@ -190,12 +190,24 @@ public abstract class AndroidInstrumentationTestTest extends AndroidBuildViewTes
                 .toList());
     assertThat(runfiles.stream().map(Artifact::toString).collect(toImmutableList()))
         .containsAtLeast(
-            getDeviceFixtureScript(getConfiguredTarget("//javatests/com/app:device_fixture"))
+            getDeviceFixtureScript(
+                    getDirectPrerequisite(
+                        androidInstrumentationTest.getConfiguredTarget(),
+                        "//javatests/com/app:device_fixture"))
                 .toString(),
-            getInstrumentationApk(getConfiguredTarget("//javatests/com/app:instrumentation_app"))
+            getInstrumentationApk(
+                    getDirectPrerequisite(
+                        androidInstrumentationTest.getConfiguredTarget(),
+                        "//javatests/com/app:instrumentation_app"))
                 .toString(),
-            getTargetApk(getConfiguredTarget("//javatests/com/app:instrumentation_app")).toString(),
-            getConfiguredTarget("//javatests/com/app/ait:foo.txt")
+            getTargetApk(
+                    getDirectPrerequisite(
+                        androidInstrumentationTest.getConfiguredTarget(),
+                        "//javatests/com/app:instrumentation_app"))
+                .toString(),
+            getDirectPrerequisite(
+                    androidInstrumentationTest.getConfiguredTarget(),
+                    "//javatests/com/app/ait:foo.txt")
                 .getProvider(FileProvider.class)
                 .getFilesToBuild()
                 .getSingleton()


### PR DESCRIPTION
correct configuration.