### PR TITLE
Remove stale extension entries from lockfile if module order changes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
@@ -66,6 +66,8 @@ public abstract class BazelDepGraphValue implements SkyValue {
    * usage occurs. For each extension identifier ID, extensionUsagesTable[ID][moduleKey] is the
    * ModuleExtensionUsage of ID in the module keyed by moduleKey.
    */
+  // Note: Equality of BazelDepGraphValue does not check for equality of the order of the rows of
+  // this table, but it is tracked implicitly via the order of the abridged modules.
   public abstract ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage>
       getExtensionUsagesTable();
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -206,14 +206,9 @@ public class BazelLockFileModule extends BlazeModule {
     // that irrelevant changes (e.g. locations or imports) don't cause the extension to be removed.
     // Note: Extension results can still be stale for other reasons, e.g. because their transitive
     // bzl hash changed, but such changes will be detected in SingleExtensionEvalFunction.
-    var currentTrimmedUsages =
-        Maps.transformValues(
-            moduleResolutionEvent.getExtensionUsagesById().row(extensionId),
-            ModuleExtensionUsage::trimForEvaluation);
-    var lockedTrimmedUsages =
-        Maps.transformValues(
-            oldExtensionUsages.row(extensionId), ModuleExtensionUsage::trimForEvaluation);
-    return currentTrimmedUsages.equals(lockedTrimmedUsages);
+    return ModuleExtensionUsage.trimForEvaluation(
+            moduleResolutionEvent.getExtensionUsagesById().row(extensionId))
+        .equals(ModuleExtensionUsage.trimForEvaluation(oldExtensionUsages.row(extensionId)));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -126,8 +126,8 @@ public abstract class BazelLockFileValue implements SkyValue, Postable {
       byte[] transitiveDigest,
       boolean filesChanged,
       ImmutableMap<String, String> envVariables,
-      ImmutableMap<ModuleKey, ModuleExtensionUsage> extensionUsages,
-      ImmutableMap<ModuleKey, ModuleExtensionUsage> lockedExtensionUsages) {
+      ImmutableList<Map.Entry<ModuleKey, ModuleExtensionUsage>> extensionUsages,
+      ImmutableList<Map.Entry<ModuleKey, ModuleExtensionUsage>> lockedExtensionUsages) {
 
     ImmutableList.Builder<String> extDiff = new ImmutableList.Builder<>();
     if (!Arrays.equals(transitiveDigest, lockedExtension.getBzlTransitiveDigest())) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionUsage.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionUsage.java
@@ -19,9 +19,13 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+
+import java.util.Map;
 import java.util.Optional;
 import net.starlark.java.syntax.Location;
 
@@ -91,10 +95,23 @@ public abstract class ModuleExtensionUsage {
   }
 
   /**
+   * Turns the given collection of usages for a particular extension into an object that can be
+   * compared for equality with another object obtained in this way and compares equal only if the
+   * two original collections of usages are equivalent for the purpose of evaluating the extension.
+   */
+  static ImmutableList<Map.Entry<ModuleKey, ModuleExtensionUsage>> trimForEvaluation(
+      ImmutableMap<ModuleKey, ModuleExtensionUsage> usages) {
+    // ImmutableMap#equals doesn't compare the order of entries, but it matters for the evaluation
+    // of the extension.
+    return ImmutableList.copyOf(
+        Maps.transformValues(usages, ModuleExtensionUsage::trimForEvaluation).entrySet());
+  }
+
+  /**
    * Returns a new usage with all information removed that does not influence the evaluation of the
    * extension.
    */
-  ModuleExtensionUsage trimForEvaluation() {
+  private ModuleExtensionUsage trimForEvaluation() {
     // We start with the full usage and selectively remove information that does not influence the
     // evaluation of the extension. Compared to explicitly copying over the parts that do, this
     // preserves correctness in case new fields are added without updating this code.

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -282,13 +282,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     boolean filesChanged = didFilesChange(env, lockedExtension.getAccumulatedFileDigests());
     // Check extension data in lockfile is still valid, disregarding usage information that is not
     // relevant for the evaluation of the extension.
-    var trimmedLockedUsages =
-        ImmutableMap.copyOf(
-            transformValues(lockedExtensionUsages, ModuleExtensionUsage::trimForEvaluation));
-    var trimmedUsages =
-        ImmutableMap.copyOf(
-            transformValues(
-                usagesValue.getExtensionUsages(), ModuleExtensionUsage::trimForEvaluation));
+    var trimmedLockedUsages = ModuleExtensionUsage.trimForEvaluation(lockedExtensionUsages);
+    var trimmedUsages = ModuleExtensionUsage.trimForEvaluation(usagesValue.getExtensionUsages());
     if (!filesChanged
         && Arrays.equals(bzlTransitiveDigest, lockedExtension.getBzlTransitiveDigest())
         && trimmedUsages.equals(trimmedLockedUsages)

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionUsagesValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionUsagesValue.java
@@ -30,6 +30,8 @@ import com.google.devtools.build.skyframe.SkyValue;
 @AutoValue
 public abstract class SingleExtensionUsagesValue implements SkyValue {
   /** All usages of this extension, by the key of the module where the usage occurs. */
+  // Note: Equality of SingleExtensionUsagesValue does not check for equality of the order of the
+  // entries of this map, but it is tracked implicitly via the order of the abridged modules.
   public abstract ImmutableMap<ModuleKey, ModuleExtensionUsage> getExtensionUsages();
 
   /**


### PR DESCRIPTION
Previously, extension entries in the lockfile were not removed when only the BFS order of modules using the extension changed. However, this change is visible in the module extension implementation function and must thus be considered when checking for staleness.