### PR TITLE
Update query docs with missing --output formats.

### DIFF
--- a/site/en/query/language.md
+++ b/site/en/query/language.md
@@ -1213,10 +1213,10 @@ Prints a
 [length-delimited](https://protobuf.dev/programming-guides/encoding/#size-limit)
 stream of
 [`Target`](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/build.proto)
-protocol buffers. This is useful to get around
+protocol buffers. This is useful to _(i)_ get around
 [size limitations](https://protobuf.dev/programming-guides/encoding/#size-limit)
 of protocol buffers when there are too many targets to fit in a single
-`QueryResult`.
+`QueryResult` or _(ii)_ to start processing while Bazel is still outputting.
 
 ### Print targets in text proto format {:#print-target-textproto}
 

--- a/site/en/query/language.md
+++ b/site/en/query/language.md
@@ -1193,6 +1193,52 @@ Like `label`, this output format prints the labels of
 each target in the resulting graph, in topological order, but it
 additionally precedes the label by the [_kind_](#kind) of the target.
 
+### Print targets in protocol buffer format {:#print-target-proto}
+
+```
+--output proto
+```
+
+Prints the query output as a
+[`QueryResult`](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/build.proto)
+protocol buffer.
+
+### Print targets in length-delimited protocol buffer format {:#print-target-length-delimited-proto}
+
+```
+--output streamed_proto
+```
+
+Prints a
+[length-delimited](https://protobuf.dev/programming-guides/encoding/#size-limit)
+stream of
+[`Target`](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/build.proto)
+protocol buffers. This is useful to get around
+[size limitations](https://protobuf.dev/programming-guides/encoding/#size-limit)
+of protocol buffers when there are too many targets to fit in a single
+`QueryResult`.
+
+### Print targets in text proto format {:#print-target-textproto}
+
+```
+--output textproto
+```
+
+Similar to `--output proto`, prints the
+[`QueryResult`](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/build.proto)
+protocol buffer but in
+[text format](https://protobuf.dev/reference/protobuf/textformat-spec/).
+
+### Print targets in ndjson format {:#print-target-streamed-jsonproto}
+
+```
+--output streamed_jsonproto
+```
+
+Similar to `--output streamed_proto`, prints a stream of
+[`Target`](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/build.proto)
+protocol buffers but in [ndjson](http://ndjson.org/) format.
+
 ### Print the label of each target, in rank order {:#print-target-label-rank-order}
 
 ```

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
@@ -41,7 +41,7 @@ public class QueryOptions extends CommonQueryOptions {
       help =
           "The format in which the query results should be printed. Allowed values for query are:"
               + " build, graph, streamed_jsonproto, label, label_kind, location, maxrank, minrank,"
-              + " package, proto, xml.")
+              + " package, proto, streamed_proto, textproto, xml.")
   public String outputFormat;
 
   @Option(


### PR DESCRIPTION
Add descriptions of --output formats (proto, streamed_proto, textproto, streamed_jsonproto) to the query docs (which were previously missing).

Fixes #19583.