### PR TITLE
[6.4.0] Use `Label` in `@bazel_tools//tools/jdk` macros

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -66,19 +66,19 @@ DEFAULT_JAVACOPTS = [
 # jdk.compiler module, and jvm_opts
 _BASE_TOOLCHAIN_CONFIGURATION = dict(
     forcibly_disable_header_compilation = False,
-    genclass = ["@remote_java_tools//:GenClass"],
-    header_compiler = ["@remote_java_tools//:TurbineDirect"],
-    header_compiler_direct = ["@remote_java_tools//:TurbineDirect"],
-    ijar = ["@bazel_tools//tools/jdk:ijar"],
-    javabuilder = ["@remote_java_tools//:JavaBuilder"],
+    genclass = [Label("@remote_java_tools//:GenClass")],
+    header_compiler = [Label("@remote_java_tools//:TurbineDirect")],
+    header_compiler_direct = [Label("@remote_java_tools//:TurbineDirect")],
+    ijar = [Label("//tools/jdk:ijar")],
+    javabuilder = [Label("@remote_java_tools//:JavaBuilder")],
     javac_supports_workers = True,
-    jacocorunner = "@remote_java_tools//:jacoco_coverage_runner_filegroup",
+    jacocorunner = Label("@remote_java_tools//:jacoco_coverage_runner_filegroup"),
     jvm_opts = BASE_JDK9_JVM_OPTS,
     misc = DEFAULT_JAVACOPTS,
-    singlejar = ["@bazel_tools//tools/jdk:singlejar"],
+    singlejar = [Label("//tools/jdk:singlejar")],
     # Code to enumerate target JVM boot classpath uses host JVM. Because
     # java_runtime-s are involved, its implementation is in @bazel_tools.
-    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
+    bootclasspath = [Label("//tools/jdk:platformclasspath")],
     source_version = "8",
     target_version = "8",
     reduced_classpath_incompatible_processors = [
@@ -95,7 +95,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
         # Turbine is not a worker and parallel GC is faster for short-lived programs.
         "-XX:+UseParallelGC",
     ],
-    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
+    java_runtime = Label("//tools/jdk:remote_jdk11"),
 )
 
 # The 'vanilla' toolchain is an unsupported alternative to the default.
@@ -112,7 +112,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
 # However it does allow using a wider range of `--host_javabase`s, including
 # versions newer than the current JDK.
 VANILLA_TOOLCHAIN_CONFIGURATION = dict(
-    javabuilder = ["@remote_java_tools//:VanillaJavaBuilder"],
+    javabuilder = [Label("@remote_java_tools//:VanillaJavaBuilder")],
     jvm_opts = [],
 )
 
@@ -130,9 +130,9 @@ PREBUILT_TOOLCHAIN_CONFIGURATION = dict(
         # Turbine is not a worker and parallel GC is faster for short-lived programs.
         "-XX:+UseParallelGC",
     ],
-    ijar = ["@bazel_tools//tools/jdk:ijar_prebuilt_binary"],
-    singlejar = ["@bazel_tools//tools/jdk:prebuilt_singlejar"],
-    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
+    ijar = [Label("//tools/jdk:ijar_prebuilt_binary")],
+    singlejar = [Label("//tools/jdk:prebuilt_singlejar")],
+    java_runtime = Label("//tools/jdk:remote_jdk11"),
 )
 
 # The new toolchain is using all the tools from sources.
@@ -145,9 +145,9 @@ NONPREBUILT_TOOLCHAIN_CONFIGURATION = dict(
         # Turbine is not a worker and parallel GC is faster for short-lived programs.
         "-XX:+UseParallelGC",
     ],
-    ijar = ["@remote_java_tools//:ijar_cc_binary"],
-    singlejar = ["@remote_java_tools//:singlejar_cc_bin"],
-    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
+    ijar = [Label("@remote_java_tools//:ijar_cc_binary")],
+    singlejar = [Label("@remote_java_tools//:singlejar_cc_bin")],
+    java_runtime = Label("//tools/jdk:remote_jdk11"),
 )
 
 def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION, toolchain_definition = True, **kwargs):
@@ -168,7 +168,7 @@ def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION
         )
         native.toolchain(
             name = name + "_definition",
-            toolchain_type = "@bazel_tools//tools/jdk:toolchain_type",
+            toolchain_type = Label("//tools/jdk:toolchain_type"),
             target_settings = [name + "_version_setting"],
             toolchain = name,
         )
@@ -183,8 +183,8 @@ def java_runtime_files(name, srcs):
     for src in srcs:
         native.genrule(
             name = "gen_%s" % src,
-            srcs = ["@bazel_tools//tools/jdk:current_java_runtime"],
-            toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+            srcs = [Label("//tools/jdk:current_java_runtime")],
+            toolchains = [Label("//tools/jdk:current_java_runtime")],
             cmd = "cp $(JAVABASE)/%s $@" % src,
             outs = [src],
         )

--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -92,7 +92,7 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
     native.toolchain(
         name = "runtime_toolchain_definition",
         target_settings = [":%s_settings_alias" % name],
-        toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
+        toolchain_type = Label("@bazel_tools//tools/jdk:runtime_toolchain_type"),
         toolchain = runtime_name,
     )
 


### PR DESCRIPTION
Fixes failures to resolve repos such as `@remote_java_tools`, which are resolved against the using repository instead of `@bazel_tools` without labels.

"Cherry-pick" of https://github.com/bazelbuild/rules_java/commit/784464a6aaa8e33cbf070b0df48e3a9686042a8a