### PR TITLE
Always pad day in `FORMATTED_DATE` volatile variable to two digits

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
@@ -86,7 +86,7 @@ public class BazelWorkspaceStatusModule extends BlazeModule {
     private final String hostname;
 
     private static final DateTimeFormatter TIME_FORMAT =
-        DateTimeFormatter.ofPattern("yyyy MMM d HH mm ss EEE");
+        DateTimeFormatter.ofPattern("yyyy MMM dd HH mm ss EEE");
 
     private static String format(long timestamp) {
       return Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC).format(TIME_FORMAT);


### PR DESCRIPTION
This caused failures of test_stable_and_volatile_status during the first third of a month and deviated from the formatting used for hours, minutes and seconds.