### PR TITLE
[6.4.0] Consider RCs equivalent to release for `bazel_compatibility`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelVersion.java
@@ -33,8 +33,8 @@ import javax.annotation.Nullable;
  *
  * <ul>
  *   <li>{RELEASE} is a sequence of decimal numbers separated by dots;
- *   <li>{SUFFIX} could be: {@code -pre.*}, {@code rc\d+}, or any other string (which compares equal
- *       to SUFFIX is absent)
+ *   <li>{SUFFIX} could be: {@code -pre.*}, or any other string (which compares equal to SUFFIX
+ *       being absent)
  * </ul>
  */
 @AutoValue
@@ -52,9 +52,9 @@ public abstract class BazelVersion {
   /** Returns the original version string. */
   public abstract String getOriginal();
 
-  /** Whether this is a prerelease or a release candidate */
-  boolean isPrereleaseOrCandidate() {
-    return getSuffix().startsWith("-pre") || getSuffix().startsWith("rc");
+  /** Whether this is a prerelease */
+  boolean isPrerelease() {
+    return getSuffix().startsWith("-pre");
   }
 
   /** Parses a version string into a {@link BazelVersion} object. */
@@ -86,7 +86,7 @@ public abstract class BazelVersion {
     int result =
         Objects.compare(
             getRelease(), compatSplit, lexicographical(Comparator.<Integer>naturalOrder()));
-    if (result == 0 && isPrereleaseOrCandidate()) {
+    if (result == 0 && isPrerelease()) {
       result = -1;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
@@ -216,12 +216,8 @@ public class BazelModuleResolutionFunction implements SkyFunction {
         if (!curVersion.satisfiesCompatibility(compatVersion)) {
           String message =
               String.format(
-                  "Bazel version %s is not compatible with module \"%s@%s\" (bazel_compatibility:"
-                      + " %s)",
-                  curVersion.getOriginal(),
-                  module.getName(),
-                  module.getVersion().getOriginal(),
-                  module.getBazelCompatibility());
+                  "Bazel version %s is not compatible with module \"%s\" (bazel_compatibility: %s)",
+                  curVersion.getOriginal(), module.getKey(), module.getBazelCompatibility());
 
           if (mode == BazelCompatibilityMode.WARNING) {
             eventHandler.handle(Event.warn(message));

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
@@ -162,7 +162,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
 
     assertThat(result.hasError()).isTrue();
     assertContainsEvent(
-        "Bazel version 5.1.4 is not compatible with module \"mod@1.0\" (bazel_compatibility:"
+        "Bazel version 5.1.4 is not compatible with module \"<root>\" (bazel_compatibility:"
             + " [>5.1.0, <5.1.4])");
   }
 
@@ -180,7 +180,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
 
     assertThat(result.hasError()).isFalse();
     assertContainsEvent(
-        "Bazel version 5.1.4 is not compatible with module \"mod@1.0\" (bazel_compatibility:"
+        "Bazel version 5.1.4 is not compatible with module \"<root>\" (bazel_compatibility:"
             + " [>5.1.0, <5.1.4])");
   }
 
@@ -198,7 +198,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
 
     assertThat(result.hasError()).isFalse();
     assertDoesNotContainEvent(
-        "Bazel version 5.1.4 is not compatible with module \"mod@1.0\" (bazel_compatibility:"
+        "Bazel version 5.1.4 is not compatible with module \"<root>\" (bazel_compatibility:"
             + " [>5.1.0, <5.1.4])");
   }
 
@@ -225,6 +225,36 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
     assertContainsEvent(
         "Bazel version 5.1.5rc444 is not compatible with module \"b@1.0\" (bazel_compatibility:"
             + " [<=5.1.4, -5.1.2])");
+  }
+
+  @Test
+  public void testRcIsCompatibleWithReleaseRequirement() throws Exception {
+    scratch.file(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='mod', version='1.0', bazel_compatibility=['>=6.4.0'])");
+
+    embedBazelVersion("6.4.0rc1");
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    assertThat(result.hasError()).isFalse();
+  }
+
+  @Test
+  public void testPrereleaseIsNotCompatibleWithReleaseRequirement() throws Exception {
+    scratch.file(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='mod', version='1.0', bazel_compatibility=['>=6.4.0'])");
+
+    embedBazelVersion("6.4.0-pre-1");
+    reporter.removeHandler(failFastHandler);
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    assertThat(result.hasError()).isTrue();
+    assertContainsEvent(
+        "Bazel version 6.4.0-pre-1 is not compatible with module \"<root>\" (bazel_compatibility:"
+            + " [>=6.4.0])");
   }
 
   private void embedBazelVersion(String version) {


### PR DESCRIPTION
We want `bazel_compatibiliy = [">=6.4.0"]` to match `6.4.0rc1` so that release candidates are indistinguishable from the actual release via Bazel version compatibility requirements. This allows more realistic testing of releases via RCs without having users to rely on hacks such as `bazel_compatibility = [">=6.3.9999"]`.

Along the way change the error message on incompatibility to include the standard module key identifier, which is `<root>` for the root module instead of `<name>@<version>`, both of which can be empty.

Closes #19678.

Commit https://github.com/bazelbuild/bazel/commit/21cd4efaa8c766ac9f1d930c7b10052d91a3958e

PiperOrigin-RevId: 569982709
Change-Id: I7dce89ac1c62c1539d71704f048dca65232c119c