### PR TITLE
[6.4.0] MODULE.bazel.lock file contains user specific paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -226,7 +226,8 @@ public class BazelRepositoryModule extends BlazeModule {
             directories,
             BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER);
     RegistryFactory registryFactory =
-        new RegistryFactoryImpl(downloadManager, clientEnvironmentSupplier);
+        new RegistryFactoryImpl(
+            directories.getWorkspace(), downloadManager, clientEnvironmentSupplier);
     singleExtensionEvalFunction =
         new SingleExtensionEvalFunction(directories, clientEnvironmentSupplier, downloadManager);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveRepoSpecBuilder.java
@@ -26,6 +26,9 @@ import net.starlark.java.eval.StarlarkInt;
  * an {@code http_archive} repo rule call.
  */
 public class ArchiveRepoSpecBuilder {
+
+  public static final String HTTP_ARCHIVE_PATH = "@bazel_tools//tools/build_defs/repo:http.bzl";
+
   private final ImmutableMap.Builder<String, Object> attrBuilder;
 
   public ArchiveRepoSpecBuilder() {
@@ -96,7 +99,7 @@ public class ArchiveRepoSpecBuilder {
 
   public RepoSpec build() {
     return RepoSpec.builder()
-        .setBzlFile("@bazel_tools//tools/build_defs/repo:http.bzl")
+        .setBzlFile(HTTP_ARCHIVE_PATH)
         .setRuleClassName("http_archive")
         .setAttributes(AttributeValues.create(attrBuilder.buildOrThrow()))
         .build();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -83,6 +83,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:caffeine",
         "//third_party:gson",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -48,14 +48,23 @@ import java.util.Optional;
  */
 // TODO(wyv): Insert "For details, see ..." when we have public documentation.
 public class IndexRegistry implements Registry {
+
+  /** The unresolved version of the url. Ex: has %workspace% placeholder */
+  private final String unresolvedUri;
+
   private final URI uri;
   private final DownloadManager downloadManager;
   private final Map<String, String> clientEnv;
   private final Gson gson;
   private volatile Optional<BazelRegistryJson> bazelRegistryJson;
 
-  public IndexRegistry(URI uri, DownloadManager downloadManager, Map<String, String> clientEnv) {
+  public IndexRegistry(
+      URI uri,
+      String unresolvedUri,
+      DownloadManager downloadManager,
+      Map<String, String> clientEnv) {
     this.uri = uri;
+    this.unresolvedUri = unresolvedUri;
     this.downloadManager = downloadManager;
     this.clientEnv = clientEnv;
     this.gson =
@@ -66,7 +75,7 @@ public class IndexRegistry implements Registry {
 
   @Override
   public String getUrl() {
-    return uri.toString();
+    return unresolvedUri;
   }
 
   private String constructUrl(String base, String... segments) {
@@ -97,7 +106,7 @@ public class IndexRegistry implements Registry {
       throws IOException, InterruptedException {
     String url =
         constructUrl(
-            getUrl(), "modules", key.getName(), key.getVersion().toString(), "MODULE.bazel");
+            uri.toString(), "modules", key.getName(), key.getVersion().toString(), "MODULE.bazel");
     return grabFile(url, eventHandler).map(content -> ModuleFile.create(content, url));
   }
 
@@ -148,12 +157,16 @@ public class IndexRegistry implements Registry {
     Optional<SourceJson> sourceJson =
         grabJson(
             constructUrl(
-                getUrl(), "modules", key.getName(), key.getVersion().toString(), "source.json"),
+                uri.toString(),
+                "modules",
+                key.getName(),
+                key.getVersion().toString(),
+                "source.json"),
             SourceJson.class,
             eventHandler);
     if (sourceJson.isEmpty()) {
       throw new FileNotFoundException(
-          String.format("Module %s's source information not found in registry %s", key, getUrl()));
+          String.format("Module %s's source information not found in registry %s", key, uri));
     }
 
     String type = sourceJson.get().type;
@@ -176,7 +189,7 @@ public class IndexRegistry implements Registry {
         if (bazelRegistryJson == null) {
           bazelRegistryJson =
               grabJson(
-                  constructUrl(getUrl(), "bazel_registry.json"),
+                  constructUrl(uri.toString(), "bazel_registry.json"),
                   BazelRegistryJson.class,
                   eventHandler);
         }
@@ -258,7 +271,7 @@ public class IndexRegistry implements Registry {
       for (Map.Entry<String, String> entry : sourceJson.get().patches.entrySet()) {
         remotePatches.put(
             constructUrl(
-                getUrl(),
+                unresolvedUri,
                 "modules",
                 key.getName(),
                 key.getVersion().toString(),
@@ -285,7 +298,7 @@ public class IndexRegistry implements Registry {
       throws IOException, InterruptedException {
     Optional<MetadataJson> metadataJson =
         grabJson(
-            constructUrl(getUrl(), "modules", moduleName, "metadata.json"),
+            constructUrl(uri.toString(), "modules", moduleName, "metadata.json"),
             MetadataJson.class,
             eventHandler);
     if (metadataJson.isEmpty()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -389,9 +389,7 @@ public class ModuleFileFunction implements SkyFunction {
     List<Registry> registryObjects = new ArrayList<>(registries.size());
     for (String registryUrl : registries) {
       try {
-        registryObjects.add(
-            registryFactory.getRegistryWithUrl(
-                registryUrl.replace("%workspace%", workspaceRoot.getPathString())));
+        registryObjects.add(registryFactory.getRegistryWithUrl(registryUrl));
       } catch (URISyntaxException e) {
         throw errorf(Code.INVALID_REGISTRY_URL, e, "Invalid registry URL");
       }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.testutil.FoundationTestCase;
+import com.google.devtools.build.lib.vfs.Path;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -60,9 +61,11 @@ public class IndexRegistryTest extends FoundationTestCase {
 
   @Before
   public void setUp() throws Exception {
+    Path workspaceRoot = scratch.dir("/ws");
     downloadManager = new DownloadManager(new RepositoryCache(), new HttpDownloader());
     registryFactory =
-        new RegistryFactoryImpl(downloadManager, Suppliers.ofInstance(ImmutableMap.of()));
+        new RegistryFactoryImpl(
+            workspaceRoot, downloadManager, Suppliers.ofInstance(ImmutableMap.of()));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryTest.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
+import com.google.devtools.build.lib.testutil.FoundationTestCase;
+import com.google.devtools.build.lib.vfs.Path;
 import java.net.URISyntaxException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,12 +31,14 @@ import org.junit.runners.JUnit4;
 
 /** Tests for {@link RegistryFactory}. */
 @RunWith(JUnit4.class)
-public class RegistryFactoryTest {
+public class RegistryFactoryTest extends FoundationTestCase {
 
   @Test
   public void badSchemes() throws Exception {
+    Path workspaceRoot = scratch.dir("/ws");
     RegistryFactory registryFactory =
         new RegistryFactoryImpl(
+            workspaceRoot,
             new DownloadManager(new RepositoryCache(), new HttpDownloader()),
             Suppliers.ofInstance(ImmutableMap.of()));
     assertThrows(URISyntaxException.class, () -> registryFactory.getRegistryWithUrl("/home/www"));


### PR DESCRIPTION
- Store the unresolved registry string "containing %workspace% placeholder" in IndexRegistry and use it to create the remote_patches
- Later when creating the repo rule, resolve the registry path in remote_patches

fixes https://github.com/bazelbuild/bazel/issues/19621

Commit https://github.com/bazelbuild/bazel/commit/736a06813d698eea0a266d09f4664a11c1ff672e

PiperOrigin-RevId: 570028910
Change-Id: I984c6b7494fb377bcf8b3568fa98c740c8618c33