### PR TITLE
Implement `SelectorValue#{equals,hashCode}`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/SelectorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/SelectorValue.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.packages;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -89,5 +90,24 @@ public final class SelectorValue implements StarlarkValue, HasBinary {
   @Override
   public void repr(Printer printer) {
     printer.append("select(").repr(dictionary).append(")");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SelectorValue that = (SelectorValue) o;
+    return Objects.equal(dictionary, that.dictionary)
+        && Objects.equal(type, that.type)
+        && Objects.equal(noMatchError, that.noMatchError);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(dictionary, type, noMatchError);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/packages/SelectorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/SelectorValue.java
@@ -97,10 +97,9 @@ public final class SelectorValue implements StarlarkValue, HasBinary {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof SelectorValue that)) {
       return false;
     }
-    SelectorValue that = (SelectorValue) o;
     return Objects.equal(dictionary, that.dictionary)
         && Objects.equal(type, that.type)
         && Objects.equal(noMatchError, that.noMatchError);

--- a/src/test/java/com/google/devtools/build/lib/packages/BuildTypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/BuildTypeTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
@@ -639,6 +640,18 @@ public final class BuildTypeTest {
                     BuildType.LABEL)
                 .isUnconditional())
         .isTrue();
+  }
+
+  @Test
+  public void testSelectorValue_equals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new SelectorValue(ImmutableMap.of("a", 1, "b", 2), ""),
+            new SelectorValue(ImmutableMap.of("b", 2, "a", 1), ""))
+        .addEqualityGroup(new SelectorValue(ImmutableMap.of("a", 1, "b", 2), "Match failed"))
+        .addEqualityGroup(new SelectorValue(ImmutableMap.of("a", 1, "c", 2), ""))
+        .addEqualityGroup(new SelectorValue(ImmutableMap.of("a", 1, "b", 3), ""))
+        .testEquals();
   }
 
   private static <T> ImmutableList<Label> collectLabels(Type<T> type, T value) {


### PR DESCRIPTION
This allows Starlark unit tests to verify that certain `select` expressions are equal.