### PR TITLE
Starlark: reuse positional array in native calls where possible

### DIFF
--- a/src/main/java/net/starlark/java/eval/BuiltinFunction.java
+++ b/src/main/java/net/starlark/java/eval/BuiltinFunction.java
@@ -156,6 +156,13 @@ public final class BuiltinFunction implements StarlarkCallable {
 
     ParamDescriptor[] parameters = desc.getParameters();
 
+    // Fast case: reuse positional as Java argument vector
+    if (desc.getPositionalsCanBeJavaArgumentVector()
+        && positional.length == parameters.length
+        && named.length == 0) {
+      return positional;
+    }
+
     // Allocate argument vector.
     int n = parameters.length;
     if (desc.acceptsExtraArgs()) {

--- a/src/main/java/net/starlark/java/eval/BuiltinFunction.java
+++ b/src/main/java/net/starlark/java/eval/BuiltinFunction.java
@@ -157,6 +157,9 @@ public final class BuiltinFunction implements StarlarkCallable {
     ParamDescriptor[] parameters = desc.getParameters();
 
     // Fast case: reuse positional as Java argument vector
+    // StringModule methods, which are treated specially below, will never match this case since
+    // their "self" parameter is restricted to String and thus
+    // getPositionalsCanBeJavaArgumentVector() is false.
     if (desc.getPositionalsCanBeJavaArgumentVector()
         && positional.length == parameters.length
         && named.length == 0) {

--- a/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
+++ b/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
@@ -22,7 +22,9 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -770,6 +772,29 @@ public final class MethodLibraryTest {
         .testIfErrorContains(
             "join() got named argument for positional-only parameter 'elements'",
             "','.join(elements=['foo', 'bar'])");
+  }
+
+  @StarlarkBuiltin(name = "named_only", doc = "")
+  static final class NamedOnly implements StarlarkValue {
+    @StarlarkMethod(
+        name = "foo",
+        documented = false,
+        parameters = {
+          @Param(name = "a"),
+          @Param(name = "b", named = true, defaultValue = "None", positional = false),
+        })
+    public Object foo(Object a, Object b) {
+      return a;
+    }
+  }
+
+  @Test
+  public void testNamedOnlyArgument() throws Exception {
+    ev.new Scenario()
+        .update("named_only", new NamedOnly())
+        .testIfErrorContains(
+            "foo() accepts no more than 1 positional argument but got 2",
+            "named_only.foo([1, 2, 3], int)");
   }
 
   @Test

--- a/src/test/java/net/starlark/java/eval/testdata/bench_call.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bench_call.star
@@ -1,0 +1,21 @@
+def bench_call_type(b):
+    for _ in range(b.n):
+        type(1)
+
+def bench_call_list_append(b):
+    for _ in range(b.n):
+        [].append("foo")
+
+def bench_call_dict_get(b):
+    d = {"foo": "bar"}
+    for _ in range(b.n):
+        d.get("baz")
+
+def bench_call_dict_get_none(b):
+    d = {"foo": "bar"}
+    for _ in range(b.n):
+        d.get("baz", None)
+
+def bench_call_bool(b):
+    for _ in range(b.n):
+        bool()


### PR DESCRIPTION
This is a resubmission of @stepancheg's #12782, which became stale, with this original description:

====

For certain calls like `type(x)` or `str(x)` or `l.append(x)` we can reuse `positional` array argument of `fastcall` to pass it to the `MethodDescriptor.call` and skip all runtime checks in `BuiltinFunction`.

This optimization cannot be applied if
* a function has extra positional or named arguments
* has arguments guarded by flag
* accepts extra `StarlarkThread` parameter
* has unfilled arguments with default values

So this optimation won't be used for calls `list(x)` or `bool()`.

For `type(1)` called in loop, the result is 15% speedup:

```
A: n=30 mean=5.705 std=0.387 se=0.071 min=5.131 med=5.827
B: n=30 mean=4.860 std=0.345 se=0.064 min=4.396 med=4.946
B/A: 0.852 0.820..0.884 (95% conf)
```

For `bool()` (no argument) called in loop, it results in 1% slowdown:

```
A: n=29 mean=9.045 std=0.603 se=0.113 min=8.096 med=9.400
B: n=29 mean=9.134 std=0.520 se=0.098 min=8.248 med=9.448
B/A: 1.010 0.976..1.045 (95% conf)
```

====

Beyond the original PR, this includes benchmarks, a test case addressing a review comment and small adaptions to the implementation to make it work with recent changes.

Benchmark results with JDK 21 and `--seconds 5`:

```
before:
File src/test/java/net/starlark/java/eval/testdata/bench_call.star:
benchmark                        ops     cpu/op    wall/op   steps/op   alloc/op
bench_call_bool             67108863      100ns      100ns          3        87B
bench_call_dict_get         33554431      159ns      158ns          5       143B
bench_call_dict_get_none    33554431      180ns      179ns          6       143B
bench_call_list_append      33554431      170ns      169ns          5       207B
bench_call_type             67108863      139ns      138ns          4       111B

after:
File src/test/java/net/starlark/java/eval/testdata/bench_call.star:
benchmark                        ops     cpu/op    wall/op   steps/op   alloc/op
bench_call_bool             67108863      100ns      100ns          3        87B
bench_call_dict_get         33554431      155ns      154ns          5       143B
bench_call_dict_get_none    33554431      174ns      174ns          6       143B
bench_call_list_append      67108863      141ns      141ns          5       183B
bench_call_type             67108863      115ns      114ns          4        87B
```