### PR TITLE
Wire up `PathMapper` in `SpawnInputsExpander`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/PathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathMapper.java
@@ -80,6 +80,16 @@ public interface PathMapper {
     return this == NOOP;
   }
 
+  /**
+   * Returns an opaque object whose equality class encodes the behavior of this mapper for use in
+   * in-memory cache keys.
+   *
+   * <p>The default implementation returns the {@link Class} of the mapper.
+   */
+  default Object cacheKey() {
+    return this.getClass();
+  }
+
   /** A {@link PathMapper} that doesn't change paths. */
   PathMapper NOOP = execPath -> execPath;
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/PathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathMapper.java
@@ -33,7 +33,15 @@ import javax.annotation.Nullable;
  * part (e.g. "k8-fastbuild") from exec paths to allow for cross-configuration cache hits.
  */
 public interface PathMapper {
-  /** Returns the exec path with the path mapping applied. */
+  /**
+   * Returns the exec path with the path mapping applied.
+   *
+   * <p>Path mappers may return paths with different roots for two paths that have the same root
+   * (e.g., they may map an artifact at {@code bazel-out/k8-fastbuild/bin/pkg/foo} to {@code
+   * bazel-out/<hash of the file>/bin/pkg/foo}). Paths of artifacts that should share the same
+   * parent directory, such as runfiles or tree artifact files, should thus be derived from the
+   * mapped path of their parent.
+   */
   PathFragment map(PathFragment execPath);
 
   /** Returns the exec path of the input with the path mapping applied. */
@@ -81,10 +89,11 @@ public interface PathMapper {
   }
 
   /**
-   * Returns an opaque object whose equality class encodes the behavior of this mapper for use in
-   * in-memory cache keys.
+   * Returns an opaque object whose equality class should encode all information that goes into the
+   * behavior of the {@link #map(PathFragment)} function of this path mapper. This is used as a key
+   * for in-memory caches.
    *
-   * <p>The default implementation returns the {@link Class} of the mapper.
+   * <p>The default implementation returns the {@link Class} of the path mapper.
    */
   default Object cacheKey() {
     return this.getClass();

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
@@ -176,11 +176,6 @@ public final class StrippingPathMapper {
         }
         return MapFn.DEFAULT;
       }
-
-      @Override
-      public Object cacheKey() {
-        return GUID;
-      }
     };
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
@@ -176,6 +176,11 @@ public final class StrippingPathMapper {
         }
         return MapFn.DEFAULT;
       }
+
+      @Override
+      public Object cacheKey() {
+        return GUID;
+      }
     };
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
@@ -147,6 +147,7 @@ public class SpawnInputExpander {
                     ? null
                     : artifactExpander.getArchivedTreeArtifact((SpecialArtifact) localArtifact);
             if (archivedTreeArtifact != null) {
+              // TODO(bazel-team): Add path mapping support for archived tree artifacts.
               addMapping(inputMap, location, localArtifact, baseDirectory);
             } else {
               List<ActionInput> expandedInputs =
@@ -170,6 +171,7 @@ public class SpawnInputExpander {
             } catch (MissingExpansionException e) {
               throw new IllegalStateException(e);
             }
+            // TODO(bazel-team): Add path mapping support for filesets.
             addFilesetManifest(location, localArtifact, filesetLinks, inputMap, baseDirectory);
           } else {
             if (strict) {
@@ -241,6 +243,7 @@ public class SpawnInputExpander {
           value == null
               ? VirtualActionInput.EMPTY_MARKER
               : ActionInputHelper.fromPath(execRoot.getRelative(value).asFragment());
+      // TODO(bazel-team): Add path mapping support for filesets.
       addMapping(inputMappings, mapping.getKey(), artifact, baseDirectory);
       }
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.FilesetManifest.RelativeSymlinkBeha
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.RunfilesSupplier;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -125,6 +126,7 @@ public class SpawnInputExpander {
       RunfilesSupplier runfilesSupplier,
       InputMetadataProvider actionFileCache,
       ArtifactExpander artifactExpander,
+      PathMapper pathMapper,
       PathFragment baseDirectory)
       throws IOException, ForbiddenActionInputException {
     Map<PathFragment, Map<PathFragment, Artifact>> rootsAndMappings =
@@ -155,7 +157,8 @@ public class SpawnInputExpander {
             for (ActionInput input : expandedInputs) {
               addMapping(
                   inputMap,
-                  location.getRelative(((TreeFileArtifact) input).getParentRelativePath()),
+                  mapForRunfiles(pathMapper, root, location).getRelative(
+                      ((TreeFileArtifact) input).getParentRelativePath()),
                   input,
                   baseDirectory);
               }
@@ -172,10 +175,12 @@ public class SpawnInputExpander {
             if (strict) {
               failIfDirectory(actionFileCache, localArtifact);
             }
-            addMapping(inputMap, location, localArtifact, baseDirectory);
+            addMapping(inputMap, mapForRunfiles(pathMapper, root, location), localArtifact,
+                baseDirectory);
           }
         } else {
-          addMapping(inputMap, location, VirtualActionInput.EMPTY_MARKER, baseDirectory);
+          addMapping(inputMap, mapForRunfiles(pathMapper, root, location),
+              VirtualActionInput.EMPTY_MARKER, baseDirectory);
         }
       }
     }
@@ -186,11 +191,12 @@ public class SpawnInputExpander {
       RunfilesSupplier runfilesSupplier,
       InputMetadataProvider actionFileCache,
       ArtifactExpander artifactExpander,
+      PathMapper pathMapper,
       PathFragment baseDirectory)
       throws IOException, ForbiddenActionInputException {
     Map<PathFragment, ActionInput> inputMap = new HashMap<>();
     addRunfilesToInputs(
-        inputMap, runfilesSupplier, actionFileCache, artifactExpander, baseDirectory);
+        inputMap, runfilesSupplier, actionFileCache, artifactExpander, pathMapper, baseDirectory);
     return inputMap;
   }
 
@@ -243,6 +249,7 @@ public class SpawnInputExpander {
       Map<PathFragment, ActionInput> inputMap,
       NestedSet<? extends ActionInput> inputFiles,
       ArtifactExpander artifactExpander,
+      PathMapper pathMapper,
       PathFragment baseDirectory) {
     // Actions that accept TreeArtifacts as inputs generally expect the directory corresponding
     // to the artifact to be created, even if it is empty. We explicitly keep empty TreeArtifacts
@@ -251,7 +258,14 @@ public class SpawnInputExpander {
         ActionInputHelper.expandArtifacts(
             inputFiles, artifactExpander, /* keepEmptyTreeArtifacts= */ true);
     for (ActionInput input : inputs) {
-      addMapping(inputMap, input.getExecPath(), input, baseDirectory);
+      if (input instanceof TreeFileArtifact) {
+        addMapping(inputMap,
+            pathMapper.map(((TreeFileArtifact) input).getParent().getExecPath())
+                .getRelative(((TreeFileArtifact) input).getParentRelativePath()), input,
+            baseDirectory);
+      } else {
+        addMapping(inputMap, pathMapper.map(input.getExecPath()), input, baseDirectory);
+      }
     }
   }
 
@@ -273,15 +287,33 @@ public class SpawnInputExpander {
       InputMetadataProvider actionInputFileCache)
       throws IOException, ForbiddenActionInputException {
     TreeMap<PathFragment, ActionInput> inputMap = new TreeMap<>();
-    addInputs(inputMap, spawn.getInputFiles(), artifactExpander, baseDirectory);
+    addInputs(inputMap, spawn.getInputFiles(), artifactExpander, spawn.getPathMapper(),
+        baseDirectory);
     addRunfilesToInputs(
         inputMap,
         spawn.getRunfilesSupplier(),
         actionInputFileCache,
         artifactExpander,
+        spawn.getPathMapper(),
         baseDirectory);
     addFilesetManifests(spawn.getFilesetMappings(), inputMap, baseDirectory);
     return inputMap;
+  }
+
+  private static PathFragment mapForRunfiles(
+      PathMapper pathMapper, PathFragment runfilesDir, PathFragment execPath) {
+    if (pathMapper.isNoop()) {
+      return execPath;
+    }
+    String runfilesDirName = runfilesDir.getBaseName();
+    Preconditions.checkArgument(runfilesDirName.endsWith(".runfiles"));
+    // Derive the path of the executable, apply the path mapping to it and then rederive the path
+    // of the runfiles dir.
+    PathFragment executable =
+        runfilesDir.replaceName(
+            runfilesDirName.substring(0, runfilesDirName.length() - ".runfiles".length()));
+    return pathMapper.map(executable).replaceName(runfilesDirName)
+        .getRelative(execPath.relativeTo(runfilesDir));
   }
 
   /** The interface for accessing part of the input hierarchy. */
@@ -326,19 +358,25 @@ public class SpawnInputExpander {
       InputMetadataProvider actionInputFileCache,
       InputVisitor visitor)
       throws IOException, ForbiddenActionInputException {
-    walkNestedSetInputs(baseDirectory, spawn.getInputFiles(), artifactExpander, visitor);
+    walkNestedSetInputs(baseDirectory, spawn.getInputFiles(), artifactExpander,
+        spawn.getPathMapper(), visitor);
 
     RunfilesSupplier runfilesSupplier = spawn.getRunfilesSupplier();
     visitor.visit(
         // Cache key for the sub-mapping containing the runfiles inputs for this spawn.
-        ImmutableList.of(runfilesSupplier, baseDirectory),
+        ImmutableList.of(runfilesSupplier, baseDirectory, spawn.getPathMapper().cacheKey()),
         new InputWalker() {
           @Override
           public SortedMap<PathFragment, ActionInput> getLeavesInputMapping()
               throws IOException, ForbiddenActionInputException {
             TreeMap<PathFragment, ActionInput> inputMap = new TreeMap<>();
             addRunfilesToInputs(
-                inputMap, runfilesSupplier, actionInputFileCache, artifactExpander, baseDirectory);
+                inputMap,
+                runfilesSupplier,
+                actionInputFileCache,
+                artifactExpander,
+                spawn.getPathMapper(),
+                baseDirectory);
             return inputMap;
           }
         });
@@ -348,7 +386,7 @@ public class SpawnInputExpander {
     // improved runtime.
     visitor.visit(
         // Cache key for the sub-mapping containing the fileset inputs for this spawn.
-        ImmutableList.of(filesetMappings, baseDirectory),
+        ImmutableList.of(filesetMappings, baseDirectory, spawn.getPathMapper().cacheKey()),
         new InputWalker() {
           @Override
           public SortedMap<PathFragment, ActionInput> getLeavesInputMapping()
@@ -365,11 +403,12 @@ public class SpawnInputExpander {
       PathFragment baseDirectory,
       NestedSet<? extends ActionInput> someInputFiles,
       ArtifactExpander artifactExpander,
+      PathMapper pathMapper,
       InputVisitor visitor)
       throws IOException, ForbiddenActionInputException {
     visitor.visit(
         // Cache key for the sub-mapping containing the files in this nested set.
-        ImmutableList.of(someInputFiles.toNode(), baseDirectory),
+        ImmutableList.of(someInputFiles.toNode(), baseDirectory, pathMapper.cacheKey()),
         new InputWalker() {
           @Override
           public SortedMap<PathFragment, ActionInput> getLeavesInputMapping() {
@@ -384,6 +423,7 @@ public class SpawnInputExpander {
                 inputMap,
                 NestedSetBuilder.wrap(someInputFiles.getOrder(), leaves),
                 artifactExpander,
+                pathMapper,
                 baseDirectory);
             return inputMap;
           }
@@ -394,11 +434,16 @@ public class SpawnInputExpander {
             for (ActionInput input : someInputFiles.getLeaves()) {
               if (isTreeArtifact(input)) {
                 walkTreeInputs(
-                    baseDirectory, (SpecialArtifact) input, artifactExpander, childVisitor);
+                    baseDirectory,
+                    (SpecialArtifact) input,
+                    artifactExpander,
+                    pathMapper,
+                    childVisitor);
               }
             }
             for (NestedSet<? extends ActionInput> subInputs : someInputFiles.getNonLeaves()) {
-              walkNestedSetInputs(baseDirectory, subInputs, artifactExpander, childVisitor);
+              walkNestedSetInputs(
+                  baseDirectory, subInputs, artifactExpander, pathMapper, childVisitor);
             }
           }
         });
@@ -409,11 +454,12 @@ public class SpawnInputExpander {
       PathFragment baseDirectory,
       SpecialArtifact tree,
       ArtifactExpander artifactExpander,
+      PathMapper pathMapper,
       InputVisitor visitor)
       throws IOException, ForbiddenActionInputException {
     visitor.visit(
         // Cache key for the sub-mapping containing the files in this tree artifact.
-        ImmutableList.of(tree, baseDirectory),
+        ImmutableList.of(tree, baseDirectory, pathMapper.cacheKey()),
         new InputWalker() {
           @Override
           public SortedMap<PathFragment, ActionInput> getLeavesInputMapping() {
@@ -422,6 +468,7 @@ public class SpawnInputExpander {
                 inputMap,
                 NestedSetBuilder.create(Order.STABLE_ORDER, tree),
                 artifactExpander,
+                pathMapper,
                 baseDirectory);
             return inputMap;
           }

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -61,7 +61,7 @@ public final class SpawnBuilder {
 
   private RunfilesSupplier runfilesSupplier = EmptyRunfilesSupplier.INSTANCE;
   private ResourceSet resourceSet = ResourceSet.ZERO;
-  private PathMapper pathMapper;
+  private PathMapper pathMapper = PathMapper.NOOP;
   private boolean builtForToolConfiguration;
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -67,6 +67,7 @@ import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.EmptyRunfilesSupplier;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -2081,12 +2082,17 @@ public class RemoteExecutionServiceTest {
     verify(service, times(6)).uncachedBuildMerkleTreeVisitor(any(), any(), any());
     assertThat(service.getMerkleTreeCache().asMap().keySet())
         .containsExactly(
-            ImmutableList.of(ImmutableMap.of(), PathFragment.EMPTY_FRAGMENT), // fileset mapping
-            ImmutableList.of(EmptyRunfilesSupplier.INSTANCE, PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(tree, PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(nodeRoot1.toNode(), PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(nodeFoo1.toNode(), PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(nodeBar.toNode(), PathFragment.EMPTY_FRAGMENT));
+            ImmutableList.of(ImmutableMap.of(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()), // fileset mapping
+            ImmutableList.of(EmptyRunfilesSupplier.INSTANCE, PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()),
+            ImmutableList.of(tree, PathFragment.EMPTY_FRAGMENT, PathMapper.NOOP.getClass()),
+            ImmutableList.of(nodeRoot1.toNode(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()),
+            ImmutableList.of(nodeFoo1.toNode(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()),
+            ImmutableList.of(nodeBar.toNode(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()));
 
     // act second time
     service.buildRemoteAction(spawn2, context2);
@@ -2095,14 +2101,21 @@ public class RemoteExecutionServiceTest {
     verify(service, times(6 + 2)).uncachedBuildMerkleTreeVisitor(any(), any(), any());
     assertThat(service.getMerkleTreeCache().asMap().keySet())
         .containsExactly(
-            ImmutableList.of(ImmutableMap.of(), PathFragment.EMPTY_FRAGMENT), // fileset mapping
-            ImmutableList.of(EmptyRunfilesSupplier.INSTANCE, PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(tree, PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(nodeRoot1.toNode(), PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(nodeRoot2.toNode(), PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(nodeFoo1.toNode(), PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(nodeFoo2.toNode(), PathFragment.EMPTY_FRAGMENT),
-            ImmutableList.of(nodeBar.toNode(), PathFragment.EMPTY_FRAGMENT));
+            ImmutableList.of(ImmutableMap.of(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()), // fileset mapping
+            ImmutableList.of(EmptyRunfilesSupplier.INSTANCE, PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()),
+            ImmutableList.of(tree, PathFragment.EMPTY_FRAGMENT, PathMapper.NOOP.getClass()),
+            ImmutableList.of(nodeRoot1.toNode(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()),
+            ImmutableList.of(nodeRoot2.toNode(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()),
+            ImmutableList.of(nodeFoo1.toNode(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()),
+            ImmutableList.of(nodeFoo2.toNode(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()),
+            ImmutableList.of(nodeBar.toNode(), PathFragment.EMPTY_FRAGMENT,
+                PathMapper.NOOP.getClass()));
   }
 
   @Test


### PR DESCRIPTION
`PathMapper`s rewrite paths in command lines to make them more cache friendly, which requires executor support to stage files at the rewritten paths. This commit wires up the `PathMapper` used by a given `Spawn` in `SpawnInputsExpander`, which takes care of this for inputs to `Spawn`s executed in a sandbox or remotely.

Constructs specific to Blaze, filesets and archived tree artifacts, are not covered by this change.

An end-to-end test will be added in #18155, but requires #19718, #19719, and #19721.

Work towards #6526