### PR TITLE
Wire up `PathMapper` in sandbox code

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
@@ -124,8 +124,7 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
         dirsToCreate,
         Iterables.concat(
             ImmutableSet.of(), inputs.getFiles().keySet(), inputs.getSymlinks().keySet()),
-        outputs.files(),
-        outputs.dirs());
+        outputs);
 
     // Allow subclasses to filter out inputs and dirs that don't need to be created.
     filterInputsAndDirsToCreate(inputsToCreate, dirsToCreate);

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.sandbox;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.devtools.build.lib.vfs.Dirent.Type.DIRECTORY;
 import static com.google.devtools.build.lib.vfs.Dirent.Type.SYMLINK;
 
@@ -28,6 +29,7 @@ import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -85,9 +87,10 @@ public final class SandboxHelpers {
    */
   public static void moveOutputs(SandboxOutputs outputs, Path sourceRoot, Path targetRoot)
       throws IOException {
-    for (PathFragment output : Iterables.concat(outputs.files(), outputs.dirs())) {
-      Path source = sourceRoot.getRelative(output);
-      Path target = targetRoot.getRelative(output);
+    for (Entry<PathFragment, PathFragment> output : Iterables.concat(outputs.files().entrySet(),
+        outputs.dirs().entrySet())) {
+      Path source = sourceRoot.getRelative(output.getValue());
+      Path target = targetRoot.getRelative(output.getKey());
       if (source.isFile() || source.isSymbolicLink()) {
         // Ensure the target directory exists in the target. The directories for the action outputs
         // have already been created, but the spawn outputs may be different from the overall action
@@ -221,8 +224,7 @@ public final class SandboxHelpers {
       Set<PathFragment> inputsToCreate,
       LinkedHashSet<PathFragment> dirsToCreate,
       Iterable<PathFragment> inputFiles,
-      ImmutableSet<PathFragment> outputFiles,
-      ImmutableSet<PathFragment> outputDirs) {
+      SandboxOutputs outputs) {
     // Add all worker files, input files, and the parent directories.
     for (PathFragment input : inputFiles) {
       inputsToCreate.add(input);
@@ -231,12 +233,12 @@ public final class SandboxHelpers {
 
     // And all parent directories of output files. Note that we don't add the files themselves --
     // any pre-existing files that have the same path as an output should get deleted.
-    for (PathFragment file : outputFiles) {
+    for (PathFragment file : outputs.files().values()) {
       dirsToCreate.add(file.getParentDirectory());
     }
 
     // Add all output directories.
-    dirsToCreate.addAll(outputDirs);
+    dirsToCreate.addAll(outputs.dirs().values());
 
     // Add some directories that should be writable, and thus exist.
     dirsToCreate.addAll(writableDirs);
@@ -544,19 +546,32 @@ public final class SandboxHelpers {
     return new SandboxInputs(inputFiles, virtualInputs, inputSymlinks, sandboxRootToSourceRoot);
   }
 
-  /** The file and directory outputs of a sandboxed spawn. */
+  /**
+   * The file and directory outputs of a sandboxed spawn.
+   */
   @AutoValue
   public abstract static class SandboxOutputs {
-    public abstract ImmutableSet<PathFragment> files();
 
-    public abstract ImmutableSet<PathFragment> dirs();
+    /** A map from output file exec paths to paths in the sandbox. **/
+    public abstract ImmutableMap<PathFragment, PathFragment> files();
+
+    /** A map from output directory exec paths to paths in the sandbox. **/
+    public abstract ImmutableMap<PathFragment, PathFragment> dirs();
 
     private static final SandboxOutputs EMPTY_OUTPUTS =
-        SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of());
+        SandboxOutputs.create(ImmutableMap.of(), ImmutableMap.of());
+
+    public static SandboxOutputs create(
+        ImmutableMap<PathFragment, PathFragment> files,
+        ImmutableMap<PathFragment, PathFragment> dirs) {
+      return new AutoValue_SandboxHelpers_SandboxOutputs(files, dirs);
+    }
 
     public static SandboxOutputs create(
         ImmutableSet<PathFragment> files, ImmutableSet<PathFragment> dirs) {
-      return new AutoValue_SandboxHelpers_SandboxOutputs(files, dirs);
+      return new AutoValue_SandboxHelpers_SandboxOutputs(
+          files.stream().collect(toImmutableMap(f -> f, f -> f)),
+          dirs.stream().collect(toImmutableMap(d -> d, d -> d)));
     }
 
     public static SandboxOutputs getEmptyInstance() {
@@ -565,14 +580,14 @@ public final class SandboxHelpers {
   }
 
   public SandboxOutputs getOutputs(Spawn spawn) {
-    ImmutableSet.Builder<PathFragment> files = ImmutableSet.builder();
-    ImmutableSet.Builder<PathFragment> dirs = ImmutableSet.builder();
+    ImmutableMap.Builder<PathFragment, PathFragment> files = ImmutableMap.builder();
+    ImmutableMap.Builder<PathFragment, PathFragment> dirs = ImmutableMap.builder();
     for (ActionInput output : spawn.getOutputFiles()) {
-      PathFragment path = PathFragment.create(output.getExecPathString());
+      PathFragment mappedPath = spawn.getPathMapper().map(output.getExecPath());
       if (output instanceof Artifact && ((Artifact) output).isTreeArtifact()) {
-        dirs.add(path);
+        dirs.put(output.getExecPath(), mappedPath);
       } else {
-        files.add(path);
+        files.put(output.getExecPath(), mappedPath);
       }
     }
     return SandboxOutputs.create(files.build(), dirs.build());

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -552,10 +552,10 @@ public final class SandboxHelpers {
   @AutoValue
   public abstract static class SandboxOutputs {
 
-    /** A map from output file exec paths to paths in the sandbox. **/
+    /** A map from output file exec paths to paths in the sandbox. */
     public abstract ImmutableMap<PathFragment, PathFragment> files();
 
-    /** A map from output directory exec paths to paths in the sandbox. **/
+    /** A map from output directory exec paths to paths in the sandbox. */
     public abstract ImmutableMap<PathFragment, PathFragment> dirs();
 
     private static final SandboxOutputs EMPTY_OUTPUTS =

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxfsSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxfsSandboxedSpawn.java
@@ -136,10 +136,10 @@ class SandboxfsSandboxedSpawn implements SandboxedSpawn {
     this.arguments = arguments;
     this.environment = environment;
     this.inputs = inputs;
-    for (PathFragment path : outputs.files()) {
+    for (PathFragment path : outputs.files().values()) {
       checkArgument(!path.isAbsolute(), "outputs %s must be relative", path);
     }
-    for (PathFragment path : outputs.dirs()) {
+    for (PathFragment path : outputs.dirs().values()) {
       checkArgument(!path.isAbsolute(), "outputs %s must be relative", path);
     }
     this.outputs = outputs;
@@ -203,10 +203,10 @@ class SandboxfsSandboxedSpawn implements SandboxedSpawn {
     sandboxScratchDir.createDirectory();
 
     Set<PathFragment> dirsToCreate = new HashSet<>(writableDirs);
-    for (PathFragment output : outputs.files()) {
+    for (PathFragment output : outputs.files().values()) {
       dirsToCreate.add(output.getParentDirectory());
     }
-    dirsToCreate.addAll(outputs.dirs());
+    dirsToCreate.addAll(outputs.dirs().values());
     for (PathFragment dir : dirsToCreate) {
       sandboxScratchDir.getRelative(dir).createDirectoryAndParents();
     }

--- a/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorkerProxy.java
@@ -79,8 +79,7 @@ public class SandboxedWorkerProxy extends WorkerProxy {
         inputsToCreate,
         dirsToCreate,
         Iterables.concat(inputFiles.getFiles().keySet(), inputFiles.getSymlinks().keySet()),
-        outputs.files(),
-        outputs.dirs());
+        outputs);
     SandboxHelpers.cleanExisting(
         sandboxDir.getParentDirectory(), inputFiles, inputsToCreate, dirsToCreate, sandboxDir);
     // Finally, create anything that is still missing. This is non-strict only for historical

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
@@ -58,8 +58,7 @@ final class WorkerExecRoot {
         inputsToCreate,
         dirsToCreate,
         Iterables.concat(workerFiles, inputs.getFiles().keySet(), inputs.getSymlinks().keySet()),
-        outputs.files(),
-        outputs.dirs());
+        outputs);
 
     // Then do a full traversal of the parent directory of `workDir`. This will use what we computed
     // above, delete anything unnecessary and update `inputsToCreate`/`dirsToCreate` if something is

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -154,8 +154,7 @@ public class WorkerMultiplexer {
           inputsToCreate,
           dirsToCreate,
           workerFiles,
-          SandboxOutputs.getEmptyInstance().files(),
-          SandboxOutputs.getEmptyInstance().dirs());
+          SandboxOutputs.getEmptyInstance());
       SandboxHelpers.cleanExisting(
           workDir.getParentDirectory(), inputFiles, inputsToCreate, dirsToCreate, workDir);
       SandboxHelpers.createDirectories(dirsToCreate, workDir, /* strict=*/ false);

--- a/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -85,6 +85,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
         "//src/main/java/com/google/devtools/common/options",
         "//src/test/java/com/google/devtools/build/lib/actions/util",
+        "//src/test/java/com/google/devtools/build/lib/exec/util",
         "//src/test/java/com/google/devtools/build/lib/testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
         "//third_party:auto_value",

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -267,12 +267,8 @@ public class SandboxHelpersTest {
         dirsToCreate,
         Iterables.concat(
             ImmutableSet.of(), inputs.getFiles().keySet(), inputs.getSymlinks().keySet()),
-        SandboxOutputs.create(
-                ImmutableSet.of(PathFragment.create("out/dir/output.txt")), ImmutableSet.of())
-            .files(),
-        SandboxOutputs.create(
-                ImmutableSet.of(PathFragment.create("out/dir/output.txt")), ImmutableSet.of())
-            .dirs());
+        SandboxOutputs.create(ImmutableSet.of(PathFragment.create("out/dir/output.txt")),
+            ImmutableSet.of()));
 
     PathFragment inputDir1 = input1.getParentDirectory();
     PathFragment inputDir2 = input2.getParentDirectory();


### PR DESCRIPTION
`PathMapper`s rewrite paths in command lines to make them more cache friendly, which requires executor support to stage files at the rewritten paths. This commit wires up the `PathMapper` used by a given `Spawn` with sandbox outputs logic for sandboxed and worker sandboxed execution.

An end-to-end test will be added in #18155, but requires #19718, #19719, and #19721.

Work towards #6526