### PR TITLE
Wire up `PathMapper` in `RemoteExecutionService`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteAction.java
@@ -117,6 +117,10 @@ public class RemoteAction {
     return command;
   }
 
+  public RemotePathResolver getRemotePathResolver() {
+    return remotePathResolver;
+  }
+
   @Nullable
   public MerkleTree getMerkleTree() {
     return merkleTree;

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
@@ -15,16 +15,20 @@ package com.google.devtools.build.lib.remote.common;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.exec.SpawnInputExpander;
+import com.google.devtools.build.lib.exec.SpawnInputExpander.InputVisitor;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A {@link RemotePathResolver} is used to resolve input/output paths for remote execution from
@@ -224,5 +228,71 @@ public interface RemotePathResolver {
     public Path outputPathToLocalPath(ActionInput actionInput) {
       return ActionInputHelper.toInputPath(actionInput, execRoot);
     }
+  }
+
+  /**
+   * Adapts a given base {@link RemotePathResolver} to also apply a {@link PathMapper} to map (and
+   * inverse map) paths.
+   */
+  static RemotePathResolver createMapped(
+      RemotePathResolver base, Path execRoot, PathMapper pathMapper) {
+    if (pathMapper.isNoop()) {
+      return base;
+    }
+    return new RemotePathResolver() {
+      private final ConcurrentHashMap<PathFragment, PathFragment> inverse =
+          new ConcurrentHashMap<>();
+
+      @Override
+      public String getWorkingDirectory() {
+        return base.getWorkingDirectory();
+      }
+
+      @Override
+      public SortedMap<PathFragment, ActionInput> getInputMapping(
+          SpawnExecutionContext context, boolean willAccessRepeatedly)
+          throws IOException, ForbiddenActionInputException {
+        return base.getInputMapping(context, willAccessRepeatedly);
+      }
+
+      @Override
+      public void walkInputs(Spawn spawn, SpawnExecutionContext context, InputVisitor visitor)
+          throws IOException, ForbiddenActionInputException {
+        base.walkInputs(spawn, context, visitor);
+      }
+
+      @Override
+      public String localPathToOutputPath(Path path) {
+        return localPathToOutputPath(path.relativeTo(execRoot));
+      }
+
+      @Override
+      public String localPathToOutputPath(PathFragment execPath) {
+        return base.localPathToOutputPath(map(execPath));
+      }
+
+      @Override
+      public Path outputPathToLocalPath(String outputPath) {
+        return execRoot.getRelative(
+            inverseMap(base.outputPathToLocalPath(outputPath).relativeTo(execRoot)));
+      }
+
+      private PathFragment map(PathFragment path) {
+        PathFragment mappedPath = pathMapper.map(path);
+        PathFragment previousPath = inverse.put(mappedPath, path);
+        Preconditions.checkState(
+            previousPath == null || previousPath.equals(path),
+            "Two different paths %s and %s map to the same path %s",
+            previousPath,
+            path,
+            mappedPath);
+        return mappedPath;
+      }
+
+      private PathFragment inverseMap(PathFragment path) {
+        return Preconditions.checkNotNull(
+            inverse.get(path), "Failed to find original path for mapped path %s", path);
+      }
+    };
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -97,6 +97,7 @@ import com.google.devtools.build.lib.remote.common.RemotePathResolver.DefaultRem
 import com.google.devtools.build.lib.remote.common.RemotePathResolver.SiblingRepositoryLayoutResolver;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.FakeSpawnExecutionContext;
 import com.google.devtools.build.lib.remote.util.InMemoryCacheClient;
@@ -115,6 +116,8 @@ import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import com.google.protobuf.ByteString;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -126,14 +129,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 /** Tests for {@link RemoteExecutionService}. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public class RemoteExecutionServiceTest {
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
   @Rule public final RxNoGlobalErrorsRule rxNoGlobalErrorsRule = new RxNoGlobalErrorsRule();
@@ -1541,6 +1543,52 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
+  public void downloadOutputs_pathUnmapped() throws Exception {
+    // Test that the output of a remote action with path mapping applied is downloaded into the
+    // correct unmapped local path.
+    Digest d1 = cache.addContents(remoteActionExecutionContext, "content1");
+    Digest d2 = cache.addContents(remoteActionExecutionContext, "content2");
+    Artifact output1 = ActionsTestUtil.createArtifact(artifactRoot, "bin/config/dir/output1");
+    Artifact output2 = ActionsTestUtil.createArtifact(artifactRoot, "bin/other_dir/output2");
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            // The action result includes the mapped paths.
+            .addOutputFiles(
+                OutputFile.newBuilder().setPath("outputs/bin/dir/output1").setDigest(d1))
+            .addOutputFiles(
+                OutputFile.newBuilder().setPath("outputs/bin/other_dir/output2").setDigest(d2))
+            .build();
+    PathMapper pathMapper =
+        execPath -> PathFragment.create(execPath.getPathString().replaceAll("config/", ""));
+    Spawn spawn =
+        new SpawnBuilder("unused")
+            .withOutput(output1)
+            .withOutput(output2)
+            .setPathMapper(pathMapper)
+            .build();
+    RemoteActionResult result = RemoteActionResult.createFromCache(CachedActionResult.remote(r));
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    remoteOutputChecker =
+        new RemoteOutputChecker(
+            new JavaClock(), "build", RemoteOutputsMode.TOPLEVEL, ImmutableList.of());
+    remoteOutputChecker.addOutputToDownload(output1);
+    remoteOutputChecker.addOutputToDownload(output2);
+    RemoteExecutionService service = newRemoteExecutionService();
+    RemoteAction action = service.buildRemoteAction(spawn, context);
+
+    InMemoryOutput inMemoryOutput = service.downloadOutputs(action, result);
+
+    assertThat(inMemoryOutput).isNull();
+    RemoteActionFileSystem actionFs = context.getActionFileSystem();
+    assertThat(actionFs.getDigest(output1.getPath().asFragment())).isEqualTo(toBinaryDigest(d1));
+    assertThat(readContent(output1.getPath(), UTF_8)).isEqualTo("content1");
+    assertThat(actionFs.getDigest(output2.getPath().asFragment())).isEqualTo(toBinaryDigest(d2));
+    assertThat(readContent(output2.getPath(), UTF_8)).isEqualTo("content2");
+    assertThat(context.isLockOutputFilesCalled()).isTrue();
+  }
+
+  @Test
   public void uploadOutputs_uploadDirectory_works() throws Exception {
     // Test that uploading a directory works.
 
@@ -2264,6 +2312,61 @@ public class RemoteExecutionServiceTest {
                 .setScrubSalt(CacheSalt.ScrubSalt.newBuilder().setSalt("NaCl"))
                 .build()
                 .toByteString());
+  }
+
+  @Test
+  public void buildRemoteActionWithPathMapping(@TestParameter boolean remoteMerkleTreeCache)
+      throws Exception {
+    remoteOptions.remoteMerkleTreeCache = remoteMerkleTreeCache;
+
+    var mappedInput = ActionsTestUtil.createArtifact(artifactRoot, "bin/config/input1");
+    fakeFileCache.createScratchInput(mappedInput, "value1");
+    var unmappedInput = ActionsTestUtil.createArtifact(artifactRoot, "bin/input2");
+    fakeFileCache.createScratchInput(unmappedInput, "value2");
+    var outputDir =
+        ActionsTestUtil.createTreeArtifactWithGeneratingAction(
+            artifactRoot, "bin/config/output_dir");
+    PathMapper pathMapper =
+        execPath -> PathFragment.create(execPath.getPathString().replaceAll("config/", ""));
+    Spawn spawn =
+        new SpawnBuilder("unused")
+            .withInputs(mappedInput, unmappedInput)
+            .withOutputs("outputs/bin/config/dir/output1", "outputs/bin/other_dir/output2")
+            .withOutputs(outputDir)
+            .setPathMapper(pathMapper)
+            .build();
+    FakeSpawnExecutionContext context = newSpawnExecutionContext(spawn);
+    RemoteExecutionService service = newRemoteExecutionService(remoteOptions);
+
+    // Check that inputs and outputs of the remote action are mapped correctly.
+    var remoteAction = service.buildRemoteAction(spawn, context);
+    assertThat(remoteAction.getInputMap(false))
+        .containsExactly(
+            PathFragment.create("outputs/bin/input1"), mappedInput,
+            PathFragment.create("outputs/bin/input2"), unmappedInput);
+    assertThat(remoteAction.getCommand().getOutputFilesList())
+        .containsExactly("outputs/bin/dir/output1", "outputs/bin/other_dir/output2");
+    assertThat(remoteAction.getCommand().getOutputDirectoriesList())
+        .containsExactly("outputs/bin/output_dir");
+    assertThat(remoteAction.getCommand().getOutputPathsList())
+        .containsExactly(
+            "outputs/bin/dir/output1", "outputs/bin/other_dir/output2", "outputs/bin/output_dir");
+
+    // Check that the Merkle tree nodes are mapped correctly, including the output directory.
+    var merkleTree = remoteAction.getMerkleTree();
+    var outputsDirectory =
+        merkleTree.getDirectoryByDigest(merkleTree.getRootProto().getDirectories(0).getDigest());
+    assertThat(outputsDirectory.getDirectoriesCount()).isEqualTo(1);
+    var binDirectory =
+        merkleTree.getDirectoryByDigest(outputsDirectory.getDirectories(0).getDigest());
+    assertThat(
+            binDirectory.getFilesList().stream().map(FileNode::getName).collect(toImmutableList()))
+        .containsExactly("input1", "input2");
+    assertThat(
+            binDirectory.getDirectoriesList().stream()
+                .map(DirectoryNode::getName)
+                .collect(toImmutableList()))
+        .containsExactly("output_dir");
   }
 
   private Spawn newSpawnFromResult(RemoteActionResult result) {


### PR DESCRIPTION
`PathMapper`s rewrite paths in command lines to make them more cache friendly, which requires executor support to stage files at the rewritten paths. This commit wires up the `PathMapper` used by a given `Spawn` in `RemoteExecutionService`, which ensures that paths of inputs and outputs are correctly mapped before being sent off to the remote executor and mapped back to the correct local paths when downloading the results.

An end-to-end test will be added in #18155, but requires #19718, #19719, and #19721.

Work towards #6526