### PR TITLE
Flip --experimental_cc_implementation_deps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -1031,7 +1031,7 @@ public class CppOptions extends FragmentOptions {
 
   @Option(
       name = "experimental_cc_implementation_deps",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {
         OptionEffectTag.LOADING_AND_ANALYSIS,

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2061,7 +2061,7 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testImplementationDepsFailsWithoutFlag() throws Exception {
+  public void testImplementationDepsSucceedsWithoutFlag() throws Exception {
     if (!analysisMock.isThisBazel()) {
       return;
     }
@@ -2077,9 +2077,9 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
         "    srcs = ['implementation_dep.cc'],",
         "    hdrs = ['implementation_dep.h'],",
         ")");
-    reporter.removeHandler(failFastHandler);
-    getConfiguredTarget("//foo:lib");
-    assertContainsEvent("requires --experimental_cc_implementation_deps");
+    assertThat(getConfiguredTarget("//foo:lib")).isNotNull();
+    ;
+    assertDoesNotContainEvent("requires --experimental_cc_implementation_deps");
   }
 
   @Test


### PR DESCRIPTION
This allows distributing libraries as source that use
`implementation_deps`.
