### PR TITLE
[WIP] Add the missing Android SDK toolchain type data to android_local_test.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidLocalTestRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidLocalTestRule.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.BaseRuleClasses;
+import com.google.devtools.build.lib.analysis.BaseRuleClasses.TestBaseRule;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
@@ -94,13 +95,14 @@ public class BazelAndroidLocalTestRule implements RuleDefinition {
 
   @Override
   public Metadata getMetadata() {
-    return RuleDefinition.Metadata.builder()
+    return Metadata.builder()
         .name("android_local_test")
         .type(RuleClassType.TEST)
         .ancestors(
             AndroidLocalTestBaseRule.class,
             BaseJavaBinaryRule.class,
-            BaseRuleClasses.TestBaseRule.class)
+            TestBaseRule.class,
+            BazelSdkToolchainRule.class)
         .factoryClass(BazelAndroidLocalTest.class)
         .build();
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidLocalTestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidLocalTestTest.java
@@ -34,13 +34,13 @@ public abstract class BazelAndroidLocalTestTest extends AndroidLocalTestTest {
   // TODO(b/161709111): With platforms, all tests fail with
   // "no attribute `$android_sdk_toolchain_type`" on AspectAwareAttributeMapper.
   /** Use platform-based toolchain resolution. */
-  /*  @RunWith(JUnit4.class)
-  public static class WithPlatforms extends GoogleAndroidLocalTestTest {
+  @RunWith(JUnit4.class)
+  public static class WithPlatforms extends BazelAndroidLocalTestTest {
     @Override
     protected boolean platformBasedToolchains() {
       return true;
     }
-  } */
+  }
 
   @Before
   @Override


### PR DESCRIPTION
Enable Android Platforms tests for android_local_test.

Part of #16285.