### PR TITLE
Keep leading zero in formatted date

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
@@ -86,7 +86,7 @@ public class BazelWorkspaceStatusModule extends BlazeModule {
     private final String hostname;
 
     private static final DateTimeFormatter TIME_FORMAT =
-        DateTimeFormatter.ofPattern("yyyy MMM d HH mm ss EEE");
+        DateTimeFormatter.ofPattern("yyyy MMM dd HH mm ss EEE");
 
     private static String format(long timestamp) {
       return Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC).format(TIME_FORMAT);


### PR DESCRIPTION
Fixes CI breakage starting from Oct 1st:
https://buildkite.com/bazel/bazel-bazel/builds/25047

```
test_stable_and_volatile_status FAILED: Timestamp formatted date: 2023 Oct 01 20 03 45 Sun differs from workspace module provided formatted date: 2023 Oct 1 20 03 45 Sun.
```

RELNOTES: None
PiperOrigin-RevId: 569993913
Change-Id: If4aeb5db0f5547d4ac3168689bb8e011ca454578