### PR TITLE
[6.4.0] Fix output materialized as symlink when building without the bytes.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1255,6 +1255,11 @@ public class RemoteExecutionService {
     if (remoteOptions.remoteOutputsMode.downloadAllOutputs()) {
       return true;
     }
+    // An output materialized as a symlink might point to one of the other outputs.
+    if (!result.getOutputSymlinks().isEmpty() || !result.getOutputFileSymlinks().isEmpty()
+        || !result.getOutputDirectorySymlinks().isEmpty()) {
+      return true;
+    }
     // In case the action failed, download all outputs. It might be helpful for debugging and there
     // is no point in injecting output metadata of a failed action.
     if (result.getExitCode() != 0) {

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -11,8 +11,8 @@ filegroup(
     srcs = glob(["**"]) + [
         "//src/test/java/com/google/devtools/build/lib/remote/circuitbreaker:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/downloader:srcs",
-        "//src/test/java/com/google/devtools/build/lib/remote/http:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/grpc:srcs",
+        "//src/test/java/com/google/devtools/build/lib/remote/http:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/logging:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/merkletree:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/options:srcs",
@@ -169,6 +169,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/standalone",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/test/java/com/google/devtools/build/lib/remote/util:integration_test_utils",
         "//third_party:guava",
         "//third_party:junit4",


### PR DESCRIPTION
This appears to have worked in 6.2.x, got broken in 6.3.x, and is working again at head. The divergence is too great at this point, so it's not possible to cherry-pick the relevant changes from head. Instead, I've written a targeted fix that falls back to downloading every action output if at least one of the outputs was materialized as a symlink.

Fixes https://github.com/bazelbuild/bazel/issues/19143.