### PR TITLE
most likely a typo for the redirection (&>2 is >&2)

### DIFF
--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -558,7 +558,7 @@ genrule(
     name = "genrule_foo1",
     target_compatible_with = [":foo1"],
     outs = ["foo1.sh"],
-    cmd = "echo 'Should not be executed' &>2; exit 1",
+    cmd = "echo 'Should not be executed' >&2; exit 1",
 )
 
 sh_binary(


### PR DESCRIPTION
Otherwise it is creating a '2' file where it addresses the echo message.