### PR TITLE
[6.4.0] Make lockfile's `RepoSpec` attributes more readable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -37,7 +37,7 @@ import java.util.Map;
 @GenerateTypeAdapter
 public abstract class BazelLockFileValue implements SkyValue, Postable {
 
-  public static final int LOCK_FILE_VERSION = 2;
+  public static final int LOCK_FILE_VERSION = 3;
 
   @SerializationConstant public static final SkyKey KEY = () -> SkyFunctions.BAZEL_LOCK_FILE;
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValuesAdapterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValuesAdapterTest.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.bazel.bzlmod.AttributeValuesAdapter.STRING_ESCAPE_SEQUENCE;
 
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.testutil.FoundationTestCase;
@@ -43,7 +44,23 @@ public class AttributeValuesAdapterTest extends FoundationTestCase {
     Label l2 = Label.parseCanonicalUnchecked("@//foo:tar");
     dict.put("Integer", StarlarkInt.of(56));
     dict.put("Boolean", false);
-    dict.put("String", "Hello");
+    dict.put("String", "Hello String");
+    dict.put("StringWithAngleBrackets", "<Hello>");
+    dict.put(
+        "LabelLikeString",
+        StarlarkList.of(Mutability.IMMUTABLE, "@//foo:bar", ":baz", "@@//baz:quz"));
+    dict.put(
+        "StringsWithEscapeSequence",
+        StarlarkList.of(
+            Mutability.IMMUTABLE,
+            "@@//foo:bar" + STRING_ESCAPE_SEQUENCE,
+            STRING_ESCAPE_SEQUENCE + "@@//foo:bar",
+            STRING_ESCAPE_SEQUENCE + "@@//foo:bar" + STRING_ESCAPE_SEQUENCE,
+            STRING_ESCAPE_SEQUENCE
+                + STRING_ESCAPE_SEQUENCE
+                + "@@//foo:bar"
+                + STRING_ESCAPE_SEQUENCE
+                + STRING_ESCAPE_SEQUENCE));
     dict.put("Label", l1);
     dict.put(
         "ListOfInts", StarlarkList.of(Mutability.IMMUTABLE, StarlarkInt.of(1), StarlarkInt.of(2)));
@@ -66,6 +83,10 @@ public class AttributeValuesAdapterTest extends FoundationTestCase {
       attributeValues = attrAdapter.read(new JsonReader(stringReader));
     }
 
+    // Verify that the JSON string does not contain any escaped angle brackets.
+    assertThat(jsonString).doesNotContain("\\u003c");
+    // Verify that the String "Hello String" is preserved as is, without any additional escaping.
+    assertThat(jsonString).contains(":\"Hello String\"");
     assertThat((Map<?, ?>) attributeValues.attributes()).containsExactlyEntriesIn(builtDict);
   }
 }


### PR DESCRIPTION
String-valued tag and repo rule attributes in the `MODULE.bazel.lock` file have to be serialized in a way that distinguishes them from label-valued attributes. This commit uses the fact that the string representation of labels always starts with `@@` to escape strings only if they start with `@@` (or happen to be of the form of an escaped string). Since string-valued attributes rarely start with `@@`, in particular when specified by humans and not macros, this greatly reduces the need for escaping in the lockfile.

This commit raises the lockfile version to 3.

Along the way also disables HTML escaping for attributes as it isn't needed and results in less readable representations of certain characters.

Closes #19684.

PiperOrigin-RevId: 571037360
Change-Id: I04bb60d371cd09326780004122e729d78c99732a