### PR TITLE
[6.4.0] Handle synthetic method parameters entries that don't have names

### DIFF
--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -1212,7 +1212,8 @@ struct MethodParametersAttribute : Attribute {
     u1 parameters_count = get_u1(p);
     for (int ii = 0; ii < parameters_count; ++ii) {
       MethodParameter* parameter = new MethodParameter;
-      parameter->name_ = constant(get_u2be(p));
+      int name_id = get_u2be(p);
+      parameter->name_ = name_id == 0 ? NULL : constant(name_id);
       parameter->access_flags_ = get_u2be(p);
       attr->parameters_.push_back(parameter);
     }
@@ -1224,7 +1225,7 @@ struct MethodParametersAttribute : Attribute {
     u1 *payload_start = p - 4;
     put_u1(p, parameters_.size());
     for (MethodParameter* parameter : parameters_) {
-      put_u2be(p, parameter->name_->slot());
+      put_u2be(p, parameter->name_ == NULL ? 0 : parameter->name_->slot());
       put_u2be(p, parameter->access_flags_);
     }
     put_u4be(payload_start, p - 4 - payload_start);  // backpatch length


### PR DESCRIPTION
> If the value of the name_index item is zero, then this parameters element indicates a formal parameter with no name.

https://docs.oracle.com/javase/specs/jvms/se20/html/jvms-4.html#jvms-4.7.24

Cherry-pick of https://github.com/bazelbuild/bazel/commit/3954a18fa6b0e3d1a1005cc3409ebc95f6adf3af

PiperOrigin-RevId: 530621691
Change-Id: I7ff5bea7a5203f10c62fde42ff10818f8c94cd9e