### PR TITLE
Fix some unclosed tags in docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -60,7 +60,7 @@ import net.starlark.java.eval.StarlarkValue;
     category = DocCategory.BUILTIN,
     doc =
         "A BUILD target identifier."
-            + "<p>For every <code>Label<code> instance <code>l</code>, the string representation"
+            + "<p>For every <code>Label</code> instance <code>l</code>, the string representation"
             + " <code>str(l)</code> has the property that <code>Label(str(l)) == l</code>,"
             + " regardless of where the <code>Label()</code> call occurs.")
 @AutoCodec

--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetSerializationCache.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetSerializationCache.java
@@ -153,7 +153,7 @@ class NestedSetSerializationCache {
   /**
    * Ensures that a fingerprint ⟺ contents association is cached in both directions.
    *
-   * <p>If the given fingerprint and array are already <em>fully<em> cached, returns the existing
+   * <p>If the given fingerprint and array are already <em>fully</em> cached, returns the existing
    * {@link FingerprintComputationResult}. Otherwise returns {@code null}.
    *
    * <p>If the given fingerprint is only <em>partially</em> cached (meaning that {@link

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/XcodeConfigRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/XcodeConfigRule.java
@@ -54,7 +54,7 @@ public class XcodeConfigRule implements RuleDefinition {
                 .allowedFileTypes()
                 .nonconfigurable("this rule determines configuration"))
         /* <!-- #BLAZE_RULE(xcode_config).ATTRIBUTE(versions) -->
-        Accepted <code>xcode_version<code> targets that may be used.
+        Accepted <code>xcode_version</code> targets that may be used.
         If the value of the <code>xcode_version</code> build flag matches one of the aliases
         or version number of any of the given <code>xcode_version</code> targets, the matching
         target will be used. This may not be set if <code>remote_versions</code> or
@@ -66,7 +66,7 @@ public class XcodeConfigRule implements RuleDefinition {
                 .allowedFileTypes()
                 .nonconfigurable("this rule determines configuration"))
         /* <!-- #BLAZE_RULE(xcode_config).ATTRIBUTE(remote_versions) -->
-        The <code>xcode_version<code> targets that are available remotely.
+        The <code>xcode_version</code> targets that are available remotely.
         These are used along with <code>remote_versions</code> to select a mutually available
         version. This may not be set if <code>versions</code> is set.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
@@ -76,7 +76,7 @@ public class XcodeConfigRule implements RuleDefinition {
                 .allowedFileTypes()
                 .nonconfigurable("this rule determines configuration"))
         /* <!-- #BLAZE_RULE(xcode_config).ATTRIBUTE(local_versions) -->
-        The <code>xcode_version<code> targets that are available locally.
+        The <code>xcode_version</code> targets that are available locally.
         These are used along with <code>local_versions</code> to select a mutually available
         version. This may not be set if <code>versions</code> is set.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */

--- a/src/main/java/com/google/devtools/build/lib/runtime/Command.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/Command.java
@@ -124,7 +124,7 @@ public @interface Command {
    * Returns the type completion help for this command, that is the type arguments that this command
    * expects. It can be a whitespace separated list if the command take several arguments. The type
    * of each arguments can be <code>label</code>, <code>path</code>, <code>string</code>, ...
-   * It can also be a comma separated list of values, e.g. <code>{value1,value2}<code>. If a command
+   * It can also be a comma separated list of values, e.g. <code>{value1,value2}</code>. If a command
    * accept several argument types, they can be combined with |, e.g <code>label|path</code>.
    */
   String completion() default "";


### PR DESCRIPTION
Previously, most of [Label docs](https://bazel.build/rules/lib/builtins/Label) renders as code