### PR TITLE
docs: extend docs for general rule (alias)

### DIFF
--- a/site/en/query/language.md
+++ b/site/en/query/language.md
@@ -85,7 +85,7 @@ tokens:
   and the special characters `*/@.-_:$~[]` (asterisk, forward slash, at, period,
   hyphen, underscore, colon, dollar sign, tilde, left square brace, right square
   brace). However, unquoted words may not start with a hyphen `-` or asterisk `*`
-  even though relative [target names][(/concepts/labels#target-names) may start
+  even though relative [target names](/concepts/labels#target-names) may start
   with those characters.
 
   Unquoted words also may not include the characters plus sign `+` or equals

--- a/src/main/java/com/google/devtools/build/lib/rules/Alias.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/Alias.java
@@ -109,6 +109,13 @@ public class Alias implements RuleConfiguredTargetFactory {
 </p>
 
 <p>
+  Aliasing may be of help in large repositories where renaming a target would require making
+  changes to lots of files. You can also use alias rule to store a
+  <a href="${link select}">select</a> function call if you want to reuse that logic for
+  multiple targets.
+</p>
+
+<p>
   The alias rule has its own visibility declaration. In all other respects, it behaves
   like the rule it references (e.g. testonly <em>on the alias</em> is ignored; the testonly-ness
    of the referenced rule is used instead) with some minor exceptions:


### PR DESCRIPTION
Fixing typo in markdown URL and extending the docs on why the `alias` rule may be helpful. I felt it may not be clear how this rule can be useful (based on the description and code example provided).

I was thinking to provide an example of how a `select` could have been used in an alias (i.e. it's convenient to be able to refer to a target by a single label):

```
alias(
    name = "rustfmt_bin",
    actual = select({
        "@rules_rust//rust/platform:osx": "@rust_darwin_x86_64__x86_64-apple-darwin_tools//:rustfmt_bin",
        "@rules_rust//rust/platform:linux": "@rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//:rustfmt_bin",
    }),
)
```

but felt this may be too detailed for the reference docs.