### PR TITLE
Add unix shebang for executables generated by analysis tests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/AnalysisTestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/AnalysisTestActionBuilder.java
@@ -48,7 +48,7 @@ public class AnalysisTestActionBuilder {
     if (ruleContext.isExecutedOnWindows()) {
       sb.append("@echo off\n");
     } else {
-      sb.append("#!/bin/sh");
+      sb.append("#!/bin/sh\n");
     }
     for (String line : Splitter.on("\n").split(escapedMessage)) {
       sb.append("echo ").append(line).append("\n");

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/AnalysisTestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/AnalysisTestActionBuilder.java
@@ -47,6 +47,8 @@ public class AnalysisTestActionBuilder {
     StringBuilder sb = new StringBuilder();
     if (ruleContext.isExecutedOnWindows()) {
       sb.append("@echo off\n");
+    } else {
+      sb.append("#!/bin/sh")
     }
     for (String line : Splitter.on("\n").split(escapedMessage)) {
       sb.append("echo ").append(line).append("\n");

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/AnalysisTestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/AnalysisTestActionBuilder.java
@@ -48,7 +48,7 @@ public class AnalysisTestActionBuilder {
     if (ruleContext.isExecutedOnWindows()) {
       sb.append("@echo off\n");
     } else {
-      sb.append("#!/bin/sh")
+      sb.append("#!/bin/sh");
     }
     for (String line : Splitter.on("\n").split(escapedMessage)) {
       sb.append("echo ").append(line).append("\n");


### PR DESCRIPTION
See #18940 for more details. I've also wanted to update the tests, but it seems that this code doesn't have any test coverage (or I couldn't find it). To be fair, it is probably simple enough to not need it.