### PR TITLE
Use JDK Optional in the downloader.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
@@ -15,13 +15,13 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.auth.Credentials;
-import com.google.common.base.Optional;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -19,7 +19,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.auth.Credentials;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -42,6 +41,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
@@ -15,13 +15,13 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.auth.Credentials;
-import com.google.common.base.Optional;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /** Interface for implementing the download of a file. */
 public interface Downloader {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 import com.google.auth.Credentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -35,6 +34,7 @@ import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Class for establishing HTTP connections.
@@ -75,7 +75,7 @@ final class HttpConnectorMultiplexer {
   }
 
   public HttpStream connect(URL url, Optional<Checksum> checksum) throws IOException {
-    return connect(url, checksum, StaticCredentials.EMPTY, Optional.absent());
+    return connect(url, checksum, StaticCredentials.EMPTY, Optional.empty());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.auth.Credentials;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
@@ -38,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Semaphore;
 
 /**
@@ -152,7 +152,7 @@ public class HttpDownloader implements Downloader {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     SEMAPHORE.acquire();
     try (HttpStream payload =
-        multiplexer.connect(url, Optional.absent(), credentials, Optional.absent())) {
+        multiplexer.connect(url, Optional.empty(), credentials, Optional.empty())) {
       ByteStreams.copy(payload, out);
     } catch (SocketTimeoutException e) {
       // SocketTimeoutExceptions are InterruptedIOExceptions; however they do not signify

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -30,6 +29,7 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.zip.GZIPInputStream;
 import javax.annotation.WillCloseWhenClosed;
@@ -64,7 +64,7 @@ final class HttpStream extends FilterInputStream {
         Optional<Checksum> checksum,
         Reconnector reconnector)
         throws IOException {
-      return create(connection, originalUrl, checksum, reconnector, Optional.<String>absent());
+      return create(connection, originalUrl, checksum, reconnector, Optional.<String>empty());
     }
 
     @SuppressWarnings("resource")

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -18,7 +18,6 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Ascii;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -77,6 +76,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
@@ -310,7 +310,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
     }
 
     if (integrity.isEmpty()) {
-      return Optional.absent();
+      return Optional.empty();
     }
 
     try {
@@ -460,7 +460,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
     try {
       checksum = validateChecksum(sha256, integrity, urls);
     } catch (RepositoryFunctionException e) {
-      checksum = Optional.<Checksum>absent();
+      checksum = Optional.<Checksum>empty();
       checksumValidation = e;
     }
 
@@ -486,7 +486,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
               authHeaders,
               checksum,
               canonicalId,
-              Optional.<String>absent(),
+              Optional.<String>empty(),
               outputPath.getPath(),
               env.getListener(),
               envVariables,
@@ -647,7 +647,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
     try {
       checksum = validateChecksum(sha256, integrity, urls);
     } catch (RepositoryFunctionException e) {
-      checksum = Optional.absent();
+      checksum = Optional.empty();
       checksumValidation = e;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -111,12 +111,12 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
   public void download(
       List<URL> urls,
       Credentials credentials,
-      com.google.common.base.Optional<Checksum> checksum,
+      Optional<Checksum> checksum,
       String canonicalId,
       Path destination,
       ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
-      com.google.common.base.Optional<String> type)
+      Optional<String> type)
       throws IOException, InterruptedException {
     RequestMetadata metadata =
         TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "remote_downloader", null);
@@ -160,10 +160,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
 
   @VisibleForTesting
   static FetchBlobRequest newFetchBlobRequest(
-      String instanceName,
-      List<URL> urls,
-      com.google.common.base.Optional<Checksum> checksum,
-      String canonicalId) {
+      String instanceName, List<URL> urls, Optional<Checksum> checksum, String canonicalId) {
     FetchBlobRequest.Builder requestBuilder =
         FetchBlobRequest.newBuilder().setInstanceName(instanceName);
     for (URL url : urls) {
@@ -194,8 +191,8 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
         .withDeadlineAfter(options.remoteTimeout.getSeconds(), TimeUnit.SECONDS);
   }
 
-  private OutputStream newOutputStream(
-      Path destination, com.google.common.base.Optional<Checksum> checksum) throws IOException {
+  private OutputStream newOutputStream(Path destination, Optional<Checksum> checksum)
+      throws IOException {
     OutputStream out = destination.getOutputStream();
     if (checksum.isPresent()) {
       out = new HashOutputStream(out, checksum.get());

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
@@ -25,7 +25,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Optional;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.testutil.ManualClock;
@@ -37,6 +36,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.authandtls.StaticCredentials;
@@ -44,6 +43,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Rule;
@@ -98,7 +98,7 @@ public class HttpConnectorMultiplexerTest {
   public void ftpUrl_throwsIae() throws Exception {
     assertThrows(
         IllegalArgumentException.class,
-        () -> multiplexer.connect(new URL("ftp://lol.example"), Optional.absent()));
+        () -> multiplexer.connect(new URL("ftp://lol.example"), Optional.empty()));
   }
 
   @Test
@@ -111,7 +111,7 @@ public class HttpConnectorMultiplexerTest {
               public void run() {
                 Thread.currentThread().interrupt();
                 try {
-                  multiplexer.connect(new URL("http://lol.example"), Optional.absent());
+                  multiplexer.connect(new URL("http://lol.example"), Optional.empty());
                 } catch (InterruptedIOException ignored) {
                   return;
                 } catch (Exception ignored) {
@@ -144,7 +144,7 @@ public class HttpConnectorMultiplexerTest {
   public void failure() throws Exception {
     when(connector.connect(any(URL.class), any(Function.class))).thenThrow(new IOException("oops"));
     IOException e =
-        assertThrows(IOException.class, () -> multiplexer.connect(TEST_URL, Optional.absent()));
+        assertThrows(IOException.class, () -> multiplexer.connect(TEST_URL, Optional.empty()));
     assertThat(e).hasMessageThat().contains("oops");
     verify(connector).connect(any(URL.class), any(Function.class));
     verifyNoMoreInteractions(connector, streamFactory);

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
@@ -47,6 +46,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -117,9 +117,9 @@ public class HttpDownloaderTest {
               Collections.singletonList(
                   new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
               Collections.emptyMap(),
-              Optional.absent(),
+              Optional.empty(),
               "testCanonicalId",
-              Optional.absent(),
+              Optional.empty(),
               fs.getPath(workingDir.newFile().getAbsolutePath()),
               eventHandler,
               Collections.emptyMap(),
@@ -181,9 +181,9 @@ public class HttpDownloaderTest {
           downloadManager.download(
               urls,
               Collections.emptyMap(),
-              Optional.absent(),
+              Optional.empty(),
               "testCanonicalId",
-              Optional.absent(),
+              Optional.empty(),
               fs.getPath(workingDir.newFile().getAbsolutePath()),
               eventHandler,
               Collections.emptyMap(),
@@ -248,9 +248,9 @@ public class HttpDownloaderTest {
           downloadManager.download(
               urls,
               Collections.emptyMap(),
-              Optional.absent(),
+              Optional.empty(),
               "testCanonicalId",
-              Optional.absent(),
+              Optional.empty(),
               fs.getPath(workingDir.newFile().getAbsolutePath()),
               eventHandler,
               Collections.emptyMap(),
@@ -317,9 +317,9 @@ public class HttpDownloaderTest {
         downloadManager.download(
             urls,
             Collections.emptyMap(),
-            Optional.absent(),
+            Optional.empty(),
             "testCanonicalId",
-            Optional.absent(),
+            Optional.empty(),
             outputFile,
             eventHandler,
             Collections.emptyMap(),
@@ -372,12 +372,12 @@ public class HttpDownloaderTest {
           Collections.singletonList(
               new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
           StaticCredentials.EMPTY,
-          Optional.absent(),
+          Optional.empty(),
           "testCanonicalId",
           destination,
           eventHandler,
           Collections.emptyMap(),
-          Optional.absent());
+          Optional.empty());
 
       assertThat(new String(readFile(destination), UTF_8)).isEqualTo("hello");
     }
@@ -411,12 +411,12 @@ public class HttpDownloaderTest {
                   Collections.singletonList(
                       new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
                   StaticCredentials.EMPTY,
-                  Optional.absent(),
+                  Optional.empty(),
                   "testCanonicalId",
                   fs.getPath(workingDir.newFile().getAbsolutePath()),
                   eventHandler,
                   Collections.emptyMap(),
-                  Optional.absent()));
+                  Optional.empty()));
     }
   }
 
@@ -471,12 +471,12 @@ public class HttpDownloaderTest {
       httpDownloader.download(
           urls,
           StaticCredentials.EMPTY,
-          Optional.absent(),
+          Optional.empty(),
           "testCanonicalId",
           destination,
           eventHandler,
           Collections.emptyMap(),
-          Optional.absent());
+          Optional.empty());
 
       assertThat(new String(readFile(destination), UTF_8)).isEqualTo("content2");
     }
@@ -572,9 +572,9 @@ public class HttpDownloaderTest {
             downloadManager.download(
                 ImmutableList.of(new URL("http://localhost")),
                 ImmutableMap.of(),
-                Optional.absent(),
+                Optional.empty(),
                 "testCanonicalId",
-                Optional.absent(),
+                Optional.empty(),
                 fs.getPath(workingDir.newFile().getAbsolutePath()),
                 eventHandler,
                 ImmutableMap.of(),
@@ -611,9 +611,9 @@ public class HttpDownloaderTest {
         downloadManager.download(
             ImmutableList.of(new URL("http://localhost")),
             ImmutableMap.of(),
-            Optional.absent(),
+            Optional.empty(),
             "testCanonicalId",
-            Optional.absent(),
+            Optional.empty(),
             fs.getPath(workingDir.newFile().getAbsolutePath()),
             eventHandler,
             ImmutableMap.of(),

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Optional;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
@@ -40,6 +39,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPOutputStream;
@@ -106,7 +106,7 @@ public class HttpStreamTest {
   @Test
   public void noChecksum_readsOk() throws Exception {
     try (HttpStream stream =
-        streamFactory.create(connection, AURL, Optional.absent(), reconnector)) {
+        streamFactory.create(connection, AURL, Optional.empty(), reconnector)) {
       assertThat(toByteArray(stream)).isEqualTo(data);
     }
   }
@@ -263,7 +263,7 @@ public class HttpStreamTest {
     when(connection.getURL()).thenReturn(AURL);
     when(connection.getContentEncoding()).thenReturn("gzip");
     thrown.expect(ZipException.class);
-    streamFactory.create(connection, AURL, Optional.absent(), reconnector);
+    streamFactory.create(connection, AURL, Optional.empty(), reconnector);
   }
 
   @Test
@@ -272,7 +272,7 @@ public class HttpStreamTest {
     when(connection.getContentEncoding()).thenReturn("x-gzip");
     when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(gzipData(data)));
     try (HttpStream stream =
-        streamFactory.create(connection, AURL, Optional.absent(), reconnector)) {
+        streamFactory.create(connection, AURL, Optional.empty(), reconnector)) {
       assertThat(toByteArray(stream)).isEqualTo(data);
     }
   }
@@ -284,7 +284,7 @@ public class HttpStreamTest {
     when(connection.getContentEncoding()).thenReturn("gzip");
     when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(gzData));
     try (HttpStream stream =
-        streamFactory.create(connection, AURL, Optional.absent(), reconnector)) {
+        streamFactory.create(connection, AURL, Optional.empty(), reconnector)) {
       assertThat(toByteArray(stream)).isEqualTo(gzData);
     }
   }
@@ -298,7 +298,7 @@ public class HttpStreamTest {
               @Override
               public void run() {
                 try (HttpStream stream =
-                    streamFactory.create(connection, AURL, Optional.absent(), reconnector)) {
+                    streamFactory.create(connection, AURL, Optional.empty(), reconnector)) {
                   stream.read();
                   Thread.currentThread().interrupt();
                   stream.read();
@@ -331,8 +331,7 @@ public class HttpStreamTest {
     when(connection.getContentEncoding()).thenReturn("gzip");
     when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(gzData));
     try (HttpStream stream =
-        streamFactory.create(
-            connection, AURL, Optional.absent(), reconnector, Optional.of("tgz"))) {
+        streamFactory.create(connection, AURL, Optional.empty(), reconnector, Optional.of("tgz"))) {
       assertThat(toByteArray(stream)).isEqualTo(gzData);
     }
   }
@@ -348,7 +347,7 @@ public class HttpStreamTest {
     when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(gzData));
     try (HttpStream stream =
         streamFactory.create(
-            connection, AURL, Optional.absent(), reconnector, Optional.of("tar.gz"))) {
+            connection, AURL, Optional.empty(), reconnector, Optional.of("tar.gz"))) {
       assertThat(toByteArray(stream)).isEqualTo(gzData);
     }
   }
@@ -359,8 +358,7 @@ public class HttpStreamTest {
     when(connection.getContentEncoding()).thenReturn("gzip");
     when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(gzipData(data)));
     try (HttpStream stream =
-        streamFactory.create(
-            connection, AURL, Optional.absent(), reconnector, Optional.of("tar"))) {
+        streamFactory.create(connection, AURL, Optional.empty(), reconnector, Optional.of("tar"))) {
       assertThat(toByteArray(stream)).isEqualTo(data);
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -169,11 +169,6 @@ public class GrpcRemoteDownloaderTest {
       GrpcRemoteDownloader downloader, URL url, Optional<Checksum> checksum)
       throws IOException, InterruptedException {
     final List<URL> urls = ImmutableList.of(url);
-    com.google.common.base.Optional<Checksum> guavaChecksum =
-        com.google.common.base.Optional.<Checksum>absent();
-    if (checksum.isPresent()) {
-      guavaChecksum = com.google.common.base.Optional.<Checksum>of(checksum.get());
-    }
 
     final String canonicalId = "";
     final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
@@ -184,12 +179,12 @@ public class GrpcRemoteDownloaderTest {
     downloader.download(
         urls,
         StaticCredentials.EMPTY,
-        guavaChecksum,
+        checksum,
         canonicalId,
         destination,
         eventHandler,
         clientEnv,
-        com.google.common.base.Optional.<String>absent());
+        Optional.<String>empty());
 
     try (InputStream in = destination.getInputStream()) {
       return ByteStreams.toByteArray(in);
@@ -352,7 +347,7 @@ public class GrpcRemoteDownloaderTest {
                 new URL("http://example.com/a"),
                 new URL("http://example.com/b"),
                 new URL("file:/not/limited/to/http")),
-            com.google.common.base.Optional.<Checksum>of(
+            Optional.<Checksum>of(
                 Checksum.fromSubresourceIntegrity(
                     "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),
             "canonical ID");


### PR DESCRIPTION
In this age, there's no reason to prefer the Guava Optional over the JDK one. Switching everything to the JDK Optional simplifies some code like the GrpcRemoteDownloader, which was juggling both Optional types.