### PR TITLE
fix: Use execProperties when remoteExecutionProperties is empty

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
@@ -95,7 +95,6 @@ public final class PlatformUtils {
         properties = spawn.getCombinedExecProperties();
       }
     } else if (spawn.getExecutionPlatform() != null) {
-      properties = new HashMap<>();
       String remoteExecutionProperties = spawn.getExecutionPlatform().remoteExecutionProperties();
       if (!remoteExecutionProperties.isEmpty()) {
         Platform.Builder platformBuilder = Platform.newBuilder();

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.analysis.platform;
 
 import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.Platform.Property;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Ordering;
@@ -101,15 +100,11 @@ public final class PlatformUtils {
       Platform.Builder platformBuilder = Platform.newBuilder();
 
       String remoteExecutionProperties = spawn.getExecutionPlatform().remoteExecutionProperties();
-      if (remoteExecutionProperties.isEmpty()) {
-        for (Map.Entry<String, String> property : spawn.getExecutionPlatform().execProperties().entrySet()) {
-          properties.put(property.getKey(), property.getValue());
-        }
-      } else {
+      if (!remoteExecutionProperties.isEmpty()) {
         // Try and get the platform info from the execution properties.
         try {
-        TextFormat.getParser()
-                .merge(spawn.getExecutionPlatform().remoteExecutionProperties(), platformBuilder);
+          TextFormat.getParser()
+                  .merge(spawn.getExecutionPlatform().remoteExecutionProperties(), platformBuilder);
         } catch (ParseException e) {
           String message =
                   String.format(
@@ -122,8 +117,9 @@ public final class PlatformUtils {
         for (Property property : platformBuilder.getPropertiesList()) {
           properties.put(property.getName(), property.getValue());
         }
+      } else {
+        properties.putAll(spawn.getExecutionPlatform().execProperties());
       }
-
     } else {
       properties = defaultExecProperties;
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
@@ -83,13 +83,12 @@ public final class PlatformUtils {
       return null;
     }
 
-    Map<String, String> properties;
+    Map<String, String> properties = new HashMap<>();
     if (!spawn.getCombinedExecProperties().isEmpty()) {
       // Apply default exec properties if the execution platform does not already set
       // exec_properties
       if (spawn.getExecutionPlatform() == null
           || spawn.getExecutionPlatform().execProperties().isEmpty()) {
-        properties = new HashMap<>();
         properties.putAll(defaultExecProperties);
         properties.putAll(spawn.getCombinedExecProperties());
       } else {
@@ -97,10 +96,9 @@ public final class PlatformUtils {
       }
     } else if (spawn.getExecutionPlatform() != null) {
       properties = new HashMap<>();
-      Platform.Builder platformBuilder = Platform.newBuilder();
-
       String remoteExecutionProperties = spawn.getExecutionPlatform().remoteExecutionProperties();
       if (!remoteExecutionProperties.isEmpty()) {
+        Platform.Builder platformBuilder = Platform.newBuilder();
         // Try and get the platform info from the execution properties.
         try {
           TextFormat.getParser()
@@ -117,10 +115,12 @@ public final class PlatformUtils {
         for (Property property : platformBuilder.getPropertiesList()) {
           properties.put(property.getName(), property.getValue());
         }
-      } else {
+      } else if (!spawn.getExecutionPlatform().execProperties().isEmpty()) {
         properties.putAll(spawn.getExecutionPlatform().execProperties());
       }
-    } else {
+    }
+
+    if (properties.isEmpty()) {
       properties = defaultExecProperties;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
@@ -114,7 +114,7 @@ public final class PlatformUtils {
         for (Property property : platformBuilder.getPropertiesList()) {
           properties.put(property.getName(), property.getValue());
         }
-      } else if (!spawn.getExecutionPlatform().execProperties().isEmpty()) {
+      } else {
         properties.putAll(spawn.getExecutionPlatform().execProperties());
       }
     }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1403,7 +1403,7 @@ function test_platform_default_properties_invalidation_with_platform_exec_proper
   mkdir -p test
   cat > test/BUILD << 'EOF'
 platform(
-    name = "platform_without_any_exec_properties",
+    name = "platform_with_exec__properties",
     exec_properties = {
         "foo": "bar",
     },
@@ -1418,7 +1418,7 @@ genrule(
 EOF
 
   bazel build \
-    --extra_execution_platforms=//test:platform_without_any_exec_properties \
+    --extra_execution_platforms=//test:platform_with_exec__properties \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_default_exec_properties="build=1234" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
@@ -1426,13 +1426,13 @@ EOF
   expect_log "2 processes: 1 internal, 1 remote"
 
   bazel build \
-    --extra_execution_platforms=//test:platform_without_any_exec_properties \
+    --extra_execution_platforms=//test:platform_with_exec__properties \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
   # Changing --remote_default_platform_properties value does not invalidate SkyFrames
-  # given its is super-seeded by the platform exec_properties.
+  # given its is superseded by the platform exec_properties.
   expect_log "1 process: 1 internal."
 }
 
@@ -1442,7 +1442,7 @@ function test_platform_default_properties_invalidation_with_platform_remote_exec
   mkdir -p test
   cat > test/BUILD << 'EOF'
 platform(
-    name = "platform_without_any_exec_properties",
+    name = "platform_with_remote_execution_properties",
     remote_execution_properties = """properties: {name: "foo" value: "baz"}""",
 )
 
@@ -1455,7 +1455,7 @@ genrule(
 EOF
 
   bazel build \
-    --extra_execution_platforms=//test:platform_without_any_exec_properties \
+    --extra_execution_platforms=//test:platform_with_remote_execution_properties \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_default_exec_properties="build=1234" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
@@ -1463,13 +1463,13 @@ EOF
   expect_log "2 processes: 1 internal, 1 remote"
 
   bazel build \
-    --extra_execution_platforms=//test:platform_without_any_exec_properties \
+    --extra_execution_platforms=//test:platform_with_remote_execution_properties \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
   # Changing --remote_default_platform_properties value does not invalidate SkyFrames
-  # given its is super-seeded by the platform remote_execution_properties.
+  # given its is superseded by the platform remote_execution_properties.
   expect_log "2 processes: 1 remote cache hit, 1 internal"
 }
 

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1339,7 +1339,7 @@ EOF
 function test_platform_default_properties_invalidation() {
   # Test that when changing values of --remote_default_platform_properties all actions are
   # invalidated.
-mkdir -p test
+  mkdir -p test
   cat > test/BUILD << 'EOF'
 genrule(
     name = "test",
@@ -1365,7 +1365,7 @@ EOF
   # caching and make it re-run the action.
   expect_log "2 processes: 1 internal, 1 remote"
 
-  bazel  build \
+  bazel build \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //a:remote"
@@ -1376,7 +1376,7 @@ EOF
 
   bazel shutdown
 
-  bazel  build \
+  bazel build \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //a:remote"

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1336,17 +1336,77 @@ EOF
   [[ ! -f bazel-bin/test.runfiles/MANIFEST ]] || fail "expected output manifest to exist"
 }
 
-# FIXME remove this comment
-#
-# - I run this test with: bazel test //src/test/shell/bazel/remote:remote_execution_test --test_filter=test_platform_default_properties_invalidation
-# - I do not understand how to set the platform yet
 function test_platform_default_properties_invalidation() {
+  # Test that when changing values of --remote_default_platform_properties all actions are
+  # invalidated if no platform is used.
+  mkdir -p test
+  cat > test/BUILD << 'EOF'
+genrule(
+    name = "test",
+    srcs = [],
+    outs = ["output.txt"],
+    cmd = "echo \"foo\" > \"$@\""
+)
+EOF
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties="build=1234" \
+    //test:test >& $TEST_log || fail "Failed to build //test:test"
+
+  expect_log "2 processes: 1 internal, 1 remote"
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties="build=88888" \
+    //test:test >& $TEST_log || fail "Failed to build //test:test"
+
+  # Changing --remote_default_platform_properties value should invalidate SkyFrames in-memory
+  # caching and make it re-run the action.
+  expect_log "2 processes: 1 internal, 1 remote"
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties="build=88888" \
+    //test:test >& $TEST_log || fail "Failed to build //test:test"
+
+  # The same value of --remote_default_platform_properties should NOT invalidate SkyFrames in-memory cache
+  #  and make the action should not be re-run.
+  expect_log "1 process: 1 internal"
+
+  bazel shutdown
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties="build=88888" \
+    //test:test >& $TEST_log || fail "Failed to build //test:test"
+
+  # The same value of --remote_default_platform_properties should NOT invalidate SkyFrames on-disk cache
+  #  and the action should not be re-run.
+  expect_log "1 process: 1 internal"
+
+  bazel build\
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties="build=88888" \
+    --remote_default_platform_properties='properties:{name:"build" value:"1234"}' \
+    //test:test >& $TEST_log && fail "Should fail" || true
+
+  # Build should fail with a proper error message if both
+  # --remote_default_platform_properties and --remote_default_exec_properties
+  # are provided via command line
+  expect_log "Setting both --remote_default_platform_properties and --remote_default_exec_properties is not allowed"
+}
+
+function test_platform_default_properties_invalidation_with_platform_exec_properties() {
   # Test that when changing values of --remote_default_platform_properties all actions are
   # invalidated.
   mkdir -p test
   cat > test/BUILD << 'EOF'
 platform(
     name = "platform_without_any_exec_properties",
+    exec_properties = {
+        "foo": "bar",
+    },
 )
 
 genrule(
@@ -1371,46 +1431,47 @@ EOF
     --remote_default_exec_properties="build=88888" \
     //test:test >& $TEST_log || fail "Failed to build //test:test"
 
-  # Changing --remote_default_platform_properties value should invalidate SkyFrames in-memory
-  # caching and make it re-run the action.
-  expect_log "2 processes: 1 internal, 1 remote"
-  # FIXME the above assert fails
-
-  bazel build \
-    --extra_execution_platforms=//test:platform_without_any_exec_properties \
-    --remote_executor=grpc://localhost:${worker_port} \
-    --remote_default_exec_properties="build=88888" \
-    //test:test >& $TEST_log || fail "Failed to build //test:test"
-
-  # The same value of --remote_default_platform_properties should NOT invalidate SkyFrames in-memory cache
-  #  and make the action should not be re-run.
-  expect_log "1 process: 1 internal"
-
-  bazel shutdown
-
-  bazel build \
-    --extra_execution_platforms=//test:platform_without_any_exec_properties \
-    --remote_executor=grpc://localhost:${worker_port} \
-    --remote_default_exec_properties="build=88888" \
-    //test:test >& $TEST_log || fail "Failed to build //test:test"
-
-  # The same value of --remote_default_platform_properties should NOT invalidate SkyFrames on-disk cache
-  #  and the action should not be re-run.
-  expect_log "1 process: 1 internal"
-
-  bazel build\
-    --extra_execution_platforms=//test:platform_without_any_exec_properties \
-    --remote_executor=grpc://localhost:${worker_port} \
-    --remote_default_exec_properties="build=88888" \
-    --remote_default_platform_properties='properties:{name:"build" value:"1234"}' \
-    //test:test >& $TEST_log && fail "Should fail" || true
-
-  # Build should fail with a proper error message if both
-  # --remote_default_platform_properties and --remote_default_exec_properties
-  # are provided via command line
-  expect_log "Setting both --remote_default_platform_properties and --remote_default_exec_properties is not allowed"
+  # Changing --remote_default_platform_properties value does not invalidate SkyFrames
+  # given its is super-seeded by the platform exec_properties.
+  expect_log "1 process: 1 internal."
 }
 
+function test_platform_default_properties_invalidation_with_platform_remote_execution_properties() {
+  # Test that when changing values of --remote_default_platform_properties all actions are
+  # invalidated.
+  mkdir -p test
+  cat > test/BUILD << 'EOF'
+platform(
+    name = "platform_without_any_exec_properties",
+    remote_execution_properties = """properties: {name: "foo" value: "baz"}""",
+)
+
+genrule(
+    name = "test",
+    srcs = [],
+    outs = ["output.txt"],
+    cmd = "echo \"foo\" > \"$@\""
+)
+EOF
+
+  bazel build \
+    --extra_execution_platforms=//test:platform_without_any_exec_properties \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties="build=1234" \
+    //test:test >& $TEST_log || fail "Failed to build //test:test"
+
+  expect_log "2 processes: 1 internal, 1 remote"
+
+  bazel build \
+    --extra_execution_platforms=//test:platform_without_any_exec_properties \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties="build=88888" \
+    //test:test >& $TEST_log || fail "Failed to build //test:test"
+
+  # Changing --remote_default_platform_properties value does not invalidate SkyFrames
+  # given its is super-seeded by the platform remote_execution_properties.
+  expect_log "2 processes: 1 remote cache hit, 1 internal"
+}
 
 function test_combined_disk_remote_exec_with_flag_combinations() {
   rm -f ${TEST_TMPDIR}/test_expected

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1385,7 +1385,7 @@ EOF
   #  and the action should not be re-run.
   expect_log "1 process: 1 internal"
 
-  bazel build\
+  bazel build \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_default_exec_properties="build=88888" \
     --remote_default_platform_properties='properties:{name:"build" value:"1234"}' \


### PR DESCRIPTION
When defining a platform (for RBE); [remote_execution_properties](https://bazel.build/reference/be/platforms-and-toolchains#platform.remote_execution_properties) is marked as deprecated, thus we do not set it. If it is not set getPlatformProto does not read the execProperties instead, before defaulting to defaultExecProperties.