### PR TITLE
Use UTF-8 paths in `JavaIoFileSystem` if there is no Latin-1 locale

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -483,6 +483,8 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
     // Paths returned from NativePosixFiles are Strings containing raw bytes from the filesystem.
     // Java's IO subsystem expects paths to be encoded per the `sun.jnu.encoding` setting. This
     // is difficult to handle generically, but we can special-case the most common case (UTF-8).
+    // The client attempts to force a locale that uses ISO-8859-1, but that may fail if no such
+    // locale is available.
     if ("UTF-8".equals(System.getProperty("sun.jnu.encoding"))) {
       final byte[] pathBytes = pathStr.getBytes(StandardCharsets.ISO_8859_1);
       return new File(new String(pathBytes, StandardCharsets.UTF_8));


### PR DESCRIPTION
Speculative fix for #19798, where a limited set of available locales on Linux arm64 leads to this failure when using the `JavaIoFileSystem`:

```
Caused by: java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: /home/build/.cache/bazel/_bazel_build/473e173c53a2f7270c35ce0fd77d7706/external/rules_pkg/tests/testdata/utf8/sübdir
	at java.base/sun.nio.fs.UnixPath.encode(Unknown Source)
	at java.base/sun.nio.fs.UnixPath.<init>(Unknown Source)
	at java.base/sun.nio.fs.UnixFileSystem.getPath(Unknown Source)
	at java.base/java.nio.file.Path.of(Unknown Source)
	at java.base/java.nio.file.Paths.get(Unknown Source)
	at com.google.devtools.build.lib.vfs.JavaIoFileSystem.getNioPath(JavaIoFileSystem.java:81)
	at com.google.devtools.build.lib.vfs.JavaIoFileSystem.createDirectoryAndParents(JavaIoFileSystem.java:250)
	at com.google.devtools.build.lib.vfs.Path.createDirectoryAndParents(Path.java:460)
```