### PR TITLE
[6.4.0] Add blake3 NEON instructions on linux arm64

### DIFF
--- a/third_party/blake3/blake3.BUILD
+++ b/third_party/blake3/blake3.BUILD
@@ -36,11 +36,17 @@ cc_library(
             "c/blake3_sse2_x86-64_unix.S",
             "c/blake3_sse41_x86-64_unix.S",
         ],
+        "@bazel_tools//src/conditions:linux_aarch64": [
+            "c/blake3_neon.c",
+        ],
         "@bazel_tools//src/conditions:windows_x64": [
             "c/blake3_avx2_x86-64_windows_msvc.asm",
             "c/blake3_avx512_x86-64_windows_msvc.asm",
             "c/blake3_sse2_x86-64_windows_msvc.asm",
             "c/blake3_sse41_x86-64_windows_msvc.asm",
+        ],
+        "@bazel_tools//src/conditions:windows_arm64": [
+            "c/blake3_neon.c",
         ],
         "@bazel_tools//src/conditions:darwin_arm64": [
             "c/blake3_neon.c",
@@ -57,9 +63,12 @@ cc_library(
             # lacking the headers to compile AVX512.
 	    "-DBLAKE3_NO_AVX512",
 	],
+        "@bazel_tools//src/conditions:linux_aarch64": [
+            "-DBLAKE3_USE_NEON=1",
+        ],
         "@bazel_tools//src/conditions:windows_x64": [],
         "@bazel_tools//src/conditions:windows_arm64": [
-            "-DBLAKE3_USE_NEON=0",
+            "-DBLAKE3_USE_NEON=1",
         ],
         "@bazel_tools//src/conditions:darwin_arm64": [
             "-DBLAKE3_USE_NEON=1",


### PR DESCRIPTION
otherwise getting libunix_jni.so: undefined symbol: blake3_hash_many_neon

see https://github.com/bazelbuild/bazel/commit/d0de5e044c65fe7c5e414f860887be20087732da

Closes #19384.

Commit https://github.com/bazelbuild/bazel/commit/31812fe7689fc317afed4e80c383d01cfcbc7087

PiperOrigin-RevId: 562479599
Change-Id: I8f0ca6b68486f5ea8db698f3f99526eb1c0de8a8