### PR TITLE
Rollforward of https://github.com/bazelbuild/bazel/commit/10a46b1e85f…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
@@ -165,7 +165,6 @@ public abstract class CommonPrerequisiteValidator implements PrerequisiteValidat
       // TODO(plf): Add the PackageSpecificationProvider to the 'visibility' attribute.
       if (!attrName.equals("visibility")
           && !attrName.equals(FunctionSplitTransitionAllowlist.ATTRIBUTE_NAME)
-          && !attrName.equals(FunctionSplitTransitionAllowlist.LEGACY_ATTRIBUTE_NAME)
           && !containsPackageSpecificationProvider) {
         context.attributeError(
             attrName,

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -521,8 +521,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
       }
       // Check for existence of the function transition allowlist attribute.
       // TODO(b/121385274): remove when we stop allowlisting starlark transitions
-      if (name.equals(FunctionSplitTransitionAllowlist.ATTRIBUTE_NAME)
-          || name.equals(FunctionSplitTransitionAllowlist.LEGACY_ATTRIBUTE_NAME)) {
+      if (name.equals(FunctionSplitTransitionAllowlist.ATTRIBUTE_NAME)) {
         if (!BuildType.isLabelType(attr.getType())) {
           throw Starlark.errorf("_allowlist_function_transition attribute must be a label type");
         }
@@ -536,13 +535,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
         if (!(defaultLabel
                     .getPackageName()
                     .equals(FunctionSplitTransitionAllowlist.LABEL.getPackageName())
-                && defaultLabel.getName().equals(FunctionSplitTransitionAllowlist.LABEL.getName()))
-            && !(defaultLabel
-                    .getPackageName()
-                    .equals(FunctionSplitTransitionAllowlist.LEGACY_LABEL.getPackageName())
-                && defaultLabel
-                    .getName()
-                    .equals(FunctionSplitTransitionAllowlist.LEGACY_LABEL.getName()))) {
+                && defaultLabel.getName().equals(FunctionSplitTransitionAllowlist.LABEL.getName()))) {
           throw Starlark.errorf(
               "_allowlist_function_transition attribute (%s) does not have the expected value %s",
               defaultLabel, FunctionSplitTransitionAllowlist.LABEL);

--- a/src/main/java/com/google/devtools/build/lib/packages/FunctionSplitTransitionAllowlist.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/FunctionSplitTransitionAllowlist.java
@@ -22,11 +22,8 @@ import com.google.devtools.build.lib.cmdline.Label;
 public class FunctionSplitTransitionAllowlist {
   public static final String NAME = "function_transition";
   public static final String ATTRIBUTE_NAME = "$allowlist_function_transition";
-  public static final String LEGACY_ATTRIBUTE_NAME = "$whitelist_function_transition";
   public static final Label LABEL =
       Label.parseCanonicalUnchecked("//tools/allowlists/function_transition_allowlist");
-  public static final Label LEGACY_LABEL =
-      Label.parseCanonicalUnchecked("//tools/whitelists/function_transition_whitelist");
 
   private FunctionSplitTransitionAllowlist() {}
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcImportBaseConfiguredTargetTest.java
@@ -487,7 +487,7 @@ public abstract class CcImportBaseConfiguredTargetTest extends BuildViewTestCase
         "apply_custom_transition = rule(",
         "    implementation = _apply_custom_transition_impl,",
         "    attrs = {",
-        "        '_whitelist_function_transition': attr.label(",
+        "        '_allowlist_function_transition': attr.label(",
         "            default = '//tools/allowlists/function_transition_allowlist',",
         "        ),",
         "        'deps': attr.label_list(cfg = custom_transition),",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -1739,7 +1739,7 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
         "apply_custom_transition = rule(",
         "    implementation = _apply_custom_transition_impl,",
         "    attrs = {",
-        "        '_whitelist_function_transition': attr.label(",
+        "        '_allowlist_function_transition': attr.label(",
         "            default = '//tools/allowlists/function_transition_allowlist',",
         "        ),",
         "        'deps': attr.label_list(cfg = custom_transition),",

--- a/src/test/shell/integration/cpp_test.sh
+++ b/src/test/shell/integration/cpp_test.sh
@@ -324,7 +324,7 @@ outer = rule(
                 "${TOOLS_REPOSITORY}//tools/cpp:current_cc_toolchain",
             ),
         ),
-        "_whitelist_function_transition": attr.label(default = "${TOOLS_REPOSITORY}//tools/whitelists/function_transition_whitelist"),
+        "_allowlist_function_transition": attr.label(default = "${TOOLS_REPOSITORY}//tools/allowlists/function_transition_allowlist"),
     },
 )
 

--- a/src/test/shell/integration/starlark_configurations_external_workspaces_test.sh
+++ b/src/test/shell/integration/starlark_configurations_external_workspaces_test.sh
@@ -194,8 +194,8 @@ rule_with_transition = rule(
     cfg = my_transition,
     attrs = {
         "src": attr.label(allow_files = True),
-        "_whitelist_function_transition":
-            attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
+        "_allowlist_function_transition":
+            attr.label(default = "@bazel_tools//tools/allowlists/function_transition_allowlist"),
     },
 )
 EOF


### PR DESCRIPTION
…0b5bf8564c125dd02cd4e70017452: Remove legacy allowlist names

NEW: Maintainers of the repos had 1 month to upgrade version of rules Go https://github.com/bazelbuild/bazel/issues/19493
NEW: syncing against code changes
PiperOrigin-RevId: 573099651
Change-Id: I517e45a83989bfa24f6487ef6d89d60aeb31e4d3