### PR TITLE
Fix Bash runfiles calling repository lookup for directly run scripts

### DIFF
--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -51,9 +51,11 @@ case "$(uname -s | tr [:upper:] [:lower:])" in
 msys*)
   # As of 2019-01-15, Bazel on Windows only supports MSYS Bash.
   declare -r is_windows=true
+  declare -r exe_suffix=.exe
   ;;
 *)
   declare -r is_windows=false
+  declare -r exe_suffix=
   ;;
 esac
 
@@ -965,7 +967,7 @@ function test_bash_runfiles_current_repository_binary_enable_runfiles_direct_run
 
   bazel build --enable_bzlmod --enable_runfiles //pkg:binary \
     &>"$TEST_log" || fail "Build should succeed"
-  clean_runfiles_run bazel-bin/pkg/binary &>"$TEST_log" \
+  clean_runfiles_run bazel-bin/pkg/binary$exe_suffix &>"$TEST_log" \
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
@@ -973,8 +975,8 @@ function test_bash_runfiles_current_repository_binary_enable_runfiles_direct_run
 
   bazel run --enable_bzlmod --enable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary &>"$TEST_log" \
-    || fail "Direct run should succeed"
+  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary$exe_suffix \
+    &>"$TEST_log" || fail "Direct run should succeed"
   expect_log "in external/other_repo/pkg/binary.sh: 'other_repo'"
   expect_log "in pkg/library.sh: ''"
   expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
@@ -1017,7 +1019,7 @@ function test_bash_runfiles_current_repository_binary_noenable_runfiles_direct_r
 
   bazel build --enable_bzlmod --noenable_runfiles //pkg:binary \
     &>"$TEST_log" || fail "Build should succeed"
-  clean_runfiles_run bazel-bin/pkg/binary &>"$TEST_log" \
+  clean_runfiles_run bazel-bin/pkg/binary$exe_suffix &>"$TEST_log" \
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
@@ -1025,8 +1027,8 @@ function test_bash_runfiles_current_repository_binary_noenable_runfiles_direct_r
 
   bazel run --enable_bzlmod --noenable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary &>"$TEST_log" \
-    || fail "Direct run should succeed"
+  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary$exe_suffix \
+    &>"$TEST_log" || fail "Direct run should succeed"
   expect_log "in external/other_repo/pkg/binary.sh: 'other_repo'"
   expect_log "in pkg/library.sh: ''"
   expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
@@ -1069,7 +1071,7 @@ function test_bash_runfiles_current_repository_binary_nobuild_runfile_links_dire
 
   bazel build --enable_bzlmod --nobuild_runfile_links //pkg:binary \
     &>"$TEST_log" || fail "Build should succeed"
-  clean_runfiles_run bazel-bin/pkg/binary &>"$TEST_log" \
+  clean_runfiles_run bazel-bin/pkg/binary$exe_suffix &>"$TEST_log" \
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
@@ -1077,8 +1079,8 @@ function test_bash_runfiles_current_repository_binary_nobuild_runfile_links_dire
 
   bazel run --enable_bzlmod --nobuild_runfile_links @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary &>"$TEST_log" \
-    || fail "Direct run should succeed"
+  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary$exe_suffix \
+    &>"$TEST_log" || fail "Direct run should succeed"
   expect_log "in external/other_repo/pkg/binary.sh: 'other_repo'"
   expect_log "in pkg/library.sh: ''"
   expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"

--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -937,6 +937,13 @@ EOF
   chmod +x other_repo/pkg/test.sh
 }
 
+# Runs the given command with all runfiles environment variables removed from
+# the environment. Also enables debug logging for the runfiles library.
+function clean_runfiles_run() {
+  env -u RUNFILES_DIR -u RUNFILES_MANIFEST_FILE -u RUNFILES_MANIFEST_ONLY \
+    RUNFILES_LIB_DEBUG=1 "$@"
+}
+
 function test_bash_runfiles_current_repository_binary_enable_runfiles() {
   setup_bash_runfiles_current_repository
 
@@ -948,6 +955,26 @@ function test_bash_runfiles_current_repository_binary_enable_runfiles() {
 
   RUNFILES_LIB_DEBUG=1 bazel run --enable_bzlmod --enable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
+  expect_log "in external/other_repo/pkg/binary.sh: 'other_repo'"
+  expect_log "in pkg/library.sh: ''"
+  expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
+}
+
+function test_bash_runfiles_current_repository_binary_enable_runfiles_direct_run() {
+  setup_bash_runfiles_current_repository
+
+  bazel build --enable_bzlmod --enable_runfiles //pkg:binary \
+    &>"$TEST_log" || fail "Build should succeed"
+  clean_runfiles_run bazel-bin/pkg/binary &>"$TEST_log" \
+    || fail "Direct run should succeed"
+  expect_log "in pkg/binary.sh: ''"
+  expect_log "in pkg/library.sh: ''"
+  expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
+
+  bazel run --enable_bzlmod --enable_runfiles @other_repo//pkg:binary \
+    &>"$TEST_log" || fail "Run should succeed"
+  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary &>"$TEST_log" \
+    || fail "Direct run should succeed"
   expect_log "in external/other_repo/pkg/binary.sh: 'other_repo'"
   expect_log "in pkg/library.sh: ''"
   expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
@@ -985,6 +1012,26 @@ function test_bash_runfiles_current_repository_binary_noenable_runfiles() {
   expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
 }
 
+function test_bash_runfiles_current_repository_binary_noenable_runfiles_direct_run() {
+  setup_bash_runfiles_current_repository
+
+  bazel build --enable_bzlmod --noenable_runfiles //pkg:binary \
+    &>"$TEST_log" || fail "Build should succeed"
+  clean_runfiles_run bazel-bin/pkg/binary &>"$TEST_log" \
+    || fail "Direct run should succeed"
+  expect_log "in pkg/binary.sh: ''"
+  expect_log "in pkg/library.sh: ''"
+  expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
+
+  bazel run --enable_bzlmod --noenable_runfiles @other_repo//pkg:binary \
+    &>"$TEST_log" || fail "Run should succeed"
+  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary &>"$TEST_log" \
+    || fail "Direct run should succeed"
+  expect_log "in external/other_repo/pkg/binary.sh: 'other_repo'"
+  expect_log "in pkg/library.sh: ''"
+  expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
+}
+
 function test_bash_runfiles_current_repository_test_noenable_runfiles() {
   setup_bash_runfiles_current_repository
 
@@ -1012,6 +1059,26 @@ function test_bash_runfiles_current_repository_binary_nobuild_runfile_links() {
 
   RUNFILES_LIB_DEBUG=1 bazel run --enable_bzlmod --nobuild_runfile_links @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
+  expect_log "in external/other_repo/pkg/binary.sh: 'other_repo'"
+  expect_log "in pkg/library.sh: ''"
+  expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
+}
+
+function test_bash_runfiles_current_repository_binary_nobuild_runfile_links_direct_run() {
+  setup_bash_runfiles_current_repository
+
+  bazel build --enable_bzlmod --nobuild_runfile_links //pkg:binary \
+    &>"$TEST_log" || fail "Build should succeed"
+  clean_runfiles_run bazel-bin/pkg/binary &>"$TEST_log" \
+    || fail "Direct run should succeed"
+  expect_log "in pkg/binary.sh: ''"
+  expect_log "in pkg/library.sh: ''"
+  expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"
+
+  bazel run --enable_bzlmod --nobuild_runfile_links @other_repo//pkg:binary \
+    &>"$TEST_log" || fail "Run should succeed"
+  clean_runfiles_run bazel-bin/external/other_repo/pkg/binary &>"$TEST_log" \
+    || fail "Direct run should succeed"
   expect_log "in external/other_repo/pkg/binary.sh: 'other_repo'"
   expect_log "in pkg/library.sh: ''"
   expect_log "in external/other_repo/pkg/library2.sh: 'other_repo'"

--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -227,7 +227,14 @@ export -f runfiles_export_envvars
 # its return value is ignored if passed to rlocation.
 function runfiles_current_repository() {
   local -r idx=${1:-1}
-  local -r caller_path="${BASH_SOURCE[$idx]}"
+  local -r raw_caller_path="${BASH_SOURCE[$idx]}"
+  # Make the caller path absolute if needed to handle the case where the script is run directly
+  # from bazel-bin, with working directory a subdirectory of bazel-bin.
+  if [[ "$raw_caller_path" =~ $_RLOCATION_ISABS_PATTERN ]]; then
+    local -r caller_path="$raw_caller_path"
+  else
+    local -r caller_path="$(cd $(dirname "$raw_caller_path"); pwd)/$(basename "$raw_caller_path")"
+  fi
   if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
     echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): caller's path is ($caller_path)"
   fi
@@ -244,6 +251,19 @@ function runfiles_current_repository() {
     if [[ -z "$rlocation_path" ]]; then
       if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
         echo >&2 "ERROR[runfiles.bash]: runfiles_current_repository($idx): ($normalized_caller_path) is not the target of an entry in the runfiles manifest ($RUNFILES_MANIFEST_FILE)"
+      fi
+      # The binary may also be run directly from bazel-bin or bazel-out.
+      local -r repository=$(echo "$normalized_caller_path" | __runfiles_maybe_grep -E -o '(^|/)(bazel-out/[^/]+/bin|bazel-bin)/external/[^/]+/' | tail -1 | rev | cut -d / -f 2 | rev)
+      if [[ -n "$repository" ]]; then
+        if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
+          echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): ($normalized_caller_path) lies in repository ($repository) (parsed exec path)"
+        fi
+        echo "$repository"
+      else
+        if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
+          echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): ($normalized_caller_path) lies in the main repository (parsed exec path)"
+        fi
+        echo ""
       fi
       return 1
     else
@@ -273,16 +293,17 @@ function runfiles_current_repository() {
       fi
       # The only shell script that is not executed from the runfiles directory (if it is populated)
       # is the sh_binary entrypoint. Parse its path under the execroot, using the last match to
-      # allow for nested execroots (e.g. in Bazel integration tests).
-      local -r repository=$(echo "$normalized_caller_path" | __runfiles_maybe_grep -E -o '(^|/)bazel-out/[^/]+/bin/external/[^/]+/' | tail -1 | rev | cut -d / -f 2 | rev)
+      # allow for nested execroots (e.g. in Bazel integration tests). The binary may also be run
+      # directly from bazel-bin.
+      local -r repository=$(echo "$normalized_caller_path" | __runfiles_maybe_grep -E -o '(^|/)(bazel-out/[^/]+/bin|bazel-bin)/external/[^/]+/' | tail -1 | rev | cut -d / -f 2 | rev)
       if [[ -n "$repository" ]]; then
         if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
-          echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): ($normalized_caller_path) lies in repository ($repository)"
+          echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): ($normalized_caller_path) lies in repository ($repository) (parsed exec path)"
         fi
         echo "$repository"
       else
         if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
-          echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): ($normalized_caller_path) lies in the main repository"
+          echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): ($normalized_caller_path) lies in the main repository (parsed exec path)"
         fi
         echo ""
       fi
@@ -292,6 +313,13 @@ function runfiles_current_repository() {
         echo >&2 "INFO[runfiles.bash]: runfiles_current_repository($idx): ($caller_path) has path ($rlocation_path) relative to the runfiles directory ($RUNFILES_DIR)"
       fi
     fi
+  fi
+
+  if [[ -z "$rlocation_path" ]]; then
+    if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
+      echo >&2 "ERROR[runfiles.bash]: runfiles_current_repository($idx): cannot determine repository for ($caller_path) since neither the runfiles directory (${RUNFILES_DIR:-}) nor the runfiles manifest (${RUNFILES_MANIFEST_FILE:-}) exist"
+    fi
+    return 1
   fi
 
   if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then


### PR DESCRIPTION
When an `sh_binary` is run directly from `bazel-bin`, its path won't be contained in the manifest and will not match a `bazel-out` regex. Instead, make the path absolute and then match after the `bazel-bin` to extract the binaries repository name.

Also improve the error message when `runfiles_current_repository` can find neither the runfiles manifest nor the runfiles directory.

Work towards fixing https://github.com/bazelbuild/bazel/pull/19796#discussion_r1358234830