### PR TITLE
Fix typo/punctuation in XcodeConfig local versions error message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/XcodeConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/XcodeConfig.java
@@ -397,7 +397,7 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
                 "--xcode_version=%1$s specified, but it is not available locally. Your build will"
                     + " fail if any actions require a local Xcode. If you believe you have '%1$s'"
                     + " installed, try running \"blaze sync --configure\", and then re-run your"
-                    + " command.  localy available versions: [%2$s]. remotely available versions:"
+                    + " command. Locally available versions: [%2$s]. Remotely available versions:"
                     + " [%3$s]",
                 versionOverrideFlag,
                 printableXcodeVersions(localVersions.getAvailableVersions()),
@@ -407,7 +407,7 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
         ruleContext.throwWithRuleError(
             String.format(
                 "--xcode_version=%1$s specified, but '%1$s' is not an available Xcode version."
-                    + " localy available versions: [%2$s]. remotely available versions:"
+                    + " Locally available versions: [%2$s]. Remotely available versions:"
                     + " [%3$s]. If you believe you have '%1$s' installed, try running \"blaze"
                     + " sync --configure\", and then re-run your command.",
                 versionOverrideFlag,

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/XcodeConfigTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/XcodeConfigTest.java
@@ -428,7 +428,7 @@ public class XcodeConfigTest extends BuildViewTestCase {
     getConfiguredTarget("//xcode:foo");
     assertContainsEvent(
         "--xcode_version=6 specified, but '6' is not an available Xcode version."
-            + " localy available versions: [8.4]. remotely available versions:"
+            + " Locally available versions: [8.4]. Remotely available versions:"
             + " [5.1.2, 8.4].");
   }
 


### PR DESCRIPTION
A small typo fix on local Xcode version discovery errors. 🙏 