### PR TITLE
Remove occurences of --experimental_cc_implementation_deps in tests

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -1890,7 +1890,6 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
 
   @Test
   public void testImplementationDepsCompilationContextIsNotPropagated() throws Exception {
-    useConfiguration("--experimental_cc_implementation_deps");
     scratch.file(
         "foo/BUILD",
         "cc_binary(",
@@ -1954,7 +1953,6 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
 
   @Test
   public void testImplementationDepsLinkingContextIsPropagated() throws Exception {
-    useConfiguration("--experimental_cc_implementation_deps");
     scratch.file(
         "foo/BUILD",
         "cc_binary(",
@@ -2003,7 +2001,6 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
   @Test
   public void testImplementationDepsDebugContextIsPropagated() throws Exception {
     useConfiguration(
-        "--experimental_cc_implementation_deps",
         "--fission=yes",
         "--features=per_object_debug_info");
     scratch.file(
@@ -2059,7 +2056,6 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
 
   @Test
   public void testImplementationDepsRunfilesArePropagated() throws Exception {
-    useConfiguration("--experimental_cc_implementation_deps");
     scratch.file(
         "foo/BUILD",
         "cc_binary(",
@@ -2097,7 +2093,6 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
 
   @Test
   public void testImplementationDepsConfigurationHostSucceeds() throws Exception {
-    useConfiguration("--experimental_cc_implementation_deps");
     scratch.file(
         "foo/BUILD",
         "cc_library(",

--- a/src/test/shell/bazel/bazel_layering_check_test.sh
+++ b/src/test/shell/bazel/bazel_layering_check_test.sh
@@ -134,7 +134,7 @@ function test_bazel_layering_check() {
 
   write_files
 
-  CC="${clang_tool}" bazel build --experimental_cc_implementation_deps \
+  CC="${clang_tool}" bazel build \
     //hello:hello --linkopt=-fuse-ld=gold --features=layering_check \
     &> "${TEST_log}" || fail "Build with layering_check failed"
 
@@ -151,14 +151,14 @@ function test_bazel_layering_check() {
   # Specifying -fuse-ld=gold explicitly to override -fuse-ld=/usr/bin/ld.gold
   # passed in by cc_configure because Ubuntu-16.04 ships with an old
   # clang version that doesn't accept that.
-  CC="${clang_tool}" bazel build --experimental_cc_implementation_deps \
+  CC="${clang_tool}" bazel build \
     --copt=-D=private_header \
     //hello:hello --linkopt=-fuse-ld=gold --features=layering_check \
     &> "${TEST_log}" && fail "Build of private header violation with "\
     "layering_check should have failed"
   expect_log "use of private header from outside its module: 'hello_private.h'"
 
-  CC="${clang_tool}" bazel build --experimental_cc_implementation_deps \
+  CC="${clang_tool}" bazel build \
     --copt=-D=layering_violation \
     //hello:hello --linkopt=-fuse-ld=gold --features=layering_check \
     &> "${TEST_log}" && fail "Build of private header violation with "\


### PR DESCRIPTION
This flag has been flipped to being enabled by default.
