### PR TITLE
Replace HTML entities with the actual characters outside the <pre> tag

### DIFF
--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -730,7 +730,7 @@ Genrule) on a per-mnemonic basis. See
 [--spawn_strategy](#spawn-strategy) for the supported
 strategies and their effects.
 
-#### `--strategy_regexp={{ "<var>" }}&lt;filter,filter,...&gt;=&lt;strategy&gt;{{ "</var>" }}` {:#strategy-regexp}
+#### `--strategy_regexp={{ "<var>" }}<filter,filter,...>=<strategy>{{ "</var>" }}` {:#strategy-regexp}
 
 This option specifies which strategy should be used to execute commands that have descriptions
 matching a certain `regex_filter`. See
@@ -1375,7 +1375,7 @@ Some common values of this option:
 *   **Suppress symlink creation:**
       `--symlink_prefix=/` will cause Bazel to not
       create or update any symlinks, including the `bazel-out` and
-      `bazel-&lt;workspace&gt;`
+      `bazel-<workspace>`
       symlinks. Use this option to suppress symlink creation entirely.
 
 *   **Reduce clutter:**
@@ -1971,7 +1971,7 @@ through `sed -ne /key:/s/key://p`:
     root directory under output_base. This directory is the root for all files
     accessible to commands executed during the build, and is the working
     directory for those commands. If the workspace directory is writable, a
-    symlink named `bazel-&lt;workspace&gt;`
+    symlink named `bazel-<workspace>`
     is placed there pointing to this directory.
 *   `output_path`: the absolute path to the output
     directory beneath the execution root used for all files actually

--- a/src/main/java/com/google/devtools/build/docgen/DocCheckerUtils.java
+++ b/src/main/java/com/google/devtools/build/docgen/DocCheckerUtils.java
@@ -36,8 +36,8 @@ public class DocCheckerUtils {
       + ">",
       Pattern.CASE_INSENSITIVE);
 
-  private static final Pattern COMMENT_PATTERN = Pattern.compile(
-      "<!--.*?-->",
+  private static final Pattern COMMENT_OR_BACKTICK_PATTERN = Pattern.compile(
+      "<!--.*?-->|`.*`",
       Pattern.CASE_INSENSITIVE);
 
   /**
@@ -57,7 +57,7 @@ public class DocCheckerUtils {
   // TODO(bazel-team): run this on the Starlark docs too.
   @Nullable
   private static String getFirstUnclosedTag(String src, boolean printHelp) {
-    Matcher commentMatcher = COMMENT_PATTERN.matcher(src);
+    Matcher commentMatcher = COMMENT_OR_BACKTICK_PATTERN.matcher(src);
     src = commentMatcher.replaceAll("");
     Matcher tagMatcher = TAG_PATTERN.matcher(src);
     Deque<String> tagStack = new ArrayDeque<>();


### PR DESCRIPTION
The current document at https://bazel.build/docs/user-manual shows some HTML entities literally.  Inside backticks, it seems that using the actual character works while inside `<pre>` using the entity works.