### PR TITLE
[6.4.0] Collect debug info context from implementation deps

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -311,7 +311,10 @@ def _cc_library_impl(ctx):
         data_runfiles = data_runfiles,
     ))
 
-    debug_context = cc_helper.merge_cc_debug_contexts(compilation_outputs, cc_helper.get_providers(ctx.attr.deps, CcInfo))
+    debug_context = cc_helper.merge_cc_debug_contexts(
+        compilation_outputs,
+        cc_helper.get_providers(ctx.attr.deps + ctx.attr.implementation_deps, CcInfo),
+    )
     cc_info = CcInfo(
         compilation_context = compilation_context,
         linking_context = linking_context,

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2005,6 +2005,63 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testImplementationDepsDebugContextIsPropagated() throws Exception {
+    useConfiguration(
+        "--experimental_cc_implementation_deps",
+        "--fission=yes",
+        "--features=per_object_debug_info");
+    scratch.file(
+        "foo/BUILD",
+        "cc_binary(",
+        "    name = 'bin',",
+        "    srcs = ['bin.cc'],",
+        "    deps = ['lib'],",
+        ")",
+        "cc_library(",
+        "    name = 'lib',",
+        "    srcs = ['lib.cc'],",
+        "    deps = ['public_dep'],",
+        ")",
+        "cc_library(",
+        "    name = 'public_dep',",
+        "    srcs = ['public_dep.cc'],",
+        "    hdrs = ['public_dep.h'],",
+        "    implementation_deps = ['implementation_dep'],",
+        "    deps = ['interface_dep'],",
+        ")",
+        "cc_library(",
+        "    name = 'interface_dep',",
+        "    srcs = ['interface_dep.cc'],",
+        "    hdrs = ['interface_dep.h'],",
+        ")",
+        "cc_library(",
+        "    name = 'implementation_dep',",
+        "    srcs = ['implementation_dep.cc'],",
+        "    hdrs = ['implementation_dep.h'],",
+        ")");
+
+    ConfiguredTarget lib = getConfiguredTarget("//foo:lib");
+    assertThat(
+            lib
+                .get(CcInfo.PROVIDER)
+                .getCcDebugInfoContext()
+                .getTransitiveDwoFiles()
+                .toList()
+                .stream()
+                .map(Artifact::getFilename))
+        .contains("public_dep.dwo");
+    assertThat(
+            lib
+                .get(CcInfo.PROVIDER)
+                .getCcDebugInfoContext()
+                .getTransitiveDwoFiles()
+                .toList()
+                .stream()
+                .map(Artifact::getFilename))
+        .contains("implementation_dep.dwo");
+  }
+
+  @Test
   public void testImplementationDepsRunfilesArePropagated() throws Exception {
     useConfiguration("--experimental_cc_implementation_deps");
     scratch.file(


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/19146

Closes #19725.

Commit https://github.com/bazelbuild/bazel/commit/e55fee2938b38605cd3da7fc9c790da71961dd1a

PiperOrigin-RevId: 573751305
Change-Id: I9b5df85dc5e52822b3a0b44fc42d90b727a5abf0