### PR TITLE
Generalize memory and cpu tracking

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
@@ -139,13 +139,13 @@ public class ResourceManager implements ResourceEstimator {
   /** Returns prediction of RAM in Mb used by registered actions. */
   @Override
   public double getUsedMemoryInMb() {
-    return usedRam;
+    return usedResources.get("memory");
   }
 
   /** Returns prediction of CPUs used by registered actions. */
   @Override
   public double getUsedCPU() {
-    return usedCpu;
+    return usedResources.get("cpu");
   }
 
   // Allocated resources are allowed to go "negative", but at least
@@ -154,8 +154,7 @@ public class ResourceManager implements ResourceEstimator {
   // Please note that this value is purely empirical - we assume that generally
   // requested resources are somewhat pessimistic and thread would end up
   // using less than requested amount.
-  private static final double MIN_NECESSARY_CPU_RATIO = 0.6;
-  private static final double MIN_NECESSARY_RAM_RATIO = 1.0;
+  private static final Map<String, Double> MIN_NECESSARY_RATIO = Map.of("cpu", 0.6);
 
   // Lists of blocked threads. Associated CountDownLatch object will always
   // be initialized to 1 during creation in the acquire() method.
@@ -179,18 +178,9 @@ public class ResourceManager implements ResourceEstimator {
   // LocalHostCapacity.getLocalHostCapacity() as an argument.
   @VisibleForTesting public ResourceSet availableResources = null;
 
-  // Used amount of CPU capacity (where 1.0 corresponds to the one fully
-  // occupied CPU core. Corresponds to the CPU resource definition in the
-  // ResourceSet class.
-  private double usedCpu;
-
-  // Used amount of RAM capacity in MB. Corresponds to the RAM resource
+  // Used amount of resources. Corresponds to the resource
   // definition in the ResourceSet class.
-  private double usedRam;
-
-  // Used amount of extra resources. Corresponds to the extra resource
-  // definition in the ResourceSet class.
-  private Map<String, Float> usedExtraResources;
+  private Map<String, Double> usedResources;
 
   // Used local test count. Corresponds to the local test count definition in the ResourceSet class.
   private int usedLocalTestCount;
@@ -206,9 +196,7 @@ public class ResourceManager implements ResourceEstimator {
    * <p>Note - it does not reset available resources. Use separate call to setAvailableResources().
    */
   public synchronized void resetResourceUsage() {
-    usedCpu = 0;
-    usedRam = 0;
-    usedExtraResources = new HashMap<>();
+    usedResources = new HashMap<>();
     usedLocalTestCount = 0;
     for (Pair<ResourceSet, LatchWithWorker> request : localRequests) {
       request.second.latch.countDown();
@@ -298,20 +286,14 @@ public class ResourceManager implements ResourceEstimator {
   @Nullable
   private Worker incrementResources(ResourceSet resources)
       throws IOException, InterruptedException {
-    usedCpu += resources.getCpuUsage();
-    usedRam += resources.getMemoryMb();
-
     resources
-        .getExtraResourceUsage()
-        .entrySet()
+        .getResources()
         .forEach(
-            resource -> {
-              String key = (String) resource.getKey();
-              float value = resource.getValue();
-              if (usedExtraResources.containsKey(key)) {
-                value += (float) usedExtraResources.get(key);
+            (key, value) -> {
+              if (usedResources.containsKey(key)) {
+                value += usedResources.get(key);
               }
-              usedExtraResources.put(key, value);
+              usedResources.put(key, value);
             });
 
     usedLocalTestCount += resources.getLocalTestCount();
@@ -324,9 +306,7 @@ public class ResourceManager implements ResourceEstimator {
 
   /** Return true if any resources have been claimed through this manager. */
   public synchronized boolean inUse() {
-    return usedCpu != 0.0
-        || usedRam != 0.0
-        || !usedExtraResources.isEmpty()
+    return !usedResources.isEmpty()
         || usedLocalTestCount != 0
         || !localRequests.isEmpty()
         || !dynamicWorkerRequests.isEmpty()
@@ -428,32 +408,23 @@ public class ResourceManager implements ResourceEstimator {
   }
 
   private synchronized void releaseResourcesOnly(ResourceSet resources) {
-    usedCpu -= resources.getCpuUsage();
-    usedRam -= resources.getMemoryMb();
-
     usedLocalTestCount -= resources.getLocalTestCount();
 
     // TODO(bazel-team): (2010) rounding error can accumulate and value below can end up being
     // e.g. 1E-15. So if it is small enough, we set it to 0. But maybe there is a better solution.
     double epsilon = 0.0001;
-    if (usedCpu < epsilon) {
-      usedCpu = 0;
-    }
-    if (usedRam < epsilon) {
-      usedRam = 0;
-    }
 
     Set<String> toRemove = new HashSet<>();
-    for (Map.Entry<String, Float> resource : resources.getExtraResourceUsage().entrySet()) {
-      String key = (String) resource.getKey();
-      float value = (float) usedExtraResources.get(key) - resource.getValue();
-      usedExtraResources.put(key, value);
+    for (Map.Entry<String, Double> resource : resources.getResources().entrySet()) {
+      String key = resource.getKey();
+      double value = usedResources.getOrDefault(key, 0.0) - resource.getValue();
+      usedResources.put(key, value);
       if (value < epsilon) {
         toRemove.add(key);
       }
     }
     for (String key : toRemove) {
-      usedExtraResources.remove(key);
+      usedResources.remove(key);
     }
   }
 
@@ -494,29 +465,27 @@ public class ResourceManager implements ResourceEstimator {
   }
 
   /** Throws an exception if requested extra resource isn't being tracked */
-  private void assertExtraResourcesTracked(ResourceSet resources) throws NoSuchElementException {
-    for (Map.Entry<String, Float> resource : resources.getExtraResourceUsage().entrySet()) {
-      String key = (String) resource.getKey();
-      if (!availableResources.getExtraResourceUsage().containsKey(key)) {
+  private void assertResourcesTracked(ResourceSet resources) throws NoSuchElementException {
+    for (Map.Entry<String, Double> resource : resources.getResources().entrySet()) {
+      String key = resource.getKey();
+      if (!availableResources.getResources().containsKey(key)) {
         throw new NoSuchElementException(
             "Resource " + key + " is not tracked in this resource set.");
       }
     }
   }
 
-  /** Return true iff all requested extra resources are considered to be available. */
-  private boolean areExtraResourcesAvailable(ResourceSet resources) throws NoSuchElementException {
-    for (Map.Entry<String, Float> resource : resources.getExtraResourceUsage().entrySet()) {
-      String key = (String) resource.getKey();
-      float used = (float) usedExtraResources.getOrDefault(key, 0f);
-      float requested = resource.getValue();
-      float available = availableResources.getExtraResourceUsage().get(key);
-      float epsilon = 0.0001f; // Account for possible rounding errors.
-      if (requested != 0.0 && used != 0.0 && requested + used > available + epsilon) {
-        return false;
-      }
-    }
-    return true;
+  private static <T extends Number> boolean isAvailable(T available, T used, T requested) {
+    // Resources are considered available if any one of the conditions below is true:
+    // 1) If resource is not requested at all, it is available.
+    // 2) If resource is not used at the moment, it is considered to be
+    // available regardless of how much is requested. This is necessary to
+    // ensure that at any given time, at least one thread is able to acquire
+    // resources even if it requests more than available.
+    // 3) If used resource amount is less than total available resource amount.
+    return requested.doubleValue() == 0
+        || used.doubleValue() == 0
+        || used.doubleValue() + requested.doubleValue() <= available.doubleValue();
   }
 
   // Method will return true if all requested resources are considered to be available.
@@ -527,59 +496,43 @@ public class ResourceManager implements ResourceEstimator {
     // by the release() method.
 
     WorkerKey workerKey = resources.getWorkerKey();
-    int availableWorkers = 0;
-    int activeWorkers = 0;
     if (workerKey != null) {
-      availableWorkers = this.workerPool.getMaxTotalPerKey(workerKey);
-      activeWorkers = this.workerPool.getNumActive(workerKey);
+      int availableWorkers = this.workerPool.getMaxTotalPerKey(workerKey);
+      int activeWorkers = this.workerPool.getNumActive(workerKey);
+      if (activeWorkers >= availableWorkers) {
+        return false;
+      }
     }
-    boolean workerIsAvailable = workerKey == null || (activeWorkers < availableWorkers);
 
     // We test for tracking of extra resources whenever acquired and throw an
     // exception before acquiring any untracked resource.
-    assertExtraResourcesTracked(resources);
+    assertResourcesTracked(resources);
 
-    if (usedCpu == 0.0
-        && usedRam == 0.0
-        && usedExtraResources.isEmpty()
-        && usedLocalTestCount == 0
-        && workerIsAvailable) {
+    if (usedResources.isEmpty() && usedLocalTestCount == 0) {
       return true;
     }
-    // Use only MIN_NECESSARY_???_RATIO of the resource value to check for
-    // allocation. This is necessary to account for the fact that most of the
-    // requested resource sets use pessimistic estimations. Note that this
-    // ratio is used only during comparison - for tracking we will actually
-    // mark whole requested amount as used.
-    double cpu = resources.getCpuUsage() * MIN_NECESSARY_CPU_RATIO;
-    double ram = resources.getMemoryMb() * MIN_NECESSARY_RAM_RATIO;
-    int localTestCount = resources.getLocalTestCount();
 
-    double availableCpu = availableResources.getCpuUsage();
-    double availableRam = availableResources.getMemoryMb();
     int availableLocalTestCount = availableResources.getLocalTestCount();
+    if (!isAvailable(availableLocalTestCount, usedLocalTestCount, resources.getLocalTestCount())) {
+      return false;
+    }
 
-    double remainingRam = availableRam - usedRam;
+    for (Map.Entry<String, Double> resource : resources.getResources().entrySet()) {
+      String key = resource.getKey();
 
-    // Resources are considered available if any one of the conditions below is true:
-    // 1) If resource is not requested at all, it is available.
-    // 2) If resource is not used at the moment, it is considered to be
-    // available regardless of how much is requested. This is necessary to
-    // ensure that at any given time, at least one thread is able to acquire
-    // resources even if it requests more than available.
-    // 3) If used resource amount is less than total available resource amount.
-    boolean cpuIsAvailable = cpu == 0.0 || usedCpu == 0.0 || usedCpu + cpu <= availableCpu;
-    boolean ramIsAvailable = ram == 0.0 || usedRam == 0.0 || ram <= remainingRam;
-    boolean localTestCountIsAvailable =
-        localTestCount == 0
-            || usedLocalTestCount == 0
-            || usedLocalTestCount + localTestCount <= availableLocalTestCount;
-    boolean extraResourcesIsAvailable = areExtraResourcesAvailable(resources);
-    return cpuIsAvailable
-        && ramIsAvailable
-        && extraResourcesIsAvailable
-        && localTestCountIsAvailable
-        && workerIsAvailable;
+      // Use only MIN_NECESSARY_RATIO of the resource value to check for
+      // allocation. This is necessary to account for the fact that most of the
+      // requested resource sets use pessimistic estimations. Note that this
+      // ratio is used only during comparison - for tracking we will actually
+      // mark whole requested amount as used.
+      double requested = resource.getValue() * MIN_NECESSARY_RATIO.getOrDefault(key, 1.0);
+      double used = usedResources.getOrDefault(key, 0.0);
+      double available = availableResources.get(key);
+      if (!isAvailable(available, used, requested)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.actions;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Doubles;
@@ -35,6 +34,8 @@ import javax.annotation.Nullable;
  */
 @Immutable
 public class ResourceSet implements ResourceSetOrBuilder {
+  public static final String CPU = "cpu";
+  public static final String MEMORY = "memory";
 
   /** For actions that consume negligible resources. */
   public static final ResourceSet ZERO = new ResourceSet(ImmutableMap.of(), 0, null);
@@ -61,7 +62,7 @@ public class ResourceSet implements ResourceSetOrBuilder {
   }
 
   public static ResourceSet createWithRamCpu(double memory, double cpu) {
-    return create(ImmutableMap.of("memory", memory, "cpu", cpu));
+    return create(ImmutableMap.of(MEMORY, memory, CPU, cpu));
   }
 
   public static ResourceSet createWithLocalTestCount(int localTestCount) {
@@ -69,7 +70,7 @@ public class ResourceSet implements ResourceSetOrBuilder {
   }
 
   public static ResourceSet create(double memory, double cpu, int localTestCount) {
-    return create(ImmutableMap.of("memory", memory, "cpu", cpu), localTestCount);
+    return create(ImmutableMap.of(MEMORY, memory, CPU, cpu), localTestCount);
   }
 
   public static ResourceSet create(ImmutableMap<String, Double> resources) {
@@ -92,11 +93,11 @@ public class ResourceSet implements ResourceSetOrBuilder {
   }
 
   public double getMemoryMb() {
-    return resources.get("memory");
+    return resources.get(MEMORY);
   }
 
   public double getCpuUsage() {
-    return resources.get("cpu");
+    return resources.get(CPU);
   }
 
   /**
@@ -120,7 +121,20 @@ public class ResourceSet implements ResourceSetOrBuilder {
   @Override
   public String toString() {
     return "Resources: \n"
-        + Joiner.on("\n").withKeyValueSeparator(": ").join(resources.entrySet())
+        + "Memory: "
+        + resources.get(MEMORY)
+        + "M\n"
+        + "CPU: "
+        + resources.get(CPU)
+        + "\n"
+        + resources
+            .entrySet()
+            .stream()
+            .filter(e -> !e.getKey().equals(CPU) && !e.getKey().equals(MEMORY))
+            .collect(
+                StringBuilder::new,
+                (a, e) -> a.append(e.getKey()).append(": ").append(e.getValue()).append("\n"),
+                StringBuilder::append)
         + "Local tests: "
         + localTestCount
         + "\n";

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -107,7 +107,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
 
   private static final ResourceSet DEFAULT_RESOURCE_SET = ResourceSet.createWithRamCpu(250, 1);
   private static final Set<String> validResources =
-      new HashSet<>(Arrays.asList("cpu", "memory", "local_test"));
+      new HashSet<>(Arrays.asList(ResourceSet.CPU, ResourceSet.MEMORY, "local_test"));
 
   // TODO(gnish): This is a temporary allowlist while new BuildInfo API becomes stable enough to
   // become public.
@@ -919,8 +919,8 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
         }
 
         return ResourceSet.create(
-            getNumericOrDefault(resourceSetMapRaw, "memory", DEFAULT_RESOURCE_SET.getMemoryMb()),
-            getNumericOrDefault(resourceSetMapRaw, "cpu", DEFAULT_RESOURCE_SET.getCpuUsage()),
+            getNumericOrDefault(resourceSetMapRaw, ResourceSet.MEMORY, DEFAULT_RESOURCE_SET.getMemoryMb()),
+            getNumericOrDefault(resourceSetMapRaw, ResourceSet.CPU, DEFAULT_RESOURCE_SET.getCpuUsage()),
             (int)
                 getNumericOrDefault(
                     resourceSetMapRaw,

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
@@ -170,7 +170,7 @@ public class TestTargetProperties {
         } else {
           requirement = ExecutionRequirements.CPU;
           value = requirement.parseIfMatches(tag);
-          resource = "cpu";
+          resource = ResourceSet.CPU;
           amount = value;
         }
         if (value != null) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
@@ -154,87 +154,62 @@ public class TestTargetProperties {
     return isExternal;
   }
 
+  static private Map<String, Double> parseTags(Label label, Map<String, String> tags)
+      throws UserExecException {
+    Map<String, Double> resources = new HashMap<>();
+    ExecutionRequirements.ParseableRequirement requirement;
+    String value, resource, amount;
+    for (String tag : tags.keySet()) {
+      requirement = ExecutionRequirements.RESOURCES;
+      try {
+        value = requirement.parseIfMatches(tag);
+        if (value != null) {
+          int splitIndex = value.indexOf(":");
+          resource = value.substring(0, splitIndex);
+          amount = value.substring(splitIndex + 1);
+        } else {
+          requirement = ExecutionRequirements.CPU;
+          value = requirement.parseIfMatches(tag);
+          resource = "cpu";
+          amount = value;
+        }
+        if (value != null) {
+          if (resources.get(resource) != null) {
+            String message =
+                String.format(
+                    "%s has more than one tag for resource '%s', but duplicate tags aren't allowed",
+                    label, resource);
+            throw new UserExecException(createFailureDetail(message, Code.DUPLICATE_CPU_TAGS));
+          }
+          resources.put(resource, Double.parseDouble(amount));
+        }
+      } catch (ValidationException e) {
+        String message =
+            String.format(
+                "%s has a '%s' tag, but its value '%s' didn't pass validation: %s",
+                label,
+                requirement.userFriendlyName(),
+                e.getTagValue(),
+                e.getMessage());
+        throw new UserExecException(createFailureDetail(message, Code.INVALID_CPU_TAG));
+      }
+    }
+    return resources;
+  }
+
   public ResourceSet getLocalResourceUsage(Label label, boolean usingLocalTestJobs)
       throws UserExecException {
     if (usingLocalTestJobs) {
       return LOCAL_TEST_JOBS_BASED_RESOURCES;
     }
 
+    Map<String, Double> resources = parseTags(label, executionInfo);
     ResourceSet testResourcesFromSize = TestTargetProperties.getResourceSetFromSize(size);
+    testResourcesFromSize.getResources().forEach(resources::putIfAbsent);
     return ResourceSet.create(
-        testResourcesFromSize.getMemoryMb(),
-        getLocalCpuResourceUsage(label),
-        getLocalExtraResourceUsage(label),
+        ImmutableMap.copyOf(resources),
         testResourcesFromSize.getLocalTestCount());
   }
-
-  private double getLocalCpuResourceUsage(Label label) throws UserExecException {
-    ResourceSet testResourcesFromSize = TestTargetProperties.getResourceSetFromSize(size);
-    // Tests can override their CPU reservation with a "cpu:<n>" tag.
-    double cpuCount = -1.0;
-    for (String tag : executionInfo.keySet()) {
-      try {
-        String cpus = ExecutionRequirements.CPU.parseIfMatches(tag);
-        if (cpus != null) {
-          if (cpuCount != -1.0) {
-            String message =
-                String.format(
-                    "%s has more than one '%s' tag, but duplicate tags aren't allowed",
-                    label, ExecutionRequirements.CPU.userFriendlyName());
-            throw new UserExecException(createFailureDetail(message, Code.DUPLICATE_CPU_TAGS));
-          }
-          cpuCount = Float.parseFloat(cpus);
-        }
-      } catch (ValidationException e) {
-        String message =
-            String.format(
-                "%s has a '%s' tag, but its value '%s' didn't pass validation: %s",
-                label,
-                ExecutionRequirements.CPU.userFriendlyName(),
-                e.getTagValue(),
-                e.getMessage());
-        throw new UserExecException(createFailureDetail(message, Code.INVALID_CPU_TAG));
-      }
-    }
-    return cpuCount != -1.0 ? cpuCount : testResourcesFromSize.getCpuUsage();
-  }
-
-  private ImmutableMap<String, Float> getLocalExtraResourceUsage(Label label)
-      throws UserExecException {
-    // Tests can specify requirements for extra resources using "resources:<resourcename>:<amount>"
-    // tag.
-    Map<String, Float> extraResources = new HashMap<>();
-    for (String tag : executionInfo.keySet()) {
-      try {
-        String extras = ExecutionRequirements.RESOURCES.parseIfMatches(tag);
-        if (extras != null) {
-          int splitIndex = extras.indexOf(":");
-          String resourceName = extras.substring(0, splitIndex);
-          String resourceCount = extras.substring(splitIndex + 1);
-          if (extraResources.get(resourceName) != null) {
-            String message =
-                String.format(
-                    "%s has more than one '%s' tag, but duplicate tags aren't allowed",
-                    label, ExecutionRequirements.RESOURCES.userFriendlyName());
-            throw new UserExecException(createFailureDetail(message, Code.DUPLICATE_CPU_TAGS));
-          }
-          extraResources.put(resourceName, Float.parseFloat(resourceCount));
-        }
-      } catch (ValidationException e) {
-        String message =
-            String.format(
-                "%s has a '%s' tag, but its value '%s' didn't pass validation: %s",
-                label,
-                ExecutionRequirements.RESOURCES.userFriendlyName(),
-                e.getTagValue(),
-                e.getMessage());
-        throw new UserExecException(createFailureDetail(message, Code.INVALID_CPU_TAG));
-      }
-    }
-    return ImmutableMap.copyOf(extraResources);
-  }
-
-
 
   private static FailureDetail createFailureDetail(String message, Code detailedCode) {
     return FailureDetail.newBuilder()

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -115,6 +115,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
@@ -988,9 +989,9 @@ public class ExecutionTool {
   public static void configureResourceManager(ResourceManager resourceMgr, BuildRequest request) {
     ExecutionOptions options = request.getOptions(ExecutionOptions.class);
     ImmutableMap<String, Double> cpuRam =
-            ImmutableMap.of("cpu", options.localCpuResources, "memory", options.localRamResources);
+            ImmutableMap.of(ResourceSet.CPU, options.localCpuResources, ResourceSet.MEMORY, options.localRamResources);
     ImmutableMap<String, Double> resources =
-       java.util.stream.Stream.concat(cpuRam.entrySet().stream(), options.localExtraResources.stream())
+       Stream.concat(options.localExtraResources.stream(), cpuRam.entrySet().stream())
             .collect(
                 ImmutableMap.toImmutableMap(
                     Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v2));

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -987,17 +987,17 @@ public class ExecutionTool {
   @VisibleForTesting
   public static void configureResourceManager(ResourceManager resourceMgr, BuildRequest request) {
     ExecutionOptions options = request.getOptions(ExecutionOptions.class);
-    ImmutableMap<String, Float> extraResources =
-        options.localExtraResources.stream()
+    ImmutableMap<String, Double> cpuRam =
+            ImmutableMap.of("cpu", options.localCpuResources, "memory", options.localRamResources);
+    ImmutableMap<String, Double> resources =
+       java.util.stream.Stream.concat(cpuRam.entrySet().stream(), options.localExtraResources.stream())
             .collect(
                 ImmutableMap.toImmutableMap(
                     Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v2));
 
     resourceMgr.setAvailableResources(
         ResourceSet.create(
-            options.localRamResources,
-            options.localCpuResources,
-            extraResources,
+            resources,
             options.usingLocalTestJobs() ? options.localTestJobs : Integer.MAX_VALUE));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -303,7 +303,7 @@ public class ExecutionOptions extends OptionsBase {
               + " default, (\"HOST_CPUS\"), Bazel will query system configuration to estimate"
               + " the number of CPU cores available.",
       converter = CpuResourceConverter.class)
-  public float localCpuResources;
+  public double localCpuResources;
 
   @Option(
       name = "local_ram_resources",
@@ -317,7 +317,7 @@ public class ExecutionOptions extends OptionsBase {
               + " default, (\"HOST_RAM*.67\"), Bazel will query system configuration to estimate"
               + " the amount of RAM available and will use 67% of it.",
       converter = RamResourceConverter.class)
-  public float localRamResources;
+  public double localRamResources;
 
   @Option(
       name = "local_extra_resources",
@@ -333,8 +333,8 @@ public class ExecutionOptions extends OptionsBase {
               + "Tests can declare the amount of extra resources they need "
               + "by using a tag of the \"resources:<resoucename>:<amount>\" format. "
               + "Available CPU, RAM and resources cannot be set with this flag.",
-      converter = Converters.StringToFloatAssignmentConverter.class)
-  public List<Map.Entry<String, Float>> localExtraResources;
+      converter = Converters.StringToDoubleAssignmentConverter.class)
+  public List<Map.Entry<String, Double>> localExtraResources;
 
   @Option(
       name = "local_test_jobs",

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -398,10 +398,8 @@ final class WorkerSpawnRunner implements SpawnRunner {
 
     Stopwatch queueStopwatch = Stopwatch.createStarted();
     ResourceSet resourceSet =
-        ResourceSet.createWithWorkerKey(
-            spawn.getLocalResources().getMemoryMb(),
-            spawn.getLocalResources().getCpuUsage(),
-            spawn.getLocalResources().getExtraResourceUsage(),
+        ResourceSet.create(
+            spawn.getLocalResources().getResources(),
             spawn.getLocalResources().getLocalTestCount(),
             key);
 

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -525,15 +525,15 @@ public final class Converters {
   }
 
   /** A converter for for assignments from a string value to a float value. */
-  public static class StringToFloatAssignmentConverter
-      extends Converter.Contextless<Map.Entry<String, Float>> {
+  public static class StringToDoubleAssignmentConverter
+      extends Converter.Contextless<Map.Entry<String, Double>> {
     private static final AssignmentConverter baseConverter = new AssignmentConverter();
 
     @Override
-    public Map.Entry<String, Float> convert(String input)
+    public Map.Entry<String, Double> convert(String input)
         throws OptionsParsingException, NumberFormatException {
       Map.Entry<String, String> stringEntry = baseConverter.convert(input);
-      return Maps.immutableEntry(stringEntry.getKey(), Float.parseFloat(stringEntry.getValue()));
+      return Maps.immutableEntry(stringEntry.getKey(), Double.parseDouble(stringEntry.getValue()));
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -69,7 +69,7 @@ public final class ResourceManagerTest {
   public void configureResourceManager() throws Exception {
     rm.setAvailableResources(
         ResourceSet.create(
-            ImmutableMap.of("memory", 1000.0, "cpu", 1.0, "gpu", 2.0, "fancyresource", 1.5),
+            ImmutableMap.of(ResourceSet.MEMORY, 1000.0, ResourceSet.CPU, 1.0, "gpu", 2.0, "fancyresource", 1.5),
             /* localTestCount= */ 2));
     counter = new AtomicInteger(0);
     sync = new CyclicBarrier(2);
@@ -113,7 +113,7 @@ public final class ResourceManagerTest {
     return rm.acquireResources(
         resourceOwner,
         ResourceSet.create(
-            ImmutableMap.of("memory", ram, "cpu", cpu), tests, createWorkerKey(mnemonic)),
+            ImmutableMap.of(ResourceSet.MEMORY, ram, ResourceSet.CPU, cpu), tests, createWorkerKey(mnemonic)),
         ResourcePriority.LOCAL);
   }
 
@@ -126,7 +126,7 @@ public final class ResourceManagerTest {
       ResourcePriority priority)
       throws InterruptedException, IOException, NoSuchElementException {
     ImmutableMap.Builder<String, Double> resources = ImmutableMap.builder();
-    resources.putAll(extraResources).put("memory", ram).put("cpu", cpu);
+    resources.putAll(extraResources).put(ResourceSet.MEMORY, ram).put(ResourceSet.CPU, cpu);
     return rm.acquireResources(
         resourceOwner, ResourceSet.create(resources.build(), tests), priority);
   }
@@ -146,7 +146,7 @@ public final class ResourceManagerTest {
       double ram, double cpu, ImmutableMap<String, Double> extraResources, int tests)
       throws InterruptedException, IOException {
   ImmutableMap.Builder<String, Double> resources = ImmutableMap.builder();
-  resources.putAll(extraResources).put("memory", ram).put("cpu", cpu);
+  resources.putAll(extraResources).put(ResourceSet.MEMORY, ram).put(ResourceSet.CPU, cpu);
     rm.releaseResources(
         resourceOwner, ResourceSet.create(resources.build(), tests), /* worker= */ null);
   }


### PR DESCRIPTION
Remove special handling of cpu and memory, and instead track them as any other resource. This has a few advantages:
  - Significant code clean up, keep only the logic for generic resource around
  - Consistent resources type (double) for all resource
  - Consistent resource tag for all resources: `resources:memory:<n>` works

Relates to #19679 