### PR TITLE
Report test exit code

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.lib.exec.TestXmlOutputParserException;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.TestAction;
 import com.google.devtools.build.lib.server.FailureDetails.TestAction.Code;
+import com.google.devtools.build.lib.shell.TerminationStatus;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.io.OutErr;
 import com.google.devtools.build.lib.vfs.Path;
@@ -393,9 +394,14 @@ public abstract class TestStrategy implements TestActionContext {
               .getEventHandler()
               .handle(Event.of(EventKind.CANCELLED, null, testName));
         } else {
+          TerminationStatus ts = TerminationStatus.builder()
+              .setWaitResponse(testResultData.getExitCode())
+              .setTimedOut(testResultData.getStatus() == BlazeTestStatus.TIMEOUT)
+              .build();
+          String message = String.format("%s (%s) (see %s)", testName, ts.toShortString(), testLog);
           actionExecutionContext
               .getEventHandler()
-              .handle(Event.of(EventKind.FAIL, null, testName + " (see " + testLog + ")"));
+              .handle(Event.of(EventKind.FAIL, null, message));
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -265,6 +265,10 @@ public class StandaloneTestStrategy extends TestStrategy {
       dataBuilder.addFailedLogs(renamedTestLog.toString());
     }
 
+    if (!result.spawnResults().isEmpty()) {
+      dataBuilder.setExitCode(result.spawnResults().get(0).exitCode());
+    }
+
     // Add the test log to the output
     TestResultData data = dataBuilder.build();
     actionExecutionContext

--- a/src/main/protobuf/test_status.proto
+++ b/src/main/protobuf/test_status.proto
@@ -83,6 +83,7 @@ message TestResultData {
   // Following data is informational.
   optional BlazeTestStatus status = 3 [default = NO_STATUS];
   optional string status_details = 16;
+  optional int32 exit_code = 17;
   repeated string failed_logs = 4;
   repeated string warning = 5;
   optional bool has_coverage = 6;

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -727,4 +727,14 @@ EOF
   expect_log_n "INFO: Build completed successfully, [456] total actions" 1
 }
 
+function test_exit_code_reported() {
+  bazel build --curses=yes --color=yes error:failwitherror 2>$TEST_log \
+    && fail "${PRODUCT_NAME} build passed"
+  expect_log '//error:failwitherror failed: (Exit 1): '
+
+  bazel test --curses=yes --color=yes pkg:false 2>$TEST_log \
+    && fail "${PRODUCT_NAME} test passed"
+  expect_log '//pkg:false (Exit 1) (see'
+}
+
 run_suite "Integration tests for ${PRODUCT_NAME}'s UI"


### PR DESCRIPTION
Actions already report their exit code on the UI. After this change, the same applies to test failures.