### PR TITLE
[7.0.0] Automatically add function transition allow list when needed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/FunctionSplitTransitionAllowlist.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/FunctionSplitTransitionAllowlist.java
@@ -16,14 +16,12 @@ package com.google.devtools.build.lib.packages;
 
 import com.google.devtools.build.lib.cmdline.Label;
 
-/**
- * This class provides constants associated with the function split transition allowlist.
- */
+/** This class provides constants associated with the function split transition allowlist. */
 public class FunctionSplitTransitionAllowlist {
   public static final String NAME = "function_transition";
   public static final String ATTRIBUTE_NAME = "$allowlist_function_transition";
-  public static final Label LABEL =
-      Label.parseCanonicalUnchecked("//tools/allowlists/function_transition_allowlist");
+  public static final String LABEL_STR = "//tools/allowlists/function_transition_allowlist";
+  public static final Label LABEL = Label.parseCanonicalUnchecked(LABEL_STR);
 
   private FunctionSplitTransitionAllowlist() {}
 }

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -1303,6 +1303,10 @@ public class RuleClass implements RuleClassData {
       return attributes.containsKey(name);
     }
 
+    public Attribute getAttribute(String name) {
+      return attributes.get(name);
+    }
+
     /** Returns a list of all attributes added to this Builder so far. */
     public ImmutableList<Attribute> getAttributes() {
       return ImmutableList.copyOf(attributes.values());

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
@@ -985,9 +985,10 @@ public final class StarlarkRuleTransitionProviderTest extends BuildViewTestCase 
   }
 
   @Test
-  public void testCannotTransitionWithoutAllowlist() throws Exception {
+  public void testTransitionIsCheckedAgainstDefaultAllowlist() throws Exception {
     scratch.overwriteFile(
-        "tools/allowlists/function_transition_allowlist/BUILD",
+        TestConstants.TOOLS_REPOSITORY_SCRATCH
+            + "tools/allowlists/function_transition_allowlist/BUILD",
         "package_group(",
         "    name = 'function_transition_allowlist',",
         "    packages = [],",
@@ -1013,7 +1014,7 @@ public final class StarlarkRuleTransitionProviderTest extends BuildViewTestCase 
 
     reporter.removeHandler(failFastHandler);
     getConfiguredTarget("//test");
-    assertContainsEvent("Use of Starlark transition without allowlist");
+    assertContainsEvent("Non-allowlisted use of Starlark transition");
   }
 
   @Test


### PR DESCRIPTION
If the allowlist is already present its value is respected (The package paths and label name are fixed/checked. Only repository name can be changed).

Automatically add allowlist with tools repository as defined by rule definition environment.

This fixes the incompatibility introduced in: https://github.com/bazelbuild/bazel/issues/19493 (because whilelist is ignored and default allowlist is added)

Commit https://github.com/bazelbuild/bazel/commit/bb7fb2d32f055f2a70a5ab394cf5aef29bc74b2e

PiperOrigin-RevId: 574226941
Change-Id: If90f78a610d7bd3c107dcd94a39902c7c939aa7b