### PR TITLE
CppLink Resource Estimation CPU and min memory options

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -855,6 +855,14 @@ public final class CppConfiguration extends Fragment
     return cppOptions.experimentalCppCompileResourcesEstimation;
   }
 
+  public int getExperimentalCppLinkResourcesEstimationCpu() {
+    return cppOptions.experimentalCppLinkResourcesEstimationCpu;
+  }
+
+  public double getExperimentalCppLinkResourcesEstimationMinMemory() {
+    return cppOptions.experimentalCppLinkResourcesEstimationMinMemory;
+  }
+
   @Override
   public boolean macosSetInstallName() {
     return cppOptions.macosSetInstallName;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
@@ -1040,7 +1040,8 @@ public class CppLinkActionBuilder {
         toolchainEnv,
         ImmutableMap.copyOf(executionInfo),
         toolchain.getToolPathFragment(Tool.LD, ruleErrorConsumer),
-        toolchain.getTargetCpu());
+        toolchain.getTargetCpu(),
+        cppConfiguration);
   }
 
   /** We're doing 4-phased lto build, and this is the final link action (4-th phase). */

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -1070,6 +1070,32 @@ public class CppOptions extends FragmentOptions {
   public boolean experimentalCppCompileResourcesEstimation;
 
   @Option(
+      name = "experimental_cpp_link_resources_estimation_cpu",
+      defaultValue = "1",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {
+        OptionEffectTag.EXECUTION,
+      },
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "Specify the number of CPU cores to allocate for local execution of CppLinkAction. "
+              + "the default configuration is to use 1 cpu core.")
+  public int experimentalCppLinkResourcesEstimationCpu;
+
+  @Option(
+      name = "experimental_cpp_link_resources_estimation_min_memory",
+      defaultValue = "-1",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {
+        OptionEffectTag.EXECUTION,
+      },
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help =
+          "Specify the minimum amount of memory (in MBs) to allocate for local execution of CppLinkAction. "
+              + "The default configuration is to use existing platform specific minimum memory.")
+  public double experimentalCppLinkResourcesEstimationMinMemory;
+
+  @Option(
       name = "experimental_platform_cc_test",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -798,7 +798,7 @@ public final class CppLinkActionTest extends BuildViewTestCase {
     NestedSet<Artifact> inputs = createInputs(ruleContext, inputsCount);
     try {
       LocalResourcesEstimator estimator =
-          new LocalResourcesEstimator(actionExecutionContext, os, inputs);
+          new LocalResourcesEstimator(actionExecutionContext, os, inputs, 1, 15.0);
       return estimator.get();
     } finally {
       for (Artifact input : inputs.toList()) {


### PR DESCRIPTION
This PR makes the allocation of CPU cores and minimum memory for CppLink actions configurable. The motivation behind this change stems from the unique requirements of certain linkers, such as lld and ld_prime, which are multi-threaded and aggressively utilize available CPU cores. In our CI environments, we have encountered issues where multiple parallel link actions compete for resources, leading to linker crashes and build failures.

The crux of the problem lies in achieving a balance between optimizing linker performance and avoiding resource contention. While adjusting the overall concurrency(`--jobs`) could potentially address the issue, it has the unintended consequence of slowing down build times for single-threaded compilation targets. This trade-off is undesirable, as it negatively impacts overall build efficiency.

To address this challenge, this PR introduces two key configurational parameters:

1. **CPU Core Allocation**: Users can now specify the number of CPU cores allocated for linker actions, allowing us to control the degree of parallelism in line with our system's capacity and stability. (also depends on the linker that is being used) **Summary:** Currently, it defaults to 1, but this PR makes it configurable.

2. **Minimum Memory Requirement:** The minimum memory allocated for each linker action is now configurable. This allows us to ensure that link actions have the necessary resources to execute without crashing, while also minimizing the potential for resource bottlenecks. **Summary**: Earlier it was always 15 Mb for macOS, which certainly would be different for different linkers. This PR makes it configurable.

**Note:**
1. This only affects local execution.
2. From my understanding, execution_requirements are only applicable to RBE and not for local execution, hence I didn't explore that direction, but can surely be extended.
3. This PR only makes the existing values configurable and doesn't change any default assumption/logic.


**Repro of the working post applying this PR**
Requirements: macOS, Xcode 15.
1. Download [ExecMemRepro-gen.zip](https://github.com/bazelbuild/bazel/files/12972707/ExecMemRepro-gen.zip)
2. The below was executed on a 10 core machine.
a.) LinkAction taking all cores.

Here we see, that a link action would be taking all the cores =10, and from the trace, note only one link action happened at a time and Bazel was in an `Acquiring resources mode` queuing up other parallel link actions.
```
./bazelc build //:UnitTests //:UnitTests1 //:UnitTests2 //:UnitTests3 //:UnitTests4 //:UnitTests5 --experimental_cpp_link_resources_estimation_cpu=10 --profile=tencores.trace.gz
```
<img width="786" alt="Screenshot 2023-10-17 at 5 36 59 PM" src="https://github.com/bazelbuild/bazel/assets/11925399/e5aeaf95-b12d-4d36-8c81-d7a79edb8ab4">


[tencores.trace.gz](https://github.com/bazelbuild/bazel/files/12972732/tencores.trace.gz)



b.) LinkAction taking only one core.
```
./bazelc build //:UnitTests //:UnitTests1 //:UnitTests2 //:UnitTests3 //:UnitTests4 //:UnitTests5 --experimental_cpp_link_resources_estimation_cpu=1 --profile=singlecore.trace.gz
```
Here we see, that all link actions are in parallel.

[single-core.trace.gz](https://github.com/bazelbuild/bazel/files/12972728/single-core.trace.gz)
<img width="445" alt="Screenshot 2023-10-17 at 5 35 19 PM" src="https://github.com/bazelbuild/bazel/assets/11925399/e36bc15a-bddc-4dd2-9ef4-0fb62df96500">

I'm open to the possibility of more efficient ways to make this configuration flexible, please let me know; I would be more than happy to explore those options further.

**TLDR:** CppLinkActions currently have a default non-configurable estimation where ResourceSet always evaluates to single core CPU and some default platform-specific minimum memory thresholds. This PR makes few of these attributes configurable.