### PR TITLE
Do not pass --add-opens to javac.

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_common_internal_for_builtins.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_common_internal_for_builtins.bzl
@@ -142,10 +142,6 @@ def compile(
         ["--add-exports=%s=ALL-UNNAMED" % x for x in add_exports],
         order = "preorder",
     ))
-    all_javac_opts.append(depset(
-        ["--add-opens=%s=ALL-UNNAMED" % x for x in add_opens],
-        order = "preorder",
-    ))
 
     # detokenize target's javacopts, it will be tokenized before compilation
     all_javac_opts.append(helper.detokenize_javacopts(helper.tokenize_javacopts(ctx, javac_opts)))


### PR DESCRIPTION
--add-opens is a noop for the compiler, and the compiler prints a warning.

Fixes https://github.com/bazelbuild/bazel/issues/19876