### PR TITLE
[7.0.0] Drop testing on ubuntu 1804 (JDK 11) and add testing on ubuntu 2204 (JDK 17)

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -7,14 +7,14 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
-  ubuntu1804:
+  ubuntu2004:
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"
     build_flags:
       - "-c"
       - "opt"
-  ubuntu2004:
+  ubuntu2204:
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -54,7 +54,7 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu1804:
+  ubuntu2204:
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
@@ -70,7 +70,6 @@ tasks:
       - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
-      - "--test_tag_filters=-no_1804"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -96,8 +95,8 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu1804_clang:
-    platform: ubuntu1804
+  ubuntu2004_clang:
+    platform: ubuntu2004
     environment:
       CC: clang
       CC_CONFIGURE_DEBUG: 1
@@ -117,7 +116,6 @@ tasks:
       - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
-      - "--test_tag_filters=-no_1804"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
     include_json_profile:
@@ -376,7 +374,6 @@ tasks:
       - "--experimental_remote_cache_async"
       - "--experimental_remote_merkle_tree_cache"
       - "--remote_download_minimal"
-      - "--test_tag_filters=-no_1804"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -55,7 +55,7 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu1804:
+  ubuntu2204:
     shards: 4
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -72,7 +72,6 @@ tasks:
       - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
-      - "--test_tag_filters=-no_1804"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -98,8 +97,8 @@ tasks:
     include_json_profile:
       - build
       - test
-  ubuntu1804_clang:
-    platform: ubuntu1804
+  ubuntu2004_clang:
+    platform: ubuntu2004
     environment:
       CC: clang
       CC_CONFIGURE_DEBUG: 1
@@ -119,7 +118,6 @@ tasks:
       - "//src/main/java/..."
     test_flags:
       - "--config=ci-linux"
-      - "--test_tag_filters=-no_1804"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
     include_json_profile:
@@ -437,7 +435,6 @@ tasks:
       - "--experimental_remote_cache_async"
       - "--experimental_remote_merkle_tree_cache"
       - "--remote_download_minimal"
-      - "--test_tag_filters=-no_1804"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -491,8 +488,8 @@ tasks:
     index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"
     index_upload_policy: Always
     index_upload_gcs: False
-  docs_ubuntu1804:
-    platform: ubuntu1804
+  docs_ubuntu2004:
+    platform: ubuntu2004
     name: "Docs"
     build_flags:
       - "--config=docs"

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/VanillaJavaBuilder.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/VanillaJavaBuilder.java
@@ -176,7 +176,9 @@ public class VanillaJavaBuilder implements Closeable {
                 new PrintWriter(output, true),
                 fileManager,
                 diagnosticCollector,
-                JavacOptions.removeBazelSpecificFlags(optionsParser.getJavacOpts()),
+                JavacOptions.removeBazelSpecificFlags(
+                    JavacOptions.normalizeOptionsWithNormalizers(
+                        optionsParser.getJavacOpts(), new JavacOptions.ReleaseOptionNormalizer())),
                 ImmutableList.<String>of() /*classes*/,
                 sources);
         setProcessors(optionsParser, fileManager, task);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/BUILD
@@ -28,6 +28,9 @@ java_library(
             "CodecScanningConstants.java",
         ],
     ),
+    add_opens = [
+        "java.base/java.lang.invoke",
+    ],
     deps = [
         ":codec-scanning-constants",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec:registered-singleton",

--- a/src/main/java/com/google/devtools/build/lib/unsafe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/unsafe/BUILD
@@ -19,5 +19,8 @@ java_library(
 java_library(
     name = "string",
     srcs = ["StringUnsafe.java"],
+    add_opens = [
+        "java.base/java.lang",
+    ],
     deps = [":unsafe-provider"],
 )


### PR DESCRIPTION
Cherry-picking two commits:

---------

Stop removing add_opens and add_exports configurations
See https://github.com/bazelbuild/bazel/issues/19850

PiperOrigin-RevId: 574291996
Change-Id: I4c2448876c8bc7cdc6dc3cc391556771b561610d

---------

Drop testing on ubuntu 1804 (JDK 11) and add testing on ubuntu 2204 (JDK 17)

According to https://wiki.ubuntu.com/Releases, ubuntu 1804 did reach end of standard support in June 2023.

Tests failure with JDK 17 resolved in: https://github.com/bazelbuild/bazel/issues/19850

Related https://github.com/bazelbuild/continuous-integration/issues/1757

PiperOrigin-RevId: 574407319
Change-Id: I97bb500a401c1f6fd4a37e4a52fee622f9d22225
