### PR TITLE
[7.0.0] Lift single file restriction of Starlark java_toolchain.oneversion.

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_toolchain.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_toolchain.bzl
@@ -239,7 +239,7 @@ _java_toolchain = rule(
         "jspecify_stubs": attr.label_list(cfg = "exec", allow_files = True),
         "jvm_opts": attr.string_list(default = []),
         "misc": attr.string_list(default = []),
-        "oneversion": attr.label(cfg = "exec", executable = True, allow_single_file = True),
+        "oneversion": attr.label(cfg = "exec", allow_files = True, executable = True),
         "oneversion_whitelist": attr.label(allow_single_file = True),
         "oneversion_allowlist_for_tests": attr.label(allow_single_file = True),
         "package_configuration": attr.label_list(cfg = "exec", providers = [JavaPackageConfigurationInfo]),


### PR DESCRIPTION
The native java_toolchain did not enforce single fileness, and it's not necessary for the operation of oneversion.

Closes #19797.

Commit https://github.com/bazelbuild/bazel/commit/c8ba1559e9f91623ae7d3a93f737e60ee937d532

PiperOrigin-RevId: 574552358
Change-Id: I7fcc56c56af89c169ff6ce0546da1cebc7567c05