### PR TITLE
Enable compiling against only direct dependencies for java_common.compile() actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -255,6 +255,12 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     return useIjars;
   }
 
+  @Override
+  public boolean getPruneTransitiveDepsInStarlark(StarlarkThread thread) throws EvalException {
+    checkPrivateAccess(thread);
+    return !compileWithTransitiveDeps;
+  }
+
   /** Returns true iff Java header compilation is enabled. */
   public boolean useHeaderCompilation() {
     return useHeaderCompilation;

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
@@ -120,6 +120,12 @@ public interface JavaConfigurationApi extends StarlarkValue {
   boolean getUseIjarsInStarlark(StarlarkThread thread) throws EvalException;
 
   @StarlarkMethod(
+          name = "experimental_prune_transitive_deps",
+          doc = "If enabled, compilation is performed against only direct dependencies.",
+          useStarlarkThread = true)
+  boolean getPruneTransitiveDepsInStarlark(StarlarkThread thread) throws EvalException;
+
+  @StarlarkMethod(
       name = "disallow_java_import_exports",
       doc = "Returns true if java_import exports are not allowed.",
       useStarlarkThread = true)

--- a/src/main/starlark/builtins_bzl/common/java/java_common_internal_for_builtins.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_common_internal_for_builtins.bzl
@@ -172,12 +172,18 @@ def compile(
     classpath_mode = ctx.fragments.java.reduce_java_classpath()
 
     direct_jars = depset()
+    transitive = [dep.transitive_compile_time_jars for dep in deps]
+
     if is_strict_mode:
         direct_jars = depset(order = "preorder", transitive = [dep.compile_jars for dep in deps])
+        pruned = ctx.fragments.java.experimental_prune_transitive_deps() and not ctx.label.workspace_root.startswith("external/")
+        transitive = [direct_jars] if pruned else [direct_jars] + [dep.transitive_compile_time_jars for dep in deps]
+
     compilation_classpath = depset(
         order = "preorder",
-        transitive = [direct_jars] + [dep.transitive_compile_time_jars for dep in deps],
+        transitive = transitive,
     )
+
     compile_time_java_deps = depset()
     if is_strict_mode and classpath_mode != "OFF":
         compile_time_java_deps = depset(transitive = [dep._compile_time_java_dependencies for dep in deps])


### PR DESCRIPTION
This path is used by kotlin rules. Without this, java compilation action in mixed sourceset module will use all transitive deps, which results in more targets being invalidated/longer build times.

To enable : `bazel build <target> --define=experimental_prune_transitive_deps=True`
