### PR TITLE
Enable `--incompatible_sandbox_hermetic_tmp` by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -350,12 +350,12 @@ public class SandboxOptions extends OptionsBase {
 
   @Option(
       name = "incompatible_sandbox_hermetic_tmp",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
           "If set to true, each Linux sandbox will have its own dedicated empty directory mounted"
-              + " as /tmp rather thansharing /tmp with the host filesystem. Use"
+              + " as /tmp rather than sharing /tmp with the host filesystem. Use"
               + " --sandbox_add_mount_pair=/tmp to keep seeing the host's /tmp in all sandboxes.")
   public boolean sandboxHermeticTmp;
 

--- a/src/test/java/com/google/devtools/build/lib/buildtool/EditDuringBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/EditDuringBuildTest.java
@@ -44,9 +44,8 @@ public class EditDuringBuildTest extends BuildIntegrationTestCase {
     Path in = write("edit/in", "line1");
     in.setLastModifiedTime(123456789);
 
-    // Make in writable from sandbox (in case sandbox strategy is used).
-    String absoluteInPath = in.getPathString();
-    addOptions("--sandbox_writable_path=" + absoluteInPath);
+    // Modify the actual source file, not a sandboxed copy.
+    addOptions("--spawn_strategy=local");
 
     // The "echo" effects editing of the source file during the build:
     write("edit/BUILD",

--- a/src/test/shell/bazel/bazel_sandboxing_networking_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_networking_test.sh
@@ -36,6 +36,8 @@ source ${CURRENT_DIR}/remote_helpers.sh \
 function set_up() {
   add_to_bazelrc "build --spawn_strategy=sandboxed"
   add_to_bazelrc "build --genrule_strategy=sandboxed"
+  # Allow the network socket to be seen in the sandbox.
+  add_to_bazelrc "build --sandbox_add_mount_pair=/tmp"
 
   sed -i.bak '/sandbox_tmpfs_path/d' $TEST_TMPDIR/bazelrc
 }

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -735,6 +735,7 @@ EOF
 
   touch "${temp_dir}/file"
   bazel test //pkg:tmp_test \
+    --sandbox_add_mount_pair=/tmp \
     --test_output=errors &>$TEST_log || fail "Expected test to pass"
 }
 
@@ -812,6 +813,7 @@ EOF
   chmod +x pkg/tmp_test.sh
 
   bazel test //pkg:tmp_test \
+    --sandbox_add_mount_pair=/tmp \
     --test_output=errors &>$TEST_log || fail "Expected test to pass"
   [[ -f "${temp_dir}/file" ]] || fail "Expected ${temp_dir}/file to exist"
 }


### PR DESCRIPTION
Fixes #3236
Closes #19915

RELNOTES[INC]: `--incompatible_sandbox_hermetic_tmp` is enabled by default. See #19915 for migration advice.