### PR TITLE
Expose repo mapping manifest to Starlark

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/FilesToRunProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/FilesToRunProvider.java
@@ -95,6 +95,13 @@ public class FilesToRunProvider implements TransitiveInfoProvider, FilesToRunPro
     return runfilesSupport != null ? runfilesSupport.getRunfilesManifest() : null;
   }
 
+  @Nullable
+  @Override
+  public Artifact getRepoMappingManifest() {
+    var runfilesSupport = getRunfilesSupport();
+    return runfilesSupport != null ? runfilesSupport.getRepoMappingManifest() : null;
+  }
+
   /** Returns a {@link RunfilesSupplier} encapsulating runfiles for this tool. */
   public final RunfilesSupplier getRunfilesSupplier() {
     return firstNonNull(getRunfilesSupport(), EmptyRunfilesSupplier.INSTANCE);

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/FilesToRunProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/FilesToRunProviderApi.java
@@ -39,4 +39,12 @@ public interface FilesToRunProviderApi<FileT extends FileApi> extends StarlarkVa
       allowReturnNones = true)
   @Nullable
   FileT getRunfilesManifest();
+
+  @StarlarkMethod(
+      name = "repo_mapping_manifest",
+      doc = "The repo mapping manifest or None if it does not exist.",
+      structField = true,
+      allowReturnNones = true)
+  @Nullable
+  FileT getRepoMappingManifest();
 }


### PR DESCRIPTION
The new `repo_mapping_manifest` field on `FilesToRunProvider` allows Starlark rule implementations to access the `File` containing the repo mapping manifest for an executable target, e.g. to include the manifest into a synthetic runfiles structure for packaging purposes.

Fixes #19937