### PR TITLE
Set the content type on the release notes HTML files.

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -200,7 +200,7 @@ function release_to_gcs() {
     create_index_html "${artifact_dir}" > "${artifact_dir}/index.html"
     gsutil -m cp "${artifact_dir}/**" "gs://bazel/${release_path}"
     # Set the content type on index.html so it isn't autodetected incorrectly by the browser.
-    gsutil setmeta -h "Content-Type: text/html; charset=utf-8" "${artifact_dir}/index.html"
+    gsutil setmeta -h "Content-Type: text/html; charset=utf-8" "gs://bazel/${release_path}/index.html"
   fi
 }
 

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -199,6 +199,8 @@ function release_to_gcs() {
     fi
     create_index_html "${artifact_dir}" > "${artifact_dir}/index.html"
     gsutil -m cp "${artifact_dir}/**" "gs://bazel/${release_path}"
+    # Set the content type on index.html so it isn't autodetected incorrectly by the browser.
+    gsutil setmeta -h "Content-Type: text/html; charset=utf-8" "${artifact_dir}/index.html"
   fi
 }
 


### PR DESCRIPTION
Fixes [#1764](https://github.com/bazelbuild/continuous-integration/issues/1764). (Except for already published files, which I'll write a separate script to retroactively fix.)