### PR TITLE
[7.0.0] Improve toolchain resolution debug logging

### DIFF
--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -689,8 +689,12 @@ EOF
     --toolchain_resolution_debug=toolchain:test_toolchain \
     --platform_mappings= \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
-  expect_log "ToolchainResolution:   Type //${pkg}/toolchain:test_toolchain: target platform ${default_host_platform}: execution ${default_host_platform}: Selected toolchain //register/${pkg}:test_toolchain_impl_1"
-  expect_log "ToolchainResolution: Target platform ${default_host_platform}: Selected execution platform ${default_host_platform}, type //${pkg}/toolchain:test_toolchain -> toolchain //register/${pkg}:test_toolchain_impl_1"
+  expect_log "Performing resolution of //${pkg}/toolchain:test_toolchain for target platform ${default_host_platform}"
+  expect_log "Toolchain //register/${pkg}:test_toolchain_impl_1 is compatible with target plaform, searching for execution platforms:"
+  expect_log "Compatible execution platform ${default_host_platform}"
+  expect_log "Recap of selected //${pkg}/toolchain:test_toolchain toolchains for target platform ${default_host_platform}:"
+  expect_log "Selected //register/${pkg}:test_toolchain_impl_1 to run on execution platform ${default_host_platform}"
+  expect_log "Target platform ${default_host_platform}: Selected execution platform ${default_host_platform}, type //${pkg}/toolchain:test_toolchain -> toolchain //register/${pkg}:test_toolchain_impl_1"
   expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from test_toolchain"'
 }
 
@@ -716,7 +720,11 @@ EOF
     --toolchain_resolution_debug=demo:use \
     --platform_mappings= \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
-  expect_log "ToolchainResolution:   Type //${pkg}/toolchain:test_toolchain: target platform ${default_host_platform}: execution ${default_host_platform}: Selected toolchain //register/${pkg}:test_toolchain_impl_1"
+  expect_log "Performing resolution of //${pkg}/toolchain:test_toolchain for target platform ${default_host_platform}"
+  expect_log "Toolchain //register/${pkg}:test_toolchain_impl_1 is compatible with target plaform, searching for execution platforms:"
+  expect_log "Compatible execution platform ${default_host_platform}"
+  expect_log "Recap of selected //${pkg}/toolchain:test_toolchain toolchains for target platform ${default_host_platform}:"
+  expect_log "Selected //register/${pkg}:test_toolchain_impl_1 to run on execution platform ${default_host_platform}"
   expect_log "ToolchainResolution: Target platform ${default_host_platform}: Selected execution platform ${default_host_platform}, type //${pkg}/toolchain:test_toolchain -> toolchain //register/${pkg}:test_toolchain_impl_1"
   expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from test_toolchain"'
 }


### PR DESCRIPTION
* Group logging into a single debug message per (toolchain type, target platform) pair to avoid mixed output lines. This allows to reduce the length of debug lines as repeated information is explicit from the context in the previous lines.
* Use indentation to highlight resolution phases
  1. looking for all toolchains matching the target platform
  2. looking for all exec platforms matching the said toolchain
* Add a summary message containing all the selected triplets
* Less aggressive printing of exec platform resolution
* Speedup toolchain resolution a bit by stopping search as soon as all
  exec platforms have a toolchain assigned.

#####  Baseline output

```
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java10; mismatching config settings: nonprebuilt_toolchain_java10_version_setting
INFO: ToolchainResolution:   Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: execution //:default_host_platform: Selected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11
INFO: ToolchainResolution:   Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: execution @local_config_platform//:host: Selected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java12; mismatching config settings: nonprebuilt_toolchain_java12_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java13; mismatching config settings: nonprebuilt_toolchain_java13_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java14; mismatching config settings: nonprebuilt_toolchain_java14_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java15; mismatching config settings: nonprebuilt_toolchain_java15_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java16; mismatching config settings: nonprebuilt_toolchain_java16_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java17; mismatching config settings: nonprebuilt_toolchain_java17_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java18; mismatching config settings: nonprebuilt_toolchain_java18_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java19; mismatching config settings: nonprebuilt_toolchain_java19_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java20; mismatching config settings: nonprebuilt_toolchain_java20_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java21; mismatching config settings: nonprebuilt_toolchain_java21_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java22; mismatching config settings: nonprebuilt_toolchain_java22_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java23; mismatching config settings: nonprebuilt_toolchain_java23_version_setting
INFO: ToolchainResolution:   Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: execution //:default_host_platform: Selected toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java24; mismatching config settings: nonprebuilt_toolchain_java24_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java25; mismatching config settings: nonprebuilt_toolchain_java25_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java26; mismatching config settings: nonprebuilt_toolchain_java26_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java27; mismatching config settings: nonprebuilt_toolchain_java27_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/cpp:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-armeabi-v7a; mismatching values: armv7, android
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java28; mismatching config settings: nonprebuilt_toolchain_java28_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java29; mismatching config settings: nonprebuilt_toolchain_java29_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java30; mismatching config settings: nonprebuilt_toolchain_java30_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java8; mismatching config settings: nonprebuilt_toolchain_java8_default_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java8; mismatching config settings: nonprebuilt_toolchain_java8_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java9; mismatching config settings: nonprebuilt_toolchain_java9_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: execution platform //:default_host_platform: Skipping toolchain //:bazel_java_toolchain; execution platform already has selected toolchain
INFO: ToolchainResolution:   Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: execution @local_config_platform//:host: Selected toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk11_linux//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk11_linux_aarch64//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk11_linux_ppc64le//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk11_linux_s390x//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk11_macos//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: execution platform @local_config_platform//:host: Skipping toolchain //:bazel_java_toolchain; execution platform already has selected toolchain
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6//toolchains:toolchain_java10; mismatching config settings: toolchain_java10_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: execution platform //:default_host_platform: Skipping toolchain @rules_java~7.0.6//toolchains:toolchain_java11; execution platform already has selected toolchain
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: execution platform @local_config_platform//:host: Skipping toolchain @rules_java~7.0.6//toolchains:toolchain_java11; execution platform already has selected toolchain
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6//toolchains:toolchain_java8; mismatching config settings: toolchain_java8_default_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6//toolchains:toolchain_java8; mismatching config settings: toolchain_java8_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6//toolchains:toolchain_java9; mismatching config settings: toolchain_java9_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6//toolchains:toolchain_jdk_17; mismatching config settings: toolchain_jdk_17_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6//toolchains:toolchain_jdk_21; mismatching config settings: toolchain_jdk_21_version_setting
INFO: ToolchainResolution:   Type @bazel_tools//tools/cpp:toolchain_type: target platform @local_config_platform//:host: execution //:default_host_platform: Selected toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8
INFO: ToolchainResolution:   Type @bazel_tools//tools/cpp:toolchain_type: target platform @local_config_platform//:host: execution @local_config_platform//:host: Selected toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8
INFO: ToolchainResolution:     Type @bazel_tools//tools/cpp:toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-armeabi-v7a; mismatching values: armv7, android
INFO: ToolchainResolution:     Type @bazel_tools//tools/cpp:toolchain_type: target platform @local_config_platform//:host: execution platform //:default_host_platform: Skipping toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8; execution platform already has selected toolchain
INFO: ToolchainResolution:     Type @bazel_tools//tools/cpp:toolchain_type: target platform @local_config_platform//:host: execution platform @local_config_platform//:host: Skipping toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8; execution platform already has selected toolchain
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk11_macos_aarch64//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk11_win//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk11_win_arm64//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk17_linux//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk17_linux_aarch64//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk17_linux_ppc64le//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk17_linux_s390x//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk17_macos//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk17_macos_aarch64//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk17_win//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk17_win_arm64//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk21_linux//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk21_linux_aarch64//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk21_macos//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk21_macos_aarch64//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution:     Type @bazel_tools//tools/jdk:runtime_toolchain_type: target platform @local_config_platform//:host: Rejected toolchain @rules_java~7.0.6~toolchains~remotejdk21_win//:jdk; mismatching config settings: prefix_version_setting
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform, type @bazel_tools//tools/cpp:toolchain_type -> toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8, type @bazel_tools//tools/jdk:toolchain_type -> toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11, type @bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform,
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform, type @bazel_tools//tools/cpp:toolchain_type -> toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform, type @bazel_tools//tools/jdk:toolchain_type -> toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform, type @bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk
DEBUG: /home/layus/.cache/bazel/_bazel_layus/9cba04cd38f91c4f00ab1cb532fc20ef/external/rules_jvm_external~5.2/private/extensions/maven.bzl:141:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
DEBUG: /home/layus/.cache/bazel/_bazel_layus/9cba04cd38f91c4f00ab1cb532fc20ef/external/rules_jvm_external~5.2/private/extensions/maven.bzl:141:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
DEBUG: /home/layus/.cache/bazel/_bazel_layus/9cba04cd38f91c4f00ab1cb532fc20ef/external/rules_jvm_external~5.2/private/extensions/maven.bzl:141:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
DEBUG: /home/layus/.cache/bazel/_bazel_layus/9cba04cd38f91c4f00ab1cb532fc20ef/external/rules_jvm_external~5.2/private/extensions/maven.bzl:141:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
INFO: Analyzed target //src:bazel_nojdk (472 packages loaded, 10806 targets configured).
INFO: Found 1 target...
Target //src:bazel_nojdk up-to-date:
  bazel-bin/src/bazel_nojdk
INFO: Elapsed time: 14.165s, Critical Path: 0.49s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
````

##### This PR

```
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Performing resolution of @bazel_tools//tools/jdk:runtime_toolchain_type for target platform @local_config_platform//:host
  Toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk is compatible with target plaform, searching for execution platforms:
    Compatible execution platform //:default_host_platform
    Compatible execution platform @local_config_platform//:host
  All execution platforms have been assigned a @bazel_tools//tools/jdk:runtime_toolchain_type toolchain, stopping
 => Recap of selected @bazel_tools//tools/jdk:runtime_toolchain_type toolchains for target platform @local_config_platform//:host:
  Selected toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk to run on exec platform //:default_host_platform
  Selected toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk to run on exec platform @local_config_platform//:host
INFO: Performing resolution of @bazel_tools//tools/jdk:toolchain_type for target platform @local_config_platform//:host
  Rejected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java10; mismatching config settings: nonprebuilt_toolchain_java10_version_setting
  Toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11 is compatible with target plaform, searching for execution platforms:
    Compatible execution platform //:default_host_platform
    Compatible execution platform @local_config_platform//:host
  All execution platforms have been assigned a @bazel_tools//tools/jdk:toolchain_type toolchain, stopping
 => Recap of selected @bazel_tools//tools/jdk:toolchain_type toolchains for target platform @local_config_platform//:host:
  Selected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11 to run on exec platform //:default_host_platform
  Selected toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11 to run on exec platform @local_config_platform//:host
INFO: Performing resolution of @bazel_tools//tools/cpp:toolchain_type for target platform @local_config_platform//:host
  Rejected toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-armeabi-v7a; mismatching values: armv7, android
  Toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8 is compatible with target plaform, searching for execution platforms:
    Compatible execution platform //:default_host_platform
    Compatible execution platform @local_config_platform//:host
  All execution platforms have been assigned a @bazel_tools//tools/cpp:toolchain_type toolchain, stopping
 => Recap of selected @bazel_tools//tools/cpp:toolchain_type toolchains for target platform @local_config_platform//:host:
  Selected toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8 to run on exec platform //:default_host_platform
  Selected toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8 to run on exec platform @local_config_platform//:host
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform, type @bazel_tools//tools/cpp:toolchain_type -> toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8, type @bazel_tools//tools/jdk:toolchain_type -> toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11, type @bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform,
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform, type @bazel_tools//tools/cpp:toolchain_type -> toolchain @bazel_tools~cc_configure_extension~local_config_cc//:cc-compiler-k8
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform, type @bazel_tools//tools/jdk:toolchain_type -> toolchain @bazel_tools//tools/jdk:nonprebuilt_toolchain_java11
INFO: ToolchainResolution: Target platform @local_config_platform//:host: Selected execution platform //:default_host_platform, type @bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @rules_java~7.0.6~toolchains~local_jdk//:jdk
DEBUG: /home/layus/.cache/bazel/_bazel_layus/9cba04cd38f91c4f00ab1cb532fc20ef/external/rules_jvm_external~5.2/private/extensions/maven.bzl:141:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
DEBUG: /home/layus/.cache/bazel/_bazel_layus/9cba04cd38f91c4f00ab1cb532fc20ef/external/rules_jvm_external~5.2/private/extensions/maven.bzl:141:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
DEBUG: /home/layus/.cache/bazel/_bazel_layus/9cba04cd38f91c4f00ab1cb532fc20ef/external/rules_jvm_external~5.2/private/extensions/maven.bzl:141:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
DEBUG: /home/layus/.cache/bazel/_bazel_layus/9cba04cd38f91c4f00ab1cb532fc20ef/external/rules_jvm_external~5.2/private/extensions/maven.bzl:141:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
INFO: Analyzed target //src:bazel_nojdk (472 packages loaded, 10806 targets configured).
INFO: Found 1 target...
Target //src:bazel_nojdk up-to-date:
  bazel-bin/src/bazel_nojdk
INFO: Elapsed time: 13.732s, Critical Path: 0.39s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```

/fixes https://github.com/bazelbuild/bazel/issues/17814

Closes #19926.

Commit https://github.com/bazelbuild/bazel/commit/0a9c9a772fbefe2addd60947d9818414e1e823d2

PiperOrigin-RevId: 576878906
Change-Id: I65517f320fde8c17e6f04a9d6b89c31ab6e6da33