### PR TITLE
[7.0.0] "I/O exception during sandboxed execution" "Directory not empty" with `--experimental_reuse_sandbox_directories`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -184,6 +184,8 @@ public final class SandboxHelpers {
         if (SYMLINK.equals(dirent.getType())
             && absPath.readSymbolicLink().equals(destination.get())) {
           inputsToCreate.remove(pathRelativeToWorkDir);
+        } else if (absPath.isDirectory()) {
+          absPath.deleteTree();
         } else {
           absPath.delete();
         }

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -293,7 +293,19 @@ public class SandboxHelpersTest {
     // outputDir only exists partially
     execRootPath.getRelative(outputDir).getParentDirectory().createDirectoryAndParents();
     execRootPath.getRelative("justSomeDir/thatIsDoomed").createDirectoryAndParents();
-    SandboxHelpers.cleanExisting(rootDir, inputs, inputsToCreate, dirsToCreate, execRootPath);
+    // `thiswillbeafile/output` simulates a directory that was in the stashed dir but whose same
+    // path is used later for a regular file.
+    scratch.dir("/execRoot/thiswillbeafile/output");
+    scratch.file("/execRoot/thiswillbeafile/output/file1");
+    dirsToCreate.add(PathFragment.create("thiswillbeafile"));
+    PathFragment input4 = PathFragment.create("thiswillbeafile/output");
+    SandboxInputs inputs2 =
+        new SandboxInputs(
+            ImmutableMap.of(input1, inputTxt, input2, inputTxt, input3, inputTxt, input4, inputTxt),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    SandboxHelpers.cleanExisting(rootDir, inputs2, inputsToCreate, dirsToCreate, execRootPath);
     assertThat(dirsToCreate).containsExactly(inputDir2, inputDir3, outputDir);
     assertThat(execRootPath.getRelative("existing/directory/with").exists()).isTrue();
     assertThat(execRootPath.getRelative("partial").exists()).isTrue();


### PR DESCRIPTION
#19935 gives a clear repro. The problem appears when a stashed sandbox
contains a directory whose same path is a regular file in a later
execution. If we try to reuse the stashed sandbox we trigger an error if
the old directory contained any files.

This was due to simply calling delete() without checking first if it
was a directory. The fix is to call deleteTree() instead in those cases.
directory.

Fixes #19935

RELNOTES:none
Commit https://github.com/bazelbuild/bazel/commit/7d87996d2c2018f0c6dd9b200482320d0e40f024

PiperOrigin-RevId: 576889004
Change-Id: I73b145cd574b83c473ffaccd90b675eb5f086c0e