### PR TITLE
Change ndjson URL to GitHub ndjson spec repo

### DIFF
--- a/site/en/query/language.md
+++ b/site/en/query/language.md
@@ -1237,7 +1237,7 @@ protocol buffer but in
 
 Similar to `--output streamed_proto`, prints a stream of
 [`Target`](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/build.proto)
-protocol buffers but in [ndjson](http://ndjson.org/) format.
+protocol buffers but in [ndjson](https://github.com/ndjson/ndjson-spec) format.
 
 ### Print the label of each target, in rank order {:#print-target-label-rank-order}
 


### PR DESCRIPTION
It seems that http://ndjson.org is available on GoDaddy Auctions now, so we probably don't want to be linking there anymore. It seems that the repo for the spec might be the most useful spot to link to today.