### PR TITLE
Fix analysis time regression with Bzlmod lockfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/events/Reportable.java
+++ b/src/main/java/com/google/devtools/build/lib/events/Reportable.java
@@ -47,6 +47,9 @@ public interface Reportable {
    *
    * <p>This method is not relevant for events which do not originate from {@link
    * com.google.devtools.build.skyframe.SkyFunction} evaluation.
+   *
+   * <p>Classes returning {@code true} should have cheap {@link Object#hashCode()} and {@link
+   * Object#equals(Object)} implementations.
    */
   default boolean storeForReplay() {
     return false;


### PR DESCRIPTION
This commit fixes a regression in analysis time caused by 19c0c809abbe4bc70d3d6b493ff966dd41c54768. Since `BazelModuleResolutionEvent` and `ModuleExtensionResolutionEvent` are both marked as `storeForReplay`, they are stored in a nested set for essentially all analysis phase nodes. This resulted in frequent (i.e., per target) calls to their `hashCode` methods, which are not cached and delegated to the likewise uncached methods on large `ImmutableMap` and `ImmutableTable` instances.

Since there is no need for these events to be deduplicated, switching to reference equality resolves this issue.

The following analysis phase measurements for a synthetic project with a single "hub and spokes" module extension and 2,000 repos illustrate the effect:

* without lockfile: 4.3s
* with lockfile before this commit: 8.3s
* with lockfile after this commit: 4.2s

Fixes #19952