### PR TITLE
[WIP] Change `--extra_toolchains` to not accumulate values.

### DIFF
--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -39,8 +39,7 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --compilation_mode=opt \
       --repository_cache=derived/repository_cache \
       --norepository_cache_urls_as_default_canonical_id \
-      --extra_toolchains=//scripts/bootstrap:all \
-      --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain \
+      --extra_toolchains=//scripts/bootstrap:all,@bazel_tools//tools/python:autodetecting_toolchain \
       --enable_bzlmod \
       --check_direct_dependencies=error \
       --lockfile_mode=update \

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
@@ -100,7 +100,6 @@ public class PlatformOptions extends FragmentOptions {
       defaultValue = "null",
       converter = CommaSeparatedOptionListConverter.class,
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-      allowMultiple = true,
       effectTags = {
         OptionEffectTag.AFFECTS_OUTPUTS,
         OptionEffectTag.CHANGES_INPUTS,
@@ -110,7 +109,8 @@ public class PlatformOptions extends FragmentOptions {
           "The toolchain rules to be considered during toolchain resolution. "
               + "Toolchains can be specified by exact target, or as a target pattern. "
               + "These toolchains will be considered before those declared in the WORKSPACE file "
-              + "by register_toolchains().")
+              + "by register_toolchains(). This option may only be set once; later "
+              + "instances will override earlier flag settings.")
   public List<String> extraToolchains;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
@@ -14,14 +14,14 @@
 
 package com.google.devtools.build.lib.analysis.config;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDefinition;
 import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsBase;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
@@ -100,18 +100,14 @@ public abstract class FragmentOptions extends OptionsBase implements Cloneable {
    *
    * <p>Example: [a, b, a, c, b] -> [a, b, c]
    */
-  protected static List<String> dedupeOnly(List<String> values) {
-    HashSet<String> alreadySeen = new HashSet<>();
-    List<String> result = new ArrayList<>();
-    for (String value : values) {
-      // Add to result only the first time we see the value
-      if (alreadySeen.add(value)) {
-        result.add(value);
-      }
+  protected static ImmutableList<String> dedupeOnly(@Nullable List<String> values) {
+    if (values == null || values.isEmpty()) {
+      return ImmutableList.of();
     }
+    ImmutableList<String> result = values.stream().distinct().collect(toImmutableList());
     // If there were no duplicates, return the exact same instance we got.
     if (result.size() == values.size()) {
-      return values;
+      return ImmutableList.copyOf(values);
     } else {
       return result;
     }

--- a/src/test/java/com/google/devtools/build/lib/rules/config/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/BUILD
@@ -41,7 +41,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/rules/config:feature_flag_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
         "//src/main/java/com/google/devtools/common/options",
-        "//src/test/java/com/google/devtools/build/lib/actions/util",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/starlark/util",
         "//src/test/java/com/google/devtools/build/lib/testutil",
@@ -51,6 +50,7 @@ java_library(
         "//third_party:jsr305",
         "//third_party:junit4",
         "//third_party:truth",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
@@ -153,7 +153,6 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
     // Verify that the target registered with the extra_toolchains flag is first in the list.
     assertToolchainLabels(result.get(toolchainsKey))
         .containsAtLeast(
-            Label.parseCanonicalUnchecked("//extra:extra_toolchain_impl_1"),
             Label.parseCanonicalUnchecked("//extra:extra_toolchain_impl_2"),
             Label.parseCanonicalUnchecked("//toolchain:toolchain_1_impl"))
         .inOrder();


### PR DESCRIPTION
This effectively reverses the current semantics. Previously, the toolchains added via `--extra_toolchains` were all accumulated, in the order the flags were parsed, and added as the highest priority to the list of available toolchains. Unfortunately, this makes it practically impossible to use `--extra_toolchains` to override a toolchain already added by `--extra_toolchains`, especially if it was added in a blazerc file.

With this change, only the _last_ `--extra_toolchains` will have any effect, but multiple comma-separated toolchains can be added. The toolchains will still be kept in order defined in the single value used.

Fixes #19945.

RELNOTES: The `--extra_toolchains` flag no longer accumulates values, instead the last usage of `--extra_toolchains` is used and others are ignored.
PiperOrigin-RevId: 576922897
Change-Id: I80261ad0c63735a8dcd42e17d948c842dca700c5