### PR TITLE
[7.0.0] Document `--experimental_output_paths`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -793,7 +793,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       name = "experimental_output_paths",
       converter = OutputPathsConverter.class,
       defaultValue = "off",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {
         OptionEffectTag.LOSES_INCREMENTAL_STATE,
         OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION,


### PR DESCRIPTION
Closes #19891.

Commit https://github.com/bazelbuild/bazel/commit/6191a70eb0cb8ddcfb0d9b3a657c2b083179fc17

PiperOrigin-RevId: 577970043
Change-Id: Ia5e9386d6fe6e0601787ec069d9054b0b8cf1418