### PR TITLE
[7.0.0] ijar: Widen some size types.

### DIFF
--- a/third_party/ijar/zip_main.cc
+++ b/third_party/ijar/zip_main.cc
@@ -254,9 +254,13 @@ char **read_filelist(char *filename) {
   }
 
   int nb_entries = 1;
-  for (int i = 0; i < file_stat.total_size; i++) {
+  for (u8 i = 0; i < file_stat.total_size; i++) {
     if (data[i] == '\n') {
       nb_entries++;
+    }
+    if (nb_entries == INT_MAX) {
+      fprintf(stderr, "too many input files");
+      return NULL;
     }
   }
 
@@ -271,7 +275,7 @@ char **read_filelist(char *filename) {
   // Create the corresponding array
   int j = 1;
   filelist[0] = content;
-  for (int i = 0; i < file_stat.total_size; i++) {
+  for (u8 i = 0; i < file_stat.total_size; i++) {
     if (content[i] == '\n') {
       content[i] = 0;
       if (i + 1 < file_stat.total_size) {


### PR DESCRIPTION
This is a follow up to https://github.com/bazelbuild/bazel/commit/ac10bac23bd138f64b071749e10b03fe22df333e.

Closes #19722.

Commit https://github.com/bazelbuild/bazel/commit/a69fdb847103ffe392c909eff815fc8f2d6cfaaa

PiperOrigin-RevId: 577864132
Change-Id: I4b7165b6abfd55f545811bd16c8e5cf02ae183ae