### PR TITLE
Use real repo mapping for `@bazel_tools` for `.bzl` loads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -944,13 +944,6 @@ public class BzlLoadFunction implements SkyFunction {
     }
 
     if (key instanceof BzlLoadValue.KeyForBzlmod) {
-      if (repoName.equals(RepositoryName.BAZEL_TOOLS)) {
-        // Special case: we're only here to get the @bazel_tools repo (for example, for
-        // http_archive). This repo shouldn't have visibility into anything else (during repo
-        // generation), so we just return an empty repo mapping.
-        // TODO(wyv): disallow fallback.
-        return RepositoryMapping.ALWAYS_FALLBACK;
-      }
       if (repoName.isMain()) {
         // Special case: when we try to run an extension in the main repo, we need to grab the repo
         // mapping for the main repo, which normally would include all WORKSPACE repos. This is


### PR DESCRIPTION
Since Bazel now forwards many `.bzl` symbols under `@bazel_tools//tools/jdk` to `@rules_java`, `@bazel_tools` needs to use its proper repo mapping when resolving `.bzl` loads, otherwise loading these symbols will fail from `.bzl` files loaded transitively during module extension evaluation.