### PR TITLE
[7.0.0] `JavaInfo` can no longer be stored in `depset`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaGenJarsProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaGenJarsProvider.java
@@ -131,6 +131,11 @@ public interface JavaGenJarsProvider
   abstract class NativeJavaGenJarsProvider implements JavaGenJarsProvider {
 
     @Override
+    public boolean isImmutable() {
+      return true;
+    }
+
+    @Override
     public abstract boolean usesAnnotationProcessing();
 
     @Nullable

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaModuleFlagsProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaModuleFlagsProvider.java
@@ -45,6 +45,11 @@ import net.starlark.java.eval.Starlark;
 abstract class JavaModuleFlagsProvider
     implements JavaInfoInternalProvider, JavaModuleFlagsProviderApi {
 
+  @Override
+  public boolean isImmutable() {
+    return true;
+  }
+
   public abstract NestedSet<String> addExports();
 
   public abstract NestedSet<String> addOpens();


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/19999

Commit https://github.com/bazelbuild/bazel/commit/e2385124b26690c30b152aace860dade774844ea

PiperOrigin-RevId: 578178718
Change-Id: I2713a4f28d3ed248e7e0e4d67bc3c489f937a8e5