### PR TITLE
[7.0.0] Don't pass `--add-opens=` to javac

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_common_internal_for_builtins.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_common_internal_for_builtins.bzl
@@ -142,10 +142,6 @@ def compile(
         ["--add-exports=%s=ALL-UNNAMED" % x for x in add_exports],
         order = "preorder",
     ))
-    all_javac_opts.append(depset(
-        ["--add-opens=%s=ALL-UNNAMED" % x for x in add_opens],
-        order = "preorder",
-    ))
 
     # detokenize target's javacopts, it will be tokenized before compilation
     all_javac_opts.append(helper.detokenize_javacopts(helper.tokenize_javacopts(ctx, javac_opts)))


### PR DESCRIPTION
They are unnecessary at compile-time, and this avoids a warning on recent javac versions:

```
warning: [options] --add-opens has no effect at compile time
```

They are still collected and passed as runtime JVM flags.

See also

* https://github.com/bazelbuild/bazel/issues/19850#issuecomment-1767934543
* https://github.com/bazelbuild/bazel/issues/19876

Closes: https://github.com/bazelbuild/bazel/pull/19859

Commit https://github.com/bazelbuild/bazel/commit/367994ab9f3bb8d06a39d6bd0c139f00dcf47f3e

PiperOrigin-RevId: 574527220
Change-Id: Ie9bfb8162869a3479b9401945e140c09875cc05e