### PR TITLE
Revert "Fix up recommendation for finding correct Xcode. "blaze sync --configure" did not appear to work."

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/XcodeConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/XcodeConfig.java
@@ -208,7 +208,6 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
     }
     return false;
   }
-
   /**
    * Returns the {@link XcodeVersionProperties} selected by the {@code--xcode_version} flag from the
    * {@code versions} attribute of the {@code xcode_config} target explicitly defined in the {@code
@@ -397,9 +396,9 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
             String.format(
                 "--xcode_version=%1$s specified, but it is not available locally. Your build will"
                     + " fail if any actions require a local Xcode. If you believe you have '%1$s'"
-                    + " installed, try running \"sudo python3 /usr/local/bin/xcode_configure.py"
-                    + " --verbose\", and then re-run your command. Locally available versions:"
-                    + " [%2$s]. Remotely available versions: [%3$s]",
+                    + " installed, try running \"blaze sync --configure\", and then re-run your"
+                    + " command.  localy available versions: [%2$s]. remotely available versions:"
+                    + " [%3$s]",
                 versionOverrideFlag,
                 printableXcodeVersions(localVersions.getAvailableVersions()),
                 printableXcodeVersions(remoteVersions.getAvailableVersions())));
@@ -408,10 +407,9 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
         ruleContext.throwWithRuleError(
             String.format(
                 "--xcode_version=%1$s specified, but '%1$s' is not an available Xcode version."
-                    + " Locally available versions: [%2$s]. Remotely available versions: [%3$s]. If"
-                    + " you believe you have '%1$s' installed, try running \"sudo python3"
-                    + " /usr/local/bin/xcode_configure.py --verbose\", and then re-run your"
-                    + " command.",
+                    + " localy available versions: [%2$s]. remotely available versions:"
+                    + " [%3$s]. If you believe you have '%1$s' installed, try running \"blaze"
+                    + " sync --configure\", and then re-run your command.",
                 versionOverrideFlag,
                 printableXcodeVersions(localVersions.getAvailableVersions()),
                 printableXcodeVersions(remoteVersions.getAvailableVersions())));
@@ -534,6 +532,7 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
 
   public static XcodeConfigInfo getXcodeConfigInfo(RuleContext ruleContext) {
     return ruleContext.getPrerequisite(
-        XcodeConfigRule.XCODE_CONFIG_ATTR_NAME, XcodeConfigInfo.PROVIDER);
+        XcodeConfigRule.XCODE_CONFIG_ATTR_NAME,
+        XcodeConfigInfo.PROVIDER);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/XcodeConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/XcodeConfig.java
@@ -208,6 +208,7 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
     }
     return false;
   }
+
   /**
    * Returns the {@link XcodeVersionProperties} selected by the {@code--xcode_version} flag from the
    * {@code versions} attribute of the {@code xcode_config} target explicitly defined in the {@code
@@ -397,7 +398,7 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
                 "--xcode_version=%1$s specified, but it is not available locally. Your build will"
                     + " fail if any actions require a local Xcode. If you believe you have '%1$s'"
                     + " installed, try running \"blaze sync --configure\", and then re-run your"
-                    + " command.  localy available versions: [%2$s]. remotely available versions:"
+                    + " command.  Locally available versions: [%2$s]. Remotely available versions:"
                     + " [%3$s]",
                 versionOverrideFlag,
                 printableXcodeVersions(localVersions.getAvailableVersions()),
@@ -407,7 +408,7 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
         ruleContext.throwWithRuleError(
             String.format(
                 "--xcode_version=%1$s specified, but '%1$s' is not an available Xcode version."
-                    + " localy available versions: [%2$s]. remotely available versions:"
+                    + " Locally available versions: [%2$s]. Remotely available versions:"
                     + " [%3$s]. If you believe you have '%1$s' installed, try running \"blaze"
                     + " sync --configure\", and then re-run your command.",
                 versionOverrideFlag,
@@ -532,7 +533,6 @@ public class XcodeConfig implements RuleConfiguredTargetFactory {
 
   public static XcodeConfigInfo getXcodeConfigInfo(RuleContext ruleContext) {
     return ruleContext.getPrerequisite(
-        XcodeConfigRule.XCODE_CONFIG_ATTR_NAME,
-        XcodeConfigInfo.PROVIDER);
+        XcodeConfigRule.XCODE_CONFIG_ATTR_NAME, XcodeConfigInfo.PROVIDER);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/XcodeConfigTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/XcodeConfigTest.java
@@ -428,7 +428,7 @@ public class XcodeConfigTest extends BuildViewTestCase {
     getConfiguredTarget("//xcode:foo");
     assertContainsEvent(
         "--xcode_version=6 specified, but '6' is not an available Xcode version."
-            + " localy available versions: [8.4]. remotely available versions:"
+            + " Locally available versions: [8.4]. Remotely available versions:"
             + " [5.1.2, 8.4].");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/XcodeConfigTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/XcodeConfigTest.java
@@ -428,7 +428,7 @@ public class XcodeConfigTest extends BuildViewTestCase {
     getConfiguredTarget("//xcode:foo");
     assertContainsEvent(
         "--xcode_version=6 specified, but '6' is not an available Xcode version."
-            + " Locally available versions: [8.4]. Remotely available versions:"
+            + " localy available versions: [8.4]. remotely available versions:"
             + " [5.1.2, 8.4].");
   }
 


### PR DESCRIPTION
This reverts commit d99266b6c7c256f330e09157572e544208fce7c4.

The change to the message is only valid for blaze. The previous message is valid for Bazel.