### PR TITLE
[7.0.0] Can't load from `@bazel_tools//tools/jdk` `.bzl` files from module extension

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -622,6 +622,10 @@ public class BzlLoadFunction implements SkyFunction {
         || (key instanceof BzlLoadValue.KeyForBzlmod && !isFileSafeForUninjectedEvaluation(key));
   }
 
+  private static final PackageIdentifier BAZEL_TOOLS_BOOTSTRAP_RULES_PACKAGE =
+      PackageIdentifier.create(
+          RepositoryName.BAZEL_TOOLS, PathFragment.create("tools/build_defs/repo"));
+
   private static boolean isFileSafeForUninjectedEvaluation(BzlLoadValue.Key key) {
     // We don't inject _builtins for repo rules to avoid a Skyframe cycle.
     // The cycle is caused only with bzlmod because the `@_builtins` repo does not declare its own
@@ -629,9 +633,7 @@ public class BzlLoadFunction implements SkyFunction {
     // Bazel module resolution, and if there are any non-registry overrides in the root MODULE.bazel
     // file (such as `git_override` or `archive_override`), the corresponding bzl files will be
     // evaluated.
-    return PackageIdentifier.create(
-            RepositoryName.BAZEL_TOOLS, PathFragment.create("tools/build_defs/repo"))
-        .equals(key.getLabel().getPackageIdentifier());
+    return key.getLabel().getPackageIdentifier().equals(BAZEL_TOOLS_BOOTSTRAP_RULES_PACKAGE);
   }
 
   /**
@@ -944,12 +946,12 @@ public class BzlLoadFunction implements SkyFunction {
     }
 
     if (key instanceof BzlLoadValue.KeyForBzlmod) {
-      if (repoName.equals(RepositoryName.BAZEL_TOOLS)) {
-        // Special case: we're only here to get the @bazel_tools repo (for example, for
-        // http_archive). This repo shouldn't have visibility into anything else (during repo
-        // generation), so we just return an empty repo mapping.
-        // TODO(wyv): disallow fallback.
-        return RepositoryMapping.ALWAYS_FALLBACK;
+      if (key.getLabel().getPackageIdentifier().equals(BAZEL_TOOLS_BOOTSTRAP_RULES_PACKAGE)) {
+        // Special case: we're only here to get one of the rules in the @bazel_tools repo that
+        // load Bazel modules. At this point we can't load from any other modules and thus use a
+        // repository mapping that contains only @bazel_tools itself.
+        return RepositoryMapping.create(
+            ImmutableMap.of("bazel_tools", RepositoryName.BAZEL_TOOLS), RepositoryName.BAZEL_TOOLS);
       }
       if (repoName.isMain()) {
         // Special case: when we try to run an extension in the main repo, we need to grab the repo

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -755,6 +755,36 @@ class BazelModuleTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(['build', '@what'], allow_failure=True)
     self.assertIn('ERROR: @@hello~override//:MODULE.bazel', '\n'.join(stderr))
 
+  def testLoadRulesJavaSymbolThroughBazelTools(self):
+    """Tests that loads from @bazel_tools that delegate to other modules resolve."""
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'ext = use_extension("//:ext.bzl", "ext")',
+            'use_repo(ext, "data")',
+        ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile(
+        'ext.bzl',
+        [
+            (
+                "load('@bazel_tools//tools/jdk:toolchain_utils.bzl',"
+                " 'find_java_toolchain')"
+            ),
+            'def _repo_impl(ctx):',
+            "  ctx.file('WORKSPACE')",
+            "  ctx.file('BUILD', 'exports_files([\"data.txt\"])')",
+            "  ctx.file('data.txt', 'hi')",
+            'repo = repository_rule(implementation = _repo_impl)',
+            'def _ext_impl(ctx):',
+            "  repo(name='data')",
+            'ext = module_extension(implementation = _ext_impl)',
+        ],
+    )
+
+    self.RunBazel(['build', '@data//:data.txt'])
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Since Bazel now forwards many `.bzl` symbols under `@bazel_tools//tools/jdk` to `@rules_java`, `@bazel_tools` needs to use its proper repo mapping when resolving `.bzl` loads, otherwise loading these symbols will fail from `.bzl` files loaded transitively during module extension evaluation.

The only exception this is when loading a repo rule that can host a Bazel module, recognized by the package `@bazel_tools//tools/build_defs/repo`. The full repo mapping of `@bazel_tools` isn't available at this point, so we use a fixed mapping that only contains `bazel_tools` itself.

Fixes #20000

Closes #20006.

Commit https://github.com/bazelbuild/bazel/commit/5f92b9ddc18b91826bf3ce5576a293d3cea35e97

PiperOrigin-RevId: 578612514
Change-Id: Icd50098f5ff8b4bd3ea21574a7c1d3fa4ed8611e