### PR TITLE
Do not print errors when repository rules are interrupted

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.Optional;
 import java.util.Set;
 import net.starlark.java.eval.Starlark;
@@ -128,6 +129,8 @@ public class DecompressorValue implements SkyValue {
       throws RepositoryFunctionException, InterruptedException {
     try {
       return getDecompressor(descriptor.archivePath()).decompress(descriptor);
+    } catch (ClosedByInterruptException e) {
+      throw new InterruptedException();
     } catch (IOException e) {
       Path destinationDirectory = descriptor.archivePath().getParentDirectory();
       throw new RepositoryFunctionException(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -494,9 +494,6 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
       if (executable) {
         outputPath.getPath().setExecutable(true);
       }
-    } catch (InterruptedException e) {
-      throw new RepositoryFunctionException(
-          new IOException("thread interrupted"), Transience.TRANSIENT);
     } catch (IOException e) {
       if (allowFail) {
         return StarlarkInfo.create(
@@ -692,10 +689,6 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
               env.getListener(),
               envVariables,
               getIdentifyingStringForLogging());
-    } catch (InterruptedException e) {
-      env.getListener().post(w);
-      throw new RepositoryFunctionException(
-          new IOException("thread interrupted"), Transience.TRANSIENT);
     } catch (IOException e) {
       env.getListener().post(w);
       if (allowFail) {


### PR DESCRIPTION
When the user interrupts a build with Ctrl+C during the download or extraction of a file, no Starlark error should be printed. This is achieved by propagating `InterruptedException`s instead of failing the repository rule with an `IOException`.