### PR TITLE
[7.0.0] testing

### DIFF
--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -31,14 +31,11 @@ fi
 
 : ${JAVA_VERSION:="11"}
 
-# TODO: remove `norepository_cache_urls_as_default_canonical_id` once all dependencies are mirrored.
-# See https://github.com/bazelbuild/bazel/pull/19549 for more context.
 _BAZEL_ARGS="--spawn_strategy=standalone \
       --nojava_header_compilation \
       --strategy=Javac=worker --worker_quit_after_build --ignore_unsupported_sandboxing \
       --compilation_mode=opt \
       --repository_cache=derived/repository_cache \
-      --norepository_cache_urls_as_default_canonical_id \
       --extra_toolchains=//scripts/bootstrap:all \
       --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain \
       --enable_bzlmod \

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -263,9 +263,8 @@ public class RepositoryOptions extends OptionsBase {
   public CheckDirectDepsMode checkDirectDependencies;
 
   @Option(
-      name = "repository_cache_urls_as_default_canonical_id",
-      oldName = "experimental_repository_cache_urls_as_default_canonical_id",
-      defaultValue = "true",
+      name = "experimental_repository_cache_urls_as_default_canonical_id",
+      defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},

--- a/src/test/java/com/google/devtools/build/lib/blackbox/bazel/DefaultToolsSetup.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/bazel/DefaultToolsSetup.java
@@ -78,9 +78,6 @@ public class DefaultToolsSetup implements ToolsSetup {
     String sharedRepoCache = System.getenv("REPOSITORY_CACHE");
     if (sharedRepoCache != null) {
       lines.add("common --repository_cache=" + sharedRepoCache);
-      // TODO(sluongng): Remove this flag once all dependencies are mirrored.
-      // See https://github.com/bazelbuild/bazel/pull/19549 for more context.
-      lines.add("common --norepository_cache_urls_as_default_canonical_id");
       if (OS.getCurrent() == OS.DARWIN) {
         // For reducing SSD usage on our physical Mac machines.
         lines.add("common --experimental_repository_cache_hardlinks");

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -127,9 +127,6 @@ class TestBase(absltest.TestCase):
       shared_repo_cache = os.environ.get('REPOSITORY_CACHE')
       if shared_repo_cache:
         f.write('common --repository_cache={}\n'.format(shared_repo_cache))
-        # TODO(sluongng): Remove this flag once all dependencies are mirrored.
-        # See https://github.com/bazelbuild/bazel/pull/19549 for more context.
-        f.write('common --norepository_cache_urls_as_default_canonical_id\n')
         if TestBase.IsDarwin():
           # For reducing SSD usage on our physical Mac machines.
           f.write('common --experimental_repository_cache_hardlinks\n')

--- a/src/test/shell/bazel/bazel_repository_cache_test.sh
+++ b/src/test/shell/bazel/bazel_repository_cache_test.sh
@@ -494,18 +494,18 @@ EOF
     || echo "Expected fetch to succeed"
 }
 
-function test_repository_cache_urls_as_default_canonical_id() {
+function test_experimental_repository_cache_urls_as_default_canonical_id() {
   setup_repository
 
   bazel fetch --repository_cache="$repo_cache_dir" \
-        --repository_cache_urls_as_default_canonical_id \
+        --experimental_repository_cache_urls_as_default_canonical_id \
         //zoo:breeding-program >& $TEST_log \
     || echo "Expected fetch to succeed"
 
   shutdown_server
 
   bazel fetch --repository_cache="$repo_cache_dir" \
-        --repository_cache_urls_as_default_canonical_id \
+        --experimental_repository_cache_urls_as_default_canonical_id \
         //zoo:breeding-program >& $TEST_log \
     || echo "Expected fetch to succeed"
 
@@ -524,44 +524,9 @@ EOF
 
   # As repository cache key should depend on urls, we expect fetching to fail now.
   bazel fetch --repository_cache="$repo_cache_dir" \
-        --repository_cache_urls_as_default_canonical_id \
+        --experimental_repository_cache_urls_as_default_canonical_id \
         //zoo:breeding-program >& $TEST_log \
     && fail "expected failure" || :
-}
-
-function test_repository_legacy_default_canonical_id() {
-  setup_repository
-
-  bazel fetch --repository_cache="$repo_cache_dir" \
-        --norepository_cache_urls_as_default_canonical_id \
-        //zoo:breeding-program >& $TEST_log \
-    || echo "Expected fetch to succeed"
-
-  shutdown_server
-
-  bazel fetch --repository_cache="$repo_cache_dir" \
-        --norepository_cache_urls_as_default_canonical_id \
-        //zoo:breeding-program >& $TEST_log \
-    || echo "Expected fetch to succeed"
-
-  # Break url in WORKSPACE
-  rm WORKSPACE
-  cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = 'endangered',
-    url = 'http://localhost:$nc_port/bleh.broken',
-    sha256 = '$sha256',
-    type = 'zip',
-)
-EOF
-
-  # As repository cache key should depend on urls, we expect fetching to fail now.
-  bazel fetch --repository_cache="$repo_cache_dir" \
-        --norepository_cache_urls_as_default_canonical_id \
-        //zoo:breeding-program >& $TEST_log \
-    || echo "Expected fetch to succeed"
 }
 
 run_suite "repository cache tests"

--- a/src/test/shell/testenv.sh.tmpl
+++ b/src/test/shell/testenv.sh.tmpl
@@ -327,9 +327,6 @@ EOF
   if [[ -n ${REPOSITORY_CACHE:-} ]]; then
     echo "testenv.sh: Using repository cache at $REPOSITORY_CACHE."
     echo "common --repository_cache=$REPOSITORY_CACHE" >> $TEST_TMPDIR/bazelrc
-    # TODO(sluongng): Remove this flag once all dependencies are mirrored.
-    # See https://github.com/bazelbuild/bazel/pull/19549 for more context.
-    echo "common --norepository_cache_urls_as_default_canonical_id" >> $TEST_TMPDIR/bazelrc
     if is_darwin; then
       # For reducing SSD usage on our physical Mac machines.
       echo "testenv.sh: Enabling --experimental_repository_cache_hardlinks"


### PR DESCRIPTION
*** Reason for rollback ***

Due to https://github.com/bazelbuild/bazel/issues/19749

*** Original change description ***

Stablize and flip repository_cache_urls_as_default_canonical_id

Introduced in #14268, this flag is very useful for bigger enterprise
context where folks often version bumping dependencies without
remembering to update the SHA256 of the downloaded file, leading to
Bazel picking up older download entries from the repository cache.

As we get more questions about this flag in Slack, marking it as
stable and flip the default seems to be the r...

***

RELNOTES: None
Commit https://github.com/bazelbuild/bazel/commit/0a1dce27650a233d8acb1f09a1181279f510cae8

PiperOrigin-RevId: 578840189
Change-Id: I390910b5dd838a4a1384c5d24cedde0b7c1b2b98