### PR TITLE
Add add_exports & add_opens parameters to JavaInfo constructor

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_info.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_info.bzl
@@ -663,7 +663,9 @@ def _javainfo_init(
         exports = [],
         exported_plugins = [],
         jdeps = None,
-        native_libraries = []):
+        native_libraries = [],
+        add_exports = [],
+        add_opens = []):
     """The JavaInfo constructor
 
     Args:
@@ -693,6 +695,8 @@ def _javainfo_init(
             is typically produced by a compiler. IDEs and other tools can use this information for
             more efficient processing. Optional.
         native_libraries: ([CcInfo]) Native library dependencies that are needed for this library.
+        add_exports: ([str]) The <module>/<package>s this library was given access to.
+        add_opens: ([str]) The <module>/<package>s this library was given reflective access to.
 
     Returns:
         (dict) arguments to the JavaInfo provider constructor
@@ -734,11 +738,11 @@ def _javainfo_init(
             ],
         ),
         module_flags_info = _create_module_flags_info(
-            add_exports = depset(transitive = [
+            add_exports = depset(add_exports, transitive = [
                 dep.module_flags_info.add_exports
                 for dep in concatenated_deps.deps_exports
             ]),
-            add_opens = depset(transitive = [
+            add_opens = depset(add_opens, transitive = [
                 dep.module_flags_info.add_opens
                 for dep in concatenated_deps.deps_exports
             ]),

--- a/src/main/starlark/builtins_bzl/common/java/java_info.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_info.bzl
@@ -456,8 +456,7 @@ def java_info_for_compilation(
             # only differs from the usual java_info.transitive_source_jars in the order of deps
             transitive = [dep.transitive_source_jars for dep in concatenated_deps.runtimedeps_exports_deps],
         ),
-        # the JavaInfo constructor does not add flags from runtime_deps nor support
-        # adding this target's exports/opens
+        # the JavaInfo constructor does not add flags from runtime_deps
         module_flags_info = _create_module_flags_info(
             add_exports = depset(add_exports, transitive = [
                 dep.module_flags_info.add_exports

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaInfoStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaInfoStarlarkApiTest.java
@@ -857,12 +857,26 @@ public class JavaInfoStarlarkApiTest extends BuildViewTestCase {
         "java_library(",
         "    name = 'my_java_lib_direct',",
         "    srcs = ['java/A.java'],",
+        "    add_exports = ['java.base/java.lang'],",
         "    add_opens = ['java.base/java.lang'],",
+        ")",
+        "java_library(",
+        "    name = 'my_java_lib_runtime',",
+        "    srcs = ['java/A.java'],",
+        "    add_opens = ['java.base/java.util'],",
+        ")",
+        "java_library(",
+        "    name = 'my_java_lib_exports',",
+        "    srcs = ['java/A.java'],",
+        "    add_opens = ['java.base/java.math'],",
         ")",
         "my_rule(",
         "    name = 'my_starlark_rule',",
         "    dep = [':my_java_lib_direct'],",
+        "    dep_runtime = [':my_java_lib_runtime'],",
+        "    dep_exports = [':my_java_lib_exports'],",
         "    output_jar = 'my_starlark_rule_lib.jar',",
+        "    add_exports = ['java.base/java.lang.invoke'],",
         ")");
     assertNoEvents();
 
@@ -870,7 +884,14 @@ public class JavaInfoStarlarkApiTest extends BuildViewTestCase {
         fetchJavaInfo().getProvider(JavaModuleFlagsProvider.class);
 
     assertThat(ruleOutputs.toFlags())
-        .containsExactly("--add-opens=java.base/java.lang=ALL-UNNAMED");
+        .containsExactly(
+            "--add-exports=java.base/java.lang=ALL-UNNAMED",
+            "--add-exports=java.base/java.lang.invoke=ALL-UNNAMED",
+            // NB: no java.base/java.util as the JavaInfo constructor doesn't
+            // look at runtime_deps for module flags.
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.math=ALL-UNNAMED")
+        .inOrder();
   }
 
   @Test
@@ -1240,6 +1261,8 @@ public class JavaInfoStarlarkApiTest extends BuildViewTestCase {
           "    native_headers_jar = ctx.file.native_headers_jar,",
           "    manifest_proto = ctx.file.manifest_proto,",
           "    native_libraries = dp_libs,",
+          "    add_exports = ctx.attr.add_exports,",
+          "    add_opens = ctx.attr.add_opens,",
           "  )",
           "  return [result(property = javaInfo)]");
       return lines.build().toArray(new String[] {});
@@ -1271,6 +1294,8 @@ public class JavaInfoStarlarkApiTest extends BuildViewTestCase {
           "    'generated_source_jar' : attr.label(allow_single_file=True),",
           "    'native_headers_jar' : attr.label(allow_single_file=True),",
           "    'manifest_proto' : attr.label(allow_single_file=True),",
+          "    'add_exports' : attr.string_list(),",
+          "    'add_opens' : attr.string_list(),",
           useIJar || stampJar || sourceFiles
               ? "    '_toolchain': attr.label(default = Label('//java/com/google/test:toolchain')),"
               : "",


### PR DESCRIPTION
There is currently no non-hacky way for third-party rule implementations to add `add_exports` and `add_opens` to a `JavaInfo`, though hacky ways exist (like using a macro to generate a `java_library` with `add_exports` / `add_opens` and add it as a dependency, or creating an empty source file and compiling it using `java_common.compile`).

Having an official way to create `JavaInfo`s with `add_exports` and `add_opens` helps third-party JVM rules better support JDK 9+ (and especially 17+, which requires `--add-opens` flags to access JDK internals through reflection).

Addresses half of #20033.