### PR TITLE
Add --incompatible_java_info_merge_runtime_module_flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -574,6 +574,17 @@ public final class BuildLanguageOptions extends OptionsBase {
   public boolean incompatibleJavaCommonParameters;
 
   @Option(
+      name = "incompatible_java_info_merge_runtime_module_flags",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+	  "If set to true, the JavaInfo constructor will merge add_exports and "
+	      + "add_opens of runtime_deps in addition to deps and exports.")
+  public boolean incompatibleJavaInfoMergeRuntimeModuleFlags;
+
+  @Option(
       name = "max_computation_steps",
       defaultValue = "0",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -757,6 +768,7 @@ public final class BuildLanguageOptions extends OptionsBase {
                 INCOMPATIBLE_FIX_PACKAGE_GROUP_REPOROOT_SYNTAX,
                 incompatibleFixPackageGroupReporootSyntax)
             .setBool(INCOMPATIBLE_JAVA_COMMON_PARAMETERS, incompatibleJavaCommonParameters)
+            .setBool(INCOMPATIBLE_JAVA_INFO_MERGE_RUNTIME_MODULE_FLAGS, incompatibleJavaInfoMergeRuntimeModuleFlags)
             .setBool(INCOMPATIBLE_NO_ATTR_LICENSE, incompatibleNoAttrLicense)
             .setBool(INCOMPATIBLE_NO_IMPLICIT_FILE_EXPORT, incompatibleNoImplicitFileExport)
             .setBool(INCOMPATIBLE_NO_PACKAGE_DISTRIBS, incompatibleNoPackageDistribs)
@@ -864,6 +876,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       "+incompatible_do_not_split_linking_cmdline";
   public static final String INCOMPATIBLE_JAVA_COMMON_PARAMETERS =
       "+incompatible_java_common_parameters";
+  public static final String INCOMPATIBLE_JAVA_INFO_MERGE_RUNTIME_MODULE_FLAGS =
+      "-incompatible_java_info_merge_runtime_module_flags";
   public static final String INCOMPATIBLE_NO_ATTR_LICENSE = "+incompatible_no_attr_license";
   public static final String INCOMPATIBLE_NO_PACKAGE_DISTRIBS = "-incompatible_no_package_distribs";
   public static final String INCOMPATIBLE_NO_IMPLICIT_FILE_EXPORT =

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -363,6 +363,15 @@ public class JavaStarlarkCommon
   }
 
   @Override
+  public boolean isJavaInfoMergeRuntimeModuleFlagsEnabled(StarlarkThread thread)
+      throws EvalException {
+    checkPrivateAccess(thread);
+    return thread
+        .getSemantics()
+        .getBool(BuildLanguageOptions.INCOMPATIBLE_JAVA_INFO_MERGE_RUNTIME_MODULE_FLAGS);
+  }
+
+  @Override
   public JavaInfo wrapJavaInfo(Info javaInfo, StarlarkThread thread)
       throws EvalException, RuleErrorException {
     checkPrivateAccess(thread);

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -701,6 +701,12 @@ public interface JavaCommonApi<
   boolean isDepsetForJavaOutputSourceJarsEnabled(StarlarkThread thread) throws EvalException;
 
   @StarlarkMethod(
+      name = "_incompatible_java_info_merge_runtime_module_flags",
+      documented = false,
+      useStarlarkThread = true)
+  boolean isJavaInfoMergeRuntimeModuleFlagsEnabled(StarlarkThread thread) throws EvalException;
+
+  @StarlarkMethod(
       name = "wrap_java_info",
       parameters = {@Param(name = "java_info")},
       documented = false,


### PR DESCRIPTION
Change the behavior of `JavaInfo` constructor to be more like `java_info_for_compilation`, by merging in the `add_exports` and `add_opens` flags for `runtime_deps` in addition to just `deps` and `exports`. Guard it under an `--incompatible_` flag which defaults to false, but I'm hoping to make it default to true in 8.x.

Second half of #20033