### PR TITLE
[7.0.0] Include whether flags need values in info

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -273,6 +273,7 @@ public final class HelpCommand implements BlazeCommand {
     flagBuilder.setHasNegativeFlag(option.hasNegativeOption());
     flagBuilder.setDocumentation(option.getHelpText());
     flagBuilder.setAllowsMultiple(option.allowsMultiple());
+    flagBuilder.setRequiresValue(option.requiresValue());
 
     List<String> optionEffectTags =
         Arrays.stream(option.getOptionEffectTags())

--- a/src/main/java/com/google/devtools/common/options/OptionDefinition.java
+++ b/src/main/java/com/google/devtools/common/options/OptionDefinition.java
@@ -270,6 +270,14 @@ public class OptionDefinition implements Comparable<OptionDefinition> {
         || getConverter() instanceof BoolOrEnumConverter;
   }
 
+  /**
+   * Returns whether an option requires a value when instantiated, or instead can be present without
+   * an explicit value.
+   */
+  public boolean requiresValue() {
+    return !isVoidField() && !usesBooleanValueSyntax();
+  }
+
   /** Returns the evaluated default value for this option & memoizes the result. */
   @Nullable
   public Object getDefaultValue(@Nullable Object conversionContext) {

--- a/src/main/java/com/google/devtools/common/options/OptionsUsage.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsUsage.java
@@ -221,7 +221,7 @@ class OptionsUsage {
         .append(flagName)
         .append("</a>");
 
-    if (optionDefinition.usesBooleanValueSyntax() || optionDefinition.isVoidField()) {
+    if (!optionDefinition.requiresValue()) {
       // Nothing for boolean, tristate, boolean_or_enum, or void options.
     } else if (!valueDescription.isEmpty()) {
       usage.append("=").append(escaper.escape(valueDescription));

--- a/src/main/protobuf/bazel_flags.proto
+++ b/src/main/protobuf/bazel_flags.proto
@@ -41,6 +41,11 @@ message FlagInfo {
   repeated string metadata_tags = 8;
   // The documentation category assigned to this flag
   optional string documentation_category = 9;
+  // Whether the flag requires a value.
+  // If false, value-less invocations are acceptable, e.g. --subcommands,
+  // but if true a value must be present for all instantiations of the flag,
+  // e.g. --jobs=100.
+  optional bool requires_value = 10;
 }
 
 message FlagCollection {


### PR DESCRIPTION
When parsing flags outside of Bazel, it can be useful to know whether the next token may be a value for a previous flag or whether the previous flag was complete because it didn't need a value.

Closes #19536.

Commit https://github.com/bazelbuild/bazel/commit/718f400c61e24b26f2d4fde78d7a455245ae2f69

PiperOrigin-RevId: 579324484
Change-Id: I47162f90dc7d5bbd770a95766e99fb06eaea52f1