### PR TITLE
[7.0.0] Prefer obtaining output digests from the action filesystem when writing to the execution log.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -118,10 +118,11 @@ public final class SpawnLogModule extends BlazeModule {
 
     spawnLogContext =
         new SpawnLogContext(
-            env.getExecRoot(),
+            env.getExecRoot().asFragment(),
             outStream,
             env.getOptions().getOptions(ExecutionOptions.class),
             env.getOptions().getOptions(RemoteOptions.class),
+            env.getRuntime().getFileSystem().getDigestFunction(),
             env.getXattrProvider());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -193,6 +193,9 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
             spawn,
             actionExecutionContext.getInputMetadataProvider(),
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ false),
+            actionExecutionContext.getActionFileSystem() != null
+                ? actionExecutionContext.getActionFileSystem()
+                : actionExecutionContext.getExecRoot().getFileSystem(),
             context.getTimeout(),
             spawnResult);
       } catch (IOException | ForbiddenActionInputException e) {

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.exec;
 
 import build.bazel.remote.execution.v2.Platform;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.hash.HashCode;
@@ -40,6 +39,7 @@ import com.google.devtools.build.lib.util.io.MessageOutputStream;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.Dirent;
+import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
@@ -66,34 +66,47 @@ public class SpawnLogContext implements ActionContext {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
-  private final Path execRoot;
+  private final PathFragment execRoot;
   private final MessageOutputStream executionLog;
   @Nullable private final ExecutionOptions executionOptions;
   @Nullable private final RemoteOptions remoteOptions;
+  private final DigestHashFunction digestHashFunction;
   private final XattrProvider xattrProvider;
 
   public SpawnLogContext(
-      Path execRoot,
+      PathFragment execRoot,
       MessageOutputStream executionLog,
       @Nullable ExecutionOptions executionOptions,
       @Nullable RemoteOptions remoteOptions,
+      DigestHashFunction digestHashFunction,
       XattrProvider xattrProvider) {
     this.execRoot = execRoot;
     this.executionLog = executionLog;
     this.executionOptions = executionOptions;
     this.remoteOptions = remoteOptions;
+    this.digestHashFunction = digestHashFunction;
     this.xattrProvider = xattrProvider;
   }
 
-  /** Log the executed spawn to the output stream. */
+  /**
+   * Logs the executed spawn to the output stream.
+   *
+   * @param spawn the spawn to log
+   * @param inputMetadataProvider provides metadata for the spawn inputs
+   * @param fileSystem the filesystem containing the spawn inputs and outputs, which might be an
+   *     action filesystem when building without the bytes
+   * @param timeout the timeout the spawn was run under
+   * @param result the spawn result
+   */
   public void logSpawn(
       Spawn spawn,
       InputMetadataProvider inputMetadataProvider,
       SortedMap<PathFragment, ActionInput> inputMap,
+      FileSystem fileSystem,
       Duration timeout,
       SpawnResult result)
       throws IOException, ExecException {
-    SortedMap<Path, ActionInput> existingOutputs = listExistingOutputs(spawn);
+    SortedMap<Path, ActionInput> existingOutputs = listExistingOutputs(spawn, fileSystem);
     SpawnExec.Builder builder = SpawnExec.newBuilder();
     builder.addAllCommandArgs(spawn.getArguments());
 
@@ -112,21 +125,21 @@ public class SpawnLogContext implements ActionContext {
         if (input instanceof VirtualActionInput.EmptyActionInput) {
           continue;
         }
-        Path inputPath = execRoot.getRelative(input.getExecPathString());
+        Path inputPath = fileSystem.getPath(execRoot.getRelative(input.getExecPathString()));
         if (inputPath.isDirectory()) {
           listDirectoryContents(inputPath, builder::addInputs, inputMetadataProvider);
-        } else {
-          Digest digest = computeDigest(input, null, inputMetadataProvider, xattrProvider);
-          boolean isTool =
-              toolFiles.contains(input)
-                  || (input instanceof TreeFileArtifact
-                      && toolFiles.contains(((TreeFileArtifact) input).getParent()));
-          builder
-              .addInputsBuilder()
-              .setPath(input.getExecPathString())
-              .setDigest(digest)
-              .setIsTool(isTool);
+          continue;
         }
+        Digest digest = computeDigest(input, inputPath, inputMetadataProvider, xattrProvider);
+        boolean isTool =
+            toolFiles.contains(input)
+                || (input instanceof TreeFileArtifact
+                    && toolFiles.contains(((TreeFileArtifact) input).getParent()));
+        builder
+            .addInputsBuilder()
+            .setPath(input.getExecPathString())
+            .setDigest(digest)
+            .setIsTool(isTool);
       }
     } catch (IOException e) {
       logger.atWarning().withCause(e).log("Error computing spawn inputs");
@@ -144,7 +157,7 @@ public class SpawnLogContext implements ActionContext {
           listDirectoryContents(path, builder::addActualOutputs, inputMetadataProvider);
         } else {
           File.Builder outputBuilder = builder.addActualOutputsBuilder();
-          outputBuilder.setPath(path.relativeTo(execRoot).toString());
+          outputBuilder.setPath(path.relativeTo(fileSystem.getPath(execRoot)).toString());
           try {
             outputBuilder.setDigest(
                 computeDigest(e.getValue(), path, inputMetadataProvider, xattrProvider));
@@ -252,10 +265,10 @@ public class SpawnLogContext implements ActionContext {
     return platformBuilder.build();
   }
 
-  private SortedMap<Path, ActionInput> listExistingOutputs(Spawn spawn) {
+  private SortedMap<Path, ActionInput> listExistingOutputs(Spawn spawn, FileSystem fileSystem) {
     TreeMap<Path, ActionInput> result = new TreeMap<>();
     for (ActionInput output : spawn.getOutputFiles()) {
-      Path outputPath = execRoot.getRelative(output.getExecPathString());
+      Path outputPath = fileSystem.getPath(execRoot.getRelative(output.getExecPathString()));
       // TODO(olaola): once symlink API proposal is implemented, report symlinks here.
       if (outputPath.exists()) {
         result.put(outputPath, output);
@@ -278,9 +291,9 @@ public class SpawnLogContext implements ActionContext {
         } else {
           String pathString;
           if (child.startsWith(execRoot)) {
-            pathString = child.relativeTo(execRoot).toString();
+            pathString = child.asFragment().relativeTo(execRoot).getPathString();
           } else {
-            pathString = child.toString();
+            pathString = child.getPathString();
           }
           addFile.accept(
               File.newBuilder()
@@ -300,45 +313,41 @@ public class SpawnLogContext implements ActionContext {
    */
   private Digest computeDigest(
       @Nullable ActionInput input,
-      @Nullable Path path,
+      Path path,
       InputMetadataProvider inputMetadataProvider,
       XattrProvider xattrProvider)
       throws IOException {
-    Preconditions.checkArgument(input != null || path != null);
-    DigestHashFunction hashFunction = execRoot.getFileSystem().getDigestFunction();
-    Digest.Builder digest = Digest.newBuilder().setHashFunctionName(hashFunction.toString());
+    Digest.Builder builder = Digest.newBuilder().setHashFunctionName(digestHashFunction.toString());
+
     if (input != null) {
       if (input instanceof VirtualActionInput) {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         ((VirtualActionInput) input).writeTo(buffer);
         byte[] blob = buffer.toByteArray();
-        return digest
-            .setHash(hashFunction.getHashFunction().hashBytes(blob).toString())
+        return builder
+            .setHash(digestHashFunction.getHashFunction().hashBytes(blob).toString())
             .setSizeBytes(blob.length)
             .build();
       }
-      // Try to access the cached metadata, otherwise fall back to local computation.
+
+      // Try to obtain a digest from the input metadata.
       try {
         FileArtifactValue metadata = inputMetadataProvider.getInputMetadata(input);
-        if (metadata != null) {
-          byte[] hash = metadata.getDigest();
-          if (hash != null) {
-            return digest
-                .setHash(HashCode.fromBytes(hash).toString())
-                .setSizeBytes(metadata.getSize())
-                .build();
-          }
+        if (metadata != null && metadata.getDigest() != null) {
+          return builder
+              .setHash(HashCode.fromBytes(metadata.getDigest()).toString())
+              .setSizeBytes(metadata.getSize())
+              .build();
         }
       } catch (IOException | IllegalStateException e) {
         // Pass through to local computation.
       }
     }
-    if (path == null) {
-      path = execRoot.getRelative(input.getExecPath());
-    }
-    // Compute digest manually.
+
     long fileSize = path.getFileSize();
-    return digest
+
+    // Try to obtain a digest from the filesystem.
+    return builder
         .setHash(
             HashCode.fromBytes(
                     DigestUtils.getDigestWithManualFallback(path, fileSize, xattrProvider))

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -27,17 +27,21 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnExecutedEvent;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.devtools.build.lib.actions.StaticInputMetadataProvider;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.events.StoredEventHandler;
@@ -56,25 +60,29 @@ import com.google.devtools.build.lib.server.FailureDetails.Spawn.Code;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.util.io.MessageOutputStream;
+import com.google.devtools.build.lib.vfs.DelegateFileSystem;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import com.google.protobuf.Duration;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link BlazeExecutor}. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public class AbstractSpawnStrategyTest {
   private static final FailureDetail NON_ZERO_EXIT_DETAILS =
       FailureDetail.newBuilder()
@@ -103,6 +111,24 @@ public class AbstractSpawnStrategyTest {
   @Mock private MessageOutputStream messageOutput;
   private StoredEventHandler eventHandler;
   private final ManualClock clock = new ManualClock();
+
+  // A fake action filesystem that provides a fast digest, but refuses to compute it from the
+  // file contents (which won't be available when building without the bytes).
+  private static final class FakeActionFileSystem extends DelegateFileSystem {
+    FakeActionFileSystem(FileSystem delegateFs) {
+      super(delegateFs);
+    }
+
+    @Override
+    protected byte[] getFastDigest(PathFragment path) throws IOException {
+      return super.getDigest(path);
+    }
+
+    @Override
+    protected byte[] getDigest(PathFragment path) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+  }
 
   @Before
   public final void setUp() throws Exception {
@@ -337,21 +363,44 @@ public class AbstractSpawnStrategyTest {
     verify(entry).store(eq(result));
   }
 
-  @Test
-  public void testLogSpawn() throws Exception {
-    setUpExecutionContext(/* remoteOptions= */ null);
+  enum LogSpawnMode {
+    WITH_BYTES,
+    WITHOUT_BYTES
+  };
 
-    Artifact input = ActionsTestUtil.createArtifact(rootDir, scratch.file("/execroot/foo", "1"));
-    scratch.file("/execroot/out1", "123");
-    scratch.file("/execroot/out2", "123");
+  @Test
+  public void testLogSpawn(@TestParameter LogSpawnMode mode) throws Exception {
+    Artifact fileInput = ActionsTestUtil.createArtifact(rootDir, "file");
+    Artifact dirInput = ActionsTestUtil.createArtifact(rootDir, "dir");
+
+    Artifact fileOutput = ActionsTestUtil.createArtifact(outputDir, "file");
+    Artifact dirOutput = ActionsTestUtil.createArtifact(outputDir, "dir");
+
+    scratch.file(fileInput.getPath().toString(), "1");
+    scratch.file(dirInput.getPath().getChild("child").toString(), "2");
+    scratch.file(fileOutput.getPath().toString(), "3");
+    scratch.file(dirOutput.getPath().getChild("child").toString(), "4");
+
+    ImmutableMap<ActionInput, FileArtifactValue> inputMetadata =
+        ImmutableMap.of(
+            fileInput, FileArtifactValue.createForTesting(fileInput),
+            dirInput, FileArtifactValue.createForTesting(dirInput));
+
+    if (mode.equals(LogSpawnMode.WITHOUT_BYTES)) {
+      FileSystem actionFs = new FakeActionFileSystem(fs);
+      setUpExecutionContext(inputMetadata, actionFs, Options.getDefaults(RemoteOptions.class));
+    } else {
+      setUpExecutionContext();
+    }
+
     Spawn spawn =
         new SpawnBuilder("/bin/echo", "Foo!")
             .withEnvironment("FOO", "v1")
             .withEnvironment("BAR", "v2")
             .withMnemonic("MyMnemonic")
             .withProgressMessage("my progress message")
-            .withInput(input)
-            .withOutputs("out2", "out1")
+            .withInputs(fileInput, dirInput)
+            .withOutputs(fileOutput, dirOutput)
             .build();
     assertThrows(
         SpawnExecException.class,
@@ -367,7 +416,18 @@ public class AbstractSpawnStrategyTest {
                 EnvironmentVariable.newBuilder().setName("FOO").setValue("v1").build())
             .addInputs(
                 File.newBuilder()
-                    .setPath("foo")
+                    .setPath("dir/child")
+                    .setDigest(
+                        Digest.newBuilder()
+                            .setHash(
+                                "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3")
+                            .setSizeBytes(2)
+                            .setHashFunctionName("SHA-256")
+                            .build())
+                    .build())
+            .addInputs(
+                File.newBuilder()
+                    .setPath("file")
                     .setDigest(
                         Digest.newBuilder()
                             .setHash(
@@ -376,27 +436,27 @@ public class AbstractSpawnStrategyTest {
                             .setHashFunctionName("SHA-256")
                             .build())
                     .build())
-            .addListedOutputs("out1")
-            .addListedOutputs("out2")
+            .addListedOutputs("out/dir")
+            .addListedOutputs("out/file")
             .addActualOutputs(
                 File.newBuilder()
-                    .setPath("out1")
+                    .setPath("out/dir/child")
                     .setDigest(
                         Digest.newBuilder()
                             .setHash(
-                                "181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b")
-                            .setSizeBytes(4)
+                                "7de1555df0c2700329e815b93b32c571c3ea54dc967b89e81ab73b9972b72d1d")
+                            .setSizeBytes(2)
                             .setHashFunctionName("SHA-256")
                             .build())
                     .build())
             .addActualOutputs(
                 File.newBuilder()
-                    .setPath("out2")
+                    .setPath("out/file")
                     .setDigest(
                         Digest.newBuilder()
                             .setHash(
-                                "181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b")
-                            .setSizeBytes(4)
+                                "1121cfccd5913f0a63fec40a6ffd44ea64f9dc135c66634ba001d10bcf4302a2")
+                            .setSizeBytes(2)
                             .setHashFunctionName("SHA-256")
                             .build())
                     .build())
@@ -418,7 +478,7 @@ public class AbstractSpawnStrategyTest {
 
   @Test
   public void testLogSpawn_noPlatform_noLoggedPlatform() throws Exception {
-    setUpExecutionContext(/* remoteOptions= */ null);
+    setUpExecutionContext();
 
     Spawn spawn = new SpawnBuilder("cmd").build();
 
@@ -575,16 +635,32 @@ public class AbstractSpawnStrategyTest {
     verify(messageOutput).write(expected); // output will reflect default properties
   }
 
+  private void setUpExecutionContext() throws Exception {
+    setUpExecutionContext(Options.getDefaults(RemoteOptions.class));
+  }
+
   private void setUpExecutionContext(RemoteOptions remoteOptions) throws Exception {
+    setUpExecutionContext(ImmutableMap.of(), fs, remoteOptions);
+  }
+
+  private void setUpExecutionContext(
+      ImmutableMap<ActionInput, FileArtifactValue> inputMetadata,
+      FileSystem actionFs,
+      RemoteOptions remoteOptions)
+      throws Exception {
     when(actionExecutionContext.getContext(eq(SpawnCache.class))).thenReturn(SpawnCache.NO_CACHE);
     when(actionExecutionContext.getExecRoot()).thenReturn(execRoot);
+    when(actionExecutionContext.getActionFileSystem()).thenReturn(actionFs);
+    when(actionExecutionContext.getInputMetadataProvider())
+        .thenReturn(new StaticInputMetadataProvider(inputMetadata));
     when(actionExecutionContext.getContext(eq(SpawnLogContext.class)))
         .thenReturn(
             new SpawnLogContext(
-                execRoot,
+                execRoot.asFragment(),
                 messageOutput,
                 Options.getDefaults(ExecutionOptions.class),
                 remoteOptions,
+                DigestHashFunction.SHA256,
                 SyscallCache.NO_CACHE));
     when(spawnRunner.exec(any(Spawn.class), any(SpawnExecutionContext.class)))
         .thenReturn(


### PR DESCRIPTION
Previously, the output digests were computed from the real filesystem, which doesn't work when building without the bytes.

PiperOrigin-RevId: 579803114
Change-Id: I5c05f83cecb53489315ab494cbddf059204fa2f4