### PR TITLE
Allow use scrubbing with remote execution (build actions with scrubbed inputs locally)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1604,6 +1604,14 @@ public class RemoteExecutionService {
     if (spawnScrubber == null) {
       return false;
     }
+    if (!spawnScrubber.getSalt().isEmpty()) {
+      return true;
+    }
+    for (String arg : spawn.getArguments()) {
+      if (!arg.equals(spawnScrubber.transformArgument(arg))) {
+        return true;
+      }
+    }
     var inputFiles = spawn.getInputFiles();
     for (ActionInput inputFile : inputFiles.getLeaves()) {
       if (spawnScrubber.shouldOmitInput(inputFile)) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1613,7 +1613,7 @@ public class RemoteExecutionService {
       }
     }
     var inputFiles = spawn.getInputFiles();
-    for (ActionInput inputFile : inputFiles.getLeaves()) {
+    for (ActionInput inputFile : inputFiles.toList()) {
       if (spawnScrubber.shouldOmitInput(inputFile)) {
         return true;
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -313,10 +313,7 @@ public final class RemoteModule extends BlazeModule {
 
     boolean enableScrubbing = remoteOptions.scrubber != null;
     if (enableScrubbing && enableRemoteExecution) {
-
-      throw createOptionsExitException(
-          "Cannot combine remote cache key scrubbing with remote execution",
-          FailureDetails.RemoteOptions.Code.EXECUTION_WITH_SCRUBBING);
+      env.getReporter().handle(Event.warn("Cannot combine remote cache key scrubbing with remote execution. All actions with cache key scrubbing will be executed locally"));
     }
 
     // TODO(bazel-team): Consider adding a warning or more validation if the remoteDownloadRegex is


### PR DESCRIPTION
Since cannot run remote cache key scrubbing action with remote execution, run this actions only locally. Actions without scrubbed input can still be executed remotely.

Same idea as:
 - https://github.com/bazelbuild/bazel/pull/16240