### PR TITLE
[7.0.0] Set the content type on the release notes HTML files.

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -199,6 +199,8 @@ function release_to_gcs() {
     fi
     create_index_html "${artifact_dir}" > "${artifact_dir}/index.html"
     gsutil -m cp "${artifact_dir}/**" "gs://bazel/${release_path}"
+    # Set the content type on index.html so it isn't autodetected incorrectly by the browser.
+    gsutil setmeta -h "Content-Type: text/html; charset=utf-8" "gs://bazel/${release_path}/index.html"
   fi
 }
 


### PR DESCRIPTION
Fixes [#1764](https://github.com/bazelbuild/continuous-integration/issues/1764). (Except for already published files, which I'll write a separate script to retroactively fix.)

Closes #19955.

Commit https://github.com/bazelbuild/bazel/commit/6747679bee18537bb7ff60d625111b8687731d52

PiperOrigin-RevId: 579182298
Change-Id: Id8dbafbf532d0b82e721edc31837a7870ec4a900