### PR TITLE
Fix java_stub_template.txt for cygwin environment

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -241,9 +241,11 @@ fi
 # Set JAVABIN to the path to the JVM launcher.
 %javabin%
 
-# Cygwin will not accept any backslashes in JAVABIN when trying to execute it.
 if is_windows; then
+  # Cygwin will not accept any backslashes in JAVABIN when trying to execute it.
   JAVABIN="$(cygpath --unix $JAVABIN)"
+  # Ensure we have .exe suffix, JARBIN resolution fails without it.
+  JAVABIN="${JAVABIN%.exe}.exe"
 fi
 
 if [[ "$PRINT_JAVABIN" == 1 || "%java_start_class%" == "--print_javabin" ]]; then

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -241,6 +241,11 @@ fi
 # Set JAVABIN to the path to the JVM launcher.
 %javabin%
 
+# Cygwin will not accept any backslashes in JAVABIN when trying to execute it.
+if is_windows; then
+  JAVABIN="$(cygpath --unix $JAVABIN)"
+fi
+
 if [[ "$PRINT_JAVABIN" == 1 || "%java_start_class%" == "--print_javabin" ]]; then
   echo -n "$JAVABIN"
   exit 0
@@ -255,8 +260,14 @@ if [[ "$SINGLEJAR" == 1 ]]; then
 else
   # Create the shortest classpath we can, by making it relative if possible.
   RUNPATH="${JAVA_RUNFILES}/%workspace_prefix%"
-  RUNPATH="${RUNPATH#$PWD/}"
+  # Keep absolute paths on windows, so we can correctly support both ':' and ';' as separators
+  if ! is_windows; then
+    RUNPATH="${RUNPATH#$PWD/}";
+  fi
   CLASSPATH=%classpath%
+  if is_windows; then
+    CLASSPATH="$(sed -E 's/:([A-Z]):/;\1:/g' <<< "$CLASSPATH")"
+  fi
 fi
 
 # Export the locations which will be used to find the location of the classes from the classpath file.

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -268,6 +268,10 @@ else
   fi
   CLASSPATH=%classpath%
   if is_windows; then
+    # We need to ensure we are using ';' as the classpath separator on windows. When cross
+    # building from Linux ':' will be used here. We take advantage of absolute paths in
+    # windows starting with e.g. C: and replace :C: -> ;C:. The expression has no effect
+    # if ';' is already used as the classpath separator.
     CLASSPATH="$(sed -E 's/:([A-Z]):/;\1:/g' <<< "$CLASSPATH")"
   fi
 fi


### PR DESCRIPTION
closes #20065 

Should be low risk change, and fix cross building java binary targets to run on Windows using cygwin.