### PR TITLE
[7.0.0] Bazel 7.0 - can't compile  with `/DUNICODE` `/D_UNICODE` 

### DIFF
--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -48,6 +48,7 @@ output_paths = [
     ('*tools/cpp/runfiles/generated_*',
      lambda x: 'tools/cpp/runfiles/' + os.path.basename(x)[len('generated_'):]),
     ('*launcher.exe', lambda x: 'tools/launcher/launcher.exe'),
+    ('*launcher_maker.exe', lambda x: 'tools/launcher/launcher_maker.exe'),
     ('*def_parser.exe', lambda x: 'tools/def_parser/def_parser.exe'),
     ('*zipper.exe', lambda x: 'tools/zip/zipper/zipper.exe'),
     ('*zipper', lambda x: 'tools/zip/zipper/zipper'),

--- a/tools/launcher/BUILD.tools
+++ b/tools/launcher/BUILD.tools
@@ -20,5 +20,18 @@ filegroup(
 
 filegroup(
     name = "launcher_maker",
-    srcs = ["//src/tools/launcher:launcher_maker"],
+    srcs = select({
+        "//src/conditions:host_windows": [":launcher_maker_windows"],
+        "//conditions:default": [
+            "//src/tools/launcher:launcher_maker",
+        ],
+    }),
+)
+
+filegroup(
+    name = "launcher_maker_windows",
+    srcs = select({
+        "//src/conditions:remote": ["//src/tools/launcher:launcher_maker"],
+        "//conditions:default": ["launcher_maker.exe"],
+    }),
 )


### PR DESCRIPTION
Using a prebuilt binary solves a few issues:
* Avoids having to build the launcher maker entirely. It is special purpose
  binary, isn't going to change much, and would otherwise incur needing a
  C++ toolchain.
* It doesn't work with `--host_copt=/DUNICODE`, as described in #19977
* Preserves behavior of Starlarkified rules that use the launcher maker.
  The non-Starlark implementation used a special Java-implemented action
  to replicate what launcher_maker does, thus avoiding the C++ toolchain
  dependency.

Fixes #19977

Commit https://github.com/bazelbuild/bazel/commit/f898da56995809140b65d2b3b6f5b631a3ec511a

PiperOrigin-RevId: 580200034
Change-Id: Ic5a65a5021ea8b0b325b68c1817180e429b6d56b