### PR TITLE
[7.0.0] Fix JVM repository rules with Bzlmod

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2106,7 +2106,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_android_deps": {
       "general": {
-        "bzlTransitiveDigest": "6AGSxM+UftLlwIp1CDxiyKB5llsivFGozNcZoLrIYRc=",
+        "bzlTransitiveDigest": "YE1RlA6YS4ztUyZvffGDzF2vAIQTseoX8IwjeYyKcFc=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2131,9 +2131,9 @@
     },
     "//:extensions.bzl%bazel_build_deps": {
       "general": {
-        "bzlTransitiveDigest": "6AGSxM+UftLlwIp1CDxiyKB5llsivFGozNcZoLrIYRc=",
+        "bzlTransitiveDigest": "YE1RlA6YS4ztUyZvffGDzF2vAIQTseoX8IwjeYyKcFc=",
         "accumulatedFileDigests": {
-          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "3690079fb96225220955f4e04363ba87470cb4cfb0f2b6deddd9929822ecc3ad"
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "23e00a4ebe85282fdd1c8206adeec448eba0618b7083739bbd78704651e32d6b"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2347,7 +2347,7 @@
     },
     "//:extensions.bzl%bazel_test_deps": {
       "general": {
-        "bzlTransitiveDigest": "6AGSxM+UftLlwIp1CDxiyKB5llsivFGozNcZoLrIYRc=",
+        "bzlTransitiveDigest": "YE1RlA6YS4ztUyZvffGDzF2vAIQTseoX8IwjeYyKcFc=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2404,7 +2404,7 @@
     },
     "//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ibouvQjJ5aiSzhyc5x57J4CnvIbuwhFJ/zMpCeHpq0c=",
+        "bzlTransitiveDigest": "EFYd5Zc37KUKoseMe8brwJ5A2j/kUvPs5pIvTfGf3ok=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2431,7 +2431,7 @@
     },
     "//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "PEh3vETU0xQzauyboFj1AYs9nvzf23oQ3vbV/5bFnE4=",
+        "bzlTransitiveDigest": "wd0+Kn35gYWv/xzdEzWg7vRQz6FZcfpne4WcwCs9d+o=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitOverride.java
@@ -24,6 +24,8 @@ import com.google.devtools.build.lib.cmdline.RepositoryName;
 /** Specifies that a module should be retrieved from a Git repository. */
 @AutoValue
 public abstract class GitOverride implements NonRegistryOverride {
+  public static final String GIT_REPOSITORY_PATH = "@bazel_tools//tools/build_defs/repo:git.bzl";
+
   public static GitOverride create(
       String remote,
       String commit,
@@ -60,7 +62,7 @@ public abstract class GitOverride implements NonRegistryOverride {
         .put("patch_cmds", getPatchCmds())
         .put("patch_args", ImmutableList.of("-p" + getPatchStrip()));
     return RepoSpec.builder()
-        .setBzlFile("@bazel_tools//tools/build_defs/repo:git.bzl")
+        .setBzlFile(GIT_REPOSITORY_PATH)
         .setRuleClassName("git_repository")
         .setAttributes(AttributeValues.create(attrBuilder.buildOrThrow()))
         .build();

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -619,21 +619,8 @@ public class BzlLoadFunction implements SkyFunction {
         // https://github.com/bazelbuild/bazel/issues/17713
         // `@_builtins` depends on `@bazel_tools` for repo mapping, so we ignore some bzl files
         // to avoid a cyclic dependency
-        || (key instanceof BzlLoadValue.KeyForBzlmod && !isFileSafeForUninjectedEvaluation(key));
-  }
-
-  private static final PackageIdentifier BAZEL_TOOLS_BOOTSTRAP_RULES_PACKAGE =
-      PackageIdentifier.create(
-          RepositoryName.BAZEL_TOOLS, PathFragment.create("tools/build_defs/repo"));
-
-  private static boolean isFileSafeForUninjectedEvaluation(BzlLoadValue.Key key) {
-    // We don't inject _builtins for repo rules to avoid a Skyframe cycle.
-    // The cycle is caused only with bzlmod because the `@_builtins` repo does not declare its own
-    // module deps and requires `@bazel_tools` to re-use the latter's repo mapping. This triggers
-    // Bazel module resolution, and if there are any non-registry overrides in the root MODULE.bazel
-    // file (such as `git_override` or `archive_override`), the corresponding bzl files will be
-    // evaluated.
-    return key.getLabel().getPackageIdentifier().equals(BAZEL_TOOLS_BOOTSTRAP_RULES_PACKAGE);
+        || (key instanceof BzlLoadValue.KeyForBzlmod
+            && !(key instanceof BzlLoadValue.KeyForBzlmodBootstrap));
   }
 
   /**
@@ -946,7 +933,7 @@ public class BzlLoadFunction implements SkyFunction {
     }
 
     if (key instanceof BzlLoadValue.KeyForBzlmod) {
-      if (key.getLabel().getPackageIdentifier().equals(BAZEL_TOOLS_BOOTSTRAP_RULES_PACKAGE)) {
+      if (key instanceof BzlLoadValue.KeyForBzlmodBootstrap) {
         // Special case: we're only here to get one of the rules in the @bazel_tools repo that
         // load Bazel modules. At this point we can't load from any other modules and thus use a
         // repository mapping that contains only @bazel_tools itself.
@@ -1324,7 +1311,7 @@ public class BzlLoadFunction implements SkyFunction {
         // TODO(#11954): We should converge all .bzl dialects regardless of whether they're loaded
         //  by BUILD, WORKSPACE, or MODULE. At the moment, WORKSPACE-loaded and MODULE-loaded .bzl
         //  files are already converged, so we use the same environment for both.
-        if (injectionDisabled || isFileSafeForUninjectedEvaluation(key)) {
+        if (injectionDisabled || key instanceof BzlLoadValue.KeyForBzlmodBootstrap) {
           return starlarkEnv.getUninjectedWorkspaceBzlEnv();
         }
         // Note that we don't actually fingerprint the injected builtins here. The actual builtins

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -785,6 +785,33 @@ class BazelModuleTest(test_base.TestBase):
 
     self.RunBazel(['build', '@data//:data.txt'])
 
+  def testHttpJar(self):
+    """Tests that using http_jar does not require a bazel_dep on rules_java."""
+
+    my_jar_path = self.ScratchFile('my_jar.jar')
+    my_jar_uri = pathlib.Path(my_jar_path).as_uri()
+
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            (
+                'http_jar ='
+                ' use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl",'
+                ' "http_jar")'
+            ),
+            'http_jar(',
+            '  name = "my_jar",',
+            '  url = "%s",' % my_jar_uri,
+            (
+                '  sha256 ='
+                ' "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",'
+            ),
+            ')',
+        ],
+    )
+
+    self.RunBazel(['build', '@my_jar//jar'])
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -646,7 +646,7 @@
     },
     "@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ibouvQjJ5aiSzhyc5x57J4CnvIbuwhFJ/zMpCeHpq0c=",
+        "bzlTransitiveDigest": "EFYd5Zc37KUKoseMe8brwJ5A2j/kUvPs5pIvTfGf3ok=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -730,7 +730,7 @@
     },
     "@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "PEh3vETU0xQzauyboFj1AYs9nvzf23oQ3vbV/5bFnE4=",
+        "bzlTransitiveDigest": "wd0+Kn35gYWv/xzdEzWg7vRQz6FZcfpne4WcwCs9d+o=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -750,7 +750,7 @@
     },
     "@rules_java~7.0.6//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "MgCo2BSYmyPA2WdKpPo9jP+FL4/VRknyohG5Q/Vm5hY=",
+        "bzlTransitiveDigest": "MikgfmqYJkp+g1SrpNduqecc6yekTHnvX4ovV4X7XpQ=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1290,7 +1290,7 @@
     },
     "@rules_python~0.4.0//bzlmod:extensions.bzl%pip_install": {
       "general": {
-        "bzlTransitiveDigest": "PqA2lCz4HPSsq9EV/J5DW2Q2zbNyBRRAHRk54HCtrTg=",
+        "bzlTransitiveDigest": "fWWk0VJDA4P65oiSwJr5IKwxMWlFzootX8ZiYu5ETv8=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -192,7 +192,7 @@ def _http_file_impl(ctx):
     return _update_sha256_attr(ctx, _http_file_attrs, download_info)
 
 _HTTP_JAR_BUILD = """\
-load("@rules_java//java:defs.bzl", "java_import")
+load("{rules_java_defs}", "java_import")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -224,7 +224,10 @@ def _http_jar_impl(ctx):
         integrity = ctx.attr.integrity,
     )
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
-    ctx.file("jar/BUILD", _HTTP_JAR_BUILD.format(file_name = downloaded_file_name))
+    ctx.file("jar/BUILD", _HTTP_JAR_BUILD.format(
+        file_name = downloaded_file_name,
+        rules_java_defs = str(Label("@rules_java//java:defs.bzl")),
+    ))
 
     return _update_sha256_attr(ctx, _http_jar_attrs, download_info)
 

--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -136,7 +136,7 @@ def _jvm_import_external(repository_ctx):
         "",
         "alias(",
         "    name = \"%s\"," % extension,
-        "    actual = \"@%s\"," % repository_ctx.name,
+        "    actual = \"//:%s\"," % name,
         ")",
         "",
         "filegroup(",
@@ -255,6 +255,7 @@ jvm_import_external = repository_rule(
 )
 
 def jvm_maven_import_external(
+        name,
         artifact,
         server_urls,
         fetch_sources = False,
@@ -269,9 +270,10 @@ def jvm_maven_import_external(
     srcjar_urls = kwargs.pop("srcjar_urls", None)
 
     rule_name = kwargs.pop("rule_name", "java_import")
+    rules_java_defs = str(Label("@rules_java//java:defs.bzl"))
     rule_load = kwargs.pop(
         "rule_load",
-        'load("@rules_java//java:defs.bzl", "java_import")',
+        'load("{}", "java_import")'.format(rules_java_defs),
     )
 
     if fetch_sources:
@@ -289,6 +291,8 @@ def jvm_maven_import_external(
     tags.append("maven_coordinates=" + artifact)
 
     jvm_import_external(
+        name = name,
+        generated_rule_name = kwargs.pop("generated_rule_name", name),
         artifact_urls = jar_urls,
         srcjar_urls = srcjar_urls,
         canonical_id = artifact,


### PR DESCRIPTION
* Lets the `http_jar` and `jvm_{maven_}import_external` rules load from `@rules_java` as resolved within `@bazel_tools` rather than the calling module extension's repository.
* Uses the user-provided apparent repository name in `jvm_maven_import_external` to generate a target name for the jar that makes the shorthand `@my_import` form work with Bzlmod.
* Ensure that Bazel loads the `http_jar` rule with the full repo mapping for `bazel_tools` so that it sees `rules_java`, while still loading `http_archive` with a trivial repo mapping to prevent a cycle during module repo creation. This requires introducing a new key type for `BzlLoadFunction`.

Closes #19997.

PiperOrigin-RevId: 579002601
Change-Id: I94c85e9759d0913384b10b9bbd0d0cb960cdd89a