### PR TITLE
[7.0.0] Print an error message when the downloader configuration file is missing.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -411,7 +411,9 @@ public class BazelRepositoryModule extends BlazeModule {
         throw new AbruptExitException(
             detailedExitCode(
                 String.format(
-                    "Failed to parse downloader config at %s: %s", e.getLocation(), e.getMessage()),
+                    "Failed to parse downloader config%s: %s",
+                    e.getLocation() != null ? String.format(" at %s", e.getLocation()) : "",
+                    e.getMessage()),
                 Code.BAD_DOWNLOADER_CONFIG));
       }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -36,7 +36,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -98,7 +97,7 @@ public class UrlRewriter {
     try (BufferedReader reader = Files.newBufferedReader(Paths.get(configPath))) {
       return new UrlRewriter(log, configPath, reader);
     } catch (IOException e) {
-      throw new UncheckedIOException(e);
+      throw new UrlRewriterParseException(e.getMessage());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterParseException.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterParseException.java
@@ -13,17 +13,24 @@
 // limitations under the License.
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
+import javax.annotation.Nullable;
 import net.starlark.java.syntax.Location;
 
 /** An {@link Exception} thrown when failed to parse {@link UrlRewriterConfig}. */
 public class UrlRewriterParseException extends Exception {
-  private final Location location;
 
-  public UrlRewriterParseException(String message, Location location) {
+  @Nullable private final Location location;
+
+  public UrlRewriterParseException(String message) {
+    this(message, /* location= */ null);
+  }
+
+  public UrlRewriterParseException(String message, @Nullable Location location) {
     super(message);
     this.location = location;
   }
 
+  @Nullable
   public Location getLocation() {
     return location;
   }


### PR DESCRIPTION
Fixes #20058.

Closes #20061.

Commit https://github.com/bazelbuild/bazel/commit/371e927323cd106de0187e1e0d9f5eb2e833a218

PiperOrigin-RevId: 580442451
Change-Id: Ic0a856e843428d655b6d11d437af7be76f3cc573