### PR TITLE
[7.0.0] Add top-level permissions to cherry-picker and remove-labels.yml

### DIFF
--- a/.github/workflows/cherry-picker.yml
+++ b/.github/workflows/cherry-picker.yml
@@ -6,6 +6,9 @@ on:
   issues:
     types: [closed, milestoned]
 
+permissions:
+  contents: read
+
 env:
   GH_TOKEN: ${{ secrets.BAZEL_IO_TOKEN }}
 

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -4,10 +4,12 @@ on:
   pull_request_target:
     types: ["closed"]
 
+permissions:
+  contents: read
+
 jobs:
   remove-label:
     permissions:
-      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes #20086.

As described in the issue, this PR adds read-only permissions to bazel's workflows that don't yet have them. This reduces the risk of supply-chain attacks via the project's CI/CD infrastructure.

My understanding is that `cherry-picker.yml` does not require any additional permissions since everything done by `bazelbuild/continuous-integration/actions/cherry_picker` uses the declared `GH_TOKEN` instead of the workflow's default `GITHUB_TOKEN`. If I'm mistaken, let me know and I'll happy fix the PR.

Closes #20087.

Commit https://github.com/bazelbuild/bazel/commit/ba61ff7d2eb6ed697e12abe3688992e85c434b30

PiperOrigin-RevId: 580542813
Change-Id: Ib45164ea8d9c0aa583e91d316ad2b552f3c9b5b7