### PR TITLE
[7.0.0] Only escape standard BRE metacharacters when preparing grep pattern.

### DIFF
--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -246,7 +246,7 @@ function runfiles_current_repository() {
     # Escape $caller_path for use in the grep regex below. Also replace \ with / since the manifest
     # uses / as the path separator even on Windows.
     local -r normalized_caller_path="$(echo "$caller_path" | sed 's|\\\\*|/|g')"
-    local -r escaped_caller_path="$(echo "$normalized_caller_path" | sed 's/[^-A-Za-z0-9_/]/\\&/g')"
+    local -r escaped_caller_path="$(echo "$normalized_caller_path" | sed 's/[.[\*^$]/\\&/g')"
     rlocation_path=$(__runfiles_maybe_grep -m1 "^[^ ]* ${escaped_caller_path}$" "${RUNFILES_MANIFEST_FILE}" | cut -d ' ' -f 1)
     if [[ -z "$rlocation_path" ]]; then
       if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then


### PR DESCRIPTION
POSIX specifies1 that grep shall by default interpret patterns as Basic Regular Expressions2. BREs only have six metacharacters: .[\*^$; all other characters are interpreted literally. Escaping non-metacharacter characters (ordinary characters) either has the effect of turning them into metacharacters3, or the interpretation is left undefined by the spec.

Because of the potential for unintended interpretations and behaviours, escaping these ordinary characters before using them in a BRE is undesirable. Unintended behaviours may range from benign (e.g. warnings about the invalid escapes) to broken (not matching entries we did intend and/or matching entries we did not intend).

Punctuation characters incorrectly escaped by the prior implementation can come from a few different places:

The ~ used by Bzlmod to manage hierarchies.
From the path to the workspace root - caller path may be absolute.
From paths within the workspace - punctuation characters accepted by Bazel4 for package and target names but are ordinary characters in BREs include !%@"#&'()-+,;<=>?]{|}~.
A small demonstration of this unnecessary escaping is available at: https://github.com/plobsing/bzlmod-bash-runfiles-grep-warning-demo/tree/main

In the example, the unnecessary escaping is reported when the script runs the rlocation function:

grep: warning: stray \ before ~
grep: warning: stray \ before @
Closes #20066.
Commit https://github.com/bazelbuild/bazel/commit/8c70d7b4ad5a9299f8e0cf7d2209fca0a29fd96f

PiperOrigin-RevId: 580820470
Change-Id: I57218d629cc771a00f05c2da06e97fb0b2ca18fd