### PR TITLE
[7.0.0] Report evaluation start and end for module extensions as fetch events

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -180,6 +180,7 @@ java_library(
         "Discovery.java",
         "GsonTypeAdapterUtil.java",
         "ModuleExtensionContext.java",
+        "ModuleExtensionEvaluationProgress.java",
         "ModuleFileFunction.java",
         "ModuleFileGlobals.java",
         "RepoSpecFunction.java",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
@@ -80,8 +80,7 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
 
   @Override
   protected String getIdentifyingStringForLogging() {
-    return String.format(
-        "module extension %s in %s", extensionId.getExtensionName(), extensionId.getBzlFileLabel());
+    return ModuleExtensionEvaluationProgress.moduleExtensionEvaluationContextString(extensionId);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvaluationProgress.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvaluationProgress.java
@@ -1,0 +1,73 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.bazel.bzlmod;
+
+import com.google.devtools.build.lib.events.ExtendedEventHandler.FetchProgress;
+
+/** Reports the progress of the evaluation of a module extension. */
+public class ModuleExtensionEvaluationProgress implements FetchProgress {
+
+  private final ModuleExtensionId extensionId;
+  private final boolean finished;
+  private final String message;
+
+  /** Returns the unique identifying string for a module extension evaluation event. */
+  public static String moduleExtensionEvaluationContextString(ModuleExtensionId extensionId) {
+    String suffix =
+        extensionId
+            .getIsolationKey()
+            .map(
+                isolationKey ->
+                    String.format(
+                        " for %s in %s",
+                        isolationKey.getUsageExportedName(), isolationKey.getModule()))
+            .orElse("");
+    return String.format(
+        "module extension %s in %s%s",
+        extensionId.getExtensionName(),
+        extensionId.getBzlFileLabel().getUnambiguousCanonicalForm(),
+        suffix);
+  }
+
+  public static ModuleExtensionEvaluationProgress ongoing(
+      ModuleExtensionId extensionId, String message) {
+    return new ModuleExtensionEvaluationProgress(extensionId, /* finished= */ false, message);
+  }
+
+  public static ModuleExtensionEvaluationProgress finished(ModuleExtensionId extensionId) {
+    return new ModuleExtensionEvaluationProgress(extensionId, /* finished= */ true, "finished.");
+  }
+
+  private ModuleExtensionEvaluationProgress(
+      ModuleExtensionId extensionId, boolean finished, String message) {
+    this.extensionId = extensionId;
+    this.finished = finished;
+    this.message = message;
+  }
+
+  @Override
+  public String getResourceIdentifier() {
+    return moduleExtensionEvaluationContextString(extensionId);
+  }
+
+  @Override
+  public String getProgress() {
+    return message;
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -175,11 +175,13 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     }
 
     // Run that extension!
+    env.getListener().post(ModuleExtensionEvaluationProgress.ongoing(extensionId, "starting"));
     RunModuleExtensionResult moduleExtensionResult =
         extension.run(env, usagesValue, starlarkSemantics, extensionId);
     if (moduleExtensionResult == null) {
       return null;
     }
+    env.getListener().post(ModuleExtensionEvaluationProgress.finished(extensionId));
     ImmutableMap<String, RepoSpec> generatedRepoSpecs =
         moduleExtensionResult.getGeneratedRepoSpecs();
     Optional<ModuleExtensionMetadata> moduleExtensionMetadata =


### PR DESCRIPTION
Closes #20100.

Commit https://github.com/bazelbuild/bazel/commit/b5c38af808a977e886b6a31974a561bd595e21d6

PiperOrigin-RevId: 580915088
Change-Id: Ia944ed2f3e45b5529546092a9bc4dd58b0c31bd6