### PR TITLE
[7.0.0] Delete the now redundant --experimental_execution_log_file flag, and optimize creation of unsorted logs.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -142,6 +142,8 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/protobuf:failure_details_java_proto",
         "//src/main/protobuf:spawn_java_proto",
+        "//third_party:guava",
+        "//third_party:jsr305",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -390,35 +390,17 @@ public class ExecutionOptions extends OptionsBase {
   public boolean statsSummary;
 
   @Option(
-      name = "experimental_execution_log_file",
-      defaultValue = "null",
-      category = "verbosity",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      converter = OptionsUtils.PathFragmentConverter.class,
-      help =
-          "Log the executed spawns into this file as delimited Spawn protos, according to "
-              + "src/main/protobuf/spawn.proto. This file is written in order of the execution "
-              + "of the Spawns. Related flags:"
-              + " --execution_log_binary_file (ordered binary protobuf format),"
-              + " --execution_log_json_file (ordered text json format),"
-              + " --subcommands (for displaying subcommands in terminal output).")
-  public PathFragment executionLogFile;
-
-  @Option(
       name = "execution_log_binary_file",
       defaultValue = "null",
       category = "verbosity",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
-      converter = OptionsUtils.PathFragmentConverter.class,
+      converter = OptionsUtils.EmptyToNullPathFragmentConverter.class,
       help =
           "Log the executed spawns into this file as delimited Spawn protos, according to"
-              + " src/main/protobuf/spawn.proto. The log is first written unordered and is then,"
-              + " at the end of the invocation, sorted in a stable order (can be CPU and memory"
-              + " intensive). Related flags:"
-              + " --execution_log_json_file (ordered text json format),"
-              + " --experimental_execution_log_file (unordered binary protobuf format),"
+              + " src/main/protobuf/spawn.proto. Related flags:"
+              + " --execution_log_json_file (text JSON format),"
+              + " --execution_log_sort (whether to sort the execution log),"
               + " --subcommands (for displaying subcommands in terminal output).")
   public PathFragment executionLogBinaryFile;
 
@@ -428,14 +410,12 @@ public class ExecutionOptions extends OptionsBase {
       category = "verbosity",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
-      converter = OptionsUtils.PathFragmentConverter.class,
+      converter = OptionsUtils.EmptyToNullPathFragmentConverter.class,
       help =
-          "Log the executed spawns into this file as json representation of the delimited Spawn"
-              + " protos, according to src/main/protobuf/spawn.proto. The log is first written"
-              + " unordered and is then, at the end of the invocation, sorted in a stable order"
-              + " (can be CPU and memory intensive). Related flags:"
-              + " Related flags: --execution_log_binary_file (ordered binary protobuf format),"
-              + " --experimental_execution_log_file (unordered binary protobuf format),"
+          "Log the executed spawns into this file as a JSON representation of the delimited Spawn"
+              + " protos, according to src/main/protobuf/spawn.proto. Related flags:"
+              + " --execution_log_binary_file (binary protobuf format),"
+              + " --execution_log_sort (whether to sort the execution log),"
               + " --subcommands (for displaying subcommands in terminal output).")
   public PathFragment executionLogJsonFile;
 
@@ -445,8 +425,9 @@ public class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "Whether to sort the execution log. Set to false to improve memory"
-              + " performance, at the cost of producing the log in nondeterministic"
+          "Whether to sort the execution log, making it easier to compare logs across invocations."
+              + " Set to false to avoid potentially significant CPU and memory usage at the end of"
+              + " the invocation, at the cost of producing the log in nondeterministic execution"
               + " order.")
   public boolean executionLogSort;
 

--- a/src/main/java/com/google/devtools/build/lib/util/OptionsUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/OptionsUtils.java
@@ -109,6 +109,24 @@ public final class OptionsUtils {
     }
   }
 
+  /** Converter from String to PathFragment. If the input is empty returns {@code null} instead. */
+  public static class EmptyToNullPathFragmentConverter extends Converter.Contextless<PathFragment> {
+
+    @Override
+    @Nullable
+    public PathFragment convert(String input) throws OptionsParsingException {
+      if (input.isEmpty()) {
+        return null;
+      }
+      return convertOptionsPathFragment(input);
+    }
+
+    @Override
+    public String getTypeDescription() {
+      return "a path";
+    }
+  }
+
   /** Converter from String to PathFragment requiring the provided path to be absolute. */
   public static class AbsolutePathFragmentConverter extends Converter.Contextless<PathFragment> {
 
@@ -127,7 +145,10 @@ public final class OptionsUtils {
     }
   }
 
-  /** Converter from String to PathFragment. If the input is empty returns {@code null} instead. */
+  /**
+   * Converter from String to PathFragment requiring the provided path to be relative. If the input
+   * is empty returns {@code null} instead.
+   */
   public static class EmptyToNullRelativePathFragmentConverter
       extends Converter.Contextless<PathFragment> {
 

--- a/src/main/java/com/google/devtools/build/lib/util/io/MessageOutputStreamWrapper.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/MessageOutputStreamWrapper.java
@@ -22,9 +22,9 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
-/** Creating a MessageOutputStream from an OutputStream */
+/** Creates a MessageOutputStream from an OutputStream. */
 public class MessageOutputStreamWrapper {
-  /** Outputs the messages in binary format */
+  /** Outputs the messages in delimited protobuf binary format. */
   public static class BinaryOutputStreamWrapper implements MessageOutputStream {
     private final OutputStream stream;
 

--- a/src/test/shell/bazel/bazel_execlog_test.sh
+++ b/src/test/shell/bazel/bazel_execlog_test.sh
@@ -115,7 +115,7 @@ genrule(
       cmd = "echo hello > $(location out.txt)"
 )
 EOF
-  bazel build //:all --experimental_execution_log_file output 2>&1 >> $TEST_log || fail "could not build"
+  bazel build //:all --execution_log_binary_file output 2>&1 >> $TEST_log || fail "could not build"
   wc output || fail "no output produced"
 }
 
@@ -135,7 +135,7 @@ genrule(
     cmd = "echo hello > $(location out.txt)"
 )
 EOF
-  bazel build //:rule --experimental_execution_log_file output 2>&1 >> $TEST_log || fail "could not build"
+  bazel build //:rule --execution_log_binary_file output 2>&1 >> $TEST_log || fail "could not build"
   [[ -e output ]] || fail "no output produced"
 }
 
@@ -147,11 +147,6 @@ genrule(
       cmd = "echo hello > $(location out.txt)"
 )
 EOF
-  bazel build //:all --experimental_execution_log_file=output --experimental_execution_log_file= 2>&1 >> $TEST_log || fail "could not build"
-  if [[ -e output ]]; then
-    fail "file shouldn't exist"
-  fi
-
   bazel build //:all --execution_log_json_file=output --execution_log_json_file= 2>&1 >> $TEST_log || fail "could not build"
   if [[ -e output ]]; then
     fail "file shouldn't exist"


### PR DESCRIPTION
Since we're about to introduce a new log format (see https://github.com/bazelbuild/bazel/issues/18643), let's take this opportunity to clean up the command line API.

Avoid a pointless copy of the execution log, if no sorting is requested, by writing directly into the requested output binary path. If a temporary file is necessary, write it to a well-known path in the output base, and delete it after conversions are successful; this ensures that large temporary files don't accumulate in /tmp.

RELNOTES[INC]: Delete the --experimental_execution_log_file flag. Use --execution_log_binary_file in conjunction with --noexecution_log_sort instead.

PiperOrigin-RevId: 580132026
Change-Id: Icca827260176b3ea804384d2bed4a56ce85cfc14