### PR TITLE
[7.0.0] Allow `--flag_alias` to be used with `common` and `always` commands

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -87,6 +87,10 @@ public final class BlazeOptionHandler {
   // being ignored as long as they are recognized by at least one (other) command.
   private static final String COMMON_PSEUDO_COMMAND = "common";
 
+  private static final String BUILD_COMMAND = "build";
+  private static final ImmutableSet<String> BUILD_COMMAND_ANCESTORS =
+      ImmutableSet.of(BUILD_COMMAND, COMMON_PSEUDO_COMMAND, ALWAYS_PSEUDO_COMMAND);
+
   // Marks an event to indicate a parsing error.
   static final String BAD_OPTION_TAG = "invalidOption";
   // Separates the invalid tag from the full error message for easier parsing.
@@ -611,12 +615,16 @@ public final class BlazeOptionHandler {
           // In production, "build" is always a valid command, but not necessarily in tests.
           // Particularly C0Command, which some tests use for low-level options parsing logic. We
           // don't want to interfere with those.
-          && validCommands.contains("build")
-          && !override.command.equals("build")) {
+          && validCommands.contains(BUILD_COMMAND)
+          && !BUILD_COMMAND_ANCESTORS.contains(override.command)) {
         throw new OptionsParsingException(
             String.format(
-                "%s: \"%s %s\" disallowed. --%s only supports the \"build\" command.",
-                rcFile, override.command, override.option, Converters.BLAZE_ALIASING_FLAG));
+                "%s: \"%s %s\" disallowed. --%s only supports these commands: %s",
+                rcFile,
+                override.command,
+                override.option,
+                Converters.BLAZE_ALIASING_FLAG,
+                String.join(", ", BUILD_COMMAND_ANCESTORS)));
       }
       String command = override.command;
       int index = command.indexOf(':');

--- a/src/test/shell/integration/starlark_configurations_test.sh
+++ b/src/test/shell/integration/starlark_configurations_test.sh
@@ -640,6 +640,19 @@ function test_rc_flag_alias_canonicalizes() {
   expect_log "--//$pkg:type=coffee"
 }
 
+function test_rc_flag_alias_supported_under_common_command() {
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg
+
+  add_to_bazelrc "common --flag_alias=drink=//$pkg:type"
+  write_build_setting_bzl
+
+  bazel canonicalize-flags -- --drink=coffee \
+    >& "$TEST_log" || fail "Expected success"
+
+  bazel build //$pkg:my_drink >& "$TEST_log" || fail "Expected success"
+}
+
 function test_rc_flag_alias_unsupported_under_test_command() {
   local -r pkg=$FUNCNAME
   mkdir -p $pkg
@@ -650,11 +663,11 @@ function test_rc_flag_alias_unsupported_under_test_command() {
   bazel canonicalize-flags -- --drink=coffee \
     >& "$TEST_log" && fail "Expected failure"
   expect_log "--flag_alias=drink=//$pkg:type\" disallowed. --flag_alias only "\
-"supports the \"build\" command."
+"supports these commands: build, common, always"
 
   bazel build //$pkg:my_drink >& "$TEST_log" && fail "Expected failure"
   expect_log "--flag_alias=drink=//$pkg:type\" disallowed. --flag_alias only "\
-"supports the \"build\" command."
+"supports these commands: build, common, always"
 
   # Post-test cleanup_workspace() calls "bazel clean", which would also fail
   # unless we reset the bazelrc.
@@ -671,11 +684,11 @@ function test_rc_flag_alias_unsupported_under_conditional_build_command() {
   bazel canonicalize-flags -- --drink=coffee \
 >& "$TEST_log" && fail "Expected failure"
   expect_log "--flag_alias=drink=//$pkg:type\" disallowed. --flag_alias only "\
-"supports the \"build\" command."
+"supports these commands: build, common, always"
 
   bazel build //$pkg:my_drink >& "$TEST_log" && fail "Expected failure"
   expect_log "--flag_alias=drink=//$pkg:type\" disallowed. --flag_alias only "\
-"supports the \"build\" command."
+"supports these commands: build, common, always"
 
   # Post-test cleanup_workspace() calls "bazel clean", which would also fail
   # unless we reset the bazelrc.
@@ -692,11 +705,11 @@ function test_rc_flag_alias_unsupported_with_space_assignment_syntax() {
   bazel canonicalize-flags -- --drink=coffee \
     >& "$TEST_log" && fail "Expected failure"
   expect_log "--flag_alias\" disallowed. --flag_alias only "\
-"supports the \"build\" command."
+"supports these commands: build, common, always"
 
   bazel build //$pkg:my_drink >& "$TEST_log" && fail "Expected failure"
   expect_log "--flag_alias\" disallowed. --flag_alias only "\
-"supports the \"build\" command."
+"supports these commands: build, common, always"
 
   # Post-test cleanup_workspace() calls "bazel clean", which would also fail
   # unless we reset the bazelrc.


### PR DESCRIPTION
Fixes #20081

Closes #20107.

Commit https://github.com/bazelbuild/bazel/commit/19c73bcedb8e73c6b1854ba2789cbe79f2e626b4

PiperOrigin-RevId: 581112821
Change-Id: I54941072faa8e9843adcdb7ff8d73ab7414dc86a