### PR TITLE
[7.0.0] Optimize RepoMappingManifestAction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -981,6 +981,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/net/starlark/java/eval",
+        "//third_party:caffeine",
         "//third_party:guava",
         "//third_party:jsr305",
     ],


### PR DESCRIPTION
The following optimizations reduce the time spent writing the repo mapping manifest from >6s to <80ms for a test referencing each of ~4,000 repos created by a module extension:

* The set of repository names appearing in runfiles paths is only constructed once rather than for each repo by moving the `build()` call out of a closure.
* The relevant entries per repository are now sorted after filtering out those for repos that don't contribute runfiles.
* Crucially, the relevant mapping entries per repository are now cached per instance of `RepositoryMapping#entries()`. Since extension repos all share the same instance due to interning, this reduces the complexity from quadratic to linear in the number of extension repos.

Closes #20091.

Commit https://github.com/bazelbuild/bazel/commit/305ab3b7eae0c2104f141f4640d3a3703bbf52a2

PiperOrigin-RevId: 581128978
Change-Id: I946e7788b8538e84714cf25ece89a86edd0d6948