### PR TITLE
[7.0.0] Support lockfile serialization of Starlark tuples in MODULE.bazel files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValuesAdapter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValuesAdapter.java
@@ -88,9 +88,11 @@ public class AttributeValuesAdapter extends TypeAdapter<AttributeValues> {
         jsonObject.add(serializeObjToString(entry.getKey()), serializeObject(entry.getValue()));
       }
       return jsonObject;
-    } else if (obj instanceof StarlarkList) {
+    } else if (obj instanceof Iterable) {
+      // ListType supports any kind of Iterable, including Tuples and StarlarkLists. All of them
+      // are converted to an equivalent StarlarkList during deserialization.
       JsonArray jsonArray = new JsonArray();
-      for (Object item : (StarlarkList<?>) obj) {
+      for (Object item : (Iterable<?>) obj) {
         jsonArray.add(serializeObject(item));
       }
       return jsonArray;

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValuesAdapterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValuesAdapterTest.java
@@ -30,6 +30,7 @@ import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.Mutability;
 import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkList;
+import net.starlark.java.eval.Tuple;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -88,5 +89,25 @@ public class AttributeValuesAdapterTest extends FoundationTestCase {
     // Verify that the String "Hello String" is preserved as is, without any additional escaping.
     assertThat(jsonString).contains(":\"Hello String\"");
     assertThat((Map<?, ?>) attributeValues.attributes()).containsExactlyEntriesIn(builtDict);
+  }
+
+  @Test
+  public void testTuple() throws IOException {
+    Dict.Builder<String, Object> dict = new Dict.Builder<>();
+    dict.put("Tuple", Tuple.of("bzl", "mod"));
+
+    Dict<String, Object> builtDict = dict.buildImmutable();
+    AttributeValuesAdapter attrAdapter = new AttributeValuesAdapter();
+    String jsonString;
+    try (StringWriter stringWriter = new StringWriter()) {
+      attrAdapter.write(new JsonWriter(stringWriter), AttributeValues.create(builtDict));
+      jsonString = stringWriter.toString();
+    }
+    AttributeValues attributeValues;
+    try (StringReader stringReader = new StringReader(jsonString)) {
+      attributeValues = attrAdapter.read(new JsonReader(stringReader));
+    }
+    assertThat((Map<?, ?>) attributeValues.attributes())
+        .containsExactly("Tuple", StarlarkList.of(Mutability.IMMUTABLE, "bzl", "mod"));
   }
 }


### PR DESCRIPTION
Fixes #20116

Closes #20129.

Commit https://github.com/bazelbuild/bazel/commit/04d81dbea8e29c7f3c9ed398512633d3e40364a0

PiperOrigin-RevId: 581276198
Change-Id: I66259e273802e94a09ff1f862001a0109cc623e6