### PR TITLE
Don't send unnecessary lockfile event

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -127,7 +127,7 @@ public class BazelDepGraphFunction implements SkyFunction {
     ImmutableBiMap<String, ModuleExtensionId> extensionUniqueNames =
         calculateUniqueNameForUsedExtensionId(extensionUsagesById);
 
-    if (!lockfileMode.equals(LockfileMode.OFF)) {
+    if (lockfileMode.equals(LockfileMode.UPDATE)) {
       // This will keep all module extension evaluation results, some of which may be stale due to
       // changed usages. They will be removed in BazelLockFileModule.
       BazelLockFileValue updateLockfile =


### PR DESCRIPTION
`BazelLockFileModule` is the only consumer of `BazelModuleResolutionEvent` and only subscribes with `--lockfile_mode=update`.