### PR TITLE
[7.0.0] Revert "Remove `--experimental_throttle_action_cache_check` flag."

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -919,6 +919,16 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
               + " of failing. This is to help use cquery diagnose failures in select.")
   public boolean debugSelectsAlwaysSucceed;
 
+  @Option(
+      name = "experimental_throttle_action_cache_check",
+      defaultValue = "true",
+      converter = BooleanConverter.class,
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      metadataTags = OptionMetadataTag.EXPERIMENTAL,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help = "Whether to throttle the check whether an action is cached.")
+  public boolean throttleActionCacheCheck;
+
   /** Ways configured targets may provide the {@link Fragment}s they require. */
   public enum IncludeConfigFragmentsEnum {
     /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -25,7 +25,6 @@ import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.util.ResourceFileLoader;
-import com.google.devtools.common.options.Converters.BooleanConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -252,16 +251,6 @@ public final class BazelRulesModule extends BlazeModule {
         },
         help = "This option is deprecated and has no effect and will be removed in the future.")
     public boolean deferParamFiles;
-
-    @Option(
-        name = "experimental_throttle_action_cache_check",
-        defaultValue = "true",
-        converter = BooleanConverter.class,
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        metadataTags = OptionMetadataTag.EXPERIMENTAL,
-        effectTags = {OptionEffectTag.EXECUTION},
-        help = "no-op")
-    public boolean throttleActionCacheCheck;
 
     @Option(
         name = "check_fileset_dependencies_recursively",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -310,7 +310,10 @@ public final class SkyframeActionExecutor {
     freeDiscoveredInputsAfterExecution =
         !trackIncrementalState && options.getOptions(CoreOptions.class).actionListeners.isEmpty();
 
-    this.cacheHitSemaphore = new Semaphore(ResourceUsage.getAvailableProcessors());
+    this.cacheHitSemaphore =
+        options.getOptions(CoreOptions.class).throttleActionCacheCheck
+            ? new Semaphore(ResourceUsage.getAvailableProcessors())
+            : null;
 
     this.actionExecutionSemaphore =
         buildRequestOptions.useSemaphoreForJobs ? new Semaphore(buildRequestOptions.jobs) : null;


### PR DESCRIPTION
This reverts commit 1e17348da7e45c00cb474390a3b8ed3103b6b5cf.

This was requested in #19924.

Closes #20162.

Commit https://github.com/bazelbuild/bazel/commit/1f75299ce6b914d804a4dc9fa1097177774de54f

PiperOrigin-RevId: 581897901
Change-Id: Ifea2330c45c97db4454ffdcc31b7b7af640cd659