### PR TITLE
[7.0.0] [Skymeld] Don't plant the symlinks to the paths specified in 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -275,6 +275,7 @@ public class ExecutionTool {
               singleSourceRoot,
               env.getEventBus(),
               env.getDirectories().getProductName() + "-",
+              skyframeExecutor.getIgnoredPaths(),
               request.getOptions(BuildLanguageOptions.class).experimentalSiblingRepositoryLayout,
               runtime.getWorkspace().doesAllowExternalRepositories());
       if (shouldSymlinksBePlanted) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -442,6 +442,9 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
   @Nullable private final WorkspaceInfoFromDiffReceiver workspaceInfoFromDiffReceiver;
   private Set<String> previousClientEnvironment = ImmutableSet.of();
 
+  // Contain the paths in the .bazelignore file.
+  private ImmutableSet<Path> ignoredPaths = ImmutableSet.of();
+
   Duration sourceDiffCheckingDuration = Duration.ofSeconds(-1L);
 
   final class PathResolverFactoryImpl implements PathResolverFactory {
@@ -1293,6 +1296,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
   public AtomicReference<PathPackageLocator> getPackageLocator() {
     return pkgLocator;
+  }
+
+  public ImmutableSet<Path> getIgnoredPaths() {
+    return ignoredPaths;
   }
 
   protected Differencer.Diff getDiff(
@@ -3120,7 +3127,6 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         // Ignored package prefixes are specified relative to the workspace root
         // by definition of .bazelignore. So, we only use ignored paths when the
         // package root is equal to the workspace path.
-        ImmutableSet<Path> ignoredPaths = ImmutableSet.of();
         if (workspacePath != null && workspacePath.equals(pathEntry.asPath())) {
           ignoredPaths =
               ignoredPackagePrefixesValue.getPatterns().stream()


### PR DESCRIPTION
Bazel in skymeld mode eagerly plants the symlinks from the execroot to every entries under the source tree. This leads to some pain points for certain groups of users (https://github.com/bazelbuild/bazel/issues/19581).

This CL offers a workaround for that issue. The users can now list the paths that they don't want Bazel to symlink to in the `.bazelignore` file in their project.

Commit https://github.com/bazelbuild/bazel/commit/caf1702ce9fa060169548181afb9e19956826f0b

PiperOrigin-RevId: 581919915
Change-Id: I329365b0655fc0bcb2db1eeea91ef74c775c72ae