### PR TITLE
[7.0.0] Make the BesUploadMode per transport instead of per invocation.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -86,7 +86,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
@@ -486,8 +485,6 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
     final ScheduledExecutorService executor =
         Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder().setNameFormat("bes-notify-ui-%d").build());
-    ScheduledFuture<?> waitMessageFuture = null;
-
     try {
       // Notify the UI handler when a transport finished closing.
       transportFutures.forEach(
@@ -522,9 +519,6 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
     } finally {
       if (besUploadModeIsSynchronous) {
         cancelAndResetPendingUploads();
-      }
-      if (waitMessageFuture != null) {
-        waitMessageFuture.cancel(/* mayInterruptIfRunning= */ true);
       }
       executor.shutdown();
     }

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceTransport.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import com.google.devtools.build.lib.buildeventservice.client.BuildEventServiceClient;
 import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent;
@@ -37,6 +38,7 @@ import javax.annotation.Nullable;
 public class BuildEventServiceTransport implements BuildEventTransport {
   private final BuildEventServiceUploader besUploader;
   private final Duration besTimeout;
+  private final BesUploadMode besUploadMode;
 
   private BuildEventServiceTransport(
       BuildEventServiceClient besClient,
@@ -49,7 +51,8 @@ public class BuildEventServiceTransport implements BuildEventTransport {
       EventBus eventBus,
       Duration closeTimeout,
       Sleeper sleeper,
-      Timestamp commandStartTime) {
+      Timestamp commandStartTime,
+      BesUploadMode besUploadMode) {
     this.besTimeout = closeTimeout;
     this.besUploader =
         new BuildEventServiceUploader.Builder()
@@ -64,6 +67,7 @@ public class BuildEventServiceTransport implements BuildEventTransport {
             .eventBus(eventBus)
             .commandStartTime(commandStartTime)
             .build();
+    this.besUploadMode = besUploadMode;
   }
 
   @Override
@@ -89,6 +93,11 @@ public class BuildEventServiceTransport implements BuildEventTransport {
   @Override
   public boolean mayBeSlow() {
     return true;
+  }
+
+  @Override
+  public BesUploadMode getBesUploadMode() {
+    return besUploadMode;
   }
 
   @Override
@@ -188,7 +197,8 @@ public class BuildEventServiceTransport implements BuildEventTransport {
           checkNotNull(eventBus),
           (besOptions.besTimeout != null) ? besOptions.besTimeout : Duration.ZERO,
           sleeper != null ? sleeper : new JavaSleeper(),
-          checkNotNull(commandStartTime));
+          checkNotNull(commandStartTime),
+          besOptions.besUploadMode);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BUILD
@@ -21,6 +21,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
+        "//src/main/java/com/google/devtools/build/lib/buildeventservice:buildeventservice-options",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventTransport.java
@@ -13,8 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.buildeventstream;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import java.time.Duration;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -24,14 +24,12 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>All implementations need to be thread-safe. All methods are expected to return quickly.
  *
- * <p>Notice that this interface does not provide any error handling API. A transport may choose
- * to log interesting errors to the command line and/or abort the whole build.
+ * <p>Notice that this interface does not provide any error handling API. A transport may choose to
+ * log interesting errors to the command line and/or abort the whole build.
  */
 @ThreadSafe
 public interface BuildEventTransport {
-  /**
-   * The name of this transport as can be displayed to a user.
-   */
+  /** The name of this transport as can be displayed to a user. */
   String name();
 
   /**
@@ -87,7 +85,9 @@ public interface BuildEventTransport {
    */
   boolean mayBeSlow();
 
-  @VisibleForTesting
+  /** Returns the desired {@link BesUploadMode} for the transport. */
+  BesUploadMode getBesUploadMode();
+
   @Nullable
   BuildEventArtifactUploader getUploader();
 }

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
@@ -15,6 +15,7 @@ java_library(
     name = "transports",
     srcs = glob(["*.java"]),
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/buildeventservice:buildeventservice-options",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BinaryFormatFileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BinaryFormatFileTransport.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.buildeventstream.transports;
 
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
@@ -34,8 +35,9 @@ public final class BinaryFormatFileTransport extends FileTransport {
       BufferedOutputStream outputStream,
       BuildEventProtocolOptions options,
       BuildEventArtifactUploader uploader,
-      ArtifactGroupNamer namer) {
-    super(outputStream, options, uploader, namer);
+      ArtifactGroupNamer namer,
+      BesUploadMode besUploadMode) {
+    super(outputStream, options, uploader, namer, besUploadMode);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.buildeventstream.transports;
 
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadModeConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -46,7 +48,6 @@ public class BuildEventStreamOptions extends OptionsBase {
       name = "build_event_binary_file",
       oldName = "experimental_build_event_binary_file",
       defaultValue = "",
-      implicitRequirements = {"--bes_upload_mode=wait_for_upload_complete"},
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
@@ -59,7 +60,6 @@ public class BuildEventStreamOptions extends OptionsBase {
       name = "build_event_json_file",
       oldName = "experimental_build_event_json_file",
       defaultValue = "",
-      implicitRequirements = {"--bes_upload_mode=wait_for_upload_complete"},
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
@@ -68,14 +68,54 @@ public class BuildEventStreamOptions extends OptionsBase {
   public String buildEventJsonFile;
 
   @Option(
+      name = "build_event_text_file_upload_mode",
+      defaultValue = "wait_for_upload_complete",
+      converter = BesUploadModeConverter.class,
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.EAGERNESS_TO_EXIT},
+      help =
+          "Specifies whether the Build Event Service upload for --build_event_text_file should"
+              + " block the build completion or should end the invocation immediately and finish"
+              + " the upload in the background. Either 'wait_for_upload_complete' (default),"
+              + " 'nowait_for_upload_complete', or 'fully_async'.")
+  public BesUploadMode buildEventTextFileUploadMode;
+
+  @Option(
+      name = "build_event_binary_file_upload_mode",
+      defaultValue = "wait_for_upload_complete",
+      converter = BesUploadModeConverter.class,
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.EAGERNESS_TO_EXIT},
+      help =
+          "Specifies whether the Build Event Service upload for --build_event_binary_file should"
+              + " block the build completion or should end the invocation immediately and finish"
+              + " the upload in the background. Either 'wait_for_upload_complete' (default),"
+              + " 'nowait_for_upload_complete', or 'fully_async'.")
+  public BesUploadMode buildEventBinaryFileUploadMode;
+
+  @Option(
+      name = "build_event_json_file_upload_mode",
+      defaultValue = "wait_for_upload_complete",
+      converter = BesUploadModeConverter.class,
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.EAGERNESS_TO_EXIT},
+      help =
+          "Specifies whether the Build Event Service upload for --build_event_json_file should"
+              + " block the build completion or should end the invocation immediately and finish"
+              + " the upload in the background. Either 'wait_for_upload_complete' (default),"
+              + " 'nowait_for_upload_complete', or 'fully_async'.")
+  public BesUploadMode buildEventJsonFileUploadMode;
+
+  @Option(
       name = "build_event_text_file_path_conversion",
       oldName = "experimental_build_event_text_file_path_conversion",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
-      help = "Convert paths in the text file representation of the build event protocol to more "
-          + "globally valid URIs whenever possible; if disabled, the file:// uri scheme will "
-          + "always be used")
+      help =
+          "Convert paths in the text file representation of the build event protocol to more "
+              + "globally valid URIs whenever possible; if disabled, the file:// uri scheme will "
+              + "always be used")
   public boolean buildEventTextFilePathConversion;
 
   @Option(
@@ -84,9 +124,10 @@ public class BuildEventStreamOptions extends OptionsBase {
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
-      help = "Convert paths in the binary file representation of the build event protocol to more "
-          + "globally valid URIs whenever possible; if disabled, the file:// uri scheme will "
-          + "always be used")
+      help =
+          "Convert paths in the binary file representation of the build event protocol to more "
+              + "globally valid URIs whenever possible; if disabled, the file:// uri scheme will "
+              + "always be used")
   public boolean buildEventBinaryFilePathConversion;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/JsonFormatFileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/JsonFormatFileTransport.java
@@ -16,6 +16,9 @@ package com.google.devtools.build.lib.buildeventstream.transports;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.flogger.GoogleLogger;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.buildeventstream.BuildEventProtocolOptions;
@@ -34,8 +37,9 @@ public final class JsonFormatFileTransport extends FileTransport {
       BufferedOutputStream outputStream,
       BuildEventProtocolOptions options,
       BuildEventArtifactUploader uploader,
-      ArtifactGroupNamer namer) {
-    super(outputStream, options, uploader, namer);
+      ArtifactGroupNamer namer,
+      BesUploadMode besUploadMode) {
+    super(outputStream, options, uploader, namer, besUploadMode);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransport.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.buildeventstream.transports;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.buildeventstream.BuildEventProtocolOptions;
@@ -35,8 +36,9 @@ public final class TextFormatFileTransport extends FileTransport {
       BufferedOutputStream outputStream,
       BuildEventProtocolOptions options,
       BuildEventArtifactUploader uploader,
-      ArtifactGroupNamer namer) {
-    super(outputStream, options, uploader, namer);
+      ArtifactGroupNamer namer,
+      BesUploadMode besUploadMode) {
+    super(outputStream, options, uploader, namer, besUploadMode);
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -74,6 +74,7 @@ java_test(
         "@googleapis//:google_devtools_build_v1_build_events_java_proto",
         "@googleapis//:google_devtools_build_v1_publish_build_event_java_grpc",
         "@googleapis//:google_devtools_build_v1_publish_build_event_java_proto",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.bugreport.BugReport;
 import com.google.devtools.build.lib.bugreport.Crash;
 import com.google.devtools.build.lib.bugreport.CrashContext;
 import com.google.devtools.build.lib.buildeventservice.BazelBuildEventServiceModule.BackendConfig;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceModule.BuildEventOutputStreamFactory;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.Aborted;
@@ -74,6 +75,8 @@ import com.google.devtools.build.v1.PublishBuildToolEventStreamResponse;
 import com.google.devtools.build.v1.PublishLifecycleEventRequest;
 import com.google.devtools.build.v1.StreamId;
 import com.google.protobuf.Empty;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Server;
@@ -84,11 +87,15 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.MutableHandlerRegistry;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -102,6 +109,7 @@ import java.util.SortedSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.junit.After;
@@ -111,10 +119,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Tests for {@link BazelBuildEventServiceModule}. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTestCase {
 
   private static final Duration WAIT_FOR_LAST_INVOCATION_TIMEOUT = Duration.ofSeconds(2);
@@ -129,6 +136,8 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
   private BlazeModule connectivityModule = new NoOpConnectivityModule();
 
   @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Nullable private BuildEventOutputStreamFactory buildEventOutputStreamFactory;
 
   @Override
   protected BlazeModule getConnectivityModule() {
@@ -167,6 +176,9 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
   private void runBuildWithOptions(String... options) throws Exception {
     addOptions(options);
     besModule = runtimeWrapper.getRuntime().getBlazeModule(BazelBuildEventServiceModule.class);
+    if (buildEventOutputStreamFactory != null) {
+      besModule.setBuildEventOutputStreamFactory(buildEventOutputStreamFactory);
+    }
     runtimeWrapper.newCommand();
     buildTarget();
   }
@@ -440,6 +452,65 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
   public void testAfterCommand_fullyAsync() throws Exception {
     runBuildWithOptions("--bes_backend=inprocess", "--bes_upload_mode=FULLY_ASYNC");
     afterBuildCommand();
+    events.assertNoWarningsOrErrors();
+  }
+
+  enum BuildEventFile {
+    TEXT,
+    JSON,
+    BINARY;
+
+    String getBuildEventFileFlag(String file) {
+      switch (this) {
+        case TEXT:
+          return "--build_event_text_file=" + file;
+        case JSON:
+          return "--build_event_json_file=" + file;
+        case BINARY:
+          return "--build_event_binary_file=" + file;
+      }
+      throw new IllegalStateException();
+    }
+
+    String getBuildEventFileUploadModeFlag(String mode) {
+      switch (this) {
+        case TEXT:
+          return "--build_event_text_file_upload_mode=" + mode;
+        case JSON:
+          return "--build_event_json_file_upload_mode=" + mode;
+        case BINARY:
+          return "--build_event_binary_file_upload_mode=" + mode;
+      }
+      throw new IllegalStateException();
+    }
+  }
+
+  @Test
+  public void testAfterCommand_buildEventFile_waitForUploadComplete(
+      @TestParameter BuildEventFile buildEventFile) throws Exception {
+    AtomicReference<DelayingCloseBufferedOutputStream> outRef = new AtomicReference<>(null);
+    buildEventOutputStreamFactory =
+        (file) -> {
+          var out =
+              new DelayingCloseBufferedOutputStream(
+                  Files.newOutputStream(Paths.get(file)), Duration.ofSeconds(1));
+          outRef.set(out);
+          return out;
+        };
+    buildEventService.setDelayBeforeClosingStream(Duration.ofSeconds(10));
+    var file = tmpFolder.newFile();
+
+    runBuildWithOptions(
+        "--bes_backend=inprocess",
+        "--bes_upload_mode=FULLY_ASYNC",
+        "--bes_timeout=1s",
+        buildEventFile.getBuildEventFileFlag(file.getAbsolutePath()),
+        buildEventFile.getBuildEventFileUploadModeFlag("wait_for_upload_complete"));
+    afterBuildCommand();
+
+    assertThat(outRef.get().isClosed()).isTrue();
+    // Expect Bazel doesn't wait for uploading to bes_backend, otherwise there will be a timeout
+    // error.
     events.assertNoWarningsOrErrors();
   }
 
@@ -1053,6 +1124,28 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
     public void onCompleted() {
       responseObserver.onError(
           new StatusRuntimeException(Status.DATA_LOSS.withDescription(errorMessage)));
+    }
+  }
+
+  private static final class DelayingCloseBufferedOutputStream extends BufferedOutputStream {
+    private final Duration delay;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    DelayingCloseBufferedOutputStream(OutputStream out, Duration delay) {
+      super(out);
+      this.delay = delay;
+      this.out = out;
+    }
+
+    @Override
+    public void close() throws IOException {
+      Uninterruptibles.sleepUninterruptibly(delay);
+      super.close();
+      closed.set(true);
+    }
+
+    public boolean isClosed() {
+      return closed.get();
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
@@ -19,6 +19,7 @@ java_test(
     test_class = "com.google.devtools.build.lib.AllTests",
     runtime_deps = ["//src/test/java/com/google/devtools/build/lib:test_runner"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/buildeventservice:buildeventservice-options",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/transports",

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/BinaryFormatFileTransportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/BinaryFormatFileTransportTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile;
@@ -107,7 +108,8 @@ public class BinaryFormatFileTransportTest {
             outputStream,
             defaultOpts,
             new LocalFilesArtifactUploader(),
-            artifactGroupNamer);
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
     transport.sendBuildEvent(buildEvent);
 
     BuildEventStreamProtos.BuildEvent progress =
@@ -157,7 +159,12 @@ public class BinaryFormatFileTransportTest {
     BufferedOutputStream outputStream =
         new BufferedOutputStream(Files.newOutputStream(Paths.get(output.getAbsolutePath())));
     BinaryFormatFileTransport transport =
-        new BinaryFormatFileTransport(outputStream, defaultOpts, uploader, artifactGroupNamer);
+        new BinaryFormatFileTransport(
+            outputStream,
+            defaultOpts,
+            uploader,
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
     transport.sendBuildEvent(event1);
 
     ExecutionException expected =
@@ -189,7 +196,8 @@ public class BinaryFormatFileTransportTest {
             outputStream,
             defaultOpts,
             new LocalFilesArtifactUploader(),
-            artifactGroupNamer);
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
 
     transport.close().get();
 
@@ -220,7 +228,8 @@ public class BinaryFormatFileTransportTest {
             outputStream,
             defaultOpts,
             new LocalFilesArtifactUploader(),
-            artifactGroupNamer);
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
 
     transport.sendBuildEvent(buildEvent);
     Future<Void> closeFuture = transport.close();
@@ -267,7 +276,12 @@ public class BinaryFormatFileTransportTest {
     BufferedOutputStream outputStream =
         new BufferedOutputStream(Files.newOutputStream(Paths.get(output.getAbsolutePath())));
     BinaryFormatFileTransport transport =
-        new BinaryFormatFileTransport(outputStream, defaultOpts, uploader, artifactGroupNamer);
+        new BinaryFormatFileTransport(
+            outputStream,
+            defaultOpts,
+            uploader,
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
     transport.sendBuildEvent(event1);
     transport.sendBuildEvent(event2);
     transport.close().get();
@@ -307,7 +321,12 @@ public class BinaryFormatFileTransportTest {
     BufferedOutputStream outputStream =
         new BufferedOutputStream(Files.newOutputStream(Paths.get(output.getAbsolutePath())));
     BinaryFormatFileTransport transport =
-        new BinaryFormatFileTransport(outputStream, defaultOpts, uploader, artifactGroupNamer);
+        new BinaryFormatFileTransport(
+            outputStream,
+            defaultOpts,
+            uploader,
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
     transport.sendBuildEvent(event1);
     transport.close().get();
 
@@ -345,7 +364,12 @@ public class BinaryFormatFileTransportTest {
     BufferedOutputStream outputStream =
         new BufferedOutputStream(Files.newOutputStream(Paths.get(output.getAbsolutePath())));
     BinaryFormatFileTransport transport =
-        new BinaryFormatFileTransport(outputStream, defaultOpts, uploader, artifactGroupNamer);
+        new BinaryFormatFileTransport(
+            outputStream,
+            defaultOpts,
+            uploader,
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
     transport.sendBuildEvent(event);
     ListenableFuture<Void> closeFuture = transport.close();
 

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/JsonFormatFileTransportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/JsonFormatFileTransportTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.buildeventstream.transports;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent;
 import com.google.devtools.build.lib.buildeventstream.BuildEventContext;
@@ -87,7 +88,8 @@ public class JsonFormatFileTransportTest {
             outputStream,
             defaultOpts,
             new LocalFilesArtifactUploader(),
-            artifactGroupNamer);
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
     transport.sendBuildEvent(buildEvent);
 
     transport.close().get();
@@ -155,7 +157,11 @@ public class JsonFormatFileTransportTest {
 
     JsonFormatFileTransport transport =
         new JsonFormatFileTransport(
-            wrappedOutputStream, defaultOpts, new LocalFilesArtifactUploader(), artifactGroupNamer);
+            wrappedOutputStream,
+            defaultOpts,
+            new LocalFilesArtifactUploader(),
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
 
     transport.sendBuildEvent(buildEvent);
     Thread.sleep(transport.getFlushInterval().toMillis() * 3);

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransportTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Joiner;
 import com.google.common.io.Files;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent;
 import com.google.devtools.build.lib.buildeventstream.BuildEventContext;
@@ -88,7 +89,8 @@ public class TextFormatFileTransportTest {
             outputStream,
             defaultOpts,
             new LocalFilesArtifactUploader(),
-            artifactGroupNamer);
+            artifactGroupNamer,
+            BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE);
     transport.sendBuildEvent(buildEvent);
 
     BuildEventStreamProtos.BuildEvent progress =

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -51,6 +51,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/bazel/rules",
         "//src/main/java/com/google/devtools/build/lib/bugreport",
+        "//src/main/java/com/google/devtools/build/lib/buildeventservice:buildeventservice-options",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/transports",

--- a/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
@@ -45,6 +45,7 @@ import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.FragmentFactory;
 import com.google.devtools.build.lib.analysis.config.FragmentRegistry;
 import com.google.devtools.build.lib.bugreport.BugReport;
+import com.google.devtools.build.lib.buildeventservice.BuildEventServiceOptions.BesUploadMode;
 import com.google.devtools.build.lib.buildeventstream.AnnounceBuildEventTransportsEvent;
 import com.google.devtools.build.lib.buildeventstream.ArtifactGroupNamer;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent;
@@ -168,6 +169,11 @@ public final class BuildEventStreamerTest extends FoundationTestCase {
     @Override
     public boolean mayBeSlow() {
       return false;
+    }
+
+    @Override
+    public BesUploadMode getBesUploadMode() {
+      return BesUploadMode.WAIT_FOR_UPLOAD_COMPLETE;
     }
 
     @Override


### PR DESCRIPTION
As a result, `--build_event_[text|json|binary]_file_upload_mode` are introduced to set the upload mode for build event file respectively. The default value for them is `wait_for_upload_complete`. The implicit requirement on `--bes_upload_mode=wait_for_upload_complete` is also removed.

Alternate to https://github.com/bazelbuild/bazel/pull/19322.

PiperOrigin-RevId: 581903589
Change-Id: I7e35f8b43f21e00fad80f5c83c9e0d0f3f435737

Fixes #20169.