### PR TITLE
[7.0.0] Build Bazel with C++17.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,6 +48,14 @@ common:bzlmod --experimental_downloader_config=bazel_downloader.cfg
 common --config=bzlmod
 common --lockfile_mode=update
 
+# Enable modern C++ features
+build:linux --cxxopt=-std=c++17
+build:linux --host_cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17
+build:macos --host_cxxopt=-std=c++17
+build:windows --cxxopt=/std:c++17
+build:windows --host_cxxopt=/std:c++17
+
 # Enable Java 11 language features (https://github.com/bazelbuild/bazel/issues/14592)
 build --java_language_version=11
 build --tool_java_language_version=11


### PR DESCRIPTION
In upcoming changes, we'd like to have the ability to use C++17 features.
This ensures that such code will build successfully on the various CI
platforms, regardless of the C++ standard version the compiler defaults to.

Closes #20085.

Commit https://github.com/bazelbuild/bazel/commit/ba38aa25b674a2fd339b4d6cfce4abf073542d0a

PiperOrigin-RevId: 581952933
Change-Id: I0753249e2182b3ab499bc91a384ad93ec59d65f8