### PR TITLE
[7.0.0] Don't send unnecessary lockfile event

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -127,7 +127,7 @@ public class BazelDepGraphFunction implements SkyFunction {
     ImmutableBiMap<String, ModuleExtensionId> extensionUniqueNames =
         calculateUniqueNameForUsedExtensionId(extensionUsagesById);
 
-    if (!lockfileMode.equals(LockfileMode.OFF)) {
+    if (lockfileMode.equals(LockfileMode.UPDATE)) {
       // This will keep all module extension evaluation results, some of which may be stale due to
       // changed usages. They will be removed in BazelLockFileModule.
       BazelLockFileValue updateLockfile =


### PR DESCRIPTION
`BazelLockFileModule` is the only consumer of `BazelModuleResolutionEvent` and only subscribes with `--lockfile_mode=update`.

Closes #20154.

Commit https://github.com/bazelbuild/bazel/commit/560327f274443df66a3d54f8f14b57d1d57cfc11

PiperOrigin-RevId: 581955314
Change-Id: I2ef8a39833c1d195eccdd32fd8e3f86782979dc5