### PR TITLE
Add dependabot to update GitHub Actions; hash-pin `actions-ecosystem/action-remove-labels`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions-ecosystem/action-remove-labels@v1
+    - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
       with:
         labels: |
           awaiting-pr-merge


### PR DESCRIPTION
Fixes #20180.

This PR adds dependabot to keep GitHub Actions up-to-date. It is set up to use grouped updates, so that you'll only receive a single monthly PR updating all Actions with new versions.

Note that even if this PR is merged, Bazel should still enable Dependabot Security Updates to guarantee that – if a vulnerability is found in an Action – Bazel will receive an "out-of-season" PR fixing that vulnerability as soon as possible.

I also noticed that `actions-ecosystem/action-remove-labels` (in `remove-labels.yml`) wasn't hash-pinned, so I pinned it.