### PR TITLE
[7.0.0] Fix inverted logic for deleting the temporary execution log output file.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -98,10 +98,10 @@ public final class SpawnLogModule extends BlazeModule {
     // pointless conversion at the end. Otherwise, use a temporary path.
     if (executionOptions.executionLogBinaryFile != null && !executionOptions.executionLogSort) {
       rawOutputPath = workingDirectory.getRelative(executionOptions.executionLogBinaryFile);
-      mayDeleteRawOutputPath = true;
+      mayDeleteRawOutputPath = false;
     } else {
       rawOutputPath = outputBase.getRelative("execution.log");
-      mayDeleteRawOutputPath = false;
+      mayDeleteRawOutputPath = true;
     }
     rawOutputStream = new AsynchronousFileOutputStream(rawOutputPath);
 


### PR DESCRIPTION
PiperOrigin-RevId: 582024717
Change-Id: Id27b8b0531f174155a8939a2c1c01c9c0a1a86a3