### PR TITLE
[7.0.0] Stop including progress messages in the execution log.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/execlog/StableSort.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/execlog/StableSort.java
@@ -111,7 +111,6 @@ public final class StableSort {
                   stripped.addAllEnvironmentVariables(o.getEnvironmentVariablesList());
                   stripped.setPlatform(o.getPlatform());
                   stripped.addAllInputs(o.getInputsList());
-                  stripped.setProgressMessage(o.getProgressMessage());
                   stripped.setMnemonic(o.getMnemonic());
 
                   return "2_" + stripped.build();

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -189,10 +189,6 @@ public class SpawnLogContext implements ActionContext {
       builder.setDigest(result.getDigest());
     }
 
-    String progressMessage = spawn.getResourceOwner().getProgressMessage();
-    if (progressMessage != null) {
-      builder.setProgressMessage(progressMessage);
-    }
     builder.setMnemonic(spawn.getMnemonic());
     builder.setWalltime(millisToProto(result.getMetrics().executionWallTimeInMs()));
 

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -139,9 +139,6 @@ message SpawnExec {
   // The Spawn timeout.
   int64 timeout_millis = 8;
 
-  // A user-friendly text message representing the spawn progress.
-  string progress_message = 9;
-
   // An opaque string that identifies the type of the Spawn's action.
   string mnemonic = 10;
 
@@ -191,4 +188,6 @@ message SpawnExec {
 
   // Timing, size and memory statistics.
   SpawnMetrics metrics = 20;
+
+  reserved 9;
 }

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -398,7 +398,6 @@ public class AbstractSpawnStrategyTest {
             .withEnvironment("FOO", "v1")
             .withEnvironment("BAR", "v2")
             .withMnemonic("MyMnemonic")
-            .withProgressMessage("my progress message")
             .withInputs(fileInput, dirInput)
             .withOutputs(fileOutput, dirOutput)
             .build();
@@ -465,7 +464,6 @@ public class AbstractSpawnStrategyTest {
             .setRemotable(true)
             .setCacheable(true)
             .setRemoteCacheable(true)
-            .setProgressMessage("my progress message")
             .setMnemonic("MyMnemonic")
             .setRunner("runner")
             .setWalltime(Duration.getDefaultInstance())
@@ -681,7 +679,6 @@ public class AbstractSpawnStrategyTest {
         .addCommandArgs(cmd)
         .setRemotable(true)
         .setCacheable(true)
-        .setProgressMessage("progress message")
         .setMnemonic("Mnemonic")
         .setRunner("runner")
         .setStatus("NON_ZERO_EXIT")

--- a/src/test/shell/bazel/bazel_execlog_test.sh
+++ b/src/test/shell/bazel/bazel_execlog_test.sh
@@ -86,10 +86,10 @@ EOF
   # If dependencies were not properly accounted for, the order would have been:
   # rule1, rule2, dir1, dir2
 
-  dir1Num=`grep "Action dir_name1" -n output.json | grep -Eo '^[^:]+'`
-  dir2Num=`grep "Action dir_name2" -n output.json | grep -Eo '^[^:]+'`
-  rule1Num=`grep "Executing genrule //:rule1" -n output.json | grep -Eo '^[^:]+'`
-  rule2Num=`grep "Executing genrule //:rule2" -n output.json | grep -Eo '^[^:]+'`
+  dir1Num=`grep "//:dir" -n output.json | grep -Eo '^[^:]+'`
+  dir2Num=`grep "//:dir2" -n output.json | grep -Eo '^[^:]+'`
+  rule1Num=`grep "//:rule1" -n output.json | grep -Eo '^[^:]+'`
+  rule2Num=`grep "//:rule2" -n output.json | grep -Eo '^[^:]+'`
 
   if [ "$rule1Num" -lt "$dir1Num" ]
   then


### PR DESCRIPTION
They're fairly verbose and represent a significant portion of the log, much more so once we switch to a compact format. It should be possible to uniquely identify spawns through a combination of mnemonic, target label and output path.

Progress on https://github.com/bazelbuild/bazel/issues/18643.

PiperOrigin-RevId: 582273738
Change-Id: Ife9edc6aaf51c96e4ac42a84f69371ab4aaa50eb