### PR TITLE
[7.0.0] Stop including the walltime field in the execution log.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -190,7 +190,6 @@ public class SpawnLogContext implements ActionContext {
     }
 
     builder.setMnemonic(spawn.getMnemonic());
-    builder.setWalltime(millisToProto(result.getMetrics().executionWallTimeInMs()));
 
     if (spawn.getTargetLabel() != null) {
       builder.setTargetLabel(spawn.getTargetLabel());

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -173,10 +173,6 @@ message SpawnExec {
   // Was the Spawn result allowed to be cached remotely.
   bool remote_cacheable = 16;
 
-  // The wall time it took to execute the Spawn. This is only the time spent in
-  // the subprocess, not including the time doing setup and teardown.
-  google.protobuf.Duration walltime = 17;
-
   // Canonical label of the target that emitted this spawn, may not always be
   // set.
   string target_label = 18;
@@ -189,5 +185,5 @@ message SpawnExec {
   // Timing, size and memory statistics.
   SpawnMetrics metrics = 20;
 
-  reserved 9;
+  reserved 9, 17;
 }

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -69,7 +69,6 @@ import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
-import com.google.protobuf.Duration;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
@@ -466,7 +465,6 @@ public class AbstractSpawnStrategyTest {
             .setRemoteCacheable(true)
             .setMnemonic("MyMnemonic")
             .setRunner("runner")
-            .setWalltime(Duration.getDefaultInstance())
             .setTargetLabel("//dummy:label")
             .setMetrics(Protos.SpawnMetrics.getDefaultInstance())
             .setDigest(DIGEST)
@@ -684,7 +682,6 @@ public class AbstractSpawnStrategyTest {
         .setStatus("NON_ZERO_EXIT")
         .setExitCode(23)
         .setRemoteCacheable(true)
-        .setWalltime(Duration.getDefaultInstance())
         .setTargetLabel("//dummy:label")
         .setDigest(DIGEST)
         .setMetrics(Protos.SpawnMetrics.getDefaultInstance());


### PR DESCRIPTION
We now unconditionally emit the full spawn metrics, which already include the wall time; the extra field is wasteful and potentially confusing.

Progress on https://github.com/bazelbuild/bazel/issues/18643.

PiperOrigin-RevId: 582282615
Change-Id: I73f87f3e1c54679506acde860991ef57947262d3