### PR TITLE
[7.0.0] NullPointerException using `file:%workspace%/registry` in registry URI on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
@@ -47,6 +47,10 @@ public class RegistryFactoryImpl implements RegistryFactory {
       throw new URISyntaxException(
           uri.toString(), "Registry URL has no scheme -- did you mean to use file://?");
     }
+    if (uri.getPath() == null) {
+      throw new URISyntaxException(
+          uri.toString(), "Registry URL path is not valid -- did you mean to use file://?");
+    }
     switch (uri.getScheme()) {
       case "http":
       case "https":


### PR DESCRIPTION
fixes https://github.com/bazelbuild/bazel/issues/20015

Commit https://github.com/bazelbuild/bazel/commit/b6a83afb5123850cc5735d87f4ab96f642a9c079

PiperOrigin-RevId: 582595371
Change-Id: If5d82aa69fc4054164fdb837434b1182746ace39