### PR TITLE
[7.0.0] `android_local_test` isn't compatible with Android Platforms

### DIFF
--- a/src/test/shell/bazel/android/android_helper.sh
+++ b/src/test/shell/bazel/android/android_helper.sh
@@ -115,7 +115,7 @@ function resolve_android_toolchains() {
     echo "This test uses platform-based Android toolchain resolution."
     add_to_bazelrc "build --incompatible_enable_android_toolchain_resolution"
     add_to_bazelrc "build --incompatible_enable_cc_toolchain_resolution"
-    add_to_bazelrc "build --platforms=//test_android_platforms:simple"
+    add_to_bazelrc "build --android_platforms=//test_android_platforms:simple"
   else
     echo "This test uses legacy Android toolchains."
     add_to_bazelrc "build --noincompatible_enable_android_toolchain_resolution"

--- a/src/test/shell/bazel/android/android_local_test_integration_test.sh
+++ b/src/test/shell/bazel/android/android_local_test_integration_test.sh
@@ -34,11 +34,6 @@ fail_if_no_android_sdk
 source "${CURRENT_DIR}/../../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-if [[ "$1" = '--with_platforms' ]]; then
-  # TODO(https://github.com/bazelbuild/bazel/issues/19829): Re-enable when
-  # android_local_test works properly with Android platforms.
-  exit 0
-fi
 resolve_android_toolchains "$1"
 
 function setup_android_local_test_env() {

--- a/tools/android/android_sdk_repository_template.bzl
+++ b/tools/android/android_sdk_repository_template.bzl
@@ -199,9 +199,6 @@ def create_android_sdk_rules(
         native.toolchain(
             name = "sdk-%d-toolchain" % api_level,
             exec_compatible_with = HOST_CONSTRAINTS,
-            target_compatible_with = [
-                "@platforms//os:android",
-            ],
             toolchain = ":sdk-%d" % api_level,
             toolchain_type = "@bazel_tools//tools/android:sdk_toolchain_type",
         )


### PR DESCRIPTION
1. Remove `target_compatible_with` from the Android toolchains generated in the Starlark and native `android_sdk_repository` rules so that they can be selected with a host JDK in android_local_test

1. Re-enable `android_local_test_integration_test.sh`

1. Switch `--platforms` to `--android_platforms` in the android integration test setup so that a host JDK can be selected in android_local_test

Fixes #19829

RELNOTES: None
Commit https://github.com/bazelbuild/bazel/commit/9bbc2cbebf5c395c5504db7dfcfc5bda7e00bd3c

PiperOrigin-RevId: 582716155
Change-Id: I49d6a9058218d522b9ebb7cc6842fe20c36e2798