### PR TITLE
[7.0.0] Remove reference to --execution_log_json_file from cache hit troubleshooting documentation.

### DIFF
--- a/site/en/remote/cache-remote.md
+++ b/site/en/remote/cache-remote.md
@@ -80,11 +80,6 @@ If you are not getting the cache hit rate you are expecting, do the following:
    in your configuration is preventing caching. Continue with this section to
    check for common problems.
 
-   If you do not need to diff execution logs, you can use the
-   human-readable `--execution_log_json_file` flag instead. It cannot be
-   used for stable diffing since it contains execution time and doesn't
-   guarantee ordering.
-
 5. Check that all actions in the execution log have `cacheable` set to true. If
    `cacheable` does not appear in the execution log for a give action, that
    means that the corresponding rule may have a `no-cache` tag in its


### PR DESCRIPTION
The claims are inaccurate (we *do* sort the JSON log in a deterministic order unless sorting is disabled; the unstable spawn metrics are present for both formats). But more importantly, we should nudge people towards the less bloaty binary format.

PiperOrigin-RevId: 582999120
Change-Id: I6937d011e7be5dee8fc2edd5d60da3457f93cdec