### PR TITLE
[7.0.0] Remove reference to the progress_message execution log field.

### DIFF
--- a/site/en/remote/cache-remote.md
+++ b/site/en/remote/cache-remote.md
@@ -88,8 +88,9 @@ If you are not getting the cache hit rate you are expecting, do the following:
 5. Check that all actions in the execution log have `cacheable` set to true. If
    `cacheable` does not appear in the execution log for a give action, that
    means that the corresponding rule may have a `no-cache` tag in its
-   definition in the `BUILD` file. Look at the human-readable `progress_message`
-   field in the execution log to help determine where the action is coming from.
+   definition in the `BUILD` file. Look at the `mnemonic` and `target_label`
+   fields in the execution log to help determine where the action is coming
+   from.
 
 6. If the actions are identical and `cacheable` but there are no cache hits, it
    is possible that your command line includes `--noremote_accept_cached` which


### PR DESCRIPTION
It was deleted in https://github.com/bazelbuild/bazel/commit/3b0b6ed419e68046ac516c60b236624ee6f570c4.

PiperOrigin-RevId: 583001648
Change-Id: I6fe5b4f632e645e83575d22fcdfaad9bc8e1e5e8