### PR TITLE
[7.0.0] Emit a fixed config segment with path stripping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
@@ -78,6 +78,8 @@ import javax.annotation.Nullable;
 public final class StrippingPathMapper {
   static final String GUID = "8eb2ad5a-85d4-435b-858f-5c192e91997d";
 
+  private static final String FIXED_CONFIG_SEGMENT = "cfg";
+
   /**
    * Creates a new {@link PathMapper} that strips config prefixes if the particular action instance
    * supports it.
@@ -209,7 +211,7 @@ public final class StrippingPathMapper {
     }
 
     public String strip(String str) {
-      return pattern.matcher(str).replaceAll(outputRoot + "/");
+      return pattern.matcher(str).replaceAll(outputRoot + "/" + FIXED_CONFIG_SEGMENT + "/");
     }
   }
 
@@ -271,7 +273,12 @@ public final class StrippingPathMapper {
    * Strips the configuration prefix from an output artifact's exec path.
    */
   private static PathFragment strip(PathFragment execPath) {
-    return execPath.subFragment(0, 1).getRelative(execPath.subFragment(2));
+    return execPath
+        .subFragment(0, 1)
+        // Keep the config segment, but replace it with a fixed string to improve cacheability while
+        // still preserving the general segment structure of the execpath.
+        .getRelative(FIXED_CONFIG_SEGMENT)
+        .getRelative(execPath.subFragment(2));
   }
 
   private StrippingPathMapper() {}

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapperTest.java
@@ -85,17 +85,16 @@ public class StrippingPathMapperTest extends BuildViewTestCase {
                 .collect(toImmutableList()))
         .containsExactly(
             "java/com/google/test/A.java",
-            outDir + "/bin/java/com/google/test/B.java",
-            outDir + "/bin/java/com/google/test/C.java",
-            outDir + "/bin/java/com/google/test/liba-hjar.jar",
-            outDir + "/bin/java/com/google/test/liba-hjar.jdeps",
-            "-XepOpt:foo:bar=" + outDir + "/bin/java/com/google/test/B.java",
+            outDir + "/cfg/bin/java/com/google/test/B.java",
+            outDir + "/cfg/bin/java/com/google/test/C.java",
+            outDir + "/cfg/bin/java/com/google/test/liba-hjar.jar",
+            outDir + "/cfg/bin/java/com/google/test/liba-hjar.jdeps",
+            "-XepOpt:foo:bar=" + outDir + "/cfg/bin/java/com/google/test/B.java",
             "-XepOpt:baz="
                 + outDir
-                + "/bin/java/com/google/test/C.java,"
+                + "/cfg/bin/java/com/google/test/C.java,"
                 + outDir
-                + "/bin/java"
-                + "/com/google/test/B.java");
+                + "/cfg/bin/java/com/google/test/B.java");
   }
 
   private void addStarlarkRule(Dict<String, String> executionRequirements) throws IOException {
@@ -171,10 +170,10 @@ public class StrippingPathMapperTest extends BuildViewTestCase {
     String outDir = analysisMock.getProductName() + "-out";
     assertThat(spawn.getArguments().stream().collect(toImmutableList()))
         .containsExactly(
-            outDir + "/bin/tool/tool",
-            outDir + "/bin/pkg/out.bin",
+            outDir + "/cfg/bin/tool/tool",
+            outDir + "/cfg/bin/pkg/out.bin",
             "-source",
-            "<" + outDir + "/bin/pkg/gen_src.txt>",
+            "<" + outDir + "/cfg/bin/pkg/gen_src.txt>",
             "-source",
             "<pkg/source.txt>")
         .inOrder();
@@ -197,10 +196,10 @@ public class StrippingPathMapperTest extends BuildViewTestCase {
     String outDir = analysisMock.getProductName() + "-out";
     assertThat(spawn.getArguments().stream().collect(toImmutableList()))
         .containsExactly(
-            outDir + "/bin/tool/tool",
-            outDir + "/bin/pkg/out.bin",
+            outDir + "/cfg/bin/tool/tool",
+            outDir + "/cfg/bin/pkg/out.bin",
             "-source",
-            "<" + outDir + "/bin/pkg/gen_src.txt>",
+            "<" + outDir + "/cfg/bin/pkg/gen_src.txt>",
             "-source",
             "<pkg/source.txt>")
         .inOrder();

--- a/src/test/shell/integration/config_stripped_outputs_lib.sh
+++ b/src/test/shell/integration/config_stripped_outputs_lib.sh
@@ -44,9 +44,9 @@ function assert_paths_stripped() {
   # "set -e" and silently ignored.
   output_paths=$(echo "$cmd" | tr -s ' ' '\n' | xargs -n 1 | grep -E -o "${bazel_out}[^)]*")
   for o in $output_paths; do
-    echo "$o" | grep -v "${bazel_out}/bin" \
+    echo "$o" | grep -v "${bazel_out}/cfg/bin" \
       && fail "expected all \"${bazel_out}\" paths to start with " \
-      "\"${bazel_out}/bin.*\": $o"
+      "\"${bazel_out}/cfg/bin.*\": $o"
     if [[ "$o" == *"$identifying_action_output"* ]]; then
       found_identifying_output=1
     fi
@@ -56,7 +56,7 @@ function assert_paths_stripped() {
   # files.
   param_files=$(echo "$cmd" | tr -s ' ' '\n' | xargs -n 1 | grep -E -o "${bazel_out}[^)]*.params" || true)
   for o in $param_files; do
-    bin_relative_path=$(echo $o | sed -r "s|${bazel_out}/bin/||")
+    bin_relative_path=$(echo $o | sed -r "s|${bazel_out}/cfg/bin/||")
     local_path="${bazel_out:0:5}-bin/${bin_relative_path}"
     # Don't fail if the file doesn't contain any output paths, but do fail if it doesn't exist.
     if [[ ! -f "$local_path" ]]; then
@@ -64,9 +64,9 @@ function assert_paths_stripped() {
     fi
     param_file_paths=$(grep "${bazel_out}" $local_path || true)
     for k in $param_file_paths; do
-      echo "$k" | grep -v "${bazel_out}/bin" \
+      echo "$k" | grep -v "${bazel_out}/cfg/bin" \
         && fail "$local_path: expected all \"${bazel_out}\" paths to start " \
-        "with \"${bazel_out}/bin.*\": $k"
+        "with \"${bazel_out}/cfg/bin.*\": $k"
       if [[ "$k" == *"$identifying_action_output"* ]]; then
         found_identifying_output=1
       fi
@@ -83,7 +83,7 @@ function assert_paths_stripped() {
 function assert_contains_no_stripped_path() {
   # For "bazel-out/x86-fastbuild/bin/...", return "bazel-out".
   output_path=$(bazel info | grep '^output_path:')
-  stripped_bin="${output_path##*/}/bin"
+  stripped_bin="${output_path##*/}/cfg/bin"
 
   assert_not_contains "$stripped_bin" "$1" "Stripped path found in $1"
 }


### PR DESCRIPTION
Instead of outright removing the config segment of exec paths with the stripping path mapper, replace it with a fixed string (`cfg`). This has the following benefits:

* Actions that make assumptions about the general exec path structure (e.g. because they use the Bash runfiles library, which parses the exec path and expects a `bazel-out/<something>/bin/...` format) continue to work.
* Path stripping becomes idempotent, which fixes issues in case an artifact's path is mapped both structurally and via the string-based stripping.

Closes #20219.

Commit https://github.com/bazelbuild/bazel/commit/0d0caba2e940f9eec2051c43c86954cf9c95635f

PiperOrigin-RevId: 583266215
Change-Id: I063fd7fd502a92660952427c5ce893eacd16436d