### PR TITLE
[7.0.0] Add add_exports & add_opens parameters to JavaInfo constructor

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_semantics.bzl
@@ -40,6 +40,9 @@ def _get_default_resource_path(path, segment_extractor):
 def _compatible_javac_options(*_args):
     return depset()
 
+def _check_java_info_opens_exports():
+    pass
+
 semantics = struct(
     JAVA_TOOLCHAIN_LABEL = "@bazel_tools//tools/jdk:current_java_toolchain",
     JAVA_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:toolchain_type",
@@ -76,4 +79,5 @@ semantics = struct(
     JAVA_PROTO_TOOLCHAIN = "@rules_java//java/proto:toolchain_type",
     JAVA_LITE_PROTO_TOOLCHAIN = "@rules_java//java/proto:lite_toolchain_type",
     PROGUARD_ALLOWLISTER_LABEL = "@bazel_tools//tools/jdk:proguard_whitelister",
+    check_java_info_opens_exports = _check_java_info_opens_exports,
 )


### PR DESCRIPTION
There is currently no non-hacky way for third-party rule implementations to add `add_exports` and `add_opens` to a `JavaInfo`, though hacky ways exist (like using a macro to generate a `java_library` with `add_exports` / `add_opens` and add it as a dependency).

Having an official way to create `JavaInfo`s with `add_exports` and `add_opens` helps third-party JVM rules better support JDK 9+ (and especially 17+, which requires `--add-opens` flags to access JDK internals through reflection).

Addresses half of #20033.

Closes #20036.

Commit https://github.com/bazelbuild/bazel/commit/d2783a3c3d1b899beb674e029bfea3519062e8be

PiperOrigin-RevId: 580472097
Change-Id: I159e3410c5480ac683fd9af85bfd1d83ac0e6d8a