### PR TITLE
[7.0.0] Add add_exports & add_opens attributes to java_import

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/view/java/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/view/java/BUILD
@@ -79,6 +79,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/rules/java:java-compilation",
         "//src/main/java/com/google/devtools/build/lib/rules/java:java-rules",
+        "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java",
         "//src/test/java/com/google/devtools/build/lib/actions/util",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/rules/java:java_compile_action_test_helper",

--- a/src/test/java/com/google/devtools/build/lib/view/java/JavaImportConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/view/java/JavaImportConfiguredTargetTest.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.rules.java.JavaInfo;
 import com.google.devtools.build.lib.rules.java.JavaRuleOutputJarsProvider;
 import com.google.devtools.build.lib.rules.java.JavaSourceJarsProvider;
 import com.google.devtools.build.lib.rules.java.ProguardSpecProvider;
+import com.google.devtools.build.lib.starlarkbuildapi.java.JavaModuleFlagsProviderApi;
 import com.google.devtools.build.lib.testutil.MoreAsserts;
 import java.util.Arrays;
 import java.util.List;
@@ -218,6 +219,47 @@ public class JavaImportConfiguredTargetTest extends BuildViewTestCase {
         "java/jarlib2/import.jar",
         "java/jarlib2/exportjar.jar",
         "java/jarlib2/depjar.jar");
+  }
+
+  @Test
+  public void testModuleFlags() throws Exception {
+    if (!analysisMock.isThisBazel()) {
+      return;
+    }
+
+    scratch.file(
+        "java/jarlib2/BUILD",
+        "java_library(name  = 'lib',",
+        "             srcs = ['Main.java'],",
+        "             deps = [':import-jar'])",
+        "java_import(name  = 'import-jar',",
+        "            jars = ['import.jar'],",
+        "            deps = ['//java/jarlib2:depjar'],",
+        "            exports = ['//java/jarlib2:exportjar'],",
+        ")",
+        "java_import(name  = 'depjar',",
+        "            jars = ['depjar.jar'],",
+        "            add_exports = ['java.base/java.lang'])",
+        "java_import(name  = 'exportjar',",
+        "            jars = ['exportjar.jar'],",
+        "            add_opens = ['java.base/java.util'])");
+
+    ConfiguredTarget importJar = getConfiguredTarget("//java/jarlib2:import-jar");
+    JavaModuleFlagsProviderApi moduleFlagsProvider =
+        JavaInfo.getJavaInfo(importJar).getJavaModuleFlagsInfo();
+    assertThat(moduleFlagsProvider.getAddExports().toList(String.class))
+        .containsExactly("java.base/java.lang");
+    assertThat(moduleFlagsProvider.getAddOpens().toList(String.class))
+        .containsExactly("java.base/java.util");
+
+    // Check that module flags propagate to Java libraries properly.
+    ConfiguredTarget lib = getConfiguredTarget("//java/jarlib2:lib");
+    JavaModuleFlagsProviderApi libModuleFlagsProvider =
+        JavaInfo.getJavaInfo(lib).getJavaModuleFlagsInfo();
+    assertThat(libModuleFlagsProvider.getAddExports().toList(String.class))
+        .containsExactly("java.base/java.lang");
+    assertThat(libModuleFlagsProvider.getAddOpens().toList(String.class))
+        .containsExactly("java.base/java.util");
   }
 
   @Test


### PR DESCRIPTION
This reduces the difference between `java_import` and other Java rules, like `java_library` and `java_binary`.

* Propagate `add_exports` and `add_opens` through `java_import`
* Add tests

Fixes #19556.

Closes #20035.

Commit https://github.com/bazelbuild/bazel/commit/77eacce3f56ce6b5b466337c123a5cdfd671f2ee

PiperOrigin-RevId: 582617247
Change-Id: I513536acd4994de36190a5d79c2e92ac3f3ccc66