### PR TITLE
python: Ignore SIGINT while running wrapped program from zip

### DIFF
--- a/tools/python/python_bootstrap_template.txt
+++ b/tools/python/python_bootstrap_template.txt
@@ -19,6 +19,7 @@ import sys
 del sys.path[0]
 
 import os
+import signal
 import subprocess
 
 def IsRunningFromZip():
@@ -354,11 +355,20 @@ def ExecuteFile(python_program, main_filename, args, env, module_space,
     ret_code = _RunForCoverage(python_program, main_filename, args, env,
                                coverage_entrypoint, workspace)
   else:
-    ret_code = subprocess.call(
-      [python_program, main_filename] + args,
-      env=env,
-      cwd=workspace
-    )
+    # Temporarily ignoring SIGINT to not interfere with python_program's own
+    # interrupt handling.
+    def noop(sig, frame):
+      pass
+    signal.signal(signal.SIGINT, noop)
+
+    try:
+      ret_code = subprocess.call(
+        [python_program, main_filename] + args,
+        env=env,
+        cwd=workspace
+      )
+    finally:
+      signal.signal(signal.SIGINT, signal.SIG_DFL)
 
   if delete_module_space:
     # NOTE: dirname() is called because CreateModuleSpace() creates a


### PR DESCRIPTION
This is a proposal to resolve https://github.com/bazelbuild/bazel/issues/20255