### PR TITLE
Ignore warning about JAVA_TOOL_OPTIONS in test

### DIFF
--- a/src/test/shell/integration/bazel_command_log_test.sh
+++ b/src/test/shell/integration/bazel_command_log_test.sh
@@ -45,6 +45,7 @@ function strip_lines_from_bazel_cc() {
     -e '/^WARNING: Waiting for server process to terminate (waited 5 seconds, waiting at most 60)$/d' \
     -e '/^WARNING: The startup option --host_javabase is deprecated; prefer --server_javabase.$/d' \
     -e '/^WARNING: The home directory is not defined, no home_rc will be looked for.$/d' \
+    -e '/^WARNING: ignoring JAVA_TOOL_OPTIONS in environment.$/d' \
     -e '/Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release/d' \
     -e '/^E[0-9]* /d' \
     $TEST_log)


### PR DESCRIPTION
Soon we'll set JAVA_TOOL_OPTIONS in MacOS CI workers, which results in a additional warning in the log, thus failing bazel_command_log_test.

Progress towards https://github.com/bazelbuild/continuous-integration/issues/1708