### PR TITLE
[7.0.0] Build failures and internal errors when switching from 7.0.0rc3 to 7.0.0rc4

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/testing/vfs/SpiedFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/testing/vfs/SpiedFileSystem.java
@@ -58,6 +58,11 @@ public class SpiedFileSystem extends DelegateFileSystem {
   }
 
   @Override
+  public byte[] getDigest(PathFragment path) throws IOException {
+    return super.getDigest(path);
+  }
+
+  @Override
   public void chmod(PathFragment path, int mode) throws IOException {
     super.chmod(path, mode);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -108,6 +108,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/runtime/commands",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
+        "//src/main/java/com/google/devtools/build/lib/testing/vfs:spied_filesystem",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:os",


### PR DESCRIPTION
The methods are documented as such in FileSystem. If we don't do this, there will be a discrepancy between getFastDigest and stat, as the latter can follow symlinks. This can manifest as a crash (see #20246) as the digest computation will take the missing fast digest for a symlink as a signal to compute the digest manually; this would fail when the symlink target is an in-memory file, which doesn't have an associated inode as required to compute the cache key (see DigestUtils#manuallyComputeDigest).

Fixes #20246.

Commit https://github.com/bazelbuild/bazel/commit/aab19f75cd383c4b09a6ae720f9fa436bf89d271

PiperOrigin-RevId: 584297990
Change-Id: I65e586ea84635a279208e24c421f54ae46ee21b8