### PR TITLE
[7.0.0] Remove the explicit inclusion of Darwin in the list of case-insensitive OSes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
@@ -475,7 +475,7 @@ public class InMemoryFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   public boolean isFilePathCaseSensitive() {
-    return OS.getCurrent() != OS.WINDOWS && OS.getCurrent() != OS.DARWIN;
+    return OS.getCurrent() != OS.WINDOWS;
   }
 
   @Override


### PR DESCRIPTION
*** Reason for rollback ***

Not required anymore for its intended purpose (Skymeld symlink planting - https://github.com/bazelbuild/bazel/commit/112df458f4e530d53ebafb3c413fce55251c958a), since we ended up using a different approach (https://github.com/bazelbuild/bazel/commit/198b7da274e22b955603db1e77806e34b2ba47b0). Apparently `OS.Darwin` doesn't always guarantee case insensitivity, since this can be customized.

Discussion: https://github.com/bazelbuild/bazel/commit/b264850ef404450e8b1672efd12a9b5de1aa2228#commitcomment-133172863

*** Original change description ***

Include DARWIN in the list of case-insensitive OSes

Commit https://github.com/bazelbuild/bazel/commit/c637041ec145e0964982a2cbf8d5693f0d1d4be0

PiperOrigin-RevId: 584334642
Change-Id: Icb0fbea3a751d3562d98e067de1f4952d9842d95