### PR TITLE
[7.0.0] Limit labeler trigger so that it's triggered only when the PR creator is not bazel-io

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,4 +20,4 @@ jobs:
         egress-policy: audit
 
     - uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b # v4.0.3
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.user.login != 'bazel-io' }}


### PR DESCRIPTION
Commit https://github.com/bazelbuild/bazel/commit/d79119ff6e702f2b08ab91e05d0a8cfe69bc9c42

PiperOrigin-RevId: 577163253
Change-Id: I1cd458a6239543ac8c45f35ae9e32da45d9d4099