### PR TITLE
[WIP] Pretty-print time displayed to users.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionStartedEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionStartedEvent.java
@@ -14,9 +14,13 @@
 package com.google.devtools.build.lib.actions;
 
 import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
+import java.time.Instant;
 
 /** This event is fired during the build, when an action is started. */
 public final class ActionStartedEvent implements Postable {
+  // TODO: remove.
+  private static final int NANOS_PER_SECOND = 1000000000;
+
   private final Action action;
   private final long nanoTimeStart;
 
@@ -42,5 +46,9 @@ public final class ActionStartedEvent implements Postable {
 
   public long getNanoTimeStart() {
     return nanoTimeStart;
+  }
+
+  public Instant getTimeStart() {
+    return Instant.ofEpochSecond(nanoTimeStart / NANOS_PER_SECOND, nanoTimeStart % NANOS_PER_SECOND);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/AggregatedSpawnMetrics.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AggregatedSpawnMetrics.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.time.Duration;
+import java.time.temporal.TemporalUnit;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -132,10 +133,11 @@ public final class AggregatedSpawnMetrics {
    * <p>Example: {@code getTotalDuration(SpawnMetrics::queueTime)} will give the total queue time
    * across all execution kinds.
    */
-  public int getTotalDuration(Function<SpawnMetrics, Integer> extract) {
-    int result = 0;
+  public Duration getTotalDuration(Function<SpawnMetrics, Integer> extract, TemporalUnit unit) {
+    Duration result = Duration.ZERO;
     for (SpawnMetrics metric : metricsMap.values()) {
-      result += extract.apply(metric);
+      int metricDurationInMillis = extract.apply(metric);
+      result = result.plus(metricDurationInMillis, unit);
     }
     return result;
   }

--- a/src/main/java/com/google/devtools/build/lib/clock/BlazeClock.java
+++ b/src/main/java/com/google/devtools/build/lib/clock/BlazeClock.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.clock;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -95,5 +96,10 @@ public abstract class BlazeClock {
     long nowInMillis = clock.currentTimeMillis();
     long nowInNanos = clock.nanoTime();
     return (timeMillis) -> nowInNanos - TimeUnit.MILLISECONDS.toNanos(nowInMillis - timeMillis);
+  }
+
+  /** Format a duration value into a human-readable string. */
+  public static String formatTime(Duration duration) {
+    return duration.toString().substring(2).toLowerCase();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/metrics/criticalpath/CriticalPathComponent.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/criticalpath/CriticalPathComponent.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.metrics.criticalpath;
 
+import static com.google.devtools.build.lib.clock.BlazeClock.formatTime;
+
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionOwner;
@@ -322,7 +324,7 @@ public class CriticalPathComponent {
     StringBuilder sb = new StringBuilder();
     String currentTime = "still running";
     if (!isRunning) {
-      currentTime = String.format("%.2f", getElapsedTimeNoCheck().toMillis() / 1000.0) + "s";
+      currentTime = formatTime(getElapsedTimeNoCheck());
     }
     sb.append(currentTime);
     if (remote) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/SpawnStats.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SpawnStats.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multiset;
 import com.google.devtools.build.lib.actions.ActionResult;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -62,8 +63,8 @@ public class SpawnStats {
     totalNumberOfActions.incrementAndGet();
   }
 
-  public long getTotalWallTimeMillis() {
-    return totalWallTimeMillis.get();
+  public Duration getTotalWallTime() {
+    return Duration.ofMillis(totalWallTimeMillis.get());
   }
 
   /*

--- a/src/test/java/com/google/devtools/build/lib/metrics/criticalpath/CriticalPathComputerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/metrics/criticalpath/CriticalPathComputerTest.java
@@ -451,7 +451,7 @@ public class CriticalPathComputerTest extends FoundationTestCase {
   public void testEmptyCriticalPath() {
     AggregatedCriticalPath empty = computer.aggregate();
     assertThat(empty.components()).isEmpty();
-    assertThat(empty.totalTimeInMs()).isEqualTo(0);
+    assertThat(empty.totalTime()).isEqualTo(Duration.ZERO);
     checkTopComponentsTimes(computer);
   }
 
@@ -560,7 +560,7 @@ public class CriticalPathComputerTest extends FoundationTestCase {
   @Test
   public void testWallTime() throws Exception {
     simulateActionExec(new NullAction(), 2000);
-    checkCriticalPath(2000, "2.00");
+    checkCriticalPath(Duration.ofMillis(2000), "2.00");
     checkTopComponentsTimes(computer, 2000L);
     NanosToMillisSinceEpochConverter converter =
         BlazeClock.createNanosToMillisSinceEpochConverter(clock);
@@ -1054,11 +1054,11 @@ public class CriticalPathComputerTest extends FoundationTestCase {
     return ActionsTestUtil.createArtifact(middlemanRoot, path);
   }
 
-  private void checkCriticalPath(int totalWallTimeInMillis, String totalWallTimeStr) {
+  private void checkCriticalPath(Duration totalWallTime, String totalWallTimeStr) {
     AggregatedCriticalPath criticalPath = computer.aggregate();
 
     assertThat(criticalPath).isNotNull();
-    assertThat(criticalPath.totalTimeInMs()).isEqualTo(totalWallTimeInMillis);
+    assertThat(criticalPath.totalTime()).isEqualTo(totalWallTime);
 
     String summary = criticalPath.toStringSummary();
     assertThat(summary).contains("Critical Path: " + totalWallTimeStr + "s");
@@ -1075,7 +1075,7 @@ public class CriticalPathComputerTest extends FoundationTestCase {
     AggregatedCriticalPath criticalPath = computer.aggregate();
 
     assertThat(criticalPath).isNotNull();
-    assertThat(criticalPath.totalTimeInMs()).isEqualTo(totalWallTime.toMillis());
+    assertThat(criticalPath.totalTime()).isEqualTo(totalWallTime);
     assertThat(criticalPath.getSpawnMetrics().getRemoteMetrics().totalTimeInMs())
         .isEqualTo(totalTime.toMillis());
     assertThat(criticalPath.getSpawnMetrics().getRemoteMetrics().executionWallTimeInMs())


### PR DESCRIPTION
Instead of:
- `Elapsed time: 67.374s, Critical Path: 65.06s`
- `Elapsed time: 1m7.374s, Critical Path: 1m5.06s`

**NOTE**: I got a little too carried away converting things to `Instant` and `Duration`. This is incredibly unlikely to merge as-is because I suspect I've hit a lot of performance-sensitive code.

I'll run tests anyway to see if the functionality is bad and next week I'll run some benchmarks.

