### PR TITLE
[JSON Trace Profile] Correctly identify GC thread

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/ThreadMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/ThreadMetadata.java
@@ -49,7 +49,7 @@ class ThreadMetadata implements TraceData {
   }
 
   private static boolean isGCThread(String threadName) {
-    return threadName.equals("Service Thread");
+    return threadName.equals("Notification Thread");
   }
 
   private static String getReadableName(String threadName) {


### PR DESCRIPTION
Currently, the thread that includes the garbace colleciton notification events is not correctly identified.
This means that in the JSON trace profile, the thread:

* is not renamed, as desired.
* is not sorted towards the top, as desired.

The thread is identified by its name, which has changed from "Service Thread" to "Notification Thread". This change updates the profile code accordingly.

In response to https://github.com/bazelbuild/bazel/issues/18548#issuecomment-1823361627
Fixes https://github.com/EngFlow/bazel_invocation_analyzer/issues/110