### PR TITLE
[JSON Trace Profile] Add `tid` to counter series

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/CounterSeriesTraceData.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/CounterSeriesTraceData.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.profiler;
 
 import static java.util.Map.entry;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.stream.JsonWriter;
@@ -30,11 +31,14 @@ import javax.annotation.Nullable;
  * opposed to individual tasks such as executing an action).
  */
 final class CounterSeriesTraceData implements TraceData {
+  @VisibleForTesting static final long PROCESS_ID = 1;
   private final Map<ProfilerTask, double[]> counterSeriesMap;
   private final Duration profileStart;
   private final Duration bucketDuration;
   private final int len;
+  private final long threadId;
   private String displayName;
+
   @Nullable private String colorName;
 
   /**
@@ -63,6 +67,7 @@ final class CounterSeriesTraceData implements TraceData {
       }
     }
     this.len = len;
+    this.threadId = Thread.currentThread().getId();
     this.counterSeriesMap = counterSeriesMap;
     this.profileStart = profileStart;
     this.bucketDuration = bucketDuration;
@@ -115,7 +120,8 @@ final class CounterSeriesTraceData implements TraceData {
       jsonWriter.beginObject();
       jsonWriter.setIndent("");
       jsonWriter.name("name").value(displayName);
-      jsonWriter.name("pid").value(1);
+      jsonWriter.name("pid").value(PROCESS_ID);
+      jsonWriter.name("tid").value(threadId);
       if (colorName != null) {
         jsonWriter.name("cname").value(colorName);
       }

--- a/src/main/java/com/google/devtools/build/lib/profiler/TraceEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/TraceEvent.java
@@ -39,6 +39,7 @@ public abstract class TraceEvent {
       @Nullable String type,
       @Nullable Duration timestamp,
       @Nullable Duration duration,
+      long processId,
       long threadId,
       @Nullable ImmutableMap<String, Object> args,
       @Nullable String primaryOutputPath,
@@ -50,6 +51,7 @@ public abstract class TraceEvent {
         type,
         timestamp,
         duration,
+        processId,
         threadId,
         args,
         primaryOutputPath,
@@ -71,6 +73,8 @@ public abstract class TraceEvent {
   @Nullable
   public abstract Duration duration();
 
+  public abstract long processId();
+
   public abstract long threadId();
 
   @Nullable
@@ -91,6 +95,7 @@ public abstract class TraceEvent {
     String name = null;
     Duration timestamp = null;
     Duration duration = null;
+    long processId = -1;
     long threadId = -1;
     String primaryOutputPath = null;
     String targetLabel = null;
@@ -117,6 +122,9 @@ public abstract class TraceEvent {
         case "dur":
           duration = Duration.ofNanos(reader.nextLong() * 1000);
           break;
+        case "pid":
+          processId = reader.nextLong();
+          break;
         case "tid":
           threadId = reader.nextLong();
           break;
@@ -141,6 +149,7 @@ public abstract class TraceEvent {
         type,
         timestamp,
         duration,
+        processId,
         threadId,
         args,
         primaryOutputPath,

--- a/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
@@ -1016,12 +1016,21 @@ public final class ProfilerTest {
         jsonProfile.getTraceEvents().stream()
             .filter(e -> "action count".equals(e.name()))
             .toArray();
-    // Two cache hit checks and one executed action.
-    assertThat(((TraceEvent) actionCountEvents[0]).args())
-        .containsExactly("action", 1.0, "local action cache", 2.0);
-    // One of the cache hit checks spilled over and used half of the second bucket.
-    assertThat(((TraceEvent) actionCountEvents[1]).args())
-        .containsExactly("local action cache", 0.5);
+
     assertThat(actionCountEvents).hasLength(2);
+
+    TraceEvent first = (TraceEvent) actionCountEvents[0];
+    assertThat(first.processId()).isEqualTo(CounterSeriesTraceData.PROCESS_ID);
+    assertThat(first.threadId()).isEqualTo(Thread.currentThread().getId());
+    // Two cache hit checks and one executed action.
+    assertThat(first.args())
+        .containsExactly("action", 1.0, "local action cache", 2.0);
+
+    TraceEvent second = (TraceEvent) actionCountEvents[1];
+    assertThat(first.processId()).isEqualTo(CounterSeriesTraceData.PROCESS_ID);
+    assertThat(first.threadId()).isEqualTo(Thread.currentThread().getId());
+    // One of the cache hit checks spilled over and used half of the second bucket.
+    assertThat(second.args())
+        .containsExactly("local action cache", 0.5);
   }
 }


### PR DESCRIPTION
The JSON trace profile includes counter for data such as action count, CPU usage, memory usage.
The code for writing the events to include these was refactored in https://github.com/bazelbuild/bazel/commit/a03674e6297ed5f6f740889cba8780d7c4ffe05c As part of that change the events written no longer include a `tid` (thread ID). However, each event in the JSON trace profile is expected to include a `tid`, as documented in
https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.uxpopqvbjezh

This change ensures the counter series events again have a `tid`, using the current thread's ID. This is consistent with the behavior that was present before the refactor.

In response to https://github.com/bazelbuild/bazel/issues/18548#issuecomment-1823361627