### PR TITLE
Make lockfile extension updates more obviously correct

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -135,7 +135,6 @@ public class BazelDepGraphFunction implements SkyFunction {
               .setLocalOverrideHashes(localOverrideHashes)
               .setModuleDepGraph(depGraph)
               .build();
-      Preconditions.checkNotNull(lockfile);
       env.getListener()
           .post(
               BazelModuleResolutionEvent.create(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -128,15 +128,18 @@ public class BazelDepGraphFunction implements SkyFunction {
         calculateUniqueNameForUsedExtensionId(extensionUsagesById);
 
     if (lockfileMode.equals(LockfileMode.UPDATE)) {
-      BazelLockFileValue updateLockfile =
+      BazelLockFileValue resolutionOnlyLockfile =
           BazelLockFileValue.builder()
               .setModuleFileHash(root.getModuleFileHash())
               .setFlags(flags)
               .setLocalOverrideHashes(localOverrideHashes)
               .setModuleDepGraph(depGraph)
               .build();
+      Preconditions.checkNotNull(lockfile);
       env.getListener()
-          .post(BazelModuleResolutionEvent.create(updateLockfile, extensionUsagesById));
+          .post(
+              BazelModuleResolutionEvent.create(
+                  lockfile, resolutionOnlyLockfile, extensionUsagesById));
     }
 
     return BazelDepGraphValue.create(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -128,11 +128,8 @@ public class BazelDepGraphFunction implements SkyFunction {
         calculateUniqueNameForUsedExtensionId(extensionUsagesById);
 
     if (lockfileMode.equals(LockfileMode.UPDATE)) {
-      // This will keep all module extension evaluation results, some of which may be stale due to
-      // changed usages. They will be removed in BazelLockFileModule.
       BazelLockFileValue updateLockfile =
-          lockfile.toBuilder()
-              .setLockFileVersion(BazelLockFileValue.LOCK_FILE_VERSION)
+          BazelLockFileValue.builder()
               .setModuleFileHash(root.getModuleFileHash())
               .setFlags(flags)
               .setLocalOverrideHashes(localOverrideHashes)

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionEvent.java
@@ -29,25 +29,41 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
  */
 public final class BazelModuleResolutionEvent implements Postable {
 
-  private final BazelLockFileValue lockfileValue;
+  private final BazelLockFileValue onDiskLockfileValue;
+  private final BazelLockFileValue resolutionOnlyLockfileValue;
   private final ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage>
       extensionUsagesById;
 
   private BazelModuleResolutionEvent(
-      BazelLockFileValue lockfileValue,
+      BazelLockFileValue onDiskLockfileValue,
+      BazelLockFileValue resolutionOnlyLockfileValue,
       ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage> extensionUsagesById) {
-    this.lockfileValue = lockfileValue;
+    this.onDiskLockfileValue = onDiskLockfileValue;
+    this.resolutionOnlyLockfileValue = resolutionOnlyLockfileValue;
     this.extensionUsagesById = extensionUsagesById;
   }
 
   public static BazelModuleResolutionEvent create(
-      BazelLockFileValue lockFileValue,
+      BazelLockFileValue onDiskLockfileValue,
+      BazelLockFileValue resolutionOnlyLockfileValue,
       ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage> extensionUsagesById) {
-    return new BazelModuleResolutionEvent(lockFileValue, extensionUsagesById);
+    return new BazelModuleResolutionEvent(
+        onDiskLockfileValue, resolutionOnlyLockfileValue, extensionUsagesById);
   }
 
-  public BazelLockFileValue getLockfileValue() {
-    return lockfileValue;
+  /**
+   * Returns the contents of the lockfile as it existed on disk before the current build.
+   */
+  public BazelLockFileValue getOnDiskLockfileValue() {
+    return onDiskLockfileValue;
+  }
+
+  /**
+   * Returns the result of Bazel module resolution in the form of a lockfile without any
+   * information about module extension results.
+   */
+  public BazelLockFileValue getResolutionOnlyLockfileValue() {
+    return resolutionOnlyLockfileValue;
   }
 
   public ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage>

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunctionTest.java
@@ -183,11 +183,8 @@ public class BazelLockFileFunctionTest extends FoundationTestCase {
                         if (localOverrideHashes == null) {
                           return null;
                         }
-                        RootedPath lockfilePath =
-                            RootedPath.toRootedPath(
-                                Root.fromPath(rootDirectory), LabelConstants.MODULE_LOCKFILE_NAME);
                         BazelLockFileModule.updateLockfile(
-                            lockfilePath,
+                            rootDirectory,
                             BazelLockFileValue.builder()
                                 .setModuleFileHash(key.moduleHash())
                                 .setFlags(flags)
@@ -546,6 +543,7 @@ public class BazelLockFileFunctionTest extends FoundationTestCase {
   abstract static class UpdateLockFileKey implements SkyKey {
 
     abstract String moduleHash();
+
     abstract ImmutableMap<ModuleKey, Module> depGraph();
 
     abstract ImmutableMap<String, ModuleOverride> overrides();


### PR DESCRIPTION
* Removes code paths in `BazelLockFileModule` that are never taken now that lockfile update events are replayed by Skyframe.
* `BazelModuleResolutionEvent` no longer contains a `BazelLockFileValue` that is internally inconsistent: Previously, this values combined the (potentially updated) extension usages resulting from the resolution with the old locked extension results obtained from the previous state of the lockfile. The logic in `BazelLockFileModule` handled this correctly, but it should now be more obvious that it does so.
* No longer parse the lockfile twice, once in `BazelLockFileFunction` and once in `BazelLockFileModule`.