### PR TITLE
[7.0.0] Return FAILED_PRECONDITION instead of NOT_FOUND when a blob referenced by an action is missing.

### DIFF
--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -265,7 +265,7 @@ final class ExecutionServer extends ExecutionImplBase {
               ExtensionRegistry.getEmptyRegistry());
       cache.downloadTree(context, action.getInputRootDigest(), execRoot);
     } catch (CacheNotFoundException e) {
-      throw StatusUtils.notFoundError(e.getMissingDigest());
+      throw StatusUtils.missingBlobError(e.getMissingDigest());
     }
 
     Path workingDirectory = execRoot.getRelative(command.getWorkingDirectory());

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/StatusUtils.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/StatusUtils.java
@@ -19,6 +19,7 @@ import com.google.protobuf.Any;
 import com.google.rpc.BadRequest;
 import com.google.rpc.BadRequest.FieldViolation;
 import com.google.rpc.Code;
+import com.google.rpc.PreconditionFailure;
 import com.google.rpc.Status;
 import io.grpc.StatusException;
 import io.grpc.protobuf.StatusProto;
@@ -83,6 +84,25 @@ final class StatusUtils {
     return Status.newBuilder()
         .setCode(Code.FAILED_PRECONDITION.getNumber())
         .setMessage(e.getMessage())
+        .build();
+  }
+
+  static StatusException missingBlobError(Digest digest) {
+    return StatusProto.toStatusException(missingBlobStatus(digest));
+  }
+
+  static com.google.rpc.Status missingBlobStatus(Digest digest) {
+    return Status.newBuilder()
+        .setCode(Code.FAILED_PRECONDITION.getNumber())
+        .setMessage("Missing Blob: " + digest)
+        .addDetails(
+            Any.pack(
+                PreconditionFailure.newBuilder()
+                    .addViolations(
+                        PreconditionFailure.Violation.newBuilder()
+                            .setType("MISSING")
+                            .setSubject("blobs/" + digest.getHash() + "/" + digest.getSizeBytes()))
+                    .build()))
         .build();
   }
 }


### PR DESCRIPTION
Fix an issue in the remote execution server used for integration tests where, if a blob is missing from the CAS, it would return NotFound instead of a PreconditionError.

See https://github.com/bazelbuild/remote-apis, file build/bazel/remote/execution/v2/remote_execution.proto:

    // Execute an action remotely.
    [...]
    // * `FAILED_PRECONDITION`: One or more errors occurred in setting up the
    //   action requested, such as a missing input or command or no worker being
    //   available. The client may be able to fix the errors and retry.
    [...]
    // In the case of a missing input or command, the server SHOULD additionally
    // send a [PreconditionFailure][google.rpc.PreconditionFailure] error detail
    // where, for each requested blob not present in the CAS, there is a
    // `Violation` with a `type` of `MISSING` and a `subject` of
    // `"blobs/{digest_function/}{hash}/{size}"` indicating the digest of the
    // missing blob. The `subject` is formatted the same way as the
    // `resource_name` provided to
    // [ByteStream.Read][google.bytestream.ByteStream.Read], with the leading
    // instance name omitted. `digest_function` MUST thus be omitted if its value
    // is one of MD5, MURMUR3, SHA1, SHA256, SHA384, SHA512, or VSO.

In particular, there is no mention of the NOT_FOUND GRPC response code in the Execute documentation.

Closes #20295.

Commit https://github.com/bazelbuild/bazel/commit/efc3754f8c95e29aac6a7b32f2e19a2210d21607

PiperOrigin-RevId: 585573706
Change-Id: Ib439363d2284523f2cf9f74c353566e98eb6025e