### PR TITLE
[7.0.0] Simplify execution log format conversion logic.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/io/MessageOutputStreamWrapper.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/MessageOutputStreamWrapper.java
@@ -20,7 +20,6 @@ import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 
 /** Creates a MessageOutputStream from an OutputStream. */
 public class MessageOutputStreamWrapper {
@@ -63,45 +62,6 @@ public class MessageOutputStreamWrapper {
     @Override
     public void close() throws IOException {
       stream.close();
-    }
-  }
-
-  /** Outputs the messages in JSON text format */
-  public static class MessageOutputStreamCollection implements MessageOutputStream {
-    private final ArrayList<MessageOutputStream> streams = new ArrayList<>();
-
-    public boolean isEmpty() {
-      return streams.isEmpty();
-    }
-
-    public void addStream(MessageOutputStream m) {
-      streams.add(m);
-    }
-
-    @Override
-    public void write(Message m) throws IOException {
-      for (MessageOutputStream stream : streams) {
-        stream.write(m);
-      }
-    }
-
-    @Override
-    public void close() throws IOException {
-      IOException firstException = null;
-      for (MessageOutputStream stream : streams) {
-        try {
-          stream.close();
-        } catch (IOException e) {
-          if (firstException == null) {
-            firstException = e;
-          } else {
-            firstException.addSuppressed(e);
-          }
-        }
-      }
-      if (firstException != null) {
-        throw firstException;
-      }
     }
   }
 }


### PR DESCRIPTION
Since https://github.com/bazelbuild/bazel/commit/4b7c808ec91333bffa84810aa6d712896cf98b37, there's no longer a need to convert to multiple formats; there will be at most a single conversion (or no conversion, if the unsorted binary format was requested).

PiperOrigin-RevId: 583048555
Change-Id: I1459723ef6e850eecbdad82fb3ce51cd1bbc8627