### PR TITLE
Remove shell legacy android tests

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -47,10 +47,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
     include_json_profile:
       - build
       - test
@@ -88,10 +86,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
     include_json_profile:
       - build
       - test
@@ -155,10 +151,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
     include_json_profile:
       - build
       - test
@@ -209,10 +203,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
       # https://github.com/bazelbuild/bazel/issues/17410
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
       # https://github.com/bazelbuild/bazel/issues/17411
@@ -407,10 +399,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,10 +48,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
     include_json_profile:
       - build
       - test
@@ -90,10 +88,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
     include_json_profile:
       - build
       - test
@@ -158,10 +154,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
     include_json_profile:
       - build
       - test
@@ -213,10 +207,8 @@ tasks:
   #     # https://github.com/bazelbuild/bazel/issues/18776
   #     - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
   #     - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-  #     - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
   #     - "-//src/test/shell/bazel/android:aapt_integration_test"
   #     - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-  #     - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
   #     # https://github.com/bazelbuild/bazel/issues/17410
   #     - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
   #     # https://github.com/bazelbuild/bazel/issues/17411
@@ -471,10 +463,8 @@ tasks:
       # https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_platforms"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
-      - "-//src/test/shell/bazel/android:aapt_integration_test_with_platforms"
     include_json_profile:
       - build
       - test

--- a/src/test/shell/bazel/android/DexFileSplitter_synthetic_classes_test.sh
+++ b/src/test/shell/bazel/android/DexFileSplitter_synthetic_classes_test.sh
@@ -33,7 +33,7 @@ source "${CURRENT_DIR}/android_helper.sh" \
   || { echo "android_helper.sh not found!" >&2; exit 1; }
 fail_if_no_android_sdk
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function create_test_app() {
 

--- a/src/test/shell/bazel/android/aapt_integration_test.sh
+++ b/src/test/shell/bazel/android/aapt_integration_test.sh
@@ -46,7 +46,7 @@ source "$(rlocation io_bazel/src/test/shell/integration_test_setup.sh)" \
 # (bazelbuild/continuous-integration#578).
 add_to_bazelrc "build --incompatible_use_python_toolchains=false"
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function test_build_with_aapt2() {
   create_new_workspace

--- a/src/test/shell/bazel/android/aar_integration_test.sh
+++ b/src/test/shell/bazel/android/aar_integration_test.sh
@@ -33,7 +33,7 @@ fail_if_no_android_sdk
 source "${CURRENT_DIR}/../../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 # Regression test for https://github.com/bazelbuild/bazel/issues/1928.
 function test_empty_tree_artifact_action_inputs_mount_empty_directories() {

--- a/src/test/shell/bazel/android/aidl_integration_test.sh
+++ b/src/test/shell/bazel/android/aidl_integration_test.sh
@@ -32,7 +32,7 @@ fail_if_no_android_sdk
 source "$(rlocation io_bazel/src/test/shell/integration_test_setup.sh)" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function test_simple_idl_srcs() {
   create_new_workspace

--- a/src/test/shell/bazel/android/android_helper.sh
+++ b/src/test/shell/bazel/android/android_helper.sh
@@ -111,16 +111,9 @@ function setup_head_android_tools_if_exists() {
 
 # Resolves Android toolchains with platforms.
 function resolve_android_toolchains() {
-  if [[ "$1" = '--with_platforms' ]]; then
-    echo "This test uses platform-based Android toolchain resolution."
-    add_to_bazelrc "build --incompatible_enable_android_toolchain_resolution"
-    add_to_bazelrc "build --incompatible_enable_cc_toolchain_resolution"
-    add_to_bazelrc "build --android_platforms=//test_android_platforms:simple"
-  else
-    echo "This test uses legacy Android toolchains."
-    add_to_bazelrc "build --noincompatible_enable_android_toolchain_resolution"
-    add_to_bazelrc "build --noincompatible_enable_cc_toolchain_resolution"
-  fi
+  add_to_bazelrc "build --incompatible_enable_android_toolchain_resolution"
+  add_to_bazelrc "build --incompatible_enable_cc_toolchain_resolution"
+  add_to_bazelrc "build --android_platforms=//test_android_platforms:simple"
 }
 
 setup_head_android_tools_if_exists

--- a/src/test/shell/bazel/android/android_instrumentation_test_integration_test.sh
+++ b/src/test/shell/bazel/android/android_instrumentation_test_integration_test.sh
@@ -34,7 +34,7 @@ source "${CURRENT_DIR}/../../integration_test_setup.sh" \
 # (bazelbuild/continuous-integration#578).
 add_to_bazelrc "build --incompatible_use_python_toolchains=false"
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function setup_android_instrumentation_test_env() {
   mkdir -p java/com/bin/res/values

--- a/src/test/shell/bazel/android/android_integration_test.sh
+++ b/src/test/shell/bazel/android/android_integration_test.sh
@@ -33,7 +33,7 @@ fail_if_no_android_sdk
 source "${CURRENT_DIR}/../../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function test_sdk_library_deps() {
   create_new_workspace
@@ -212,7 +212,6 @@ android_binary(
 )
 EOF
   cat > MODULE.bazel << 'EOF'
-# Required for android_integration_test_with_platforms
 bazel_dep(name = "platforms", version = "0.0.7")
 EOF
 

--- a/src/test/shell/bazel/android/android_local_test_integration_test.sh
+++ b/src/test/shell/bazel/android/android_local_test_integration_test.sh
@@ -34,7 +34,7 @@ fail_if_no_android_sdk
 source "${CURRENT_DIR}/../../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function setup_android_local_test_env() {
   mkdir -p java/com/bin/res/values

--- a/src/test/shell/bazel/android/android_ndk_integration_test.sh
+++ b/src/test/shell/bazel/android/android_ndk_integration_test.sh
@@ -38,7 +38,7 @@ fail_if_no_android_ndk
 source "${CURRENT_DIR}/../../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains $1
+resolve_android_toolchains
 
 function create_android_binary() {
   mkdir -p java/bazel

--- a/src/test/shell/bazel/android/android_sdk_integration_test.sh
+++ b/src/test/shell/bazel/android/android_sdk_integration_test.sh
@@ -33,7 +33,7 @@ fail_if_no_android_sdk
 source "${CURRENT_DIR}/../../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function test_android_sdk_repository_path_from_environment() {
   create_new_workspace

--- a/src/test/shell/bazel/android/android_sh_test.bzl
+++ b/src/test/shell/bazel/android/android_sh_test.bzl
@@ -47,7 +47,6 @@ def android_sh_test(create_test_with_released_tools = True, **kwargs):
         # Test with released android_tools version.
         native.sh_test(
             name = name,
-            args = ["--with_platforms"],
             data = data,
             **kwargs
         )
@@ -56,7 +55,6 @@ def android_sh_test(create_test_with_released_tools = True, **kwargs):
     # as the test itself.
     native.sh_test(
         name = name + "_with_head_android_tools",
-        args = ["--with_platforms"],
         data = data + [
             "//tools/android/runtime_deps:android_tools.tar",
         ],

--- a/src/test/shell/bazel/android/android_sh_test.bzl
+++ b/src/test/shell/bazel/android/android_sh_test.bzl
@@ -30,7 +30,7 @@ CHECK_FOR_ANDROID_SDK = select(
 )
 
 def android_sh_test(create_test_with_released_tools = True, **kwargs):
-    """Creates versions of the test with and without platforms and head android tools.
+    """Creates versions of the test with and without head android tools.
 
     Args:
         create_test_with_released_tools: Whether to create a version of the test with the released
@@ -47,16 +47,8 @@ def android_sh_test(create_test_with_released_tools = True, **kwargs):
         # Test with released android_tools version.
         native.sh_test(
             name = name,
-            args = ["--without_platforms"],
-            data = data,
-            **kwargs
-        )
-
-        # Test with platform-based toolchain resolution.
-        native.sh_test(
-            name = name + "_with_platforms",
-            data = data,
             args = ["--with_platforms"],
+            data = data,
             **kwargs
         )
 
@@ -64,7 +56,7 @@ def android_sh_test(create_test_with_released_tools = True, **kwargs):
     # as the test itself.
     native.sh_test(
         name = name + "_with_head_android_tools",
-        args = ["--without_platforms"],
+        args = ["--with_platforms"],
         data = data + [
             "//tools/android/runtime_deps:android_tools.tar",
         ],

--- a/src/test/shell/bazel/android/desugarer_integration_test.sh
+++ b/src/test/shell/bazel/android/desugarer_integration_test.sh
@@ -38,7 +38,7 @@ fail_if_no_android_sdk
 source "$(rlocation io_bazel/src/test/shell/integration_test_setup.sh)" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function create_java_8_android_binary() {
   mkdir -p java/bazel

--- a/src/test/shell/bazel/android/library_desugarer_integration_test.sh
+++ b/src/test/shell/bazel/android/library_desugarer_integration_test.sh
@@ -38,7 +38,7 @@ fail_if_no_android_sdk
 source "$(rlocation io_bazel/src/test/shell/integration_test_setup.sh)" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function test_library_desugar_lib_builds() {
   # TODO(b/299338002): Move this to the main desugarer test suite.

--- a/src/test/shell/bazel/android/proguard_integration_test.sh
+++ b/src/test/shell/bazel/android/proguard_integration_test.sh
@@ -38,7 +38,7 @@ fail_if_no_android_sdk
 source "$(rlocation io_bazel/src/test/shell/integration_test_setup.sh)" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function test_proguard() {
   create_new_workspace

--- a/src/test/shell/bazel/android/resource_processing_integration_test.sh
+++ b/src/test/shell/bazel/android/resource_processing_integration_test.sh
@@ -38,7 +38,7 @@ fail_if_no_android_sdk
 source "$(rlocation io_bazel/src/test/shell/integration_test_setup.sh)" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-resolve_android_toolchains "$1"
+resolve_android_toolchains
 
 function setup_font_resources() {
   rm java/bazel/BUILD


### PR DESCRIPTION
This should help reduce overall CI time by reducing the number of tests.