### PR TITLE
[docs] Fix weird spacing in documentation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcImportRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcImportRule.java
@@ -159,7 +159,7 @@ cc_binary(
 cc_import(
   name = "curl_lib",
   hdrs = glob(["vendor/curl/include/curl/*.h"]),
-  includes = [ "vendor/curl/include" ],
+  includes = ["vendor/curl/include"],
   shared_library = "vendor/curl/lib/.libs/libcurl.dylib",
 )
 </pre>


### PR DESCRIPTION
Fix weird spacing around attribute value.

(no code changes)