### PR TITLE
Don't issue GetCapabilities calls if the requirement is NONE

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ChannelConnectionWithServerCapabilitiesFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChannelConnectionWithServerCapabilitiesFactory.java
@@ -28,15 +28,15 @@ public interface ChannelConnectionWithServerCapabilitiesFactory extends ChannelC
 
   /** A {@link ChannelConnection} that provides {@link ServerCapabilities}. */
   class ChannelConnectionWithServerCapabilities extends ChannelConnection {
-    private final ServerCapabilities serverCapabilities;
+    private final Single<ServerCapabilities> serverCapabilities;
 
     public ChannelConnectionWithServerCapabilities(
-        ManagedChannel channel, ServerCapabilities serverCapabilities) {
+        ManagedChannel channel, Single<ServerCapabilities> serverCapabilities) {
       super(channel);
       this.serverCapabilities = serverCapabilities;
     }
 
-    public ServerCapabilities getServerCapabilities() {
+    public Single<ServerCapabilities> getServerCapabilities() {
       return serverCapabilities;
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/GoogleChannelConnectionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GoogleChannelConnectionFactory.java
@@ -99,7 +99,7 @@ public class GoogleChannelConnectionFactory
                   RxFutures.toSingle(
                       () -> getAndVerifyServerCapabilities(channel), directExecutor());
 
-              // Don't issue GetCapabilities calls if the requirement is NONE because some endpoint,
+              // Don't issue GetCapabilities calls if the requirement is NONE because the endpoint,
               // e.g. Remote Asset API, might not implement the API. See #20342.
               if (requirement == ServerCapabilitiesRequirement.NONE) {
                 return Single.just(

--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
@@ -78,7 +78,7 @@ public class ReferenceCountedChannel implements ReferenceCounted {
     try (var s = Profiler.instance().profile("getServerCapabilities")) {
       return blockingGet(
           withChannelConnection(
-              channelConnection -> Single.just(channelConnection.getServerCapabilities())));
+              ChannelConnectionWithServerCapabilities::getServerCapabilities));
     } catch (ExecutionException e) {
       throw new IOException(e);
     } catch (InterruptedException e) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1132,4 +1132,9 @@ public final class RemoteModule extends BlazeModule {
 
     return credentials;
   }
+
+  @VisibleForTesting
+  MutableSupplier<Downloader> getRemoteDownloaderSupplier() {
+    return remoteDownloaderSupplier;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -199,4 +199,9 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     }
     return out;
   }
+
+  @VisibleForTesting
+  public ReferenceCountedChannel getChannel() {
+    return channel;
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -104,6 +104,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/common:bulk_transfer_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/disk",
+        "//src/main/java/com/google/devtools/build/lib/remote/downloader",
         "//src/main/java/com/google/devtools/build/lib/remote/http",
         "//src/main/java/com/google/devtools/build/lib/remote/merkletree",
         "//src/main/java/com/google/devtools/build/lib/remote/options",

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -131,7 +131,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
             return Single.just(
                 new ChannelConnectionWithServerCapabilities(
                     InProcessChannelBuilder.forName(serverName).build(),
-                    ServerCapabilities.getDefaultInstance()));
+                    Single.just(ServerCapabilities.getDefaultInstance())));
           }
 
           @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -127,7 +127,7 @@ public class ByteStreamUploaderTest {
                 return Single.just(
                     new ChannelConnectionWithServerCapabilities(
                         InProcessChannelBuilder.forName(serverName).build(),
-                        ServerCapabilities.getDefaultInstance()));
+                        Single.just(ServerCapabilities.getDefaultInstance())));
               }
 
               @Override
@@ -1069,7 +1069,7 @@ public class ByteStreamUploaderTest {
                         InProcessChannelBuilder.forName(serverName)
                             .intercept(MetadataUtils.newAttachHeadersInterceptor(metadata))
                             .build(),
-                        ServerCapabilities.getDefaultInstance()));
+                        Single.just(ServerCapabilities.getDefaultInstance())));
               }
 
               @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -195,7 +195,7 @@ public class GrpcCacheClientTest {
                         .build();
                 return Single.just(
                     new ChannelConnectionWithServerCapabilities(
-                        ch, ServerCapabilities.getDefaultInstance()));
+                        ch, Single.just(ServerCapabilities.getDefaultInstance())));
               }
 
               @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTestBase.java
@@ -117,7 +117,8 @@ public abstract class GrpcRemoteExecutorTestBase {
                         .setExecutionCapabilities(
                             ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
                         .build();
-                return Single.just(new ChannelConnectionWithServerCapabilities(ch, caps));
+                return Single.just(
+                    new ChannelConnectionWithServerCapabilities(ch, Single.just(caps)));
               }
 
               @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -224,6 +224,8 @@ public final class RemoteModuleTest {
 
   @Test
   public void testVerifyCapabilities_none() throws Exception {
+    // Test that Bazel doesn't issue GetCapabilities calls if the requirement is NONE.
+    // Regression test for https://github.com/bazelbuild/bazel/issues/20342.
     CapabilitiesImpl executionServerCapabilitiesImpl = new CapabilitiesImpl(EXEC_AND_CACHE_CAPS);
     Server executionServer =
         createFakeServer(EXECUTION_SERVER_NAME, executionServerCapabilitiesImpl);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.exec.BinTools;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.pkgcache.PackageOptions;
 import com.google.devtools.build.lib.remote.circuitbreaker.FailureCircuitBreaker;
+import com.google.devtools.build.lib.remote.downloader.GrpcRemoteDownloader;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.runtime.BlazeRuntime;
 import com.google.devtools.build.lib.runtime.BlazeServerStartupOptions;
@@ -219,6 +220,40 @@ public final class RemoteModuleTest {
         (target, proxy, options, interceptors) ->
             InProcessChannelBuilder.forName(target).directExecutor().build());
     remoteOptions = Options.getDefaults(RemoteOptions.class);
+  }
+
+  @Test
+  public void testVerifyCapabilities_none() throws Exception {
+    CapabilitiesImpl executionServerCapabilitiesImpl = new CapabilitiesImpl(EXEC_AND_CACHE_CAPS);
+    Server executionServer =
+        createFakeServer(EXECUTION_SERVER_NAME, executionServerCapabilitiesImpl);
+    executionServer.start();
+
+    CapabilitiesImpl cacheCapabilitiesImpl = new CapabilitiesImpl(CACHE_ONLY_CAPS);
+    Server cacheServer = createFakeServer(CACHE_SERVER_NAME, cacheCapabilitiesImpl);
+    cacheServer.start();
+
+    try {
+      remoteOptions.remoteExecutor = EXECUTION_SERVER_NAME;
+      remoteOptions.remoteDownloader = CACHE_SERVER_NAME;
+
+      beforeCommand();
+
+      // Wait for the channel to be connected.
+      var downloader = (GrpcRemoteDownloader) remoteModule.getRemoteDownloaderSupplier().get();
+      var unused = downloader.getChannel().withChannelBlocking(ch -> new Object());
+
+      // Remote downloader uses Remote Asset API, and Bazel doesn't have any capability requirement
+      // on the endpoint. Expecting the request count is 0.
+      assertThat(cacheCapabilitiesImpl.getRequestCount()).isEqualTo(0);
+      assertCircuitBreakerInstance();
+    } finally {
+      executionServer.shutdownNow();
+      cacheServer.shutdownNow();
+
+      executionServer.awaitTermination();
+      cacheServer.awaitTermination();
+    }
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -313,7 +313,8 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
                         .setExecutionCapabilities(
                             ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
                         .build();
-                return Single.just(new ChannelConnectionWithServerCapabilities(ch, caps));
+                return Single.just(
+                    new ChannelConnectionWithServerCapabilities(ch, Single.just(caps)));
               }
 
               @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -145,7 +145,7 @@ public class GrpcRemoteDownloaderTest {
                     InProcessChannelBuilder.forName(fakeServerName).directExecutor().build();
                 return Single.just(
                     new ChannelConnectionWithServerCapabilities(
-                        ch, ServerCapabilities.getDefaultInstance()));
+                        ch, Single.just(ServerCapabilities.getDefaultInstance())));
               }
 
               @Override


### PR DESCRIPTION
Because the endpoint might not implement the `GetCapabilities` API,  e.g. Remote Asset API.

Fixes #20342.