### PR TITLE
[7.0.0] Remove RunfilesSupplier.getManifest().

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/CompositeRunfilesSupplier.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CompositeRunfilesSupplier.java
@@ -94,15 +94,6 @@ public final class CompositeRunfilesSupplier implements RunfilesSupplier {
   }
 
   @Override
-  public ImmutableList<Artifact> getManifests() {
-    ImmutableList.Builder<Artifact> result = ImmutableList.builder();
-    for (RunfilesSupplier supplier : suppliers) {
-      result.addAll(supplier.getManifests());
-    }
-    return result.build();
-  }
-
-  @Override
   @Nullable
   public RunfileSymlinksMode getRunfileSymlinksMode(PathFragment runfilesDir) {
     for (RunfilesSupplier supplier : suppliers) {

--- a/src/main/java/com/google/devtools/build/lib/actions/EmptyRunfilesSupplier.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/EmptyRunfilesSupplier.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.actions;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.RunfileSymlinksMode;
@@ -47,11 +46,6 @@ public final class EmptyRunfilesSupplier implements RunfilesSupplier {
   @Override
   public ImmutableMap<PathFragment, Map<PathFragment, Artifact>> getMappings() {
     return ImmutableMap.of();
-  }
-
-  @Override
-  public ImmutableList<Artifact> getManifests() {
-    return ImmutableList.of();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/RunfilesSupplier.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/RunfilesSupplier.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.actions;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.RunfileSymlinksMode;
@@ -40,9 +39,6 @@ public interface RunfilesSupplier extends StarlarkValue {
 
   /** Returns mappings from runfiles directories to artifact mappings in that directory. */
   ImmutableMap<PathFragment, Map<PathFragment, Artifact>> getMappings();
-
-  /** Returns the runfiles manifest artifacts, if any. */
-  ImmutableList<Artifact> getManifests();
 
   /**
    * Returns the {@link RunfileSymlinksMode} for the given {@code runfilesDir}, or {@code null} if

--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
@@ -555,18 +555,12 @@ public final class RunfilesSupport implements RunfilesSupplier {
   }
 
   @Override
-  public ImmutableList<Artifact> getManifests() {
-    return ImmutableList.of();
-  }
-
-  @Override
   public RunfilesSupplier withOverriddenRunfilesDir(PathFragment newRunfilesDir) {
     return newRunfilesDir.equals(getRunfilesDirectoryExecPath())
         ? this
         : new SingleRunfilesSupplier(
             newRunfilesDir,
             runfiles,
-            /* manifest= */ null,
             repoMappingManifest,
             runfileSymlinksMode,
             buildRunfileLinks);

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -378,11 +378,6 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     // definition and the output of an action shouldn't change whether something is considered a
     // tool or not.
     fp.addPaths(runfilesSupplier.getRunfilesDirs());
-    ImmutableList<Artifact> runfilesManifests = runfilesSupplier.getManifests();
-    fp.addInt(runfilesManifests.size());
-    for (Artifact runfilesManifest : runfilesManifests) {
-      fp.addPath(runfilesManifest.getExecPath());
-    }
     env.addTo(fp);
     fp.addStringMap(getExecutionInfo());
     PathMappers.addToFingerprint(getMnemonic(), getExecutionInfo(), outputPathsMode, fp);
@@ -522,9 +517,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
           parent,
           parent.resourceSetOrBuilder);
       NestedSetBuilder<ActionInput> inputsBuilder = NestedSetBuilder.stableOrder();
-      ImmutableList<Artifact> manifests = getRunfilesSupplier().getManifests();
       for (Artifact input : inputs.toList()) {
-        if (!input.isFileset() && !manifests.contains(input)) {
+        if (!input.isFileset()) {
           inputsBuilder.add(input);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LtoBackendAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LtoBackendAction.java
@@ -261,10 +261,6 @@ public final class LtoBackendAction extends SpawnAction {
     }
     fp.addString(getMnemonic());
     fp.addPaths(getRunfilesSupplier().getRunfilesDirs());
-    ImmutableList<Artifact> runfilesManifests = getRunfilesSupplier().getManifests();
-    for (Artifact runfilesManifest : runfilesManifests) {
-      fp.addPath(runfilesManifest.getExecPath());
-    }
     for (Artifact input : mandatoryInputs.toList()) {
       fp.addPath(input.getExecPath());
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -237,11 +237,6 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     // definition and the output of an action shouldn't change whether something is considered a
     // tool or not.
     fp.addPaths(getRunfilesSupplier().getRunfilesDirs());
-    ImmutableList<Artifact> runfilesManifests = getRunfilesSupplier().getManifests();
-    fp.addInt(runfilesManifests.size());
-    for (Artifact runfilesManifest : runfilesManifests) {
-      fp.addPath(runfilesManifest.getExecPath());
-    }
     getEnvironment().addTo(fp);
     fp.addStringMap(executionInfo);
     PathMappers.addToFingerprint(

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PyBuiltins.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PyBuiltins.java
@@ -150,7 +150,6 @@ public abstract class PyBuiltins implements StarlarkValue {
     return new SingleRunfilesSupplier(
         PathFragment.create(runfilesStr),
         runfiles,
-        /* manifest= */ null,
         /* repoMappingManifest= */ null,
         ruleContext.getConfiguration().getRunfileSymlinksMode(),
         ruleContext.getConfiguration().buildRunfileLinks());

--- a/src/test/java/com/google/devtools/build/lib/analysis/SingleRunfilesSupplierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SingleRunfilesSupplierTest.java
@@ -56,7 +56,6 @@ public final class SingleRunfilesSupplierTest {
         new SingleRunfilesSupplier(
             PathFragment.create("notimportant"),
             mkRunfiles(artifacts),
-            /* manifest= */ null,
             /* repoMappingManifest= */ null,
             RunfileSymlinksMode.SKIP,
             /* buildRunfileLinks= */ false);
@@ -65,39 +64,11 @@ public final class SingleRunfilesSupplierTest {
   }
 
   @Test
-  public void testGetManifestsWhenNone() {
-    RunfilesSupplier underTest =
-        new SingleRunfilesSupplier(
-            PathFragment.create("ignored"),
-            Runfiles.EMPTY,
-            /* manifest= */ null,
-            /* repoMappingManifest= */ null,
-            RunfileSymlinksMode.SKIP,
-            /* buildRunfileLinks= */ false);
-    assertThat(underTest.getManifests()).isEmpty();
-  }
-
-  @Test
-  public void testGetManifestsWhenSupplied() {
-    Artifact manifest = ActionsTestUtil.createArtifact(rootDir, "manifest");
-    RunfilesSupplier underTest =
-        new SingleRunfilesSupplier(
-            PathFragment.create("ignored"),
-            Runfiles.EMPTY,
-            manifest,
-            /* repoMappingManifest= */ null,
-            RunfileSymlinksMode.SKIP,
-            /* buildRunfileLinks= */ false);
-    assertThat(underTest.getManifests()).containsExactly(manifest);
-  }
-
-  @Test
   public void withOverriddenRunfilesDir() {
     SingleRunfilesSupplier original =
         new SingleRunfilesSupplier(
             PathFragment.create("old"),
             Runfiles.EMPTY,
-            ActionsTestUtil.createArtifact(rootDir, "manifest"),
             /* repoMappingManifest= */ null,
             RunfileSymlinksMode.SKIP,
             /* buildRunfileLinks= */ false);
@@ -109,7 +80,6 @@ public final class SingleRunfilesSupplierTest {
     assertThat(overridden.getMappings())
         .containsExactly(newDir, Iterables.getOnlyElement(original.getMappings().values()));
     assertThat(overridden.getArtifacts()).isEqualTo(original.getArtifacts());
-    assertThat(overridden.getManifests()).isEqualTo(original.getManifests());
   }
 
   @Test
@@ -119,7 +89,6 @@ public final class SingleRunfilesSupplierTest {
         new SingleRunfilesSupplier(
             dir,
             Runfiles.EMPTY,
-            ActionsTestUtil.createArtifact(rootDir, "manifest"),
             /* repoMappingManifest= */ null,
             RunfileSymlinksMode.SKIP,
             /* buildRunfileLinks= */ false);

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
@@ -369,15 +369,12 @@ public final class SpawnActionTest extends BuildViewTestCase {
 
   @Test
   public void testInputManifestsRemovedIfSupplied() throws Exception {
-    Artifact manifest = getSourceArtifact("MANIFEST");
     SpawnAction action =
         builder()
-            .addInput(manifest)
             .addRunfilesSupplier(
                 new SingleRunfilesSupplier(
                     PathFragment.create("destination"),
                     Runfiles.EMPTY,
-                    manifest,
                     /* repoMappingManifest= */ null,
                     RunfileSymlinksMode.SKIP,
                     /* buildRunfileLinks= */ false))
@@ -394,7 +391,6 @@ public final class SpawnActionTest extends BuildViewTestCase {
     EXECUTABLE_PATH,
     EXECUTABLE,
     MNEMONIC,
-    RUNFILES_SUPPLIER,
     RUNFILES_SUPPLIER_PATH,
     ENVIRONMENT
   }
@@ -425,16 +421,10 @@ public final class SpawnActionTest extends BuildViewTestCase {
 
             builder.setMnemonic(attributesToFlip.contains(KeyAttributes.MNEMONIC) ? "a" : "b");
 
-            if (attributesToFlip.contains(KeyAttributes.RUNFILES_SUPPLIER)) {
-              builder.addRunfilesSupplier(runfilesSupplier(artifactA, PathFragment.create("a")));
-            } else {
-              builder.addRunfilesSupplier(runfilesSupplier(artifactB, PathFragment.create("a")));
-            }
-
             if (attributesToFlip.contains(KeyAttributes.RUNFILES_SUPPLIER_PATH)) {
-              builder.addRunfilesSupplier(runfilesSupplier(artifactA, PathFragment.create("aa")));
+              builder.addRunfilesSupplier(runfilesSupplier(PathFragment.create("aa")));
             } else {
-              builder.addRunfilesSupplier(runfilesSupplier(artifactA, PathFragment.create("ab")));
+              builder.addRunfilesSupplier(runfilesSupplier(PathFragment.create("ab")));
             }
 
             Map<String, String> env = new HashMap<>();
@@ -585,11 +575,10 @@ public final class SpawnActionTest extends BuildViewTestCase {
         .isEqualTo("ToolPoolMnemonic");
   }
 
-  private static RunfilesSupplier runfilesSupplier(Artifact manifest, PathFragment dir) {
+  private static RunfilesSupplier runfilesSupplier(PathFragment dir) {
     return new SingleRunfilesSupplier(
         dir,
         Runfiles.EMPTY,
-        manifest,
         /* repoMappingManifest= */ null,
         RunfileSymlinksMode.SKIP,
         /* buildRunfileLinks= */ false);

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisTestUtil.java
@@ -545,7 +545,6 @@ public final class AnalysisTestUtil {
     return new SingleRunfilesSupplier(
         runfilesDir,
         runfiles,
-        /* manifest= */ null,
         /* repoMappingManifest= */ null,
         RunfileSymlinksMode.SKIP,
         /* buildRunfileLinks= */ false);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -2517,11 +2517,6 @@ public class RemoteExecutionServiceTest {
       }
 
       @Override
-      public ImmutableList<Artifact> getManifests() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
       public RunfileSymlinksMode getRunfileSymlinksMode(PathFragment runfilesDir) {
         throw new UnsupportedOperationException();
       }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LtoBackendActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LtoBackendActionTest.java
@@ -173,7 +173,6 @@ public class LtoBackendActionTest extends BuildViewTestCase {
     EXECUTABLE,
     IMPORTS_INFO,
     MNEMONIC,
-    RUNFILES_SUPPLIER,
     INPUT,
     FIXED_ENVIRONMENT
   }
@@ -211,25 +210,13 @@ public class LtoBackendActionTest extends BuildViewTestCase {
 
             builder.setMnemonic(attributesToFlip.contains(KeyAttributes.MNEMONIC) ? "a" : "b");
 
-            if (attributesToFlip.contains(KeyAttributes.RUNFILES_SUPPLIER)) {
-              builder.addRunfilesSupplier(
-                  new SingleRunfilesSupplier(
-                      PathFragment.create("a"),
-                      Runfiles.EMPTY,
-                      artifactA,
-                      /* repoMappingManifest= */ null,
-                      RunfileSymlinksMode.SKIP,
-                      /* buildRunfileLinks= */ false));
-            } else {
-              builder.addRunfilesSupplier(
-                  new SingleRunfilesSupplier(
-                      PathFragment.create("a"),
-                      Runfiles.EMPTY,
-                      artifactB,
-                      /* repoMappingManifest= */ null,
-                      RunfileSymlinksMode.SKIP,
-                      /* buildRunfileLinks= */ false));
-            }
+            builder.addRunfilesSupplier(
+                new SingleRunfilesSupplier(
+                    PathFragment.create("a"),
+                    Runfiles.EMPTY,
+                    /* repoMappingManifest= */ null,
+                    RunfileSymlinksMode.SKIP,
+                    /* buildRunfileLinks= */ false));
 
             if (attributesToFlip.contains(KeyAttributes.INPUT)) {
               builder.addInput(artifactA);


### PR DESCRIPTION
It appears to be always empty.

RELNOTES: None.
PiperOrigin-RevId: 585627763
Change-Id: I7f39896c7f3a4ffb1040211265793b7f64d8d64d