### PR TITLE
[7.0.0] Prevent nested set flattening in ActionSpawn if there are no input filesets.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -516,14 +516,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
           parent.getRunfilesSupplier(),
           parent,
           parent.resourceSetOrBuilder);
-      NestedSetBuilder<ActionInput> inputsBuilder = NestedSetBuilder.stableOrder();
-      for (Artifact input : inputs.toList()) {
-        if (!input.isFileset()) {
-          inputsBuilder.add(input);
-        }
-      }
-      inputsBuilder.addAll(additionalInputs);
-      this.inputs = inputsBuilder.build();
+      this.inputs = getNonFilesetInputs(inputs).addAll(additionalInputs).build();
       this.filesetMappings = filesetMappings;
       this.pathMapper = pathMapper;
 
@@ -536,6 +529,27 @@ public class SpawnAction extends AbstractAction implements CommandAction {
         effectiveEnvironment = parent.getEffectiveEnvironment(env);
       }
       this.reportOutputs = reportOutputs;
+    }
+
+    /** Returns a {@link NestedSetBuilder} containing only the non-fileset inputs. */
+    private static NestedSetBuilder<ActionInput> getNonFilesetInputs(NestedSet<Artifact> inputs) {
+      NestedSetBuilder<ActionInput> builder = NestedSetBuilder.stableOrder();
+      // TODO(tjgq): Investigate whether we can avoid flattening when filesetMappings is empty.
+      // This requires auditing getSpawnForExtraAction(), which doesn't appear to propagate the
+      // filesetMappings from the shadowed action.
+      boolean hasFilesets = false;
+      for (Artifact input : inputs.toList()) {
+        if (!input.isFileset()) {
+          builder.add(input);
+        } else {
+          hasFilesets = true;
+        }
+      }
+      // If possible, keep the original nested set. This aids callers that exploit the nested set
+      // structure to perform optimizations (see SpawnInputExpander#walkInputs and its callers).
+      return hasFilesets
+          ? builder
+          : NestedSetBuilder.<ActionInput>stableOrder().addTransitive(inputs);
     }
 
     @Override


### PR DESCRIPTION
This is always the case in Bazel. The nested set structure can be exploited to perform optimizations, notably by --experimental_remote_merkle_tree_cache.

PiperOrigin-RevId: 585657594
Change-Id: I83042b5c40b3b9e6ce511a230a0cbd0677dda5b3