### PR TITLE
startup_options.cc: add BAZEL_OUTPUT_USER_ROOT env variable

### DIFF
--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -2311,6 +2311,10 @@ You can use the `--output_user_root` option to choose an
 alternate base location for all of Bazel's output (install base and output
 base) if there is a better location in your filesystem layout.
 
+You can also use the environment variable `BAZEL_OUTPUT_USER_ROOT` to set this directory for
+all further invocations. The value set by the environment variable will be overriden by a
+value explicitly specified on the commandline.
+
 Note: We recommend you do not use an NFS or similar networked file system for the root
 directory, as the higher access latency will cause noticeably slower builds.
 

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -123,6 +123,9 @@ StartupOptions::StartupOptions(const string &product_name,
   const string product_name_lower = GetLowercaseProductName();
   output_user_root = blaze_util::JoinPath(
       output_root, "_" + product_name_lower + "_" + GetUserName());
+  string env_output_user_root = blaze_util::MakeAbsolute(blaze::GetPathEnv("BAZEL_OUTPUT_USER_ROOT"));
+  if (!env_output_user_root.empty())
+    output_user_root = env_output_user_root;
 
   // IMPORTANT: Before modifying the statements below please contact a Bazel
   // core team member that knows the internal procedure for adding/deprecating


### PR DESCRIPTION
Most other build systems with a global cache store have an environment variable as a knob to tell the cache where to go, without having to create another global config file (like Gradle has `GRADLE_HOME`). This PR adds an equivalent variable to control the output root.

Things I am not sure about:
 - If more documentation needs to be added, and if so, where?
 - whether there is a better place to add the check for the variable in the code