### PR TITLE
Add client option to disable updating the `mtime` of the `install_base`

### DIFF
--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -92,6 +92,7 @@ StartupOptions::StartupOptions(const string &product_name,
       expand_configs_in_place(true),
       digest_function(),
       idle_server_tasks(true),
+      update_install_base_mtime(true),
       original_startup_options_(std::vector<RcStartupFlag>()),
 #if defined(__APPLE__)
       macos_qos_class(QOS_CLASS_UNSPECIFIED),
@@ -143,6 +144,7 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterNullaryStartupFlag("shutdown_on_low_sys_mem",
                              &shutdown_on_low_sys_mem);
   RegisterNullaryStartupFlagNoRc("ignore_all_rc_files", &ignore_all_rc_files);
+  RegisterNullaryStartupFlag("update_install_base_mtime", &update_install_base_mtime);
   RegisterNullaryStartupFlag("unlimit_coredumps", &unlimit_coredumps);
   RegisterNullaryStartupFlag("watchfs", &watchfs);
   RegisterNullaryStartupFlag("write_command_log", &write_command_log);

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -146,6 +146,10 @@ class StartupOptions {
   // Installation base for a specific release installation.
   std::string install_base;
 
+  // Whether to attempt to update the mtime of the provided `install_base`
+  // directory.
+  bool update_install_base_mtime;
+
   // The toplevel directory containing Blaze's output.  When Blaze is
   // run by a test, we use TEST_TMPDIR, simplifying the correct
   // hermetic invocation of Blaze from tests.

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -92,6 +92,16 @@ public class BlazeServerStartupOptions extends OptionsBase {
       help = "This launcher option is intended for use only by tests.")
   public PathFragment installBase;
 
+  @Option(
+      name = "update_install_base_mtime",
+      defaultValue = "true", // NOTE: only for documentation, value is set and used by the client.
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      help =
+          "If set, the client will attempt to update the `mtime` of the `install_base` directory. "
+              + "Changing this option will not cause the server to restart.")
+  public boolean updateInstallBaseMtime;
+
   /*
    * The installation MD5 - a content hash of the blaze binary (includes the Blaze deploy JAR and
    * any other embedded binaries - anything that ends up in the install_base).

--- a/src/test/cpp/bazel_startup_options_test.cc
+++ b/src/test/cpp/bazel_startup_options_test.cc
@@ -104,6 +104,7 @@ TEST_F(BazelStartupOptionsTest, ValidStartupFlags) {
   ExpectValidNullaryOption(options, "ignore_all_rc_files");
   ExpectValidNullaryOption(options, "shutdown_on_low_sys_mem");
   ExpectValidNullaryOption(options, "system_rc");
+  ExpectValidNullaryOption(options, "update_install_base_mtime");
   ExpectValidNullaryOption(options, "watchfs");
   ExpectValidNullaryOption(options, "workspace_rc");
   ExpectValidNullaryOption(options, "write_command_log");


### PR DESCRIPTION
Currently if the `--install_base` path passed is not writeable by the user invoking Bazel, the Bazel client crashes[^1], even if the path already contains a suitable extracted Bazel installation:
```console
❯ bazel --install_base=/some/read/only/path/with/a/pre-existing/bazel/install version
FATAL: failed to set timestamp on '/some/read/only/path/with/a/pre-existing/bazel/install': (error: 30): Read-only file system
```

This happens because the Bazel client (unconditionally) attempts to update the `mtime` of this path:
https://github.com/bazelbuild/bazel/blob/a3c677dfea2de636a719d50345a5a97af96fae60/src/main/cpp/blaze.cc#L1010-L1021

This PR gates this `mtime` update on a new client startup option: `--update_install_base_mtime`.

[^1]: Note that if you invoke Bazel again after this happens, it will successfully start up because the `install` symlink in the output base [that inhibits the `mtime` update/install base check] has already been [created].

[that inhibits the `mtime` update/install base check]: https://github.com/bazelbuild/bazel/blob/a3c677dfea2de636a719d50345a5a97af96fae60/src/main/cpp/blaze.cc#L983-L993
[created]: https://github.com/bazelbuild/bazel/blob/a3c677dfea2de636a719d50345a5a97af96fae60/src/main/cpp/blaze.cc#L1003

---

This commit:
  - [x] adds the `update_install_base_mtime` option to `startup_options.cc` and `BlazeServerStartupOptions.java`
  - [x] adds logic to `src/main/cpp/blaze.cc` to ensure that changes to this option do not cause server restarts
  - [x] updates `bazel_startup_options_test.cc`
  - [x] adds tests to `client_test.sh` that test that:
    * the install base `mtime` **is** updated when `--update_install_base_mtime` is passed (the default)
    * the install base `mtime` is **not** updated when `--noupdate_install_base_mtime` is passed
    * changes to `--install_base_mtime` do not cause server restarts

---

TODO:
  - [ ] Both [`bazel_startup_options_test.cc`](https://github.com/bazelbuild/bazel/blob/a3c677dfea2de636a719d50345a5a97af96fae60/src/test/cpp/bazel_startup_options_test.cc#L92-L94) and [`startup_options.cc`](https://github.com/bazelbuild/bazel/blob/a3c677dfea2de636a719d50345a5a97af96fae60/src/main/cpp/startup_options.cc#L127-L129) describe a special procedure for updating startup flags:

    https://github.com/bazelbuild/bazel/blob/a3c677dfea2de636a719d50345a5a97af96fae60/src/test/cpp/bazel_startup_options_test.cc#L92-L94

    https://github.com/bazelbuild/bazel/blob/a3c677dfea2de636a719d50345a5a97af96fae60/src/main/cpp/startup_options.cc#L127-L129