### PR TITLE
[7.0.0] Fix memory regression in BEP with `--bes_upload_mode=wait_for_upload_complete`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -209,6 +209,10 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
         closeFuturesWithTimeoutsMap.entrySet().stream()
             .filter(entry -> !transportFutures.containsKey(entry.getKey()))
             .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+    halfCloseFuturesWithTimeoutsMap =
+        halfCloseFuturesWithTimeoutsMap.entrySet().stream()
+            .filter(entry -> !transportFutures.containsKey(entry.getKey()))
+            .collect(toImmutableMap(Entry::getKey, Entry::getValue));
   }
 
   private static boolean isTimeoutException(ExecutionException e) {


### PR DESCRIPTION
353000ebc512e4f1654d123713b003011751e07e introduced a memory regression in retained heap because it doesn't clean the references to fully closed transports from the half closed map, preventing GC from freeing all the memory related to the transports.

It was cherry-picked into 7.0.0 but rolled back in the HEAD via af4d29ec102925a0f2595aedc7c7374447678128. It was then rolled forward with a fix in 4b13eee7b45a06fca1224ab5ce04d3e937ce35b0.

This PR cherry-picks the fix into 7.0.0.