### PR TITLE
[7.0.0] Emit a clearer error message when a mandatory output is missing from an ActionResult.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1278,11 +1278,7 @@ public class RemoteExecutionService {
               && !metadata.directories.containsKey(localPath)
               && !metadata.symlinks.containsKey(localPath)) {
             throw new IOException(
-                "Invalid action cache entry "
-                    + action.getActionKey().getDigest().getHash()
-                    + ": expected output "
-                    + prettyPrint(output)
-                    + " does not exist.");
+                String.format("mandatory output %s was not created", prettyPrint(output)));
           }
         }
       }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -1542,7 +1542,7 @@ public class RemoteExecutionServiceTest {
     IOException error =
         assertThrows(IOException.class, () -> service.downloadOutputs(action, result));
 
-    assertThat(error).hasMessageThat().containsMatch("expected output .+ does not exist.");
+    assertThat(error).hasMessageThat().containsMatch("mandatory output .+ was not created");
   }
 
   @Test


### PR DESCRIPTION
The remote execution spec allows an action to succeed, but produce only a subset of its declared outputs, so Bazel must verify that outputs marked as mandatory have been produced. Outputs are always mandatory except for a few specialized native actions (C++ and Java).

The current error message makes it sound like a programmer error rather than a user or rules author error.

See also https://github.com/bazelbuild/remote-apis/issues/6 for the discussion that prompted this fix.

PiperOrigin-RevId: 586625265
Change-Id: I8846614917c82eff87c8495696e55b80c096c02c