### PR TITLE
[7.0.0] Bazel calls GetCapabilities when using Remote Asset API in 7.0.0

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ChannelConnectionWithServerCapabilitiesFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ChannelConnectionWithServerCapabilitiesFactory.java
@@ -28,15 +28,15 @@ public interface ChannelConnectionWithServerCapabilitiesFactory extends ChannelC
 
   /** A {@link ChannelConnection} that provides {@link ServerCapabilities}. */
   class ChannelConnectionWithServerCapabilities extends ChannelConnection {
-    private final ServerCapabilities serverCapabilities;
+    private final Single<ServerCapabilities> serverCapabilities;
 
     public ChannelConnectionWithServerCapabilities(
-        ManagedChannel channel, ServerCapabilities serverCapabilities) {
+        ManagedChannel channel, Single<ServerCapabilities> serverCapabilities) {
       super(channel);
       this.serverCapabilities = serverCapabilities;
     }
 
-    public ServerCapabilities getServerCapabilities() {
+    public Single<ServerCapabilities> getServerCapabilities() {
       return serverCapabilities;
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/GoogleChannelConnectionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GoogleChannelConnectionFactory.java
@@ -94,12 +94,21 @@ public class GoogleChannelConnectionFactory
     return Single.fromCallable(
             () -> channelFactory.newChannel(target, proxy, options, interceptors))
         .flatMap(
-            channel ->
-                RxFutures.toSingle(() -> getAndVerifyServerCapabilities(channel), directExecutor())
-                    .map(
-                        serverCapabilities ->
-                            new ChannelConnectionWithServerCapabilities(
-                                channel, serverCapabilities)));
+            channel -> {
+              var serverCapabilitiesSingle =
+                  RxFutures.toSingle(
+                      () -> getAndVerifyServerCapabilities(channel), directExecutor());
+
+              // Don't issue GetCapabilities calls if the requirement is NONE because the endpoint,
+              // e.g. Remote Asset API, might not implement the API. See #20342.
+              if (requirement == ServerCapabilitiesRequirement.NONE) {
+                return Single.just(
+                    new ChannelConnectionWithServerCapabilities(channel, serverCapabilitiesSingle));
+              }
+
+              return serverCapabilitiesSingle.map(
+                  sc -> new ChannelConnectionWithServerCapabilities(channel, Single.just(sc)));
+            });
   }
 
   private ListenableFuture<ServerCapabilities> getAndVerifyServerCapabilities(

--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
@@ -77,8 +77,7 @@ public class ReferenceCountedChannel implements ReferenceCounted {
   public ServerCapabilities getServerCapabilities() throws IOException {
     try (var s = Profiler.instance().profile("getServerCapabilities")) {
       return blockingGet(
-          withChannelConnection(
-              channelConnection -> Single.just(channelConnection.getServerCapabilities())));
+          withChannelConnection(ChannelConnectionWithServerCapabilities::getServerCapabilities));
     } catch (ExecutionException e) {
       throw new IOException(e);
     } catch (InterruptedException e) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1132,4 +1132,9 @@ public final class RemoteModule extends BlazeModule {
 
     return credentials;
   }
+
+  @VisibleForTesting
+  MutableSupplier<Downloader> getRemoteDownloaderSupplier() {
+    return remoteDownloaderSupplier;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -199,4 +199,9 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     }
     return out;
   }
+
+  @VisibleForTesting
+  public ReferenceCountedChannel getChannel() {
+    return channel;
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -104,6 +104,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/common:bulk_transfer_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/common:cache_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/remote/disk",
+        "//src/main/java/com/google/devtools/build/lib/remote/downloader",
         "//src/main/java/com/google/devtools/build/lib/remote/http",
         "//src/main/java/com/google/devtools/build/lib/remote/merkletree",
         "//src/main/java/com/google/devtools/build/lib/remote/options",

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -131,7 +131,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
             return Single.just(
                 new ChannelConnectionWithServerCapabilities(
                     InProcessChannelBuilder.forName(serverName).build(),
-                    ServerCapabilities.getDefaultInstance()));
+                    Single.just(ServerCapabilities.getDefaultInstance())));
           }
 
           @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -127,7 +127,7 @@ public class ByteStreamUploaderTest {
                 return Single.just(
                     new ChannelConnectionWithServerCapabilities(
                         InProcessChannelBuilder.forName(serverName).build(),
-                        ServerCapabilities.getDefaultInstance()));
+                        Single.just(ServerCapabilities.getDefaultInstance())));
               }
 
               @Override
@@ -1069,7 +1069,7 @@ public class ByteStreamUploaderTest {
                         InProcessChannelBuilder.forName(serverName)
                             .intercept(MetadataUtils.newAttachHeadersInterceptor(metadata))
                             .build(),
-                        ServerCapabilities.getDefaultInstance()));
+                        Single.just(ServerCapabilities.getDefaultInstance())));
               }
 
               @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -195,7 +195,7 @@ public class GrpcCacheClientTest {
                         .build();
                 return Single.just(
                     new ChannelConnectionWithServerCapabilities(
-                        ch, ServerCapabilities.getDefaultInstance()));
+                        ch, Single.just(ServerCapabilities.getDefaultInstance())));
               }
 
               @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTestBase.java
@@ -117,7 +117,8 @@ public abstract class GrpcRemoteExecutorTestBase {
                         .setExecutionCapabilities(
                             ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
                         .build();
-                return Single.just(new ChannelConnectionWithServerCapabilities(ch, caps));
+                return Single.just(
+                    new ChannelConnectionWithServerCapabilities(ch, Single.just(caps)));
               }
 
               @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -313,7 +313,8 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
                         .setExecutionCapabilities(
                             ExecutionCapabilities.newBuilder().setExecEnabled(true).build())
                         .build();
-                return Single.just(new ChannelConnectionWithServerCapabilities(ch, caps));
+                return Single.just(
+                    new ChannelConnectionWithServerCapabilities(ch, Single.just(caps)));
               }
 
               @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -145,7 +145,7 @@ public class GrpcRemoteDownloaderTest {
                     InProcessChannelBuilder.forName(fakeServerName).directExecutor().build();
                 return Single.just(
                     new ChannelConnectionWithServerCapabilities(
-                        ch, ServerCapabilities.getDefaultInstance()));
+                        ch, Single.just(ServerCapabilities.getDefaultInstance())));
               }
 
               @Override


### PR DESCRIPTION
Because the endpoint might not implement the `GetCapabilities` API,  e.g. Remote Asset API.

Fixes #20342.

Closes #20355.

Commit https://github.com/bazelbuild/bazel/commit/d7adb9a52e5777cdff5bbfb751111c3ae87bdf16

PiperOrigin-RevId: 586642258
Change-Id: If9ca3a1909729ea5d9410b7198bcacb5d67781aa