### PR TITLE
Fix error when the test class is not found for a java_test at the workspace root

### DIFF
--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl
@@ -70,7 +70,8 @@ def _bazel_base_binary_impl(ctx, is_test_rule_class):
         if test_class == "":
             test_class = helper.primary_class(ctx)
         if test_class == None:
-            fail("cannot determine test class")
+            fail("cannot determine test class. You might want to rename the " +
+                 " rule or add a 'test_class' attribute.")
         jvm_flags.extend([
             "-ea",
             "-Dbazel.test_suite=" + helper.shell_escape(test_class),

--- a/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
@@ -93,7 +93,7 @@ def _primary_class(ctx):
         for src in ctx.files.srcs:
             if src.basename == main:
                 return _full_classname(_strip_extension(src))
-    return _full_classname(ctx.label.package + "/" + ctx.label.name)
+    return _full_classname(paths.get_relative(ctx.label.package, ctx.label.name))
 
 def _strip_extension(file):
     return file.dirname + "/" + (

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/java/JavaConfiguredTargetsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/java/JavaConfiguredTargetsTest.java
@@ -18,6 +18,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.testutil.TestConstants.TOOLS_REPOSITORY;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.Joiner;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -92,5 +93,16 @@ public final class JavaConfiguredTargetsTest extends BuildViewTestCase {
                   .getValue();
       assertThat(jvmFlags).contains("-Djava.security.manager=allow");
     }
+  }
+
+  // regression test for https://github.com/bazelbuild/bazel/issues/20378
+  @Test
+  public void javaTestInvalidTestClassAtRootPackage() throws Exception {
+    scratch.file("BUILD", "java_test(name = 'some_test', srcs = ['SomeTest.java'])");
+
+    AssertionError error =
+        assertThrows(AssertionError.class, () -> getConfiguredTarget("//:some_test"));
+
+    assertThat(error).hasMessageThat().contains("cannot determine test class");
   }
 }


### PR DESCRIPTION
Fixes relativization of the target label with respect to the package

Fixes https://github.com/bazelbuild/bazel/issues/20378