### PR TITLE
[7.0.0] Generalize memory and cpu tracking

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceSet.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.actions;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Doubles;
@@ -35,21 +34,17 @@ import javax.annotation.Nullable;
  */
 @Immutable
 public class ResourceSet implements ResourceSetOrBuilder {
+  public static final String CPU = "cpu";
+  public static final String MEMORY = "memory";
 
   /** For actions that consume negligible resources. */
-  public static final ResourceSet ZERO = new ResourceSet(0.0, 0.0, 0);
-
-  /** The amount of real memory (resident set size). */
-  private final double memoryMb;
-
-  /** The number of CPUs, or fractions thereof. */
-  private final double cpuUsage;
+  public static final ResourceSet ZERO = new ResourceSet(ImmutableMap.of(), 0, null);
 
   /**
    * Map of extra resources (for example: GPUs, embedded boards, ...) mapping name of the resource
    * to a value.
    */
-  private final ImmutableMap<String, Float> extraResourceUsage;
+  private final ImmutableMap<String, Double> resources;
 
   /** The number of local tests. */
   private final int localTestCount;
@@ -58,99 +53,47 @@ public class ResourceSet implements ResourceSetOrBuilder {
   @Nullable private final WorkerKey workerKey;
 
   private ResourceSet(
-      double memoryMb, double cpuUsage, int localTestCount, @Nullable WorkerKey workerKey) {
-    this(memoryMb, cpuUsage, ImmutableMap.of(), localTestCount, workerKey);
-  }
-
-  private ResourceSet(
-      double memoryMb,
-      double cpuUsage,
-      @Nullable ImmutableMap<String, Float> extraResourceUsage,
-      int localTestCount,
-      @Nullable WorkerKey workerKey) {
-    this.memoryMb = memoryMb;
-    this.cpuUsage = cpuUsage;
-    this.extraResourceUsage = extraResourceUsage;
+      ImmutableMap<String, Double> resources, int localTestCount, @Nullable WorkerKey workerKey) {
+    this.resources = resources;
     this.localTestCount = localTestCount;
     this.workerKey = workerKey;
   }
 
-  private ResourceSet(double memoryMb, double cpuUsage, int localTestCount) {
-    this(memoryMb, cpuUsage, localTestCount, /* workerKey= */ null);
+  public static ResourceSet createWithRamCpu(double memoryMb, double cpu) {
+    return create(ImmutableMap.of(MEMORY, memoryMb, CPU, cpu));
   }
 
-  /**
-   * Returns a new ResourceSet with the provided values for memoryMb and cpuUsage, and with 0.0 for
-   * ioUsage and localTestCount. Use this method in action resource definitions when they aren't
-   * local tests.
-   */
-  public static ResourceSet createWithRamCpu(double memoryMb, double cpuUsage) {
-    if (memoryMb == 0 && cpuUsage == 0) {
-      return ZERO;
-    }
-    return new ResourceSet(memoryMb, cpuUsage, 0);
-  }
-
-  /**
-   * Returns a new ResourceSet with the provided value for localTestCount, and 0.0 for memoryMb,
-   * cpuUsage, and ioUsage. Use this method in action resource definitions when they are local tests
-   * that acquire no local resources.
-   */
   public static ResourceSet createWithLocalTestCount(int localTestCount) {
-    return new ResourceSet(0.0, 0.0, localTestCount);
+    return create(ImmutableMap.of(), localTestCount);
   }
 
-  /**
-   * Returns a new ResourceSet with the provided values for memoryMb, cpuUsage, and localTestCount.
-   * Most action resource definitions should use {@link #createWithRamCpu} or {@link
-   * #createWithLocalTestCount(int)}. Use this method primarily when constructing ResourceSets that
-   * represent available resources.
-   */
-  public static ResourceSet create(double memoryMb, double cpuUsage, int localTestCount) {
-    return ResourceSet.createWithWorkerKey(
-        memoryMb, cpuUsage, ImmutableMap.of(), localTestCount, /* workerKey= */ null);
+  public static ResourceSet create(double memoryMb, double cpu, int localTestCount) {
+    return create(ImmutableMap.of(MEMORY, memoryMb, CPU, cpu), localTestCount);
   }
 
-  /**
-   * Returns a new ResourceSet with the provided values for memoryMb, cpuUsage, extraResources, and
-   * localTestCount. Most action resource definitions should use {@link #createWithRamCpu} or {@link
-   * #createWithLocalTestCount(int)}. Use this method primarily when constructing ResourceSets that
-   * represent available resources.
-   */
+  public static ResourceSet create(ImmutableMap<String, Double> resources) {
+    return create(resources, 0);
+  }
+
+  public static ResourceSet create(ImmutableMap<String, Double> resources, int localTestCount) {
+    return create(resources, localTestCount, null);
+  }
+
   public static ResourceSet create(
-      double memoryMb,
-      double cpuUsage,
-      ImmutableMap<String, Float> extraResourceUsage,
-      int localTestCount) {
-    return createWithWorkerKey(
-        memoryMb, cpuUsage, extraResourceUsage, localTestCount, /* workerKey= */ null);
+      ImmutableMap<String, Double> resources, int localTestCount, @Nullable WorkerKey workerKey) {
+    return new ResourceSet(resources, localTestCount, workerKey);
   }
 
-  public static ResourceSet createWithWorkerKey(
-      double memoryMb, double cpuUsage, int localTestCount, WorkerKey workerKey) {
-    return ResourceSet.createWithWorkerKey(
-        memoryMb, cpuUsage, /* extraResourceUsage= */ ImmutableMap.of(), localTestCount, workerKey);
+  public double get(String resource) {
+    return resources.getOrDefault(resource, 0.0);
   }
 
-  public static ResourceSet createWithWorkerKey(
-      double memoryMb,
-      double cpuUsage,
-      ImmutableMap<String, Float> extraResourceUsage,
-      int localTestCount,
-      WorkerKey workerKey) {
-    if (memoryMb == 0
-        && cpuUsage == 0
-        && extraResourceUsage.size() == 0
-        && localTestCount == 0
-        && workerKey == null) {
-      return ZERO;
-    }
-    return new ResourceSet(memoryMb, cpuUsage, extraResourceUsage, localTestCount, workerKey);
-  }
-
-  /** Returns the amount of real memory (resident set size) used in MB. */
   public double getMemoryMb() {
-    return memoryMb;
+    return get(MEMORY);
+  }
+
+  public double getCpuUsage() {
+    return get(CPU);
   }
 
   /**
@@ -162,18 +105,8 @@ public class ResourceSet implements ResourceSetOrBuilder {
     return workerKey;
   }
 
-  /**
-   * Returns the number of CPUs (or fractions thereof) used. For a CPU-bound single-threaded
-   * process, this will be 1.0. For a single-threaded process which spends part of its time waiting
-   * for I/O, this will be somewhere between 0.0 and 1.0. For a multi-threaded or multi-process
-   * application, this may be more than 1.0.
-   */
-  public double getCpuUsage() {
-    return cpuUsage;
-  }
-
-  public ImmutableMap<String, Float> getExtraResourceUsage() {
-    return extraResourceUsage;
+  public ImmutableMap<String, Double> getResources() {
+    return resources;
   }
 
   /** Returns the local test count used. */
@@ -185,12 +118,17 @@ public class ResourceSet implements ResourceSetOrBuilder {
   public String toString() {
     return "Resources: \n"
         + "Memory: "
-        + memoryMb
+        + resources.get(MEMORY)
         + "M\n"
         + "CPU: "
-        + cpuUsage
+        + resources.get(CPU)
         + "\n"
-        + Joiner.on("\n").withKeyValueSeparator(": ").join(extraResourceUsage.entrySet())
+        + resources.entrySet().stream()
+            .filter(e -> !e.getKey().equals(CPU) && !e.getKey().equals(MEMORY))
+            .collect(
+                StringBuilder::new,
+                (a, e) -> a.append(e.getKey()).append(": ").append(e.getValue()).append("\n"),
+                StringBuilder::append)
         + "Local tests: "
         + localTestCount
         + "\n";

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -107,7 +107,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
 
   private static final ResourceSet DEFAULT_RESOURCE_SET = ResourceSet.createWithRamCpu(250, 1);
   private static final Set<String> validResources =
-      new HashSet<>(Arrays.asList("cpu", "memory", "local_test"));
+      new HashSet<>(Arrays.asList(ResourceSet.CPU, ResourceSet.MEMORY, "local_test"));
 
   // TODO(gnish): This is a temporary allowlist while new BuildInfo API becomes stable enough to
   // become public.
@@ -919,8 +919,10 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
         }
 
         return ResourceSet.create(
-            getNumericOrDefault(resourceSetMapRaw, "memory", DEFAULT_RESOURCE_SET.getMemoryMb()),
-            getNumericOrDefault(resourceSetMapRaw, "cpu", DEFAULT_RESOURCE_SET.getCpuUsage()),
+            getNumericOrDefault(
+                resourceSetMapRaw, ResourceSet.MEMORY, DEFAULT_RESOURCE_SET.getMemoryMb()),
+            getNumericOrDefault(
+                resourceSetMapRaw, ResourceSet.CPU, DEFAULT_RESOURCE_SET.getCpuUsage()),
             (int)
                 getNumericOrDefault(
                     resourceSetMapRaw,

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -96,7 +96,7 @@ import javax.annotation.Nullable;
 public final class CoverageReportActionBuilder {
 
   private static final ResourceSet LOCAL_RESOURCES =
-      ResourceSet.createWithRamCpu(/* memoryMb= */ 750, /* cpuUsage= */ 1);
+      ResourceSet.createWithRamCpu(/* memoryMb= */ 750, /* cpu= */ 1);
 
   private static final ActionOwner ACTION_OWNER = ActionOwner.SYSTEM_ACTION_OWNER;
 

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -303,7 +303,7 @@ public class ExecutionOptions extends OptionsBase {
               + " default, (\"HOST_CPUS\"), Bazel will query system configuration to estimate"
               + " the number of CPU cores available.",
       converter = CpuResourceConverter.class)
-  public float localCpuResources;
+  public double localCpuResources;
 
   @Option(
       name = "local_ram_resources",
@@ -317,7 +317,7 @@ public class ExecutionOptions extends OptionsBase {
               + " default, (\"HOST_RAM*.67\"), Bazel will query system configuration to estimate"
               + " the amount of RAM available and will use 67% of it.",
       converter = RamResourceConverter.class)
-  public float localRamResources;
+  public double localRamResources;
 
   @Option(
       name = "local_extra_resources",
@@ -333,8 +333,8 @@ public class ExecutionOptions extends OptionsBase {
               + "Tests can declare the amount of extra resources they need "
               + "by using a tag of the \"resources:<resoucename>:<amount>\" format. "
               + "Available CPU, RAM and resources cannot be set with this flag.",
-      converter = Converters.StringToFloatAssignmentConverter.class)
-  public List<Map.Entry<String, Float>> localExtraResources;
+      converter = Converters.StringToDoubleAssignmentConverter.class)
+  public List<Map.Entry<String, Double>> localExtraResources;
 
   @Option(
       name = "local_test_jobs",

--- a/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
@@ -65,7 +65,7 @@ import javax.annotation.Nullable;
 public class SpawnIncludeScanner {
   /** The grep-includes tool is very lightweight, so don't use the default from AbstractAction. */
   private static final ResourceSet LOCAL_RESOURCES =
-      ResourceSet.createWithRamCpu(/*memoryMb=*/ 10, /*cpuUsage=*/ 1);
+      ResourceSet.createWithRamCpu(/* memoryMb= */ 10, /* cpu= */ 1);
 
   private final Path execRoot;
   private OutputService outputService;

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java
@@ -98,7 +98,7 @@ public class AndroidCommon {
 
   private static final int DEX_THREADS = 5;
   private static final ResourceSet DEX_RESOURCE_SET =
-      ResourceSet.createWithRamCpu(/* memoryMb= */ 4096.0, /* cpuUsage= */ DEX_THREADS);
+      ResourceSet.createWithRamCpu(/* memoryMb= */ 4096.0, /* cpu= */ DEX_THREADS);
 
   public static final <T extends Info> Iterable<T> getTransitivePrerequisites(
       RuleContext ruleContext, BuiltinProvider<T> key) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1238,16 +1238,14 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
         switch (os) {
           case DARWIN:
           case LINUX:
-            return ResourceSet.createWithRamCpu(
-                /* memoryMb= */ 80 + 0.7 * inputs, /* cpuUsage= */ 1);
+            return ResourceSet.createWithRamCpu(/* memoryMb= */ 80 + 0.7 * inputs, /* cpu= */ 1);
           default:
             return AbstractAction.DEFAULT_RESOURCE_SET;
         }
       case OBJC_COMPILE_MNEMONIC:
         switch (os) {
           case DARWIN:
-            return ResourceSet.createWithRamCpu(
-                /* memoryMb= */ 80 + 0.2 * inputs, /* cpuUsage= */ 1);
+            return ResourceSet.createWithRamCpu(/* memoryMb= */ 80 + 0.2 * inputs, /* cpu= */ 1);
           default:
             return AbstractAction.DEFAULT_RESOURCE_SET;
         }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
@@ -546,17 +546,16 @@ public final class CppLinkAction extends AbstractAction implements CommandAction
       switch (os) {
         case DARWIN:
           resourceSet =
-              ResourceSet.createWithRamCpu(
-                  /* memoryMb= */ 15 + 0.05 * inputsCount, /* cpuUsage= */ 1);
+              ResourceSet.createWithRamCpu(/* memoryMb= */ 15 + 0.05 * inputsCount, /* cpu= */ 1);
           break;
         case LINUX:
           resourceSet =
               ResourceSet.createWithRamCpu(
-                  /* memoryMb= */ Math.max(50, -100 + 0.1 * inputsCount), /* cpuUsage= */ 1);
+                  /* memoryMb= */ Math.max(50, -100 + 0.1 * inputsCount), /* cpu= */ 1);
           break;
         default:
           resourceSet =
-              ResourceSet.createWithRamCpu(/* memoryMb= */ 1500 + inputsCount, /* cpuUsage= */ 1);
+              ResourceSet.createWithRamCpu(/* memoryMb= */ 1500 + inputsCount, /* cpu= */ 1);
           break;
       }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/DeployArchiveBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/DeployArchiveBuilder.java
@@ -56,7 +56,7 @@ public class DeployArchiveBuilder {
   private static final int SINGLEJAR_MEMORY_MB = 1600;
 
   private static final ResourceSet DEPLOY_ACTION_RESOURCE_SET =
-      ResourceSet.createWithRamCpu(/*memoryMb = */ SINGLEJAR_MEMORY_MB, /*cpuUsage = */ 1);
+      ResourceSet.createWithRamCpu(/* memoryMb= */ SINGLEJAR_MEMORY_MB, /* cpu= */ 1);
 
   private final RuleContext ruleContext;
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -99,7 +99,7 @@ import net.starlark.java.eval.StarlarkList;
 public final class JavaCompileAction extends AbstractAction implements CommandAction {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   private static final ResourceSet LOCAL_RESOURCES =
-      ResourceSet.createWithRamCpu(/* memoryMb= */ 750, /* cpuUsage= */ 1);
+      ResourceSet.createWithRamCpu(/* memoryMb= */ 750, /* cpu= */ 1);
   private static final UUID GUID = UUID.fromString("e423747c-2827-49e6-b961-f6c08c10bb51");
 
   private static final ParamFileInfo PARAM_FILE_INFO =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/DoubleCodec.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/DoubleCodec.java
@@ -1,0 +1,40 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.skyframe.serialization;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import java.io.IOException;
+
+/** Codec for {@link Double}. */
+public class DoubleCodec implements ObjectCodec<Double> {
+
+  @Override
+  public Class<? extends Double> getEncodedClass() {
+    return Double.class;
+  }
+
+  @Override
+  public void serialize(SerializationContext context, Double value, CodedOutputStream codedOut)
+      throws SerializationException, IOException {
+    codedOut.writeDoubleNoTag(value);
+  }
+
+  @Override
+  public Double deserialize(DeserializationContext context, CodedInputStream codedIn)
+      throws SerializationException, IOException {
+    return codedIn.readDouble();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -397,10 +397,8 @@ final class WorkerSpawnRunner implements SpawnRunner {
 
     Stopwatch queueStopwatch = Stopwatch.createStarted();
     ResourceSet resourceSet =
-        ResourceSet.createWithWorkerKey(
-            spawn.getLocalResources().getMemoryMb(),
-            spawn.getLocalResources().getCpuUsage(),
-            spawn.getLocalResources().getExtraResourceUsage(),
+        ResourceSet.create(
+            spawn.getLocalResources().getResources(),
             spawn.getLocalResources().getLocalTestCount(),
             key);
 

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -525,15 +525,15 @@ public final class Converters {
   }
 
   /** A converter for for assignments from a string value to a float value. */
-  public static class StringToFloatAssignmentConverter
-      extends Converter.Contextless<Map.Entry<String, Float>> {
+  public static class StringToDoubleAssignmentConverter
+      extends Converter.Contextless<Map.Entry<String, Double>> {
     private static final AssignmentConverter baseConverter = new AssignmentConverter();
 
     @Override
-    public Map.Entry<String, Float> convert(String input)
+    public Map.Entry<String, Double> convert(String input)
         throws OptionsParsingException, NumberFormatException {
       Map.Entry<String, String> stringEntry = baseConverter.convert(input);
-      return Maps.immutableEntry(stringEntry.getKey(), Float.parseFloat(stringEntry.getValue()));
+      return Maps.immutableEntry(stringEntry.getKey(), Double.parseDouble(stringEntry.getValue()));
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -69,11 +69,8 @@ public final class ResourceManagerTest {
   public void configureResourceManager() throws Exception {
     rm.setAvailableResources(
         ResourceSet.create(
-            /* memoryMb= */ 1000,
-            /* cpuUsage= */ 1,
-            /* extraResourceUsage= */ ImmutableMap.of(
-                "gpu", 2.0f,
-                "fancyresource", 1.5f),
+            ImmutableMap.of(
+                ResourceSet.MEMORY, 1000.0, ResourceSet.CPU, 1.0, "gpu", 2.0, "fancyresource", 1.5),
             /* localTestCount= */ 2));
     counter = new AtomicInteger(0);
     sync = new CyclicBarrier(2);
@@ -116,7 +113,10 @@ public final class ResourceManagerTest {
 
     return rm.acquireResources(
         resourceOwner,
-        ResourceSet.createWithWorkerKey(ram, cpu, tests, createWorkerKey(mnemonic)),
+        ResourceSet.create(
+            ImmutableMap.of(ResourceSet.MEMORY, ram, ResourceSet.CPU, cpu),
+            tests,
+            createWorkerKey(mnemonic)),
         ResourcePriority.LOCAL);
   }
 
@@ -124,17 +124,19 @@ public final class ResourceManagerTest {
   private ResourceHandle acquire(
       double ram,
       double cpu,
-      ImmutableMap<String, Float> extraResources,
+      ImmutableMap<String, Double> extraResources,
       int tests,
       ResourcePriority priority)
       throws InterruptedException, IOException, NoSuchElementException {
+    ImmutableMap.Builder<String, Double> resources = ImmutableMap.builder();
+    resources.putAll(extraResources).put(ResourceSet.MEMORY, ram).put(ResourceSet.CPU, cpu);
     return rm.acquireResources(
-        resourceOwner, ResourceSet.create(ram, cpu, extraResources, tests), priority);
+        resourceOwner, ResourceSet.create(resources.buildOrThrow(), tests), priority);
   }
 
   @CanIgnoreReturnValue
   private ResourceHandle acquire(
-      double ram, double cpu, ImmutableMap<String, Float> extraResources, int tests)
+      double ram, double cpu, ImmutableMap<String, Double> extraResources, int tests)
       throws InterruptedException, IOException, NoSuchElementException {
     return acquire(ram, cpu, extraResources, tests, ResourcePriority.LOCAL);
   }
@@ -144,10 +146,12 @@ public final class ResourceManagerTest {
   }
 
   private void release(
-      double ram, double cpu, ImmutableMap<String, Float> extraResources, int tests)
+      double ram, double cpu, ImmutableMap<String, Double> extraResources, int tests)
       throws InterruptedException, IOException {
+    ImmutableMap.Builder<String, Double> resources = ImmutableMap.builder();
+    resources.putAll(extraResources).put(ResourceSet.MEMORY, ram).put(ResourceSet.CPU, cpu);
     rm.releaseResources(
-        resourceOwner, ResourceSet.create(ram, cpu, extraResources, tests), /* worker= */ null);
+        resourceOwner, ResourceSet.create(resources.buildOrThrow(), tests), /* worker= */ null);
   }
 
   private void validate(int count) {
@@ -199,8 +203,8 @@ public final class ResourceManagerTest {
     assertThat(rm.inUse()).isFalse();
 
     // Ditto, for extra resources:
-    ImmutableMap<String, Float> bigExtraResources =
-        ImmutableMap.of("gpu", 10.0f, "fancyresource", 10.0f);
+    ImmutableMap<String, Double> bigExtraResources =
+        ImmutableMap.of("gpu", 10.0, "fancyresource", 10.0);
     acquire(0, 0, bigExtraResources, 0);
     assertThat(rm.inUse()).isTrue();
     release(0, 0, bigExtraResources, 0);
@@ -291,11 +295,11 @@ public final class ResourceManagerTest {
     assertThat(rm.inUse()).isFalse();
 
     // Given a partially acquired extra resources:
-    acquire(0, 0, ImmutableMap.of("gpu", 1.0f), 1);
+    acquire(0, 0, ImmutableMap.of("gpu", 1.0), 1);
 
     // When a request for extra resources is made that would overallocate,
     // Then the request fails:
-    TestThread thread1 = new TestThread(() -> acquire(0, 0, ImmutableMap.of("gpu", 1.1f), 0));
+    TestThread thread1 = new TestThread(() -> acquire(0, 0, ImmutableMap.of("gpu", 1.1), 0));
     thread1.start();
     AssertionError e = assertThrows(AssertionError.class, () -> thread1.joinAndAssertState(1000));
     assertThat(e).hasCauseThat().hasMessageThat().contains("is still alive");
@@ -305,7 +309,7 @@ public final class ResourceManagerTest {
   public void testHasResources() throws Exception {
     assertThat(rm.inUse()).isFalse();
     assertThat(rm.threadHasResources()).isFalse();
-    acquire(1, 0.1, ImmutableMap.of("gpu", 1.0f), 1);
+    acquire(1, 0.1, ImmutableMap.of("gpu", 1.0), 1);
     assertThat(rm.threadHasResources()).isTrue();
 
     // We have resources in this thread - make sure other threads
@@ -326,15 +330,15 @@ public final class ResourceManagerTest {
               assertThat(rm.threadHasResources()).isTrue();
               release(0, 0, 1);
               assertThat(rm.threadHasResources()).isFalse();
-              acquire(0, 0, ImmutableMap.of("gpu", 1.0f), 0);
+              acquire(0, 0, ImmutableMap.of("gpu", 1.0), 0);
               assertThat(rm.threadHasResources()).isTrue();
-              release(0, 0, ImmutableMap.of("gpu", 1.0f), 0);
+              release(0, 0, ImmutableMap.of("gpu", 1.0), 0);
               assertThat(rm.threadHasResources()).isFalse();
             });
     thread1.start();
     thread1.joinAndAssertState(10000);
 
-    release(1, 0.1, ImmutableMap.of("gpu", 1.0f), 1);
+    release(1, 0.1, ImmutableMap.of("gpu", 1.0), 1);
     assertThat(rm.threadHasResources()).isFalse();
     assertThat(rm.inUse()).isFalse();
   }
@@ -407,7 +411,7 @@ public final class ResourceManagerTest {
     // This should process the queue. If the request from above is still present, it will take all
     // the available memory. But it shouldn't.
     rm.setAvailableResources(
-        ResourceSet.create(/*memoryMb=*/ 2000, /*cpuUsage=*/ 1, /* localTestCount= */ 2));
+        ResourceSet.create(/* memoryMb= */ 2000, /* cpu= */ 1, /* localTestCount= */ 2));
     TestThread thread2 =
         new TestThread(
             () -> {
@@ -670,11 +674,10 @@ public final class ResourceManagerTest {
     // If we try to use nonexisting resource we should return an error
     TestThread thread1 =
         new TestThread(
-            () -> {
-              assertThrows(
-                  NoSuchElementException.class,
-                  () -> acquire(0, 0, ImmutableMap.of("nonexisting", 1.0f), 0));
-            });
+            () ->
+                assertThrows(
+                    NoSuchElementException.class,
+                    () -> acquire(0, 0, ImmutableMap.of("nonexisting", 1.0), 0)));
     thread1.start();
     thread1.joinAndAssertState(1000);
   }


### PR DESCRIPTION
Remove special handling of cpu and memory, and instead track them as any other resource. This has a few advantages:
  - Significant code clean up, keep only the logic for generic resource around
  - Consistent resources type (double) for all resource

Relates to #19679

Closes #19839.

Commit https://github.com/bazelbuild/bazel/commit/ebe4d0dac36b2211f1fb38838d79c78064a66ebe

PiperOrigin-RevId: 585926931
Change-Id: Id0d6a14e9c151c3895f55d1808b6bd66eecf98b3