### PR TITLE
[7.0.0] BAZEL_CURRENT_REPOSITORY double escaped when using param files

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -634,7 +634,7 @@ def cc_binary_impl(ctx, additional_linkopts):
         cc_toolchain = cc_toolchain,
         user_compile_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions),
         defines = cc_helper.defines(ctx, additional_make_variable_substitutions),
-        local_defines = cc_helper.local_defines(ctx, additional_make_variable_substitutions) + cc_helper.get_local_defines_for_runfiles_lookup(ctx),
+        local_defines = cc_helper.local_defines(ctx, additional_make_variable_substitutions) + cc_helper.get_local_defines_for_runfiles_lookup(ctx, ctx.attr.deps),
         system_includes = cc_helper.system_include_dirs(ctx, additional_make_variable_substitutions),
         private_hdrs = cc_helper.get_private_hdrs(ctx),
         public_hdrs = cc_helper.get_public_hdrs(ctx),

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -965,8 +965,13 @@ def _is_stamping_enabled_for_aspect(ctx):
         stamp = ctx.rule.attr.stamp
     return stamp
 
-def _get_local_defines_for_runfiles_lookup(ctx):
-    return ["BAZEL_CURRENT_REPOSITORY=\"{}\"".format(ctx.label.workspace_name)]
+_RUNFILES_LIBRARY_TARGET = Label("@bazel_tools//tools/cpp/runfiles")
+
+def _get_local_defines_for_runfiles_lookup(ctx, all_deps):
+    for dep in all_deps:
+        if dep.label == _RUNFILES_LIBRARY_TARGET:
+            return ["BAZEL_CURRENT_REPOSITORY=\"{}\"".format(ctx.label.workspace_name)]
+    return []
 
 # This should be enough to assume if two labels are equal.
 def _are_labels_equal(a, b):

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -57,7 +57,7 @@ def _cc_library_impl(ctx):
         feature_configuration = feature_configuration,
         user_compile_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions),
         defines = cc_helper.defines(ctx, additional_make_variable_substitutions),
-        local_defines = cc_helper.local_defines(ctx, additional_make_variable_substitutions) + cc_helper.get_local_defines_for_runfiles_lookup(ctx),
+        local_defines = cc_helper.local_defines(ctx, additional_make_variable_substitutions) + cc_helper.get_local_defines_for_runfiles_lookup(ctx, ctx.attr.deps + ctx.attr.implementation_deps),
         system_includes = cc_helper.system_include_dirs(ctx, additional_make_variable_substitutions),
         copts_filter = cc_helper.copts_filter(ctx, additional_make_variable_substitutions),
         purpose = "cc_library-compile",

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1519,19 +1519,26 @@ cc_library(
   name = "library",
   srcs = ["library.cpp"],
   hdrs = ["library.h"],
+  implementation_deps = ["@bazel_tools//tools/cpp/runfiles"],
   visibility = ["//visibility:public"],
 )
 
 cc_binary(
   name = "binary",
   srcs = ["binary.cpp"],
-  deps = [":library"],
+  deps = [
+    ":library",
+    "@bazel_tools//tools/cpp/runfiles",
+  ],
 )
 
 cc_test(
   name = "test",
   srcs = ["test.cpp"],
-  deps = [":library"],
+  deps = [
+    ":library",
+    "@bazel_tools//tools/cpp/runfiles",
+  ],
 )
 EOF
 
@@ -1573,13 +1580,19 @@ EOF
 cc_binary(
   name = "binary",
   srcs = ["binary.cpp"],
-  deps = ["@//pkg:library"],
+  deps = [
+    "@//pkg:library",
+    "@bazel_tools//tools/cpp/runfiles",
+  ],
 )
 
 cc_test(
   name = "test",
   srcs = ["test.cpp"],
-  deps = ["@//pkg:library"],
+  deps = [
+    "@//pkg:library",
+    "@bazel_tools//tools/cpp/runfiles",
+  ],
 )
 EOF
 

--- a/tools/cpp/runfiles/runfiles_src.h
+++ b/tools/cpp/runfiles/runfiles_src.h
@@ -48,6 +48,8 @@
 //         ...
 //
 //      The code above creates a Runfiles object and retrieves a runfile path.
+//      The BAZEL_CURRENT_REPOSITORY macro is available in every target that
+//      depends on the runfiles library.
 //
 //      The Runfiles::Create function uses the runfiles manifest and the
 //      runfiles directory from the RUNFILES_MANIFEST_FILE and RUNFILES_DIR


### PR DESCRIPTION
RELNOTES[INC]: The `BAZEL_CURRENT_REPOSITORY` preprocessor variable, which holds the canonical name of the Bazel repository containing a `cc_*` target, is now only set during compilation if the target depends on the C/C++ runfiles library `@bazel_tools//tools/cpp/runfiles` via `deps` or `implementation_deps`.

Fixes #20371

Closes #20388.

Commit https://github.com/bazelbuild/bazel/commit/454b5506d82584616fcd707ed2e9bd1fe627c974

PiperOrigin-RevId: 587070254
Change-Id: I774dc38b031199179df1c63e04000a2ecc15e010