### PR TITLE
Fix LocalFileType computation when the artifact and its metadata disagree.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutedEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutedEvent.java
@@ -186,7 +186,7 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
       localFiles.add(
           new LocalFile(
               primaryOutput,
-              LocalFileType.forArtifact(outputArtifact),
+              LocalFileType.forArtifact(outputArtifact, primaryOutputMetadata),
               outputArtifact,
               primaryOutputMetadata));
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
@@ -406,12 +406,13 @@ public final class TargetCompleteEvent
             new ArtifactReceiver() {
               @Override
               public void accept(Artifact artifact) {
+                FileArtifactValue metadata = completionContext.getFileArtifactValue(artifact);
                 builder.add(
                     new LocalFile(
                         completionContext.pathResolver().toPath(artifact),
-                        LocalFileType.forArtifact(artifact),
+                        LocalFileType.forArtifact(artifact, metadata),
                         artifact,
-                        completionContext.getFileArtifactValue(artifact)));
+                        metadata));
               }
 
               @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/NamedArtifactGroup.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/NamedArtifactGroup.java
@@ -75,14 +75,14 @@ class NamedArtifactGroup implements BuildEvent {
     for (Object elem : set.getLeaves()) {
       ExpandedArtifact expandedArtifact = (ExpandedArtifact) elem;
       if (expandedArtifact.relPath == null) {
-        FileArtifactValue fileMetadata =
+        FileArtifactValue metadata =
             completionContext.getFileArtifactValue(expandedArtifact.artifact);
         artifacts.add(
             new LocalFile(
                 completionContext.pathResolver().toPath(expandedArtifact.artifact),
-                getOutputType(fileMetadata),
-                fileMetadata == null ? null : expandedArtifact.artifact,
-                fileMetadata));
+                LocalFileType.forArtifact(expandedArtifact.artifact, metadata),
+                metadata == null ? null : expandedArtifact.artifact,
+                metadata));
       } else {
         // TODO(b/199940216): Can fileset metadata be properly handled here?
         artifacts.add(
@@ -94,20 +94,6 @@ class NamedArtifactGroup implements BuildEvent {
       }
     }
     return artifacts.build();
-  }
-
-  private static LocalFileType getOutputType(@Nullable FileArtifactValue fileMetadata) {
-    if (fileMetadata == null) {
-      return LocalFileType.OUTPUT;
-    }
-    switch (fileMetadata.getType()) {
-      case DIRECTORY:
-        return LocalFileType.OUTPUT_DIRECTORY;
-      case SYMLINK:
-        return LocalFileType.OUTPUT_SYMLINK;
-      default:
-        return LocalFileType.OUTPUT_FILE;
-    }
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/analysis/TargetCompleteEventTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/TargetCompleteEventTest.java
@@ -73,10 +73,8 @@ public class TargetCompleteEventTest extends AnalysisTestCase {
             artifactsToBuild.getAllArtifactsByOutputGroup(),
             /* announceTargetSummary= */ false);
 
-    assertThat(event.referencedLocalFiles()).hasSize(1);
-    LocalFile localFile = event.referencedLocalFiles().get(0);
-    assertThat(localFile.path).isEqualTo(artifact.getPath());
-    assertThat(localFile.type).isEqualTo(LocalFileType.OUTPUT_FILE);
+    assertThat(event.referencedLocalFiles()).containsExactly(
+        new LocalFile(artifact.getPath(), LocalFileType.OUTPUT_FILE, artifact, metadata));
   }
 
   @Test
@@ -97,11 +95,8 @@ public class TargetCompleteEventTest extends AnalysisTestCase {
             artifactsToBuild.getAllArtifactsByOutputGroup(),
             /* announceTargetSummary= */ false);
 
-    assertThat(event.referencedLocalFiles()).hasSize(1);
-    LocalFile localFile = event.referencedLocalFiles().get(0);
-    assertThat(localFile.path).isEqualTo(artifact.getPath());
-    // TODO(tjgq): This should be reported as a directory.
-    assertThat(localFile.type).isEqualTo(LocalFileType.OUTPUT_FILE);
+    assertThat(event.referencedLocalFiles()).containsExactly(
+        new LocalFile(artifact.getPath(), LocalFileType.OUTPUT_DIRECTORY, artifact, metadata));
   }
 
   @Test
@@ -110,10 +105,7 @@ public class TargetCompleteEventTest extends AnalysisTestCase {
         "defs.bzl",
         "def _impl(ctx):",
         "  d = ctx.actions.declare_directory(ctx.label.name)",
-        "  ctx.actions.run_shell(",
-        "    outputs = [d],",
-        "    command = 'touch %s/file.txt' % d.path,",
-        "  )",
+        "  ctx.actions.run_shell(outputs = [d], command = 'does not matter')",
         "  return DefaultInfo(files = depset([d]))",
         "dir = rule(_impl)");
     scratch.file(
@@ -123,16 +115,23 @@ public class TargetCompleteEventTest extends AnalysisTestCase {
         "filegroup(name = 'files', srcs = ['dir'])");
     ConfiguredTargetAndData ctAndData = getCtAndData("//:files");
     ArtifactsToBuild artifactsToBuild = getArtifactsToBuild(ctAndData);
-    SpecialArtifact artifact =
+    SpecialArtifact tree =
         (SpecialArtifact) Iterables.getOnlyElement(artifactsToBuild.getAllArtifacts().toList());
+    TreeFileArtifact fileChild = TreeFileArtifact.createTreeOutput(tree,
+        PathFragment.create("dir/file.txt"));
+    FileArtifactValue fileMetadata = FileArtifactValue.createForNormalFile(new byte[]{1, 2, 3},
+        null, 10);
+    // A TreeFileArtifact can be a directory, when materialized by a symlink.
+    // See https://github.com/bazelbuild/bazel/issues/20418.
+    TreeFileArtifact dirChild = TreeFileArtifact.createTreeOutput(tree, PathFragment.create("sym"));
+    FileArtifactValue dirMetadata = FileArtifactValue.createForDirectoryWithMtime(123456789);
     TreeArtifactValue metadata =
-        TreeArtifactValue.newBuilder(artifact)
-            .putChild(
-                TreeFileArtifact.createTreeOutput(artifact, PathFragment.create("file")),
-                FileArtifactValue.createForNormalFile(new byte[] {1, 2, 3}, null, 10))
+        TreeArtifactValue.newBuilder(tree)
+            .putChild(fileChild, fileMetadata)
+            .putChild(dirChild, dirMetadata)
             .build();
     CompletionContext completionContext =
-        getCompletionContext(ImmutableMap.of(), ImmutableMap.of(artifact, metadata));
+        getCompletionContext(ImmutableMap.of(), ImmutableMap.of(tree, metadata));
 
     TargetCompleteEvent event =
         TargetCompleteEvent.successfulBuild(
@@ -141,11 +140,9 @@ public class TargetCompleteEventTest extends AnalysisTestCase {
             artifactsToBuild.getAllArtifactsByOutputGroup(),
             /* announceTargetSummary= */ false);
 
-    assertThat(event.referencedLocalFiles()).hasSize(1);
-    LocalFile localFile = event.referencedLocalFiles().get(0);
-    assertThat(localFile.path)
-        .isEqualTo(Iterables.getOnlyElement(metadata.getChildren()).getPath());
-    assertThat(localFile.type).isEqualTo(LocalFileType.OUTPUT_FILE);
+    assertThat(event.referencedLocalFiles()).containsExactly(
+        new LocalFile(fileChild.getPath(), LocalFileType.OUTPUT_FILE, fileChild, fileMetadata),
+        new LocalFile(dirChild.getPath(), LocalFileType.OUTPUT_DIRECTORY, dirChild, dirMetadata));
   }
 
   @Test
@@ -154,10 +151,7 @@ public class TargetCompleteEventTest extends AnalysisTestCase {
         "defs.bzl",
         "def _impl(ctx):",
         "  s = ctx.actions.declare_symlink(ctx.label.name)",
-        "  ctx.actions.symlink(",
-        "    output = s,",
-        "    target_path = '/some/path',",
-        "  )",
+        "  ctx.actions.symlink(output = s, target_path = 'does not matter')",
         "  return DefaultInfo(files = depset([s]))",
         "sym = rule(_impl)");
     scratch.file(
@@ -181,10 +175,8 @@ public class TargetCompleteEventTest extends AnalysisTestCase {
             artifactsToBuild.getAllArtifactsByOutputGroup(),
             /* announceTargetSummary= */ false);
 
-    assertThat(event.referencedLocalFiles()).hasSize(1);
-    LocalFile localFile = event.referencedLocalFiles().get(0);
-    assertThat(localFile.path).isEqualTo(artifact.getPath());
-    assertThat(localFile.type).isEqualTo(LocalFileType.OUTPUT_SYMLINK);
+    assertThat(event.referencedLocalFiles()).containsExactly(
+        new LocalFile(artifact.getPath(), LocalFileType.OUTPUT_SYMLINK, artifact, metadata));
   }
 
   /** Regression test for b/165671166. */


### PR DESCRIPTION
When a tree artifact contains a symlink to a directory, the TreeArtifactValue contains a TreeFileArtifact mapping to a DirectoryArtifactValue (see #20418).

Because the file type to be uploaded to the BES is determined solely by the Artifact type, this causes the uploader to attempt to upload a directory as if it were a file. This fails silently when building with the bytes; when building without the bytes, it crashes when attempting to digest the (in-memory) directory, which has no associated inode (see #20415).

This PR fixes the file type computation to take into account both the artifact and its metadata, preferring the latter when available.

Fixes #20415.