### PR TITLE
[7.0.0] "Cannot get node id for DirectoryArtifactValue" on tree artifact containing symlink to directory + remote cache + BES

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutedEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutedEvent.java
@@ -173,7 +173,7 @@ public final class ActionExecutedEvent implements BuildEventWithConfiguration {
       localFiles.add(
           new LocalFile(
               primaryOutput,
-              LocalFileType.forArtifact(outputArtifact),
+              LocalFileType.forArtifact(outputArtifact, primaryOutputMetadata),
               outputArtifact,
               primaryOutputMetadata));
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
@@ -406,12 +406,13 @@ public final class TargetCompleteEvent
             new ArtifactReceiver() {
               @Override
               public void accept(Artifact artifact) {
+                FileArtifactValue metadata = completionContext.getFileArtifactValue(artifact);
                 builder.add(
                     new LocalFile(
                         completionContext.pathResolver().toPath(artifact),
-                        LocalFileType.forArtifact(artifact),
+                        LocalFileType.forArtifact(artifact, metadata),
                         artifact,
-                        completionContext.getFileArtifactValue(artifact)));
+                        metadata));
               }
 
               @Override

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEvent.java
@@ -66,7 +66,22 @@ public interface BuildEvent extends ChainableEvent, ExtendedEventHandler.Postabl
             || this == OUTPUT_SYMLINK;
       }
 
-      public static LocalFileType forArtifact(Artifact artifact) {
+      /**
+       * Returns the {@link LocalFileType} implied by a {@link FileArtifactValue}, or the associated
+       * {@link Artifact} if metadata is not available.
+       */
+      public static LocalFileType forArtifact(
+          Artifact artifact, @Nullable FileArtifactValue metadata) {
+        if (metadata != null) {
+          switch (metadata.getType()) {
+            case DIRECTORY:
+              return LocalFileType.OUTPUT_DIRECTORY;
+            case SYMLINK:
+              return LocalFileType.OUTPUT_SYMLINK;
+            default:
+              return LocalFileType.OUTPUT_FILE;
+          }
+        }
         if (artifact.isDirectory()) {
           return LocalFileType.OUTPUT_DIRECTORY;
         } else if (artifact.isSymlink()) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/NamedArtifactGroup.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/NamedArtifactGroup.java
@@ -75,14 +75,14 @@ class NamedArtifactGroup implements BuildEvent {
     for (Object elem : set.getLeaves()) {
       ExpandedArtifact expandedArtifact = (ExpandedArtifact) elem;
       if (expandedArtifact.relPath == null) {
-        FileArtifactValue fileMetadata =
+        FileArtifactValue metadata =
             completionContext.getFileArtifactValue(expandedArtifact.artifact);
         artifacts.add(
             new LocalFile(
                 completionContext.pathResolver().toPath(expandedArtifact.artifact),
-                getOutputType(fileMetadata),
-                fileMetadata == null ? null : expandedArtifact.artifact,
-                fileMetadata));
+                LocalFileType.forArtifact(expandedArtifact.artifact, metadata),
+                metadata == null ? null : expandedArtifact.artifact,
+                metadata));
       } else {
         // TODO(b/199940216): Can fileset metadata be properly handled here?
         artifacts.add(
@@ -94,20 +94,6 @@ class NamedArtifactGroup implements BuildEvent {
       }
     }
     return artifacts.build();
-  }
-
-  private static LocalFileType getOutputType(@Nullable FileArtifactValue fileMetadata) {
-    if (fileMetadata == null) {
-      return LocalFileType.OUTPUT;
-    }
-    switch (fileMetadata.getType()) {
-      case DIRECTORY:
-        return LocalFileType.OUTPUT_DIRECTORY;
-      case SYMLINK:
-        return LocalFileType.OUTPUT_SYMLINK;
-      default:
-        return LocalFileType.OUTPUT_FILE;
-    }
   }
 
   @Override


### PR DESCRIPTION
When a tree artifact contains a symlink to a directory, the TreeArtifactValue contains a TreeFileArtifact mapping to a DirectoryArtifactValue (see #20418).

Because the file type to be uploaded to the BES is determined solely by the Artifact type, this causes the uploader to attempt to upload a directory as if it were a file. This fails silently when building with the bytes; when building without the bytes, it crashes when attempting to digest the (in-memory) directory, which has no associated inode (see #20415).

This PR fixes the file type computation to take into account both the artifact and its metadata, preferring the latter when available.

Fixes #20415.

Closes #20419.

Commit https://github.com/bazelbuild/bazel/commit/bb5ff63d18abda883f2ccf7cf47e009ef6012420

PiperOrigin-RevId: 587654070
Change-Id: Ib62bbaaed62b00c12bcabdc2bc9bee57aee0bcef