### PR TITLE
[7.0.0] Allow most forms of symlink inside a remotely produced tree artifact, matching a locally produced one.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1234,23 +1234,6 @@ public class RemoteExecutionService {
     List<SymlinkMetadata> symlinksInDirectories = new ArrayList<>();
     for (Entry<Path, DirectoryMetadata> entry : metadata.directories()) {
       for (SymlinkMetadata symlink : entry.getValue().symlinks()) {
-        // Symlinks should not be allowed inside directories because their semantics are unclear:
-        // tree artifacts are defined as a collection of regular files, and resolving a remotely
-        // produced symlink against the local filesystem is asking for trouble.
-        //
-        // Sadly, we started permitting relative symlinks at some point, so we have to allow them
-        // until the --incompatible_remote_disallow_symlink_in_tree_artifact flag is flipped.
-        // Absolute symlinks, on the other hand, have never been allowed.
-        //
-        // See also https://github.com/bazelbuild/bazel/issues/16361 for potential future work
-        // to allow *unresolved* symlinks in a tree artifact.
-        boolean isAbsolute = symlink.target().isAbsolute();
-        if (remoteOptions.incompatibleRemoteDisallowSymlinkInTreeArtifact || isAbsolute) {
-          throw new IOException(
-              String.format(
-                  "Unsupported symlink '%s' inside tree artifact '%s'",
-                  symlink.path().relativeTo(entry.getKey()), entry.getKey().relativeTo(execRoot)));
-        }
         symlinksInDirectories.add(symlink);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -424,17 +424,6 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public boolean incompatibleRemoteDanglingSymlinks;
 
   @Option(
-      name = "incompatible_remote_disallow_symlink_in_tree_artifact",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      effectTags = {OptionEffectTag.EXECUTION},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "If set to true, a remotely executed action cannot produce a tree artifact containing a"
-              + " relative symlink. Absolute symlinks are never allowed irrespective of this flag.")
-  public boolean incompatibleRemoteDisallowSymlinkInTreeArtifact;
-
-  @Option(
       name = "remote_cache_compression",
       oldName = "experimental_remote_cache_compression",
       defaultValue = "false",


### PR DESCRIPTION
This CL harmonizes the criteria for permitting a symlink for locally and remotely produced tree artifacts, namely:

1. A symlink to an absolute path is allowed.
2. A symlink to a relative path is allowed, as long as the target is inside the tree artifact.
3. The target path must exist (a consequence of tree artifacts transparently dereferencing symlinks; see also #15454).

as enforced by TreeArtifactValue#visitTree (see https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java;l=585;drc=de9d1f59915a36229978d46b78a22c9e5389db92).

The admonition about symlinks potentially compromising hermeticity is still valid, but there's little gain in making the behavior divergent between local and remote execution. I don't believe we can go in the other direction and extend the restriction to cover local execution, as it would break existing projects.

The --incompatible_remote_disallow_symlink_in_tree_artifact flag is deleted. It was added at a time when symlink resolution was extremely unreliable when building without the bytes; the state of symlink handling has improved a lot since then. I'm deleting the flag entirely (as opposed to making it a no-op) because it was only introduced in the Bazel 7 tree and hasn't made it into a stable release yet.

Makes #18284 obsolete.

PiperOrigin-RevId: 587691220
Change-Id: I470a8fc523bdbb7577ad5a564b6b2c0acab17d7d