### PR TITLE
[7.0.0] Don't follow symlinks when deleting test outputs

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -421,15 +421,16 @@ fi
 
 # Zip up undeclared outputs.
 if [[ -n "$TEST_UNDECLARED_OUTPUTS_ZIP" ]] && cd "$TEST_UNDECLARED_OUTPUTS_DIR"; then
-  shopt -s dotglob
-  if [[ "$(echo *)" != "*" ]]; then
-    # If * found nothing, echo printed the literal *.
-    # Otherwise echo printed the top-level files and directories.
-    # Pass files to zip with *, so paths with spaces aren't broken up.
-    # Remove original files after zipping them.
-    if ! zip_output="$(zip -qrm "$TEST_UNDECLARED_OUTPUTS_ZIP" -- * 2>&1)"; then
+  shopt -s dotglob nullglob
+  # Capture the contents of TEST_UNDECLARED_OUTPUTS_DIR prior to creating the output.zip
+  UNDECLARED_OUTPUTS=(*)
+  if [[ "${#UNDECLARED_OUTPUTS[@]}" != 0 ]]; then
+    if ! zip_output="$(zip -qr "$TEST_UNDECLARED_OUTPUTS_ZIP" -- "${UNDECLARED_OUTPUTS[@]}")" ; then
         echo >&2 "Could not create \"$TEST_UNDECLARED_OUTPUTS_ZIP\": $zip_output"
     fi
+    # Use 'rm' instead of 'zip -m' so that we don't follow symlinks when deleting the
+    # contents.
+    rm -r "${UNDECLARED_OUTPUTS[@]}"
   fi
 fi
 


### PR DESCRIPTION
Update tools/test/test-setup.sh to preserve symlinks when performing the zip of `$TEST_UNDECLARED_OUTPUTS_DIR`.

This fixes a serious bug where an absolute symlink generated in the test could delete files anywhere on the filesystem.

For example, a `sh_test` containing a line like:

    ln -s "$HOME" "$TEST_UNDECLARED_OUTPUTS_DIR/home"

would have caused the users home directory to be deleted after copying it in to the output.zip. With this change, the output.zip only contains a (possibly dangling) symlink, but more importantly the deletions are limited to the `$TEST_UNDECLARED_OUTPUTS_DIR`.

RELNOTES: `--zip_undeclared_test_outputs` now preserves symlinks when zipping `$TEST_UNDECLARED_OUTPUTS_DIR`.

Closes #19948.

Change-Id: Ia4a8a9699e4e2f40498342af55babc5554a9ac93
Commit https://github.com/bazelbuild/bazel/commit/8e639dfa8c7aa0723123ee90dc933d528a4f2b68

PiperOrigin-RevId: 587696908