### PR TITLE
[7.0.0] Experimental extend rule and subrule functionality

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
@@ -338,10 +338,6 @@ public final class RuleConfiguredTargetBuilder {
    *
    * <p>This is done within {@link RuleConfiguredTargetBuilder} so that every rule always and
    * automatically propagates the validation action output group.
-   *
-   * <p>Note that in addition to {@link LabelClass#DEPENDENCY}, there is also {@link
-   * LabelClass#FILESET_ENTRY}, however the fileset implementation takes care of propagating the
-   * validation action output group itself.
    */
   private void propagateTransitiveValidationOutputGroups() {
     if (outputGroupBuilders.containsKey(OutputGroupInfo.VALIDATION_TRANSITIVE)) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -98,6 +98,7 @@ import com.google.devtools.build.lib.util.FileTypeSet;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.errorprone.annotations.FormatMethod;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -947,6 +948,16 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
         ImmutableSet.copyOf(subrules));
   }
 
+  private static ImmutableSet<String> getLegacyAnyTypeAttrs(RuleClass ruleClass) {
+    Attribute attr = ruleClass.getAttributeByNameMaybe("$legacy_any_type_attrs");
+    if (attr == null
+        || attr.getType() != STRING_LIST
+        || !(attr.getDefaultValueUnchecked() instanceof List<?>)) {
+      return ImmutableSet.of();
+    }
+    return ImmutableSet.copyOf(STRING_LIST.cast(attr.getDefaultValueUnchecked()));
+  }
+
   /**
    * The implementation for the magic function "rule" that creates Starlark rule classes.
    *
@@ -1020,6 +1031,8 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
 
       validateRulePropagatedAspects(ruleClass);
 
+      ImmutableSet<String> legacyAnyTypeAttrs = getLegacyAnyTypeAttrs(ruleClass);
+
       // Remove {@link BazelStarlarkContext} to prevent calls to load and analysis time functions.
       // Mutating values in initializers is mostly not a problem, because the attribute values are
       // copied before calling the initializers (<-TODO) and before they are set on the target.
@@ -1052,11 +1065,13 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
                   continue;
                 }
                 Object reifiedValue =
-                    BuildType.copyAndLiftStarlarkValue(
-                        currentRuleClass.getName(),
-                        attr,
-                        value,
-                        pkgContext.getBuilder().getLabelConverter());
+                    legacyAnyTypeAttrs.contains(attr.getName())
+                        ? value
+                        : BuildType.copyAndLiftStarlarkValue(
+                            currentRuleClass.getName(),
+                            attr,
+                            value,
+                            pkgContext.getBuilder().getLabelConverter());
                 initializerKwargs.put(attr.getName(), reifiedValue);
               }
             }
@@ -1090,7 +1105,9 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
             }
             Object value = newKwargs.get(arg);
             Object reifiedValue =
-                attr == null || value == Starlark.NONE
+                attr == null
+                        || value == Starlark.NONE
+                        || legacyAnyTypeAttrs.contains(attr.getName())
                     ? value
                     : BuildType.copyAndLiftStarlarkValue(
                         currentRuleClass.getName(),

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.analysis.starlark;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.RUN_UNDER;
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.TIMEOUT_DEFAULT;
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.getTestRuntimeLabelList;
@@ -380,8 +381,6 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
       failIf(testUnchecked != Starlark.UNBOUND, "Omit test parameter when extending rules.");
       // TODO b/300201845 - add cfg support
       failIf(cfg != Starlark.NONE, "cfg is not supported in extended rules yet.");
-      // TODO b/300201845 - add subrules support
-      failIf(!subrules.isEmpty(), "subrules are not supported in extended rules yet.");
       failIf(
           implicitOutputs != Starlark.NONE,
           "implicit_outputs is not supported when extending rules (deprecated).");
@@ -1164,7 +1163,12 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
       // exploit dependency resolution for "free"
       ImmutableList<Pair<String, Descriptor>> subruleAttributes;
       try {
-        subruleAttributes = StarlarkSubrule.discoverAttributes(builder.getSubrules());
+        var parentSubrules = builder.getParentSubrules();
+        ImmutableList<StarlarkSubruleApi> subrulesNotInParents =
+            builder.getSubrules().stream()
+                .filter(subrule -> !parentSubrules.contains(subrule))
+                .collect(toImmutableList());
+        subruleAttributes = StarlarkSubrule.discoverAttributes(subrulesNotInParents);
       } catch (EvalException e) {
         errorf(handler, "%s", e.getMessage());
         return;

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -44,6 +44,7 @@ import com.google.devtools.build.lib.analysis.TemplateVariableInfo;
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
 import com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition;
 import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
+import com.google.devtools.build.lib.analysis.config.transitions.ComposingTransitionFactory;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.StarlarkExposedRuleTransitionFactory;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
@@ -83,6 +84,7 @@ import com.google.devtools.build.lib.packages.RuleFactory;
 import com.google.devtools.build.lib.packages.RuleFactory.BuildLangTypedAttributeValuesMap;
 import com.google.devtools.build.lib.packages.RuleFactory.InvalidRuleException;
 import com.google.devtools.build.lib.packages.RuleFunction;
+import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.StarlarkAspect;
 import com.google.devtools.build.lib.packages.StarlarkCallbackHelper;
 import com.google.devtools.build.lib.packages.StarlarkDefinedAspect;
@@ -379,8 +381,6 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
           executableUnchecked != Starlark.UNBOUND,
           "Omit executable parameter when extending rules.");
       failIf(testUnchecked != Starlark.UNBOUND, "Omit test parameter when extending rules.");
-      // TODO b/300201845 - add cfg support
-      failIf(cfg != Starlark.NONE, "cfg is not supported in extended rules yet.");
       failIf(
           implicitOutputs != Starlark.NONE,
           "implicit_outputs is not supported when extending rules (deprecated).");
@@ -643,23 +643,37 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     if (!buildSetting.equals(Starlark.NONE)) {
       builder.setBuildSetting((BuildSetting) buildSetting);
     }
+
+    TransitionFactory<RuleTransitionData> transitionFactory = null;
     if (!cfg.equals(Starlark.NONE)) {
       if (cfg instanceof StarlarkDefinedConfigTransition) {
         // defined in Starlark via, cfg = transition
         StarlarkDefinedConfigTransition starlarkDefinedConfigTransition =
             (StarlarkDefinedConfigTransition) cfg;
-        builder.cfg(new StarlarkRuleTransitionProvider(starlarkDefinedConfigTransition));
+        transitionFactory = new StarlarkRuleTransitionProvider(starlarkDefinedConfigTransition);
         hasStarlarkDefinedTransition = true;
       } else if (cfg instanceof StarlarkExposedRuleTransitionFactory) {
         // only used for native Android transitions (platforms and feature flags)
         StarlarkExposedRuleTransitionFactory transition =
             (StarlarkExposedRuleTransitionFactory) cfg;
-        builder.cfg(transition);
         transition.addToStarlarkRule(ruleDefinitionEnvironment, builder);
+        transitionFactory = transition;
       } else {
         throw Starlark.errorf(
             "`cfg` must be set to a transition object initialized by the transition() function.");
       }
+    }
+    if (parent != null && parent.getTransitionFactory() != null) {
+      if (transitionFactory == null) {
+        transitionFactory = parent.getTransitionFactory();
+      } else {
+        transitionFactory =
+            ComposingTransitionFactory.of(transitionFactory, parent.getTransitionFactory());
+      }
+      hasStarlarkDefinedTransition = true;
+    }
+    if (transitionFactory != null) {
+      builder.cfg(transitionFactory);
     }
 
     boolean hasFunctionTransitionAllowlist = false;

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -44,10 +44,8 @@ import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
 import com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition;
 import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
-import com.google.devtools.build.lib.analysis.config.transitions.PatchTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.StarlarkExposedRuleTransitionFactory;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
-import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory.TransitionType;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkAttrModule.Descriptor;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration;
@@ -84,7 +82,6 @@ import com.google.devtools.build.lib.packages.RuleFactory;
 import com.google.devtools.build.lib.packages.RuleFactory.BuildLangTypedAttributeValuesMap;
 import com.google.devtools.build.lib.packages.RuleFactory.InvalidRuleException;
 import com.google.devtools.build.lib.packages.RuleFunction;
-import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.StarlarkAspect;
 import com.google.devtools.build.lib.packages.StarlarkCallbackHelper;
 import com.google.devtools.build.lib.packages.StarlarkDefinedAspect;
@@ -648,31 +645,17 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     }
     if (!cfg.equals(Starlark.NONE)) {
       if (cfg instanceof StarlarkDefinedConfigTransition) {
+        // defined in Starlark via, cfg = transition
         StarlarkDefinedConfigTransition starlarkDefinedConfigTransition =
             (StarlarkDefinedConfigTransition) cfg;
         builder.cfg(new StarlarkRuleTransitionProvider(starlarkDefinedConfigTransition));
         hasStarlarkDefinedTransition = true;
-      } else if (cfg instanceof PatchTransition) {
-        builder.cfg((PatchTransition) cfg);
       } else if (cfg instanceof StarlarkExposedRuleTransitionFactory) {
+        // only used for native Android transitions (platforms and feature flags)
         StarlarkExposedRuleTransitionFactory transition =
             (StarlarkExposedRuleTransitionFactory) cfg;
         builder.cfg(transition);
         transition.addToStarlarkRule(ruleDefinitionEnvironment, builder);
-      } else if (cfg instanceof TransitionFactory) {
-        // This may be redundant with StarlarkExposedRuleTransitionFactory infra
-        TransitionFactory<? extends TransitionFactory.Data> transitionFactory =
-            (TransitionFactory<? extends TransitionFactory.Data>) cfg;
-        if (transitionFactory.transitionType().isCompatibleWith(TransitionType.RULE)) {
-          @SuppressWarnings("unchecked") // Actually checked due to above isCompatibleWith call.
-          TransitionFactory<RuleTransitionData> ruleTransitionFactory =
-              (TransitionFactory<RuleTransitionData>) transitionFactory;
-          builder.cfg(ruleTransitionFactory);
-        } else {
-          throw Starlark.errorf(
-              "`cfg` must be set to a transition appropriate for a rule, not an attribute-specific"
-                  + " transition.");
-        }
       } else {
         throw Starlark.errorf(
             "`cfg` must be set to a transition object initialized by the transition() function.");

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -326,8 +326,12 @@ public final class StarlarkRuleContext
     if (isForAspect()) {
       return getRuleContext().getMainAspect().getDefinition().getSubrules();
     } else {
-      return getRuleContext().getRule().getRuleClassObject().getSubrules();
+      return getRuleClassUnderEvaluation().getSubrules();
     }
+  }
+
+  public RuleClass getRuleClassUnderEvaluation() {
+    return ruleClassUnderEvaluation;
   }
 
   void setLockedForSubrule(@Nullable SubruleContext lockedBy) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubrule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubrule.java
@@ -192,7 +192,7 @@ public class StarlarkSubrule implements StarlarkExportable, StarlarkCallable, St
     } else {
       return Starlark.errorf(
           "rule '%s' must declare '%s' in 'subrules'",
-          starlarkRuleContext.getRuleContext().getRule().getRuleClass(), this.getName());
+          starlarkRuleContext.getRuleClassUnderEvaluation(), this.getName());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -454,6 +454,12 @@ public final class BuildType {
     }
 
     @Override
+    public Object copyAndLiftStarlarkValue(
+        Object x, Object what, @Nullable LabelConverter labelConverter) throws ConversionException {
+      return STRING_LIST.copyAndLiftStarlarkValue(x, what, labelConverter);
+    }
+
+    @Override
     public License getDefaultValue() {
       return License.NO_LICENSE;
     }

--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -18,8 +18,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Interner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.packages.License.DistributionType;
@@ -163,8 +165,8 @@ public final class BuildType {
    *
    * <p>The caller is responsible for casting the returned value appropriately.
    */
-  public static <T> Object selectableConvert(
-      Type<T> type, Object x, Object what, LabelConverter context) throws ConversionException {
+  static <T> Object selectableConvert(Type<T> type, Object x, Object what, LabelConverter context)
+      throws ConversionException {
     if (x instanceof com.google.devtools.build.lib.packages.SelectorList) {
       return new SelectorList<>(
           ((com.google.devtools.build.lib.packages.SelectorList) x).getElements(),
@@ -173,6 +175,69 @@ public final class BuildType {
           type);
     } else {
       return type.convert(x, what, context);
+    }
+  }
+
+  /**
+   * Converts the build-language-typed {@code buildLangValue} to a native value via {@link
+   * BuildType#selectableConvert}. Canonicalizes the value's order if it is a {@link List} type and
+   * {@code attr.isOrderIndependent()} returns {@code true}.
+   *
+   * <p>Throws {@link ConversionException} if the conversion fails, or if {@code buildLangValue} is
+   * a selector expression but {@code attr.isConfigurable()} is {@code false}.
+   */
+  public static Object convertFromBuildLangType(
+      String ruleClass,
+      Attribute attr,
+      Object buildLangValue,
+      LabelConverter labelConverter,
+      Interner<ImmutableList<?>> listInterner)
+      throws ConversionException {
+    Object converted =
+        BuildType.selectableConvert(
+            attr.getType(),
+            buildLangValue,
+            new AttributeConversionContext(attr.getName(), ruleClass),
+            labelConverter);
+
+    if ((converted instanceof SelectorList<?>) && !attr.isConfigurable()) {
+      throw new ConversionException(
+          String.format("attribute \"%s\" is not configurable", attr.getName()));
+    }
+
+    if (converted instanceof List<?>) {
+      if (attr.isOrderIndependent()) {
+        @SuppressWarnings("unchecked")
+        List<? extends Comparable<?>> list = (List<? extends Comparable<?>>) converted;
+        converted = Ordering.natural().sortedCopy(list);
+      }
+      // It's common for multiple rule instances in the same package to have the same value for some
+      // attributes. As a concrete example, consider a package having several 'java_test' instances,
+      // each with the same exact 'tags' attribute value.
+      converted = listInterner.intern(ImmutableList.copyOf((List<?>) converted));
+    }
+
+    return converted;
+  }
+
+  /**
+   * Provides a {@link #toString()} description of the attribute being converted for {@link
+   * BuildType#selectableConvert}. This is preferred over a raw string to avoid uselessly
+   * constructing strings which are never used. A separate class instead of inline to avoid
+   * accidental memory leaks.
+   */
+  private static class AttributeConversionContext {
+    private final String attrName;
+    private final String ruleClass;
+
+    AttributeConversionContext(String attrName, String ruleClass) {
+      this.attrName = attrName;
+      this.ruleClass = ruleClass;
+    }
+
+    @Override
+    public String toString() {
+      return "attribute '" + attrName + "' in '" + ruleClass + "' rule";
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -753,6 +753,8 @@ public class RuleClass implements RuleClassData {
     private final RuleClassType type;
     @Nullable private RuleClass starlarkParent = null;
     @Nullable private StarlarkFunction initializer = null;
+    @Nullable private LabelConverter labelConverterForInitializer = null;
+
     // The extendable may take 3 value, null means that the default allowlist should be use when
     // rule is extendable in practice.
     @Nullable private Boolean extendable = null;
@@ -961,6 +963,7 @@ public class RuleClass implements RuleClassData {
           type,
           starlarkParent,
           initializer,
+          labelConverterForInitializer,
           starlark,
           extendable,
           extendableAllowlist,
@@ -1041,8 +1044,10 @@ public class RuleClass implements RuleClassData {
     }
 
     @CanIgnoreReturnValue
-    public Builder initializer(StarlarkFunction initializer) {
+    public Builder initializer(
+        StarlarkFunction initializer, LabelConverter labelConverterForInitializer) {
       this.initializer = initializer;
+      this.labelConverterForInitializer = labelConverterForInitializer;
       return this;
     }
 
@@ -1679,6 +1684,7 @@ public class RuleClass implements RuleClassData {
   private final RuleClassType type;
   @Nullable private final RuleClass starlarkParent;
   @Nullable private final StarlarkFunction initializer;
+  @Nullable private final LabelConverter labelConverterForInitializer;
   private final boolean isStarlark;
   private final boolean extendable;
   @Nullable private final Label extendableAllowlist;
@@ -1816,6 +1822,7 @@ public class RuleClass implements RuleClassData {
       RuleClassType type,
       RuleClass starlarkParent,
       @Nullable StarlarkFunction initializer,
+      @Nullable LabelConverter labelConverterForInitializer,
       boolean isStarlark,
       boolean extendable,
       @Nullable Label extendableAllowlist,
@@ -1855,6 +1862,7 @@ public class RuleClass implements RuleClassData {
     this.type = type;
     this.starlarkParent = starlarkParent;
     this.initializer = initializer;
+    this.labelConverterForInitializer = labelConverterForInitializer;
     this.isStarlark = isStarlark;
     this.extendable = extendable;
     this.extendableAllowlist = extendableAllowlist;
@@ -1958,6 +1966,11 @@ public class RuleClass implements RuleClassData {
   @Nullable
   public StarlarkFunction getInitializer() {
     return initializer;
+  }
+
+  @Nullable
+  public LabelConverter getLabelConverterForInitializer() {
+    return labelConverterForInitializer;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -1373,6 +1373,16 @@ public class RuleClass implements RuleClassData {
       return subrules;
     }
 
+    public ImmutableSet<? extends StarlarkSubruleApi> getParentSubrules() {
+      ImmutableSet.Builder<StarlarkSubruleApi> builder = ImmutableSet.builder();
+      RuleClass currentParent = starlarkParent;
+      while (currentParent != null) {
+        builder.addAll(starlarkParent.getSubrules());
+        currentParent = currentParent.starlarkParent;
+      }
+      return builder.build();
+    }
+
     @CanIgnoreReturnValue
     public Builder setExternalBindingsFunction(Function<? super Rule, Map<String, Label>> func) {
       this.externalBindingsFunction = func;

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
@@ -109,8 +109,8 @@ public class RuleFactory {
    * @param attributeValues a {@link BuildLangTypedAttributeValuesMap} mapping attribute names to
    *     attribute values of build-language type. Each attribute must be defined for this class of
    *     rule, and have a build-language-typed value which can be converted to the appropriate
-   *     native type of the attribute (i.e. via {@link BuildType#selectableConvert}). There must be
-   *     a map entry for each non-optional attribute of this class of rule.
+   *     native type of the attribute (i.e. via {@link BuildType#convertFromBuildLangType}). There
+   *     must be a map entry for each non-optional attribute of this class of rule.
    * @param eventHandler a eventHandler on which errors and warnings are reported during rule
    *     creation
    * @param callstack the stack of active calls in the Starlark thread
@@ -159,7 +159,8 @@ public class RuleFactory {
     /**
      * Returns {@code true} if all the map's values are "build-language typed", i.e., resulting from
      * the evaluation of an expression in the build language. Returns {@code false} if all the map's
-     * values are "natively typed", i.e. of a type returned by {@link BuildType#selectableConvert}.
+     * values are "natively typed", i.e. of a type returned by {@link
+     * BuildType#convertFromBuildLangType}.
      */
     boolean valuesAreBuildLanguageTyped();
 

--- a/src/main/java/com/google/devtools/build/lib/packages/Type.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Type.java
@@ -95,7 +95,7 @@ public abstract class Type<T> {
    * <p>x must be directly convertible to this type. This therefore disqualifies "selector
    * expressions" of the form "{ config1: 'value1_of_orig_type', config2: 'value2_of_orig_type; }"
    * (which support configurable attributes). To handle those expressions, see {@link
-   * com.google.devtools.build.lib.packages.BuildType#selectableConvert}.
+   * com.google.devtools.build.lib.packages.BuildType#convertFromBuildLangType}.
    *
    * @param x The Starlark value to convert.
    * @param what An object whose toString method returns a description of the purpose of x.
@@ -108,6 +108,7 @@ public abstract class Type<T> {
    */
   public abstract T convert(Object x, Object what, @Nullable LabelConverter labelConverter)
       throws ConversionException;
+
   // TODO(bazel-team): Check external calls (e.g. in PackageFactory), verify they always want
   // this over selectableConvert.
 

--- a/src/main/java/com/google/devtools/build/lib/packages/Type.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Type.java
@@ -220,11 +220,6 @@ public abstract class Type<T> {
     GENQUERY_SCOPE_REFERENCE,
     /** Used for types which use labels to declare an output path. */
     OUTPUT,
-    /**
-     * Used for types which contain Fileset entries, which contain labels but do not produce normal
-     * dependencies.
-     */
-    FILESET_ENTRY
   }
 
   /** Returns the class of labels contained by this type, if any. */

--- a/src/main/java/com/google/devtools/build/lib/packages/Type.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Type.java
@@ -276,9 +276,6 @@ public abstract class Type<T> {
   /** The type of a boolean. */
   @SerializationConstant public static final Type<Boolean> BOOLEAN = new BooleanType();
 
-  /** The type of a list of not-yet-typed objects. */
-  @SerializationConstant public static final ObjectListType OBJECT_LIST = new ObjectListType();
-
   /** The type of a list of strings. */
   @SerializationConstant public static final ListType<String> STRING_LIST = ListType.create(STRING);
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -495,7 +495,9 @@ public interface StarlarkRuleFunctionsApi {
                     + " <code>executable</code> and <code>test</code> from the parent. Values of"
                     + " <code>fragments</code>, <code>toolchains</code>,"
                     + " <code>exec_compatible_with</code>, and <code>exec_groups</code> are"
-                    + " merged. Legacy or deprecated parameters may not be set."),
+                    + " merged. Legacy or deprecated parameters may not be set. Incoming "
+                    + "configuration transition <code>cfg</code> of parent is applied after this"
+                    + "rule's incoming configuration."),
         @Param(
             name = "extendable",
             named = true,

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/transitions/NoConfigTransitionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/transitions/NoConfigTransitionTest.java
@@ -32,7 +32,8 @@ public class NoConfigTransitionTest extends BuildViewTestCase {
   private static final MockRule NO_CONFIG_RULE =
       () ->
           MockRule.define(
-              "no_config_rule", (builder, env) -> builder.cfg(NoConfigTransition.INSTANCE));
+              "no_config_rule",
+              (builder, env) -> builder.cfg(unused -> NoConfigTransition.INSTANCE));
 
   @Override
   protected ConfiguredRuleClassProvider createRuleClassProvider() {

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -1026,6 +1026,7 @@ public final class RuleClassTest extends PackageLoadingTestCase {
         RuleClassType.NORMAL,
         /* starlarkParent= */ null,
         /* initializer= */ null,
+        /* labelConverterForInitializer= */ null,
         /* isStarlark= */ starlarkExecutable,
         /* extendable= */ false,
         /* extendableAllowlist= */ null,

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQuerySemanticsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQuerySemanticsTest.java
@@ -241,7 +241,8 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
         () ->
             MockRule.define(
                 "rule_class_transition",
-                (builder, env) -> builder.cfg(new FooPatchTransition("SET BY PATCH")).build());
+                (builder, env) ->
+                    builder.cfg(unused -> new FooPatchTransition("SET BY PATCH")).build());
 
     helper.useRuleClassProvider(setRuleClassProviders(ruleClassTransition).build());
     helper.setUniverseScope("//test:rule_class");

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterTest.java
@@ -205,7 +205,7 @@ public class TransitionsOutputFormatterTest extends ConfiguredTargetQueryTest {
                 "my_rule",
                 (builder, env) ->
                     builder
-                        .cfg(ruleClassTransition)
+                        .cfg(unused -> ruleClassTransition)
                         .add(
                             attr("patched", LABEL_LIST)
                                 .allowedFileTypes(FileTypeSet.ANY_FILE)

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/PostAnalysisQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/PostAnalysisQueryTest.java
@@ -555,7 +555,8 @@ public abstract class PostAnalysisQueryTest<T> extends AbstractQueryTest<T> {
         () ->
             MockRule.define(
                 "transitioned_rule",
-                (builder, env) -> builder.cfg(new FooPatchTransition("SET BY PATCH")).build());
+                (builder, env) ->
+                    builder.cfg(unused -> new FooPatchTransition("SET BY PATCH")).build());
 
     MockRule untransitionedRule = () -> MockRule.define("untransitioned_rule");
 
@@ -587,7 +588,7 @@ public abstract class PostAnalysisQueryTest<T> extends AbstractQueryTest<T> {
                 "rule_with_transition_and_dep",
                 (builder, env) ->
                     builder
-                        .cfg(new FooPatchTransition("SET BY PATCH"))
+                        .cfg(unused -> new FooPatchTransition("SET BY PATCH"))
                         .addAttribute(
                             attr("dep", LABEL).allowedFileTypes(FileTypeSet.ANY_FILE).build())
                         .build());

--- a/src/test/java/com/google/devtools/build/lib/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlark/BUILD
@@ -41,6 +41,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/template_expansion_action",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/starlark_defined_config_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/toolchain_type_requirement",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/no_transition",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -4340,17 +4340,15 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
   }
 
   private void scratchStarlarkTransition() throws IOException {
-    if (!TestConstants.PRODUCT_NAME.equals("bazel")) {
-      scratch.overwriteFile(
-          TestConstants.TOOLS_REPOSITORY_SCRATCH
-              + "tools/allowlists/function_transition_allowlist/BUILD",
-          "package_group(",
-          "    name = 'function_transition_allowlist',",
-          "    packages = [",
-          "        '//extend_rule_testing/...',",
-          "    ],",
-          ")");
-    }
+    scratch.overwriteFile(
+        TestConstants.TOOLS_REPOSITORY_SCRATCH
+            + "tools/allowlists/function_transition_allowlist/BUILD",
+        "package_group(",
+        "    name = 'function_transition_allowlist',",
+        "    packages = [",
+        "        'public',",
+        "    ],",
+        ")");
     scratch.file(
         "test/build_settings.bzl",
         "def _impl(ctx):",

--- a/src/test/shell/integration/starlark_configurations_test.sh
+++ b/src/test/shell/integration/starlark_configurations_test.sh
@@ -740,7 +740,7 @@ EOF
 
   bazel build //$pkg:demo >& "$TEST_log" && fail "Expected failure"
   expect_not_log "crashed due to an internal error"
-  expect_log "`cfg` must be set to a transition appropriate for a rule"
+  expect_log "`cfg` must be set to a transition object initialized by the transition() function"
 }
 
 run_suite "${PRODUCT_NAME} starlark configurations tests"


### PR DESCRIPTION
Following commits were cleanly cherry-picked:

e4c7cb6ecb  ilist@google.com	 Support incoming configuration transition in extended rules
faa2f3d6a1  ilist@google.com	 Support subrules in extended rules
d70d198e92  ilist@google.com	 Add an escape hatch for any type attributes in the initializer
c00c272097  ilist@google.com	 Cleanup incoming configuration transitions on Starlark rules
82a469ffc0  ilist@google.com	 Copy and lift labels in arguments of initializers
6733c1844b  ilist@google.com	 Remove unused OBJECT_LIST type
e7a3dabfb6  ilist@google.com	 Remove unused FILESET_ENTRY label class
c95999046a  ilist@google.com	 Implement type checks and label conversion for Starlark values
c4f4073aa8  ilist@google.com	 Move convertFromBuildLangType into BuildType class

Additional commit "Define function_transition_allowlist in StarlarkRuleClassFunctionsTest" just fixes the mocking of the the tests.