### PR TITLE
Don't print all subcommands in `assert_build`.

### DIFF
--- a/src/test/shell/testenv.sh.tmpl
+++ b/src/test/shell/testenv.sh.tmpl
@@ -699,7 +699,7 @@ function cleanup() {
 # Simples assert to make the tests more readable
 #
 function assert_build() {
-  bazel build -s --verbose_failures $* || fail "Failed to build $*"
+  bazel build --verbose_failures $* || fail "Failed to build $*"
 }
 
 function assert_build_output() {


### PR DESCRIPTION
This just clogs up the logs, since `--verbose_failures` is present the failing command lines will still show.