### PR TITLE
Re-disable android_instrumentation_test_integration_test on macOS.

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -216,6 +216,11 @@ tasks:
       - "-//src/test/shell/bazel:bazel_determinism_test"
       # https://github.com/bazelbuild/bazel/issues/17457
       - "-//src/test/shell/bazel:jdeps_test"
+      # Macs can't find python, so these fail: https://github.com/bazelbuild/bazel/issues/18776
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
+      - "-//src/test/shell/bazel/android:aapt_integration_test"
+      - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
     include_json_profile:
       - build
       - test
@@ -266,6 +271,11 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"
       # https://github.com/bazelbuild/bazel/issues/17007
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
+      # Macs can't find python, so these fail: https://github.com/bazelbuild/bazel/issues/18776
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
+      - "-//src/test/shell/bazel/android:aapt_integration_test"
+      - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -220,6 +220,11 @@ tasks:
   #     - "-//src/test/shell/bazel:bazel_determinism_test"
   #     # https://github.com/bazelbuild/bazel/issues/17457
   #     - "-//src/test/shell/bazel:jdeps_test"
+  #     # Macs can't find python, so these fail: https://github.com/bazelbuild/bazel/issues/18776
+  #     - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
+  #     - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
+  #     - "-//src/test/shell/bazel/android:aapt_integration_test"
+  #     - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
   #   include_json_profile:
   #     - build
   #     - test
@@ -324,6 +329,11 @@ tasks:
   #     - "-//src/test/shell/bazel:bazel_repository_cache_test"
   #     - "-//src/test/shell/integration:aquery_test"
   #     - "-//src/test/shell/integration:py_args_escaping_test"
+  #     # Macs can't find python, so these fail: https://github.com/bazelbuild/bazel/issues/18776
+  #     - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
+  #     - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
+  #     - "-//src/test/shell/bazel/android:aapt_integration_test"
+  #     - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
   #   include_json_profile:
   #     - build
   #     - test


### PR DESCRIPTION
Still seeing problems with finding python: https://buildkite.com/bazel/bazel-bazel/builds/25852#018c37b0-3cb4-4829-826b-eced53b34e5f

Part of #20437 and #18776.