### PR TITLE
[7.0.0] Add more details to the warning message in --keep_going mode

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/analysis/BuildViewTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BuildViewTest.java
@@ -1066,9 +1066,9 @@ public class BuildViewTest extends BuildViewTestBase {
     assertContainsEvent("in cc_library rule //cycle:foo: cycle in dependency graph:");
     assertContainsEvent("in cc_library rule //cycle:bas: cycle in dependency graph:");
     assertContainsEvent(
-        "errors encountered while analyzing target '//cycle:foo': it will not be built");
+        "errors encountered while analyzing target '//cycle:foo', it will not be built");
     assertContainsEvent(
-        "errors encountered while analyzing target '//cycle:bat': it will not be built");
+        "errors encountered while analyzing target '//cycle:bat', it will not be built");
     // With interleaved loading and analysis, we can no longer distinguish loading-phase cycles
     // and analysis-phase cycles. This was previously reported as a loading-phase cycle, as it
     // happens with any configuration (cycle is hard-coded in the BUILD files). Also see the


### PR DESCRIPTION
The current message is too generic and not helpful for the user.

```
Before:
WARNING: errors encountered while analyzing target '//:bin': it will not be built

---
After:
WARNING: errors encountered while analyzing target '//:bin', it will not be built.
Target //:bin is incompatible and cannot be built, but was explicitly requested.
Dependency chain:
    //:bin (8250b5)   <-- target platform (@@local_config_platform//:host) didn't satisfy constraint @@platforms//:incompatible

```

Fixes https://github.com/bazelbuild/bazel/issues/20443

Commit https://github.com/bazelbuild/bazel/commit/c5493b9557502fe6ec48e78b0b5f06f4c1d75238

PiperOrigin-RevId: 588363260
Change-Id: I70e151cd9baa6a0dd7b307b7ddeb9f43ee30b526