### PR TITLE
Re-enable minimal_jdk_test with a higher tolerance

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -227,7 +227,6 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"
       - "-//src/test/java/com/google/devtools/build/lib/rules/objc:BazelJ2ObjcLibraryTest"
       - "-//src/test/java/com/google/devtools/build/lib/rules/cpp:CcToolchainTest"
-      - "-//src/test/shell/integration:minimal_jdk_test"
     include_json_profile:
       - build
       - test
@@ -293,7 +292,6 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"
       - "-//src/test/java/com/google/devtools/build/lib/rules/objc:BazelJ2ObjcLibraryTest"
       - "-//src/test/java/com/google/devtools/build/lib/rules/cpp:CcToolchainTest"
-      - "-//src/test/shell/integration:minimal_jdk_test"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -231,7 +231,6 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"
       - "-//src/test/java/com/google/devtools/build/lib/rules/objc:BazelJ2ObjcLibraryTest"
       - "-//src/test/java/com/google/devtools/build/lib/rules/cpp:CcToolchainTest"
-      - "-//src/test/shell/integration:minimal_jdk_test"
     include_json_profile:
       - build
       - test

--- a/src/test/shell/integration/minimal_jdk_test.sh
+++ b/src/test/shell/integration/minimal_jdk_test.sh
@@ -42,9 +42,9 @@ export BAZEL_SUFFIX="_jdk_minimal"
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-# Bazel's install base is < 370MB with minimal JDK and > 370MB with an all
+# Bazel's install base is < 450MB with minimal JDK and > 450MB with an all
 # modules JDK.
-function test_size_less_than_370MB() {
+function test_size_less_than_450MB() {
   bazel info
   ib=$(bazel info install_base)
   size=$(du -s "$ib" | cut -d\	 -f1)

--- a/src/test/shell/integration/minimal_jdk_test.sh
+++ b/src/test/shell/integration/minimal_jdk_test.sh
@@ -48,7 +48,7 @@ function test_size_less_than_450MB() {
   bazel info
   ib=$(bazel info install_base)
   size=$(du -s "$ib" | cut -d\	 -f1)
-  maxsize=$((1024*370))
+  maxsize=$((1024*450))
   if [ $size -gt $maxsize ]; then
     echo "$ib was too big:" 1>&2
     du -a "$ib" 1>&2


### PR DESCRIPTION
Re-enable `minimal_jdk_test` with a higher tolerance.