### PR TITLE
[6.5.0] Don't pass --add-opens= to javac

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java
@@ -303,7 +303,7 @@ final class JavaInfoBuildHelper {
         .addAll(
             JavaCommon.computePerPackageJavacOpts(
                 starlarkRuleContext.getRuleContext(), toolchainProvider))
-        .addAll(JavaModuleFlagsProvider.toFlags(addExports, addOpens))
+        .addAll(JavaModuleFlagsProvider.toFlags(addExports, /* addOpens = */ ImmutableList.of()))
         .addAll(tokenize(javacOpts));
 
     JavaLibraryHelper helper =

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.rules.java;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.rules.java.JavaCompileActionTestHelper.getJavacArguments;
 
+import com.google.common.base.Joiner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -143,5 +144,17 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
                     .reducedJars))
         .containsExactly(
             "bin java/com/google/test/libb-hjar.jar", "bin java/com/google/test/libc-hjar.jar");
+  }
+
+  @Test
+  public void testAddOpensNotPassedToJavac() throws Exception {
+    scratch.file(
+        "java/com/google/test/BUILD",
+        "java_library(name = 'a', srcs = ['A.java'], add_opens = ['java.base/java.lang'])");
+
+    JavaCompileAction action =
+        (JavaCompileAction) getGeneratingActionForLabel("//java/com/google/test:liba.jar");
+
+    assertThat(Joiner.on(" ").join(action.getArguments())).doesNotContain("--add-opens");
   }
 }


### PR DESCRIPTION
Backported from https://github.com/bazelbuild/bazel/commit/367994ab9f3bb8d06a39d6bd0c139f00dcf47f3e

Fixes https://github.com/bazelbuild/bazel/issues/20468