### PR TITLE
Add profiling to `remoteActionBuildingSemaphore.acquire()`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -538,7 +538,10 @@ public class RemoteExecutionService {
   /** Creates a new {@link RemoteAction} instance from spawn. */
   public RemoteAction buildRemoteAction(Spawn spawn, SpawnExecutionContext context)
       throws IOException, ExecException, ForbiddenActionInputException, InterruptedException {
-    remoteActionBuildingSemaphore.acquire();
+    try (SilentCloseable c =
+        Profiler.instance().profile(ProfilerTask.REMOTE_SETUP, "acquiring semaphore")) {
+      remoteActionBuildingSemaphore.acquire();
+    }
     try {
       // Create a remote path resolver that is aware of the spawn's path mapper, which rewrites
       // the paths of the inputs and outputs as well as paths appearing in the command line for

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1436,7 +1436,10 @@ public class RemoteExecutionService {
     // concurrency. This prevents memory exhaustion. We assume that
     // ensureInputsPresent() provides enough parallelism to saturate the
     // network connection.
-    remoteActionBuildingSemaphore.acquire();
+    try (SilentCloseable c =
+        Profiler.instance().profile(ProfilerTask.UPLOAD_TIME, "acquiring semaphore")) {
+      remoteActionBuildingSemaphore.acquire();
+    }
     try {
       MerkleTree merkleTree = action.getMerkleTree();
       if (merkleTree == null) {


### PR DESCRIPTION
Without this there can be large gaps in the profile when using remote execution that are hard to reason about.