### PR TITLE
update lockfile for 7.0.0

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -13,7 +13,7 @@
     "compatibilityMode": "ERROR"
   },
   "localOverrideHashes": {
-    "bazel_tools": "0cc38516259ab87144b82461dd874e139f093d8e356667c3a3c5a52441ac448f",
+    "bazel_tools": "922ea6752dc9105de5af957f7a99a6933c0a6a712d23df6aad16a9c399f7e787",
     "googleapis": "89bad67656f73e953cbf62f12165f56e97cf2cc17d56974c593de76200fa3471",
     "remoteapis": "3862bfbe3d308e71852b8f025f4b33ea9c0dc8790829eda4a71425c5a2ca814e"
   },
@@ -1864,7 +1864,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 13,
+            "line": 17,
             "column": 29
           },
           "imports": {
@@ -1882,7 +1882,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 17,
+            "line": 21,
             "column": 32
           },
           "imports": {
@@ -1899,7 +1899,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 20,
+            "line": 24,
             "column": 32
           },
           "imports": {
@@ -1921,7 +1921,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 31,
+            "line": 35,
             "column": 39
           },
           "imports": {
@@ -1938,7 +1938,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 35,
+            "line": 39,
             "column": 48
           },
           "imports": {
@@ -1955,7 +1955,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 38,
+            "line": 42,
             "column": 42
           },
           "imports": {
@@ -1977,6 +1977,7 @@
         "platforms": "platforms@0.0.8",
         "com_google_protobuf": "protobuf@21.7",
         "zlib": "zlib@1.3",
+        "build_bazel_apple_support": "apple_support@1.8.1",
         "local_config_platform": "local_config_platform@_"
       }
     },
@@ -2228,7 +2229,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_android_deps": {
       "general": {
-        "bzlTransitiveDigest": "GePZH6z20Bg8DBJJz2KRAeVWAUspcD8Fl2sAoNAktTg=",
+        "bzlTransitiveDigest": "DSeXJLRZhP/A/L6FhhbvcMg1auJWnRmHqERfXhXJwZY=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2247,10 +2248,10 @@
     },
     "//:extensions.bzl%bazel_build_deps": {
       "general": {
-        "bzlTransitiveDigest": "GePZH6z20Bg8DBJJz2KRAeVWAUspcD8Fl2sAoNAktTg=",
+        "bzlTransitiveDigest": "DSeXJLRZhP/A/L6FhhbvcMg1auJWnRmHqERfXhXJwZY=",
         "accumulatedFileDigests": {
-        "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "d1de0c7a82ede5b9126e764faf1e228c7ee518d86fc3d193b2b47640cacd535b",
-        "@@//:MODULE.bazel": "181678df5c28839fced02f5f546f99ae5a99c21eb263975d3244e17497b7064f"
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "d1de0c7a82ede5b9126e764faf1e228c7ee518d86fc3d193b2b47640cacd535b",
+          "@@//:MODULE.bazel": "181678df5c28839fced02f5f546f99ae5a99c21eb263975d3244e17497b7064f"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2505,7 +2506,7 @@
     },
     "//:extensions.bzl%bazel_test_deps": {
       "general": {
-        "bzlTransitiveDigest": "GePZH6z20Bg8DBJJz2KRAeVWAUspcD8Fl2sAoNAktTg=",
+        "bzlTransitiveDigest": "DSeXJLRZhP/A/L6FhhbvcMg1auJWnRmHqERfXhXJwZY=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2600,9 +2601,9 @@
         }
       }
     },
-    "@apple_support~1.8.1//crosstool:setup.bzl%apple_cc_configure_extension": {
+    "@@apple_support~1.8.1//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "7J0IA1pG+laSU0NHOBUkFCW3hv6qExIXQ/zkWQXzm0I=",
+        "bzlTransitiveDigest": "JFciz9+xRmE31CdyrcEUeZSKFxwiLTQ+PNMg6Bcc6s8=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2623,7 +2624,7 @@
         }
       }
     },
-    "@bazel_features~1.1.0//private:extensions.bzl%version_extension": {
+    "@@bazel_features~1.1.0//private:extensions.bzl%version_extension": {
       "general": {
         "bzlTransitiveDigest": "LKmXjK1avT44pRhO3x6Hplu1mU9qrNOaHP+/tJ0VFfE=",
         "accumulatedFileDigests": {},
@@ -2651,9 +2652,9 @@
         }
       }
     },
-    "@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
+    "@@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "4+Dj2H7maLh8JtpJKiuaI7PSXiIZw6oWX9xsVhnJ5DU=",
+        "bzlTransitiveDigest": "iz3RFYDcsjupaT10sdSPAhA44WL3eDYkTEnYThllj1w=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2662,8 +2663,8 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "name": "bazel_tools~remote_android_tools_extensions~android_tools",
-              "sha256": "1afa4b7e13c82523c8b69e87f8d598c891ec7e2baa41d9e24e08becd723edb4d",
-              "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.27.0.tar.gz"
+              "sha256": "2b661a761a735b41c41b3a78089f4fc1982626c76ddb944604ae3ff8c545d3c2",
+              "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.30.0.tar"
             }
           },
           "android_gmaven_r8": {
@@ -2671,16 +2672,16 @@
             "ruleClassName": "http_jar",
             "attributes": {
               "name": "bazel_tools~remote_android_tools_extensions~android_gmaven_r8",
-              "sha256": "ab1379835c7d3e5f21f80347c3c81e2f762e0b9b02748ae5232c3afa14adf702",
-              "url": "https://maven.google.com/com/android/tools/r8/8.0.40/r8-8.0.40.jar"
+              "sha256": "57a696749695a09381a87bc2f08c3a8ed06a717a5caa3ef878a3077e0d3af19d",
+              "url": "https://maven.google.com/com/android/tools/r8/8.1.56/r8-8.1.56.jar"
             }
           }
         }
       }
     },
-    "@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
+    "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "sftnIlf92nP/IUiWiMkgL9Sh8Drk9kKhTXHvoavVJZg=",
+        "bzlTransitiveDigest": "O9sf6ilKWU9Veed02jG9o2HM/xgV/UAyciuFBuxrFRY=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2701,9 +2702,9 @@
         }
       }
     },
-    "@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
+    "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "CtmyZVPtInM72JKIFfarSKOF0R/GbDRl8HBuOsRWhRs=",
+        "bzlTransitiveDigest": "Qh2bWTU6QW6wkrd87qrU4YeY+SG37Nvw3A0PR4Y0L2Y=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2719,7 +2720,7 @@
         }
       }
     },
-    "@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
+    "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "hp4NgmNjEg5+xgvzfh6L83bt9/aiiWETuNpwNuF1MSU=",
         "accumulatedFileDigests": {},
@@ -2735,9 +2736,9 @@
         }
       }
     },
-    "@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
+    "@@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "IWFtZ+6M0WGmNpfnHZMxnVFSDZ6pRTEWt7jixp7XffQ=",
+        "bzlTransitiveDigest": "cizrA62cv8WUgb0cCmx5B6PRijtr/I4TAWxg/4caNGU=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2755,9 +2756,9 @@
         }
       }
     },
-    "@gazelle~0.30.0//:extensions.bzl%go_deps": {
+    "@@gazelle~0.30.0//:extensions.bzl%go_deps": {
       "general": {
-        "bzlTransitiveDigest": "BoYvkoiu4JJx2ptGuMiFUuXn9wupdeJIWbn2MXOkBb8=",
+        "bzlTransitiveDigest": "qA0ex33bTMERZ7C8nXKz92cjvx42TwSWN1J1CSDT0K8=",
         "accumulatedFileDigests": {
           "@@rules_go~0.39.1//:go.sum": "022d36c9ebcc7b5dee1e9b85b3da9c9f3a529ee6f979946d66e4955b8d54614a",
           "@@rules_go~0.39.1//:go.mod": "a7143f329c2a3e0b983ce74a96c0c25b0d0c59d236d75f7e1b069aadd988d55e",
@@ -3017,7 +3018,7 @@
         }
       }
     },
-    "@gazelle~0.30.0//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
+    "@@gazelle~0.30.0//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "30wev+wJfzc4s72MCfbP9U8W+3Js2b+Xbo5ofgZbHw8=",
         "accumulatedFileDigests": {},
@@ -3043,9 +3044,9 @@
         }
       }
     },
-    "@grpc~1.48.1.bcr.1//bazel:grpc_deps.bzl%grpc_repo_deps_ext": {
+    "@@grpc~1.48.1.bcr.1//bazel:grpc_deps.bzl%grpc_repo_deps_ext": {
       "general": {
-        "bzlTransitiveDigest": "S5rdtWt3QVZgX2cP/Ot1NLUmlqgtcoz1cPNksEQYtFQ=",
+        "bzlTransitiveDigest": "nxHzYwbUjUMDeQq5bbYk2PqDj2Rteb4bkFZ770jZXZ8=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3347,9 +3348,9 @@
         }
       }
     },
-    "@grpc~1.48.1.bcr.1//bazel:grpc_extra_deps.bzl%grpc_extra_deps_ext": {
+    "@@grpc~1.48.1.bcr.1//bazel:grpc_extra_deps.bzl%grpc_extra_deps_ext": {
       "general": {
-        "bzlTransitiveDigest": "ALqwntEqKRNf03LlwK9t4Oh/flVzCF6ZWFL9xTX69uI=",
+        "bzlTransitiveDigest": "rL9a8acJqmUhFMIsYZNpaKrfuBBHUNMCxk2FbIUYZ1M=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3501,9 +3502,9 @@
         }
       }
     },
-    "@rules_go~0.39.1//go:extensions.bzl%go_sdk": {
+    "@@rules_go~0.39.1//go:extensions.bzl%go_sdk": {
       "general": {
-        "bzlTransitiveDigest": "baCc5Mc6nJAIoj3TovuW1bOINXCqP/9lOv0UCbAkhsk=",
+        "bzlTransitiveDigest": "gBJGz8DL9u8JFPOtmIrNHdEjOz0gTO2WfSYk7XPS03g=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3549,9 +3550,9 @@
         }
       }
     },
-    "@rules_go~0.39.1//go/private:extensions.bzl%non_module_dependencies": {
+    "@@rules_go~0.39.1//go/private:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "lISD5Aqr6V4eTUAf5oZ4MilfT1BSlMybWvnRzRfSmM4=",
+        "bzlTransitiveDigest": "y43a3cwEIWdeHkwWSeCkbDbXuHaYPPz9N8N0b4RgNT4=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3774,7 +3775,7 @@
         }
       }
     },
-    "@rules_graalvm~0.10.3//:extensions.bzl%graalvm": {
+    "@@rules_graalvm~0.10.3//:extensions.bzl%graalvm": {
       "general": {
         "bzlTransitiveDigest": "RNOMan/EiPbz5i2nh2YxhbeTAOvTd9ReDe7arDK0PeY=",
         "accumulatedFileDigests": {},
@@ -3805,9 +3806,9 @@
         }
       }
     },
-    "@rules_java~7.3.1//java:extensions.bzl%toolchains": {
+    "@@rules_java~7.3.1//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "dG4jIQsMv4/0WJErJQROWqdFbLDnAK+3CFEWkfbv9WM=",
+        "bzlTransitiveDigest": "KSu3EzOsgA5I4iHPuY9tSp974k847ZckOC2+AqHeN3U=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -4345,9 +4346,9 @@
         }
       }
     },
-    "@rules_jvm_external~5.2//:extensions.bzl%maven": {
+    "@@rules_jvm_external~5.2//:extensions.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "WAWsskOl4eHIskcL0TuHZGIMjV8sMJaAbAo2luMqofo=",
+        "bzlTransitiveDigest": "O2wrZVUk2BiYC47qy5RFwQi+BsKi2WFGxeywFsr4HPk=",
         "accumulatedFileDigests": {
           "@@//:maven_install.json": "cc25122f058cf9683ab23f43b25fe0142aaf79c4f99b74c84905f7d03220950b",
           "@@rules_jvm_external~5.2//:rules_jvm_external_deps_install.json": "3ab1f67b0de4815df110bc72ccd6c77882b3b21d3d1e0a84445847b6ce3235a3",
@@ -8110,9 +8111,9 @@
         }
       }
     },
-    "@rules_jvm_external~5.2//:non-module-deps.bzl%non_module_deps": {
+    "@@rules_jvm_external~5.2//:non-module-deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "QlnkwH7xmrau2+KLjoV5wWr0r3Ne+JfXhrHUVpwVloQ=",
+        "bzlTransitiveDigest": "/rh2kt+7d77UiyuaTMepsRWJdj6Aot4FxGP6oW8S+U0=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -8130,9 +8131,9 @@
         }
       }
     },
-    "@rules_python~0.26.0//python/extensions:pip.bzl%pip": {
+    "@@rules_python~0.26.0//python/extensions:pip.bzl%pip": {
       "os:osx,arch:aarch64": {
-        "bzlTransitiveDigest": "3iiHV+GZxb29EibXM58xw9ynl4eXer7LUeklMudK8c8=",
+        "bzlTransitiveDigest": "shSLRxSm2IldZrKYJQFQvQybGd4SIL6XQSPu84HpeJE=",
         "accumulatedFileDigests": {
           "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
         },
@@ -8175,7 +8176,7 @@
         }
       },
       "os:osx,arch:x86_64": {
-        "bzlTransitiveDigest": "a5tzIU8ui/JG1+hfqKNsm5DwhtSJ92Ik6fDbVsH+DLo=",
+        "bzlTransitiveDigest": "78B4TR2R7hyLdKqsk9J9c+QKXzs6+h9jxPpij/zjmhE=",
         "accumulatedFileDigests": {
           "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
         },
@@ -8218,7 +8219,7 @@
         }
       },
       "os:windows,arch:amd64": {
-        "bzlTransitiveDigest": "t9ERYX2zk37KX0zf2bB9xTaAJizBCbvGTkggUllVb6Y=",
+        "bzlTransitiveDigest": "1n3i6I4QaccRmHfapI0NgKddkJyR6/zBp0gptv/qmV0=",
         "accumulatedFileDigests": {
           "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
         },
@@ -8261,7 +8262,7 @@
         }
       },
       "os:linux,arch:amd64": {
-        "bzlTransitiveDigest": "pVKyjaQclFqcXU75ZG356yob20MIl6uJwB2dKrAmw0U=",
+        "bzlTransitiveDigest": "r06IxPoMys64H4SehNDLcinBWTvN8335IGht0hO/3RY=",
         "accumulatedFileDigests": {
           "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
         },
@@ -8304,9 +8305,9 @@
         }
       }
     },
-    "@rules_python~0.26.0//python/extensions:python.bzl%python": {
+    "@@rules_python~0.26.0//python/extensions:python.bzl%python": {
       "general": {
-        "bzlTransitiveDigest": "xlkyXQiU87j2f+jKiO4buHXyNexVt0a6ildROtqkRMA=",
+        "bzlTransitiveDigest": "um1PsPhf8NOD6Qkf5ix7Gf2asyhE3Fl6J5gEfPfNz/s=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -8594,9 +8595,9 @@
         }
       }
     },
-    "@rules_python~0.26.0//python/extensions/private:internal_deps.bzl%internal_deps": {
+    "@@rules_python~0.26.0//python/extensions/private:internal_deps.bzl%internal_deps": {
       "general": {
-        "bzlTransitiveDigest": "jUOfMQMD7xfqag93qbgPiLoApHOns1ZshqQ1V21x5Kc=",
+        "bzlTransitiveDigest": "CKx26MNlWNsr4E/LYsW92dGknfpBmnJcBaDZkHl3AgI=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {


### PR DESCRIPTION
After 7ddf29697cc4da29143b0bf31eeae64b0dc0bd42, CI runs started failing because our lockfile is now out-of-date (as in, it's not keeping track with the latest .bazelversion file).