### PR TITLE
Added missing incompatible_strip_executable_safely to exec platforms

### DIFF
--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -394,6 +394,7 @@ bazel_fragments["ObjcCommandLineOptions"] = fragment(
         "//command_line_option:incompatible_avoid_hardcoded_objc_compilation_flags",
         "//command_line_option:incompatible_disallow_sdk_frameworks_attributes",
         "//command_line_option:incompatible_objc_alwayslink_by_default",
+        "//command_line_option:incompatible_strip_executable_safely",
     ],
 )
 


### PR DESCRIPTION
Fixes //src/test/java/com/google/devtools/build/lib/analysis:AnalysisTests test fail introduced in 104a711ae1772be62b6034506d51c5fee486b589