### PR TITLE
Remove Bazel 6 workarounds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,9 +14,6 @@ build:remote_shared --tool_java_runtime_version=rbe_jdk
 build:remote_shared --noexperimental_check_desugar_deps
 
 # Configuration to build and test Bazel on RBE on Ubuntu 18.04 with Java 11
-# Workaround for https://github.com/bazelbuild/bazel/issues/19837.
-# TODO(bazel-team): Remove this toolchain when .bazelversion is 7.0.0rc2 or later.
-build:ubuntu2004_java11 --extra_toolchains=//:bazel_rbe_java_toolchain_definition
 build:ubuntu2004_java11 --extra_toolchains=@rbe_ubuntu2004_java11//java:all
 build:ubuntu2004_java11 --crosstool_top=@rbe_ubuntu2004_java11//cc:toolchain
 build:ubuntu2004_java11 --extra_toolchains=@rbe_ubuntu2004_java11//config:cc-toolchain

--- a/BUILD
+++ b/BUILD
@@ -285,20 +285,3 @@ REMOTE_PLATFORMS = ("rbe_ubuntu2004_java11",)
     )
     for platform_name in REMOTE_PLATFORMS
 ]
-
-# Workaround for https://github.com/bazelbuild/bazel/issues/19837.
-# TODO(bazel-team): Remove these two targets when .bazelversion is 7.0.0rc2 or later.
-default_java_toolchain(
-    name = "bazel_java_toolchain",
-    bootclasspath = ["@rules_java//toolchains:platformclasspath"],
-    source_version = "11",
-    tags = ["manual"],
-    target_version = "11",
-)
-
-default_java_toolchain(
-    name = "bazel_rbe_java_toolchain",
-    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
-    source_version = "11",
-    target_version = "11",
-)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -307,6 +307,7 @@ gvm.graalvm(
     version = "20.0.2",
 )
 use_repo(gvm, "graalvm_toolchains")
+
 register_toolchains("@graalvm_toolchains//:gvm")
 
 # =========================================
@@ -320,10 +321,6 @@ register_toolchains("@bazel_tools//tools/python:autodetecting_toolchain")
 register_toolchains("@local_config_winsdk//:all")
 
 register_toolchains("//src/main/res:empty_rc_toolchain")
-
-# Workaround for https://github.com/bazelbuild/bazel/issues/19837.
-# TODO(bazel-team): Remove when .bazelversion is 7.0.0rc2 or later.
-register_toolchains("//:bazel_java_toolchain_definition")
 
 # =========================================
 # Android tools dependencies

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "181678df5c28839fced02f5f546f99ae5a99c21eb263975d3244e17497b7064f",
+  "moduleFileHash": "40a8230b8e83c355a617701c5c9ed2df3932ab037d3b4ad036dc056738bcf888",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -30,8 +30,7 @@
         "@graalvm_toolchains//:gvm",
         "@bazel_tools//tools/python:autodetecting_toolchain",
         "@local_config_winsdk//:all",
-        "//src/main/res:empty_rc_toolchain",
-        "//:bazel_java_toolchain_definition"
+        "//src/main/res:empty_rc_toolchain"
       ],
       "extensionUsages": [
         {
@@ -332,7 +331,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 333,
+                "line": 330,
                 "column": 22
               }
             }
@@ -580,7 +579,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 355,
+            "line": 352,
             "column": 35
           },
           "imports": {
@@ -597,7 +596,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 358,
+            "line": 355,
             "column": 42
           },
           "imports": {
@@ -2251,7 +2250,7 @@
         "bzlTransitiveDigest": "DSeXJLRZhP/A/L6FhhbvcMg1auJWnRmHqERfXhXJwZY=",
         "accumulatedFileDigests": {
           "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "7fd09363e734c78e66a87157b9baab177a58dec56bc8645ecc084ef3eff14360",
-          "@@//:MODULE.bazel": "181678df5c28839fced02f5f546f99ae5a99c21eb263975d3244e17497b7064f"
+          "@@//:MODULE.bazel": "40a8230b8e83c355a617701c5c9ed2df3932ab037d3b4ad036dc056738bcf888"
         },
         "envVariables": {},
         "generatedRepoSpecs": {


### PR DESCRIPTION
The workarounds are no longer relevant with Bazel 7.0.0 in `.bazelversion`.