### PR TITLE
[6.5.0] Add profiling to `remoteActionBuildingSemaphore.acquire()`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -517,7 +517,10 @@ public class RemoteExecutionService {
   /** Creates a new {@link RemoteAction} instance from spawn. */
   public RemoteAction buildRemoteAction(Spawn spawn, SpawnExecutionContext context)
       throws IOException, ExecException, ForbiddenActionInputException, InterruptedException {
-    remoteActionBuildingSemaphore.acquire();
+    try (SilentCloseable c =
+        Profiler.instance().profile(ProfilerTask.REMOTE_SETUP, "acquiring semaphore")) {
+      remoteActionBuildingSemaphore.acquire();
+    }
     try {
       ToolSignature toolSignature = getToolSignature(spawn, context);
       final MerkleTree merkleTree = buildInputMerkleTree(spawn, context, toolSignature);
@@ -1460,7 +1463,10 @@ public class RemoteExecutionService {
     // concurrency. This prevents memory exhaustion. We assume that
     // ensureInputsPresent() provides enough parallelism to saturate the
     // network connection.
-    remoteActionBuildingSemaphore.acquire();
+    try (SilentCloseable c =
+        Profiler.instance().profile(ProfilerTask.UPLOAD_TIME, "acquiring semaphore")) {
+      remoteActionBuildingSemaphore.acquire();
+    }
     try {
       MerkleTree merkleTree = action.getMerkleTree();
       if (merkleTree == null) {


### PR DESCRIPTION
Without this there can be large gaps in the profile when using remote execution that are hard to reason about.

Closes #20474.

Commit https://github.com/bazelbuild/bazel/commit/75fffbf1bc55bf58f358d98802c2eeb9001553cd

PiperOrigin-RevId: 590475989
Change-Id: Ic6e042c36f85e8098a468c73c62bd45cc367423e