### PR TITLE
[6.5.0] RemoteSpawnRunner: record inbetween phases in timing profile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.devtools.build.lib.profiler.ProfilerTask.PROCESS_TIME;
+import static com.google.devtools.build.lib.profiler.ProfilerTask.FETCH;
 import static com.google.devtools.build.lib.profiler.ProfilerTask.REMOTE_DOWNLOAD;
 import static com.google.devtools.build.lib.profiler.ProfilerTask.REMOTE_EXECUTION;
 import static com.google.devtools.build.lib.profiler.ProfilerTask.REMOTE_QUEUE;
@@ -334,16 +335,34 @@ public class RemoteSpawnRunner implements SpawnRunner {
         "queue");
     logProfileTask(
         converter,
+        executedActionMetadata.getWorkerStartTimestamp(),
+        executedActionMetadata.getInputFetchStartTimestamp(),
+        REMOTE_SETUP,
+        "pre-fetch");
+    logProfileTask(
+        converter,
         executedActionMetadata.getInputFetchStartTimestamp(),
         executedActionMetadata.getInputFetchCompletedTimestamp(),
-        REMOTE_SETUP,
+        FETCH,
         "fetch");
+    logProfileTask(
+        converter,
+        executedActionMetadata.getInputFetchCompletedTimestamp(),
+        executedActionMetadata.getExecutionStartTimestamp(),
+        REMOTE_SETUP,
+        "pre-execute");
     logProfileTask(
         converter,
         executedActionMetadata.getExecutionStartTimestamp(),
         executedActionMetadata.getExecutionCompletedTimestamp(),
         PROCESS_TIME,
         "execute");
+    logProfileTask(
+        converter,
+        executedActionMetadata.getExecutionCompletedTimestamp(),
+        executedActionMetadata.getOutputUploadStartTimestamp(),
+        REMOTE_SETUP,
+        "pre-upload");
     logProfileTask(
         converter,
         executedActionMetadata.getOutputUploadStartTimestamp(),


### PR DESCRIPTION
After an action was executed remotely, RemoteSpawnRunner would use the timestamps in the execution metadata to record appropriate timing phases into the JSON profile.

However, there are durations in-between the existing phases that are unaccounted for. Depending on the RBE server implemenation, these phases could mean different things:
- Sandbox preparation
- Cleaning up sandbox environments post-execution
- Others

Missing these durations inside the timing profile would cause confusion to end users as it would be interpreted as nothing happened in between the existing phases.

Add these durations into the profile as "pre-X" phases so that user is aware of activities could still be happening during that time. RBE server implementation should be able to alter these label programmatically if necessary.

Closes #20387.

Commit https://github.com/bazelbuild/bazel/commit/fe9e9e04cbc7174fc33fa18810ff6647766100c4

PiperOrigin-RevId: 590816782
Change-Id: I2bee36be928db24a14fab18bc519c3893723b7d6