### PR TITLE
`java_binary` wrapper should forward `restricted_to`

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_binary_wrapper.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary_wrapper.bzl
@@ -120,6 +120,7 @@ _DEPLOY_JAR_RULE_ATTRS = {key: None for key in [
     "testonly",
     "tags",
     "compatible_with",
+    "restricted_to",
     "target_compatible_with",
 ]}
 


### PR DESCRIPTION
Otherwise, the synthetic deploy jar target won't be buildable if the `java_binary` has `restricted_to` set to a non-default value. For example, consider the following top-level `BUILD` file.
```
environment_group(
    name = "foo-env",
    defaults = [
        "foo-default",
    ],
    environments = [
        "foo-default",
        "foo-custom",
    ],
)

environment(
    name = "foo-default",
)

environment(
    name = "foo-custom",
)

java_binary(
    name = "foo",
    create_executable = False,
    restricted_to = ["foo-custom"],
)
```

With Bazel 7, one gets an error when building the synthetic `foo_deployjars_internal_rule`.
```
> bazel build //:foo_deployjars_internal_rule
ERROR: /Users/tgeng/tmp/java_playground/BUILD:20:12: in deploy_jars_nonexec rule //:foo_deployjars_internal_rule: dependency //:foo doesn't support expected environment: //:foo-default
ERROR: /Users/tgeng/tmp/java_playground/BUILD:20:12: in deploy_jars_nonexec rule //:foo_deployjars_internal_rule: the current command line flags disqualify all supported environments because of incompatible select() paths:
 
  environment: //:foo-default
    removed by: //:foo_deployjars_internal_rule (/Users/tgeng/tmp/java_playground/BUILD:20:12)
    because of a select() that chooses dep: //:foo
    which lacks: //:foo-default

To see why, run: blaze build --target_environment=//:foo-default //:foo
ERROR: /Users/tgeng/tmp/java_playground/BUILD:20:12: Analysis of target '//:foo_deployjars_internal_rule' failed
ERROR: Analysis of target '//:foo_deployjars_internal_rule' failed; build aborted
INFO: Elapsed time: 0.070s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```
