### PR TITLE
[7.0.1] Auto-create deploy jars for Bazel `java_test` targets if requested

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.packages.BuiltinRestriction;
 import com.google.devtools.build.lib.starlarkbuildapi.java.JavaConfigurationApi;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -113,6 +114,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   private final boolean multiReleaseDeployJars;
   private final boolean disallowJavaImportExports;
   private final boolean disallowJavaImportEmptyJars;
+  private final boolean autoCreateDeployJarForJavaTests;
 
   // TODO(dmarting): remove once we have a proper solution for #2539
   private final boolean useLegacyBazelJavaTest;
@@ -153,7 +155,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     this.multiReleaseDeployJars = javaOptions.multiReleaseDeployJars;
     this.disallowJavaImportExports = javaOptions.disallowJavaImportExports;
     this.disallowJavaImportEmptyJars = javaOptions.disallowJavaImportEmptyJars;
-
+    this.autoCreateDeployJarForJavaTests = javaOptions.autoCreateDeployJarForJavaTests;
     Map<String, Label> optimizers = javaOptions.bytecodeOptimizers;
     if (optimizers.size() != 1) {
       throw new InvalidConfigurationException(
@@ -545,4 +547,9 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     return experimentalEnableJspecify;
   }
 
+  @Override
+  public boolean autoCreateJavaTestDeployJars(StarlarkThread thread) throws EvalException {
+    BuiltinRestriction.failIfCalledOutsideBuiltins(thread);
+    return autoCreateDeployJarForJavaTests;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -592,6 +592,14 @@ public class JavaOptions extends FragmentOptions {
       help = "Enable experimental jspecify integration.")
   public boolean experimentalEnableJspecify;
 
+  @Option(
+      name = "experimental_java_test_auto_create_deploy_jar",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "DO NOT USE")
+  public boolean autoCreateDeployJarForJavaTests;
+
   @Override
   public FragmentOptions getExec() {
     // Note validation actions don't run in exec config, so no need copying flags related to that.

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaConfigurationApi.java
@@ -147,4 +147,10 @@ public interface JavaConfigurationApi extends StarlarkValue {
               + " optimizer into. Note that if split_bytecode_optimization_pass is set, this will"
               + " only change behavior if it is > 2.")
   int bytecodeOptimizationPassActions();
+
+  @StarlarkMethod(
+      name = "auto_create_java_test_deploy_jars",
+      useStarlarkThread = true,
+      documented = false)
+  boolean autoCreateJavaTestDeployJars(StarlarkThread thread) throws EvalException;
 }

--- a/src/main/starlark/builtins_bzl/common/java/java_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary.bzl
@@ -18,6 +18,7 @@ load(":common/cc/cc_common.bzl", "cc_common")
 load(":common/cc/cc_info.bzl", "CcInfo")
 load(":common/cc/semantics.bzl", cc_semantics = "semantics")
 load(":common/java/basic_java_library.bzl", "BASIC_JAVA_LIBRARY_IMPLICIT_ATTRS", "basic_java_library", "collect_deps")
+load(":common/java/java_binary_deploy_jar.bzl", "create_deploy_archive")
 load(":common/java/java_common.bzl", "java_common")
 load(
     ":common/java/java_common_internal_for_builtins.bzl",
@@ -266,8 +267,31 @@ def basic_java_binary(
 
     java_binary_info = to_java_binary_info(java_info)
 
+    internal_deploy_jar_info = InternalDeployJarInfo(
+        java_attrs = java_attrs,
+        launcher_info = struct(
+            runtime_jars = launcher_info.runtime_jars,
+            launcher = launcher_info.launcher,
+            unstripped_launcher = launcher_info.unstripped_launcher,
+        ),
+        shared_archive = shared_archive,
+        main_class = main_class,
+        coverage_main_class = coverage_main_class,
+        strip_as_default = strip_as_default,
+        stamp = ctx.attr.stamp,
+        hermetic = hasattr(ctx.attr, "hermetic") and ctx.attr.hermetic,
+        add_exports = add_exports,
+        add_opens = add_opens,
+        manifest_lines = ctx.attr.deploy_manifest_lines,
+    )
+
+    # "temporary" workaround for https://github.com/bazelbuild/intellij/issues/5845
+    extra_files = []
+    if is_test_rule_class and ctx.fragments.java.auto_create_java_test_deploy_jars():
+        extra_files.append(_auto_create_deploy_jar(ctx, internal_deploy_jar_info))
+
     default_info = struct(
-        files = files,
+        files = depset(extra_files, transitive = [files]),
         runfiles = runfiles,
         executable = executable,
     )
@@ -277,23 +301,7 @@ def basic_java_binary(
         "JavaInfo": java_binary_info,
         "InstrumentedFilesInfo": target["InstrumentedFilesInfo"],
         "JavaRuntimeClasspathInfo": java_common.JavaRuntimeClasspathInfo(runtime_classpath = java_info.transitive_runtime_jars),
-        "InternalDeployJarInfo": InternalDeployJarInfo(
-            java_attrs = java_attrs,
-            launcher_info = struct(
-                runtime_jars = launcher_info.runtime_jars,
-                launcher = launcher_info.launcher,
-                unstripped_launcher = launcher_info.unstripped_launcher,
-            ),
-            shared_archive = shared_archive,
-            main_class = main_class,
-            coverage_main_class = coverage_main_class,
-            strip_as_default = strip_as_default,
-            stamp = ctx.attr.stamp,
-            hermetic = hasattr(ctx.attr, "hermetic") and ctx.attr.hermetic,
-            add_exports = add_exports,
-            add_opens = add_opens,
-            manifest_lines = ctx.attr.deploy_manifest_lines,
-        ),
+        "InternalDeployJarInfo": internal_deploy_jar_info,
     }, default_info, jvm_flags
 
 def _collect_attrs(ctx, runtime_classpath, classpath_resources):
@@ -479,6 +487,43 @@ def _get_validations_from_target(target):
         return target[OutputGroupInfo]._validation
     else:
         return depset()
+
+# TODO: bazelbuild/intellij/issues/5845 - remove this once no longer required
+# this need not be completely identical to the regular deploy jar since we only
+# care about packaging the classpath
+def _auto_create_deploy_jar(ctx, info):
+    output = ctx.actions.declare_file(ctx.label.name + "_auto_deploy.jar")
+    java_attrs = info.java_attrs
+    runtime_classpath = depset(
+        direct = info.launcher_info.runtime_jars,
+        transitive = [
+            java_attrs.runtime_jars,
+            java_attrs.runtime_classpath_for_archive,
+        ],
+        order = "preorder",
+    )
+    create_deploy_archive(
+        ctx,
+        launcher = info.launcher_info.launcher,
+        runfiles = depset(),
+        main_class = info.main_class,
+        coverage_main_class = info.coverage_main_class,
+        resources = java_attrs.resources,
+        classpath_resources = java_attrs.classpath_resources,
+        runtime_classpath = runtime_classpath,
+        manifest_lines = info.manifest_lines,
+        build_info_files = [],
+        build_target = str(ctx.label),
+        output = output,
+        shared_archive = info.shared_archive,
+        one_version_level = ctx.fragments.java.one_version_enforcement_level,
+        one_version_allowlist = helper.check_and_get_one_version_attribute(ctx, "_one_version_allowlist"),
+        multi_release = ctx.fragments.java.multi_release_deploy_jars,
+        hermetic = info.hermetic,
+        add_exports = info.add_exports,
+        add_opens = info.add_opens,
+    )
+    return output
 
 BASIC_JAVA_BINARY_ATTRIBUTES = merge_attrs(
     BASIC_JAVA_LIBRARY_IMPLICIT_ATTRS,


### PR DESCRIPTION
This adds bazel support for fixing https://github.com/bazelbuild/intellij/issues/5845. Once released, the necessary changes will need to be made to the IntelliJ plugin.

PiperOrigin-RevId: 592136548
Change-Id: I6158f379e76b61e75ca51f34888aeecaf0303cc6

(cherry picked from commit 103830fd6431f0de7cc43fc5b5522c906f8fd076)

Fixes https://github.com/bazelbuild/bazel/issues/20601