### PR TITLE
[7.0.1] Mount user-specified bind mounts before Bazel's own magic.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -423,6 +423,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
     LinuxSandboxUtil.validateBindMounts(bindMounts);
     ImmutableList.Builder<BindMount> result = ImmutableList.builder();
+    bindMounts.forEach((k, v) -> result.add(BindMount.of(k, v)));
 
     if (sandboxTmp != null) {
       // First mount the real exec root and the empty directory created as the working dir of the
@@ -445,7 +446,6 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
       result.add(BindMount.of(tmpPath, sandboxTmp));
     }
 
-    bindMounts.forEach((k, v) -> result.add(BindMount.of(k, v)));
     return result.build();
   }
 


### PR DESCRIPTION
This makes it possible to mount directories under /tmp somewhere else. Before, /tmp was overridden by the implementation of hermetic /tmp.

Fixes #20527.

RELNOTES: None.
Commit https://github.com/bazelbuild/bazel/commit/3748084889d85b132e0a8371cb2ab1eafdc311da

PiperOrigin-RevId: 592247867
Change-Id: Ib5b75cd21ffe4fa4c8ee3f75d82894da6dd61f54