### PR TITLE
[7.0.1] Fix bootstrapped Bazel binary

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -1,5 +1,5 @@
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("//tools/build_rules:java_rules_skylark.bzl", "bootstrap_java_binary", "bootstrap_java_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
 # Description:
 #   The Java library builders, which are used by Bazel to compile Java
@@ -174,7 +174,6 @@ bootstrap_java_library(
     name = "starlark-deps",
     srcs = ["//:bootstrap-derived-java-srcs"],
     jars = [
-        "//third_party:auto_value-jars",
         "//:bootstrap-derived-java-jars",
         "//third_party:bootstrap_guava_and_error_prone-jars",
         "//third_party:jsr305-jars",
@@ -182,6 +181,7 @@ bootstrap_java_library(
         "//third_party/grpc-java:bootstrap-grpc-jars",
         "//third_party:tomcat_annotations_api-jars",
     ],
+    neverlink_jars = ["//third_party:auto_value-jars"],
     tags = ["manual"],
 )
 
@@ -213,6 +213,7 @@ bootstrap_java_binary(
         "javac/WerrorCustomOption.java",
     ],
     main_class = "com.google.devtools.build.buildjar.VanillaJavaBuilder",
+    neverlink_jars = ["//third_party:auto_value-jars"],
     tags = ["manual"],
     deps = [
         ":starlark-deps",

--- a/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
+++ b/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
@@ -104,11 +104,22 @@ function test_bootstrap() {
 
     env EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk" ./compile.sh \
         || fail "Expected to be able to bootstrap bazel. If you updated MODULE.bazel, see the NOTE in that file."
+
     ./output/bazel \
       --server_javabase=$JAVABASE --host_jvm_args=--add-opens=java.base/java.nio=ALL-UNNAMED \
       version --nognu_format &> "${TEST_log}" \
       || fail "Generated bazel not working"
     expect_log "${SOURCE_DATE_EPOCH}"
+
+    # TODO: make the build work without network and check for success
+    # the repo cache is currently missing:
+    # 1) canonical IDs
+    # 2) remote jdks & java_tools (if not using a custom java_toolchain)
+    ./output/bazel \
+      --server_javabase=$JAVABASE --host_jvm_args=--add-opens=java.base/java.nio=ALL-UNNAMED \
+      build --nobuild --repository_cache=derived/repository_cache \
+      //src:bazel_nojdk &> "${TEST_log}" || true
+    expect_not_log "FATAL: bazel crashed due to an internal error"
 }
 
 run_suite "bootstrap test"


### PR DESCRIPTION
For the bootstrap VanillaJavaBuilder, it is important that the AutoValue plugin classes do not end up in the deploy jar. If they do, the processor class is loaded from the app classloader (instead of the processor path classloader). When this happens, AutoValueProcessor uses the app classloader to load extensions (such as auto-value-gson needed by bzlmod), instead of the processor path classloader. Unless all extensions are also correctly present in the app classloder (i.e. in the VanillaJavaBuilder deploy jar), they won't be loaded.

Unfortunately, simply adding the jars to the deploy jar is insufficient, we need to also correctly merge the `META-INF/service/...` files as well, which does not happen in our bootstrap java_binary/java_library rules. So, to fix, we remove the auto value plugins from the deploy jar, and use them only to compile our sources that require them.

Added a regression test for the crash. We should probably improve it so that we can actually build with the bootstapped Bazel in tests without network access. But I don't think we need block this patch release on that.

Fixes https://github.com/bazelbuild/bazel/issues/20501

Commit https://github.com/bazelbuild/bazel/commit/2a2def82ba5f86d96ba49d4ae9dc7878f9329214

PiperOrigin-RevId: 592266992
Change-Id: I08ac91ee74140df0c4f22ad2553a8c017b497181