### PR TITLE
Improve repo mapping performance

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
@@ -67,12 +67,9 @@ public abstract class RepositoryMapping {
 
   private static RepositoryMapping createInternal(
       Map<String, RepositoryName> entries, RepositoryName ownerRepo) {
-    System.out.println("Creating inverse map!");
     Map<RepositoryName, String> inverseMap = new HashMap<>();
     for (Map.Entry<String, RepositoryName> entry : entries.entrySet()) {
-      if (!inverseMap.containsKey(entry.getValue())) {
-        inverseMap.put(entry.getValue(), entry.getKey());
-      }
+      inverseMap.putIfAbsent(entry.getValue(), entry.getKey());
     }
     return new AutoValue_RepositoryMapping(ImmutableMap.copyOf(entries), ImmutableMap.copyOf(inverseMap), ownerRepo);
   }


### PR DESCRIPTION
This solves the issue described here: https://github.com/bazelbuild/bazel/issues/20613

We replace linear search with a lookup into the inverted map that we store.

From reading the code this is always a single object so the memory increase should be neglible.

**How was it tested?**

I ran hyperfine before and after on the repro setup from the linked issue.

```
hyperfine 'bazel query --output streamed_proto "//external:all-targets + deps(//...:all-targets)"  --keep_going --enable_bzlmod &> /dev/null'
```
**before**
```
  Time (mean ± σ):     21.364 s ±  0.292 s    [User: 0.033 s, System: 0.068 s]
  Range (min … max):   20.870 s … 21.827 s    10 runs
```

**after**
```
  Time (mean ± σ):      1.347 s ±  1.654 s    [User: 0.028 s, System: 0.073 s]
  Range (min … max):    0.683 s …  5.914 s    10 runs
```