### PR TITLE
[7.0.1] Attempt to make main repo mapping inverse more efficient

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
@@ -126,14 +126,17 @@ public class RepositoryMappingFunction implements SkyFunction {
             .withAdditionalMappings(
                 ImmutableMap.of(
                     externalPackageValue.getPackage().getWorkspaceName(), RepositoryName.MAIN))
-            .withAdditionalMappings(additionalMappings);
+            .withAdditionalMappings(additionalMappings)
+            .withCachedInverseMap();
       }
 
       // Try and see if this is a repo generated from a Bazel module.
       Optional<RepositoryMappingValue> mappingValue =
           computeForBazelModuleRepo(repositoryName, bazelDepGraphValue);
       if (mappingValue.isPresent()) {
-        return mappingValue.get();
+        return repositoryName.isMain()
+            ? mappingValue.get().withCachedInverseMap()
+            : mappingValue.get();
       }
 
       // Now try and see if this is a repo generated from a module extension.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingValue.java
@@ -107,6 +107,17 @@ public abstract class RepositoryMappingValue implements SkyValue {
         getAssociatedModuleVersion());
   }
 
+  /**
+   * Replaces the inner {@link #getRepositoryMapping() repository mapping} with one returned by
+   * calling its {@link RepositoryMapping#withCachedInverseMap} method.
+   */
+  public final RepositoryMappingValue withCachedInverseMap() {
+    return new AutoValue_RepositoryMappingValue(
+        getRepositoryMapping().withCachedInverseMap(),
+        getAssociatedModuleName(),
+        getAssociatedModuleVersion());
+  }
+
   /** Returns the {@link Key} for {@link RepositoryMappingValue}s. */
   public static Key key(RepositoryName repositoryName) {
     return RepositoryMappingValue.Key.create(


### PR DESCRIPTION
During `bazel query`, `Label#getDisplayForm(mainRepoMapping)` might be called many many times. We can optimize for that case without sacrificing too much memory by computing a reverse mapping for the main repo mapping only.

Fixes https://github.com/bazelbuild/bazel/issues/20613.

Closes https://github.com/bazelbuild/bazel/pull/20617.

Commit https://github.com/bazelbuild/bazel/commit/d9169ab4deca6d533efe7b5f99c281d58cbeb638

PiperOrigin-RevId: 592607904
Change-Id: Iaaa709a51fe39556f03408080c1fe5e73689b761