### PR TITLE
[7.1.0] Use a larger buffer size for `java.util.zip.*Stream` classes

### DIFF
--- a/src/java_tools/singlejar/java/com/google/devtools/build/zip/ZipEntryInputStream.java
+++ b/src/java_tools/singlejar/java/com/google/devtools/build/zip/ZipEntryInputStream.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.zip;
 
 import com.google.devtools.build.zip.ZipFileEntry.Compression;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.Inflater;
@@ -24,6 +23,7 @@ import java.util.zip.ZipException;
 
 /** An input stream for reading the file data of a ZIP file entry. */
 class ZipEntryInputStream extends InputStream {
+  private static final int INFLATER_BUFFER_BYTES = 8192;
   private InputStream stream;
   private long rem;
 
@@ -61,7 +61,7 @@ class ZipEntryInputStream extends InputStream {
       rem = zipEntry.getSize();
     }
     if (!raw && zipEntry.getMethod() == Compression.DEFLATED) {
-      stream = new InflaterInputStream(stream, new Inflater(true));
+      stream = new InflaterInputStream(stream, new Inflater(true), INFLATER_BUFFER_BYTES);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryOutputStream.java
@@ -43,6 +43,8 @@ class GenQueryOutputStream extends OutputStream {
    */
   private static final int COMPRESSION_THRESHOLD = 1 << 20;
 
+  private static final int GZIP_BYTES_BUFFER = 8192;
+
   /**
    * Encapsulates the output of a {@link GenQuery}'s query. CPU and memory overhead of individual
    * methods depends on the underlying content and settings.
@@ -83,7 +85,7 @@ class GenQueryOutputStream extends OutputStream {
   GenQueryOutputStream(boolean compressedOutputRequested) throws IOException {
     this.compressedOutputRequested = compressedOutputRequested;
     if (compressedOutputRequested) {
-      this.out = new GZIPOutputStream(bytesOut);
+      this.out = new GZIPOutputStream(bytesOut, GZIP_BYTES_BUFFER);
       this.outputWasCompressed = true;
     } else {
       this.out = bytesOut;
@@ -138,7 +140,7 @@ class GenQueryOutputStream extends OutputStream {
     }
 
     ByteString.Output compressedBytesOut = ByteString.newOutput();
-    GZIPOutputStream gzipOut = new GZIPOutputStream(compressedBytesOut);
+    GZIPOutputStream gzipOut = new GZIPOutputStream(compressedBytesOut, GZIP_BYTES_BUFFER);
     bytesOut.writeTo(gzipOut);
     bytesOut = compressedBytesOut;
     out = gzipOut;


### PR DESCRIPTION
`DeflaterInputStream`, `GZIPInputStream`, `GZIPOutputStream`, and `InflaterInputStream`, all use an internal byte buffer of 512 bytes by default.

Whenever the wrapped stream exceeds this size, a full copy to a new buffer will occur, which will increase at increments of the same size. For example, a stream of length 2K will be copied four times. Increasing the size of the buffer we use can result in significant reductions in CPU usage (read: copies).

Examples in the repository
--------------------------

There are already two places where we increase the default size of these buffers:

- `//src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java`
- `//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java`

Prior art
---------

There is an open enhancement issue in the OpenJDK tracker on this which contains a benchmark for `InflaterOutputStream`:

> Increase the default, internal buffer size of the Streams in `java.util.zip`
> https://bugs.openjdk.org/browse/JDK-8242864

A similar change was merged in for JDK15+ in 2020:

> Improve performance of `InflaterOutputStream.write()`
> https://bugs.openjdk.org/browse/JDK-8242848

Providing a simple benchmark
----------------------------

I'm inlining a simple `jmh` benchmark and the results underneath it for one `GzipInputStream` case.

The benchmark:

```
@Fork(1)
@Threads(1)
@Warmup(iterations = 2)
@State(Scope.Benchmark)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
public class GZIPInputStreamBenchmark {
    @Param({"1024", "3072", "9216"})
    long inputLength;
    @Param({"512", "1024", "4096", "8192"})
    int bufferSize;
    private byte[] content;

    @Setup(Level.Iteration)
    public void setup() throws IOException {
        var baos = new ByteArrayOutputStream();
        // No need to set the buffer size on this as it's a one-time cost for setup and not counted in the result.
        var gzip = new GZIPOutputStream(baos);

        var inputBytes = generateRandomByteArrayOfLength(inputLength);
        gzip.write(inputBytes);
        gzip.finish();

        this.content = baos.toByteArray();
    }

    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    public void getGzipInputStream(Blackhole bh) throws IOException {
        try (var is = new ByteArrayInputStream(this.content);
             var gzip = new GZIPInputStream(is, bufferSize)) {
            bh.consume(gzip.readAllBytes());
        }
    }

    byte[] generateRandomByteArrayOfLength(long length) {
        var random = new Random();
        var intStream = random.ints(0, 5000).limit(length).boxed();

        return intStream.collect(
                ByteArrayOutputStream::new,
                (baos, i) -> baos.write(i.intValue()),
                (baos1, baos2) -> baos1.write(baos2.toByteArray(), 0, baos2.size())
        ).toByteArray();
    }
}
```

The results:

```
Benchmark                                    (bufferSize)  (inputLength)  Mode  Cnt      Score    Error  Units
GZIPInputStreamBenchmark.getGzipInputStream           512           1024  avgt    5   3207.217 ± 24.919  ns/op
GZIPInputStreamBenchmark.getGzipInputStream           512           3072  avgt    5   5874.191 ±  5.827  ns/op
GZIPInputStreamBenchmark.getGzipInputStream           512           9216  avgt    5  15567.345 ± 93.281  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          1024           1024  avgt    5   2580.566 ± 14.566  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          1024           3072  avgt    5   4154.582 ± 16.016  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          1024           9216  avgt    5   9942.521 ± 61.215  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          4096           1024  avgt    5   2150.255 ± 52.770  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          4096           3072  avgt    5   2289.185 ± 71.396  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          4096           9216  avgt    5   5656.891 ± 28.499  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          8192           1024  avgt    5   2177.427 ± 30.896  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          8192           3072  avgt    5   2517.390 ± 21.296  ns/op
GZIPInputStreamBenchmark.getGzipInputStream          8192           9216  avgt    5   5227.932 ± 55.525  ns/op
```

Co-authored-by: Kushal Pisavadia <kushal.p@apple.com>

Closes #20316.

Commit https://github.com/bazelbuild/bazel/commit/75a66937bb85270b35ff1b5e421be95dcf740a51

PiperOrigin-RevId: 588444920
Change-Id: I1fb47f0b08dcb8d72f3e2c43534c33d60efb87f2