### PR TITLE
[7.1.0] Ignore read-only errors when updating the `mtime` of the `install_base`

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1011,7 +1011,9 @@ static void EnsureCorrectRunningVersion(const StartupOptions &startup_options,
     // find install bases that haven't been used for a long time
     std::unique_ptr<blaze_util::IFileMtime> mtime(
         blaze_util::CreateFileMtime());
-    if (!mtime->SetToNow(blaze_util::Path(startup_options.install_base))) {
+    // Ignore permissions errors (i.e. if the install base is not writable):
+    if (!mtime->SetToNowIfPossible(
+            blaze_util::Path(startup_options.install_base))) {
       string err = GetLastErrorString();
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
           << "failed to set timestamp on '" << startup_options.install_base

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -48,6 +48,12 @@ class IFileMtime {
   // Returns true if the mtime was changed successfully.
   virtual bool SetToNow(const Path &path) = 0;
 
+  // Attempt to set the mtime of file under `path` to the current time.
+  //
+  // Returns true if the mtime was changed successfully OR if setting the mtime
+  // failed due to permissions errors.
+  virtual bool SetToNowIfPossible(const Path &path) = 0;
+
   // Sets the mtime of file under `path` to the distant future.
   // "Distant future" should be on the order of some years into the future, like
   // a decade.


### PR DESCRIPTION
Currently if the `--install_base` path passed is not writable by the user invoking Bazel, the Bazel client crashes:
```console
❯ bazel --install_base=/some/read/only/path version
FATAL: failed to set timestamp on '/some/read/only/path': (error: 30): Read-only file system
```

This happens because the Bazel client (unconditionally) attempts to update the `mtime` of this path:
https://github.com/bazelbuild/bazel/blob/a3c677dfea2de636a719d50345a5a97af96fae60/src/main/cpp/blaze.cc#L1010-L1021

This commit updates the client to ignore such errors. See #20373 for context.

Closes #20442.

Commit https://github.com/bazelbuild/bazel/commit/7f782e3c1a1c4a21beea19c2cedb614be8316e67

PiperOrigin-RevId: 591266054
Change-Id: If53e7cad48cb62406f7883f72b413e4b5a0bb8e2