### PR TITLE
[7.1.0] Accept labels of aliases in config_setting.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -497,10 +497,14 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
         } else if (target.satisfies(BuildSettingProvider.REQUIRE_BUILD_SETTING_PROVIDER)) {
           // build setting
           BuildSettingProvider provider = target.getProvider(BuildSettingProvider.class);
-          Object configurationValue =
-              optionDetails.getOptionValue(specifiedLabel) != null
-                  ? optionDetails.getOptionValue(specifiedLabel)
-                  : provider.getDefaultValue();
+
+          Object configurationValue;
+          if (optionDetails.getOptionValue(provider.getLabel()) != null) {
+            configurationValue = optionDetails.getOptionValue(provider.getLabel());
+          } else {
+            configurationValue = provider.getDefaultValue();
+          }
+
           Object convertedSpecifiedValue;
           try {
             // We don't need to supply a base package or repo mapping for the conversion here,

--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -2175,6 +2175,27 @@ public class ConfigSettingTest extends BuildViewTestCase {
   }
 
   @Test
+  public void aliasedStarlarkFlag() throws Exception {
+    scratch.file(
+        "test/flagdef.bzl",
+        "def _impl(ctx):",
+        "    return []",
+        "my_flag = rule(",
+        "    implementation = _impl,",
+        "    build_setting = config.string(flag = True))");
+
+    scratch.file(
+        "test/BUILD",
+        "load('//test:flagdef.bzl', 'my_flag')",
+        "my_flag(name = 'flag', build_setting_default = 'default')",
+        "alias(name = 'alias', actual = ':flag')",
+        "config_setting(name = 'alias_setting', flag_values = {':alias': 'specified'})");
+
+    useConfiguration(ImmutableMap.of("//test:flag", "specified"));
+    assertThat(getConfigMatchingProviderResultAsBoolean("//test:alias_setting")).isTrue();
+  }
+
+  @Test
   public void simpleStarlarkFlag() throws Exception {
     scratch.file(
         "test/flagdef.bzl",


### PR DESCRIPTION
Previously, if a config_setting referenced a Starlark setting through an alias, it was always evaluated as if the setting had its default value. Now, it is evaluated correctly.

This is done by looking up the value of the build setting in the configuration based on its own label as specified in BuildSettingProvider.

Fixes #13463 .

RELNOTES: None.
Commit https://github.com/bazelbuild/bazel/commit/d44c3f98f717328d399899005e6e5ed1263e9725

PiperOrigin-RevId: 585658985
Change-Id: Id534cd95282355f1143302bf703145bb53708a41