### PR TITLE
[7.1.0] DigestUtils: avoid throwing on invalid digest function name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
@@ -13,11 +13,13 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.util;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashCode;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -30,6 +32,7 @@ import com.google.protobuf.Message;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Arrays;
 
 /** Utility methods to work with {@link Digest}. */
 public class DigestUtil {
@@ -43,12 +46,13 @@ public class DigestUtil {
     this.digestFunction = getDigestFunctionFromHashFunction(hashFn);
   }
 
+  private static final ImmutableSet<String> DIGEST_FUNCTION_NAMES =
+      Arrays.stream(DigestFunction.Value.values()).map(Enum::name).collect(toImmutableSet());
+
   private static DigestFunction.Value getDigestFunctionFromHashFunction(DigestHashFunction hashFn) {
     for (String name : hashFn.getNames()) {
-      try {
+      if (DIGEST_FUNCTION_NAMES.contains(name)) {
         return DigestFunction.Value.valueOf(name);
-      } catch (IllegalArgumentException e) {
-        // continue.
       }
     }
     return DigestFunction.Value.UNKNOWN;


### PR DESCRIPTION
9% of samples in a profile of one of our builds were inside the `fillInStackTrace()` method. Collecting the valid names into a hashset avoids needing to construct errors every time an invalid digest function name is passed into this function.

Tested with Bazel 6.4.0. Our codebase is not yet compatible with Bazel 7.

I have not investigated why this function was receiving so many invalid names.

Before:

![Screenshot 2023-12-15 at 2 39 01 pm](https://github.com/bazelbuild/bazel/assets/18002432/be4bd311-ca73-46ec-a06d-93bb0ca9c6ba)

After:

![Screenshot 2023-12-15 at 2 43 10 pm](https://github.com/bazelbuild/bazel/assets/18002432/64b15739-538f-4752-aafd-6b2c94886595)

My understanding is that this will not speed up builds directly, but it will allow BEP events to be processed more quickly.

Closes #20574.

Commit https://github.com/bazelbuild/bazel/commit/cb08d62f26b152543130a8ec33e73cfbdcc2efb8

PiperOrigin-RevId: 592094151
Change-Id: Ie23241c9ec40e59ba2aac1fc83e4830340260f45