### PR TITLE
remote_cache_proxy -> remote_proxy in unix socket docs

### DIFF
--- a/site/en/remote/caching.md
+++ b/site/en/remote/caching.md
@@ -283,7 +283,7 @@ domain socket:
 
 ```posix-terminal
    build --remote_cache=http://{{ '<var>' }}your.host:port{{ '</var>' }}
-   build --remote_cache_proxy=unix:/{{ '<var>' }}path/to/socket{{ '</var>' }}
+   build --remote_proxy=unix:/{{ '<var>' }}path/to/socket{{ '</var>' }}
 ```
 
 This feature is unsupported on Windows.


### PR DESCRIPTION
Copied out of docs: https://bazel.build/remote/caching#unix-sockets

Got warning:
```
WARNING: Option 'remote_cache_proxy' is deprecated: Use --remote_proxy instead
```

Figured I might as well update the docs for the next person.