### PR TITLE
Offer Shell completion for top-level packages without subpackages

### DIFF
--- a/scripts/bash_completion_test.sh
+++ b/scripts/bash_completion_test.sh
@@ -794,4 +794,16 @@ test_workspace_boundary() {
                      'build //sub_repo/'
 }
 
+test_complete_root_package() {
+    mkdir pkgs_repo
+    touch pkgs_repo/WORKSPACE
+    cat > pkgs_repo/BUILD <<'EOF'
+cc_binary(name = "main")
+EOF
+    cd pkgs_repo 2>/dev/null
+
+    assert_expansion 'build //' \
+                     'build //:'
+}
+
 run_suite "Tests of bash completion of 'blaze' command."

--- a/scripts/bazel-complete-template.bash
+++ b/scripts/bazel-complete-template.bash
@@ -269,6 +269,14 @@ _bazel__expand_package_name() {
         fi
       fi
     done
+    # The loop over the compgen -d output above does not include the top-level
+    # package.
+    if [ -f $root$current/BUILD.bazel -o -f $root$current/BUILD ]; then
+      found=1
+      if [ "${type}" != "label-package" ]; then
+        echo "${current}:"
+      fi
+    fi
     [ $found -gt 0 ] && break  # Stop searching package path upon first match.
   done
 }


### PR DESCRIPTION
`bazel build //` now completes to `bazel build //:` when there are no packages beneath the top-level package. While this is mostly an edge case that doesn't apply to real projects, it will become more relevant when completion support is added for external repositories in a future PR.