### PR TITLE
Add `bazel mod dump_repo_mapping`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/BUILD
@@ -19,6 +19,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:inspection",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:module_extension",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:repo_rule_value",
+        "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/packages:label_printer",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModOptions.java
@@ -172,7 +172,8 @@ public class ModOptions extends OptionsBase {
     PATH(true),
     EXPLAIN(true),
     SHOW_REPO(false),
-    SHOW_EXTENSION(false);
+    SHOW_EXTENSION(false),
+    DUMP_REPO_MAPPING(false);
 
     /** Whether this subcommand produces a graph output. */
     private final boolean isGraph;

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
@@ -65,6 +65,7 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/java/net/starlark/java/eval",
         "//src/main/protobuf:failure_details_java_proto",
+        "//third_party:gson",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/mod.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/mod.txt
@@ -12,6 +12,7 @@ The command will display the external dependency graph or parts thereof, structu
     - explain <module>...: Prints all the places where the module is (or was) requested as a direct dependency, along with the reason why the respective final version was selected. It will display a pruned version of the `all_paths <module>...` command which only contains the direct deps of the root, the <module(s)> leaves, along with their dependants (can be modified with --depth).
     - show_repo <module>...: Prints the rule that generated the specified repos (i.e. http_archive()). The arguments may refer to extension-generated repos.
     - show_extension <extension>...: Prints information about the given extension(s). Usages can be filtered down to only those from modules in --extension_usage.
+    - dump_repo_mapping <canonical_repo_name>...: Prints the mappings from apparent repo names to canonical repo names for the given repos in NDJSON format. The order of entries within each JSON object is unspecified. This command is intended for use by tools such as IDEs and Starlark language servers.
 
 
 <module> arguments must be one of the following:
@@ -24,5 +25,7 @@ The command will display the external dependency graph or parts thereof, structu
     - @@<repo_name>: The canonical name of any repo. Unless otherwise specified, this must refer to a module, not an extension-generated repo.
 
 <extension> arguments must be of the form <module><label_to_bzl_file>%<extension_name>. For example, both rules_java//java:extensions.bzl%toolchains and @rules_java//java:extensions.bzl%toolchains are valid specifications of extensions.
+
+<canonical_repo_name> arguments are canonical repo names without any leading @ characters. The canonical repo name of the root module repository is the empty string.
 
 %{options}

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tests the mod command."""
 
+import json
 import os
 import tempfile
 from absl.testing import absltest
@@ -452,6 +453,64 @@ class ModCommandTest(test_base.TestBase):
         ' exist, available versions: [bar@2.0]. (Note that unused modules'
         " cannot be used here). Type 'bazel help mod' for syntax and help.",
         stderr,
+    )
+
+  def testDumpRepoMapping(self):
+    _, stdout, _ = self.RunBazel(
+      [
+        'mod',
+        'dump_repo_mapping',
+        '',
+        'foo~2.0',
+      ],
+    )
+    root_mapping, foo_mapping = [json.loads(l) for l in stdout]
+
+    self.assertContainsSubset(
+      {
+        "my_project": "",
+        "foo1": "foo~1.0",
+        "foo2": "foo~2.0",
+        "myrepo2": "ext2~1.0~ext~repo1",
+        "bazel_tools": "bazel_tools",
+      }.items(), root_mapping.items())
+
+    self.assertContainsSubset(
+      {
+        "foo": "foo~2.0",
+        "ext_mod": "ext~1.0",
+        "my_repo3": "ext~1.0~ext~repo3",
+        "bazel_tools": "bazel_tools",
+      }.items(), foo_mapping.items())
+
+  def testDumpRepoMappingThrowsNoRepos(self):
+    _, _, stderr = self.RunBazel(
+      ['mod', 'dump_repo_mapping'],
+      allow_failure=True,
+    )
+    self.assertIn(
+      "ERROR: No repository name(s) specified. Type 'bazel help mod' for syntax and help.",
+      stderr,
+    )
+
+  def testDumpRepoMappingThrowsInvalidRepoName(self):
+    _, _, stderr = self.RunBazel(
+      ['mod', 'dump_repo_mapping', '{}'],
+      allow_failure=True,
+    )
+    self.assertIn(
+      "ERROR: invalid repository name '{}': repo names may contain only A-Z, a-z, 0-9, '-', '_', '.' and '~' and must not start with '~'. Type 'bazel help mod' for syntax and help.",
+      stderr,
+    )
+
+  def testDumpRepoMappingThrowsUnknownRepoName(self):
+    _, _, stderr = self.RunBazel(
+      ['mod', 'dump_repo_mapping', 'does_not_exist'],
+      allow_failure=True,
+    )
+    self.assertIn(
+      "ERROR: Repositories not found: does_not_exist. Type 'bazel help mod' for syntax and help.",
+      stderr,
     )
 
 


### PR DESCRIPTION
`bazel mod dump_repo_mapping` with no arguments is explicitly made an
error so that a new mode that dumps all repository mappings with a
single Bazel invocation can be added later if needed, e.g. to support
IntelliJ's "sync" workflow.

RELNOTES: `bazel mod dump_repo_mapping <canonical repo name>...` returns
the repository mappings of the given repositories in NDJSON. This
information can be used by IDEs and Starlark language servers to resolve
labels with `--enable_bzlmod`.

Work towards #20631