### PR TITLE
Fix `constraint_value` link

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/exec_compatible_with.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/exec_compatible_with.html
@@ -4,7 +4,7 @@
 
 <p>
 A list of
-<code><a href="platform.html#constraint_value">constraint_values</a></code>
+<code><a href="platforms-and-toolchains#constraint_value">constraint_values</a></code>
 that must be present in the execution platform for this target. This is in
 addition to any constraints already set by the rule type. Constraints are used
 to restrict the list of available execution platforms. For more details, see

--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/target_compatible_with.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/target_compatible_with.html
@@ -4,7 +4,7 @@ List of <a href="${link build-ref#labels}">labels</a>; default is <code>[]</code
 
 <p>
 A list of
-<code><a href="platform.html#constraint_value">constraint_value</a></code>s
+<code><a href="platforms-and-toolchains#constraint_value">constraint_value</a></code>s
 that must be present in the target platform for this target to be considered
 <em>compatible</em>. This is in addition to any constraints already set by the
 rule type. If the target platform does not satisfy all listed constraints then

--- a/src/main/java/com/google/devtools/build/docgen/templates/be/functions.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/functions.vm
@@ -687,7 +687,7 @@ sh_binary(
   configuration conditions to matching values. Each condition is a label
   reference to
   a <code><a href="general.html#config_setting">config_setting</a></code> or
-  <code><a href="platform.html#constraint_value">constraint_value</a></code>,
+  <code><a href="platforms-and-toolchains#constraint_value">constraint_value</a></code>,
   which "matches" if the target's configuration matches an expected set of
   values. The value of <code>mytarget#srcs</code> then becomes whichever
   label list matches the current invocation.


### PR DESCRIPTION
platform.html does not exist (anymore)

it now points to: https://bazel.build/reference/be/platforms-and-toolchains#constraint_value