### PR TITLE
Add CUDA to IDE Autocomplete Section

### DIFF
--- a/site/en/install/ide.md
+++ b/site/en/install/ide.md
@@ -103,7 +103,7 @@ Eclipse projects.
 
 ## Autocomplete for Source Code {:#autocomplete-for-source-code}
 
-### C Language Family (C++, C, Objective-C, and Objective-C++)
+### C Language Family (C++, C, Objective-C, Objective-C++, and CUDA)
 
 [`hedronvision/bazel-compile-commands-extractor`](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete, smart navigation, quick fixes, and more in a wide variety of extensible editors, including VSCode, Vim, Emacs, Atom, and Sublime. It lets language servers, like clangd and ccls, and other types of tooling, draw upon Bazel's understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
 


### PR DESCRIPTION
Already supports it via clang; NVCC support will have landed by the time you read this.

Thanks for all you do,
Chris
(Compile commands extractor author and ex-Googler)