### PR TITLE
objc_import: add missing data argument

### DIFF
--- a/src/main/starlark/builtins_bzl/common/objc/objc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/objc_import.bzl
@@ -81,6 +81,7 @@ objc_import = rule(
     attrs = common_attrs.union(
         {
             "archives": attr.label_list(allow_empty = False, mandatory = True, allow_files = [".a"]),
+            "data": attr.label_list(allow_files = True),
         },
         common_attrs.ALWAYSLINK_RULE,
         common_attrs.CC_TOOLCHAIN_RULE,


### PR DESCRIPTION
Adding Bazel-core part as per @keith's suggestion in https://github.com/bazelbuild/bazel/issues/17018#issuecomment-1867977500

Prerequisite, https://github.com/bazelbuild/rules_apple/pull/2346, already landed.

Thanks!
Chris
(ex-Googler & [compile commands extractor](https://github.com/hedronvision/bazel-compile-commands-extractor) author)