### PR TITLE
[7.0.1] Disable PyTest.testSmoke on macOS

### DIFF
--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -46,6 +46,9 @@ class PyTest(test_base.TestBase):
         ])
 
   def testSmoke(self):
+    if test_base.TestBase.IsDarwin():
+      # Re-enable after fixing https://github.com/bazelbuild/bazel/issues/20660
+      return
     self.createSimpleFiles()
     _, stdout, _ = self.RunBazel(['run', '//a:a'])
     self.assertIn('Hello, World', stdout)


### PR DESCRIPTION
Due to https://github.com/bazelbuild/bazel/issues/20660

RELNOTES: None
Commit https://github.com/bazelbuild/bazel/commit/d9dc4fde4c8d06498f39b54a81d4e7fa1e5b5b30

PiperOrigin-RevId: 593115090
Change-Id: Ifc2a282dbd6dd8a3abfec987398388e5844af91c