### PR TITLE
[7.1.0] Improve `use_repo_rule` error when not referencing a `repository_rule`

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2448,7 +2448,35 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "load('@data//:data.bzl', self_data='data')",
         "data=self_data");
     scratch.file(
-        workspaceRoot.getRelative("repo.bzl").getPathString(), "data_repo = 3  # not a repo rule");
+        workspaceRoot.getRelative("repo.bzl").getPathString(),
+        "# not a repo rule",
+        "def data_repo(name):",
+        "    pass");
+
+    SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
+    reporter.removeHandler(failFastHandler);
+    EvaluationResult<BzlLoadValue> result =
+        evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertThat(result.getError().getException())
+        .hasMessageThat()
+        .contains(
+            "//:repo.bzl exports a value called data_repo of type function, yet a repository_rule"
+                + " is requested at /ws/MODULE.bazel");
+  }
+
+  @Test
+  public void innate_noSuchValue() throws Exception {
+    scratch.file(
+        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "data_repo = use_repo_rule('//:repo.bzl', 'data_repo')",
+        "data_repo(name='data', data='get up at 6am.')");
+    scratch.file(workspaceRoot.getRelative("BUILD").getPathString());
+    scratch.file(
+        workspaceRoot.getRelative("data.bzl").getPathString(),
+        "load('@data//:data.bzl', self_data='data')",
+        "data=self_data");
+    scratch.file(workspaceRoot.getRelative("repo.bzl").getPathString(), "");
 
     SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
     reporter.removeHandler(failFastHandler);


### PR DESCRIPTION
Makes the error message less confusing when referencing an existing symbol that happens to be a macro, not a repository rule.

Closes #20657.

Commit https://github.com/bazelbuild/bazel/commit/69fa6cb169e23c1b985bfa08ea8bc0b1f1199a63

PiperOrigin-RevId: 595434847
Change-Id: Ifc37a65685c0196301d79a439f3245037cf39e21