### PR TITLE
python: fix bazel py_test testSmoke for Python 3.11+

### DIFF
--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -28,7 +28,7 @@ class PyTest(test_base.TestBase):
         'a/BUILD',
         [
             'py_binary(name="a", srcs=["a.py"], deps=[":b"])',
-            'py_library(name="b", srcs=["b.py"])',
+            'py_library(name="b", srcs=["b.py"], imports=["."])',
         ])
 
     self.ScratchFile(

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -562,7 +562,7 @@ class TestBase(absltest.TestCase):
         ]
 
         if not allow_failure:
-          self.AssertExitCode(exit_code, 0, stderr_lines)
+          self.AssertExitCode(exit_code, 0, stderr_lines, stdout_lines)
 
         return exit_code, stdout_lines, stderr_lines
 


### PR DESCRIPTION
The test was failing because the `b.py` file couldn't be imported because, starting with Python 3.11, the `PYTHONSAFEPATH` environment variable (set by the bootstrap startup) is respected. This setting inhibits the default Python behavior of adding the main script's directory to sys.path.

To fix, use `py_library.imports` to explicitly add the necessary directory to `sys.path`.

Fixes https://github.com/bazelbuild/bazel/issues/20660