### PR TITLE
Fix bazel documentation for "http repository rules"

### DIFF
--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -40,6 +40,7 @@ Alternatively, you can directly call these repo rules in your MODULE.bazel file 
 ```python
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(name = "foo", urls = [...])
+```
 """
 
 load(


### PR DESCRIPTION
See https://bazel.build/rules/lib/repo/http, currently it is mostly one big code block. This PR closes a code fence which was accidentally left open