### PR TITLE
Let module extensions track calls to `Label()`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -1278,7 +1278,8 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     // environment across .bzl files. Hence, we opt for stack inspection.
     BazelModuleContext moduleContext = BazelModuleContext.ofInnermostBzlOrFail(thread, "Label()");
     try {
-      return Label.parseWithPackageContext((String) input, moduleContext.packageContext());
+      return Label.parseWithPackageContextRecordingRepoMapping((String) input,
+          moduleContext.packageContext(), thread.getThreadLocal(Label.RepoMappingRecorder.class));
     } catch (LabelSyntaxException e) {
       throw Starlark.errorf("invalid label in Label(): %s", e.getMessage());
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -1278,7 +1278,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     // environment across .bzl files. Hence, we opt for stack inspection.
     BazelModuleContext moduleContext = BazelModuleContext.ofInnermostBzlOrFail(thread, "Label()");
     try {
-      return Label.parseWithPackageContextRecordingRepoMapping((String) input,
+      return Label.parseWithPackageContext((String) input,
           moduleContext.packageContext(), thread.getThreadLocal(Label.RepoMappingRecorder.class));
     } catch (LabelSyntaxException e) {
       throw Starlark.errorf("invalid label in Label(): %s", e.getMessage());

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -222,6 +222,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:client_environment_function",
         "//src/main/java/com/google/devtools/build/lib/skyframe:client_environment_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:precomputed_value",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:repository_mapping_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:os",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -25,7 +25,6 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.Serializat
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
-import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -117,37 +116,5 @@ public abstract class BazelLockFileValue implements SkyValue, Postable {
       }
     }
     return moduleDiff.build();
-  }
-
-  /** Returns the differences between an extension and its locked data */
-  public ImmutableList<String> getModuleExtensionDiff(
-      ModuleExtensionId extensionId,
-      LockFileModuleExtension lockedExtension,
-      byte[] transitiveDigest,
-      boolean filesChanged,
-      ImmutableMap<String, String> envVariables,
-      ImmutableList<Map.Entry<ModuleKey, ModuleExtensionUsage>> extensionUsages,
-      ImmutableList<Map.Entry<ModuleKey, ModuleExtensionUsage>> lockedExtensionUsages) {
-
-    ImmutableList.Builder<String> extDiff = new ImmutableList.Builder<>();
-    if (!Arrays.equals(transitiveDigest, lockedExtension.getBzlTransitiveDigest())) {
-        extDiff.add(
-            "The implementation of the extension '"
-                + extensionId
-                + "' or one of its transitive .bzl files has changed");
-    }
-    if (filesChanged) {
-      extDiff.add("One or more files the extension '" + extensionId + "' is using have changed");
-    }
-    if (!extensionUsages.equals(lockedExtensionUsages)) {
-      extDiff.add("The usages of the extension '" + extensionId + "' have changed");
-    }
-    if (!envVariables.equals(lockedExtension.getEnvVariables())) {
-      extDiff.add(
-          "The environment variables the extension '"
-              + extensionId
-              + "' depends on (or their values) have changed");
-    }
-    return extDiff.build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -23,9 +23,12 @@ import static com.google.devtools.build.lib.bazel.bzlmod.DelegateTypeAdapterFact
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
 import com.google.devtools.build.lib.bazel.bzlmod.Version.ParseException;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -40,8 +43,10 @@ import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import net.starlark.java.syntax.Location;
 
@@ -92,7 +97,7 @@ public final class GsonTypeAdapterUtil {
       };
 
   public static final TypeAdapter<Label> LABEL_TYPE_ADAPTER =
-      new TypeAdapter<Label>() {
+      new TypeAdapter<>() {
         @Override
         public void write(JsonWriter jsonWriter, Label label) throws IOException {
           jsonWriter.value(label.getUnambiguousCanonicalForm());
@@ -101,6 +106,19 @@ public final class GsonTypeAdapterUtil {
         @Override
         public Label read(JsonReader jsonReader) throws IOException {
           return Label.parseCanonicalUnchecked(jsonReader.nextString());
+        }
+      };
+
+  public static final TypeAdapter<RepositoryName> REPOSITORY_NAME_TYPE_ADAPTER =
+      new TypeAdapter<>() {
+        @Override
+        public void write(JsonWriter jsonWriter, RepositoryName repoName) throws IOException {
+          jsonWriter.value(repoName.getName());
+        }
+
+        @Override
+        public RepositoryName read(JsonReader jsonReader) throws IOException {
+          return RepositoryName.createUnvalidated(jsonReader.nextString());
         }
       };
 
@@ -284,6 +302,68 @@ public final class GsonTypeAdapterUtil {
   }
 
   /**
+   * Converts Guava tables into a JSON array of 3-tuples (one per cell). Each 3-tuple is a JSON
+   * array itself (rowKey, columnKey, value).
+   */
+  public static final TypeAdapterFactory IMMUTABLE_TABLE =
+      new TypeAdapterFactory() {
+        @Nullable
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+          if (typeToken.getRawType() != ImmutableTable.class) {
+            return null;
+          }
+          Type type = typeToken.getType();
+          if (!(type instanceof ParameterizedType)) {
+            return null;
+          }
+          Type[] typeArgs = ((ParameterizedType) typeToken.getType()).getActualTypeArguments();
+          if (typeArgs.length != 3) {
+            return null;
+          }
+          var typeArgAdapters = Arrays.stream(typeArgs)
+              .map(t -> (TypeAdapter<Object>) gson.getAdapter(TypeToken.get(t)))
+              .collect(Collectors.toList());
+          if (typeArgAdapters.contains(null)) {
+            return null;
+          }
+          return (TypeAdapter<T>) new TypeAdapter<ImmutableTable<Object, Object, Object>>() {
+            @Override
+            public void write(JsonWriter jsonWriter, ImmutableTable<Object, Object, Object> t)
+                throws IOException {
+              jsonWriter.beginArray();
+              for (Table.Cell<Object, Object, Object> cell : t.cellSet()) {
+                jsonWriter.beginArray();
+                typeArgAdapters.get(0).write(jsonWriter, cell.getRowKey());
+                typeArgAdapters.get(1).write(jsonWriter, cell.getColumnKey());
+                typeArgAdapters.get(2).write(jsonWriter, cell.getValue());
+                jsonWriter.endArray();
+              }
+              jsonWriter.endArray();
+            }
+
+            @Override
+            public ImmutableTable<Object, Object, Object> read(JsonReader jsonReader)
+                throws IOException {
+              var builder = ImmutableTable.builder();
+              jsonReader.beginArray();
+              while (jsonReader.peek() != JsonToken.END_ARRAY) {
+                jsonReader.beginArray();
+                builder.put(
+                    typeArgAdapters.get(0).read(jsonReader),
+                    typeArgAdapters.get(1).read(jsonReader),
+                    typeArgAdapters.get(2).read(jsonReader));
+                jsonReader.endArray();
+              }
+              jsonReader.endArray();
+              return builder.buildOrThrow();
+            }
+          };
+        }
+      };
+
+  /**
    * A variant of {@link Location} that converts the absolute path to the root module file to a
    * constant and back.
    */
@@ -371,8 +451,10 @@ public final class GsonTypeAdapterUtil {
         .registerTypeAdapterFactory(IMMUTABLE_BIMAP)
         .registerTypeAdapterFactory(IMMUTABLE_SET)
         .registerTypeAdapterFactory(OPTIONAL)
+        .registerTypeAdapterFactory(IMMUTABLE_TABLE)
         .registerTypeAdapterFactory(new LocationTypeAdapterFactory(moduleFilePath))
         .registerTypeAdapter(Label.class, LABEL_TYPE_ADAPTER)
+        .registerTypeAdapter(RepositoryName.class, REPOSITORY_NAME_TYPE_ADAPTER)
         .registerTypeAdapter(Version.class, VERSION_TYPE_ADAPTER)
         .registerTypeAdapter(ModuleKey.class, MODULE_KEY_TYPE_ADAPTER)
         .registerTypeAdapter(ModuleExtensionId.class, MODULE_EXTENSION_ID_TYPE_ADAPTER)

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -303,7 +303,8 @@ public final class GsonTypeAdapterUtil {
 
   /**
    * Converts Guava tables into a JSON array of 3-tuples (one per cell). Each 3-tuple is a JSON
-   * array itself (rowKey, columnKey, value).
+   * array itself (rowKey, columnKey, value). For example, a JSON snippet could be: {@code
+   * [ ["row1", "col1", "value1"], ["row2", "col2", "value2"], ... ]}
    */
   public static final TypeAdapterFactory IMMUTABLE_TABLE =
       new TypeAdapterFactory() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -323,10 +323,10 @@ public final class GsonTypeAdapterUtil {
           if (typeArgs.length != 3) {
             return null;
           }
-          var typeArgAdapters = Arrays.stream(typeArgs)
-              .map(t -> (TypeAdapter<Object>) gson.getAdapter(TypeToken.get(t)))
-              .collect(Collectors.toList());
-          if (typeArgAdapters.contains(null)) {
+          var rowTypeAdapter = (TypeAdapter<Object>) gson.getAdapter(TypeToken.get(typeArgs[0]));
+          var colTypeAdapter = (TypeAdapter<Object>) gson.getAdapter(TypeToken.get(typeArgs[1]));
+          var valTypeAdapter = (TypeAdapter<Object>) gson.getAdapter(TypeToken.get(typeArgs[2]));
+          if (rowTypeAdapter == null || colTypeAdapter == null || valTypeAdapter == null) {
             return null;
           }
           return (TypeAdapter<T>) new TypeAdapter<ImmutableTable<Object, Object, Object>>() {
@@ -336,9 +336,9 @@ public final class GsonTypeAdapterUtil {
               jsonWriter.beginArray();
               for (Table.Cell<Object, Object, Object> cell : t.cellSet()) {
                 jsonWriter.beginArray();
-                typeArgAdapters.get(0).write(jsonWriter, cell.getRowKey());
-                typeArgAdapters.get(1).write(jsonWriter, cell.getColumnKey());
-                typeArgAdapters.get(2).write(jsonWriter, cell.getValue());
+                rowTypeAdapter.write(jsonWriter, cell.getRowKey());
+                colTypeAdapter.write(jsonWriter, cell.getColumnKey());
+                valTypeAdapter.write(jsonWriter, cell.getValue());
                 jsonWriter.endArray();
               }
               jsonWriter.endArray();
@@ -351,10 +351,8 @@ public final class GsonTypeAdapterUtil {
               jsonReader.beginArray();
               while (jsonReader.peek() != JsonToken.END_ARRAY) {
                 jsonReader.beginArray();
-                builder.put(
-                    typeArgAdapters.get(0).read(jsonReader),
-                    typeArgAdapters.get(1).read(jsonReader),
-                    typeArgAdapters.get(2).read(jsonReader));
+                builder.put(rowTypeAdapter.read(jsonReader), colTypeAdapter.read(jsonReader),
+                    valTypeAdapter.read(jsonReader));
                 jsonReader.endArray();
               }
               jsonReader.endArray();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
@@ -16,7 +16,9 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableTable;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.util.Optional;
@@ -32,7 +34,8 @@ public abstract class LockFileModuleExtension implements Postable {
 
   public static Builder builder() {
     return new AutoValue_LockFileModuleExtension.Builder()
-        .setModuleExtensionMetadata(Optional.empty());
+        .setModuleExtensionMetadata(Optional.empty())
+        .setRecordedRepoMappingEntries(ImmutableTable.of());
   }
 
   @SuppressWarnings("mutable")
@@ -45,6 +48,8 @@ public abstract class LockFileModuleExtension implements Postable {
   public abstract ImmutableMap<String, RepoSpec> getGeneratedRepoSpecs();
 
   public abstract Optional<ModuleExtensionMetadata> getModuleExtensionMetadata();
+
+  public abstract ImmutableTable<RepositoryName, String, RepositoryName> getRecordedRepoMappingEntries();
 
   public abstract Builder toBuilder();
 
@@ -61,6 +66,9 @@ public abstract class LockFileModuleExtension implements Postable {
     public abstract Builder setGeneratedRepoSpecs(ImmutableMap<String, RepoSpec> value);
 
     public abstract Builder setModuleExtensionMetadata(Optional<ModuleExtensionMetadata> value);
+
+    public abstract Builder setRecordedRepoMappingEntries(
+        ImmutableTable<RepositoryName, String, RepositoryName> value);
 
     public abstract LockFileModuleExtension build();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
@@ -57,6 +58,7 @@ import com.google.devtools.build.lib.skyframe.BzlLoadFailedException;
 import com.google.devtools.build.lib.skyframe.BzlLoadFunction;
 import com.google.devtools.build.lib.skyframe.BzlLoadValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
+import com.google.devtools.build.lib.skyframe.RepositoryMappingValue;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
@@ -158,14 +160,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       }
       try {
         SingleExtensionEvalValue singleExtensionEvalValue =
-            tryGettingValueFromLockFile(
-                env,
-                extensionId,
-                extension.getEvalFactors(),
-                extension.getEnvVars(),
-                usagesValue,
-                extension.getBzlTransitiveDigest(),
-                lockfile);
+            tryGettingValueFromLockFile(env, extensionId, extension, usagesValue, lockfile);
         if (singleExtensionEvalValue != null) {
           return singleExtensionEvalValue;
         }
@@ -204,6 +199,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                       .setEnvVariables(extension.getEnvVars())
                       .setGeneratedRepoSpecs(generatedRepoSpecs)
                       .setModuleExtensionMetadata(moduleExtensionMetadata)
+                      .setRecordedRepoMappingEntries(
+                          moduleExtensionResult.getRecordedRepoMappingEntries())
                       .build()));
     }
     return validateAndCreateSingleExtensionEvalValue(
@@ -221,10 +218,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
   private SingleExtensionEvalValue tryGettingValueFromLockFile(
       Environment env,
       ModuleExtensionId extensionId,
-      ModuleExtensionEvalFactors extensionFactors,
-      ImmutableMap<String, String> envVariables,
+      RunnableExtension extension,
       SingleExtensionUsagesValue usagesValue,
-      byte[] bzlTransitiveDigest,
       BazelLockFileValue lockfile)
       throws SingleExtensionEvalFunctionException,
           InterruptedException,
@@ -233,7 +228,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
 
     var lockedExtensionMap = lockfile.getModuleExtensions().get(extensionId);
     LockFileModuleExtension lockedExtension =
-        lockedExtensionMap == null ? null : lockedExtensionMap.get(extensionFactors);
+        lockedExtensionMap == null ? null : lockedExtensionMap.get(extension.getEvalFactors());
     if (lockedExtension == null) {
       if (lockfileMode.equals(LockfileMode.ERROR)) {
         throw new SingleExtensionEvalFunctionException(
@@ -241,7 +236,9 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                 Code.BAD_MODULE,
                 "The module extension '%s'%s does not exist in the lockfile",
                 extensionId,
-                extensionFactors.isEmpty() ? "" : " for platform " + extensionFactors),
+                extension.getEvalFactors().isEmpty()
+                    ? ""
+                    : " for platform " + extension.getEvalFactors()),
             Transience.PERSISTENT);
       }
       return null;
@@ -258,43 +255,129 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       throw new SingleExtensionEvalFunctionException(e, Transience.PERSISTENT);
     }
 
-    boolean filesChanged = didFilesChange(env, lockedExtension.getAccumulatedFileDigests());
-    // Check extension data in lockfile is still valid, disregarding usage information that is not
-    // relevant for the evaluation of the extension.
-    var trimmedLockedUsages = ModuleExtensionUsage.trimForEvaluation(lockedExtensionUsages);
-    var trimmedUsages = ModuleExtensionUsage.trimForEvaluation(usagesValue.getExtensionUsages());
-    if (!filesChanged
-        && Arrays.equals(bzlTransitiveDigest, lockedExtension.getBzlTransitiveDigest())
-        && trimmedUsages.equals(trimmedLockedUsages)
-        && envVariables.equals(lockedExtension.getEnvVariables())) {
+    LockedExtensionDiffDetector diffDetector = new LockedExtensionDiffDetector(/* recordDiffMessages= */
+        lockfileMode.equals(LockfileMode.ERROR));
+    diffDetector.detectDiffs(extensionId, env, extension, lockedExtension,
+        usagesValue.getExtensionUsages(), lockedExtensionUsages);
+    if (!diffDetector.anyDiffsDetected()) {
       return validateAndCreateSingleExtensionEvalValue(
           lockedExtension.getGeneratedRepoSpecs(),
           lockedExtension.getModuleExtensionMetadata(),
           extensionId,
           usagesValue,
           env);
-    } else if (lockfileMode.equals(LockfileMode.ERROR)) {
-      ImmutableList<String> extDiff =
-          lockfile.getModuleExtensionDiff(
-              extensionId,
-              lockedExtension,
-              bzlTransitiveDigest,
-              filesChanged,
-              envVariables,
-              trimmedUsages,
-              trimmedLockedUsages);
+    }
+    if (lockfileMode.equals(LockfileMode.ERROR)) {
       throw new SingleExtensionEvalFunctionException(
           ExternalDepsException.withMessage(
               Code.BAD_MODULE,
               "MODULE.bazel.lock is no longer up-to-date because: %s. "
                   + "Please run `bazel mod deps --lockfile_mode=update` to update your lockfile.",
-              String.join(", ", extDiff)),
+              diffDetector.getRecordedDiffMessages()),
           Transience.PERSISTENT);
     }
     return null;
   }
 
-  private boolean didFilesChange(
+  private static final class LockedExtensionDiffDetector {
+    private boolean diffDetected = false;
+    private final ImmutableList.Builder<String> diffMessages;
+
+    LockedExtensionDiffDetector(boolean recordDiffs) {
+      diffMessages = recordDiffs ? ImmutableList.builder() : null;
+    }
+
+    static class DiffFoundEarlyExitException extends Exception {
+    }
+
+    private void reportDiff(String message) throws DiffFoundEarlyExitException {
+      diffDetected = true;
+      if (diffMessages != null) {
+        diffMessages.add(message);
+      } else {
+        throw new DiffFoundEarlyExitException();
+      }
+    }
+
+    public void detectDiffs(ModuleExtensionId extensionId, Environment env,
+        RunnableExtension extension,
+        LockFileModuleExtension lockedExtension,
+        ImmutableMap<ModuleKey, ModuleExtensionUsage> extensionUsages,
+        ImmutableMap<ModuleKey, ModuleExtensionUsage> lockedExtensionUsages)
+        throws InterruptedException, NeedsSkyframeRestartException {
+      try {
+        // Put faster diff detections earlier, so that we can short-circuit in UPDATE mode.
+        if (!Arrays.equals(extension.getBzlTransitiveDigest(),
+            lockedExtension.getBzlTransitiveDigest())) {
+          reportDiff(
+              "The implementation of the extension '"
+                  + extensionId
+                  + "' or one of its transitive .bzl files has changed");
+        }
+        if (!extension.getEnvVars().equals(lockedExtension.getEnvVariables())) {
+          reportDiff(
+              "The environment variables the extension '"
+                  + extensionId
+                  + "' depends on (or their values) have changed");
+        }
+        // Check extension data in lockfile is still valid, disregarding usage information that is not
+        // relevant for the evaluation of the extension.
+        if (!ModuleExtensionUsage.trimForEvaluation(extensionUsages)
+            .equals(ModuleExtensionUsage.trimForEvaluation(lockedExtensionUsages))) {
+          reportDiff("The usages of the extension '" + extensionId + "' have changed");
+        }
+        if (didRepoMappingsChange(env, lockedExtension.getRecordedRepoMappingEntries())) {
+          reportDiff("The repo mapping of certain repos used by the extension '" + extensionId
+              + "' have changed");
+        }
+        if (didFilesChange(env, lockedExtension.getAccumulatedFileDigests())) {
+          reportDiff(
+              "One or more files the extension '" + extensionId + "' is using have changed");
+        }
+      } catch (DiffFoundEarlyExitException ignored) {
+        // ignored
+      }
+    }
+
+    public boolean anyDiffsDetected() {
+      return diffDetected;
+    }
+
+    public String getRecordedDiffMessages() {
+      return String.join(",", diffMessages.build());
+    }
+  }
+
+  private static boolean didRepoMappingsChange(Environment env,
+      ImmutableTable<RepositoryName, String, RepositoryName> recordedRepoMappings)
+      throws InterruptedException, NeedsSkyframeRestartException {
+    SkyframeLookupResult result = env.getValuesAndExceptions(
+        recordedRepoMappings.rowKeySet().stream().map(
+            RepositoryMappingValue::key).collect(toImmutableSet()));
+    if (env.valuesMissing()) {
+      // This shouldn't really happen, since the RepositoryMappingValues of any recorded repos
+      // should have already been requested by the time we load the .bzl for the extension. And this
+      // method is only called if the transitive .bzl digest hasn't changed.
+      // However, we pretend to restart Skyframe anyway because we're good citizens.
+      throw new NeedsSkyframeRestartException();
+    }
+    for (Table.Cell<RepositoryName, String, RepositoryName> cell : recordedRepoMappings.cellSet()) {
+      RepositoryMappingValue repoMappingValue = (RepositoryMappingValue) result.get(
+          RepositoryMappingValue.key(cell.getRowKey()));
+      if (repoMappingValue == null) {
+        // Again, this shouldn't happen. But anyway.
+        throw new NeedsSkyframeRestartException();
+      }
+      if (!cell.getValue().equals(
+          repoMappingValue.getRepositoryMapping().get(cell.getColumnKey()))) {
+        // Wee woo wee woo -- diff detected!
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean didFilesChange(
       Environment env, ImmutableMap<Label, String> accumulatedFileDigests)
       throws InterruptedException, NeedsSkyframeRestartException {
     // Turn labels into FileValue keys & get those values
@@ -690,7 +773,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
         generatedRepoSpecs.put(name, repoSpec);
       }
       return RunModuleExtensionResult.create(
-          ImmutableMap.of(), generatedRepoSpecs.buildOrThrow(), Optional.empty());
+          ImmutableMap.of(), generatedRepoSpecs.buildOrThrow(), Optional.empty(),
+          ImmutableTable.of());
     }
   }
 
@@ -790,12 +874,16 @@ public class SingleExtensionEvalFunction implements SkyFunction {
               env.getListener());
       ModuleExtensionContext moduleContext;
       Optional<ModuleExtensionMetadata> moduleExtensionMetadata;
+      var repoMappingRecorder = new Label.RepoMappingRecorder();
       try (Mutability mu =
           Mutability.create("module extension", usagesValue.getExtensionUniqueName())) {
         StarlarkThread thread = new StarlarkThread(mu, starlarkSemantics);
         thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
         moduleContext = createContext(env, usagesValue, starlarkSemantics, extensionId);
         threadContext.storeInThread(thread);
+        // This is used by the `Label()` constructor in Starlark, to record any attempts to resolve
+        // apparent repo names to canonical repo names. See #20721 for why this is necessary.
+        thread.setThreadLocal(Label.RepoMappingRecorder.class, repoMappingRecorder);
         try (SilentCloseable c =
             Profiler.instance()
                 .profile(
@@ -853,7 +941,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       return RunModuleExtensionResult.create(
           moduleContext.getAccumulatedFileDigests(),
           threadContext.getGeneratedRepoSpecs(),
-          moduleExtensionMetadata);
+          moduleExtensionMetadata,
+          repoMappingRecorder.recordedEntries());
     }
 
     private ModuleExtensionContext createContext(
@@ -916,12 +1005,16 @@ public class SingleExtensionEvalFunction implements SkyFunction {
 
     abstract Optional<ModuleExtensionMetadata> getModuleExtensionMetadata();
 
+    abstract ImmutableTable<RepositoryName, String, RepositoryName> getRecordedRepoMappingEntries();
+
     static RunModuleExtensionResult create(
         ImmutableMap<Label, String> accumulatedFileDigests,
         ImmutableMap<String, RepoSpec> generatedRepoSpecs,
-        Optional<ModuleExtensionMetadata> moduleExtensionMetadata) {
+        Optional<ModuleExtensionMetadata> moduleExtensionMetadata,
+        ImmutableTable<RepositoryName, String, RepositoryName> recordedRepoMappingEntries) {
       return new AutoValue_SingleExtensionEvalFunction_RunModuleExtensionResult(
-          accumulatedFileDigests, generatedRepoSpecs, moduleExtensionMetadata);
+          accumulatedFileDigests, generatedRepoSpecs, moduleExtensionMetadata,
+          recordedRepoMappingEntries);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
-import com.google.devtools.build.lib.bazel.bzlmod.SingleExtensionEvalFunction.DiffRecorder.DiffFoundEarlyExitException;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule.RepositoryRuleFunction;
@@ -311,15 +310,14 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     return null;
   }
 
+  private static final class DiffFoundEarlyExitException extends Exception {}
+
   private static final class DiffRecorder {
     private boolean diffDetected = false;
     private final ImmutableList.Builder<String> diffMessages;
 
     DiffRecorder(boolean recordMessages) {
       diffMessages = recordMessages ? ImmutableList.builder() : null;
-    }
-
-    static class DiffFoundEarlyExitException extends Exception {
     }
 
     private void record(String message) throws DiffFoundEarlyExitException {

--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -224,7 +224,7 @@ public final class Label implements Comparable<Label>, StarlarkValue, SkyKey, Co
     }
   }
 
-  public static Label parseWithPackageContextRecordingRepoMapping(String raw,
+  public static Label parseWithPackageContext(String raw,
       PackageContext packageContext, @Nullable RepoMappingRecorder repoMappingRecorder)
       throws LabelSyntaxException {
     Parts parts = Parts.parse(raw);

--- a/src/test/java/com/google/devtools/build/lib/cmdline/LabelTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/LabelTest.java
@@ -17,9 +17,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Tables;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.cmdline.Label.PackageContext;
 import com.google.devtools.build.lib.cmdline.Label.RepoContext;
+import com.google.devtools.build.lib.cmdline.Label.RepoMappingRecorder;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.skyframe.serialization.testutils.SerializationTester;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -513,5 +515,38 @@ public class LabelTest {
         .setVerificationFunction(
             (original, deserialized) -> assertThat(original).isSameInstanceAs(deserialized))
         .runTests();
+  }
+
+  @Test
+  public void parseWithPackageContext_recordingRepoMapping() throws Exception {
+    RepositoryName foo = RepositoryName.createUnvalidated("foo");
+    RepositoryName bar = RepositoryName.createUnvalidated("bar");
+    RepositoryName quux = RepositoryName.createUnvalidated("quux");
+    PackageContext fooPackageContext =
+        PackageContext.of(
+            PackageIdentifier.create(foo, PathFragment.create("hah")),
+            RepositoryMapping.create(ImmutableMap.of("bar", quux, "quux", bar), foo));
+    PackageContext barPackageContext =
+        PackageContext.of(
+            PackageIdentifier.create(bar, PathFragment.EMPTY_FRAGMENT),
+            RepositoryMapping.create(ImmutableMap.of("foo", quux, "quux", foo), bar));
+
+    RepoMappingRecorder recorder = new RepoMappingRecorder();
+    // Not recorded: no repo part
+    Label.parseWithPackageContext("//foo/bar", fooPackageContext, recorder);
+    // Recorded: <foo, bar, quux>
+    Label.parseWithPackageContext("@bar//foo/bar", fooPackageContext, recorder);
+    // Recorded: <bar, quux, foo>
+    Label.parseWithPackageContext("@quux//foo/bar", barPackageContext, recorder);
+    // Recorded: <bar, foo, quux>
+    Label.parseWithPackageContext("@foo//foo/bar", barPackageContext, recorder);
+    // Not recorded: canonical repo name
+    Label.parseWithPackageContext("@@quux//foo/bar", fooPackageContext, recorder);
+
+    // Recorded entries are sorted by row and then column
+    assertThat(recorder.recordedEntries().cellSet()).containsExactly(
+        Tables.immutableCell(bar, "foo", quux),
+        Tables.immutableCell(bar, "quux", foo),
+        Tables.immutableCell(foo, "bar", quux)).inOrder();
   }
 }

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -1493,6 +1493,84 @@ class BazelLockfileTest(test_base.TestBase):
           'general']['generatedRepoSpecs']['hello']['attributes']
       self.assertEqual(hello_attrs['value'], '@@//:hello.txt')
 
+  def testExtensionRepoMappingChange(self):
+    # Regression test for #20721
+    self.main_registry.createCcModule('foo', '1.0')
+    self.main_registry.createCcModule('foo', '2.0')
+    self.main_registry.createCcModule('bar', '1.0')
+    self.main_registry.createCcModule('bar', '2.0')
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name="foo",version="1.0")',
+            'bazel_dep(name="bar",version="1.0")',
+            'ext = use_extension(":ext.bzl", "ext")',
+            'use_repo(ext, "repo")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel',
+                     [
+                         'load("@repo//:defs.bzl", "STR")',
+                         'print("STR="+STR)',
+                         'filegroup(name="lol")',
+                     ])
+    self.ScratchFile(
+        'ext.bzl',
+        [
+            'def _repo_impl(rctx):',
+            '  rctx.file("BUILD")',
+            '  rctx.file("defs.bzl", "STR = " + repr(str(rctx.attr.value)))',
+            'repo = repository_rule(_repo_impl,attrs={"value":attr.label()})',
+            'def _ext_impl(mctx):',
+            '  print("ran the extension!")',
+            '  repo(name = "repo", value = Label("@foo//:lib_foo"))',
+            'ext = module_extension(_ext_impl)',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(['build', ':lol'])
+    self.assertIn('STR=@@foo~1.0//:lib_foo', '\n'.join(stderr))
+
+    # Shutdown bazel to make sure we rely on the lockfile and not skyframe
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(['build', ':lol'])
+    self.assertNotIn('ran the extension!', '\n'.join(stderr))
+
+    # Shutdown bazel to make sure we rely on the lockfile and not skyframe
+    self.RunBazel(['shutdown'])
+    # Now, for something spicy: upgrade foo to 2.0 and change nothing else.
+    # The extension should rerun despite the lockfile being present, and no
+    # usages or .bzl files having changed.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name="foo",version="2.0")',
+            'bazel_dep(name="bar",version="1.0")',
+            'ext = use_extension(":ext.bzl", "ext")',
+            'use_repo(ext, "repo")',
+        ],
+    )
+    _, _, stderr = self.RunBazel(['build', ':lol'])
+    self.assertIn('STR=@@foo~2.0//:lib_foo', '\n'.join(stderr))
+
+    # Shutdown bazel to make sure we rely on the lockfile and not skyframe
+    self.RunBazel(['shutdown'])
+    # More spicy! upgrade bar to 2.0 and change nothing else.
+    # The extension should NOT rerun, since it never used the @bar repo mapping.
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name="foo",version="2.0")',
+            'bazel_dep(name="bar",version="2.0")',
+            'ext = use_extension(":ext.bzl", "ext")',
+            'use_repo(ext, "repo")',
+        ],
+    )
+    _, _, stderr = self.RunBazel(['build', ':lol'])
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('ran the extension!', stderr)
+    self.assertIn('STR=@@foo~2.0//:lib_foo', stderr)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
... that use repo mapping. This is a rather obscure case of the lockfile being stale; if the `Label()` constructor is called in an extension impl function, and that call uses repo mapping of any form (i.e. the argument looks like `@foo//bar`), then we need to be ready to rerun the extension if `@foo` were to suddenly map to something else.

I also did a minor refactoring in `SingleExtensionEvalFunction` around the logic to decide whether the locked extension is up-to-date. Right now we perform a "diff" between the locked extension and what we expect to be up-to-date, and if a "diff" is found *and* `--lockfile_mode=error`, we basically perform a diff again. We also don't short circuit; that is, if the transitive bzl digest has changed, there's no point in seeing whether any files have changed, but we do right now.

A follow-up will be sent to fix the analogous bug for repo rules.

Fixes #20721.