### PR TITLE
Close test.err before deleteing it

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -800,9 +800,12 @@ public class StandaloneTestStrategy extends TestStrategy {
         // Make sure that the test.log exists.Spaw
         FileSystemUtils.touchFile(fileOutErr.getOutputPath());
       }
-      // Append any error output to the test.log. This is very rare.
-      writeOutFile(fileOutErr.getErrorPath(), fileOutErr.getOutputPath());
       fileOutErr.close();
+      // Append any error output to the test.log. This is very rare.
+      //
+      // Only write after the error output stream has been closed. Otherwise, Bazel cannot delete test.err file on
+      // Windows. See https://github.com/bazelbuild/bazel/issues/20741.
+      writeOutFile(fileOutErr.getErrorPath(), fileOutErr.getOutputPath());
       if (streamed != null) {
         streamed.close();
       }

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -1038,4 +1038,23 @@ EOF
       //:x  &> $TEST_log || fail "expected success"
 }
 
+function test_append_stderr_to_test_log() {
+  cat <<'EOF' > BUILD
+sh_test(
+    name = 'x',
+    srcs = ['x.sh'],
+)
+EOF
+  cat <<'EOF' > x.sh
+#!/bin/sh
+echo foo > /dev/stderr
+EOF
+  chmod +x x.sh
+
+  bazel test //:x  &> $TEST_log || fail "expected success"
+
+  cat bazel-testlogs/x/test.log > $TEST_log
+  expect_log "foo"
+}
+
 run_suite "bazel test tests"

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -14,11 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -euo pipefail
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
 
 # Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up_jobcount() {
@@ -1036,25 +1056,6 @@ EOF
   bazel test \
       --incompatible_check_sharding_support \
       //:x  &> $TEST_log || fail "expected success"
-}
-
-function test_append_stderr_to_test_log() {
-  cat <<'EOF' > BUILD
-sh_test(
-    name = 'x',
-    srcs = ['x.sh'],
-)
-EOF
-  cat <<'EOF' > x.sh
-#!/bin/sh
-echo foo > /dev/stderr
-EOF
-  chmod +x x.sh
-
-  bazel test //:x  &> $TEST_log || fail "expected success"
-
-  cat bazel-testlogs/x/test.log > $TEST_log
-  expect_log "foo"
 }
 
 run_suite "bazel test tests"

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -14,31 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
-
-# --- begin runfiles.bash initialization ---
-if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  if [[ -f "$0.runfiles_manifest" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-    export RUNFILES_DIR="$0.runfiles"
-  fi
-fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
+set -eu
 
 # Load the test setup defined in the parent directory
-source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up_jobcount() {


### PR DESCRIPTION
Unfortuantely, there isn't an easy way to add integration test for this specific edge case on Windows.

Fixes #20741.