### PR TITLE
[7.1.0] Auto-create deploy jars for Bazel `java_test` targets if requested

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary.bzl
@@ -290,6 +290,29 @@ def basic_java_binary(
     if is_test_rule_class and ctx.fragments.java.auto_create_java_test_deploy_jars():
         extra_files.append(_auto_create_deploy_jar(ctx, internal_deploy_jar_info))
 
+    internal_deploy_jar_info = InternalDeployJarInfo(
+        java_attrs = java_attrs,
+        launcher_info = struct(
+            runtime_jars = launcher_info.runtime_jars,
+            launcher = launcher_info.launcher,
+            unstripped_launcher = launcher_info.unstripped_launcher,
+        ),
+        shared_archive = shared_archive,
+        main_class = main_class,
+        coverage_main_class = coverage_main_class,
+        strip_as_default = strip_as_default,
+        stamp = ctx.attr.stamp,
+        hermetic = hasattr(ctx.attr, "hermetic") and ctx.attr.hermetic,
+        add_exports = add_exports,
+        add_opens = add_opens,
+        manifest_lines = ctx.attr.deploy_manifest_lines,
+    )
+
+    # "temporary" workaround for https://github.com/bazelbuild/intellij/issues/5845
+    extra_files = []
+    if is_test_rule_class and ctx.fragments.java.auto_create_java_test_deploy_jars():
+        extra_files.append(_auto_create_deploy_jar(ctx, internal_deploy_jar_info))
+
     default_info = struct(
         files = depset(extra_files, transitive = [files]),
         runfiles = runfiles,


### PR DESCRIPTION
This adds bazel support for fixing https://github.com/bazelbuild/intellij/issues/5845. Once released, the necessary changes will need to be made to the IntelliJ plugin.

PiperOrigin-RevId: 592136548
Change-Id: I6158f379e76b61e75ca51f34888aeecaf0303cc6