### PR TITLE
[7.1.0] Print interactive sandboxed shell command with `--sandbox_debug`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -72,6 +72,7 @@ java_library(
         ":sandbox_helpers",
         ":sandbox_options",
         "//src/main/java/com/google/devtools/build/lib/exec:tree_deleter",
+        "//src/main/java/com/google/devtools/build/lib/util:command",
         "//src/main/java/com/google/devtools/build/lib/util:describable_execution_unit",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -258,29 +258,30 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         allowNetwork
             || Spawns.requiresNetwork(spawn, getSandboxOptions().defaultSandboxAllowNetwork);
 
-      return new SymlinkedSandboxedSpawn(
-          sandboxPath,
-          sandboxExecRoot,
-          commandLine,
-          environment,
-          inputs,
-          outputs,
-          writableDirs,
-          treeDeleter,
-          /* sandboxDebugPath= */ null,
-          statisticsPath,
-          spawn.getMnemonic()) {
-        @Override
-        public void createFileSystem() throws IOException, InterruptedException {
-          super.createFileSystem();
-          writeConfig(
-              sandboxConfigPath,
-              writableDirs,
-              getInaccessiblePaths(),
-              allowNetworkForThisSpawn,
-              statisticsPath);
-        }
-      };
+    return new SymlinkedSandboxedSpawn(
+        sandboxPath,
+        sandboxExecRoot,
+        commandLine,
+        environment,
+        inputs,
+        outputs,
+        writableDirs,
+        treeDeleter,
+        /* sandboxDebugPath= */ null,
+        statisticsPath,
+        /* interactiveDebugArguments= */ null,
+        spawn.getMnemonic()) {
+      @Override
+      public void createFileSystem() throws IOException, InterruptedException {
+        super.createFileSystem();
+        writeConfig(
+            sandboxConfigPath,
+            writableDirs,
+            getInaccessiblePaths(),
+            allowNetworkForThisSpawn,
+            statisticsPath);
+      }
+    };
   }
 
   private void writeConfig(

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxCommandLineBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxCommandLineBuilder.java
@@ -51,7 +51,6 @@ public class LinuxSandboxCommandLineBuilder {
   }
 
   private final Path linuxSandboxPath;
-  private final List<String> commandArguments;
   private Path hermeticSandboxPath;
   private Path workingDirectory;
   private Duration timeout;
@@ -72,15 +71,13 @@ public class LinuxSandboxCommandLineBuilder {
   private boolean sigintSendsSigterm = false;
   private String cgroupsDir;
 
-  private LinuxSandboxCommandLineBuilder(Path linuxSandboxPath, List<String> commandArguments) {
+  private LinuxSandboxCommandLineBuilder(Path linuxSandboxPath) {
     this.linuxSandboxPath = linuxSandboxPath;
-    this.commandArguments = commandArguments;
   }
 
   /** Returns a new command line builder for the {@code linux-sandbox} tool. */
-  public static LinuxSandboxCommandLineBuilder commandLineBuilder(
-      Path linuxSandboxPath, List<String> commandArguments) {
-    return new LinuxSandboxCommandLineBuilder(linuxSandboxPath, commandArguments);
+  public static LinuxSandboxCommandLineBuilder commandLineBuilder(Path linuxSandboxPath) {
+    return new LinuxSandboxCommandLineBuilder(linuxSandboxPath);
   }
 
   /**
@@ -247,7 +244,7 @@ public class LinuxSandboxCommandLineBuilder {
   }
 
   /** Builds the command line to invoke a specific command using the {@code linux-sandbox} tool. */
-  public ImmutableList<String> build() {
+  public ImmutableList<String> buildForCommand(List<String> commandArguments) {
     Preconditions.checkState(
         !(this.useFakeUsername && this.useFakeRoot),
         "useFakeUsername and useFakeRoot are exclusive");

--- a/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
@@ -106,18 +106,19 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
             null);
     SandboxOutputs outputs = helpers.getOutputs(spawn);
 
-      return new SymlinkedSandboxedSpawn(
-          sandboxPath,
-          sandboxExecRoot,
-          commandLineBuilder.build(),
-          environment,
-          inputs,
-          outputs,
-          getWritableDirs(sandboxExecRoot, sandboxExecRoot, environment),
-          treeDeleter,
-          /* sandboxDebugPath= */ null,
-          statisticsPath,
-          spawn.getMnemonic());
+    return new SymlinkedSandboxedSpawn(
+        sandboxPath,
+        sandboxExecRoot,
+        commandLineBuilder.build(),
+        environment,
+        inputs,
+        outputs,
+        getWritableDirs(sandboxExecRoot, sandboxExecRoot, environment),
+        treeDeleter,
+        /* sandboxDebugPath= */ null,
+        statisticsPath,
+        /* interactiveDebugArguments= */ null,
+        spawn.getMnemonic());
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxedSpawn.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.sandbox;
 import com.google.devtools.build.lib.util.DescribableExecutionUnit;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -61,4 +62,12 @@ interface SandboxedSpawn extends DescribableExecutionUnit {
 
   /** Deletes the sandbox directory. */
   void delete();
+
+  /**
+   * Returns user-facing instructions for starting an interactive sandboxed environment identical to
+   * the one in which this spawn is executed.
+   */
+  default Optional<String> getInteractiveDebugInstructions() {
+    return Optional.empty();
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -21,10 +21,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.exec.TreeDeleter;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
+import com.google.devtools.build.lib.util.CommandDescriptionForm;
+import com.google.devtools.build.lib.util.CommandFailureUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -37,6 +40,8 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
   /** Mnemonic of the action running in this spawn. */
   private final String mnemonic;
 
+  @Nullable private final ImmutableList<String> interactiveDebugArguments;
+
   public SymlinkedSandboxedSpawn(
       Path sandboxPath,
       Path sandboxExecRoot,
@@ -48,6 +53,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
       TreeDeleter treeDeleter,
       @Nullable Path sandboxDebugPath,
       @Nullable Path statisticsPath,
+      @Nullable ImmutableList<String> interactiveDebugArguments,
       String mnemonic) {
     super(
         sandboxPath,
@@ -62,6 +68,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
         statisticsPath,
         mnemonic);
     this.mnemonic = isNullOrEmpty(mnemonic) ? "_NoMnemonic_" : mnemonic;
+    this.interactiveDebugArguments = interactiveDebugArguments;
   }
 
   @Override
@@ -95,5 +102,24 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
   public void delete() {
     SandboxStash.stashSandbox(sandboxPath, mnemonic);
     super.delete();
+  }
+
+  @Nullable
+  @Override
+  public Optional<String> getInteractiveDebugInstructions() {
+    if (interactiveDebugArguments == null) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        "Run this command to start an interactive shell in an identical sandboxed environment:\n"
+            + CommandFailureUtils.describeCommand(
+                CommandDescriptionForm.COMPLETE,
+                /* prettyPrintArgs= */ false,
+                interactiveDebugArguments,
+                getEnvironment(),
+                /* environmentVariablesToClear= */ null,
+                /* cwd= */ null,
+                /* configurationChecksum= */ null,
+                /* executionPlatformLabel= */ null));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorker.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorker.java
@@ -181,7 +181,7 @@ final class SandboxedWorker extends SingleplexWorker {
       // Mostly tests require network, and some blaze run commands, but no workers.
       LinuxSandboxCommandLineBuilder commandLineBuilder =
           LinuxSandboxCommandLineBuilder.commandLineBuilder(
-                  this.hardenedSandboxOptions.sandboxBinary(), args)
+                  this.hardenedSandboxOptions.sandboxBinary())
               .setWritableFilesAndDirectories(getWritableDirs(workDir))
               .setTmpfsDirectories(ImmutableSet.copyOf(this.hardenedSandboxOptions.tmpfsPath()))
               .setPersistentProcess(true)
@@ -202,7 +202,7 @@ final class SandboxedWorker extends SingleplexWorker {
         commandLineBuilder.setUseFakeUsername(true);
       }
 
-      args = commandLineBuilder.build();
+      args = commandLineBuilder.buildForCommand(args);
     }
     return createProcessBuilder(args).start();
   }

--- a/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxCommandLineBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxCommandLineBuilderTest.java
@@ -53,11 +53,10 @@ public final class LinuxSandboxCommandLineBuilderTest {
         assertThrows(
             IllegalStateException.class,
             () ->
-                LinuxSandboxCommandLineBuilder.commandLineBuilder(
-                        linuxSandboxPath, commandArguments)
+                LinuxSandboxCommandLineBuilder.commandLineBuilder(linuxSandboxPath)
                     .setUseFakeRoot(true)
                     .setUseFakeUsername(true)
-                    .build());
+                    .buildForCommand(commandArguments));
     assertThat(e).hasMessageThat().contains("exclusive");
   }
 
@@ -75,8 +74,8 @@ public final class LinuxSandboxCommandLineBuilderTest {
             .build();
 
     List<String> commandLine =
-        LinuxSandboxCommandLineBuilder.commandLineBuilder(linuxSandboxPath, commandArguments)
-            .build();
+        LinuxSandboxCommandLineBuilder.commandLineBuilder(linuxSandboxPath)
+            .buildForCommand(commandArguments);
 
     assertThat(commandLine).containsExactlyElementsIn(expectedCommandLine).inOrder();
   }
@@ -163,7 +162,7 @@ public final class LinuxSandboxCommandLineBuilderTest {
             .build();
 
     List<String> commandLine =
-        LinuxSandboxCommandLineBuilder.commandLineBuilder(linuxSandboxPath, commandArguments)
+        LinuxSandboxCommandLineBuilder.commandLineBuilder(linuxSandboxPath)
             .setWorkingDirectory(workingDirectory)
             .setStdoutPath(stdoutPath)
             .setStderrPath(stderrPath)
@@ -180,7 +179,7 @@ public final class LinuxSandboxCommandLineBuilderTest {
             .setSandboxDebugPath(sandboxDebugPath.getPathString())
             .setPersistentProcess(true)
             .setCgroupsDir(cgroupsDir)
-            .build();
+            .buildForCommand(commandArguments);
 
     assertThat(commandLine).containsExactlyElementsIn(expectedCommandLine).inOrder();
   }

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
@@ -83,6 +83,7 @@ public class SymlinkedSandboxedSpawnTest {
             new SynchronousTreeDeleter(),
             /* sandboxDebugPath= */ null,
             /* statisticsPath= */ null,
+            /* interactiveDebugArguments= */ null,
             "SomeMnemonic");
 
     symlinkedExecRoot.createFileSystem();
@@ -114,6 +115,7 @@ public class SymlinkedSandboxedSpawnTest {
             new SynchronousTreeDeleter(),
             /* sandboxDebugPath= */ null,
             /* statisticsPath= */ null,
+            /* interactiveDebugArguments= */ null,
             "SomeMnemonic");
     symlinkedExecRoot.createFileSystem();
 

--- a/src/test/java/com/google/devtools/build/lib/shell/CommandUsingLinuxSandboxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/shell/CommandUsingLinuxSandboxTest.java
@@ -76,8 +76,8 @@ public final class CommandUsingLinuxSandboxTest {
     ImmutableList<String> commandArguments = ImmutableList.of("echo", "sleep furiously");
 
     List<String> fullCommandLine =
-        LinuxSandboxCommandLineBuilder.commandLineBuilder(getLinuxSandboxPath(), commandArguments)
-            .build();
+        LinuxSandboxCommandLineBuilder.commandLineBuilder(getLinuxSandboxPath())
+            .buildForCommand(commandArguments);
 
     Command command = new Command(fullCommandLine.toArray(new String[0]));
     CommandResult commandResult = command.execute();
@@ -98,9 +98,9 @@ public final class CommandUsingLinuxSandboxTest {
     Path statisticsFilePath = outputDir.getRelative("stats.out");
 
     List<String> fullCommandLine =
-        LinuxSandboxCommandLineBuilder.commandLineBuilder(getLinuxSandboxPath(), commandArguments)
+        LinuxSandboxCommandLineBuilder.commandLineBuilder(getLinuxSandboxPath())
             .setStatisticsPath(statisticsFilePath)
-            .build();
+            .buildForCommand(commandArguments);
 
     ExecutionStatisticsTestUtil.executeCommandAndCheckStatisticsAboutCpuTimeSpent(
         userTimeToSpend, systemTimeToSpend, fullCommandLine, statisticsFilePath);

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -383,8 +383,8 @@ public final class RemoteWorker {
     CommandResult cmdResult = null;
     Command cmd =
         new Command(
-            LinuxSandboxCommandLineBuilder.commandLineBuilder(sandboxPath, ImmutableList.of("true"))
-                .build()
+            LinuxSandboxCommandLineBuilder.commandLineBuilder(sandboxPath)
+                .buildForCommand(ImmutableList.of("true"))
                 .toArray(new String[0]),
             ImmutableMap.of(),
             sandboxPath.getParentDirectory().getPathFile());


### PR DESCRIPTION
The `--sandbox_debug` output for the Linux sandbox now also contains a copyable command that drops the user into an interactive shell in an identical sandboxed environment. This is in particular meant to address the increased complexity of the bind mount structure incurred by the flip of `--incompatible_sandbox_hermetic_tmp`.

Closes #20708.

Commit https://github.com/bazelbuild/bazel/commit/48ce49b6234f80f170eadddff2882fdebcf8e5da

PiperOrigin-RevId: 595457357
Change-Id: I6dfd410895b93fce67b9666c76c5f7757e77dc3a