### PR TITLE
[6.5.0] Upgrade abseil-cpp to fix build on macos_arm64

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,14 @@ build:windows_arm64 --extra_toolchains=@local_config_cc//:cc-toolchain-arm64_win
 # Enable Bzlmod
 build:bzlmod --experimental_enable_bzlmod
 
+# Enable modern C++ features
+build:linux --cxxopt=-std=c++17
+build:linux --host_cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17
+build:macos --host_cxxopt=-std=c++17
+build:windows --cxxopt=/std:c++17
+build:windows --host_cxxopt=/std:c++17
+
 # Enable Java 11 language features (https://github.com/bazelbuild/bazel/issues/14592)
 build --java_language_version=11
 build --tool_java_language_version=11

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -229,17 +229,16 @@ DIST_DEPS = {
         ],
     },
     "com_google_absl": {
-        "archive": "20211102.0.tar.gz",
-        "sha256": "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
+        "archive": "20230802.0.tar.gz",
+        "sha256": "59d2976af9d6ecf001a81a35749a6e551a335b949d34918cfade07737b9d93c5",
         "urls": [
-            "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz",
-            "https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz",
+            "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz",
         ],
         "used_in": [
             "additional_distfiles",
             "test_WORKSPACE_files",
         ],
-        "strip_prefix": "abseil-cpp-20211102.0",
+        "strip_prefix": "abseil-cpp-20230802.0",
     },
     "zstd-jni": {
         "archive": "v1.5.2-3.zip",

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -20,7 +20,7 @@
 #   EMBED_LABEL: the label to embed in tools using --embed_label (optional)
 #   BAZELRC: the rc file to use
 
-: ${BAZELRC:="/dev/null"}
+: ${BAZELRC:=".bazelrc"}
 : ${EMBED_LABEL:=""}
 : ${SOURCE_DATE_EPOCH:=""}
 

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -20,7 +20,7 @@
 #   EMBED_LABEL: the label to embed in tools using --embed_label (optional)
 #   BAZELRC: the rc file to use
 
-: ${BAZELRC:=".bazelrc"}
+: ${BAZELRC:="/dev/null"}
 : ${EMBED_LABEL:=""}
 : ${SOURCE_DATE_EPOCH:=""}
 
@@ -31,12 +31,19 @@ fi
 
 : ${JAVA_VERSION:="11"}
 
+CXX_OPT="-std=c++17"
+if [ "${PLATFORM}" = "windows" ]; then
+  CXX_OPT="/std=c++17"
+fi
+
 _BAZEL_ARGS="--spawn_strategy=standalone \
       --nojava_header_compilation \
       --strategy=Javac=worker --worker_quit_after_build --ignore_unsupported_sandboxing \
       --compilation_mode=opt \
       --distdir=derived/distdir \
       --extra_toolchains=//scripts/bootstrap:bootstrap_toolchain_definition \
+      --cxxopt=${CXX_OPT} \
+      --host_cxxopt=${CXX_OPT} \
       ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"
 


### PR DESCRIPTION
This should fix https://buildkite.com/bazel-trusted/publish-bazel-binaries/builds/19494, which was caused by recent OS update.