### PR TITLE
[7.0.1] Add tree artifact metadata for the coverage post-processing spawn, Rewrite paths of writable directories that are under the execroot, Always add containing trees of input tree file artifacts to the metadata map

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -740,6 +740,12 @@ public class StandaloneTestStrategy extends TestStrategy {
               .getOutputMetadataStore()
               .getTreeArtifactChildren(
                   (SpecialArtifact) testAction.getCoverageDirectoryTreeArtifact());
+      ImmutableSet<ActionInput> coverageSpawnMetadata =
+          ImmutableSet.<ActionInput>builder()
+              .addAll(expandedCoverageDir)
+              .add(testAction.getCoverageDirectoryTreeArtifact())
+              .build();
+
       Spawn coveragePostProcessingSpawn =
           createCoveragePostProcessingSpawn(
               actionExecutionContext,
@@ -759,7 +765,7 @@ public class StandaloneTestStrategy extends TestStrategy {
       ActionExecutionContext coverageActionExecutionContext =
           actionExecutionContext
               .withFileOutErr(coverageOutErr)
-              .withOutputsAsInputs(expandedCoverageDir);
+              .withOutputsAsInputs(coverageSpawnMetadata);
 
       writeOutFile(coverageOutErr.getErrorPath(), coverageOutErr.getOutputPath());
       appendCoverageLog(coverageOutErr, fileOutErr);


### PR DESCRIPTION
This makes --experimental_split_coverage_postprocessing work in the wake of https://github.com/bazelbuild/bazel/commit/fb6658c86164b81205a056a9a54975a62f2f957a: before, it was enough to add the metadata of the tree file artifacts to the metadata provider of the post-processing action, but that change made the metadata of the tree artifact necessary, too.

Progress towards #20753.

RELNOTES: None.
Commit https://github.com/bazelbuild/bazel/commit/b0db044227d62178a7e578b8e03c452d8c17af33

PiperOrigin-RevId: 596929659
Change-Id: I481ef36328de7f7ab07f2ec7a0ac83d5fd508c36