### PR TITLE
Update convenience symlinks targets in output-directories.md

### DIFF
--- a/site/en/remote/output-directories.md
+++ b/site/en/remote/output-directories.md
@@ -67,8 +67,8 @@ The directories are laid out as follows:
 
 <pre>
 &lt;workspace-name&gt;/                         <== The workspace root
-  bazel-my-project => <...my-project>     <== Symlink to execRoot
-  bazel-out => <...bin>                   <== Convenience symlink to outputPath
+  bazel-my-project => <..._main>          <== Symlink to execRoot
+  bazel-out => <...bazel-out>             <== Convenience symlink to outputPath
   bazel-bin => <...bin>                   <== Convenience symlink to most recent written bin dir $(BINDIR)
   bazel-testlogs => <...testlogs>         <== Convenience symlink to the test logs directory
 


### PR DESCRIPTION
`my-project -> _main` -- this is somewhat recent change with how execroot main directory is named (possibly change missed in https://github.com/bazelbuild/bazel/commit/13ecdf583301a94484a1ae0eb27c56fcf3248dc5#diff-71e1b6da0280d54a76bc7d07e1fcd689c4327fa8d3bd3c92201d1644fc9aeb7d)

`bin -> bazel-out` -- looks like this was incorrect for longer time