### PR TITLE
Replace TestEnvironment with RunEnvironmentInfo in docs

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/binary/env.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/binary/env.html
@@ -8,7 +8,12 @@
 
 <p>
   This attribute only applies to native rules, like <code>cc_binary</code>, <code>py_binary</code>,
-  and <code>sh_binary</code>.  It does not apply to Starlark-defined executable rules.
+  and <code>sh_binary</code>.  It does not apply to Starlark-defined executable rules. For your own
+  Starlark rules, you can add an "env" attribute and use it to populate a
+
+    <a href="/rules/lib/providers/RunEnvironmentInfo.html">RunEnvironmentInfo</a>
+
+  Provider.
 </p>
 
 <p>

--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/test/env.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/test/env.html
@@ -1,7 +1,7 @@
 <p>
   Dictionary of strings; values are subject to
   <a href="${link make-variables#predefined_label_variables}">$(location)</a> and
-  <a href="${link make-variables}">"Make variable"</a> substitution; default is <code>[]</code>
+  <a href="${link make-variables}">"Make variable"</a> substitution; default is <code>{}</code>
 </p>
 
 <p>
@@ -15,7 +15,7 @@
   Starlark-defined test rules. For your own Starlark rules, you can add an "env"
   attribute and use it to populate a
 
-    <a href="/rules/lib/toplevel/testing#TestEnvironment">TestEnvironment</a>
+    <a href="/rules/lib/providers/RunEnvironmentInfo.html">RunEnvironmentInfo</a>
   
   Provider.
 </p>


### PR DESCRIPTION
The RunEnvironmentInfo was introduced in https://github.com/bazelbuild/bazel/pull/15766 and TestEnvironment deprecated, 
Also, documented that custom binary starlark rules also can return this provider.