### PR TITLE
[7.0.1] Fix NPE in BzlmodRepoRuleFunction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
@@ -39,7 +39,6 @@ import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.packages.NoSuchPackageException;
-import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClassProvider;
@@ -148,10 +147,7 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
       return BzlmodRepoRuleValue.REPO_RULE_NOT_FOUND_VALUE;
     }
     RepoSpec extRepoSpec = extensionEval.getGeneratedRepoSpecs().get(internalRepo);
-    Package pkg = createRuleFromSpec(extRepoSpec, starlarkSemantics, env).getRule().getPackage();
-    Preconditions.checkNotNull(pkg);
-
-    return new BzlmodRepoRuleValue(pkg, repositoryName.getName());
+    return createRuleFromSpec(extRepoSpec, starlarkSemantics, env);
   }
 
   private static Optional<RepoSpec> checkRepoFromNonRegistryOverrides(


### PR DESCRIPTION
Speculative fix for this crash:

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'BZLMOD_REPO_RULE:@@_main~remote_jdk8_repos~remote_jdk8_macos_aarch64_toolchain_config_repo' (requested by nodes 'REPOSITORY_DIRECTORY:@@_main~remote_jdk8_repos~remote_jdk8_macos_aarch64_toolchain_config_repo')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:550)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:414)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.NullPointerException: Cannot invoke "com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue.getRule()" because the return value of "com.google.devtools.build.lib.skyframe.BzlmodRepoRuleFunction.createRuleFromSpec(com.google.devtools.build.lib.bazel.bzlmod.RepoSpec, net.starlark.java.eval.StarlarkSemantics, com.google.devtools.build.skyframe.SkyFunction$Environment)" is null
	at com.google.devtools.build.lib.skyframe.BzlmodRepoRuleFunction.compute(BzlmodRepoRuleFunction.java:151)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:461)
	... 7 more
```

Closes #20807.

Commit https://github.com/bazelbuild/bazel/commit/35ba3967df117234e182bec3f97536e824a0b4f0

PiperOrigin-RevId: 597050428
Change-Id: Ie8e5c3800be1a7adbacab4ac115acfd308c0f59e