### PR TITLE
Circuit Breaker for HTTP Cache Client

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -219,6 +219,8 @@ public final class RemoteModule extends BlazeModule {
       RemoteOptions remoteOptions,
       DigestUtil digestUtil) {
     RemoteCacheClient cacheClient;
+    Retrier.CircuitBreaker circuitBreaker =
+        CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
     try {
       cacheClient =
           RemoteCacheClientFactory.create(
@@ -228,7 +230,7 @@ public final class RemoteModule extends BlazeModule {
               Preconditions.checkNotNull(env.getWorkingDirectory(), "workingDirectory"),
               digestUtil,
               new RemoteRetrier(
-                  remoteOptions, RETRIABLE_HTTP_ERRORS, retryScheduler, Retrier.ALLOW_ALL_CALLS));
+                  remoteOptions, RETRIABLE_HTTP_ERRORS, retryScheduler, circuitBreaker));
     } catch (IOException e) {
       handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
       return;


### PR DESCRIPTION
This PR addresses an issue discovered during the evaluation of fallback HTTP remote cache support. It was noted that the circuit breaker functioned effectively with gRPC, but not for HTTP, due to the absence of Failure Circuit Breaker integration in the RemoteRetrier init context for HTTP. 

To resolve this, the PR implements the integration of the same retrier used for gRPC into the HTTP context as well.