### PR TITLE
Fix java_proto_library example in the docs

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/proto/java_lite_proto_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/proto/java_lite_proto_library.bzl
@@ -156,7 +156,7 @@ Example:
 <code class="lang-starlark">
 java_library(
     name = "lib",
-    deps = [":foo"],
+    runtime_deps = [":foo"],
 )
 
 java_lite_proto_library(

--- a/src/main/starlark/builtins_bzl/common/java/proto/java_proto_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/proto/java_proto_library.bzl
@@ -189,7 +189,7 @@ Example:
 <code class="lang-starlark">
 java_library(
     name = "lib",
-    deps = [":foo_java_proto"],
+    runtime_deps = [":foo_java_proto"],
 )
 
 java_proto_library(


### PR DESCRIPTION
Adding the `java_proto_library` as a non-runtime dependency is incorrect, it needs to be added to the `runtime_deps` attribute.