### PR TITLE
Introduce --default_test_resources flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -2760,7 +2760,10 @@ java_library(
 
 java_library(
     name = "test/test_configuration",
-    srcs = ["test/TestConfiguration.java"],
+    srcs = [
+        "test/TestConfiguration.java",
+        "test/TestResourcesConverter.java",
+    ],
     deps = [
         ":config/build_options",
         ":config/core_option_converters",
@@ -2773,6 +2776,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:resource_converter",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -361,7 +361,7 @@ public class TestConfiguration extends Fragment {
     return testTimeout;
   }
 
-  /** Returns test resource mapping as set by --test_resources options. */
+  /** Returns test resource mapping as set by --default_test_resources options. */
   public ImmutableMap<String, Double> getTestResources(TestSize size) {
     return testResources.getOrDefault(size, ImmutableMap.of());
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -43,7 +43,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /** Test-related options. */
 @RequiresOptions(options = {TestConfiguration.TestOptions.class})
@@ -87,7 +86,7 @@ public class TestConfiguration extends Fragment {
     public Map<TestTimeout, Duration> testTimeout;
 
     @Option(
-        name = "test_resources",
+        name = "default_test_resources",
         defaultValue = "null",
         converter = TestResourcesConverter.class,
         allowMultiple = true,
@@ -100,8 +99,7 @@ public class TestConfiguration extends Fragment {
                 + " comma-separated numbers are specified, they will override the resource"
                 + " amount for respectively the small, medium, large, enormous test sizes."
                 + " Values can also be HOST_RAM/HOST_CPU, optionally followed"
-                + " by [-|*]<float> (eg. memory=HOST_RAM*.1,HOST_RAM*.2,HOST_RAM*.3,HOST_RAM*.4)."
-                + " Multiple usages are accumulated and the last value of each resource is used.")
+                + " by [-|*]<float> (eg. memory=HOST_RAM*.1,HOST_RAM*.2,HOST_RAM*.3,HOST_RAM*.4).")
     public List<Map.Entry<String, Map<TestSize, Double>>> testResources;
 
     @Option(
@@ -365,7 +363,7 @@ public class TestConfiguration extends Fragment {
 
   /** Returns test resource mapping as set by --test_resources options. */
   public ImmutableMap<String, Double> getTestResources(TestSize size) {
-    return testResources.get(size);
+    return testResources.getOrDefault(size, ImmutableMap.of());
   }
 
   public String getTestFilter() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestResourcesConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestResourcesConverter.java
@@ -1,0 +1,52 @@
+package com.google.devtools.build.lib.analysis.test;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.packages.TestSize;
+import com.google.devtools.build.lib.util.ResourceConverter;
+import com.google.devtools.common.options.Converter;
+import com.google.devtools.common.options.Converters;
+import com.google.devtools.common.options.OptionsParsingException;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestResourcesConverter extends Converter.Contextless<Map.Entry<String, Map<TestSize, Double>>> {
+    final private static Converters.AssignmentConverter assignmentConverter =
+      new Converters.AssignmentConverter();
+    final private static ResourceConverter.DoubleConverter resourceConverter =
+      new ResourceConverter.DoubleConverter(
+        /* keywords= */ ImmutableMap.of(
+          ResourceConverter.HOST_CPUS_KEYWORD, () -> (double) ResourceConverter.HOST_CPUS_SUPPLIER.get(),
+          ResourceConverter.HOST_RAM_KEYWORD, () -> (double) ResourceConverter.HOST_RAM_SUPPLIER.get()),
+        /* minValue= */ 0.0,
+        /* maxValue= */ Double.MAX_VALUE);
+
+    @Override
+    public String getTypeDescription() {
+      return "a resource name followed by equal and 1 float or 4 float, e.g memory=10,30,60,100";
+    }
+
+    @Override
+    public Map.Entry<String, Map<TestSize, Double>> convert(String input) throws OptionsParsingException {
+      Map.Entry<String, String> assignment = assignmentConverter.convert(input);
+      ArrayList<Double> values = new ArrayList<>(TestSize.values().length);
+      for (String s: Splitter.on(",").split(assignment.getValue())) {
+        values.add(resourceConverter.convert(s));
+      }
+
+      if (values.size() != 1 && values.size() != TestSize.values().length) {
+        throw new OptionsParsingException("Invalid number of comma-separated entries in " + input);
+      }
+
+      EnumMap<TestSize, Double> amounts = Maps.newEnumMap(TestSize.class);
+      for (TestSize size: TestSize.values()) {
+        amounts.put(size, values.get(Math.min(values.size() - 1, size.ordinal())));
+      }
+      return Map.entry(assignment.getKey(), amounts);
+    }
+  }

--- a/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
@@ -64,10 +64,10 @@ public class TestTargetPropertiesTest extends BuildViewTestCase {
         "  tags = ['resources:gpu:4'],",
         ")");
     useConfiguration(
-        "--test_resources=memory=10,20,30,40",
-        "--test_resources=cpu=1,2,3,4",
-        "--test_resources=gpu=1",
-        "--test_resources=cpu=5");
+        "--default_test_resources=memory=10,20,30,40",
+        "--default_test_resources=cpu=1,2,3,4",
+        "--default_test_resources=gpu=1",
+        "--default_test_resources=cpu=5");
     ConfiguredTarget testTarget = getConfiguredTarget("//tests:test");
     TestRunnerAction testAction =
         (TestRunnerAction)


### PR DESCRIPTION
Add `--default_test_resources=<resource>=<value(s)>` that allows setting the default resource utilization for tests. The flag follow a syntax simialar to `--local_resources=<resource>=<value>`, in that it allow assigning different resource types, and `--test_timeout=<value(s)>`, which accepts either 1 or 4 intergers to assign to all test sizes or to each individually.

Relates to #19679