### PR TITLE
[7.1.0] Add new flag `--enable_workspace` that allows us to disable WORKSPACE…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.bazel.repository.RepositoryResolvedEvent;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.starlark.RepoFetchingSkyKeyComputeState.Signal;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.BazelStarlarkContext;
@@ -44,6 +45,7 @@ import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
 import com.google.devtools.build.lib.skyframe.IgnoredPackagePrefixesValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.util.CPU;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SyscallCache;
@@ -337,8 +339,12 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
           new IOException(rule + " must create a directory"), Transience.TRANSIENT);
     }
 
-    if (!WorkspaceFileHelper.doesWorkspaceFileExistUnder(outputDirectory)) {
-      createWorkspaceFile(outputDirectory, rule.getTargetKind(), rule.getName());
+    if (!WorkspaceFileHelper.isValidRepoRoot(outputDirectory)) {
+      try {
+        FileSystemUtils.createEmptyFile(outputDirectory.getRelative(LabelConstants.REPO_FILE_NAME));
+      } catch (IOException e) {
+        throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+      }
     }
 
     return RepositoryDirectoryValue.builder().setPath(outputDirectory);

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.bazel.rules.android.ndkcrosstools.StlImpl;
 import com.google.devtools.build.lib.bazel.rules.android.ndkcrosstools.StlImpls;
 import com.google.devtools.build.lib.bazel.rules.android.ndkcrosstools.StlImpls.GnuLibStdCppStlImpl;
 import com.google.devtools.build.lib.bazel.rules.android.ndkcrosstools.StlImpls.LibCppStlImpl;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Type;
@@ -281,7 +282,12 @@ public class AndroidNdkRepositoryFunction extends AndroidRepositoryFunction {
     if (environ == null) {
       return null;
     }
-    prepareLocalRepositorySymlinkTree(rule, outputDirectory);
+    try {
+      outputDirectory.createDirectoryAndParents();
+      FileSystemUtils.createEmptyFile(outputDirectory.getRelative(LabelConstants.REPO_FILE_NAME));
+    } catch (IOException e) {
+      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    }
     WorkspaceAttributeMapper attributes = WorkspaceAttributeMapper.of(rule);
     PathFragment pathFragment;
     String userDefinedPath = null;

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.bugreport.BugReport;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.io.InconsistentFilesystemException;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Type;
@@ -37,6 +38,7 @@ import com.google.devtools.build.lib.skyframe.Dirents;
 import com.google.devtools.build.lib.util.ResourceFileLoader;
 import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -199,7 +201,12 @@ public class AndroidSdkRepositoryFunction extends AndroidRepositoryFunction {
     if (environ == null) {
       return null;
     }
-    prepareLocalRepositorySymlinkTree(rule, outputDirectory);
+    try {
+      outputDirectory.createDirectoryAndParents();
+      FileSystemUtils.createEmptyFile(outputDirectory.getRelative(LabelConstants.REPO_FILE_NAME));
+    } catch (IOException e) {
+      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    }
     WorkspaceAttributeMapper attributes = WorkspaceAttributeMapper.of(rule);
     FileSystem fs = directories.getOutputBase().getFileSystem();
     Path androidSdkPath;

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -206,6 +206,16 @@ public final class BuildLanguageOptions extends OptionsBase {
   public boolean enableBzlmod;
 
   @Option(
+      name = "enable_workspace",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = OptionEffectTag.LOADING_AND_ANALYSIS,
+      help =
+          "If true, enables the legacy WORKSPACE system for external dependencies. See"
+              + " https://bazel.build/external/overview for more information.")
+  public boolean enableWorkspace;
+
+  @Option(
       name = "experimental_isolated_extension_usages",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -739,6 +749,7 @@ public final class BuildLanguageOptions extends OptionsBase {
                 EXPERIMENTAL_ENABLE_ANDROID_MIGRATION_APIS, experimentalEnableAndroidMigrationApis)
             .setBool(EXPERIMENTAL_ENABLE_SCL_DIALECT, experimentalEnableSclDialect)
             .setBool(ENABLE_BZLMOD, enableBzlmod)
+            .setBool(ENABLE_WORKSPACE, enableWorkspace)
             .setBool(EXPERIMENTAL_ISOLATED_EXTENSION_USAGES, experimentalIsolatedExtensionUsages)
             .setBool(
                 INCOMPATIBLE_EXISTING_RULES_IMMUTABLE_VIEW, incompatibleExistingRulesImmutableView)
@@ -846,6 +857,7 @@ public final class BuildLanguageOptions extends OptionsBase {
       "-experimental_enable_android_migration_apis";
   public static final String EXPERIMENTAL_ENABLE_SCL_DIALECT = "-experimental_enable_scl_dialect";
   public static final String ENABLE_BZLMOD = "+enable_bzlmod";
+  public static final String ENABLE_WORKSPACE = "+enable_workspace";
   public static final String EXPERIMENTAL_ISOLATED_EXTENSION_USAGES =
       "-experimental_isolated_extension_usages";
   public static final String INCOMPATIBLE_EXISTING_RULES_IMMUTABLE_VIEW =

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -237,12 +237,16 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       }
     }
 
-    // fallback to look up the repository in the WORKSPACE file.
-    try {
-      return getRepoRuleFromWorkspace(repositoryName, env);
-    } catch (NoSuchRepositoryException e) {
-      return null;
+    if (starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)) {
+      // fallback to look up the repository in the WORKSPACE file.
+      try {
+        return getRepoRuleFromWorkspace(repositoryName, env);
+      } catch (NoSuchRepositoryException e) {
+        return null;
+      }
     }
+
+    return null;
   }
 
   @Nullable
@@ -428,47 +432,15 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
           Transience.PERSISTENT);
     }
 
-    // Check that the repository contains a WORKSPACE file.
-    // Note that we need to do this here since we're not creating a WORKSPACE file ourselves, but
-    // entrusting the entire contents of the repo root to this target directory.
-    FileValue workspaceFileValue = getWorkspaceFile(targetDirRootedPath, env);
-    if (workspaceFileValue == null) {
-      return null;
-    }
-
-    if (!workspaceFileValue.exists()) {
+    // Check that the directory contains a repo boundary file.
+    // Note that we need to do this here since we're not creating a repo boundary file ourselves,
+    // but entrusting the entire contents of the repo root to this target directory.
+    if (!WorkspaceFileHelper.isValidRepoRoot(destination)) {
       throw new RepositoryFunctionException(
-          new IOException("No WORKSPACE file found in " + source), Transience.PERSISTENT);
+          new IOException("No MODULE.bazel, REPO.bazel, or WORKSPACE file found in " + destination),
+          Transience.PERSISTENT);
     }
     return RepositoryDirectoryValue.builder().setPath(source);
-  }
-
-  @Nullable
-  private static FileValue getWorkspaceFile(RootedPath directory, Environment env)
-      throws RepositoryFunctionException, InterruptedException {
-    RootedPath workspaceRootedFile;
-    try {
-      workspaceRootedFile = WorkspaceFileHelper.getWorkspaceRootedFile(directory, env);
-      if (workspaceRootedFile == null) {
-        return null;
-      }
-    } catch (IOException e) {
-      throw new RepositoryFunctionException(
-          new IOException(
-              "Could not determine workspace file (\"WORKSPACE.bazel\" or \"WORKSPACE\"): "
-                  + e.getMessage()),
-          Transience.PERSISTENT);
-    }
-    SkyKey workspaceFileKey = FileValue.key(workspaceRootedFile);
-    FileValue value;
-    try {
-      value = (FileValue) env.getValueOrThrow(workspaceFileKey, IOException.class);
-    } catch (IOException e) {
-      throw new RepositoryFunctionException(
-          new IOException("Could not access " + workspaceRootedFile + ": " + e.getMessage()),
-          Transience.PERSISTENT);
-    }
-    return value;
   }
 
   // Escape a value for the marker file

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.rules.repository;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -400,35 +399,6 @@ public abstract class RepositoryFunction {
   /** Wheather the rule declares it inspects the local environment for configure purpose. */
   protected boolean isConfigure(Rule rule) {
     return false;
-  }
-
-  protected Path prepareLocalRepositorySymlinkTree(Rule rule, Path repositoryDirectory)
-      throws RepositoryFunctionException {
-    try {
-      repositoryDirectory.createDirectoryAndParents();
-    } catch (IOException e) {
-      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
-    }
-
-    // Add x/WORKSPACE.
-    createWorkspaceFile(repositoryDirectory, rule.getTargetKind(), rule.getName());
-    return repositoryDirectory;
-  }
-
-  public static void createWorkspaceFile(Path repositoryDirectory, String ruleKind, String ruleName)
-      throws RepositoryFunctionException {
-    try {
-      Path workspaceFile = repositoryDirectory.getRelative(LabelConstants.WORKSPACE_FILE_NAME);
-      FileSystemUtils.writeContent(
-          workspaceFile,
-          UTF_8,
-          String.format(
-              "# DO NOT EDIT: automatically generated WORKSPACE file for %s\n"
-                  + "workspace(name = \"%s\")\n",
-              ruleKind, ruleName));
-    } catch (IOException e) {
-      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
-    }
   }
 
   protected static RepositoryDirectoryValue.Builder writeFile(

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/WorkspaceFileHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/WorkspaceFileHelper.java
@@ -17,7 +17,6 @@ import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyKey;
@@ -26,12 +25,6 @@ import javax.annotation.Nullable;
 
 /** A class to help dealing with WORKSPACE.bazel and WORKSAPCE file */
 public class WorkspaceFileHelper {
-
-  public static RootedPath getWorkspaceRootedFile(Root directory, Environment env)
-      throws IOException, InterruptedException {
-    return getWorkspaceRootedFile(
-        RootedPath.toRootedPath(directory, PathFragment.EMPTY_FRAGMENT), env);
-  }
 
   /**
    * Get a RootedPath of the WORKSPACE file we should use for a given directory. This function
@@ -70,23 +63,17 @@ public class WorkspaceFileHelper {
         directory.getRootRelativePath().getRelative(LabelConstants.WORKSPACE_FILE_NAME));
   }
 
-  public static boolean doesWorkspaceFileExistUnder(Path directory) {
+  public static boolean isValidRepoRoot(Path directory) {
+    // Keep in sync with //src/main/cpp/workspace_layout.h
     return directory.getRelative(LabelConstants.WORKSPACE_DOT_BAZEL_FILE_NAME).exists()
-        || directory.getRelative(LabelConstants.WORKSPACE_FILE_NAME).exists();
-  }
-
-  public static boolean matchWorkspaceFileName(String name) {
-    return matchWorkspaceFileName(PathFragment.create(name));
+        || directory.getRelative(LabelConstants.WORKSPACE_FILE_NAME).exists()
+        || directory.getRelative(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME).exists()
+        || directory.getRelative(LabelConstants.REPO_FILE_NAME).exists();
   }
 
   public static boolean matchWorkspaceFileName(PathFragment name) {
     return name.equals(LabelConstants.WORKSPACE_DOT_BAZEL_FILE_NAME)
         || name.equals(LabelConstants.WORKSPACE_FILE_NAME);
-  }
-
-  public static boolean endsWithWorkspaceFileName(PathFragment pathFragment) {
-    return pathFragment.endsWith(LabelConstants.WORKSPACE_DOT_BAZEL_FILE_NAME)
-        || pathFragment.endsWith(LabelConstants.WORKSPACE_FILE_NAME);
   }
 
   private WorkspaceFileHelper() {}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
@@ -333,6 +333,15 @@ public class PackageFunction implements SkyFunction {
     if (env.valuesMissing()) {
       return null;
     }
+    if (!starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)) {
+      throw PackageFunctionException.builder()
+          .setType(PackageFunctionException.Type.NO_SUCH_PACKAGE)
+          .setTransience(Transience.PERSISTENT)
+          .setPackageIdentifier(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER)
+          .setMessage("the WORKSPACE file is disabled via --noenable_workspace")
+          .setPackageLoadingCode(PackageLoading.Code.WORKSPACE_FILE_ERROR)
+          .build();
+    }
 
     SkyKey workspaceKey = ExternalPackageFunction.key();
     PackageValue workspace = null;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
@@ -116,6 +116,7 @@ public class PackageLookupFunction implements SkyFunction {
 
     if (packageKey.equals(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER)) {
       return semantics.getBool(BuildLanguageOptions.EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE)
+              || !semantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)
           ? PackageLookupValue.NO_BUILD_FILE_VALUE
           : computeWorkspacePackageLookupValue(env);
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
@@ -57,6 +57,7 @@ public class RepositoryMappingFunction implements SkyFunction {
     }
     RepositoryName repositoryName = ((RepositoryMappingValue.Key) skyKey).repoName();
     boolean enableBzlmod = starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_BZLMOD);
+    boolean enableWorkspace = starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE);
 
     if (enableBzlmod) {
       if (StarlarkBuiltinsValue.isBuiltinsRepo(repositoryName)) {
@@ -102,7 +103,8 @@ public class RepositoryMappingFunction implements SkyFunction {
       }
 
       if (repositoryName.isMain()
-          && ((RepositoryMappingValue.Key) skyKey).rootModuleShouldSeeWorkspaceRepos()) {
+          && ((RepositoryMappingValue.Key) skyKey).rootModuleShouldSeeWorkspaceRepos()
+          && enableWorkspace) {
         // The root module should be able to see repos defined in WORKSPACE. Therefore, we find all
         // workspace repos and add them as extra visible repos in root module's repo mappings.
         PackageValue externalPackageValue =
@@ -157,22 +159,26 @@ public class RepositoryMappingFunction implements SkyFunction {
       }
     }
 
-    PackageValue externalPackageValue =
-        (PackageValue) env.getValue(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER);
-    RepositoryMappingValue rootModuleRepoMappingValue =
-        enableBzlmod
-            ? (RepositoryMappingValue)
-                env.getValue(RepositoryMappingValue.KEY_FOR_ROOT_MODULE_WITHOUT_WORKSPACE_REPOS)
-            : null;
-    if (env.valuesMissing()) {
-      return null;
+    if (enableWorkspace) {
+      PackageValue externalPackageValue =
+          (PackageValue) env.getValue(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER);
+      RepositoryMappingValue rootModuleRepoMappingValue =
+          enableBzlmod
+              ? (RepositoryMappingValue)
+                  env.getValue(RepositoryMappingValue.KEY_FOR_ROOT_MODULE_WITHOUT_WORKSPACE_REPOS)
+              : null;
+      if (env.valuesMissing()) {
+        return null;
+      }
+
+      RepositoryMapping rootModuleRepoMapping =
+          rootModuleRepoMappingValue == null
+              ? null
+              : rootModuleRepoMappingValue.getRepositoryMapping();
+      return computeFromWorkspace(repositoryName, externalPackageValue, rootModuleRepoMapping);
     }
 
-    RepositoryMapping rootModuleRepoMapping =
-        rootModuleRepoMappingValue == null
-            ? null
-            : rootModuleRepoMappingValue.getRepositoryMapping();
-    return computeFromWorkspace(repositoryName, externalPackageValue, rootModuleRepoMapping);
+    throw new RepositoryMappingFunctionException();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/WorkspaceNameFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/WorkspaceNameFunction.java
@@ -59,16 +59,19 @@ public class WorkspaceNameFunction implements SkyFunction {
       // danger (i.e. going through repo mapping is idempotent).
       return WorkspaceNameValue.withName(ruleClassProvider.getRunfilesPrefix());
     }
-    PackageValue externalPackageValue =
-        (PackageValue) env.getValue(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER);
-    if (externalPackageValue == null) {
-      return null;
+    if (starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)) {
+      PackageValue externalPackageValue =
+          (PackageValue) env.getValue(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER);
+      if (externalPackageValue == null) {
+        return null;
+      }
+      Package externalPackage = externalPackageValue.getPackage();
+      if (externalPackage.containsErrors()) {
+        throw new WorkspaceNameFunctionException();
+      }
+      return WorkspaceNameValue.withName(externalPackage.getWorkspaceName());
     }
-    Package externalPackage = externalPackageValue.getPackage();
-    if (externalPackage.containsErrors()) {
-      throw new WorkspaceNameFunctionException();
-    }
-    return WorkspaceNameValue.withName(externalPackage.getWorkspaceName());
+    throw new WorkspaceNameFunctionException();
   }
 
   private static class WorkspaceNameFunctionException extends SkyFunctionException {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunction.java
@@ -116,7 +116,8 @@ public class RegisteredExecutionPlatformsFunction implements SkyFunction {
     // Get the registered execution platforms from the WORKSPACE.
     // The WORKSPACE suffixes don't register any execution platforms, so we can register all
     // platforms in WORKSPACE before those in non-root Bazel modules.
-    ImmutableList<TargetPattern> workspaceExecutionPlatforms = getWorkspaceExecutionPlatforms(env);
+    ImmutableList<TargetPattern> workspaceExecutionPlatforms =
+        getWorkspaceExecutionPlatforms(starlarkSemantics, env);
     if (workspaceExecutionPlatforms == null) {
       return null;
     }
@@ -161,8 +162,11 @@ public class RegisteredExecutionPlatformsFunction implements SkyFunction {
    */
   @Nullable
   @VisibleForTesting
-  public static ImmutableList<TargetPattern> getWorkspaceExecutionPlatforms(Environment env)
-      throws InterruptedException {
+  public static ImmutableList<TargetPattern> getWorkspaceExecutionPlatforms(
+      StarlarkSemantics semantics, Environment env) throws InterruptedException {
+    if (!semantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)) {
+      return ImmutableList.of();
+    }
     PackageValue externalPackageValue =
         (PackageValue) env.getValue(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER);
     if (externalPackageValue == null) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunction.java
@@ -106,7 +106,7 @@ public class RegisteredToolchainsFunction implements SkyFunction {
 
     // Get the toolchains from the user-supplied WORKSPACE file.
     ImmutableList<TargetPattern> userRegisteredWorkspaceToolchains =
-        getWorkspaceToolchains(env, /* userRegistered= */ true);
+        getWorkspaceToolchains(starlarkSemantics, env, /* userRegistered= */ true);
     if (userRegisteredWorkspaceToolchains == null) {
       return null;
     }
@@ -122,7 +122,7 @@ public class RegisteredToolchainsFunction implements SkyFunction {
 
     // Get the toolchains from the Bazel-supplied WORKSPACE suffix.
     ImmutableList<TargetPattern> workspaceSuffixToolchains =
-        getWorkspaceToolchains(env, /* userRegistered= */ false);
+        getWorkspaceToolchains(starlarkSemantics, env, /* userRegistered= */ false);
     if (workspaceSuffixToolchains == null) {
       return null;
     }
@@ -160,7 +160,11 @@ public class RegisteredToolchainsFunction implements SkyFunction {
   @Nullable
   @VisibleForTesting
   public static ImmutableList<TargetPattern> getWorkspaceToolchains(
-      Environment env, boolean userRegistered) throws InterruptedException {
+      StarlarkSemantics semantics, Environment env, boolean userRegistered)
+      throws InterruptedException {
+    if (!semantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)) {
+      return ImmutableList.of();
+    }
     PackageValue externalPackageValue =
         (PackageValue) env.getValue(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER);
     if (externalPackageValue == null) {

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -128,6 +128,7 @@ public class ConsistencyTest {
         "--experimental_bzl_visibility=" + rand.nextBoolean(),
         "--experimental_enable_android_migration_apis=" + rand.nextBoolean(),
         "--enable_bzlmod=" + rand.nextBoolean(),
+        "--enable_workspace=" + rand.nextBoolean(),
         "--experimental_isolated_extension_usages=" + rand.nextBoolean(),
         "--experimental_google_legacy_api=" + rand.nextBoolean(),
         "--experimental_platforms_api=" + rand.nextBoolean(),
@@ -174,6 +175,7 @@ public class ConsistencyTest {
         .setBool(
             BuildLanguageOptions.EXPERIMENTAL_ENABLE_ANDROID_MIGRATION_APIS, rand.nextBoolean())
         .setBool(BuildLanguageOptions.ENABLE_BZLMOD, rand.nextBoolean())
+        .setBool(BuildLanguageOptions.ENABLE_WORKSPACE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_ISOLATED_EXTENSION_USAGES, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_GOOGLE_LEGACY_API, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_PLATFORMS_API, rand.nextBoolean())

--- a/src/test/java/com/google/devtools/build/lib/repository/ExternalPackageHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/repository/ExternalPackageHelperTest.java
@@ -84,6 +84,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkSemantics;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -413,12 +414,14 @@ public class ExternalPackageHelperTest extends BuildViewTestCase {
     public SkyValue compute(SkyKey skyKey, Environment env)
         throws SkyFunctionException, InterruptedException {
       ImmutableList<TargetPattern> userRegisteredToolchains =
-          RegisteredToolchainsFunction.getWorkspaceToolchains(env, /* userRegistered= */ true);
+          RegisteredToolchainsFunction.getWorkspaceToolchains(
+              StarlarkSemantics.DEFAULT, env, /* userRegistered= */ true);
       if (userRegisteredToolchains == null) {
         return null;
       }
       ImmutableList<TargetPattern> workspaceSuffixRegisteredToolchains =
-          RegisteredToolchainsFunction.getWorkspaceToolchains(env, /* userRegistered= */ false);
+          RegisteredToolchainsFunction.getWorkspaceToolchains(
+              StarlarkSemantics.DEFAULT, env, /* userRegistered= */ false);
       if (workspaceSuffixRegisteredToolchains == null) {
         return null;
       }
@@ -451,7 +454,8 @@ public class ExternalPackageHelperTest extends BuildViewTestCase {
     public SkyValue compute(SkyKey skyKey, Environment env)
         throws SkyFunctionException, InterruptedException {
       List<TargetPattern> registeredExecutionPlatforms =
-          RegisteredExecutionPlatformsFunction.getWorkspaceExecutionPlatforms(env);
+          RegisteredExecutionPlatformsFunction.getWorkspaceExecutionPlatforms(
+              StarlarkSemantics.DEFAULT, env);
       if (registeredExecutionPlatforms == null) {
         return null;
       }

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryFunctionTest.java
@@ -30,7 +30,6 @@ import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.vfs.FileStatus;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -99,18 +98,6 @@ public class RepositoryFunctionTest extends BuildViewTestCase {
             TestingRepositoryFunction.getTargetPath(
                 TestingRepositoryFunction.getPathAttr(rule), rootDirectory))
         .isEqualTo(PathFragment.create("/a/b/c"));
-  }
-
-  @Test
-  public void testGenerateWorkspaceFile() throws Exception {
-    Rule rule = scratchRule("external", "abc", "local_repository(",
-        "    name = 'abc',",
-        "    path = '/a/b/c',",
-        ")");
-    RepositoryFunction.createWorkspaceFile(rootDirectory, rule.getTargetKind(), rule.getName());
-    String workspaceContent = new String(
-        FileSystemUtils.readContentAsLatin1(rootDirectory.getRelative("WORKSPACE")));
-    assertThat(workspaceContent).contains("workspace(name = \"abc\")");
   }
 
   private static void assertMarkerFileEscaping(String testCase) {

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -34,7 +34,7 @@ class BazelFetchTest(test_base.TestBase):
         [
             # In ipv6 only network, this has to be enabled.
             # 'startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true',
-            'common --enable_bzlmod',
+            'common --noenable_workspace',
             'common --experimental_isolated_extension_usages',
             'common --registry=' + self.main_registry.getURL(),
             'common --verbose_failures',
@@ -44,21 +44,16 @@ class BazelFetchTest(test_base.TestBase):
             'common --lockfile_mode=update',
         ],
     )
-    self.ScratchFile('WORKSPACE')
-    # The existence of WORKSPACE.bzlmod prevents WORKSPACE prefixes or suffixes
-    # from being used; this allows us to test built-in modules actually work
-    self.ScratchFile('WORKSPACE.bzlmod')
+    self.ScratchFile('MODULE.bazel')
     self.generatBuiltinModules()
 
   def generatBuiltinModules(self):
     self.ScratchFile('platforms_mock/BUILD')
-    self.ScratchFile('platforms_mock/WORKSPACE')
     self.ScratchFile(
         'platforms_mock/MODULE.bazel', ['module(name="local_config_platform")']
     )
 
     self.ScratchFile('tools_mock/BUILD')
-    self.ScratchFile('tools_mock/WORKSPACE')
     self.ScratchFile('tools_mock/MODULE.bazel', ['module(name="bazel_tools")'])
     self.ScratchFile('tools_mock/tools/build_defs/repo/BUILD')
     self.CopyFile(
@@ -94,7 +89,6 @@ class BazelFetchTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD")',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
             '',
@@ -132,7 +126,6 @@ class BazelFetchTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD")',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
             'repo_rule2 = repository_rule(implementation=_repo_rule_impl, ',
@@ -243,7 +236,6 @@ class BazelFetchTest(test_base.TestBase):
             'def _repo_rule_impl(ctx):',
             '    file_content = ctx.read("' + file_path + '").strip()',
             '    print(file_content)',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD")',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
             '',

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -43,7 +43,7 @@ class BazelLockfileTest(test_base.TestBase):
         [
             # In ipv6 only network, this has to be enabled.
             # 'startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true',
-            'build --enable_bzlmod',
+            'build --noenable_workspace',
             'build --experimental_isolated_extension_usages',
             'build --registry=' + self.main_registry.getURL(),
             # We need to have BCR here to make sure built-in modules like
@@ -56,10 +56,6 @@ class BazelLockfileTest(test_base.TestBase):
             'build --lockfile_mode=update',
         ],
     )
-    self.ScratchFile('WORKSPACE')
-    # The existence of WORKSPACE.bzlmod prevents WORKSPACE prefixes or suffixes
-    # from being used; this allows us to test built-in modules actually work
-    self.ScratchFile('WORKSPACE.bzlmod')
     # TODO(pcloudy): investigate why this is needed, MODULE.bazel.lock is not
     # deterministic?
     os.remove(self.Path('MODULE.bazel.lock'))
@@ -223,7 +219,6 @@ class BazelLockfileTest(test_base.TestBase):
     )
     self.ScratchFile('BUILD', ['filegroup(name = "hello")'])
     self.ScratchFile('bar/MODULE.bazel', ['module(name="bar")'])
-    self.ScratchFile('bar/WORKSPACE', [])
     self.ScratchFile('bar/BUILD', ['filegroup(name = "hello from bar")'])
     self.RunBazel(
         [
@@ -271,7 +266,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
@@ -326,7 +320,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
@@ -374,7 +367,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
@@ -446,7 +438,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
             'def _ext_a_impl(ctx):',
@@ -482,7 +473,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
             'repo_rule = repository_rule(implementation = _repo_rule_impl)',
             'def _mod_ext_impl(ctx):',
@@ -510,7 +500,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
             'repo_rule = repository_rule(implementation = _repo_rule_impl)',
             'def _mod_ext_impl(ctx):',
@@ -541,7 +530,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
             'repo_rule = repository_rule(implementation = _repo_rule_impl)',
             'def _mod_ext_impl(ctx):',
@@ -559,7 +547,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\\"lalo\\")")',
             'repo_rule = repository_rule(implementation = _repo_rule_impl)',
             'def _mod_ext_impl(ctx):',
@@ -601,7 +588,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
             'def _ext_impl(ctx):',
@@ -640,7 +626,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
@@ -700,7 +685,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
             'repo_rule = repository_rule(implementation = _repo_rule_impl)',
             'def _module_ext_impl(ctx):',
@@ -742,7 +726,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
             'repo_rule = repository_rule(implementation = _repo_rule_impl)',
             'def _module_ext_impl(ctx):',
@@ -786,7 +769,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
@@ -870,7 +852,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
@@ -992,7 +973,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
@@ -1034,7 +1014,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
             '',
@@ -1069,7 +1048,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
             '',
@@ -1102,7 +1080,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             'repo_rule = repository_rule(implementation=_repo_rule_impl)',
             '',
@@ -1146,7 +1123,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "exports_files([\\"data.txt\\"])")',
             '    ctx.file("data.txt", ctx.attr.value)',
             '    print(ctx.attr.value)',
@@ -1365,7 +1341,6 @@ class BazelLockfileTest(test_base.TestBase):
         'extension.bzl',
         [
             'def _repo_rule_impl(ctx):',
-            '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "exports_files([\\"data.txt\\"])")',
             '    ctx.file("data.txt", ctx.attr.value)',
             '    print(ctx.attr.value)',

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -41,7 +41,7 @@ class BazelOverridesTest(test_base.TestBase):
         [
             # In ipv6 only network, this has to be enabled.
             # 'startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true',
-            'build --enable_bzlmod',
+            'build --noenable_workspace',
             'build --registry=' + self.main_registry.getURL(),
             # We need to have BCR here to make sure built-in modules like
             # bazel_tools can work.
@@ -53,10 +53,6 @@ class BazelOverridesTest(test_base.TestBase):
             'build --lockfile_mode=update',
         ],
     )
-    self.ScratchFile('WORKSPACE')
-    # The existence of WORKSPACE.bzlmod prevents WORKSPACE prefixes or suffixes
-    # from being used; this allows us to test built-in modules actually work
-    self.ScratchFile('WORKSPACE.bzlmod')
 
   def writeMainProjectFiles(self):
     self.ScratchFile(
@@ -237,7 +233,6 @@ class BazelOverridesTest(test_base.TestBase):
         ],
     )
     self.ScratchFile('BUILD')
-    self.ScratchFile('WORKSPACE')
 
     self.ScratchFile(
         'aa/MODULE.bazel',
@@ -251,7 +246,6 @@ class BazelOverridesTest(test_base.TestBase):
             'filegroup(name = "never_ever")',
         ],
     )
-    self.ScratchFile('aa/WORKSPACE')
 
     self.ScratchFile(
         'bb/MODULE.bazel',
@@ -265,7 +259,6 @@ class BazelOverridesTest(test_base.TestBase):
             'filegroup(name = "choose_me")',
         ],
     )
-    self.ScratchFile('bb/WORKSPACE')
 
     _, _, stderr = self.RunBazel(
         ['build', '@ss//:all', '--override_module', 'ss=' + self.Path('bb')]
@@ -276,7 +269,6 @@ class BazelOverridesTest(test_base.TestBase):
     )
 
   def testCmdRelativeModuleOverride(self):
-    self.ScratchFile('aa/WORKSPACE')
     self.ScratchFile(
         'aa/MODULE.bazel',
         [
@@ -287,7 +279,6 @@ class BazelOverridesTest(test_base.TestBase):
 
     self.ScratchFile('aa/cc/BUILD')
 
-    self.ScratchFile('bb/WORKSPACE')
     self.ScratchFile(
         'bb/MODULE.bazel',
         [
@@ -316,7 +307,6 @@ class BazelOverridesTest(test_base.TestBase):
     )
 
   def testCmdWorkspaceRelativeModuleOverride(self):
-    self.ScratchFile('WORKSPACE')
     self.ScratchFile(
         'MODULE.bazel',
         [
@@ -325,7 +315,6 @@ class BazelOverridesTest(test_base.TestBase):
     )
     self.ScratchFile('BUILD')
     self.ScratchFile('aa/BUILD')
-    self.ScratchFile('bb/WORKSPACE')
     self.ScratchFile(
         'bb/MODULE.bazel',
         [

--- a/src/test/py/bazel/bzlmod/bazel_yanked_versions_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_yanked_versions_test.py
@@ -49,10 +49,6 @@ class BazelYankedVersionsTest(test_base.TestBase):
         'yanked2', yanked_versions={'1.0': 'sketchy'}
     )
     self.writeBazelrcFile()
-    self.ScratchFile('WORKSPACE')
-    # The existence of WORKSPACE.bzlmod prevents WORKSPACE prefixes or suffixes
-    # from being used; this allows us to test built-in modules actually work
-    self.ScratchFile('WORKSPACE.bzlmod')
 
   def writeBazelrcFile(self, allow_yanked_versions=True):
     self.ScratchFile(
@@ -60,7 +56,7 @@ class BazelYankedVersionsTest(test_base.TestBase):
         [
             # In ipv6 only network, this has to be enabled.
             # 'startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true',
-            'build --enable_bzlmod',
+            'build --noenable_workspace',
             'build --registry=' + self.main_registry.getURL(),
             # We need to have BCR here to make sure built-in modules like
             # bazel_tools can work.
@@ -95,7 +91,6 @@ class BazelYankedVersionsTest(test_base.TestBase):
             ')',
         ],
     )
-    self.ScratchFile('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -116,7 +111,6 @@ class BazelYankedVersionsTest(test_base.TestBase):
             'bazel_dep(name = "yanked1", version = "1.0")',
         ],
     )
-    self.ScratchFile('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -145,7 +139,6 @@ class BazelYankedVersionsTest(test_base.TestBase):
             'bazel_dep(name = "ddd", version = "1.0")',
         ],
     )
-    self.ScratchFile('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -173,7 +166,6 @@ class BazelYankedVersionsTest(test_base.TestBase):
             'bazel_dep(name = "ddd", version = "1.0")',
         ],
     )
-    self.ScratchFile('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -210,7 +202,6 @@ class BazelYankedVersionsTest(test_base.TestBase):
             'bazel_dep(name = "ddd", version = "1.0")',
         ],
     )
-    self.ScratchFile('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [

--- a/src/test/py/bazel/bzlmod/bzlmod_credentials_test.py
+++ b/src/test/py/bazel/bzlmod/bzlmod_credentials_test.py
@@ -38,15 +38,11 @@ class BzlmodCredentialsTest(test_base.TestBase):
         [
             # In ipv6 only network, this has to be enabled.
             # 'startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true',
-            'common --enable_bzlmod',
+            'common --noenable_workspace',
             # Disable yanked version check so we are not affected BCR changes.
             'common --allow_yanked_versions=all',
         ],
     )
-    self.ScratchFile('WORKSPACE')
-    # The existence of WORKSPACE.bzlmod prevents WORKSPACE prefixes or suffixes
-    # from being used; this allows us to test built-in modules actually work
-    self.ScratchFile('WORKSPACE.bzlmod')
     self.ScratchFile(
         'MODULE.bazel',
         [

--- a/src/test/py/bazel/bzlmod/bzlmod_query_test.py
+++ b/src/test/py/bazel/bzlmod/bzlmod_query_test.py
@@ -40,7 +40,7 @@ class BzlmodQueryTest(test_base.TestBase):
         [
             # In ipv6 only network, this has to be enabled.
             # 'startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true',
-            'common --experimental_enable_bzlmod',
+            'common --noenable_workspace',
             'common --registry=' + self.main_registry.getURL(),
             # We need to have BCR here to make sure built-in modules like
             # bazel_tools can work.
@@ -49,10 +49,6 @@ class BzlmodQueryTest(test_base.TestBase):
             'common --allow_yanked_versions=all',
         ],
     )
-    self.ScratchFile('WORKSPACE')
-    # The existence of WORKSPACE.bzlmod prevents WORKSPACE prefixes or suffixes
-    # from being used; this allows us to test built-in modules actually work
-    self.ScratchFile('WORKSPACE.bzlmod')
 
   def testQueryModuleRepoTargetsBelow(self):
     self.ScratchFile('MODULE.bazel', [

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -40,7 +40,7 @@ class ModCommandTest(test_base.TestBase):
         [
             # In ipv6 only network, this has to be enabled.
             # 'startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true',
-            'mod --enable_bzlmod',
+            'mod --noenable_workspace',
             'mod --registry=' + self.main_registry.getURL(),
             # We need to have BCR here to make sure built-in modules like
             # bazel_tools can work.
@@ -51,10 +51,6 @@ class ModCommandTest(test_base.TestBase):
             'mod --charset=ascii',
         ],
     )
-    self.ScratchFile('WORKSPACE')
-    # The existence of WORKSPACE.bzlmod prevents WORKSPACE prefixes or suffixes
-    # from being used; this allows us to test built-in modules actually work
-    self.ScratchFile('WORKSPACE.bzlmod')
 
     self.ScratchFile(
         'MODULE.bazel',
@@ -130,13 +126,9 @@ class ModCommandTest(test_base.TestBase):
     ]
 
     self.main_registry.createLocalPathModule('ext', '1.0', 'ext')
-    self.projects_dir.joinpath('ext').mkdir(exist_ok=True)
-    scratchFile(self.projects_dir.joinpath('ext', 'WORKSPACE'))
     scratchFile(self.projects_dir.joinpath('ext', 'BUILD'))
     scratchFile(self.projects_dir.joinpath('ext', 'ext.bzl'), ext_src)
     self.main_registry.createLocalPathModule('ext2', '1.0', 'ext2')
-    self.projects_dir.joinpath('ext2').mkdir(exist_ok=True)
-    scratchFile(self.projects_dir.joinpath('ext2', 'WORKSPACE'))
     scratchFile(self.projects_dir.joinpath('ext2', 'BUILD'))
     scratchFile(self.projects_dir.joinpath('ext2', 'ext.bzl'), ext_src)
 

--- a/src/test/py/bazel/bzlmod/test_utils.py
+++ b/src/test/py/bazel/bzlmod/test_utils.py
@@ -155,7 +155,6 @@ class BazelRegistry:
         return ''
       return ', repo_name = "%s"' % repo_names[dep]
 
-    scratchFile(src_dir.joinpath('WORKSPACE'))
     scratchFile(
         src_dir.joinpath('MODULE.bazel'),
         [
@@ -330,13 +329,15 @@ class BazelRegistry:
     if deps is None:
       deps = {}
 
-    scratchFile(
-        module_dir.joinpath('MODULE.bazel'), [
-            'module(',
-            '  name = "%s",' % name,
-            '  version = "%s",' % version,
-            ')',
-        ] + ['bazel_dep(name="%s",version="%s")' % p for p in deps.items()])
+    module_file_lines = [
+        'module(',
+        '  name = "%s",' % name,
+        '  version = "%s",' % version,
+        ')',
+    ] + ['bazel_dep(name="%s",version="%s")' % p for p in deps.items()]
+    scratchFile(module_dir.joinpath('MODULE.bazel'), module_file_lines)
+    self.projects.joinpath(path).mkdir(exist_ok=True)
+    scratchFile(self.projects.joinpath(path, 'MODULE.bazel'), module_file_lines)
 
     with module_dir.joinpath('source.json').open('w') as f:
       json.dump(source, f, indent=4, sort_keys=True)

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -1165,17 +1165,12 @@ local_repository(
 EOF
 
   bazel build @r//... &> $TEST_log && fail "Build succeeded unexpectedly"
-  expect_log "No WORKSPACE file found"
+  expect_log "No MODULE.bazel, REPO.bazel, or WORKSPACE file found"
 
   # Create the workspace and verify it now succeeds.
   create_workspace_with_default_repos $r/WORKSPACE
   bazel build @r//... &> $TEST_log || fail "Build failed unexpectedly"
-  expect_not_log "No WORKSPACE file found"
-
-  # Remove again and verify it fails again.
-  rm -f $r/WORKSPACE
-  bazel build @r//... &> $TEST_log && fail "Build succeeded unexpectedly"
-  expect_log "No WORKSPACE file found"
+  expect_not_log "No MODULE.bazel, REPO.bazel, or WORKSPACE file found"
 }
 
 # Regression test for #1697.


### PR DESCRIPTION
… handling

* This flag defaults to true
* When turned off (`--noenable_workspace`), no WORKSPACE file reading is ever done (including `WORKSPACE.bzlmod`, `WORKSPACE.resolved`, prefixes, suffixes, etc). No `//external` package is created or used.
* Bzlmod and WORKSPACE can't both be turned off.
* We no longer mandate that a WORKSPACE file has to be at the root of a repo; that is now replaced by `REPO.bazel`. But it's still okay to have a `WORKSPACE` file and no `REPO.bazel` file at the root of a `local_repository`, for example.
* All Bzlmod integration tests now have `--noenable_workspace` set.

Fixes https://github.com/bazelbuild/bazel/issues/20185.

RELNOTES: Added a flag `--enable_workspace` (defaults to True) that allows the user to completely disable WORKSPACE logic when turned off.

PiperOrigin-RevId: 589978780
Change-Id: I07a1b8674aaad2758ded57c3a48dba2a19c91e04