### PR TITLE
[7.1.0] Document `--digest_function` startup flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -402,18 +402,15 @@ public class BlazeServerStartupOptions extends OptionsBase {
       help = "The maximum amount of time the client waits to connect to the server")
   public int localStartupTimeoutSecs;
 
-  // TODO(b/109764197): Add OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS & remove the
-  // experimental tag once this has been tested and is ready for use.
   @Option(
       name = "digest_function",
       defaultValue = "null",
       converter = DigestHashFunction.DigestFunctionConverter.class,
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
       effectTags = {
         OptionEffectTag.LOSES_INCREMENTAL_STATE,
         OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION
       },
-      metadataTags = OptionMetadataTag.EXPERIMENTAL,
       help = "The hash function to use when computing file digests.")
   public DigestHashFunction digestHashFunction;
 


### PR DESCRIPTION
This flag is in use in production today (e.g. when using `blake3`).

Closes #20747.

Commit https://github.com/bazelbuild/bazel/commit/6d302147eb7b2d2dc64fb92187f30591caf275ae

PiperOrigin-RevId: 597704594
Change-Id: I92b5cfc4bf70c86d50049c6881f7b5f4fb7d30be