### PR TITLE
[7.1.0] Remove suffix from fastutil alias.

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -280,7 +280,7 @@ alias(
 
 alias(
     name = "fastutil",
-    actual = "@maven//:it_unimi_dsi_fastutil_7_2_1",
+    actual = "@maven//:it_unimi_dsi_fastutil",
 )
 
 alias(


### PR DESCRIPTION
The derived @maven BUILD.vendor file doesn't contain the versioned alias target.

Test: cherrypick unknown commit and run bazelisk test //src/test/shell/bazel:bazel_bootstrap_distfile_tar_test

RELNOTES:
PiperOrigin-RevId: 586942730
Change-Id: I033c80608da06cffd478348b6187e23ad0c64b09