### PR TITLE
java_common.pack_sources shouldn't derive paths from file.short_path

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
@@ -295,7 +295,13 @@ def _executable_providers(ctx):
 def _resource_mapper(file):
     return "%s:%s" % (
         file.path,
-        semantics.get_default_resource_path(file.short_path, segment_extractor = _java_segments),
+        semantics.get_default_resource_path(
+            paths.relativize(
+                file.path,
+                paths.normalize(paths.join(file.root.path, file.owner.workspace_root)),
+            ),
+            segment_extractor = _java_segments,
+        ),
     )
 
 def _create_single_jar(


### PR DESCRIPTION
This commit tweaks the Starlark implementation of `java_common.pack_sources` to behave more like its original Java counterpart.  Specifically, we don't use `file.short_path`, because when `file` comes from an external repository, `short_path` will have a `../<externalrepo>` prefix.

Resolves #20882.