### PR TITLE
Error on odd .bazelrc lines

### DIFF
--- a/src/main/cpp/rc_file.cc
+++ b/src/main/cpp/rc_file.cc
@@ -94,6 +94,14 @@ RcFile::ParseError RcFile::ParseFile(const std::string& filename,
     // Could happen if line starts with "#"
     if (words.empty()) continue;
 
+    // Error out on lines with a single word as the command was probably forgotten
+    if (words.size() <= 1) {
+      *error_text = absl::StrFormat(
+          "Incomplete line in .blazerc file '%s': '%s'",
+          canonical_filename.c_str(), line.c_str());
+      return ParseError::INVALID_FORMAT;
+    }
+
     const absl::string_view command = words[0];
     if (command != kCommandImport && command != kCommandTryImport) {
       for (absl::string_view word : absl::MakeConstSpan(words).subspan(1)) {
@@ -162,6 +170,7 @@ RcFile::ParseError RcFile::ParseFile(const std::string& filename,
       }
     }
     import_stack.pop_back();
+
   }
 
   return ParseError::NONE;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -686,15 +686,13 @@ public final class BlazeOptionHandler {
       if (!validCommands.contains(command)
           && !command.equals(ALWAYS_PSEUDO_COMMAND)
           && !command.equals(COMMON_PSEUDO_COMMAND)) {
-        eventHandler.handle(
-            Event.warn(
-                "while reading option defaults file '"
-                    + rcFile
-                    + "':\n"
-                    + "  invalid command name '"
-                    + override.command
-                    + "'."));
-        continue;
+        throw new OptionsParsingException(
+            "while reading option defaults file '"
+            + rcFile
+            + "':\n"
+            + "  invalid command name '"
+            + override.command
+            + "'.");
       }
 
       // We've moved on to another rc file "chunk," store the accumulated args from the last one.

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -156,14 +156,20 @@ public class BlazeOptionHandlerTest {
 
   @Test
   public void testStructureRcOptionsAndConfigs_invalidCommand() throws Exception {
-    BlazeOptionHandler.structureRcOptionsAndConfigs(
-        eventHandler,
-        Arrays.asList("rc1", "rc2"),
-        Arrays.asList(new ClientOptions.OptionOverride(0, "c1", "a")),
-        ImmutableSet.of("build"));
-    assertThat(eventHandler.getEvents())
-        .contains(
-            Event.warn("while reading option defaults file 'rc1':\n  invalid command name 'c1'."));
+    OptionsParsingException e =
+        assertThrows(
+            OptionsParsingException.class,
+            () ->
+                BlazeOptionHandler.structureRcOptionsAndConfigs(
+                    eventHandler,
+                    Arrays.asList("rc1", "rc2"),
+                    Arrays.asList(new ClientOptions.OptionOverride(0, "c1", "a")),
+                    ImmutableSet.of("build")));
+    assertThat(parser.getResidue()).isEmpty();
+    assertThat(optionHandler.getRcfileNotes()).isEmpty();
+    assertThat(e)
+        .hasMessageThat()
+        .contains("while reading option defaults file 'rc1':\n  invalid command name 'c1'.");
   }
 
   @Test


### PR DESCRIPTION
I have tried to spare users a long debugging session searching for a .bazelrc
line that was not applied.

The main issue is in the client parser, which assumes that the first word on a line is _always_ a command. If you are unlucky enough, you forgot the command an passed a single flag. The client assumes it is a command with no flags, and passes nothing to the server, hence silently ignoring the bogus line.

I have changed the client to refuse lines with a single word, which is both simpler to do, and prevents what seems like a code smell anyway.

It is thus a breaking change for users who used to comment only the flag and not the command, or those who have empty commands to keep blocks together.
Overall, the RC files lack a proper specification, which makes it impossible to know precisely what is valid.

```
# The two following lines will no more work.
common # --host_jvm_args=-Xmx1024m
common
```

The second commit is optional. It turns a warning about unrecognized command names into an error.
I think it makes sense to address these issues early. It may break users config if commands are removed in the future, but that set is pretty stable now.

Fixes #15245
