### PR TITLE
[7.0.1] Fix singlejar resource mapping for external repositories

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
@@ -293,9 +293,13 @@ def _executable_providers(ctx):
     return []
 
 def _resource_mapper(file):
+    root_relative_path = paths.relativize(
+        path = file.path,
+        start = paths.join(file.root.path, file.owner.workspace_root),
+    )
     return "%s:%s" % (
         file.path,
-        semantics.get_default_resource_path(file.short_path, segment_extractor = _java_segments),
+        semantics.get_default_resource_path(root_relative_path, segment_extractor = _java_segments),
     )
 
 def _create_single_jar(

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
@@ -3486,6 +3486,57 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testPackSourcesWithExternalResourceArtifact() throws Exception {
+    JavaTestUtil.writeBuildFileForJavaToolchain(scratch);
+    scratch.file(
+        "foo/custom_rule.bzl",
+        "def _impl(ctx):",
+        "  out = ctx.actions.declare_file('output.jar')",
+        "  java_toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo]",
+        "  java_common.pack_sources(",
+        "    ctx.actions,",
+        "    java_toolchain = java_toolchain,",
+        "    output_source_jar = out,",
+        "    sources = ctx.files.srcs,",
+        "  )",
+        "  return [DefaultInfo(files = depset([out]))]",
+        "java_custom_library = rule(",
+        "  implementation = _impl,",
+        "  attrs = {",
+        "    'srcs': attr.label_list(allow_files = True),",
+        "    '_java_toolchain': attr.label(default = Label('//java/com/google/test:toolchain')),",
+        "  },",
+        "  toolchains = ['" + TestConstants.JAVA_TOOLCHAIN_TYPE + "'],",
+        "  fragments = ['java']",
+        ")");
+    scratch.file("my_other_repo/WORKSPACE");
+    scratch.file("my_other_repo/external-file.txt");
+    scratch.file("my_other_repo/BUILD", "exports_files(['external-file.txt'])");
+    rewriteWorkspace("local_repository(name = 'other_repo', path = './my_other_repo')");
+    scratch.file(
+        "foo/BUILD",
+        "load(':custom_rule.bzl', 'java_custom_library')",
+        "java_custom_library(",
+        "  name = 'custom',",
+        "  srcs = [",
+        "    'internal-file.txt',",
+        "    '@other_repo//:external-file.txt',",
+        "  ]",
+        ")");
+
+    List<String> arguments =
+        ((SpawnAction) getGeneratingAction(getConfiguredTarget("//foo:custom"), "foo/output.jar"))
+            .getArguments();
+
+    assertThat(arguments)
+        .containsAtLeast(
+            "--resources",
+            "foo/internal-file.txt:foo/internal-file.txt",
+            "external/other_repo/external-file.txt:external-file.txt")
+        .inOrder();
+  }
+
+  @Test
   public void mergeAddExports() throws Exception {
     scratch.file(
         "foo/custom_library.bzl",

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
@@ -3487,7 +3487,7 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
 
   @Test
   public void testPackSourcesWithExternalResourceArtifact() throws Exception {
-    JavaTestUtil.writeBuildFileForJavaToolchain(scratch);
+    JavaToolchainTestUtil.writeBuildFileForJavaToolchain(scratch);
     scratch.file(
         "foo/custom_rule.bzl",
         "def _impl(ctx):",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/20882

Commit https://github.com/bazelbuild/bazel/commit/6ae53e5b5b0b1f4aa08b4f7f6790fe1c51f6735c

PiperOrigin-RevId: 598608807
Change-Id: If9230cd1c143eef09beabaf33cb1cb56e4540ae1