### PR TITLE
[7.1.0] Increase maximal length of profile span for repository function calls

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -125,8 +125,8 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
     boolean cancel();
   }
 
-  /** Max. number of command line args added as a profiler description. */
-  private static final int MAX_PROFILE_ARGS_LEN = 80;
+  /** Max. length of command line args added as a profiler description. */
+  private static final int MAX_PROFILE_ARGS_LEN = 512;
 
   protected final Path workingDirectory;
   protected final Environment env;


### PR DESCRIPTION
Previously, when calling tools under the install base like
```
local: /home/twerth/.cache/bazel/_bazel_twerth/install/3b42d7048466237272cc2c9346f0b8ea/process-wrapper --timeout=600 --kill_delay=15 whoami
```
you would not even see that `process-wrapper` has been called.

There is only a handful of Starlark repository function calls in a typical build and their description should also be well-compressible, so the increase is fine.

Commit https://github.com/bazelbuild/bazel/commit/38918be4f665e4eca69c9f3f5d469be6d63a486b

PiperOrigin-RevId: 598584702
Change-Id: I03fcf504e4a805aee21f92e3bf16b44e58bfbf10