### PR TITLE
Remove arch attribute from repo markerfile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -223,7 +223,6 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
       return null;
     }
     markerData.put(SEMANTICS, describeSemantics(starlarkSemantics));
-    markerData.put("ARCH:", CPU.getCurrent().getCanonicalName());
 
     PathPackageLocator packageLocator = PrecomputedValue.PATH_PACKAGE_LOCATOR.get(env);
     if (env.valuesMissing()) {


### PR DESCRIPTION
Now that the marker files will be also used for vendoring, each vendored repository has its marker file. To maintain platform independence, we should not include architecture details in these files. So that, if a repository is vendored on one platform and checked in, it should seamlessly work on other platforms, as long as it is up-to-date.

Additionally, this information was initially intended for a specific scenario involving Mac ships. But, we might not need them anymore!