### PR TITLE
[7.1.0] Still generate a WORKSPACE file in repo rules if --enable_workspace is set

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.BazelStarlarkContext;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.SymbolGenerator;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
@@ -355,6 +356,10 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
     if (!WorkspaceFileHelper.isValidRepoRoot(outputDirectory)) {
       try {
         FileSystemUtils.createEmptyFile(outputDirectory.getRelative(LabelConstants.REPO_FILE_NAME));
+        if (starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)) {
+          FileSystemUtils.createEmptyFile(
+              outputDirectory.getRelative(LabelConstants.WORKSPACE_FILE_NAME));
+        }
       } catch (IOException e) {
         throw new RepositoryFunctionException(e, Transience.TRANSIENT);
       }

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2408,4 +2408,26 @@ EOF
     || fail "Expected build to succeed"
 }
 
+function test_repo_boundary_files() {
+  create_new_workspace
+  cat > MODULE.bazel <<EOF
+r = use_repo_rule("//:r.bzl", "r")
+r(name = "r")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _r(rctx):
+  rctx.file("BUILD", "filegroup(name='r', srcs=glob(['*']))")
+r = repository_rule(_r)
+EOF
+
+  bazel query --noenable_workspace --output=build @r > output || fail "expected bazel to succeed"
+  assert_contains 'REPO.bazel' output
+  assert_not_contains 'WORKSPACE' output
+
+  bazel query --enable_workspace --output=build @r > output || fail "expected bazel to succeed"
+  assert_contains 'REPO.bazel' output
+  assert_contains 'WORKSPACE' output
+}
+
 run_suite "local repository tests"


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/commit/47e48a13563742473abdcaef46b7c4f222a86831 made it so that, after a repo rule finishes, we no longer generate an empty WORKSPACE file if one is not found at the repo root. (We generate a REPO.bazel file instead, which also marks the boundary of the repo just fine.) But some users actually expect a WORKSPACE file specifically, so this CL restores the behavior of creating an empty WORKSPACE file if --enable_workspace is set.

Note that neither WORKSPACE nor REPO.bazel is created if the repo rule logic creates any repo boundary file itself.

Fixes https://github.com/bazelbuild/bazel/issues/20498.
Commit https://github.com/bazelbuild/bazel/commit/c6a5ebb9af3d3e114a055c566f9aca777263a945

PiperOrigin-RevId: 590492936
Change-Id: I43bfc7bf79b3749f1fb02ce31be789d92c36a2c0