### PR TITLE
[7.1.0] python: make incompatible_python_disallow_native_rules work for top-level external repo targets

### DIFF
--- a/src/main/starlark/builtins_bzl/common/python/common.bzl
+++ b/src/main/starlark/builtins_bzl/common/python/common.bzl
@@ -486,9 +486,10 @@ def check_native_allowed(ctx):
         # package_group doesn't allow @repo syntax, so we work around that
         # by prefixing external repos with a fake package path. This also
         # makes it easy to enable or disable all external repos.
-        check_label = Label("@//__EXTERNAL_REPOS__/{workspace}/{package}".format(
+        check_label = Label("@//__EXTERNAL_REPOS__/{workspace}{package}".format(
             workspace = ctx.label.workspace_name,
-            package = ctx.label.package,
+            # Prevent a label with trailing slash, which is malformed.
+            package = "/" + ctx.label.package if ctx.label.package else "",
         ))
     allowlist = ctx.attr._native_rules_allowlist
     if allowlist:


### PR DESCRIPTION
This basically makes it usable with the downloaded runtimes rules_python makes
available, which reference their runtimes as e.g. `@python_3_11//:python`.

The issue was the code to construct the label was leaving a trailing "/" when
the the target being checked at the root of the workspace. To fix, just omit
the trailing slash when the package name is empty to prevent the trailing
slash.

Work towards https://github.com/bazelbuild/bazel/issues/17773

Closes https://github.com/bazelbuild/bazel/pull/20516

Commit https://github.com/bazelbuild/bazel/commit/1533cd123fa465480bbbcd4bdd2b438ebc5fb9eb

PiperOrigin-RevId: 591053422
Change-Id: I7790df2db10278844ae2b36cfe671de03164972f