### PR TITLE
[Fix] Extend cache key scrubbing to Empty virtual input path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
@@ -143,13 +143,9 @@ public class Scrubber {
     }
 
     /** Whether the given input should be omitted from the cache key. */
-    public boolean shouldOmitInput(ActionInput input) {
-      if (input.equals(VirtualActionInput.EMPTY_MARKER)) {
-        return false;
-      }
-      String execPath = input.getExecPathString();
+    public boolean shouldOmitInput(String path) {
       for (Pattern pattern : omittedInputPatterns) {
-        if (pattern.matcher(execPath).matches()) {
+        if (pattern.matcher(path).matches()) {
           return true;
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
@@ -262,10 +262,11 @@ class DirectoryTreeBuilder {
       PathFragment path = e.getKey();
       T input = e.getValue();
 
-      if (scrubber != null
-          && input instanceof ActionInput
-          && scrubber.shouldOmitInput((ActionInput) input)) {
-        continue;
+      if (scrubber != null && input instanceof ActionInput) {
+        String inputPath = input.equals(VirtualActionInput.EMPTY_MARKER) ? path.getPathString() : ((ActionInput)input).getExecPathString();
+        if (scrubber.shouldOmitInput(inputPath)) {
+          continue;
+        }
       }
 
       if (input instanceof DerivedArtifact && ((DerivedArtifact) input).isTreeArtifact()) {


### PR DESCRIPTION
Empty virtual path can also contain platform specific parts, therefore they should also be subject to xplat scrubbing.