### PR TITLE
[7.1.0] Point _virtual_includes to stable locations so IDE integrations survive builds

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
@@ -16,6 +16,7 @@
 
 load(":common/cc/cc_common.bzl", "cc_common")
 load(":common/cc/cc_helper.bzl", "cc_helper")
+load(":common/cc/semantics.bzl", "USE_EXEC_ROOT_FOR_VIRTUAL_INCLUDES_SYMLINKS")
 load(":common/paths.bzl", "paths")
 
 cc_internal = _builtins.internal.cc_internal
@@ -120,7 +121,7 @@ def _compute_public_headers(
                 output = virtual_header,
                 target_file = original_header,
                 progress_message = "Symlinking virtual headers for " + label.name,
-                use_exec_root_for_source = True,
+                use_exec_root_for_source = USE_EXEC_ROOT_FOR_VIRTUAL_INCLUDES_SYMLINKS,
             )
             module_map_headers.append(virtual_header)
             if config.coverage_enabled:

--- a/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
@@ -14,6 +14,11 @@
 
 """Semantics for Bazel cc rules"""
 
+# Point virtual includes symlinks to the source root for better IDE integration.
+# See https://github.com/bazelbuild/bazel/pull/20540.
+# TODO: b/320980684 - Add a test that fails if this is flipped to True.
+USE_EXEC_ROOT_FOR_VIRTUAL_INCLUDES_SYMLINKS = False
+
 def _get_proto_aspects():
     return []
 


### PR DESCRIPTION
Closes #20540.

Commit https://github.com/bazelbuild/bazel/commit/347407a88fd480fc5e0fbd42cc8196e4356a690b

PiperOrigin-RevId: 599516682
Change-Id: I57ac896c9fe127b428367043015feaaaf7b57339