### PR TITLE
[7.1.0] Cherry-pick the change to reduce repository invalidations to Bazel 7.1

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -308,6 +308,10 @@ public abstract class RepositoryFunction {
   protected Map<String, String> declareEnvironmentDependencies(
       Map<String, String> markerData, Environment env, Set<String> keys)
       throws InterruptedException {
+    if (keys.isEmpty()) {
+      return ImmutableMap.of();
+    }
+
     ImmutableMap<String, String> envDep = getEnvVarValues(env, keys);
     if (envDep == null) {
       return null;
@@ -349,6 +353,10 @@ public abstract class RepositoryFunction {
   protected boolean verifyEnvironMarkerData(
       Map<String, String> markerData, Environment env, Set<String> keys)
       throws InterruptedException {
+    if (keys.isEmpty()) {
+      return true;
+    }
+
     ImmutableMap<String, String> environ = ActionEnvironmentFunction.getEnvironmentView(env, keys);
     if (env.valuesMissing()) {
       return false; // Returns false so caller knows to return immediately


### PR DESCRIPTION
HEAD is wasteful because sometimes just checking the up-to-dateness of fetched repositories takes a lot of time (if there is a lot of hashing to be done), so it's better to get a Skyframe cache hit if at all possible.

This is not the full answer because repositories that depend only on unchanged environment variables will still need to be re-checked if there is an environment variable that does change, but it's still a step forward.

RELNOTES: None.
Commit https://github.com/bazelbuild/bazel/commit/80a4a1483e38353e9472ed8bfd5261efe1a6e23b

PiperOrigin-RevId: 599242763
Change-Id: I895c5793ed06ef2c7a3337ef232ab13a7596b325