### PR TITLE
Remove broken docs link to `java_output` builtin

### DIFF
--- a/site/en/docs/bazel-and-java.md
+++ b/site/en/docs/bazel-and-java.md
@@ -138,7 +138,6 @@ projects:
 
     *   [`java_annotation_processing`](/rules/lib/builtins/java_annotation_processing)
     *   [`java_compilation_info`](/rules/lib/providers/java_compilation_info)
-    *   [`java_output`](/rules/lib/builtins/java_output)
     *   [`java_output_jars`](/rules/lib/providers/java_output_jars)
     *   [`JavaRuntimeInfo`](/rules/lib/providers/JavaRuntimeInfo)
     *   [`JavaToolchainInfo`](/rules/lib/providers/JavaToolchainInfo)


### PR DESCRIPTION
The documentation page bazel-and-java contains a link to `/rules/lib/builtins/java_output`, a page that no longer exists. I do not see any references to a `java_output` builtin that remains in the repo, and suspect this is a removed feature.