### PR TITLE
[7.1.0] Cherry pick a few changes to address flaky tests

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -231,6 +231,7 @@ tasks:
       - build
       - test
   macos_arm64:
+    xcode_version: "15.1"
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -236,6 +236,7 @@ tasks:
       - test
   macos_arm64:
     shards: 2
+    xcode_version: "15.1"
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod

--- a/bazel_downloader.cfg
+++ b/bazel_downloader.cfg
@@ -1,2 +1,6 @@
 rewrite (github.com)/(.*) https://mirror.bazel.build/$1/$2
 rewrite (github.com)/(.*) https://$1/$2
+rewrite (maven.google.com)/(.*) https://mirror.bazel.build/$1/$2
+rewrite (maven.google.com)/(.*) https://$1/$2
+rewrite (cdn.azul.com)/(.*) https://mirror.bazel.build/$1/$2
+rewrite (cdn.azul.com)/(.*) https://$1/$2

--- a/src/test/java/com/google/devtools/build/lib/server/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/server/BUILD
@@ -49,6 +49,7 @@ java_library(
 java_test(
     name = "ServerTests",
     size = "medium",
+    tags = ["requires-network"],  # https://github.com/bazelbuild/bazel/issues/20743
     test_class = "com.google.devtools.build.lib.AllTests",
     runtime_deps = [
         ":ServerTests_lib",

--- a/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/BUILD
@@ -27,6 +27,7 @@ java_test(
     name = "StarlarkDebugServerTest",
     size = "medium",
     srcs = ["StarlarkDebugServerTest.java"],
+    tags = ["requires-network"],  # https://github.com/bazelbuild/bazel/issues/20743
     deps = [
         ":utils",
         "//src/main/java/com/google/devtools/build/lib/events",

--- a/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/BUILD
@@ -45,6 +45,7 @@ java_test(
 java_test(
     name = "DebugServerTransportTest",
     srcs = ["DebugServerTransportTest.java"],
+    tags = ["requires-network"],  # https://github.com/bazelbuild/bazel/issues/20743
     deps = [
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/starlarkdebug/proto:starlark_debugging_java_proto",


### PR DESCRIPTION
Set Xcode version to 15.1 on macOS arm64 machines
bazel_determinism_test seems to be flaky due to an non-determinsitc issue of the clang compiler in Xcode 14.2

Fixes https://github.com/bazelbuild/bazel/issues/20690

PiperOrigin-RevId: 598760276
Change-Id: Ibc46dfa64fe91f26acfa5091a07c17e3bf97f29c

____

Allow network for two Java tests to avoid binding issue on macOS sandbox
https://buildkite.com/bazel/bazel-bazel/builds/26312#018d1722-0e79-47b4-82ed-9cc47487e05a

Related issues:
- https://github.com/bazelbuild/bazel/issues/20743
- https://github.com/bazelbuild/bazel/issues/5206

PiperOrigin-RevId: 599452705
Change-Id: I2fdccd9df513064e5bc9add4f1802d4c1ce9c6da

____

Allow network for StarlarkDebugServerTest
Related issues:
- https://github.com/bazelbuild/bazel/issues/20743
- https://github.com/bazelbuild/bazel/issues/5206

PiperOrigin-RevId: 599754818
Change-Id: I228201d578b7459332aebfea6ab4d7c041b3e6c4

___

Add mirror for embedded JDKs URLs
Reduce flakiness like: https://buildkite.com/bazel/bazel-bazel/builds/26343#018d1e09-4c23-404c-a307-7476e092c7ab

PiperOrigin-RevId: 599759327
Change-Id: I43fa2ec996f03e77da926c2afeaca13cbf029a1b

