### PR TITLE
site: build.md: Use consistent language

### DIFF
--- a/site/en/run/build.md
+++ b/site/en/run/build.md
@@ -160,12 +160,12 @@ workspace.
 </tr>
 <tr>
   <td><code>//...</code></td>
-  <td>All targets in packages in the workspace. This does not include targets
+  <td>All rule targets in packages in the main repository. Does not include targets
   from <a href="/docs/external">external repositories</a>.</td>
 </tr>
 <tr>
   <td><code>//:all</code></td>
-  <td>All targets in the top-level package, if there is a `BUILD` file at the
+  <td>All rule targets in the top-level package, if there is a `BUILD` file at the
   root of the workspace.</td>
 </tr>
 </table>


### PR DESCRIPTION
According to https://bazel.build/concepts/build-ref#workspace, the workspace "encompasses the main repo and the set of all defined external repos." Since `//...` excludes targets in external repositories, clarify that it applies to the main repo, not to the workspace.

Similarly, clarify that `//...` and `//:all` refer only to rule targets, not to file targets.