### PR TITLE
Remove `git rev-parse master` from issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,7 +72,7 @@ body:
     id: source
     attributes:
       label: >
-        What's the output of `git remote get-url origin; git rev-parse master; git rev-parse HEAD` ?
+        What's the output of `git remote get-url origin; git rev-parse main; git rev-parse HEAD` ?
       render: text
   - type: textarea
     id: bisect

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,7 +72,7 @@ body:
     id: source
     attributes:
       label: >
-        What's the output of `git remote get-url origin; git rev-parse main; git rev-parse HEAD` ?
+        What's the output of `git remote get-url origin; git rev-parse HEAD` ?
       render: text
   - type: textarea
     id: bisect

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -71,7 +71,7 @@ body:
     id: source
     attributes:
       label: >
-        What's the output of `git remote get-url origin; git rev-parse main; git rev-parse HEAD` ?
+        What's the output of `git remote get-url origin; git rev-parse HEAD` ?
       render: text
   - type: textarea
     id: relevant-info

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -71,7 +71,7 @@ body:
     id: source
     attributes:
       label: >
-        What's the output of `git remote get-url origin; git rev-parse master; git rev-parse HEAD` ?
+        What's the output of `git remote get-url origin; git rev-parse main; git rev-parse HEAD` ?
       render: text
   - type: textarea
     id: relevant-info


### PR DESCRIPTION
The main branch's state is not relevant to the issue, and has different names for different repositories. The HEAD revision is still included.