### PR TITLE
Disregard WORKSPACE while verifying lockfile repo mapping entries in extension eval

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -344,9 +344,9 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       throws InterruptedException, NeedsSkyframeRestartException {
     // Request repo mappings for any 'source repos' in the recorded mapping entries.
     // Note specially that the main repo needs to be treated differently: if any .bzl file from the
-    // main repo was used for module extension eval, it _has_ to be before WORKSPACE is evaluated,
-    // so we only request the main repo mapping _without_ WORKSPACE repos. See #20942 for more
-    // information.
+    // main repo was used for module extension eval, it _has_ to be before WORKSPACE is evaluated
+    // (see relevant code in BzlLoadFunction#getRepositoryMapping), so we only request the main repo
+    // mapping _without_ WORKSPACE repos. See #20942 for more information.
     SkyframeLookupResult result =
         env.getValuesAndExceptions(
             recordedRepoMappings.rowKeySet().stream()

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -342,10 +342,17 @@ public class SingleExtensionEvalFunction implements SkyFunction {
   private static boolean didRepoMappingsChange(
       Environment env, ImmutableTable<RepositoryName, String, RepositoryName> recordedRepoMappings)
       throws InterruptedException, NeedsSkyframeRestartException {
+    // Request repo mappings for any 'source repos' in the recorded mapping entries.
+    // Note specially that the main repo needs to be treated differently: if any .bzl file from the
+    // main repo was used for module extension eval, it _has_ to be before WORKSPACE is evaluated,
+    // so we only request the main repo mapping _without_ WORKSPACE repos. See #20942 for more
+    // information.
     SkyframeLookupResult result =
         env.getValuesAndExceptions(
             recordedRepoMappings.rowKeySet().stream()
-                .map(RepositoryMappingValue::key)
+                .map(repoName -> repoName.isMain()
+                    ? RepositoryMappingValue.KEY_FOR_ROOT_MODULE_WITHOUT_WORKSPACE_REPOS
+                    : RepositoryMappingValue.key(repoName))
                 .collect(toImmutableSet()));
     if (env.valuesMissing()) {
       // This likely means that one of the 'source repos' in the recorded mapping entries is no
@@ -354,7 +361,9 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     }
     for (Table.Cell<RepositoryName, String, RepositoryName> cell : recordedRepoMappings.cellSet()) {
       RepositoryMappingValue repoMappingValue =
-          (RepositoryMappingValue) result.get(RepositoryMappingValue.key(cell.getRowKey()));
+          (RepositoryMappingValue) result.get(cell.getRowKey().isMain()
+              ? RepositoryMappingValue.KEY_FOR_ROOT_MODULE_WITHOUT_WORKSPACE_REPOS
+              : RepositoryMappingValue.key(cell.getRowKey()));
       if (repoMappingValue == null) {
         throw new NeedsSkyframeRestartException();
       }


### PR DESCRIPTION
See code comment and linked issue for more information.

Fixes #20942.