### PR TITLE
[7.1.0] Force output checking for incremental run commands without the bytes.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -515,11 +515,15 @@ public class ExecutionTool {
         startLocalOutputBuild();
       }
     }
-    if (!request.getPackageOptions().checkOutputFiles
-        // Do not skip invalidation in case the output tree is empty -- this can happen
-        // after it's cleaned or corrupted.
-        && !modifiedOutputFiles.treatEverythingAsDeleted()) {
-      modifiedOutputFiles = ModifiedFileSet.NOTHING_MODIFIED;
+    if (!request.getPackageOptions().checkOutputFiles) {
+      // Do not skip output invalidation in the following cases:
+      // 1. If the output tree is empty: this can happen after it's cleaned or corrupted.
+      // 2. For a run command: so that outputs are downloaded even if they were previously built
+      //    with --remote_download_minimal. See https://github.com/bazelbuild/bazel/issues/20843.
+      if (!modifiedOutputFiles.treatEverythingAsDeleted()
+          && !request.getCommandName().equals("run")) {
+        return ModifiedFileSet.NOTHING_MODIFIED;
+      }
     }
     return modifiedOutputFiles;
   }


### PR DESCRIPTION
When building without the bytes, outputs are only materialized when either (1) an action prefetches them, or (2) they've been explicitly requested. When both --remote_download_minimal and --noexperimental_check_output_files are set, this presents a problem for a build command followed by a run command for the same target: the build command won't download the outputs and the run command won't check for their presence, proceeding without them. A non-incremental run command works, because the outputs are considered top-level even in minimal mode.

This is only a problem for a run command because it exists outside of action execution, and doesn't get a chance to prefetch inputs; it would have been better to implement the run command by injecting a specially crafted action into the build graph, but that will have to wait for another day. The present fix might theoretically slow things down if output checking is truly unnecessary, but I doubt that would cause a significant regression in practice.

Fixes #20843.

Closes #20853.

Commit https://github.com/bazelbuild/bazel/commit/2f899ef8b39935d9ca131b71a24e67ef286bc378

PiperOrigin-RevId: 597909909
Change-Id: I66aedef4994fbda41fe5378c80940fa8ba637bfd