### PR TITLE
Suggest to use bazelisk as a lockfile best practice.

### DIFF
--- a/site/en/external/lockfile.md
+++ b/site/en/external/lockfile.md
@@ -213,6 +213,14 @@ practices:
     ensure that all team members have access to the same lockfile, promoting
     consistent development environments across the project.
 
+*   Use [`bazelisk`](/install/bazelisk) to run Bazel, and include a
+    `.bazeliskrc` file in version control that lists the Bazel version
+    corresponding to the lockfile. Because Bazel itself is a dependency of
+    your build, the lockfile is specific to the Bazel version, and will
+    change between [backwards compatible](/release/backward-compatibility)
+    Bazel releases. Using `bazelisk` ensures that all developers are using
+    a Bazel version that matches the lockfile.
+
 By following these best practices, you can effectively utilize the lockfile
 feature in Bazel, leading to more efficient, reliable, and collaborative
 software development workflows.

--- a/site/en/external/lockfile.md
+++ b/site/en/external/lockfile.md
@@ -214,7 +214,7 @@ practices:
     consistent development environments across the project.
 
 *   Use [`bazelisk`](/install/bazelisk) to run Bazel, and include a
-    `.bazeliskrc` file in version control that lists the Bazel version
+    `.bazelversuib` file in version control that specifies the Bazel version
     corresponding to the lockfile. Because Bazel itself is a dependency of
     your build, the lockfile is specific to the Bazel version, and will
     change even between [backwards compatible](/release/backward-compatibility)

--- a/site/en/external/lockfile.md
+++ b/site/en/external/lockfile.md
@@ -217,7 +217,7 @@ practices:
     `.bazeliskrc` file in version control that lists the Bazel version
     corresponding to the lockfile. Because Bazel itself is a dependency of
     your build, the lockfile is specific to the Bazel version, and will
-    change between [backwards compatible](/release/backward-compatibility)
+    change even between [backwards compatible](/release/backward-compatibility)
     Bazel releases. Using `bazelisk` ensures that all developers are using
     a Bazel version that matches the lockfile.
 

--- a/site/en/external/lockfile.md
+++ b/site/en/external/lockfile.md
@@ -214,7 +214,7 @@ practices:
     consistent development environments across the project.
 
 *   Use [`bazelisk`](/install/bazelisk) to run Bazel, and include a
-    `.bazelversuib` file in version control that specifies the Bazel version
+    `.bazelversion` file in version control that specifies the Bazel version
     corresponding to the lockfile. Because Bazel itself is a dependency of
     your build, the lockfile is specific to the Bazel version, and will
     change even between [backwards compatible](/release/backward-compatibility)


### PR DESCRIPTION
As noted in #20974, the bazel version contributes to the lockfile, so all developers need to be using the same bazel version to avoid lockfile skew stemming from bazel version skew.