### PR TITLE
[7.1.0] Show a warning message when the credential helper invocation fails

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -112,7 +112,7 @@ final class HttpConnectorMultiplexer {
     baseHeaders.putAll(REQUEST_HEADERS);
 
     Function<URL, ImmutableMap<String, List<String>>> headerFunction =
-        getHeaderFunction(baseHeaders.buildKeepingLast(), credentials);
+        getHeaderFunction(baseHeaders.buildKeepingLast(), credentials, eventHandler);
     URLConnection connection = connector.connect(url, headerFunction);
     return httpStreamFactory.create(
         connection,
@@ -134,7 +134,7 @@ final class HttpConnectorMultiplexer {
 
   @VisibleForTesting
   static Function<URL, ImmutableMap<String, List<String>>> getHeaderFunction(
-      Map<String, List<String>> baseHeaders, Credentials credentials) {
+      Map<String, List<String>> baseHeaders, Credentials credentials, EventHandler eventHandler) {
     Preconditions.checkNotNull(baseHeaders);
     Preconditions.checkNotNull(credentials);
 
@@ -146,6 +146,8 @@ final class HttpConnectorMultiplexer {
         // If we can't convert the URL to a URI (because it is syntactically malformed), or fetching
         // credentials fails for any other reason, still try to do the connection, not adding
         // authentication information as we cannot look it up.
+        eventHandler.handle(
+            Event.warn("Error retrieving auth headers, continuing without: " + e.getMessage()));
       }
       return ImmutableMap.copyOf(headers);
     };

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
@@ -165,7 +165,7 @@ public class HttpConnectorMultiplexerTest {
 
     Function<URL, ImmutableMap<String, List<String>>> headerFunction =
         HttpConnectorMultiplexer.getHeaderFunction(
-            baseHeaders, new StaticCredentials(additionalHeaders));
+            baseHeaders, new StaticCredentials(additionalHeaders), eventHandler);
 
     // Unrelated URL
     assertThat(headerFunction.apply(new URL("http://example.org/some/path/file.txt")))
@@ -218,7 +218,7 @@ public class HttpConnectorMultiplexerTest {
         ImmutableMap.of("Authentication", ImmutableList.of("YW5vbnltb3VzOmZvb0BleGFtcGxlLm9yZw=="));
     Function<URL, ImmutableMap<String, List<String>>> combinedHeaders =
         HttpConnectorMultiplexer.getHeaderFunction(
-            annonAuth, new StaticCredentials(additionalHeaders));
+            annonAuth, new StaticCredentials(additionalHeaders), eventHandler);
     assertThat(combinedHeaders.apply(new URL("http://hosting.example.com/user/foo/file.txt")))
         .containsExactly("Authentication", ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
     assertThat(combinedHeaders.apply(new URL("http://unreleated.example.org/user/foo/file.txt")))


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/20146.

PiperOrigin-RevId: 581891244
Change-Id: Ifbcdba69b731c0a4e3d8f3e45184054b4e52b62e