### PR TITLE
Fix example in site/en/migrate/maven.md

### DIFF
--- a/site/en/migrate/maven.md
+++ b/site/en/migrate/maven.md
@@ -207,6 +207,7 @@ java_library(
         "guava/src/**/*.java",
         "futures/failureaccess/src/**/*.java",
     ]),
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_errorprone_error_prone_annotations",


### PR DESCRIPTION
The maven migration example isn't compiling.  A quick solution was to include a flag to turn off errorprone, so it won't cause any trouble for those who want to give bazel a shot.

```
$ bazel build ...
INFO: Analyzed target //:everything (0 packages loaded, 622 targets configured).
ERROR: /home/fredrik/Projects/guava/BUILD:1:13: Building libeverything.jar (621 source files) failed: (Exit 1): java failed: error executing Javac command (from target //:everything) external/rules_java~7.1.0~toolchains~remotejdk21_linux/bin/java '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED' ... (remaining 19 arguments skipped)
guava/src/com/google/common/util/concurrent/AbstractFuture.java:33: warning: [removal] AccessController in java.security has been deprecated and marked for removal
import java.security.AccessController;
                    ^
guava/src/com/google/common/reflect/Types.java:42: warning: [removal] AccessControlException in java.security has been deprecated and marked for removal
import java.security.AccessControlException;
                    ^
guava/src/com/google/common/util/concurrent/AbstractFuture.java:1329: warning: [removal] AccessController in java.security has been deprecated and marked for removal
              AccessController.doPrivileged(
              ^
guava/src/com/google/common/cache/Striped64.java:296: warning: [removal] AccessController in java.security has been deprecated and marked for removal
      return java.security.AccessController.doPrivileged(
                          ^
guava/src/com/google/common/hash/LittleEndianByteArray.java:175: warning: [removal] AccessController in java.security has been deprecated and marked for removal
        return java.security.AccessController.doPrivileged(
                            ^
guava/src/com/google/common/hash/Striped64.java:296: warning: [removal] AccessController in java.security has been deprecated and marked for removal
      return java.security.AccessController.doPrivileged(
                          ^
guava/src/com/google/common/primitives/UnsignedBytes.java:346: warning: [removal] AccessController in java.security has been deprecated and marked for removal
          return java.security.AccessController.doPrivileged(
                              ^
guava/src/com/google/common/reflect/Types.java:368: warning: [removal] AccessControlException in java.security has been deprecated and marked for removal
          } catch (AccessControlException e) {
                   ^
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
guava/src/com/google/common/math/MathPreconditions.java:30: error: [NoCanIgnoreReturnValueOnClasses] @CanIgnoreReturnValue should not be applied to classes as it almost always overmatches (as it applies to constructors and all methods), and the CIRVness isn't conferred to its subclasses.
final class MathPreconditions {
      ^
    (see https://errorprone.info/bugpattern/NoCanIgnoreReturnValueOnClasses)
  Did you mean to remove this line?
Target //:everything failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 11.983s, Critical Path: 11.70s
INFO: 2 processes: 2 internal.
ERROR: Build did NOT complete successfully
``