### PR TITLE
[7.1.0] Remove user specific path from the lockfile (Fixes #19621)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunction.java
@@ -84,7 +84,7 @@ public class BazelLockFileFunction implements SkyFunction {
     }
 
     try (SilentCloseable c = Profiler.instance().profile(ProfilerTask.BZLMOD, "parse lockfile")) {
-      return getLockfileValue(lockfilePath);
+      return getLockfileValue(lockfilePath, rootDirectory);
     } catch (IOException | JsonSyntaxException | NullPointerException e) {
       throw new BazelLockfileFunctionException(
           ExternalDepsException.withMessage(
@@ -96,7 +96,8 @@ public class BazelLockFileFunction implements SkyFunction {
     }
   }
 
-  public static BazelLockFileValue getLockfileValue(RootedPath lockfilePath) throws IOException {
+  public static BazelLockFileValue getLockfileValue(RootedPath lockfilePath, Path rootDirectory)
+      throws IOException {
     BazelLockFileValue bazelLockFileValue;
     try {
       String json = FileSystemUtils.readContent(lockfilePath.asPath(), UTF_8);
@@ -108,7 +109,8 @@ public class BazelLockFileFunction implements SkyFunction {
                     lockfilePath
                         .asPath()
                         .getParentDirectory()
-                        .getRelative(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME))
+                        .getRelative(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME),
+                    rootDirectory)
                 .fromJson(json, BazelLockFileValue.class);
       } else {
         // This is an old version, needs to be updated

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -201,7 +201,8 @@ public class BazelLockFileModule extends BlazeModule {
                       lockfilePath
                           .asPath()
                           .getParentDirectory()
-                          .getRelative(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME))
+                          .getRelative(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME),
+                      workspaceRoot)
                   .toJson(updatedLockfile)
               + "\n");
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -301,23 +301,23 @@ public final class GsonTypeAdapterUtil {
 
     public abstract int column();
 
-    public Location toLocation(String moduleFilePath) {
+    public Location toLocation(String moduleFilePath, String workspaceRoot) {
       String file;
       if (file().equals(ROOT_MODULE_FILE_LABEL)) {
         file = moduleFilePath;
       } else {
-        file = file();
+        file = file().replace("%workspace%", workspaceRoot);
       }
       return Location.fromFileLineColumn(file, line(), column());
     }
 
     public static RootModuleFileEscapingLocation fromLocation(
-        Location location, String moduleFilePath) {
+        Location location, String moduleFilePath, String workspaceRoot) {
       String file;
       if (location.file().equals(moduleFilePath)) {
         file = ROOT_MODULE_FILE_LABEL;
       } else {
-        file = location.file();
+        file = location.file().replace(workspaceRoot, "%workspace%");
       }
       return new AutoValue_GsonTypeAdapterUtil_RootModuleFileEscapingLocation(
           file, location.line(), location.column());
@@ -327,9 +327,11 @@ public final class GsonTypeAdapterUtil {
   private static final class LocationTypeAdapterFactory implements TypeAdapterFactory {
 
     private final String moduleFilePath;
+    private final String workspaceRoot;
 
-    public LocationTypeAdapterFactory(Path moduleFilePath) {
+    public LocationTypeAdapterFactory(Path moduleFilePath, Path workspaceRoot) {
       this.moduleFilePath = moduleFilePath.getPathString();
+      this.workspaceRoot = workspaceRoot.getPathString();
     }
 
     @Nullable
@@ -348,18 +350,21 @@ public final class GsonTypeAdapterUtil {
             public void write(JsonWriter jsonWriter, Location location) throws IOException {
               relativizedLocationTypeAdapter.write(
                   jsonWriter,
-                  RootModuleFileEscapingLocation.fromLocation(location, moduleFilePath));
+                  RootModuleFileEscapingLocation.fromLocation(
+                      location, moduleFilePath, workspaceRoot));
             }
 
             @Override
             public Location read(JsonReader jsonReader) throws IOException {
-              return relativizedLocationTypeAdapter.read(jsonReader).toLocation(moduleFilePath);
+              return relativizedLocationTypeAdapter
+                  .read(jsonReader)
+                  .toLocation(moduleFilePath, workspaceRoot);
             }
           };
     }
   }
 
-  public static Gson createLockFileGson(Path moduleFilePath) {
+  public static Gson createLockFileGson(Path moduleFilePath, Path workspaceRoot) {
     return new GsonBuilder()
         .setPrettyPrinting()
         .disableHtmlEscaping()
@@ -371,7 +376,8 @@ public final class GsonTypeAdapterUtil {
         .registerTypeAdapterFactory(IMMUTABLE_BIMAP)
         .registerTypeAdapterFactory(IMMUTABLE_SET)
         .registerTypeAdapterFactory(OPTIONAL)
-        .registerTypeAdapterFactory(new LocationTypeAdapterFactory(moduleFilePath))
+        .registerTypeAdapterFactory(IMMUTABLE_TABLE)
+        .registerTypeAdapterFactory(new LocationTypeAdapterFactory(moduleFilePath, workspaceRoot))
         .registerTypeAdapter(Label.class, LABEL_TYPE_ADAPTER)
         .registerTypeAdapter(Version.class, VERSION_TYPE_ADAPTER)
         .registerTypeAdapter(ModuleKey.class, MODULE_KEY_TYPE_ADAPTER)

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -376,7 +376,6 @@ public final class GsonTypeAdapterUtil {
         .registerTypeAdapterFactory(IMMUTABLE_BIMAP)
         .registerTypeAdapterFactory(IMMUTABLE_SET)
         .registerTypeAdapterFactory(OPTIONAL)
-        .registerTypeAdapterFactory(IMMUTABLE_TABLE)
         .registerTypeAdapterFactory(new LocationTypeAdapterFactory(moduleFilePath, workspaceRoot))
         .registerTypeAdapter(Label.class, LABEL_TYPE_ADAPTER)
         .registerTypeAdapter(Version.class, VERSION_TYPE_ADAPTER)


### PR DESCRIPTION
If a local registry is specified using a workspace placeholder, the lockfile stores location details of the files with resolved workspace information, including user-specific paths.

To fix that: Updating the logic to use the workspace placeholder %workspace% during lockfile writing and reverting to the resolved paths when reading.

PiperOrigin-RevId: 600876401
Change-Id: I6162d8e8f1fe5e29b7899fc5bb218d1b6be926d0