### PR TITLE
[7.1.0] Close test.err before deleteing it

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -808,9 +808,12 @@ public class StandaloneTestStrategy extends TestStrategy {
         // Make sure that the test.log exists.Spaw
         FileSystemUtils.touchFile(fileOutErr.getOutputPath());
       }
-      // Append any error output to the test.log. This is very rare.
-      writeOutFile(fileOutErr.getErrorPath(), fileOutErr.getOutputPath());
       fileOutErr.close();
+      // Append any error output to the test.log. This is very rare.
+      //
+      // Only write after the error output stream has been closed. Otherwise, Bazel cannot delete
+      // test.err file on Windows. See https://github.com/bazelbuild/bazel/issues/20741.
+      writeOutFile(fileOutErr.getErrorPath(), fileOutErr.getOutputPath());
       if (streamed != null) {
         streamed.close();
       }


### PR DESCRIPTION
Unfortuantely, there isn't an easy way to add integration test for this specific edge case on Windows.

Fixes #20741.

Closes #20752.

Commit https://github.com/bazelbuild/bazel/commit/958e0c485d5afc9f69f1cdaa85c2ea7c0afc4007

PiperOrigin-RevId: 596547046
Change-Id: I4f517b161c03793329d5a4e21ec8ac4a5b53abb0