### PR TITLE
[7.1.0] Add `bazel mod dump_repo_mapping`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModOptions.java
@@ -172,7 +172,8 @@ public class ModOptions extends OptionsBase {
     PATH(true),
     EXPLAIN(true),
     SHOW_REPO(false),
-    SHOW_EXTENSION(false);
+    SHOW_EXTENSION(false),
+    DUMP_REPO_MAPPING(false);
 
     /** Whether this subcommand produces a graph output. */
     private final boolean isGraph;

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
@@ -65,6 +65,7 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/java/net/starlark/java/eval",
         "//src/main/protobuf:failure_details_java_proto",
+        "//third_party:gson",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.bazel.commands;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.devtools.build.lib.bazel.bzlmod.modcommand.ModOptions.Charset.UTF8;
@@ -44,6 +45,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.modcommand.ModOptions.ModSubco
 import com.google.devtools.build.lib.bazel.bzlmod.modcommand.ModOptions.ModSubcommandConverter;
 import com.google.devtools.build.lib.bazel.bzlmod.modcommand.ModuleArg;
 import com.google.devtools.build.lib.bazel.bzlmod.modcommand.ModuleArg.ModuleArgConverter;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
@@ -57,6 +59,7 @@ import com.google.devtools.build.lib.runtime.LoadingPhaseThreadsOption;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.ModCommand.Code;
+import com.google.devtools.build.lib.skyframe.RepositoryMappingValue;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
@@ -70,11 +73,17 @@ import com.google.devtools.common.options.OptionPriority.PriorityCategory;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 /** Queries the Bzlmod external dependency graph. */
 @Command(
@@ -125,50 +134,6 @@ public final class ModCommand implements BlazeCommand {
   }
 
   private BlazeCommandResult execInternal(CommandEnvironment env, OptionsParsingResult options) {
-    BazelDepGraphValue depGraphValue;
-    BazelModuleInspectorValue moduleInspector;
-
-    SkyframeExecutor skyframeExecutor = env.getSkyframeExecutor();
-    LoadingPhaseThreadsOption threadsOption = options.getOptions(LoadingPhaseThreadsOption.class);
-
-    EvaluationContext evaluationContext =
-        EvaluationContext.newBuilder()
-            .setParallelism(threadsOption.threads)
-            .setEventHandler(env.getReporter())
-            .build();
-
-    try {
-      env.syncPackageLoading(options);
-
-      EvaluationResult<SkyValue> evaluationResult =
-          skyframeExecutor.prepareAndGet(
-              ImmutableSet.of(BazelDepGraphValue.KEY, BazelModuleInspectorValue.KEY),
-              evaluationContext);
-
-      if (evaluationResult.hasError()) {
-        Exception e = evaluationResult.getError().getException();
-        String message = "Unexpected error during repository rule evaluation.";
-        if (e != null) {
-          message = e.getMessage();
-        }
-        return reportAndCreateFailureResult(env, message, Code.INVALID_ARGUMENTS);
-      }
-
-      depGraphValue = (BazelDepGraphValue) evaluationResult.get(BazelDepGraphValue.KEY);
-
-      moduleInspector =
-          (BazelModuleInspectorValue) evaluationResult.get(BazelModuleInspectorValue.KEY);
-
-    } catch (InterruptedException e) {
-      String errorMessage = "mod command interrupted: " + e.getMessage();
-      env.getReporter().handle(Event.error(errorMessage));
-      return BlazeCommandResult.detailedExitCode(
-          InterruptedFailureDetails.detailedExitCode(errorMessage));
-    } catch (AbruptExitException e) {
-      env.getReporter().handle(Event.error(null, "Unknown error: " + e.getMessage()));
-      return BlazeCommandResult.detailedExitCode(e.getDetailedExitCode());
-    }
-
     ModOptions modOptions = options.getOptions(ModOptions.class);
     Preconditions.checkArgument(modOptions != null);
 
@@ -190,6 +155,104 @@ public final class ModCommand implements BlazeCommand {
       return reportAndCreateFailureResult(env, errorMessage, Code.MOD_COMMAND_UNKNOWN);
     }
     List<String> args = options.getResidue().subList(1, options.getResidue().size());
+
+    ImmutableList.Builder<RepositoryMappingValue.Key> repositoryMappingKeysBuilder =
+        ImmutableList.builder();
+    if (subcommand.equals(ModSubcommand.DUMP_REPO_MAPPING)) {
+      if (args.isEmpty()) {
+        // Make this case an error so that we are free to add a mode that emits all mappings in a
+        // single JSON object later.
+        return reportAndCreateFailureResult(
+            env, "No repository name(s) specified", Code.INVALID_ARGUMENTS);
+      }
+      for (String arg : args) {
+        try {
+          repositoryMappingKeysBuilder.add(RepositoryMappingValue.key(RepositoryName.create(arg)));
+        } catch (LabelSyntaxException e) {
+          return reportAndCreateFailureResult(env, e.getMessage(), Code.INVALID_ARGUMENTS);
+        }
+      }
+    }
+    ImmutableList<RepositoryMappingValue.Key> repoMappingKeys =
+        repositoryMappingKeysBuilder.build();
+
+    BazelDepGraphValue depGraphValue;
+    BazelModuleInspectorValue moduleInspector;
+    ImmutableList<RepositoryMappingValue> repoMappingValues;
+
+    SkyframeExecutor skyframeExecutor = env.getSkyframeExecutor();
+    LoadingPhaseThreadsOption threadsOption = options.getOptions(LoadingPhaseThreadsOption.class);
+
+    EvaluationContext evaluationContext =
+        EvaluationContext.newBuilder()
+            .setParallelism(threadsOption.threads)
+            .setEventHandler(env.getReporter())
+            .build();
+
+    try {
+      env.syncPackageLoading(options);
+
+      ImmutableSet.Builder<SkyKey> keys = ImmutableSet.builder();
+      if (subcommand.equals(ModSubcommand.DUMP_REPO_MAPPING)) {
+        keys.addAll(repoMappingKeys);
+      } else {
+        keys.add(BazelDepGraphValue.KEY, BazelModuleInspectorValue.KEY);
+      }
+      EvaluationResult<SkyValue> evaluationResult =
+          skyframeExecutor.prepareAndGet(keys.build(), evaluationContext);
+
+      if (evaluationResult.hasError()) {
+        Exception e = evaluationResult.getError().getException();
+        String message = "Unexpected error during repository rule evaluation.";
+        if (e != null) {
+          message = e.getMessage();
+        }
+        return reportAndCreateFailureResult(env, message, Code.INVALID_ARGUMENTS);
+      }
+
+      depGraphValue = (BazelDepGraphValue) evaluationResult.get(BazelDepGraphValue.KEY);
+
+      moduleInspector =
+          (BazelModuleInspectorValue) evaluationResult.get(BazelModuleInspectorValue.KEY);
+
+      repoMappingValues =
+          repoMappingKeys.stream()
+              .map(evaluationResult::get)
+              .map(RepositoryMappingValue.class::cast)
+              .collect(toImmutableList());
+    } catch (InterruptedException e) {
+      String errorMessage = "mod command interrupted: " + e.getMessage();
+      env.getReporter().handle(Event.error(errorMessage));
+      return BlazeCommandResult.detailedExitCode(
+          InterruptedFailureDetails.detailedExitCode(errorMessage));
+    } catch (AbruptExitException e) {
+      env.getReporter().handle(Event.error(null, "Unknown error: " + e.getMessage()));
+      return BlazeCommandResult.detailedExitCode(e.getDetailedExitCode());
+    }
+
+    if (subcommand.equals(ModSubcommand.DUMP_REPO_MAPPING)) {
+      String missingRepos =
+          IntStream.range(0, repoMappingKeys.size())
+              .filter(i -> repoMappingValues.get(i) == RepositoryMappingValue.NOT_FOUND_VALUE)
+              .mapToObj(repoMappingKeys::get)
+              .map(RepositoryMappingValue.Key::repoName)
+              .map(RepositoryName::getName)
+              .collect(joining(", "));
+      if (!missingRepos.isEmpty()) {
+        return reportAndCreateFailureResult(
+            env, "Repositories not found: " + missingRepos, Code.INVALID_ARGUMENTS);
+      }
+      try {
+        dumpRepoMappings(
+            repoMappingValues,
+            new OutputStreamWriter(
+                env.getReporter().getOutErr().getOutputStream(),
+                modOptions.charset == UTF8 ? UTF_8 : US_ASCII));
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+      return BlazeCommandResult.success();
+    }
 
     // Extract and check the --base_module argument first to use it when parsing the other args.
     // Can only be a TargetModule or a repoName relative to the ROOT.
@@ -453,6 +516,8 @@ public final class ModCommand implements BlazeCommand {
       case SHOW_EXTENSION:
         modExecutor.showExtension(argsAsExtensions, usageKeys);
         break;
+      default:
+        throw new IllegalStateException("Unexpected subcommand: " + subcommand);
     }
 
     return BlazeCommandResult.success();
@@ -509,5 +574,22 @@ public final class ModCommand implements BlazeCommand {
                 .setModCommand(FailureDetails.ModCommand.newBuilder().setCode(detailedCode).build())
                 .setMessage(message)
                 .build()));
+  }
+
+  public static void dumpRepoMappings(List<RepositoryMappingValue> repoMappings, Writer writer)
+      throws IOException {
+    Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+    for (RepositoryMappingValue repoMapping : repoMappings) {
+      JsonWriter jsonWriter = gson.newJsonWriter(writer);
+      jsonWriter.beginObject();
+      for (Entry<String, RepositoryName> entry :
+          repoMapping.getRepositoryMapping().entries().entrySet()) {
+        jsonWriter.name(entry.getKey());
+        jsonWriter.value(entry.getValue().getName());
+      }
+      jsonWriter.endObject();
+      writer.write('\n');
+    }
+    writer.flush();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/mod.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/mod.txt
@@ -12,6 +12,7 @@ The command will display the external dependency graph or parts thereof, structu
     - explain <module>...: Prints all the places where the module is (or was) requested as a direct dependency, along with the reason why the respective final version was selected. It will display a pruned version of the `all_paths <module>...` command which only contains the direct deps of the root, the <module(s)> leaves, along with their dependants (can be modified with --depth).
     - show_repo <module>...: Prints the rule that generated the specified repos (i.e. http_archive()). The arguments may refer to extension-generated repos.
     - show_extension <extension>...: Prints information about the given extension(s). Usages can be filtered down to only those from modules in --extension_usage.
+    - dump_repo_mapping <canonical_repo_name>...: Prints the mappings from apparent repo names to canonical repo names for the given repos in NDJSON format. The order of entries within each JSON object is unspecified. This command is intended for use by tools such as IDEs and Starlark language servers.
 
 
 <module> arguments must be one of the following:
@@ -24,5 +25,7 @@ The command will display the external dependency graph or parts thereof, structu
     - @@<repo_name>: The canonical name of any repo. Unless otherwise specified, this must refer to a module, not an extension-generated repo.
 
 <extension> arguments must be of the form <module><label_to_bzl_file>%<extension_name>. For example, both rules_java//java:extensions.bzl%toolchains and @rules_java//java:extensions.bzl%toolchains are valid specifications of extensions.
+
+<canonical_repo_name> arguments are canonical repo names without any leading @ characters. The canonical repo name of the root module repository is the empty string.
 
 %{options}


### PR DESCRIPTION
`bazel mod dump_repo_mapping` with no arguments is explicitly made an
error so that a new mode that dumps all repository mappings with a
single Bazel invocation can be added later if needed, e.g. to support
IntelliJ's "sync" workflow.

RELNOTES: `bazel mod dump_repo_mapping <canonical repo name>...` returns
the repository mappings of the given repositories in NDJSON. This
information can be used by IDEs and Starlark language servers to resolve
labels with `--enable_bzlmod`.

Work towards #20631

Closes #20686.

Commit https://github.com/bazelbuild/bazel/commit/59ac9ce297eb1bc0c47d4dc5de788908208735e0

PiperOrigin-RevId: 601332180
Change-Id: I828d7c88637bea175e11eccc52c6202f6da4c32c