### PR TITLE
Add clarification to jacoco upgrade instructions

### DIFF
--- a/third_party/java/jacoco/README.md
+++ b/third_party/java/jacoco/README.md
@@ -16,6 +16,7 @@ This PR needs to be merged.
 ## 2nd pull request
 
 - Update versions in the tools/jdk/BUILD.java_tools
+- Update asm versions in third_party/BUILD
 
 Or anywhere else outside of third_party.
 


### PR DESCRIPTION
`third_party/BUILD` is also handled by copybara so needs to be part of the second PR.