### PR TITLE
[7.1.0] bzlmod: support git repos in source.json

### DIFF
--- a/site/en/external/registry.md
+++ b/site/en/external/registry.md
@@ -64,6 +64,16 @@ An index registry must follow the format below:
                 By default, the archive type is determined from the file extension of the URL. If the file has
                 no extension, you can explicitly specify one of the following: `"zip"`, `"jar"`, `"war"`, `"aar"`,
                 `"tar"`, `"tar.gz"`, `"tgz"`, `"tar.xz"`, `"txz"`, `"tar.zst"`, `"tzst"`, `tar.bz2`, `"ar"`, or `"deb"`.
+        *   The type can be changed to use a git repository, with these fields:
+            *   `type`: `git_repository`
+            *   The following fields as described at https://bazel.build/rules/lib/repo/git:
+                * `remote`
+                * `commit`
+                * `shallow_since`
+                * `tag`
+                * `init_submodules`
+                * `verbose`
+                * `strip_prefix`
         *   The type can be changed to use a local path, representing a
             `local_repository` repo, with these fields:
             *   `type`: `local_path`

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -18,6 +18,7 @@ java_library(
     srcs = [
         "ArchiveRepoSpecBuilder.java",
         "AttributeValues.java",
+        "GitRepoSpecBuilder.java",
         "ModuleFile.java",
         "ModuleKey.java",
         "RepoSpec.java",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -1,0 +1,132 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.devtools.build.lib.bazel.bzlmod;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.List;
+
+/**
+ * Builder for a {@link RepoSpec} object that indicates how to materialize a repo corresponding to a
+ * {@code git_repository} repo rule call.
+ */
+public class GitRepoSpecBuilder {
+
+  public static final String GIT_REPO_PATH = "@bazel_tools//tools/build_defs/repo:git.bzl";
+
+  private final ImmutableMap.Builder<String, Object> attrBuilder;
+
+  public GitRepoSpecBuilder() {
+    attrBuilder = new ImmutableMap.Builder<>();
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRepoName(String repoName) {
+    return setAttr("name", repoName);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setRemote(String remoteRepoUrl) {
+    return setAttr("remote", remoteRepoUrl);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setCommit(String gitCommitHash) {
+    return setAttr("commit", gitCommitHash);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setShallowSince(String shallowSince) {
+    return setAttr("shallow_since", shallowSince);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setTag(String tag) {
+    return setAttr("tag", tag);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setInitSubmodules(boolean initSubmodules) {
+    setAttr("init_submodules", initSubmodules);
+    setAttr("recursive_init_submodules", initSubmodules);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setVerbose(boolean verbose) {
+    return setAttr("verbose", verbose);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setStripPrefix(String stripPrefix) {
+    return setAttr("strip_prefix", stripPrefix);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setPatches(List<String> patches) {
+    return setAttr("patches", patches);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setPatchTool(String patchTool) {
+    return setAttr("patch_tool", patchTool);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setPatchArgs(List<String> patchArgs) {
+    return setAttr("patch_args", patchArgs);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setPatchCmds(List<String> patchCmds) {
+    return setAttr("patch_cmds", patchCmds);
+  }
+
+  @CanIgnoreReturnValue
+  public GitRepoSpecBuilder setPatchCmdsWin(List<String> patchCmdsWin) {
+    return setAttr("patch_cmds_win", patchCmdsWin);
+  }
+
+  public RepoSpec build() {
+    return RepoSpec.builder()
+        .setBzlFile(GIT_REPO_PATH)
+        .setRuleClassName("git_repository")
+        .setAttributes(AttributeValues.create(attrBuilder.buildOrThrow()))
+        .build();
+  }
+
+  @CanIgnoreReturnValue
+  private GitRepoSpecBuilder setAttr(String name, String value) {
+    if (value != null && !value.isEmpty()) {
+      attrBuilder.put(name, value);
+    }
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  private GitRepoSpecBuilder setAttr(String name, boolean value) {
+    attrBuilder.put(name, value);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  private GitRepoSpecBuilder setAttr(String name, List<String> value) {
+    if (value != null && !value.isEmpty()) {
+      attrBuilder.put(name, value);
+    }
+    return this;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -1038,6 +1038,12 @@ public class ModuleFileGlobals {
             named = true,
             positional = false,
             defaultValue = "0"),
+        @Param(
+            name = "init_submodules",
+            doc = "Whether submodules in the fetched repo should be recursively initialized.",
+            named = true,
+            positional = false,
+            defaultValue = "False"),
       })
   public void gitOverride(
       String moduleName,
@@ -1045,7 +1051,8 @@ public class ModuleFileGlobals {
       String commit,
       Iterable<?> patches,
       Iterable<?> patchCmds,
-      StarlarkInt patchStrip)
+      StarlarkInt patchStrip,
+      boolean initSubmodules)
       throws EvalException {
     hadNonModuleCall = true;
     addOverride(
@@ -1055,7 +1062,8 @@ public class ModuleFileGlobals {
             commit,
             Sequence.cast(patches, String.class, "patches").getImmutableList(),
             Sequence.cast(patchCmds, String.class, "patchCmds").getImmutableList(),
-            patchStrip.toInt("git_override.patch_strip")));
+            patchStrip.toInt("git_override.patch_strip"),
+            initSubmodules));
   }
 
   @StarlarkMethod(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
@@ -26,7 +26,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.AttributeValues;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleCreator;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue;
-import com.google.devtools.build.lib.bazel.bzlmod.GitOverride;
+import com.google.devtools.build.lib.bazel.bzlmod.GitRepoSpecBuilder;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleExtensionId;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
@@ -246,7 +246,7 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
   private static final Set<String> BOOTSTRAP_RULE_CLASSES =
       ImmutableSet.of(
           ArchiveRepoSpecBuilder.HTTP_ARCHIVE_PATH + "%http_archive",
-          GitOverride.GIT_REPOSITORY_PATH + "%git_repository");
+          GitRepoSpecBuilder.GIT_REPO_PATH + "%git_repository");
 
   /** Loads modules from the given bzl file. */
   private ImmutableMap<String, Module> loadBzlModules(

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -16,6 +16,8 @@
 
 import os
 import pathlib
+import shutil
+import subprocess
 import tempfile
 from absl.testing import absltest
 from src.test.py.bazel import test_base
@@ -293,7 +295,9 @@ class BazelModuleTest(test_base.TestBase):
     self.main_registry.generateCcSource(dep_name, dep_version)
     self.main_registry.createLocalPathModule(dep_name, dep_version,
                                              dep_name + '/' + dep_version)
+    self.writeCcProjectFiles(dep_name, dep_version)
 
+  def writeCcProjectFiles(self, dep_name, dep_version):
     self.ScratchFile('main.cc', [
         '#include "%s.h"' % dep_name,
         'int main() {',
@@ -311,6 +315,41 @@ class BazelModuleTest(test_base.TestBase):
         ')',
     ])
 
+  def setUpProjectWithGitRegistryModule(self, dep_name, dep_version):
+    src_dir = self.main_registry.generateCcSource(dep_name, dep_version)
+
+    # Move the src_dir to a temp dir and make that temp dir a git repo.
+    repo_dir = os.path.join(self.registries_work_dir, 'git_repo', dep_name)
+    os.makedirs(repo_dir)
+    shutil.move(
+        # Workaround https://bugs.python.org/issue32689 for Python < 3.9
+        str(src_dir),
+        repo_dir,
+    )
+    repo_dir = os.path.join(repo_dir, os.path.basename(src_dir))
+    subprocess.check_output(['git', 'init'], cwd=repo_dir)
+    subprocess.check_output(
+        ['git', 'config', 'user.email', 'example@bazel-dev.org'], cwd=repo_dir
+    )
+    subprocess.check_output(
+        ['git', 'config', 'user.name', 'example'], cwd=repo_dir
+    )
+    subprocess.check_output(['git', 'add', '--all'], cwd=repo_dir)
+    subprocess.check_output(['git', 'commit', '-m', 'Initialize'], cwd=repo_dir)
+    commit = subprocess.check_output(
+        ['git', 'rev-parse', 'HEAD'], cwd=repo_dir, universal_newlines=True
+    ).strip()
+
+    self.main_registry.createGitRepoModule(
+        dep_name,
+        dep_version,
+        repo_dir,
+        commit=commit,
+        verbose=True,
+        shallow_since='2000-01-02',
+    )
+    self.writeCcProjectFiles(dep_name, dep_version)
+
   def testLocalRepoInSourceJsonAbsoluteBasePath(self):
     self.main_registry.setModuleBasePath(str(self.main_registry.projects))
     self.setUpProjectWithLocalRegistryModule('sss', '1.3')
@@ -320,6 +359,12 @@ class BazelModuleTest(test_base.TestBase):
   def testLocalRepoInSourceJsonRelativeBasePath(self):
     self.main_registry.setModuleBasePath('projects')
     self.setUpProjectWithLocalRegistryModule('sss', '1.3')
+    _, stdout, _ = self.RunBazel(['run', '//:main'])
+    self.assertIn('main function => sss@1.3', stdout)
+
+  def testGitRepoAbsoluteBasePath(self):
+    self.main_registry.setModuleBasePath(str(self.main_registry.projects))
+    self.setUpProjectWithGitRegistryModule('sss', '1.3')
     _, stdout, _ = self.RunBazel(['run', '//:main'])
     self.assertIn('main function => sss@1.3', stdout)
 

--- a/src/test/py/bazel/bzlmod/test_utils.py
+++ b/src/test/py/bazel/bzlmod/test_utils.py
@@ -326,6 +326,30 @@ class BazelRegistry:
         'path': path,
     }
 
+    self._createModuleAndSourceJson(
+        module_dir, name, version, path, deps, source
+    )
+
+  def createGitRepoModule(self, name, version, path, deps=None, **kwargs):
+    """Add a git repo module into the registry."""
+    module_dir = self.root.joinpath('modules', name, version)
+    module_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create source.json & copy patch files to the registry
+    source = {
+        'type': 'git_repository',
+        'remote': f'file://{path}',
+    }
+    source.update(**kwargs)
+
+    self._createModuleAndSourceJson(
+        module_dir, name, version, path, deps, source
+    )
+
+  def _createModuleAndSourceJson(
+      self, module_dir, name, version, path, deps, source
+  ):
+    """Create the MODULE.bazel and source.json files for a module."""
     if deps is None:
       deps = {}
 


### PR DESCRIPTION
bzlmod: support git repos in source.json

Closes #20912.

RELNOTES: Added `init_submodules` attribute to `git_override`. Registries now support the `git_repository` type in `source.json`. 

Change-Id: Ia267131e6d081572a642888ba34e285805bbbe9f
PiperOrigin-RevId: 601268823