### PR TITLE
[7.1.0] Cherry-picks for elimination of repo rule restarts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -340,10 +340,22 @@ public class BazelRepositoryModule extends BlazeModule {
           starlarkRepositoryFunction.setWorkerExecutorService(repoFetchingWorkerThreadPool);
           break;
         case VIRTUAL:
-          throw new AbruptExitException(
-              detailedExitCode(
-                  "using a virtual worker thread for repo fetching is not yet supported",
-                  Code.BAD_DOWNLOADER_CONFIG));
+          try {
+            // Since Google hasn't migrated to JDK 21 yet, we can't directly call
+            // Executors.newVirtualThreadPerTaskExecutor here. But a bit of reflection never hurt
+            // anyone... right? (OSS Bazel already ships with a bundled JDK 21)
+            starlarkRepositoryFunction.setWorkerExecutorService(
+                (ExecutorService)
+                    Executors.class
+                        .getDeclaredMethod("newVirtualThreadPerTaskExecutor")
+                        .invoke(null));
+          } catch (ReflectiveOperationException e) {
+            throw new AbruptExitException(
+                detailedExitCode(
+                    "couldn't create virtual worker thread executor for repo fetching",
+                    Code.BAD_DOWNLOADER_CONFIG),
+                e);
+          }
       }
       downloadManager.setDisableDownload(repoOptions.disableDownload);
       if (repoOptions.repositoryDownloaderRetries >= 0) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -216,7 +216,8 @@ public class RepositoryOptions extends OptionsBase {
   public enum WorkerForRepoFetching {
     OFF,
     PLATFORM,
-    VIRTUAL;
+    VIRTUAL,
+    AUTO;
 
     static class Converter extends EnumConverter<WorkerForRepoFetching> {
       public Converter() {
@@ -227,14 +228,16 @@ public class RepositoryOptions extends OptionsBase {
 
   @Option(
       name = "experimental_worker_for_repo_fetching",
-      defaultValue = "off",
+      defaultValue = "auto",
       converter = WorkerForRepoFetching.Converter.class,
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "The threading mode to use for repo fetching. If set to 'off', no worker thread is used,"
               + " and the repo fetching is subject to restarts. Otherwise, uses a platform thread"
-              + " (i.e. OS thread) if set to 'platform' or a virtual thread if set to 'virtual'.")
+              + " (i.e. OS thread) if set to 'platform' or a virtual thread if set to 'virtual'. If"
+              + " set to 'auto', virtual threads are used if available (i.e. running on JDK 21+),"
+              + " otherwise no worker thread is used.")
   public WorkerForRepoFetching workerForRepoFetching;
 
   @Option(

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2384,6 +2384,12 @@ EOF
   bazel build @foo//:bar --experimental_worker_for_repo_fetching=platform >& $TEST_log \
     || fail "Expected build to succeed"
   expect_log_n "hello world!" 1
+
+  # virtual worker thread, never restarts
+  bazel shutdown
+  bazel build @foo//:bar --experimental_worker_for_repo_fetching=virtual >& $TEST_log \
+    || fail "Expected build to succeed"
+  expect_log_n "hello world!" 1
 }
 
 function test_duplicate_value_in_environ() {


### PR DESCRIPTION
RELNOTES: The flag `--experimental_worker_for_repo_fetching` now defaults to `auto`, which uses virtual threads from JDK 21 if it's available. This eliminates restarts during repo fetching.