### PR TITLE
[7.1.0] Follow directory symlink in RemoteActionFileSystem#getDirectoryEntries().

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -606,7 +606,7 @@ public abstract class FileSystem {
 
   /**
    * Returns a collection containing the names of all entities within the directory denoted by the
-   * {@code path}.
+   * {@code path}. Symlinks are followed when resolving the directory whose entries are to be read.
    *
    * @throws IOException if there was an error reading the directory entries
    */


### PR DESCRIPTION
Although the semantics weren't explicitly specified by the FileSystem interface, the Unix implementation calls readdir(3), which always dereferences a symlink for the directory itself.

Also deduplicate the common logic.

PiperOrigin-RevId: 598543913
Change-Id: I9bcab70c57ef4e8c4da58f4871397c6f2362f43c