### PR TITLE
[7.1.0] Clarify where to find the definition of the --experimental_remote_scrubbing_config configuration format.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -710,7 +710,8 @@ public final class RemoteOptions extends CommonRemoteOptions {
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "Enables remote cache key scrubbing with the supplied configuration file, which must be a"
-              + " ScrubbingConfig protocol buffer in text format.\n\n"
+              + " protocol buffer in text format (see"
+              + " src/main/protobuf/remote_scrubbing.proto).\n\n"
               + "This feature is intended to facilitate sharing a remote/disk cache between actions"
               + " executing on different platforms but targeting the same platform. It should be"
               + " used with extreme care, as improper settings may cause accidental sharing of"


### PR DESCRIPTION
PiperOrigin-RevId: 597764071
Change-Id: I9ea7000509e29c327034db5fd0087b35c0fcdfb9