### PR TITLE
Clean up `.bazelrc`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,8 +10,6 @@ build:remote_shared --jobs=100
 build:remote_shared --action_env=PATH=/bin:/usr/bin:/usr/local/bin
 build:remote_shared --java_runtime_version=rbe_jdk
 build:remote_shared --tool_java_runtime_version=rbe_jdk
-# Workaround for singlejar incompatibility with RBE
-build:remote_shared --noexperimental_check_desugar_deps
 
 # Configuration to build and test Bazel on RBE on Ubuntu 18.04 with Java 11
 build:ubuntu2004_java11 --extra_toolchains=@rbe_ubuntu2004_java11//java:all
@@ -58,12 +56,6 @@ build --tool_java_language_version=11
 
 # Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
 build --incompatible_disallow_empty_glob
-
-# Manually enable cc toolchain resolution before it is flipped. https://github.com/bazelbuild/bazel/issues/7260
-build --incompatible_enable_cc_toolchain_resolution
-
-# Fix non-deterministic Java compilation failures (https://github.com/bazelbuild/bazel/issues/3236)
-build --incompatible_sandbox_hermetic_tmp
 
 # User-specific .bazelrc
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
* Remove flags that have been flipped.
* Remove workaround for singlejar issue that is no longer needed.
