### PR TITLE
[7.1.0] Add an option to set a minimum size threshold for zstd blob compression.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -430,8 +430,20 @@ public final class RemoteOptions extends CommonRemoteOptions {
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "If enabled, compress/decompress cache blobs with zstd.")
+      help =
+          "If enabled, compress/decompress cache blobs with zstd when their size is at least"
+              + " --experimental_remote_cache_compression_threshold.")
   public boolean cacheCompression;
+
+  @Option(
+      name = "experimental_remote_cache_compression_threshold",
+      defaultValue = "0",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "The minimum blob size required to compress/decompress with zstd. Ineffectual unless"
+              + " --remote_cache_compression is set.")
+  public int cacheCompressionThreshold;
 
   @Option(
       name = "build_event_upload_max_threads",


### PR DESCRIPTION
As discussed in #18997, compression causes performance degradation for small blobs. The flag defaults to zero (always compress) for backwards compatibility, but the discussion suggests that 100 might be an appropriate value to set it to.

Fixes #18997.

Commit https://github.com/bazelbuild/bazel/commit/69eb0ec181012d31123f4ee862effe5d51c1725e

PiperOrigin-RevId: 602353295
Change-Id: Ie9ef8c10e221e9190d3c5cb5f267fcf35a63fd3b