### PR TITLE
Only use BzlmodRepoCycleReporter for cycles it can print

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoCycleReporter.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoCycleReporter.java
@@ -157,26 +157,6 @@ public class BzlmodRepoCycleReporter implements CyclesReporter.SingleCycleReport
       // repositories were defined.
       requestRepoDefinitions(eventHandler, repos);
       return true;
-    } else if (Iterables.any(cycle, IS_BZL_LOAD)) {
-      Label fileLabel =
-          ((BzlLoadValue.Key) Iterables.getLast(Iterables.filter(cycle, IS_BZL_LOAD))).getLabel();
-      eventHandler.handle(
-          Event.error(
-              null,
-              String.format(
-                  "Failed to load .bzl file '%s': possible dependency cycle detected.\n",
-                  fileLabel)));
-      return true;
-    } else if (Iterables.any(cycle, IS_PACKAGE_LOOKUP)) {
-      PackageIdentifier pkg =
-          (PackageIdentifier)
-              Iterables.getLast(Iterables.filter(cycle, IS_PACKAGE_LOOKUP)).argument();
-      eventHandler.handle(
-          Event.error(
-              null,
-              String.format(
-                  "cannot load package '%s': possible dependency cycle detected.\n", pkg)));
-      return true;
     }
     return false;
   }


### PR DESCRIPTION
Previously, `BzlmodRepoCycleReporter` would apply to all cycles involving `.bzl` files and produce a very concise error message that doesn't contain any information on the structure of the cycle.