### PR TITLE
[7.1.0] Avoid using `InputStream.available()` to detect EOF while reading delimited protos.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
@@ -268,8 +268,8 @@ public class ExpandedSpawnLogContext implements SpawnLogContext {
       if (sorted) {
         StableSort.stableSort(in, convertedOutputStream);
       } else {
-        while (in.available() > 0) {
-          SpawnExec ex = SpawnExec.parseDelimitedFrom(in);
+        SpawnExec ex;
+        while ((ex = SpawnExec.parseDelimitedFrom(in)) != null) {
           convertedOutputStream.write(ex);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/exec/StableSort.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StableSort.java
@@ -37,8 +37,8 @@ import java.util.PriorityQueue;
 public final class StableSort {
   private static ImmutableList<SpawnExec> read(InputStream in) throws IOException {
     ImmutableList.Builder<SpawnExec> result = ImmutableList.builder();
-    while (in.available() > 0) {
-      SpawnExec ex = SpawnExec.parseDelimitedFrom(in);
+    SpawnExec ex;
+    while ((ex = SpawnExec.parseDelimitedFrom(in)) != null) {
       result.add(ex);
     }
     return result.build();

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
@@ -730,8 +730,9 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
 
     List<BuildEvent> buildEvents = new ArrayList<>();
     try (InputStream in = new FileInputStream(buildEventBinaryFile)) {
-      while (in.available() > 0) {
-        buildEvents.add(BuildEvent.parseDelimitedFrom(in));
+      BuildEvent ev;
+      while ((ev = BuildEvent.parseDelimitedFrom(in)) != null) {
+        buildEvents.add(ev);
       }
     }
 
@@ -842,8 +843,9 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
 
     List<BuildEvent> buildEvents = new ArrayList<>();
     try (InputStream in = new FileInputStream(buildEventBinaryFile)) {
-      while (in.available() > 0) {
-        buildEvents.add(BuildEvent.parseDelimitedFrom(in));
+      BuildEvent ev;
+      while ((ev = BuildEvent.parseDelimitedFrom(in)) != null) {
+        buildEvents.add(ev);
       }
     }
     Aborted expectedAbort =

--- a/src/test/java/com/google/devtools/build/lib/buildtool/TargetCompleteEventTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/TargetCompleteEventTest.java
@@ -269,8 +269,9 @@ public final class TargetCompleteEventTest extends BuildIntegrationTestCase {
       throws IOException {
     ImmutableList.Builder<BuildEvent> buildEvents = ImmutableList.builder();
     try (InputStream in = new FileInputStream(bep)) {
-      while (in.available() > 0) {
-        buildEvents.add(BuildEvent.parseDelimitedFrom(in));
+      BuildEvent ev;
+      while ((ev = BuildEvent.parseDelimitedFrom(in)) != null) {
+        buildEvents.add(ev);
       }
     }
     return buildEvents.build();

--- a/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
@@ -131,8 +131,8 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
 
     ArrayList<SpawnExec> actual = new ArrayList<>();
     try (InputStream in = new ZstdInputStream(logPath.getInputStream())) {
-      while (in.available() > 0) {
-        ExecLogEntry e = ExecLogEntry.parseDelimitedFrom(in);
+      ExecLogEntry e;
+      while ((e = ExecLogEntry.parseDelimitedFrom(in)) != null) {
         entryMap.put(e.getId(), e);
         if (e.hasSpawn()) {
           actual.add(reconstructSpawnExec(e.getSpawn(), entryMap));

--- a/src/test/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContextTest.java
@@ -59,8 +59,8 @@ public final class ExpandedSpawnLogContextTest extends SpawnLogContextTestBase {
 
     ArrayList<SpawnExec> actual = new ArrayList<>();
     try (InputStream in = logPath.getInputStream()) {
-      while (in.available() > 0) {
-        SpawnExec ex = SpawnExec.parseDelimitedFrom(in);
+      SpawnExec ex;
+      while ((ex = SpawnExec.parseDelimitedFrom(in)) != null) {
         actual.add(ex);
       }
     }

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogParser.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogParser.java
@@ -59,14 +59,12 @@ final class ExecLogParser {
     public SpawnExec getNext() throws IOException {
       SpawnExec ex;
       // Find the next record whose runner matches
-      do {
-        if (in.available() <= 0) {
-          // End of file
-          return null;
+      while ((ex = SpawnExec.parseDelimitedFrom(in)) != null) {
+        if (restrictToRunner == null || restrictToRunner.equals(ex.getRunner())) {
+          return ex;
         }
-        ex = SpawnExec.parseDelimitedFrom(in);
-      } while (restrictToRunner != null && !restrictToRunner.equals(ex.getRunner()));
-      return ex;
+      }
+      return null;
     }
   }
 


### PR DESCRIPTION
It's not a reliable method to check for EOF: it returns how many bytes are guaranteed to be read without blocking, and the base implementation always returns 0.

Instead, leverage the fact that parseDelimitedFrom() returns null if the stream is at EOF.

PiperOrigin-RevId: 602257598
Change-Id: I61e51774611196fb44745dc0aa2dc836b41fcd68