### PR TITLE
Add `target_kind` to scrubber matching rules

### DIFF
--- a/src/main/protobuf/remote_scrubbing.proto
+++ b/src/main/protobuf/remote_scrubbing.proto
@@ -34,7 +34,7 @@ message Config {
     // Whether to match actions built for a tool configuration.
     // The default is to match only actions built for non-tool configurations.
     bool match_tools = 3;
-    // A regex matching the action target kind.
+    // A regex matching the rule kind of the action owner.
     // Use .* if a partial match is desired.
     // If empty, matches every target kind.
     string target_kind = 4;

--- a/src/main/protobuf/remote_scrubbing.proto
+++ b/src/main/protobuf/remote_scrubbing.proto
@@ -34,6 +34,10 @@ message Config {
     // Whether to match actions built for a tool configuration.
     // The default is to match only actions built for non-tool configurations.
     bool match_tools = 3;
+    // A regex matching the action target kind.
+    // Use .* if a partial match is desired.
+    // If empty, matches every target kind.
+    string target_kind = 4;
   }
 
   // Describes a string replacement.

--- a/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
@@ -44,6 +44,7 @@ public class FakeOwner implements ActionExecutionMetadata {
   private final String mnemonic;
   private final String progressMessage;
   @Nullable private final String ownerLabel;
+  private final String ownerRuleKind;
   @Nullable private final Artifact primaryOutput;
   @Nullable private final PlatformInfo platform;
   private final ImmutableMap<String, String> execProperties;
@@ -53,6 +54,7 @@ public class FakeOwner implements ActionExecutionMetadata {
       String mnemonic,
       String progressMessage,
       String ownerLabel,
+      String ownerRuleKind,
       @Nullable Artifact primaryOutput,
       @Nullable PlatformInfo platform,
       ImmutableMap<String, String> execProperties,
@@ -60,6 +62,7 @@ public class FakeOwner implements ActionExecutionMetadata {
     this.mnemonic = mnemonic;
     this.progressMessage = progressMessage;
     this.ownerLabel = checkNotNull(ownerLabel);
+    this.ownerRuleKind = ownerRuleKind;
     this.primaryOutput = primaryOutput;
     this.platform = platform;
     this.execProperties = execProperties;
@@ -72,6 +75,7 @@ public class FakeOwner implements ActionExecutionMetadata {
         mnemonic,
         progressMessage,
         ownerLabel,
+        /* ownerRuleKind= */ "dummy-target-kind",
         /* primaryOutput= */ null,
         platform,
         ImmutableMap.of(),
@@ -87,7 +91,7 @@ public class FakeOwner implements ActionExecutionMetadata {
     return ActionOwner.createDummy(
         Label.parseCanonicalUnchecked(ownerLabel),
         new Location("dummy-file", 0, 0),
-        /* targetKind= */ "dummy-target-kind",
+        ownerRuleKind,
         mnemonic,
         /* configurationChecksum= */ "configurationChecksum",
         new BuildConfigurationEvent(

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -46,6 +46,7 @@ public final class SpawnBuilder {
   private String mnemonic = "Mnemonic";
   private String progressMessage = "progress message";
   private String ownerLabel = "//dummy:label";
+  private String ownerRuleKind = "dummy-target-kind";
   @Nullable private Artifact ownerPrimaryOutput;
   @Nullable private PlatformInfo platform;
   private final List<String> args;
@@ -95,6 +96,7 @@ public final class SpawnBuilder {
             mnemonic,
             progressMessage,
             ownerLabel,
+            ownerRuleKind,
             ownerPrimaryOutput,
             platform,
             execProperties,
@@ -136,6 +138,12 @@ public final class SpawnBuilder {
   @CanIgnoreReturnValue
   public SpawnBuilder withOwnerLabel(String ownerLabel) {
     this.ownerLabel = checkNotNull(ownerLabel);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public SpawnBuilder withOwnerRuleKind(String ownerRuleKind) {
+    this.ownerRuleKind = checkNotNull(ownerRuleKind);
     return this;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ScrubberTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ScrubberTest.java
@@ -126,6 +126,50 @@ public class ScrubberTest {
   }
 
   @Test
+  public void matchExactTargetKind() {
+    var scrubber =
+      new Scrubber(
+        Config.newBuilder()
+          .addRules(
+            Config.Rule.newBuilder()
+              .setMatcher(Config.Matcher.newBuilder().setTargetKind("java_library")))
+          .build());
+
+    assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo", "java_library",false))).isNotNull();
+    assertThat(scrubber.forSpawn(createSpawn("//foo:barbaz", "Foo", "java_test",false))).isNull();
+  }
+
+  @Test
+  public void matchUnionTargetKind() {
+    var scrubber =
+      new Scrubber(
+        Config.newBuilder()
+          .addRules(
+            Config.Rule.newBuilder()
+              .setMatcher(Config.Matcher.newBuilder().setTargetKind("java_library|java_test")))
+          .build());
+
+    assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo", "java_library",false))).isNotNull();
+    assertThat(scrubber.forSpawn(createSpawn("//spam:eggs", "Foo", "java_test", false))).isNotNull();
+    assertThat(scrubber.forSpawn(createSpawn("//quux:xyzzy", "Foo", "go_library", false))).isNull();
+  }
+
+  @Test
+  public void matchWildcardTargetKind() {
+    var scrubber =
+      new Scrubber(
+        Config.newBuilder()
+          .addRules(
+            Config.Rule.newBuilder()
+              .setMatcher(Config.Matcher.newBuilder().setTargetKind("java_.*")))
+          .build());
+
+    assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo", "java_library", false))).isNotNull();
+    assertThat(scrubber.forSpawn(createSpawn("//foo:baz", "Foo", "java_test", false))).isNotNull();
+    assertThat(scrubber.forSpawn(createSpawn("//spam:eggs", "Foo", "go_library", false))).isNull();
+  }
+
+  @Test
   public void rejectToolAction() {
     var scrubber =
         new Scrubber(
@@ -137,7 +181,7 @@ public class ScrubberTest {
                 .build());
 
     assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo"))).isNotNull();
-    assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo", /* forTool= */ true))).isNull();
+    assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo", "java_library", /* forTool= */ true))).isNull();
   }
 
   @Test
@@ -155,7 +199,7 @@ public class ScrubberTest {
                 .build());
 
     assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo"))).isNotNull();
-    assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo", /* forTool= */ true))).isNotNull();
+    assertThat(scrubber.forSpawn(createSpawn("//foo:bar", "Foo", "java_library", /* forTool= */ true))).isNotNull();
   }
 
   @Test
@@ -420,13 +464,14 @@ public class ScrubberTest {
   }
 
   private static Spawn createSpawn(String label, String mnemonic) {
-    return createSpawn(label, mnemonic, /* forTool= */ false);
+    return createSpawn(label, mnemonic, /* ruleKind= */ "dummy-target-kind", /* forTool= */ false);
   }
 
-  private static Spawn createSpawn(String label, String mnemonic, boolean forTool) {
+  private static Spawn createSpawn(String label, String mnemonic, String ruleKind, boolean forTool) {
     return new SpawnBuilder("cmd")
         .withOwnerLabel(label)
         .withMnemonic(mnemonic)
+        .withOwnerRuleKind(ruleKind)
         .setBuiltForToolConfiguration(forTool)
         .build();
   }


### PR DESCRIPTION
Allow the use of the target kind (for example, `cc_library`, `go_binary`, `go_test`...) in the scrubbing matcher configuration.
This is useful, as different target kinds can have the same mnemonic.