### PR TITLE
[7.1.0] Split StableSort into a separate target.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -261,9 +261,9 @@ java_library(
         "CompactSpawnLogContext.java",
         "ExpandedSpawnLogContext.java",
         "SpawnLogContext.java",
-        "StableSort.java",
     ],
     deps = [
+        ":spawn_log_context_utils",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
@@ -283,6 +283,17 @@ java_library(
         "//third_party/protobuf:protobuf_java",
         "//third_party/protobuf:protobuf_java_util",
         "@zstd-jni",
+    ],
+)
+
+java_library(
+    name = "spawn_log_context_utils",
+    srcs = ["StableSort.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/profiler",
+        "//src/main/java/com/google/devtools/build/lib/util/io",
+        "//src/main/protobuf:spawn_java_proto",
+        "//third_party:guava",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/exec/BUILD
@@ -50,6 +50,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_exec_exception",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_input_expander",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_log_context",
+        "//src/main/java/com/google/devtools/build/lib/exec:spawn_log_context_utils",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_strategy_registry",
         "//src/main/java/com/google/devtools/build/lib/exec:standalone_test_result",


### PR DESCRIPTION
This is to allow StableSort (and other utilities to be added soon) to be shared between Bazel and a future log conversion tool, without bringing in unnecessary dependencies for the latter.

PiperOrigin-RevId: 602385146
Change-Id: I29419c2715338a1845f79568d86119033f7ff5ff