### PR TITLE
Expose virtual:original header mappings via CcToolchain variables

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1332,7 +1332,8 @@ public final class CcCompilationHelper {
           ccCompilationContext.getSystemIncludeDirs(),
           ccCompilationContext.getFrameworkIncludeDirs(),
           ccCompilationContext.getDefines(),
-          ccCompilationContext.getNonTransitiveDefines());
+          ccCompilationContext.getNonTransitiveDefines(),
+          ccCompilationContext.getVirtualToOriginalDirs());
 
       if (usePrebuiltParent) {
         parent = buildVariables.build();

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -369,7 +369,8 @@ public abstract class CcModule
                     Depset.noneableCast(
                         frameworkIncludeDirs, String.class, "framework_include_directories"),
                     Depset.noneableCast(defines, String.class, "preprocessor_defines").toList(),
-                    ImmutableList.of()))
+                    ImmutableList.of(),
+                    /* virtualToOriginalDirs= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER)))
             .addStringSequenceVariable("stripopts", asClassImmutableList(stripOpts));
     String inputFileString = convertFromNoneable(inputFile, null);
     if (inputFileString != null) {
@@ -807,6 +808,7 @@ public abstract class CcModule
       Object labelForMiddlemanNameObject,
       Object externalIncludes,
       Object virtualToOriginalHeaders,
+      Object virtualToOriginalDirs,
       Sequence<?> dependentCcCompilationContexts,
       Sequence<?> nonCodeInputs,
       Sequence<?> looseHdrsDirsObject,
@@ -877,6 +879,9 @@ public abstract class CcModule
 
     ccCompilationContext.addVirtualToOriginalHeaders(
         Depset.cast(virtualToOriginalHeaders, Tuple.class, "virtual_to_original_headers"));
+
+    ccCompilationContext.addVirtualToOriginalDirs(
+        Depset.cast(virtualToOriginalDirs, Tuple.class, "virtual_to_original_dirs"));
 
     ccCompilationContext.addDependentCcCompilationContexts(
         Sequence.cast(

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkstampCompileHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkstampCompileHelper.java
@@ -198,7 +198,8 @@ public final class CppLinkstampCompileHelper {
               ccToolchainProvider,
               fdoBuildStamp,
               codeCoverageEnabled),
-          /* localDefines= */ ImmutableList.of());
+          /* localDefines= */ ImmutableList.of(),
+          /* virtualToOriginalDirs= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER));
     } catch (EvalException e) {
       throw new RuleErrorException(e.getMessage());
     }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcCompilationContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcCompilationContextApi.java
@@ -170,6 +170,12 @@ public interface CcCompilationContextApi<
   Depset getStarlarkVirtualToOriginalHeaders(StarlarkThread thread) throws EvalException;
 
   @StarlarkMethod(
+      name = "virtual_to_original_dirs",
+      documented = false,
+      useStarlarkThread = true)
+  Depset getStarlarkVirtualToOriginalDirs(StarlarkThread thread) throws EvalException;
+
+  @StarlarkMethod(
       name = "module_map",
       documented = false,
       useStarlarkThread = true,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
@@ -1280,6 +1280,12 @@ public interface CcModuleApi<
             named = true,
             defaultValue = "unbound"),
         @Param(
+            name = "virtual_to_original_dirs",
+            documented = false,
+            positional = false,
+            named = true,
+            defaultValue = "unbound"),
+        @Param(
             name = "dependent_cc_compilation_contexts",
             documented = false,
             positional = false,
@@ -1363,6 +1369,7 @@ public interface CcModuleApi<
       Object labelForMiddlemanNameObject,
       Object externalIncludes,
       Object virtualToOriginalHeaders,
+      Object virtualToOriginalDirs,
       Sequence<?> dependentCcCompilationContexts,
       Sequence<?> nonCodeInputs,
       Sequence<?> looseHdrsDirs,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
@@ -432,6 +432,7 @@ def _create_compilation_context(
         label = _UNBOUND,
         external_includes = _UNBOUND,
         virtual_to_original_headers = _UNBOUND,
+        virtual_to_original_dirs = _UNBOUND,
         dependent_cc_compilation_contexts = _UNBOUND,
         non_code_inputs = _UNBOUND,
         headers_checking_mode = _UNBOUND,
@@ -447,6 +448,7 @@ def _create_compilation_context(
        actions != _UNBOUND or \
        external_includes != _UNBOUND or \
        virtual_to_original_headers != _UNBOUND or \
+       virtual_to_original_dirs != _UNBOUND or \
        dependent_cc_compilation_contexts != _UNBOUND or \
        non_code_inputs != _UNBOUND or \
        headers_checking_mode != _UNBOUND or \
@@ -471,6 +473,8 @@ def _create_compilation_context(
         external_includes = depset()
     if virtual_to_original_headers == _UNBOUND:
         virtual_to_original_headers = depset()
+    if virtual_to_original_dirs == _UNBOUND:
+        virtual_to_original_dirs = depset()
     if dependent_cc_compilation_contexts == _UNBOUND:
         dependent_cc_compilation_contexts = []
     if non_code_inputs == _UNBOUND:
@@ -508,6 +512,7 @@ def _create_compilation_context(
         label = label,
         external_includes = external_includes,
         virtual_to_original_headers = virtual_to_original_headers,
+        virtual_to_original_dirs = virtual_to_original_dirs,
         dependent_cc_compilation_contexts = dependent_cc_compilation_contexts,
         non_code_inputs = non_code_inputs,
         loose_hdrs_dirs = [],

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -177,6 +177,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/main/java/net/starlark/java/eval",
         "//src/test/java/com/google/devtools/build/lib/actions/util",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/packages:testutil",

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -791,6 +791,21 @@ def _impl(ctx):
         ],
     )
 
+    virtual_prefix_map_feature = feature(
+        name = "virtual_prefix_map",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-ffile-prefix-map=%{virtual_to_original_dirs}"],
+                        iterate_over = "virtual_to_original_dirs",
+                    ),
+                ],
+            ),
+        ],
+    )
+
     strip_debug_symbols_feature = feature(
         name = "strip_debug_symbols",
         flag_sets = [
@@ -1390,6 +1405,7 @@ def _impl(ctx):
             archiver_flags_feature,
             force_pic_flags_feature,
             fission_support_feature,
+            virtual_prefix_map_feature,
             strip_debug_symbols_feature,
             coverage_feature,
             supports_pic_feature,


### PR DESCRIPTION
Whenever `prefix` and/or `strip_include_prefix` is passed into `cc_library` rules, Bazel copies the headers into a special "_virtual_includes" directory that allows for such path transformations to occur.  Unfortunately, this also has the side-effect of changing how source files are designated within the source binaries: they will refer to the file in the `_virtual_includes` sandbox directory instead of the actual files in the build tree.

This change allows us to work around this problem by providing a mapping between the "virtual" and where they are in the filesystem as a [CcToolchainConfigInfo variable][1], `virtual_to_original_dirs`, which ends up being a list of `<virtual>=<original>` mappings that can be used in rules_cc toolchain features, specifically using [-ffile-prefix-map][2].

Questions
=========
- Is `<virtual>=<original>` okay, or do we need a more sophisticated lazy expansion involving subvariables like what `libraries_to_link` has? E.g., do we imagine another compiler command-line flag format that'd require `A:B` instead of `A=B`?  (Then again, considering MSVC's ASan is implemented w/ `/fsanitize=address`, maybe they're on the `A=B` train now?)

Notes
=====
- We mostly mimicked coverage's `virtual_to_original_headers`.

Fixes upstream #11874.

[1]: https://docs.bazel.build/versions/master/cc-toolchain-config-reference.html#cctoolchainconfiginfo-build-variables
[2]: https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html#index-ffile-prefix-map