### PR TITLE
[7.1.0] Fix the comment for MessageOutputStream#write().

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/io/MessageOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/MessageOutputStream.java
@@ -18,12 +18,9 @@ import java.io.IOException;
 
 /** A variation of OutputStream for protobuf messages. */
 public interface MessageOutputStream<T extends Message> {
-  /**
-   * Writes a delimited protocol buffer message in the same format as {@link
-   * MessageLite#writeDelimitedTo(java.io.OutputStream)}.
-   */
+  /** Writes a protobuf message to the underlying stream. */
   void write(T m) throws IOException;
 
-  /** Closes the underlying stream, following writes will fail. */
+  /** Closes the underlying stream. Any following writes will fail. */
   void close() throws IOException;
 }


### PR DESCRIPTION
It's just a general interface for encoding a stream of protobuf messages. Some implementations, notably JsonOutputStreamWrapper, don't encode in length-delimited wire format.

PiperOrigin-RevId: 602907082
Change-Id: Ib35eeb15d92b4eca9b827f44927b6a9370d3107c