### PR TITLE
Error on invalid path characters in `.bazelignore`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredPackagePrefixesFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredPackagePrefixesFunction.java
@@ -31,6 +31,9 @@ import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+
 import javax.annotation.Nullable;
 
 /**
@@ -60,13 +63,15 @@ public class IgnoredPackagePrefixesFunction implements SkyFunction {
                   + " is not readable because: "
                   + errorMessage
                   + ". Was it modified mid-build?"));
+    } catch (InvalidPathException e) {
+      throw new IgnoredPatternsFunctionException(new InvalidIgnorePathException(e, patternFile.asPath().toString()));
     }
   }
 
   @Nullable
   @Override
   public SkyValue compute(SkyKey key, Environment env)
-      throws SkyFunctionException, InterruptedException {
+      throws IgnoredPatternsFunctionException, InterruptedException {
     RepositoryName repositoryName = (RepositoryName) key.argument();
 
     ImmutableSet.Builder<PathFragment> ignoredPackagePrefixesBuilder = ImmutableSet.builder();
@@ -122,6 +127,15 @@ public class IgnoredPackagePrefixesFunction implements SkyFunction {
     public boolean processLine(String line) {
       if (!line.isEmpty() && !line.startsWith("#")) {
         fragments.add(PathFragment.create(line));
+
+        // This is called for its side-effects rather than its output.
+        // Specifically, it validates that the line is a valid path. This
+        // doesn't do much on UNIX machines where only NUL is an invalid
+        // character but can reject paths on Windows.
+        //
+        // This logic would need to be adjusted if wildcards are ever supported
+        // (https://github.com/bazelbuild/bazel/issues/7093).
+        Path.of(line);
       }
       return true;
     }
@@ -132,9 +146,19 @@ public class IgnoredPackagePrefixesFunction implements SkyFunction {
     }
   }
 
+  private static class InvalidIgnorePathException extends Exception {
+    public InvalidIgnorePathException(InvalidPathException e, String path) {
+      super("Invalid path in " + path + ": " + e);
+    }
+  }
+
   private static final class IgnoredPatternsFunctionException extends SkyFunctionException {
     public IgnoredPatternsFunctionException(InconsistentFilesystemException e) {
       super(e, Transience.TRANSIENT);
+    }
+
+    public IgnoredPatternsFunctionException(InvalidIgnorePathException e) {
+      super(e, Transience.PERSISTENT);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3176,7 +3176,8 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         // Ignored package prefixes are specified relative to the workspace root
         // by definition of .bazelignore. So, we only use ignored paths when the
         // package root is equal to the workspace path.
-        if (workspacePath != null && workspacePath.equals(pathEntry.asPath())) {
+        if (workspacePath != null && workspacePath.equals(pathEntry.asPath()) &&
+            ignoredPackagePrefixesValue != null) {
           ignoredPaths =
               ignoredPackagePrefixesValue.getPatterns().stream()
                   .map(pathEntry::getRelative)

--- a/src/test/shell/bazel/bazelignore_test.sh
+++ b/src/test/shell/bazel/bazelignore_test.sh
@@ -206,4 +206,16 @@ EOI
     assert_not_contains "ignoreme" output
 }
 
+test_invalid_path() {
+    rm -rf work && mkdir work && cd work
+    create_workspace_with_default_repos WORKSPACE
+    echo -e "foo/\0/bar" > .bazelignore
+    echo 'filegroup(name="f", srcs=glob(["**"]))' > BUILD
+    if bazel build //... 2> "$TEST_log"; then
+      fail "Bazel build should have failed"
+    fi
+    expect_log "java.nio.file.InvalidPathException: Nul character not allowed"
+    bazel shutdown
+}
+
 run_suite "Integration tests for .bazelignore"

--- a/src/test/shell/bazel/bazelignore_test.sh
+++ b/src/test/shell/bazel/bazelignore_test.sh
@@ -215,7 +215,6 @@ test_invalid_path() {
       fail "Bazel build should have failed"
     fi
     expect_log "java.nio.file.InvalidPathException: Nul character not allowed"
-    bazel shutdown
 }
 
 run_suite "Integration tests for .bazelignore"


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/20906.
cc @meteorcloudy 