### PR TITLE
[7.1.0] Make repo marker files sensitive to repo mapping changes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -20,6 +20,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.bazel.repository.RepositoryResolvedEvent;
@@ -242,6 +243,10 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
     try (Mutability mu = Mutability.create("Starlark repository")) {
       StarlarkThread thread = new StarlarkThread(mu, starlarkSemantics);
       thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
+      var repoMappingRecorder = new Label.RepoMappingRecorder();
+      repoMappingRecorder.mergeEntries(
+          rule.getRuleClassObject().getRuleDefinitionEnvironmentRepoMappingEntries());
+      thread.setThreadLocal(Label.RepoMappingRecorder.class, repoMappingRecorder);
 
       new BazelStarlarkContext(
               BazelStarlarkContext.Phase.LOADING, // ("fetch")
@@ -328,6 +333,16 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
       // Ditto for environment variables accessed via `getenv`.
       for (String envKey : starlarkRepositoryContext.getAccumulatedEnvKeys()) {
         markerData.put("ENV:" + envKey, clientEnvironment.get(envKey));
+      }
+
+      for (Table.Cell<RepositoryName, String, RepositoryName> repoMappings :
+          repoMappingRecorder.recordedEntries().cellSet()) {
+        markerData.put(
+            "REPO_MAPPING:"
+                + repoMappings.getRowKey().getName()
+                + ","
+                + repoMappings.getColumnKey(),
+            repoMappings.getValue().getName());
       }
 
       env.getListener().post(resolved);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -113,6 +113,11 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
     BazelModuleContext moduleContext = BazelModuleContext.ofInnermostBzlOrThrow(thread);
     builder.setRuleDefinitionEnvironmentLabelAndDigest(
         moduleContext.label(), moduleContext.bzlTransitiveDigest());
+    Label.RepoMappingRecorder repoMappingRecorder =
+        thread.getThreadLocal(Label.RepoMappingRecorder.class);
+    if (repoMappingRecorder != null) {
+      builder.setRuleDefinitionEnvironmentRepoMappingEntries(repoMappingRecorder.recordedEntries());
+    }
     builder.setWorkspaceOnly();
     return new RepositoryRuleFunction(
         builder,

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -29,6 +29,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -38,6 +39,7 @@ import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.packages.Attribute.ComputedDefault;
@@ -161,9 +163,7 @@ public class RuleClass implements RuleClassData {
    */
   public static final String APPLICABLE_LICENSES_ATTR = "applicable_licenses";
 
-  /**
-   * A constraint for the package name of the Rule instances.
-   */
+  /** A constraint for the package name of the Rule instances. */
   public static class PackageNameConstraint implements PredicateWithMessage<Rule> {
 
     public static final int ANY_SEGMENT = 0;
@@ -173,8 +173,8 @@ public class RuleClass implements RuleClassData {
     private final Set<String> values;
 
     /**
-     * The pathSegment-th segment of the package must be one of the specified values.
-     * The path segment indexing starts from 1.
+     * The pathSegment-th segment of the package must be one of the specified values. The path
+     * segment indexing starts from 1.
      */
     public PackageNameConstraint(int pathSegment, String... values) {
       this.values = ImmutableSet.copyOf(values);
@@ -195,15 +195,20 @@ public class RuleClass implements RuleClassData {
     @Override
     public String getErrorReason(Rule param) {
       if (pathSegment == ANY_SEGMENT) {
-        return param.getRuleClass() + " rules have to be under a "
-            + StringUtil.joinEnglishList(values, "or", "'") + " directory";
+        return param.getRuleClass()
+            + " rules have to be under a "
+            + StringUtil.joinEnglishList(values, "or", "'")
+            + " directory";
       } else if (pathSegment == 1) {
         return param.getRuleClass()
             + " rules are only allowed in "
             + StringUtil.joinEnglishList(Iterables.transform(values, s -> "//" + s), "or");
       } else {
-          return param.getRuleClass() + " rules are only allowed in packages which "
-              + StringUtil.ordinal(pathSegment) + " is " + StringUtil.joinEnglishList(values, "or");
+        return param.getRuleClass()
+            + " rules are only allowed in packages which "
+            + StringUtil.ordinal(pathSegment)
+            + " is "
+            + StringUtil.joinEnglishList(values, "or");
       }
     }
 
@@ -277,7 +282,7 @@ public class RuleClass implements RuleClassData {
 
   /** A factory or builder class for rule implementations. */
   public interface ConfiguredTargetFactory<
-      TConfiguredTarget, TContext, TActionConflictException extends Throwable> {
+      ConfiguredTargetT, ContextT, ActionConflictExceptionT extends Throwable> {
     /**
      * Returns a fully initialized configured target instance using the given context, or {@code
      * null} on certain rule errors (typically if {@code ruleContext.hasErrors()} becomes {@code
@@ -288,8 +293,8 @@ public class RuleClass implements RuleClassData {
      * @throws TActionConflictException if there were conflicts during action registration
      */
     @Nullable
-    TConfiguredTarget create(TContext ruleContext)
-        throws InterruptedException, RuleErrorException, TActionConflictException;
+    ConfiguredTargetT create(ContextT ruleContext)
+        throws InterruptedException, RuleErrorException, ActionConflictExceptionT;
 
     /**
      * Exception indicating that configured target creation could not be completed. General error
@@ -391,27 +396,24 @@ public class RuleClass implements RuleClassData {
   public static final String CONFIG_SETTING_DEPS_ATTRIBUTE = "$config_dependencies";
 
   /**
-   * A support class to make it easier to create {@code RuleClass} instances.
-   * This class follows the 'fluent builder' pattern.
+   * A support class to make it easier to create {@code RuleClass} instances. This class follows the
+   * 'fluent builder' pattern.
    *
-   * <p>The {@link #addAttribute} method will throw an exception if an attribute
-   * of that name already exists. Use {@link #overrideAttribute} in that case.
+   * <p>The {@link #addAttribute} method will throw an exception if an attribute of that name
+   * already exists. Use {@link #overrideAttribute} in that case.
    */
   public static final class Builder {
     private static final Pattern RULE_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
 
-    /**
-     * The type of the rule class, which determines valid names and required
-     * attributes.
-     */
+    /** The type of the rule class, which determines valid names and required attributes. */
     public enum RuleClassType {
       /**
-       * Abstract rules are intended for rule classes that are just used to
-       * factor out common attributes, and for rule classes that are used only
-       * internally. These rules cannot be instantiated by a BUILD file.
+       * Abstract rules are intended for rule classes that are just used to factor out common
+       * attributes, and for rule classes that are used only internally. These rules cannot be
+       * instantiated by a BUILD file.
        *
-       * <p>The rule name must contain a '$' and {@link
-       * TargetUtils#isTestRuleName} must return false for the name.
+       * <p>The rule name must contain a '$' and {@link TargetUtils#isTestRuleName} must return
+       * false for the name.
        */
       ABSTRACT {
         @Override
@@ -427,9 +429,8 @@ public class RuleClass implements RuleClassData {
       },
 
       /**
-       * Invisible rule classes should contain a dollar sign so that they cannot be instantiated
-       * by the user. They are different from abstract rules in that they can be instantiated
-       * at will.
+       * Invisible rule classes should contain a dollar sign so that they cannot be instantiated by
+       * the user. They are different from abstract rules in that they can be instantiated at will.
        */
       INVISIBLE {
         @Override
@@ -444,34 +445,40 @@ public class RuleClass implements RuleClassData {
       },
 
       /**
-       * Normal rules are instantiable by BUILD files. Their names must therefore
-       * obey the rules for identifiers in the BUILD language. In addition,
-       * {@link TargetUtils#isTestRuleName} must return false for the name.
+       * Normal rules are instantiable by BUILD files. Their names must therefore obey the rules for
+       * identifiers in the BUILD language. In addition, {@link TargetUtils#isTestRuleName} must
+       * return false for the name.
        */
       NORMAL {
         @Override
         public void checkName(String name) {
           Preconditions.checkArgument(
               !TargetUtils.isTestRuleName(name) && RULE_NAME_PATTERN.matcher(name).matches(),
-              "Invalid rule name: %s", name);
+              "Invalid rule name: %s",
+              name);
         }
 
         @Override
         public void checkAttributes(Map<String, Attribute> attributes) {
           for (Attribute attribute : REQUIRED_ATTRIBUTES_FOR_NORMAL_RULES) {
             Attribute presentAttribute = attributes.get(attribute.getName());
-            Preconditions.checkState(presentAttribute != null,
-                "Missing mandatory '%s' attribute in normal rule class.", attribute.getName());
-            Preconditions.checkState(presentAttribute.getType().equals(attribute.getType()),
+            Preconditions.checkState(
+                presentAttribute != null,
+                "Missing mandatory '%s' attribute in normal rule class.",
+                attribute.getName());
+            Preconditions.checkState(
+                presentAttribute.getType().equals(attribute.getType()),
                 "Mandatory attribute '%s' in normal rule class has incorrect type (expected"
-                + " %s).", attribute.getName(), attribute.getType());
+                    + " %s).",
+                attribute.getName(),
+                attribute.getType());
           }
         }
       },
 
       /**
-       * Workspace rules can only be instantiated from a WORKSPACE file. Their names obey the
-       * rule for identifiers.
+       * Workspace rules can only be instantiated from a WORKSPACE file. Their names obey the rule
+       * for identifiers.
        */
       WORKSPACE {
         @Override
@@ -486,10 +493,9 @@ public class RuleClass implements RuleClassData {
       },
 
       /**
-       * Test rules are instantiable by BUILD files and are handled specially
-       * when run with the 'test' command. Their names must obey the rules
-       * for identifiers in the BUILD language and {@link
-       * TargetUtils#isTestRuleName} must return true for the name.
+       * Test rules are instantiable by BUILD files and are handled specially when run with the
+       * 'test' command. Their names must obey the rules for identifiers in the BUILD language and
+       * {@link TargetUtils#isTestRuleName} must return true for the name.
        *
        * <p>In addition, test rules must contain certain attributes. See {@link
        * Builder#REQUIRED_ATTRIBUTES_FOR_TESTS}.
@@ -497,19 +503,23 @@ public class RuleClass implements RuleClassData {
       TEST {
         @Override
         public void checkName(String name) {
-          Preconditions.checkArgument(TargetUtils.isTestRuleName(name)
-              && RULE_NAME_PATTERN.matcher(name).matches());
+          Preconditions.checkArgument(
+              TargetUtils.isTestRuleName(name) && RULE_NAME_PATTERN.matcher(name).matches());
         }
 
         @Override
         public void checkAttributes(Map<String, Attribute> attributes) {
           for (Attribute attribute : REQUIRED_ATTRIBUTES_FOR_TESTS) {
             Attribute presentAttribute = attributes.get(attribute.getName());
-            Preconditions.checkState(presentAttribute != null,
-                "Missing mandatory '%s' attribute in test rule class.", attribute.getName());
-            Preconditions.checkState(presentAttribute.getType().equals(attribute.getType()),
+            Preconditions.checkState(
+                presentAttribute != null,
+                "Missing mandatory '%s' attribute in test rule class.",
+                attribute.getName());
+            Preconditions.checkState(
+                presentAttribute.getType().equals(attribute.getType()),
                 "Mandatory attribute '%s' in test rule class has incorrect type (expected %s).",
-                attribute.getName(), attribute.getType());
+                attribute.getName(),
+                attribute.getType());
           }
         }
       },
@@ -521,7 +531,7 @@ public class RuleClass implements RuleClassData {
        * class is deserialized, the rule is assigned a placeholder rule class. This is compatible
        * with our limited set of package serialization use cases.
        *
-       * Placeholder rule class names obey the rule for identifiers.
+       * <p>Placeholder rule class names obey the rule for identifiers.
        */
       PLACEHOLDER {
         @Override
@@ -784,10 +794,17 @@ public class RuleClass implements RuleClassData {
         NO_TOOLCHAINS_TO_REGISTER;
     private Function<? super Rule, ? extends Set<String>> optionReferenceFunction =
         NO_OPTION_REFERENCE;
+
     /** This field and the next are null iff the rule is native. */
     @Nullable private Label ruleDefinitionEnvironmentLabel;
 
     @Nullable private byte[] ruleDefinitionEnvironmentDigest = null;
+
+    /** This field is non-null iff the rule is a Starlark repo rule. */
+    @Nullable
+    private ImmutableTable<RepositoryName, String, RepositoryName>
+        ruleDefinitionEnvironmentRepoMappingEntries;
+
     private final ConfigurationFragmentPolicy.Builder configurationFragmentPolicy =
         new ConfigurationFragmentPolicy.Builder();
 
@@ -869,8 +886,10 @@ public class RuleClass implements RuleClassData {
       // TODO(bazel-team): move this testonly attribute setting to somewhere else
       // preferably to some base RuleClass implementation.
       if (this.type.equals(RuleClassType.TEST)) {
-        Attribute.Builder<Boolean> testOnlyAttr = attr("testonly", BOOLEAN).value(true)
-            .nonconfigurable("policy decision: this shouldn't depend on the configuration");
+        Attribute.Builder<Boolean> testOnlyAttr =
+            attr("testonly", BOOLEAN)
+                .value(true)
+                .nonconfigurable("policy decision: this shouldn't depend on the configuration");
         if (attributes.containsKey("testonly")) {
           override(testOnlyAttr);
         } else {
@@ -880,8 +899,8 @@ public class RuleClass implements RuleClassData {
     }
 
     /**
-     * Checks that required attributes for test rules are present, creates the
-     * {@link RuleClass} object and returns it.
+     * Checks that required attributes for test rules are present, creates the {@link RuleClass}
+     * object and returns it.
      *
      * @throws IllegalStateException if any of the required attributes is missing
      */
@@ -984,6 +1003,7 @@ public class RuleClass implements RuleClassData {
           optionReferenceFunction,
           ruleDefinitionEnvironmentLabel,
           ruleDefinitionEnvironmentDigest,
+          ruleDefinitionEnvironmentRepoMappingEntries,
           configurationFragmentPolicy.build(),
           supportsConstraintChecking,
           toolchainTypes,
@@ -1144,8 +1164,10 @@ public class RuleClass implements RuleClassData {
      */
     @CanIgnoreReturnValue
     public Builder setOutputToGenfiles() {
-      Preconditions.checkState(type != RuleClassType.ABSTRACT,
-          "Setting not inherited property (output to genrules) of abstract rule class '%s'", name);
+      Preconditions.checkState(
+          type != RuleClassType.ABSTRACT,
+          "Setting not inherited property (output to genrules) of abstract rule class '%s'",
+          name);
       this.outputsToBindir = false;
       return this;
     }
@@ -1161,22 +1183,22 @@ public class RuleClass implements RuleClassData {
      */
     @CanIgnoreReturnValue
     public Builder setImplicitOutputsFunction(ImplicitOutputsFunction implicitOutputsFunction) {
-      Preconditions.checkState(type != RuleClassType.ABSTRACT,
+      Preconditions.checkState(
+          type != RuleClassType.ABSTRACT,
           "Setting not inherited property (implicit output function) of abstract rule class '%s'",
           name);
       this.implicitOutputsFunction = implicitOutputsFunction;
       return this;
     }
 
-    /**
-     * Applies the given transition factory to all incoming edges for this rule class.
-     */
+    /** Applies the given transition factory to all incoming edges for this rule class. */
     @CanIgnoreReturnValue
     public Builder cfg(TransitionFactory<RuleTransitionData> transitionFactory) {
-      Preconditions.checkState(type != RuleClassType.ABSTRACT,
-          "Setting not inherited property (cfg) of abstract rule class '%s'", name);
-      Preconditions.checkState(this.transitionFactory == null,
-          "Property cfg has already been set");
+      Preconditions.checkState(
+          type != RuleClassType.ABSTRACT,
+          "Setting not inherited property (cfg) of abstract rule class '%s'",
+          name);
+      Preconditions.checkState(this.transitionFactory == null, "Property cfg has already been set");
       Preconditions.checkNotNull(transitionFactory);
       Preconditions.checkArgument(!transitionFactory.isSplit());
       this.transitionFactory = transitionFactory;
@@ -1258,13 +1280,18 @@ public class RuleClass implements RuleClassData {
 
     private void overrideAttribute(Attribute attribute) {
       String attrName = attribute.getName();
-      Preconditions.checkState(attributes.containsKey(attrName),
-          "No such attribute '%s' to override in ruleclass '%s'.", attrName, name);
+      Preconditions.checkState(
+          attributes.containsKey(attrName),
+          "No such attribute '%s' to override in ruleclass '%s'.",
+          attrName,
+          name);
       Type<?> origType = attributes.get(attrName).getType();
       Type<?> newType = attribute.getType();
-      Preconditions.checkState(origType.equals(newType),
+      Preconditions.checkState(
+          origType.equals(newType),
           "The type of the new attribute '%s' is different from the original one '%s'.",
-          newType, origType);
+          newType,
+          origType);
       attributes.put(attrName, attribute);
     }
 
@@ -1410,6 +1437,13 @@ public class RuleClass implements RuleClassData {
       return this.ruleDefinitionEnvironmentLabel;
     }
 
+    @CanIgnoreReturnValue
+    public Builder setRuleDefinitionEnvironmentRepoMappingEntries(
+        ImmutableTable<RepositoryName, String, RepositoryName> recordedRepoMappingEntries) {
+      this.ruleDefinitionEnvironmentRepoMappingEntries = recordedRepoMappingEntries;
+      return this;
+    }
+
     /**
      * Removes an attribute with the same name from this rule class.
      *
@@ -1417,8 +1451,8 @@ public class RuleClass implements RuleClassData {
      */
     @CanIgnoreReturnValue
     public Builder removeAttribute(String name) {
-      Preconditions.checkState(attributes.containsKey(name), "No such attribute '%s' to remove.",
-          name);
+      Preconditions.checkState(
+          attributes.containsKey(name), "No such attribute '%s' to remove.", name);
       attributes.remove(name);
       return this;
     }
@@ -1510,11 +1544,9 @@ public class RuleClass implements RuleClassData {
      */
     @CanIgnoreReturnValue
     public Builder restrictedTo(Label firstEnvironment, Label... otherEnvironments) {
-      ImmutableList<Label> environments = ImmutableList.<Label>builder().add(firstEnvironment)
-          .add(otherEnvironments).build();
-      add(
-          attr(DEFAULT_RESTRICTED_ENVIRONMENT_ATTR, LABEL_LIST)
-              .value(environments));
+      ImmutableList<Label> environments =
+          ImmutableList.<Label>builder().add(firstEnvironment).add(otherEnvironments).build();
+      add(attr(DEFAULT_RESTRICTED_ENVIRONMENT_ATTR, LABEL_LIST).value(environments));
       return this;
     }
 
@@ -1645,14 +1677,14 @@ public class RuleClass implements RuleClassData {
     }
 
     /**
-     * Returns an Attribute.Builder object which contains a replica of the
-     * same attribute in the parent rule if exists.
+     * Returns an Attribute.Builder object which contains a replica of the same attribute in the
+     * parent rule if exists.
      *
      * @param name the name of the attribute
      */
     public Attribute.Builder<?> copy(String name) {
-      Preconditions.checkArgument(attributes.containsKey(name),
-          "Attribute %s does not exist in parent rule class.", name);
+      Preconditions.checkArgument(
+          attributes.containsKey(name), "Attribute %s does not exist in parent rule class.", name);
       return attributes.get(name).cloneBuilder();
     }
   }
@@ -1663,10 +1695,9 @@ public class RuleClass implements RuleClassData {
   private final String key; // Just the name for native, label + name for Starlark
 
   /**
-   * The kind of target represented by this RuleClass (e.g. "cc_library rule").
-   * Note: Even though there is partial duplication with the {@link RuleClass#name} field,
-   * we want to store this as a separate field instead of generating it on demand in order to
-   * avoid string duplication.
+   * The kind of target represented by this RuleClass (e.g. "cc_library rule"). Note: Even though
+   * there is partial duplication with the {@link RuleClass#name} field, we want to store this as a
+   * separate field instead of generating it on demand in order to avoid string duplication.
    */
   private final String targetKind;
 
@@ -1689,24 +1720,20 @@ public class RuleClass implements RuleClassData {
   private final boolean hasAspects;
 
   /**
-   * A (unordered) mapping from attribute names to small integers indexing into
-   * the {@code attributes} array.
+   * A (unordered) mapping from attribute names to small integers indexing into the {@code
+   * attributes} array.
    */
   private final Map<String, Integer> attributeIndex;
 
   /**
-   *  All attributes of this rule class (including inherited ones) ordered by
-   *  attributeIndex value.
+   * All attributes of this rule class (including inherited ones) ordered by attributeIndex value.
    */
   private final ImmutableList<Attribute> attributes;
 
   /** Names of the non-configurable attributes of this rule class. */
   private final ImmutableList<String> nonConfigurableAttributes;
 
-  /**
-   * The set of implicit outputs generated by a rule, expressed as a function
-   * of that rule.
-   */
+  /** The set of implicit outputs generated by a rule, expressed as a function of that rule. */
   private final ImplicitOutputsFunction implicitOutputsFunction;
 
   /**
@@ -1718,14 +1745,10 @@ public class RuleClass implements RuleClassData {
   /** The factory that creates configured targets from this rule. */
   private final ConfiguredTargetFactory<?, ?, ?> configuredTargetFactory;
 
-  /**
-   * The constraint the package name of the rule instance must fulfill
-   */
+  /** The constraint the package name of the rule instance must fulfill */
   private final PredicateWithMessage<Rule> validityPredicate;
 
-  /**
-   * The list of transitive info providers this class advertises to aspects.
-   */
+  /** The list of transitive info providers this class advertises to aspects. */
   private final AdvertisedProviderSet advertisedProviders;
 
   /**
@@ -1752,9 +1775,7 @@ public class RuleClass implements RuleClassData {
   /** Returns the toolchains a workspace function wants to have registered in the WORKSPACE file. */
   private final Function<? super Rule, ? extends List<String>> toolchainsToRegisterFunction;
 
-  /**
-   * Returns the options referenced by this rule's attributes.
-   */
+  /** Returns the options referenced by this rule's attributes. */
   private final Function<? super Rule, ? extends Set<String>> optionReferenceFunction;
 
   /**
@@ -1764,6 +1785,11 @@ public class RuleClass implements RuleClassData {
   @Nullable private final Label ruleDefinitionEnvironmentLabel;
 
   @Nullable private final byte[] ruleDefinitionEnvironmentDigest;
+
+  @Nullable
+  private final ImmutableTable<RepositoryName, String, RepositoryName>
+      ruleDefinitionEnvironmentRepoMappingEntries;
+
   private final OutputFile.Kind outputFileKind;
 
   /**
@@ -1772,9 +1798,9 @@ public class RuleClass implements RuleClassData {
   private final ConfigurationFragmentPolicy configurationFragmentPolicy;
 
   /**
-   * Determines whether instances of this rule should be checked for constraint compatibility
-   * with their dependencies and the rules that depend on them. This should be true for
-   * everything except for rules that are intrinsically incompatible with the constraint system.
+   * Determines whether instances of this rule should be checked for constraint compatibility with
+   * their dependencies and the rules that depend on them. This should be true for everything except
+   * for rules that are intrinsically incompatible with the constraint system.
    */
   private final boolean supportsConstraintChecking;
 
@@ -1835,6 +1861,9 @@ public class RuleClass implements RuleClassData {
       Function<? super Rule, ? extends Set<String>> optionReferenceFunction,
       @Nullable Label ruleDefinitionEnvironmentLabel,
       @Nullable byte[] ruleDefinitionEnvironmentDigest,
+      @Nullable
+          ImmutableTable<RepositoryName, String, RepositoryName>
+              ruleDefinitionEnvironmentRepoMappingEntries,
       ConfigurationFragmentPolicy configurationFragmentPolicy,
       boolean supportsConstraintChecking,
       Set<ToolchainTypeRequirement> toolchainTypes,
@@ -1870,6 +1899,7 @@ public class RuleClass implements RuleClassData {
     this.optionReferenceFunction = optionReferenceFunction;
     this.ruleDefinitionEnvironmentLabel = ruleDefinitionEnvironmentLabel;
     this.ruleDefinitionEnvironmentDigest = ruleDefinitionEnvironmentDigest;
+    this.ruleDefinitionEnvironmentRepoMappingEntries = ruleDefinitionEnvironmentRepoMappingEntries;
     this.outputFileKind = outputFileKind;
     this.attributes = attributes;
     this.workspaceOnly = workspaceOnly;
@@ -1993,8 +2023,7 @@ public class RuleClass implements RuleClassData {
   }
 
   /**
-   * Returns true iff the attribute 'attrName' is defined for this rule class,
-   * and has type 'type'.
+   * Returns true iff the attribute 'attrName' is defined for this rule class, and has type 'type'.
    */
   public boolean hasAttr(String attrName, Type<?> type) {
     Integer index = getAttributeIndex(attrName);
@@ -2002,10 +2031,10 @@ public class RuleClass implements RuleClassData {
   }
 
   /**
-   * Returns the index of the specified attribute name. Use of indices allows
-   * space-efficient storage of attribute values in rules, since hashtables are
-   * not required. (The index mapping is specific to each RuleClass and an
-   * attribute may have a different index in the parent RuleClass.)
+   * Returns the index of the specified attribute name. Use of indices allows space-efficient
+   * storage of attribute values in rules, since hashtables are not required. (The index mapping is
+   * specific to each RuleClass and an attribute may have a different index in the parent
+   * RuleClass.)
    *
    * <p>Returns null if the named attribute is not defined for this class of Rule.
    */
@@ -2013,10 +2042,7 @@ public class RuleClass implements RuleClassData {
     return attributeIndex.get(attrName);
   }
 
-  /**
-   * Returns the attribute whose index is 'attrIndex'.  Fails if attrIndex is
-   * not in range.
-   */
+  /** Returns the attribute whose index is 'attrIndex'. Fails if attrIndex is not in range. */
   Attribute getAttribute(int attrIndex) {
     return attributes.get(attrIndex);
   }
@@ -2025,8 +2051,9 @@ public class RuleClass implements RuleClassData {
    * Returns the attribute whose name is 'attrName'; fails with NullPointerException if not found.
    */
   public Attribute getAttributeByName(String attrName) {
-    Integer attrIndex = Preconditions.checkNotNull(getAttributeIndex(attrName),
-        "Attribute %s does not exist", attrName);
+    Integer attrIndex =
+        Preconditions.checkNotNull(
+            getAttributeIndex(attrName), "Attribute %s does not exist", attrName);
     return attributes.get(attrIndex);
   }
 
@@ -2075,16 +2102,12 @@ public class RuleClass implements RuleClassData {
     return advertisedProviders;
   }
 
-  /**
-   * Returns this rule's policy for configuration fragment access.
-   */
+  /** Returns this rule's policy for configuration fragment access. */
   public ConfigurationFragmentPolicy getConfigurationFragmentPolicy() {
     return configurationFragmentPolicy;
   }
 
-  /**
-   * Returns true if rules of this type can be used with the constraint enforcement system.
-   */
+  /** Returns true if rules of this type can be used with the constraint enforcement system. */
   public boolean supportsConstraintChecking() {
     return supportsConstraintChecking;
   }
@@ -2310,7 +2333,7 @@ public class RuleClass implements RuleClassData {
         attrsWithComputedDefaults.add(attr);
 
       } else if (attr.isLateBound()) {
-        rule.setAttributeValue(attr, attr.getLateBoundDefault(), /*explicit=*/ false);
+        rule.setAttributeValue(attr, attr.getLateBoundDefault(), /* explicit= */ false);
 
       } else if (attr.getName().equals(APPLICABLE_LICENSES_ATTR)
           && attr.getType() == BuildType.LABEL_LIST) {
@@ -2401,13 +2424,13 @@ public class RuleClass implements RuleClassData {
       } else {
         valueToSet = defaultValue;
       }
-      rule.setAttributeValue(attr, valueToSet, /*explicit=*/ false);
+      rule.setAttributeValue(attr, valueToSet, /* explicit= */ false);
     }
   }
 
   /**
-   * Collects all labels used as keys for configurable attributes and places them into
-   * the special implicit attribute that tracks them.
+   * Collects all labels used as keys for configurable attributes and places them into the special
+   * implicit attribute that tracks them.
    */
   private static void populateConfigDependenciesAttribute(Rule rule) {
     RawAttributeMapper attributes = RawAttributeMapper.of(rule);
@@ -2425,13 +2448,13 @@ public class RuleClass implements RuleClassData {
       }
     }
 
-    rule.setAttributeValue(configDepsAttribute, ImmutableList.copyOf(configLabels),
-        /*explicit=*/false);
+    rule.setAttributeValue(
+        configDepsAttribute, ImmutableList.copyOf(configLabels), /* explicit= */ false);
   }
 
   /**
-   * Report an error for each label that appears more than once in a LABEL_LIST attribute
-   * of the given rule.
+   * Report an error for each label that appears more than once in a LABEL_LIST attribute of the
+   * given rule.
    *
    * @param rule The rule.
    * @param eventHandler The eventHandler to use to report the duplicated deps.
@@ -2454,8 +2477,8 @@ public class RuleClass implements RuleClassData {
   }
 
   /**
-   * Report an error if the rule has a timeout or size attribute that is not a
-   * legal value. These attributes appear on all tests.
+   * Report an error if the rule has a timeout or size attribute that is not a legal value. These
+   * attributes appear on all tests.
    *
    * @param rule the rule to check
    * @param eventHandler the eventHandler to use to report the duplicated deps
@@ -2465,8 +2488,8 @@ public class RuleClass implements RuleClassData {
       String size = NonconfigurableAttributeMapper.of(rule).get("size", Type.STRING);
       if (TestSize.getTestSize(size) == null) {
         rule.reportError(
-          String.format("In rule '%s', size '%s' is not a valid size.", rule.getName(), size),
-          eventHandler);
+            String.format("In rule '%s', size '%s' is not a valid size.", rule.getName(), size),
+            eventHandler);
       }
     }
     if (rule.getRuleClassObject().hasAttr("timeout", Type.STRING)) {
@@ -2494,24 +2517,21 @@ public class RuleClass implements RuleClassData {
     if (attribute.checkAllowedValues()) {
       PredicateWithMessage<Object> allowedValues = attribute.getAllowedValues();
       Iterable<?> values =
-          AggregatingAttributeMapper.of(rule).visitAttribute(
-              attribute.getName(), attribute.getType());
+          AggregatingAttributeMapper.of(rule)
+              .visitAttribute(attribute.getName(), attribute.getType());
       for (Object value : values) {
         if (!allowedValues.apply(value)) {
           rule.reportError(
               String.format(
                   "%s: invalid value in '%s' attribute: %s",
-                  rule.getLabel(),
-                  attribute.getName(),
-                  allowedValues.getErrorReason(value)),
+                  rule.getLabel(), attribute.getName(), allowedValues.getErrorReason(value)),
               eventHandler);
         }
       }
     }
   }
 
-  private static void checkAspectAllowedValues(
-      Rule rule, EventHandler eventHandler) {
+  private static void checkAspectAllowedValues(Rule rule, EventHandler eventHandler) {
     if (rule.hasAspects()) {
       for (Attribute attrOfRule : rule.getAttributes()) {
         for (Aspect aspect : attrOfRule.getAspects(rule)) {
@@ -2594,9 +2614,7 @@ public class RuleClass implements RuleClassData {
     return toolchainsToRegisterFunction;
   }
 
-  /**
-   * Returns a function that computes the options referenced by a rule.
-   */
+  /** Returns a function that computes the options referenced by a rule. */
   public Function<? super Rule, ? extends Set<String>> getOptionReferenceFunction() {
     return optionReferenceFunction;
   }
@@ -2631,6 +2649,12 @@ public class RuleClass implements RuleClassData {
   @Nullable
   public byte[] getRuleDefinitionEnvironmentDigest() {
     return ruleDefinitionEnvironmentDigest;
+  }
+
+  @Nullable
+  public ImmutableTable<RepositoryName, String, RepositoryName>
+      getRuleDefinitionEnvironmentRepoMappingEntries() {
+    return ruleDefinitionEnvironmentRepoMappingEntries;
   }
 
   /** Returns true if this RuleClass is a Starlark-defined RuleClass. */

--- a/src/main/java/com/google/devtools/build/lib/rules/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/BUILD
@@ -414,6 +414,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:package_lookup_function",
         "//src/main/java/com/google/devtools/build/lib/skyframe:package_lookup_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:precomputed_value",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:repository_mapping_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:sky_functions",
         "//src/main/java/com/google/devtools/build/lib/skyframe:sky_value_dirtiness_checker",
         "//src/main/java/com/google/devtools/build/lib/util",

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -86,7 +86,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
 
   // The marker file version is inject in the rule key digest so the rule key is always different
   // when we decide to update the format.
-  private static final int MARKER_FILE_VERSION = 3;
+  private static final int MARKER_FILE_VERSION = 4;
 
   // Mapping of rule class name to RepositoryFunction.
   private final ImmutableMap<String, RepositoryFunction> handlers;

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -1050,6 +1050,7 @@ public final class RuleClassTest extends PackageLoadingTestCase {
         /* optionReferenceFunction= */ RuleClass.NO_OPTION_REFERENCE,
         /* ruleDefinitionEnvironmentLabel= */ null,
         /* ruleDefinitionEnvironmentDigest= */ null,
+        /* ruleDefinitionEnvironmentRepoMappingEntries= */ null,
         new ConfigurationFragmentPolicy.Builder()
             .requiresConfigurationFragments(allowedConfigurationFragments)
             .build(),


### PR DESCRIPTION
Similar to the fix for https://github.com/bazelbuild/bazel/issues/20721, we write recorded repo mapping entries into the marker file so that repo fetching is sensitive to any relevant repo mapping changes.

Fixes #20722.

Closes #21131.

Commit https://github.com/bazelbuild/bazel/commit/9edaddd6273de776a3f60245f5c56f82f9622caf

PiperOrigin-RevId: 603310262
Change-Id: I806f383e8579fed3533fac9b181efd8b75e76fcd