### PR TITLE
[7.1.0] Include the digest hash function in the compact execution log.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
@@ -177,7 +177,12 @@ public class ExpandedSpawnLogContext implements SpawnLogContext {
 
           Digest digest =
               computeDigest(
-                  input, contentPath, inputMetadataProvider, xattrProvider, digestHashFunction);
+                  input,
+                  contentPath,
+                  inputMetadataProvider,
+                  xattrProvider,
+                  digestHashFunction,
+                  /* includeHashFunctionName= */ true);
 
           builder
               .addInputsBuilder()
@@ -213,7 +218,12 @@ public class ExpandedSpawnLogContext implements SpawnLogContext {
                 .setPath(output.getExecPathString())
                 .setDigest(
                     computeDigest(
-                        output, path, inputMetadataProvider, xattrProvider, digestHashFunction));
+                        output,
+                        path,
+                        inputMetadataProvider,
+                        xattrProvider,
+                        digestHashFunction,
+                        /* includeHashFunctionName= */ true));
           }
         } catch (IOException ex) {
           logger.atWarning().withCause(ex).log("Error computing spawn output properties");
@@ -332,7 +342,8 @@ public class ExpandedSpawnLogContext implements SpawnLogContext {
                       childContentPath,
                       inputMetadataProvider,
                       xattrProvider,
-                      digestHashFunction))
+                      digestHashFunction,
+                      /* includeHashFunctionName= */ true))
               .setIsTool(isTool)
               .build());
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -139,9 +139,14 @@ public interface SpawnLogContext extends ActionContext {
       Path path,
       InputMetadataProvider inputMetadataProvider,
       XattrProvider xattrProvider,
-      DigestHashFunction digestHashFunction)
+      DigestHashFunction digestHashFunction,
+      boolean includeHashFunctionName)
       throws IOException {
-    Digest.Builder builder = Digest.newBuilder().setHashFunctionName(digestHashFunction.toString());
+    Digest.Builder builder = Digest.newBuilder();
+
+    if (includeHashFunctionName) {
+      builder.setHashFunctionName(digestHashFunction.toString());
+    }
 
     if (input != null) {
       if (input instanceof VirtualActionInput) {

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -28,16 +28,13 @@ option java_outer_classname = "Protos";
 
 // Digest of a file or action cache entry.
 message Digest {
-  // The content hash.
+  // The content hash as a lowercase hex string including any leading zeroes.
   string hash = 1;
 
   // The original content size in bytes.
   int64 size_bytes = 2;
 
-  // The digest function that was used to generate the hash.
-  // This is not an enum for compatibility reasons, and also because the
-  // purpose of these logs is to enable analysis by comparison of multiple
-  // builds. So, from the programmatic perspective, this is an opaque field.
+  // The name of the digest function used to compute the hash.
   string hash_function_name = 3;
 }
 
@@ -46,6 +43,7 @@ message File {
   string path = 1;
 
   // File digest.
+  // May be omitted for empty files.
   Digest digest = 2;
 
   // Whether the file is a tool.
@@ -211,16 +209,19 @@ message SpawnExec {
 message ExecLogEntry {
   // Information pertaining to the entire invocation.
   // May appear at most once in the initial position.
-  message Invocation {}
+  message Invocation {
+    // The hash function used to compute digests.
+    string hash_function_name = 1;
+  }
 
   // An input or output file.
   message File {
     // The file path.
     string path = 1;
-    // The file size in bytes.
-    int64 size_bytes = 2;
-    // A digest of the file contents. Unset if the file is empty.
-    string digest = 3;
+    // A digest of the file contents.
+    // The hash function name is omitted. It can be obtained from Invocation.
+    // May be omitted for empty files.
+    Digest digest = 2;
   }
 
   // An input or output directory.
@@ -305,7 +306,9 @@ message ExecLogEntry {
     bool remote_cacheable = 15;
 
     // See SpawnExec.digest.
-    string digest = 16;
+    // The hash function name is omitted. It can be obtained from Invocation.
+    // Unset if the file is empty.
+    Digest digest = 16;
 
     // See SpawnExec.timeout_millis.
     int64 timeout_millis = 17;

--- a/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
@@ -23,7 +23,6 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
-import com.google.devtools.build.lib.exec.Protos.Digest;
 import com.google.devtools.build.lib.exec.Protos.ExecLogEntry;
 import com.google.devtools.build.lib.exec.Protos.File;
 import com.google.devtools.build.lib.exec.Protos.SpawnExec;
@@ -128,14 +127,20 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
     context.close();
 
     HashMap<Integer, ExecLogEntry> entryMap = new HashMap<>();
+    String hashFunctionName = "";
 
     ArrayList<SpawnExec> actual = new ArrayList<>();
     try (InputStream in = new ZstdInputStream(logPath.getInputStream())) {
       ExecLogEntry e;
       while ((e = ExecLogEntry.parseDelimitedFrom(in)) != null) {
         entryMap.put(e.getId(), e);
+
+        if (e.hasInvocation()) {
+          hashFunctionName = e.getInvocation().getHashFunctionName();
+        }
+
         if (e.hasSpawn()) {
-          actual.add(reconstructSpawnExec(e.getSpawn(), entryMap));
+          actual.add(reconstructSpawnExec(e.getSpawn(), hashFunctionName, entryMap));
         }
       }
     }
@@ -144,7 +149,7 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
   }
 
   private SpawnExec reconstructSpawnExec(
-      ExecLogEntry.Spawn entry, Map<Integer, ExecLogEntry> entryMap) {
+      ExecLogEntry.Spawn entry, String hashFunctionName, Map<Integer, ExecLogEntry> entryMap) {
     SpawnExec.Builder builder =
         SpawnExec.newBuilder()
             .addAllCommandArgs(entry.getArgsList())
@@ -165,8 +170,10 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
       builder.setPlatform(entry.getPlatform());
     }
 
-    SortedMap<String, File> inputs = reconstructInputs(entry.getInputSetId(), entryMap);
-    SortedMap<String, File> toolInputs = reconstructInputs(entry.getToolSetId(), entryMap);
+    SortedMap<String, File> inputs =
+        reconstructInputs(entry.getInputSetId(), hashFunctionName, entryMap);
+    SortedMap<String, File> toolInputs =
+        reconstructInputs(entry.getToolSetId(), hashFunctionName, entryMap);
 
     for (Map.Entry<String, File> e : inputs.entrySet()) {
       File file = e.getValue();
@@ -181,14 +188,14 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
         case FILE_ID:
           ExecLogEntry.File file = checkNotNull(entryMap.get(output.getFileId())).getFile();
           builder.addListedOutputs(file.getPath());
-          builder.addActualOutputs(reconstructFile(/* parentDir= */ null, file));
+          builder.addActualOutputs(reconstructFile(/* parentDir= */ null, file, hashFunctionName));
           break;
         case DIRECTORY_ID:
           ExecLogEntry.Directory dir =
               checkNotNull(entryMap.get(output.getDirectoryId())).getDirectory();
           builder.addListedOutputs(dir.getPath());
           for (ExecLogEntry.File dirFile : dir.getFilesList()) {
-            builder.addActualOutputs(reconstructFile(dir, dirFile));
+            builder.addActualOutputs(reconstructFile(dir, dirFile, hashFunctionName));
           }
           break;
         case MISSING_PATH:
@@ -199,15 +206,16 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
       }
     }
 
-    if (!entry.getDigest().isEmpty()) {
-      builder.setDigest(Digest.newBuilder().setHash(entry.getDigest()).build());
+    if (entry.hasDigest()) {
+      builder.setDigest(
+          entry.getDigest().toBuilder().setHashFunctionName(hashFunctionName).build());
     }
 
     return builder.build();
   }
 
   private SortedMap<String, File> reconstructInputs(
-      int setId, Map<Integer, ExecLogEntry> entryMap) {
+      int setId, String hashFunctionName, Map<Integer, ExecLogEntry> entryMap) {
     TreeMap<String, File> inputs = new TreeMap<>();
     ArrayDeque<Integer> setsToVisit = new ArrayDeque<>();
     if (setId != 0) {
@@ -218,12 +226,12 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
           checkNotNull(entryMap.get(setsToVisit.removeFirst())).getInputSet();
       for (int fileId : set.getFileIdsList()) {
         ExecLogEntry.File file = checkNotNull(entryMap.get(fileId)).getFile();
-        inputs.put(file.getPath(), reconstructFile(null, file));
+        inputs.put(file.getPath(), reconstructFile(null, file, hashFunctionName));
       }
       for (int dirId : set.getDirectoryIdsList()) {
         ExecLogEntry.Directory dir = checkNotNull(entryMap.get(dirId)).getDirectory();
         for (ExecLogEntry.File dirFile : dir.getFilesList()) {
-          inputs.put(dirFile.getPath(), reconstructFile(dir, dirFile));
+          inputs.put(dirFile.getPath(), reconstructFile(dir, dirFile, hashFunctionName));
         }
       }
       setsToVisit.addAll(set.getTransitiveSetIdsList());
@@ -231,16 +239,17 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
     return inputs;
   }
 
-  private File reconstructFile(@Nullable ExecLogEntry.Directory parentDir, ExecLogEntry.File file) {
-    String path = parentDir != null ? parentDir.getPath() + "/" + file.getPath() : file.getPath();
-    File.Builder builder = File.newBuilder().setPath(path);
-    if (file.getSizeBytes() > 0) {
-      builder.setDigest(
-          Digest.newBuilder()
-              .setSizeBytes(file.getSizeBytes())
-              .setHash(file.getDigest())
-              .setHashFunctionName(digestHashFunction.toString()));
+  private File reconstructFile(
+      @Nullable ExecLogEntry.Directory parentDir, ExecLogEntry.File file, String hashFunctionName) {
+    File.Builder builder = File.newBuilder();
+
+    builder.setPath(
+        parentDir != null ? parentDir.getPath() + "/" + file.getPath() : file.getPath());
+
+    if (file.hasDigest()) {
+      builder.setDigest(file.getDigest().toBuilder().setHashFunctionName(hashFunctionName).build());
     }
+
     return builder.build();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -630,7 +630,7 @@ public abstract class SpawnLogContextTestBase {
   public void testDigest() throws Exception {
     SpawnLogContext context = createSpawnLogContext();
 
-    Digest digest = Digest.newBuilder().setHash("deadbeef").build();
+    Digest digest = getDigest("something");
 
     SpawnResult result = defaultSpawnResultBuilder().setDigest(digest).build();
 


### PR DESCRIPTION
The digest function is the same for every digest computed by an invocation. To save space, it is stored once in the Invocation log entry.

Also embed a Digest proto in File and Spawn messages, with the proviso that the hash_function_name field will be empty. The size is always required because the hash alone might not be sufficient to retrieve an entry from a remote cache.

PiperOrigin-RevId: 602684865
Change-Id: I6f4882051aad9ea72bea0232f8ad4b2cd7b8e335