### PR TITLE
[7.1.0] Remove obsolete comments and dividers.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -398,16 +398,13 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
     return localFs.getPath(path).getDigest();
   }
 
-  // -------------------- File Permissions --------------------
-  // Remote files are always readable, writable and executable since we can't control their
-  // permissions.
-
   @Override
   protected boolean isReadable(PathFragment path) throws IOException {
     path = resolveSymbolicLinks(path).asFragment();
     try {
       return localFs.getPath(path).isReadable();
     } catch (FileNotFoundException e) {
+      // Remote files are always readable since we can't control their permissions.
       return true;
     }
   }
@@ -418,6 +415,7 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
     try {
       return localFs.getPath(path).isWritable();
     } catch (FileNotFoundException e) {
+      // Remote files are always writable since we can't control their permissions.
       return true;
     }
   }
@@ -428,6 +426,7 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
     try {
       return localFs.getPath(path).isExecutable();
     } catch (FileNotFoundException e) {
+      // Remote files are always executable since we can't control their permissions.
       return true;
     }
   }
@@ -471,8 +470,6 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
       // Intentionally ignored.
     }
   }
-
-  // -------------------- Symlinks --------------------
 
   @Override
   protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
@@ -535,8 +532,6 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
     var stat = statUnchecked(path, FollowMode.FOLLOW_NONE, StatSources.ALL);
     return stat.isSymbolicLink() ? readSymbolicLink(path) : null;
   }
-
-  // -------------------- Implementations based on stat() --------------------
 
   @Override
   protected long getLastModifiedTime(PathFragment path, boolean followSymlinks) throws IOException {
@@ -841,15 +836,6 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
     }
     return new Dirent(entry.getName(), direntFromStat(st));
   }
-
-  /*
-   * -------------------- TODO(buchgr): Not yet implemented --------------------
-   *
-   * The below methods have not (yet) been properly implemented due to time constraints mostly and
-   * with little risk as they currently don't seem to be used by internal actions in Bazel. However,
-   * before making the --experimental_remote_download_outputs flag non-experimental we should make
-   * sure to fully implement this file system.
-   */
 
   @Override
   protected void createFSDependentHardLink(PathFragment linkPath, PathFragment originalPath)


### PR DESCRIPTION
PiperOrigin-RevId: 585632524
Change-Id: I559bc9f6abc859ab7578a8918efb863c5bfe9e9b