### PR TITLE
Allow `@repo_name` labels in override attributes

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2741,7 +2741,7 @@
       "general": {
         "bzlTransitiveDigest": "wiyY30lgHvAgghminN0h4lxMWexDIg/6r/+eOIA5bPU=",
         "accumulatedFileDigests": {
-          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "c5a21b1716921abcd71d97668caa3dddc331daa5c7a1a80e4e041f2fd0e74767",
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "fe01365e67163a67a1620e4aeb3aec24e8d6b4cc20c49ca9582a5d090b8185b4",
           "@@//:MODULE.bazel": "f291782aef1d2989f49c0e884b32ec8d7814ae48c598b6f3060870ccb3f5c0b6"
         },
         "envVariables": {},

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveOverride.java
@@ -25,7 +25,7 @@ public abstract class ArchiveOverride implements NonRegistryOverride {
 
   public static ArchiveOverride create(
       ImmutableList<String> urls,
-      ImmutableList<String> patches,
+      ImmutableList<Object> patches,
       ImmutableList<String> patchCmds,
       String integrity,
       String stripPrefix,
@@ -37,8 +37,8 @@ public abstract class ArchiveOverride implements NonRegistryOverride {
   /** The URLs pointing at the archives. Can be HTTP(S) or file URLs. */
   public abstract ImmutableList<String> getUrls();
 
-  /** The patches to apply after extracting the archive. Should be a list of labels. */
-  public abstract ImmutableList<String> getPatches();
+  /** The labels of patches to apply after extracting the archive. */
+  public abstract ImmutableList<Object> getPatches();
 
   /** The patch commands to execute after extracting the archive. Should be a list of commands. */
   public abstract ImmutableList<String> getPatchCmds();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveRepoSpecBuilder.java
@@ -27,7 +27,7 @@ import net.starlark.java.eval.StarlarkInt;
  */
 public class ArchiveRepoSpecBuilder {
 
-  public static final String HTTP_ARCHIVE_PATH = "@bazel_tools//tools/build_defs/repo:http.bzl";
+  public static final String HTTP_ARCHIVE_PATH = "@@bazel_tools//tools/build_defs/repo:http.bzl";
 
   private final ImmutableMap.Builder<String, Object> attrBuilder;
 
@@ -54,7 +54,7 @@ public class ArchiveRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
-  public ArchiveRepoSpecBuilder setPatches(ImmutableList<String> patches) {
+  public ArchiveRepoSpecBuilder setPatches(ImmutableList<Object> patches) {
     attrBuilder.put("patches", patches);
     return this;
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitOverride.java
@@ -25,7 +25,7 @@ public abstract class GitOverride implements NonRegistryOverride {
   public static GitOverride create(
       String remote,
       String commit,
-      ImmutableList<String> patches,
+      ImmutableList<Object> patches,
       ImmutableList<String> patchCmds,
       int patchStrip,
       boolean initSubmodules) {
@@ -39,8 +39,8 @@ public abstract class GitOverride implements NonRegistryOverride {
   /** The commit hash to use. */
   public abstract String getCommit();
 
-  /** The patches to apply after fetching from Git. Should be a list of labels. */
-  public abstract ImmutableList<String> getPatches();
+  /** The labels of patches to apply after fetching from Git. */
+  public abstract ImmutableList<Object> getPatches();
 
   /** The patch commands to execute after fetching from Git. Should be a list of commands. */
   public abstract ImmutableList<String> getPatchCmds();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 public class GitRepoSpecBuilder {
 
-  public static final String GIT_REPO_PATH = "@bazel_tools//tools/build_defs/repo:git.bzl";
+  public static final String GIT_REPO_PATH = "@@bazel_tools//tools/build_defs/repo:git.bzl";
 
   private final ImmutableMap.Builder<String, Object> attrBuilder;
 
@@ -71,7 +71,7 @@ public class GitRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
-  public GitRepoSpecBuilder setPatches(List<String> patches) {
+  public GitRepoSpecBuilder setPatches(List<Object> patches) {
     return setAttr("patches", patches);
   }
 
@@ -113,7 +113,7 @@ public class GitRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
-  private GitRepoSpecBuilder setAttr(String name, List<String> value) {
+  private GitRepoSpecBuilder setAttr(String name, List<?> value) {
     if (value != null && !value.isEmpty()) {
       attrBuilder.put(name, value);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -59,6 +59,8 @@ import net.starlark.java.eval.Structure;
 import net.starlark.java.eval.Tuple;
 import net.starlark.java.syntax.Location;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 /** A collection of global Starlark build API functions that apply to MODULE.bazel files. */
 @GlobalMethods(environment = Environment.MODULE)
 public class ModuleFileGlobals {
@@ -513,6 +515,27 @@ public class ModuleFileGlobals {
     }
   }
 
+  /**
+   * Returns a {@link Label} when the given string is a valid label, otherwise the string itself.
+   */
+  private Object parseOverrideLabelAttribute(String rawLabel) {
+    RepositoryMapping repoMapping =
+        RepositoryMapping.create(
+            ImmutableMap.<String, RepositoryName>builder()
+                .put("", RepositoryName.MAIN)
+                .put(module.getRepoName().orElse(module.getName()), RepositoryName.MAIN)
+                .buildKeepingLast(),
+            RepositoryName.MAIN);
+    try {
+      return Label.parseWithPackageContext(
+          rawLabel, Label.PackageContext.of(PackageIdentifier.EMPTY_PACKAGE_ID, repoMapping));
+    } catch (LabelSyntaxException e) {
+      // Preserve backwards compatibility by not failing eagerly, rather keep the invalid label and
+      // let the module repo fail when fetched.
+      return rawLabel;
+    }
+  }
+
   class ModuleExtensionUsageBuilder {
     private final String extensionBzlFile;
     private final String extensionName;
@@ -848,7 +871,9 @@ public class ModuleFileGlobals {
         SingleVersionOverride.create(
             parsedVersion,
             registry,
-            Sequence.cast(patches, String.class, "patches").getImmutableList(),
+            Sequence.cast(patches, String.class, "patches").stream()
+                .map(this::parseOverrideLabelAttribute)
+                .collect(toImmutableList()),
             Sequence.cast(patchCmds, String.class, "patchCmds").getImmutableList(),
             patchStrip.toInt("single_version_override.patch_strip")));
   }
@@ -984,7 +1009,9 @@ public class ModuleFileGlobals {
         moduleName,
         ArchiveOverride.create(
             urlList,
-            Sequence.cast(patches, String.class, "patches").getImmutableList(),
+            Sequence.cast(patches, String.class, "patches").stream()
+                .map(this::parseOverrideLabelAttribute)
+                .collect(toImmutableList()),
             Sequence.cast(patchCmds, String.class, "patchCmds").getImmutableList(),
             integrity,
             stripPrefix,
@@ -1060,7 +1087,9 @@ public class ModuleFileGlobals {
         GitOverride.create(
             remote,
             commit,
-            Sequence.cast(patches, String.class, "patches").getImmutableList(),
+            Sequence.cast(patches, String.class, "patches").stream()
+                .map(this::parseOverrideLabelAttribute)
+                .collect(toImmutableList()),
             Sequence.cast(patchCmds, String.class, "patchCmds").getImmutableList(),
             patchStrip.toInt("git_override.patch_strip"),
             initSubmodules));

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpec.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpec.java
@@ -29,7 +29,8 @@ import javax.annotation.Nullable;
 public abstract class RepoSpec implements SkyValue {
 
   /**
-   * The label string for the bzl file this repository rule is defined in, empty for native rule.
+   * The unambiguous canonical label string for the bzl file this repository rule is defined in,
+   * empty for native rule.
    */
   @Nullable
   public abstract String bzlFile();
@@ -51,6 +52,8 @@ public abstract class RepoSpec implements SkyValue {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setBzlFile(String bzlFile);
+
+    abstract String bzlFile();
 
     public abstract Builder setRuleClassName(String name);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleVersionOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleVersionOverride.java
@@ -33,7 +33,7 @@ public abstract class SingleVersionOverride implements RegistryOverride {
   public static SingleVersionOverride create(
       Version version,
       String registry,
-      ImmutableList<String> patches,
+      ImmutableList<Object> patches,
       ImmutableList<String> patchCmds,
       int patchStrip) {
     return new AutoValue_SingleVersionOverride(version, registry, patches, patchCmds, patchStrip);
@@ -48,8 +48,8 @@ public abstract class SingleVersionOverride implements RegistryOverride {
   @Override
   public abstract String getRegistry();
 
-  /** The patches to apply after retrieving per the registry. Should be a list of labels. */
-  public abstract ImmutableList<String> getPatches();
+  /** The labels of patches to apply after retrieving per the registry. */
+  public abstract ImmutableList<Object> getPatches();
 
   /**
    * The patch commands to execute after retrieving per the registry. Should be a list of commands.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
@@ -70,14 +70,11 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
   private final BlazeDirectories directories;
 
   /**
-   * An empty repo mapping anchored to the main repo.
-   *
-   * <p>None of the labels present in RepoSpecs can point to any repo other than the main repo
-   * or @bazel_tools, because at this point we don't know how any other repo is defined yet. The
-   * RepoSpecs processed by this class can only contain labels from the MODULE.bazel file (from
-   * overrides). In the future, they might contain labels from the lockfile, but those will need to
-   * be canonical label literals, which bypass repo mapping anyway.
+   * An empty repo mapping anchored to the main repo. Label strings in {@link RepoSpec}s are always
+   * in unambiguous canonical form and thus require no mapping, except instances read from old
+   * lockfiles.
    */
+  // TODO(fmeum): Make this mapping truly empty after bumping LOCK_FILE_VERSION.
   private static final RepositoryMapping EMPTY_MAIN_REPO_MAPPING =
       RepositoryMapping.create(
           ImmutableMap.of("", RepositoryName.MAIN, "bazel_tools", RepositoryName.BAZEL_TOOLS),

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -228,7 +228,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -330,7 +330,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -356,7 +356,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -385,7 +385,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -491,7 +491,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -557,7 +557,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -586,7 +586,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -665,7 +665,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -698,7 +698,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -750,7 +750,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -780,7 +780,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -809,7 +809,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -839,7 +839,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -872,7 +872,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -958,7 +958,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -987,7 +987,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -1017,7 +1017,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [


### PR DESCRIPTION
This is made possible by a refactoring that moves the label parsing of `RepoSpec` attributes coming from module overrides as well as `.bzl` file labels containing repo rules from `BzlmodRepoRuleFunction` into `ModuleFileGlobals`. Also adds a TODO to `BzlmodRepoRuleFunction` to further simplify the logic after the next lockfile version bumps, as old lockfiles are now the only source of non-canonical labels in `RepoSpec`s.

Work towards #19301