### PR TITLE
Generate `.ifso` libraries with `llvm-ifs`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,6 +42,8 @@ common --check_direct_dependencies=error
 # Add mirrors for certain download URLs
 common --experimental_downloader_config=bazel_downloader.cfg
 
+common --noincompatible_sandbox_hermetic_tmp
+
 # Enable modern C++ features
 build:linux --cxxopt=-std=c++17
 build:linux --host_cxxopt=-std=c++17

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2741,7 +2741,7 @@
       "general": {
         "bzlTransitiveDigest": "g6qGPWUm4UpvMDi2JEl6cZAF/EKNUF5lycSDGGnF68Y=",
         "accumulatedFileDigests": {
-          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "ac3cd4f5df8dfbfef3548a2b758974b636071167208fbce03f27804e9598d7fb",
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "0e8dfc0c089361c43c280b3d2c0b15d91bb66a8e7be2f0abc60a53ca2dbbb5d9",
           "@@//:MODULE.bazel": "4d4b578dd607ef6ca79369c6c5d896c09e9aaa0fa4787f7865333fb2303d5b70"
         },
         "envVariables": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2741,7 +2741,7 @@
       "general": {
         "bzlTransitiveDigest": "g6qGPWUm4UpvMDi2JEl6cZAF/EKNUF5lycSDGGnF68Y=",
         "accumulatedFileDigests": {
-          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "0a80fbbd4241dc7ccd3f7665029acd69a64c8d79fa49108c1c46ef778c857685",
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "ac3cd4f5df8dfbfef3548a2b758974b636071167208fbce03f27804e9598d7fb",
           "@@//:MODULE.bazel": "4d4b578dd607ef6ca79369c6c5d896c09e9aaa0fa4787f7865333fb2303d5b70"
         },
         "envVariables": {},

--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -576,6 +576,15 @@ Modes:
   [mostly static](/reference/be/c-cpp#cc_binary.linkstatic) mode.
   If `-static` is set in linkopts, targets will change to fully static.
 
+#### `--interface_shared_objects` {:#interface-shared-objects}
+
+If enabled, Bazel will link against interface libraries instead of dynamic libraries (if
+[dynamic linking](#dynamic-mode) is enabled). This avoids relinking when changes only affect the
+implementation of the library, but not its interface. Interface libraries are always available on
+Windows. The default Linux C++ toolchain automatically generates interface libraries if the
+[`llvm-ifs`](https://llvm.org/docs/CommandGuide/llvm-ifs.html) tool is provided via
+the `BAZEL_LLVM_IFS` environment variable or can be found in `PATH`.
+
 #### `--fission (yes|no|[dbg][,opt][,fastbuild])` {:#fission}
 
 Enables [Fission](https://gcc.gnu.org/wiki/DebugFission){: .external},

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1026,7 +1026,7 @@
     },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "2LC5INJ/KSraqEsbNl9rSibnM7ApBho21h1gyUQbjPg=",
+        "bzlTransitiveDigest": "3IMVDG8bzZqXZz1r5KNZcMFhAWrxZY36ZmbIIGGGouM=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1026,7 +1026,7 @@
     },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "3IMVDG8bzZqXZz1r5KNZcMFhAWrxZY36ZmbIIGGGouM=",
+        "bzlTransitiveDigest": "EZ7U5ovF4M4RbnQUNpi4TQxWklXrWaSus3AwOfFAF+4=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/tools/cpp/build_interface_so
+++ b/tools/cpp/build_interface_so
@@ -7,4 +7,13 @@ if [ $# != 2 ]; then
    exit 1
 fi
 
-exec "$LLVM_IFS_PATH" --input-format=ELF "$1" --output-elf "$2"
+has_versioned_symbol() {
+  "$NM" --dynamic --format=just-symbols --no-sort "$1" \
+    | grep --quiet --max-count=1 --fixed-strings @
+}
+
+if has_versioned_symbol "$1"; then
+  exec cp "$1" "$2"
+else
+  "$LLVM_IFS" --input-format=ELF "$1" --output-elf "$2"
+fi

--- a/tools/cpp/build_interface_so
+++ b/tools/cpp/build_interface_so
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
-if [[ $# != 2 ]]; then
+set -eu
+
+if [ $# != 2 ]; then
    echo "Usage: $0 <so> <interface so>" 1>&2
    exit 1
 fi
 
-exec cp $1 $2
+exec "$LLVM_IFS_PATH" --input-format=ELF "$1" --output-elf "$2"

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -591,7 +591,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
                 False,
             )),
             "%{tool_paths}": ",\n        ".join(
-                ['"%s": "%s"' % (k, v) for k, v in tool_paths.items()],
+                ['"%s": "%s"' % (k, v) for k, v in tool_paths.items() if v != None],
             ),
             "%{cxx_builtin_include_directories}": get_starlark_list(builtin_include_directories),
             "%{compile_flags}": get_starlark_list(

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -554,7 +554,10 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
             "%{cc_toolchain_identifier}": cc_toolchain_identifier,
             "%{name}": cpu_value,
             "%{modulemap}": ("\":module.modulemap\"" if generate_modulemap else "None"),
-            "%{cc_compiler_deps}": get_starlark_list([":builtin_include_directory_paths"] + (
+            "%{cc_compiler_deps}": get_starlark_list([
+                ":builtin_include_directory_paths",
+                "@bazel_tools//tools/cpp:link_dynamic_library",
+            ] + (
                 [":cc_wrapper"] if darwin else []
             )),
             "%{compiler}": escape_string(get_env_var(

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -83,6 +83,7 @@ def _get_tool_paths(repository_ctx, overriden_tools):
             "ld",
             "llvm-cov",
             "llvm-profdata",
+            "llvm-ifs",
             "cpp",
             "gcc",
             "dwp",
@@ -369,6 +370,14 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         repository_ctx,
         "llvm-profdata",
         "BAZEL_LLVM_PROFDATA",
+        overriden_tools,
+        warn = True,
+        silent = True,
+    )
+    overriden_tools["llvm-ifs"] = _find_generic(
+        repository_ctx,
+        "llvm-ifs",
+        "BAZEL_LLVM_IFS",
         overriden_tools,
         warn = True,
         silent = True,

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -96,8 +96,10 @@ def layering_check_features(compiler):
         ),
     ]
 
-def interface_shared_libraries_support(cc_path, llvm_ifs_path, link_dynamic_library_tool):
-    if not llvm_ifs_path:
+def interface_shared_libraries_support(tool_paths, link_dynamic_library_tool):
+    llvm_ifs_path = tool_paths.get("llvm-ifs")
+    nm_path = tool_paths.get("nm")
+    if not llvm_ifs_path or not nm_path:
         return [], []
     dynamic_library_actions = [
         ACTION_NAMES.cpp_link_dynamic_library,
@@ -158,8 +160,12 @@ def interface_shared_libraries_support(cc_path, llvm_ifs_path, link_dynamic_libr
                     actions = dynamic_library_actions,
                     env_entries = [
                         env_entry(
-                            key = "LLVM_IFS_PATH",
+                            key = "LLVM_IFS",
                             value = llvm_ifs_path,
+                        ),
+                        env_entry(
+                            key = "NM",
+                            value = nm_path,
                         ),
                     ],
                 ),
@@ -172,7 +178,7 @@ def interface_shared_libraries_support(cc_path, llvm_ifs_path, link_dynamic_libr
                     actions = dynamic_library_actions,
                     flag_groups = [
                         flag_group(
-                            flags = [cc_path],
+                            flags = [tool_paths["gcc"]],
                             expand_if_available = "generate_interface_library",
                         ),
                     ],
@@ -1398,8 +1404,7 @@ def _impl(ctx):
         # Linux artifact name patterns are the default.
         artifact_name_patterns = []
         ifso_action_configs, ifso_features = interface_shared_libraries_support(
-            cc_path = ctx.attr.tool_paths["gcc"],
-            llvm_ifs_path = ctx.attr.tool_paths.get("llvm-ifs"),
+            tool_paths = ctx.attr.tool_paths,
             link_dynamic_library_tool = ctx.file._link_dynamic_library,
         )
         action_configs.extend(ifso_action_configs)

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -185,26 +185,29 @@ def _impl(ctx):
     ]
     action_configs = []
 
-    llvm_cov_action = action_config(
-        action_name = ACTION_NAMES.llvm_cov,
-        tools = [
-            tool(
-                path = ctx.attr.tool_paths["llvm-cov"],
-            ),
-        ],
-    )
+    llvm_cov = ctx.attr.tool_paths.get("llvm-cov")
+    if llvm_cov:
+        llvm_cov_action = action_config(
+            action_name = ACTION_NAMES.llvm_cov,
+            tools = [
+                tool(
+                    path = llvm_cov,
+                ),
+            ],
+        )
+        action_configs.append(llvm_cov_action)
 
-    objcopy_action = action_config(
-        action_name = ACTION_NAMES.objcopy_embed_data,
-        tools = [
-            tool(
-                path = ctx.attr.tool_paths["objcopy"],
-            ),
-        ],
-    )
-
-    action_configs.append(llvm_cov_action)
-    action_configs.append(objcopy_action)
+    objcopy = ctx.attr.tool_paths.get("objcopy")
+    if objcopy:
+        objcopy_action = action_config(
+            action_name = ACTION_NAMES.objcopy_embed_data,
+            tools = [
+                tool(
+                    path = objcopy,
+                ),
+            ],
+        )
+        action_configs.append(objcopy_action)
 
     supports_pic_feature = feature(
         name = "supports_pic",


### PR DESCRIPTION
RELNOTES: The default Linux C++ toolchain now generates interface libraries from dynamic libraries to prevent relinking on changes that only affect the implementation, not the interface of a library. This requires the `llvm-ifs` tool to be specified via the `BAZEL_LLVM_IFS` environment variable or available in `PATH`. If this behavior is not desired, it can be disabled via `--nointerface_shared_objects`.

Fixes #4135