### PR TITLE
Expose build event stream and starlark debugging protos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
@@ -25,6 +25,7 @@ java_proto_library(
 proto_library(
     name = "build_event_stream_proto",
     srcs = ["build_event_stream.proto"],
+    visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/packages/metrics:package_load_metrics_proto",
         "//src/main/protobuf:action_cache_proto",

--- a/src/main/java/com/google/devtools/build/lib/starlarkdebug/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdebug/proto/BUILD
@@ -26,4 +26,5 @@ java_proto_library(
 proto_library(
     name = "starlark_debugging_proto",
     srcs = ["starlark_debugging.proto"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This makes the build event stream and starlark debugging proto libraries public. This is for consumption by the vscode-bazel plugin, which already uses these but in a very hacky way.

Fixes #16335
Fixes #3684