### PR TITLE
Account for cache type for uploads in AsyncTaskCache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -181,6 +181,18 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
     channel.release();
   }
 
+  /** Waits for active network I/Os to finish. */
+  @Override
+  public void awaitTermination() throws InterruptedException {
+    casUploadCache.awaitTermination();
+  }
+
+  /** Shuts the cache down and cancels active network I/Os. */
+  @Override
+  public void shutdownNow() {
+    casUploadCache.shutdownNow();
+  }
+
   /** Returns true if 'options.remoteCache' uses 'grpc' or an empty scheme */
   public static boolean isRemoteCacheOptions(RemoteOptions options) {
     if (isNullOrEmpty(options.remoteCache)) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -83,7 +83,7 @@ public class RemoteCache extends AbstractReferenceCounted {
   private static final ListenableFuture<byte[]> EMPTY_BYTES = immediateFuture(new byte[0]);
 
   private final CountDownLatch closeCountDownLatch = new CountDownLatch(1);
-  protected final AsyncTaskCache.NoResult<Digest> casUploadCache = AsyncTaskCache.NoResult.create();
+  protected final AsyncTaskCache.NoResult<String> casUploadCache = AsyncTaskCache.NoResult.create();
 
   protected final RemoteCacheClient cacheProtocol;
   protected final RemoteOptions options;
@@ -162,7 +162,7 @@ public class RemoteCache extends AbstractReferenceCounted {
 
     Completable upload =
         casUploadCache.execute(
-            digest,
+            digest + context.getWriteCachePolicy().toString(),
             RxFutures.toCompletable(
                 () -> cacheProtocol.uploadFile(context, digest, file), directExecutor()),
             force);
@@ -193,7 +193,7 @@ public class RemoteCache extends AbstractReferenceCounted {
 
     Completable upload =
         casUploadCache.execute(
-            digest,
+            digest + context.getWriteCachePolicy().toString(),
             RxFutures.toCompletable(
                 () -> cacheProtocol.uploadBlob(context, digest, data), directExecutor()),
             force);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -196,7 +196,7 @@ public class RemoteExecutionCache extends RemoteCache {
           uploadTask.completion = Completable.fromObservable(completion);
           Completable upload =
               casUploadCache.execute(
-                  digest,
+                  digest.getHash() + context.getWriteCachePolicy().toString(),
                   Single.<Boolean>create(
                           continuation -> {
                             uploadTask.continuation = continuation;

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
@@ -155,8 +155,8 @@ public interface RemoteCacheClient extends MissingDigestsFinder {
    * @param force Whether to force the upload, even if an upload was already attempted.
    * @return A future representing pending completion of the upload.
    */
-  ListenableFuture<Void> uploadFile(RemoteActionExecutionContext context, Digest digest, Path file, boolean force);
-
+  ListenableFuture<Void> uploadFile(
+      RemoteActionExecutionContext context, Digest digest, Path file, boolean force);
 
   /**
    * Uploads a BLOB to the CAS.
@@ -179,8 +179,14 @@ public interface RemoteCacheClient extends MissingDigestsFinder {
    * @return A future representing pending completion of the upload.
    */
   ListenableFuture<Void> uploadBlob(
-      RemoteActionExecutionContext context, Digest digest, ByteString data, boolean force);      
+      RemoteActionExecutionContext context, Digest digest, ByteString data, boolean force);
 
   /** Close resources associated with the remote cache. */
   void close();
+
+  /** Waits for active network I/Os to finish. */
+  void awaitTermination() throws InterruptedException;
+
+  /** Shuts the cache down and cancels active network I/Os. */
+  void shutdownNow();
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
@@ -147,6 +147,18 @@ public interface RemoteCacheClient extends MissingDigestsFinder {
   ListenableFuture<Void> uploadFile(RemoteActionExecutionContext context, Digest digest, Path file);
 
   /**
+   * Uploads a {@code file} to the CAS.
+   *
+   * @param context the context for the action.
+   * @param digest The digest of the file.
+   * @param file The file to upload.
+   * @param force Whether to force the upload, even if an upload was already attempted.
+   * @return A future representing pending completion of the upload.
+   */
+  ListenableFuture<Void> uploadFile(RemoteActionExecutionContext context, Digest digest, Path file, boolean force);
+
+
+  /**
    * Uploads a BLOB to the CAS.
    *
    * @param context the context for the action.
@@ -156,6 +168,18 @@ public interface RemoteCacheClient extends MissingDigestsFinder {
    */
   ListenableFuture<Void> uploadBlob(
       RemoteActionExecutionContext context, Digest digest, ByteString data);
+
+  /**
+   * Uploads a BLOB to the CAS.
+   *
+   * @param context the context for the action.
+   * @param digest The digest of the blob.
+   * @param data The BLOB to upload.
+   * @param force Whether to force the upload, even if an upload was already attempted.
+   * @return A future representing pending completion of the upload.
+   */
+  ListenableFuture<Void> uploadBlob(
+      RemoteActionExecutionContext context, Digest digest, ByteString data, boolean force);      
 
   /** Close resources associated with the remote cache. */
   void close();

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -23,6 +23,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:guava",
         "//third_party:jsr305",
+        "//third_party:rxjava3",
         "//third_party/protobuf:protobuf_java",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
@@ -74,11 +74,25 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
     remoteCache.close();
   }
 
+  /** Waits for active network I/Os to finish. */
   @Override
-    public ListenableFuture<Void> uploadFile(
-        RemoteActionExecutionContext context, Digest digest, Path file) {
-    return uploadFile(context, digest, file, /*force=*/false);
-  }  
+  public void awaitTermination() throws InterruptedException {
+    diskCache.awaitTermination();
+    remoteCache.awaitTermination();
+  }
+
+  /** Shuts the cache down and cancels active network I/Os. */
+  @Override
+  public void shutdownNow() {
+    diskCache.shutdownNow();
+    remoteCache.shutdownNow();
+  }
+
+  @Override
+  public ListenableFuture<Void> uploadFile(
+      RemoteActionExecutionContext context, Digest digest, Path file) {
+    return uploadFile(context, digest, file, /* force= */ false);
+  }
 
   @Override
   public ListenableFuture<Void> uploadFile(
@@ -97,12 +111,12 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
     return future;
   }
 
-  
   @Override
   public ListenableFuture<Void> uploadBlob(
       RemoteActionExecutionContext context, Digest digest, ByteString data) {
-    return uploadBlob(context, digest, data, /*force=*/false);
+    return uploadBlob(context, digest, data, /* force= */ false);
   }
+
   @Override
   public ListenableFuture<Void> uploadBlob(
       RemoteActionExecutionContext context, Digest digest, ByteString data, boolean force) {

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
@@ -75,35 +75,47 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
   }
 
   @Override
+    public ListenableFuture<Void> uploadFile(
+        RemoteActionExecutionContext context, Digest digest, Path file) {
+    return uploadFile(context, digest, file, /*force=*/false);
+  }  
+
+  @Override
   public ListenableFuture<Void> uploadFile(
-      RemoteActionExecutionContext context, Digest digest, Path file) {
+      RemoteActionExecutionContext context, Digest digest, Path file, boolean force) {
     ListenableFuture<Void> future = Futures.immediateVoidFuture();
 
     if (context.getWriteCachePolicy().allowDiskCache()) {
-      future = diskCache.uploadFile(context, digest, file);
+      future = diskCache.uploadFile(context, digest, file, force);
     }
 
     if (context.getWriteCachePolicy().allowRemoteCache()) {
       future =
           Futures.transformAsync(
-              future, v -> remoteCache.uploadFile(context, digest, file), directExecutor());
+              future, v -> remoteCache.uploadFile(context, digest, file, force), directExecutor());
     }
     return future;
   }
 
+  
   @Override
   public ListenableFuture<Void> uploadBlob(
       RemoteActionExecutionContext context, Digest digest, ByteString data) {
+    return uploadBlob(context, digest, data, /*force=*/false);
+  }
+  @Override
+  public ListenableFuture<Void> uploadBlob(
+      RemoteActionExecutionContext context, Digest digest, ByteString data, boolean force) {
     ListenableFuture<Void> future = Futures.immediateVoidFuture();
 
     if (context.getWriteCachePolicy().allowDiskCache()) {
-      future = diskCache.uploadBlob(context, digest, data);
+      future = diskCache.uploadBlob(context, digest, data, force);
     }
 
     if (context.getWriteCachePolicy().allowRemoteCache()) {
       future =
           Futures.transformAsync(
-              future, v -> remoteCache.uploadBlob(context, digest, data), directExecutor());
+              future, v -> remoteCache.uploadBlob(context, digest, data, force), directExecutor());
     }
     return future;
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -33,6 +33,7 @@ java_library(
         "//third_party:jsr305",
         "//third_party:netty",
         "//third_party/protobuf:protobuf_java",
+        "@maven//:io_reactivex_rxjava3_rxjava",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -878,6 +878,14 @@ public class GrpcCacheClientTest {
   }
 
   @Test
+  public void testUpload_deduplicationWorks() throws Exception {
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    GrpcCacheClient client = newClient(remoteOptions);
+    RemoteCache remoteCache = new RemoteCache(client, remoteOptions, DIGEST_UTIL);
+
+  }
+
+  @Test
   public void testUploadSplitMissingDigestsCall() throws Exception {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.maxOutboundMessageSize = 80; // Enough for one digest, but not two.
@@ -1409,3 +1417,4 @@ public class GrpcCacheClientTest {
     assertThat(GrpcCacheClient.isRemoteCacheOptions(options)).isFalse();
   }
 }
+

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
@@ -626,7 +626,8 @@ public class RemoteCacheTest {
 
     ListenableFuture<Void> upload =
         remoteCache.uploadFile(remoteActionExecutionContext, digest, file);
-    assertThat(remoteCache.casUploadCache.getInProgressTasks()).contains(digest);
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).contains(
+        digest + remoteActionExecutionContext.getWriteCachePolicy().toString());
     remoteCache.shutdownNow();
 
     assertThat(upload.isCancelled()).isTrue();

--- a/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
@@ -136,6 +136,12 @@ public class InMemoryCacheClient implements RemoteCacheClient {
   @Override
   public ListenableFuture<Void> uploadFile(
       RemoteActionExecutionContext context, Digest digest, Path file) {
+    return uploadFile(context, digest, file, /* force= */ false);
+  }  
+
+  @Override
+  public ListenableFuture<Void> uploadFile(
+      RemoteActionExecutionContext context, Digest digest, Path file, boolean force) {
     try (InputStream in = file.getInputStream()) {
       cas.put(digest, ByteStreams.toByteArray(in));
     } catch (IOException e) {
@@ -147,6 +153,12 @@ public class InMemoryCacheClient implements RemoteCacheClient {
   @Override
   public ListenableFuture<Void> uploadBlob(
       RemoteActionExecutionContext context, Digest digest, ByteString data) {
+    return uploadBlob(context, digest, data, /* force= */ false);
+  }
+
+  @Override
+  public ListenableFuture<Void> uploadBlob(
+      RemoteActionExecutionContext context, Digest digest, ByteString data, boolean force) {
     try (InputStream in = data.newInput()) {
       cas.put(digest, data.toByteArray());
     } catch (IOException e) {
@@ -178,4 +190,13 @@ public class InMemoryCacheClient implements RemoteCacheClient {
     cas.clear();
     ac.clear();
   }
+
+  @Override
+  public void shutdownNow() {
+    
+  }
+
+  @Override
+  public void awaitTermination() throws InterruptedException {}
+
 }

--- a/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
+++ b/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
@@ -270,10 +270,10 @@ EOF
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"
 
-  expect_bes_file_not_uploaded foo.txt
+  expect_bes_file_uploaded foo.txt
   expect_bes_file_uploaded command.profile.gz
   remote_cas_files="$(count_remote_cas_files)"
-  [[ "$remote_cas_files" == 1 ]] || fail "Expected 1 remote cas entries, not $remote_cas_files"
+  [[ "$remote_cas_files" == 2 ]] || fail "Expected 2 remote cas entries, not $remote_cas_files"
   disk_cas_files="$(count_disk_cas_files $cache_dir)"
   # foo.txt, stdout and stderr for action 'foo'
   [[ "$disk_cas_files" == 3 ]] || fail "Expected 3 disk cas entries, not $disk_cas_files"


### PR DESCRIPTION
Currently, the AsyncTaskCache for remote execution uses the digest as a key to determine whether or not a task has already been run. Normally this works if there is only a single cache in use. However, when using a disk cache and a remote cache, some calls try to upload files using only a single cache through one code path and another cache through another code path.

This is problematic if only disk caching is used through one code path, when remote caching is enabled though another code path (ie, uploading BES referenced artifacts), the files are not uploaded to the remote cache since the digest is the same. This change uses a String of the digest and the cache type as the key rather than just the digest to allow for uploading to both caches.

The download path is not affected by this bug, so we don't need to make any changes there.

Also, update the combined cache test to reflect what should happen:
when remote_build_event_upload=all, *all* files referenced in the BES
stream are uploaded, including build artifacts (this test now functions as intended based on documentation due to this change).


Fixes #20962, #20296