### PR TITLE
[7.1.0] Make sure we build as well as test //src/tools/execlog/... on CI.

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -18,6 +18,7 @@ tasks:
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
       - "//src/main/java/..."
+      - "//src/tools/execlog/..."
     test_flags:
       - "--config=ci-linux"
       # Override REMOTE_NETWORK_ADDRESS since bazel_sandboxing_networking_test doesn't work on this platform

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,6 +19,7 @@ tasks:
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
       - "//src/main/java/..."
+      - "//src/tools/execlog/..."
     test_flags:
       - "--config=ci-linux"
       # Override REMOTE_NETWORK_ADDRESS since bazel_sandboxing_networking_test doesn't work on this platform

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
@@ -32,7 +32,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_log_context_utils",
-        "//src/main/java/com/google/devtools/build/lib/util/io:io-proto",
+        "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:spawn_java_proto",
         "//third_party:auto_value",


### PR DESCRIPTION
Cherry-pick only: also fix a target that currently fails to build due to a bad dependency.

PiperOrigin-RevId: 604423841
Change-Id: I641b5e75ae52dc65ecb264c87dc46426acf64cb1