### PR TITLE
[7.1.0] Switch macOS minimum version flag to gcc compatible version

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -1337,7 +1337,7 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 actions = all_compile_actions + all_link_actions,
-                flag_groups = [flag_group(flags = ["-mmacos-version-min={}".format(_target_os_version(ctx))])],
+                flag_groups = [flag_group(flags = ["-mmacosx-version-min={}".format(_target_os_version(ctx))])],
             ),
         ],
     )


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/discussions/20698

I'm not sure how that user got into that state yet, but it doesn't hurt for this to be gcc compatible just in case the user is intentionally using gcc on macOS

Closes #20798.

Commit https://github.com/bazelbuild/bazel/commit/05b1f061c9256ec0eb6fb71716ed93feb0c31b59

PiperOrigin-RevId: 604515755
Change-Id: Ib9087fe6afbbb3514513a7d5d120fcf448e54f65