### PR TITLE
[7.1.0] Mark gcc-<version> as `gcc` instead of `compiler` in Unix CC toolchain

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2293,8 +2293,8 @@
       "general": {
         "bzlTransitiveDigest": "TaEUQXsOyJBUS1hp5pqPajfzBJlceug58PemF8nCEa8=",
         "accumulatedFileDigests": {
-          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "0398b2a48c58023e0736fcb5b0937f39a3a95b4ed34941f482deb898ca3d21e1",
-          "@@//:MODULE.bazel": "f0f6c040c50ad1d3555157b29dea32260bdaf5cc7205dfc346d4b1b6b008baca"
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "ce05b19e5797eeb041153a783455ae7b822676eb25c1e813f7e1f65c389920b0",
+          "@@//:MODULE.bazel": "4d4b578dd607ef6ca79369c6c5d896c09e9aaa0fa4787f7865333fb2303d5b70"
         },
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -8527,7 +8527,7 @@
     },
     "@@rules_python~0.26.0//python/extensions:pip.bzl%pip": {
       "os:osx,arch:aarch64": {
-        "bzlTransitiveDigest": "c5rSaV6x0pI1k3yDrGa+nTeCN9zzlhd11tP9VzHzc+o=",
+        "bzlTransitiveDigest": "udSms4Q/6hNLCjKfjNOdbSYN66ZRD2hHVyobSu652iM=",
         "accumulatedFileDigests": {
           "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
         },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2293,8 +2293,8 @@
       "general": {
         "bzlTransitiveDigest": "TaEUQXsOyJBUS1hp5pqPajfzBJlceug58PemF8nCEa8=",
         "accumulatedFileDigests": {
-          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "ce05b19e5797eeb041153a783455ae7b822676eb25c1e813f7e1f65c389920b0",
-          "@@//:MODULE.bazel": "4d4b578dd607ef6ca79369c6c5d896c09e9aaa0fa4787f7865333fb2303d5b70"
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "c61fe9fb628aaae087bfa754fc5d1f7a7d19b0d5debaf9bf84eb37fc1a365e71",
+          "@@//:MODULE.bazel": "f0f6c040c50ad1d3555157b29dea32260bdaf5cc7205dfc346d4b1b6b008baca"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -8527,7 +8527,7 @@
     },
     "@@rules_python~0.26.0//python/extensions:pip.bzl%pip": {
       "os:osx,arch:aarch64": {
-        "bzlTransitiveDigest": "udSms4Q/6hNLCjKfjNOdbSYN66ZRD2hHVyobSu652iM=",
+        "bzlTransitiveDigest": "c5rSaV6x0pI1k3yDrGa+nTeCN9zzlhd11tP9VzHzc+o=",
         "accumulatedFileDigests": {
           "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
         },

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1002,7 +1002,7 @@
     },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "R+z/o9z6DUWAxJKuQZet/vuZ78BjspYvMfHxTQ3VEb4=",
+        "bzlTransitiveDigest": "PHpT2yqMGms2U4L3E/aZ+WcQalmZWm+ILdP3yiLsDhA=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1002,7 +1002,7 @@
     },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "mcsWHq3xORJexV5/4eCvNOLxFOQKV6eli3fkr+tEaqE=",
+        "bzlTransitiveDigest": "R+z/o9z6DUWAxJKuQZet/vuZ78BjspYvMfHxTQ3VEb4=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -272,7 +272,8 @@ def _is_clang(repository_ctx, cc):
 def _is_gcc(repository_ctx, cc):
     # GCC's version output uses the basename of argv[0] as the program name:
     # https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/gcc.cc;h=158461167951c1b9540322fb19be6a89d6da07fc;hb=HEAD#l8728
-    return repository_ctx.execute([cc, "--version"]).stdout.startswith("gcc ")
+    cc_stdout = repository_ctx.execute([cc, "--version"]).stdout
+    return cc_stdout.startswith("gcc ") or cc_stdout.startswith("gcc-")
 
 def _get_compiler_name(repository_ctx, cc):
     if _is_clang(repository_ctx, cc):


### PR DESCRIPTION
Fixes #17794

I was looking at writing a test for this, but not sure how you'd like me to go about that. Hard-code a gcc, e.g. `gcc-11`, or search the `$PATH` for a `gcc-<version>`?
    
Closes #20350.

Commit https://github.com/bazelbuild/bazel/commit/88771830d92a93027ed7dfb5d130b3311400dbc4
    
PiperOrigin-RevId: 604543138
Change-Id: I71ebbac77e4e32ebc5d99ec4a81415727af12cbc