### PR TITLE
[7.1.0] Fix NPE in ResourceManager when collecting local resource estimation in the profiler.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
@@ -140,13 +140,13 @@ public class ResourceManager implements ResourceEstimator {
   /** Returns prediction of RAM in Mb used by registered actions. */
   @Override
   public double getUsedMemoryInMb() {
-    return usedResources.get(ResourceSet.MEMORY);
+    return usedResources.getOrDefault(ResourceSet.MEMORY, 0d);
   }
 
   /** Returns prediction of CPUs used by registered actions. */
   @Override
   public double getUsedCPU() {
-    return usedResources.get(ResourceSet.CPU);
+    return usedResources.getOrDefault(ResourceSet.CPU, 0d);
   }
 
   // Allocated resources are allowed to go "negative", but at least
@@ -182,7 +182,7 @@ public class ResourceManager implements ResourceEstimator {
 
   // Used amount of resources. Corresponds to the resource
   // definition in the ResourceSet class.
-  private Map<String, Double> usedResources;
+  private Map<String, Double> usedResources = new HashMap<>();
 
   // Used local test count. Corresponds to the local test count definition in the ResourceSet class.
   private int usedLocalTestCount;


### PR DESCRIPTION
Fixes #21133.

RELNOTES: None.
Commit https://github.com/bazelbuild/bazel/commit/5c4becc5b4b13f7e8870dfc2367579a25af20574

PiperOrigin-RevId: 603631744
Change-Id: Ied224fd14e2be1465098135e0cab87584bbedb28