### PR TITLE
[7.1.0] Cherry-pick: linker_param_file only added to command line if it starts with "@"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
@@ -34,7 +34,6 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.CommandAction;
-import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.CommandLines.CommandLineAndParamFileInfo;
 import com.google.devtools.build.lib.actions.ExecException;
@@ -287,11 +286,8 @@ public final class CppLinkAction extends AbstractAction implements CommandAction
         getInputs().toList().stream()
             .filter(Artifact::isDirectory)
             .collect(ImmutableSet.toImmutableSet());
-
-    CommandLine commandLine = linkCommandLine.getCommandLineForStarlark();
-
     CommandLineAndParamFileInfo commandLineAndParamFileInfo =
-        new CommandLineAndParamFileInfo(commandLine, /* paramFileInfo= */ null);
+        new CommandLineAndParamFileInfo(linkCommandLine, /* paramFileInfo= */ null);
 
     Args args = Args.forRegisteredAction(commandLineAndParamFileInfo, directoryInputs);
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
@@ -399,7 +399,7 @@ public final class CppLinkAction extends AbstractAction implements CommandAction
     info.setLinkStaticness(linkCommandLine.getLinkingMode().name());
     info.addAllLinkStamp(Artifact.toExecPaths(getLinkstampObjects()));
     info.addAllBuildInfoHeaderArtifact(Artifact.toExecPaths(getBuildInfoHeaderArtifacts()));
-    info.addAllLinkOpt(linkCommandLine.getRawLinkArgv(null));
+    info.addAllLinkOpt(linkCommandLine.arguments());
 
     try {
       return super.getExtraActionInfo(actionKeyContext)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java
@@ -289,23 +289,12 @@ public final class LinkCommandLine extends CommandLine {
 
   /**
    * Returns a raw link command for the given link invocation, including both command and arguments
-   * (argv). The version that uses the expander is preferred, but that one can't be used during
-   * analysis.
-   *
-   * @return raw link command line.
-   */
-  public List<String> getRawLinkArgv() throws CommandLineExpansionException {
-    return getRawLinkArgv(null);
-  }
-
-  /**
-   * Returns a raw link command for the given link invocation, including both command and arguments
    * (argv).
    *
    * @param expander ArtifactExpander for expanding TreeArtifacts.
    * @return raw link command line.
    */
-  public List<String> getRawLinkArgv(@Nullable ArtifactExpander expander)
+  private List<String> getRawLinkArgv(@Nullable ArtifactExpander expander)
       throws CommandLineExpansionException {
     return getRawLinkArgv(
         expander, forcedToolPath, featureConfiguration, actionName, linkTargetType, variables);

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoObjDirTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoObjDirTest.java
@@ -278,9 +278,9 @@ public class CcBinaryThinLtoObjDirTest extends BuildViewTestCase {
     assertThat(ActionsTestUtil.getFirstArtifactEndingWith(linkAction.getInputs(), "linkstamp.o"))
         .isNotNull();
 
-    List<String> commandLine = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
-    String prefix = getTargetConfiguration().getOutputDirectory(RepositoryName.MAIN)
-        .getExecPathString();
+    List<String> commandLine = linkAction.getLinkCommandLineForTesting().arguments();
+    String prefix =
+        getTargetConfiguration().getOutputDirectory(RepositoryName.MAIN).getExecPathString();
     assertThat(commandLine)
         .containsAtLeast(
             prefix + "/bin/pkg/bin.lto.merged.o",
@@ -421,9 +421,9 @@ public class CcBinaryThinLtoObjDirTest extends BuildViewTestCase {
     CppLinkAction linkAction = getLinkAction();
     String rootExecPath = getRootExecPath();
 
-    List<String> commandLine = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
-    String prefix = getTargetConfiguration().getOutputDirectory(RepositoryName.MAIN)
-        .getExecPathString();
+    List<String> commandLine = linkAction.getLinkCommandLineForTesting().arguments();
+    String prefix =
+        getTargetConfiguration().getOutputDirectory(RepositoryName.MAIN).getExecPathString();
 
     assertThat(commandLine).contains("-Wl,@" + prefix + "/bin/pkg/bin-lto-final.params");
 
@@ -1818,7 +1818,7 @@ public class CcBinaryThinLtoObjDirTest extends BuildViewTestCase {
     assertThat(ActionsTestUtil.baseArtifactNames(linkAction.getInputs()))
         .contains("ld_profile.txt");
 
-    List<String> commandLine = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
+    List<String> commandLine = linkAction.getLinkCommandLineForTesting().arguments();
     assertThat(commandLine.toString())
         .containsMatch("-Wl,--symbol-ordering-file=.*/ld_profile.txt");
 
@@ -1965,7 +1965,7 @@ public class CcBinaryThinLtoObjDirTest extends BuildViewTestCase {
         (CppLinkAction) getPredecessorByInputName(genruleAction, "pkg/gen_lib");
     assertThat(ActionsTestUtil.baseArtifactNames(hostLinkAction.getInputs()))
         .doesNotContain("ld_profile.txt");
-    assertThat(hostLinkAction.getLinkCommandLineForTesting().getRawLinkArgv().toString())
+    assertThat(hostLinkAction.getLinkCommandLineForTesting().arguments().toString())
         .doesNotContainMatch("-Wl,--symbol-ordering-file=.*/ld_profile.txt");
 
     // The hostLinkAction inputs has a different root from the backendAction.
@@ -1985,7 +1985,7 @@ public class CcBinaryThinLtoObjDirTest extends BuildViewTestCase {
     assertThat(hostIndexAction).isNotNull();
     assertThat(ActionsTestUtil.baseArtifactNames(hostIndexAction.getInputs()))
         .doesNotContain("ld_profile.txt");
-    assertThat(hostIndexAction.getLinkCommandLineForTesting().getRawLinkArgv().toString())
+    assertThat(hostIndexAction.getLinkCommandLineForTesting().arguments().toString())
         .doesNotContainMatch("-Wl,--symbol-ordering-file=.*/ld_profile.txt");
 
     CppCompileAction hostBitcodeAction =
@@ -2023,7 +2023,7 @@ public class CcBinaryThinLtoObjDirTest extends BuildViewTestCase {
     CppLinkAction linkAction = (CppLinkAction) getGeneratingAction(binArtifact);
     assertThat(linkAction.getOutputs()).containsExactly(binArtifact);
 
-    List<String> commandLine = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
+    List<String> commandLine = linkAction.getLinkCommandLineForTesting().arguments();
     assertThat(commandLine.toString())
         .containsMatch("-Wl,--symbol-ordering-file=.*/ld_profile.txt");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoTest.java
@@ -166,9 +166,9 @@ public class CcBinaryThinLtoTest extends BuildViewTestCase {
     assertThat(ActionsTestUtil.getFirstArtifactEndingWith(linkAction.getInputs(), "linkstamp.o"))
         .isNotNull();
 
-    List<String> commandLine = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
-    String prefix = getTargetConfiguration().getOutputDirectory(RepositoryName.MAIN)
-        .getExecPathString();
+    List<String> commandLine = linkAction.getLinkCommandLineForTesting().arguments();
+    String prefix =
+        getTargetConfiguration().getOutputDirectory(RepositoryName.MAIN).getExecPathString();
     assertThat(commandLine)
         .containsAtLeast(
             prefix + "/bin/pkg/bin.lto.merged.o",
@@ -303,9 +303,9 @@ public class CcBinaryThinLtoTest extends BuildViewTestCase {
     CppLinkAction linkAction = getLinkAction();
     String rootExecPath = getRootExecPath();
 
-    List<String> commandLine = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
-    String prefix = getTargetConfiguration().getOutputDirectory(RepositoryName.MAIN)
-        .getExecPathString();
+    List<String> commandLine = linkAction.getLinkCommandLineForTesting().arguments();
+    String prefix =
+        getTargetConfiguration().getOutputDirectory(RepositoryName.MAIN).getExecPathString();
 
     assertThat(commandLine).contains("-Wl,@" + prefix + "/bin/pkg/bin-lto-final.params");
 
@@ -1738,7 +1738,7 @@ public class CcBinaryThinLtoTest extends BuildViewTestCase {
     assertThat(ActionsTestUtil.baseArtifactNames(linkAction.getInputs()))
         .contains("ld_profile.txt");
 
-    List<String> commandLine = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
+    List<String> commandLine = linkAction.getLinkCommandLineForTesting().arguments();
     assertThat(commandLine.toString())
         .containsMatch("-Wl,--symbol-ordering-file=.*/ld_profile.txt");
 
@@ -1923,7 +1923,7 @@ public class CcBinaryThinLtoTest extends BuildViewTestCase {
         (CppLinkAction) getPredecessorByInputName(genruleAction, "pkg/gen_lib");
     assertThat(ActionsTestUtil.baseArtifactNames(hostLinkAction.getInputs()))
         .doesNotContain("ld_profile.txt");
-    assertThat(hostLinkAction.getLinkCommandLineForTesting().getRawLinkArgv().toString())
+    assertThat(hostLinkAction.getLinkCommandLineForTesting().arguments().toString())
         .doesNotContainMatch("-Wl,--symbol-ordering-file=.*/ld_profile.txt");
 
     // The hostLinkAction inputs has a different root from the backendAction.
@@ -1943,7 +1943,7 @@ public class CcBinaryThinLtoTest extends BuildViewTestCase {
     assertThat(hostIndexAction).isNotNull();
     assertThat(ActionsTestUtil.baseArtifactNames(hostIndexAction.getInputs()))
         .doesNotContain("ld_profile.txt");
-    assertThat(hostIndexAction.getLinkCommandLineForTesting().getRawLinkArgv().toString())
+    assertThat(hostIndexAction.getLinkCommandLineForTesting().arguments().toString())
         .doesNotContainMatch("-Wl,--symbol-ordering-file=.*/ld_profile.txt");
 
     CppCompileAction hostBitcodeAction =
@@ -1981,7 +1981,7 @@ public class CcBinaryThinLtoTest extends BuildViewTestCase {
     CppLinkAction linkAction = (CppLinkAction) getGeneratingAction(binArtifact);
     assertThat(linkAction.getOutputs()).containsExactly(binArtifact);
 
-    List<String> commandLine = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
+    List<String> commandLine = linkAction.getLinkCommandLineForTesting().arguments();
     assertThat(commandLine.toString())
         .containsMatch("-Wl,--symbol-ordering-file=.*/ld_profile.txt");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -1079,13 +1079,13 @@ public final class CppLinkActionTest extends BuildViewTestCase {
 
     // Should only reference the tree artifact.
     verifyArguments(
-        linkAction.getLinkCommandLineForTesting().getRawLinkArgv(),
+        linkAction.getLinkCommandLineForTesting().arguments(),
         treeArtifactsPaths,
         treeFileArtifactsPaths);
 
     // Should only reference tree file artifacts.
     verifyArguments(
-        linkAction.getLinkCommandLineForTesting().getRawLinkArgv(expander),
+        linkAction.getLinkCommandLineForTesting().arguments(expander, null),
         treeFileArtifactsPaths,
         treeArtifactsPaths);
   }
@@ -1166,7 +1166,7 @@ public final class CppLinkActionTest extends BuildViewTestCase {
             .setLibraryIdentifier("foo")
             .build();
 
-    List<String> argv = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
+    List<String> argv = linkAction.getLinkCommandLineForTesting().arguments();
     assertThat(argv).doesNotContain("-pie");
     assertThat(argv).contains("-other");
   }
@@ -1188,7 +1188,7 @@ public final class CppLinkActionTest extends BuildViewTestCase {
             .addLinkopts(ImmutableList.of("-pie", "-other", "-pie"))
             .build();
 
-    List<String> argv = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
+    List<String> argv = linkAction.getLinkCommandLineForTesting().arguments();
     assertThat(argv).contains("-pie");
     assertThat(argv).contains("-other");
   }
@@ -1218,7 +1218,7 @@ public final class CppLinkActionTest extends BuildViewTestCase {
             .addLinkopts(ImmutableList.of("FakeLinkopt1", "FakeLinkopt2"))
             .build();
 
-    List<String> argv = linkAction.getLinkCommandLineForTesting().getRawLinkArgv();
+    List<String> argv = linkAction.getLinkCommandLineForTesting().arguments();
     int lastLinkerInputIndex =
         Ints.max(
             argv.indexOf("FakeLinkerInput1"), argv.indexOf("FakeLinkerInput2"),

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLineTest.java
@@ -163,7 +163,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setActionName(LinkTargetType.EXECUTABLE.getActionName())
             .setLinkTargetType(LinkTargetType.EXECUTABLE)
             .build();
-    List<String> rawLinkArgv = linkConfig.getRawLinkArgv();
+    List<String> rawLinkArgv = linkConfig.arguments();
     assertThat(linkConfig.arguments()).isEqualTo(rawLinkArgv);
   }
 
@@ -176,7 +176,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setLinkTargetType(LinkTargetType.NODEPS_DYNAMIC_LIBRARY)
             .setLinkingMode(LinkingMode.STATIC)
             .build();
-    List<String> argv = linkConfig.getRawLinkArgv();
+    List<String> argv = linkConfig.arguments();
     for (String arg : argv) {
       assertThat(arg).doesNotContain("print-symbol-counts");
     }
@@ -199,7 +199,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setLinkTargetType(LinkTargetType.NODEPS_DYNAMIC_LIBRARY)
             .setLinkingMode(LinkingMode.STATIC)
             .build();
-    String commandLine = Joiner.on(" ").join(linkConfig.getRawLinkArgv());
+    String commandLine = Joiner.on(" ").join(linkConfig.arguments());
     assertThat(commandLine).matches(".*foo -Wl,-whole-archive bar -Wl,-no-whole-archive.*");
   }
 
@@ -217,7 +217,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setLinkTargetType(LinkTargetType.NODEPS_DYNAMIC_LIBRARY)
             .setLinkingMode(LinkingMode.STATIC)
             .build();
-    assertThat(linkConfig.getRawLinkArgv()).containsAtLeast("-Lfoo", "-Lbar").inOrder();
+    assertThat(linkConfig.arguments()).containsAtLeast("-Lfoo", "-Lbar").inOrder();
   }
 
   @Test
@@ -233,7 +233,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setLinkTargetType(LinkTargetType.STATIC_LIBRARY)
             .setLinkingMode(Link.LinkingMode.STATIC)
             .build();
-    assertThat(linkConfig.getRawLinkArgv()).contains("@foo/bar.param");
+    assertThat(linkConfig.arguments()).contains("@foo/bar.param");
   }
 
   @Test
@@ -249,7 +249,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setLinkTargetType(LinkTargetType.NODEPS_DYNAMIC_LIBRARY)
             .setLinkingMode(Link.LinkingMode.STATIC)
             .build();
-    assertThat(linkConfig.getRawLinkArgv()).contains("@foo/bar.param");
+    assertThat(linkConfig.arguments()).contains("@foo/bar.param");
   }
 
   private List<String> basicArgv(LinkTargetType targetType) throws Exception {
@@ -352,7 +352,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setActionName(LinkTargetType.STATIC_LIBRARY.getActionName())
             .setLinkTargetType(LinkTargetType.STATIC_LIBRARY)
             .build();
-    List<String> result = linkConfig.getRawLinkArgv();
+    List<String> result = linkConfig.arguments();
     assertThat(result).isEqualTo(Arrays.asList("foo/bar/ar", "rcsD", "a/FakeOutput"));
   }
 
@@ -445,7 +445,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
     // Should only reference the tree artifact.
     verifyArguments(
         linkConfig.arguments(null, PathMapper.NOOP), treeArtifactsPaths, treeFileArtifactsPaths);
-    verifyArguments(linkConfig.getRawLinkArgv(null), treeArtifactsPaths, treeFileArtifactsPaths);
+    verifyArguments(linkConfig.arguments(), treeArtifactsPaths, treeFileArtifactsPaths);
     verifyArguments(
         linkConfig.paramCmdLine().arguments(null, PathMapper.NOOP),
         treeArtifactsPaths,
@@ -457,7 +457,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
         treeFileArtifactsPaths,
         treeArtifactsPaths);
     verifyArguments(
-        linkConfig.getRawLinkArgv(expander), treeFileArtifactsPaths, treeArtifactsPaths);
+        linkConfig.arguments(expander, null), treeFileArtifactsPaths, treeArtifactsPaths);
     verifyArguments(
         linkConfig.paramCmdLine().arguments(expander, PathMapper.NOOP),
         treeFileArtifactsPaths,

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLineTest.java
@@ -36,7 +36,6 @@ import com.google.devtools.build.lib.rules.cpp.CppActionConfigs.CppPlatform;
 import com.google.devtools.build.lib.rules.cpp.Link.LinkTargetType;
 import com.google.devtools.build.lib.rules.cpp.Link.LinkingMode;
 import com.google.devtools.build.lib.testutil.TestUtils;
-import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -233,7 +232,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setLinkTargetType(LinkTargetType.STATIC_LIBRARY)
             .setLinkingMode(Link.LinkingMode.STATIC)
             .build();
-    assertThat(linkConfig.arguments()).contains("@foo/bar.param");
+    assertThat(linkConfig.getCommandLine(null)).contains("@foo/bar.param");
   }
 
   @Test
@@ -249,7 +248,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .setLinkTargetType(LinkTargetType.NODEPS_DYNAMIC_LIBRARY)
             .setLinkingMode(Link.LinkingMode.STATIC)
             .build();
-    assertThat(linkConfig.arguments()).contains("@foo/bar.param");
+    assertThat(linkConfig.getCommandLine(null)).contains("@foo/bar.param");
   }
 
   private List<String> basicArgv(LinkTargetType targetType) throws Exception {
@@ -312,9 +311,12 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .forceToolPath("foo/bar/ar")
             .setParamFile(paramFile)
             .build();
-    Pair<List<String>, List<String>> result = linkConfig.splitCommandline();
-    assertThat(result.first).isEqualTo(Arrays.asList("foo/bar/ar", "@some/file.params"));
-    assertThat(result.second).isEqualTo(Arrays.asList("rcsD", "a/FakeOutput"));
+    assertThat(linkConfig.getCommandLine(null))
+        .containsExactly("foo/bar/ar", "@some/file.params")
+        .inOrder();
+    assertThat(linkConfig.getParamCommandLine(null))
+        .containsExactly("rcsD", "a/FakeOutput")
+        .inOrder();
   }
 
   @Test
@@ -335,9 +337,12 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .forceToolPath("foo/bar/linker")
             .setParamFile(paramFile)
             .build();
-    Pair<List<String>, List<String>> result = linkConfig.splitCommandline();
-    assertThat(result.first).containsExactly("foo/bar/linker", "@some/file.params").inOrder();
-    assertThat(result.second).containsExactly("-shared", "-o", "a/FakeOutput", "").inOrder();
+    assertThat(linkConfig.getCommandLine(null))
+        .containsExactly("foo/bar/linker", "@some/file.params")
+        .inOrder();
+    assertThat(linkConfig.getParamCommandLine(null))
+        .containsExactly("-shared", "-o", "a/FakeOutput", "")
+        .inOrder();
   }
 
   @Test
@@ -378,10 +383,13 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .forceToolPath("foo/bar/ar")
             .setParamFile(paramFile)
             .build();
-    Pair<List<String>, List<String>> result = linkConfig.splitCommandline();
 
-    assertThat(result.first).isEqualTo(Arrays.asList("foo/bar/ar", "@some/file.params"));
-    assertThat(result.second).isEqualTo(Arrays.asList("rcsD", "a/FakeOutput", "foo.o", "bar.o"));
+    assertThat(linkConfig.getCommandLine(null))
+        .containsExactly("foo/bar/ar", "@some/file.params")
+        .inOrder();
+    assertThat(linkConfig.getParamCommandLine(null))
+        .containsExactly("rcsD", "a/FakeOutput", "foo.o", "bar.o")
+        .inOrder();
   }
 
   private SpecialArtifact createTreeArtifact(String name) {


### PR DESCRIPTION
Cherry-picks of:
c92ecbf Replace calls to getRawLinkArgv with calls to arguments
3490df2 Merge extractArgumentsForStaticLinkParamFile and extractArgumentsForDynamicLinkParamFile
b5cfea5 Refactor splitting of LinkerCommandLine

Fixes: https://github.com/bazelbuild/bazel/issues/20761