### PR TITLE
[7.1.0] Avoid exception-based control flow in RemoteActionFileSystem#stat.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -605,14 +605,16 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
       }
     }
 
-    try {
-      return remoteOutputTree.stat(path, /* followSymlinks= */ false);
-    } catch (FileNotFoundException e) {
-      if (statSources == StatSources.ALL) {
-        return localFs.getPath(path).stat(Symlinks.NOFOLLOW);
-      }
-      throw e;
+    FileStatus stat = remoteOutputTree.statIfFound(path, /* followSymlinks= */ false);
+    if (stat != null) {
+      return stat;
     }
+
+    if (statSources == StatSources.ALL) {
+      return localFs.getPath(path).stat(Symlinks.NOFOLLOW);
+    }
+
+    throw new FileNotFoundException(path.getPathString() + " (No such file or directory)");
   }
 
   private static FileStatusWithMetadata statFromMetadata(FileArtifactValue m) {


### PR DESCRIPTION
When statting a file in the local filesystem, we first call InMemoryFileSystem#stat, which unnecessarily allocates and throws a FileNotFoundException. Instead, call InMemoryFileSystem#statIfFound, which doesn't.

PiperOrigin-RevId: 604253151
Change-Id: Iabb9573f710e657a9ea893f1f7577a6b4bb147d2