### PR TITLE
cpp/blaze_util: handle clock_gettime failure

### DIFF
--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -148,7 +148,10 @@ string GetSelfPath(const char* argv0) {
 
 uint64_t GetMillisecondsMonotonic() {
   struct timespec ts = {};
-  clock_gettime(CLOCK_MONOTONIC, &ts);
+  if (clock_gettime(CLOCK_MONOTONIC, &ts)) {
+    BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
+        << "error calling clock_gettime: " << GetLastErrorString();
+  }
   return ts.tv_sec * 1000LL + (ts.tv_nsec / 1000000LL);
 }
 

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -84,7 +84,10 @@ void WarnFilesystemType(const blaze_util::Path &output_base) {
 
 uint64_t GetMillisecondsMonotonic() {
   struct timespec ts = {};
-  clock_gettime(CLOCK_MONOTONIC, &ts);
+  if (clock_gettime(CLOCK_MONOTONIC, &ts)) {
+    BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
+        << "error calling clock_gettime: " << GetLastErrorString();
+  }
   return ts.tv_sec * 1000LL + (ts.tv_nsec / 1000000LL);
 }
 


### PR DESCRIPTION
On some client environments, the system clock could erronous causing
clock_gettime to fail with invalid values.

Capture the exist code of this syscall and terminate Bazel accordingly.
