### PR TITLE
[7.1.0] Error on invalid path characters in `.bazelignore`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3127,7 +3127,9 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         // Ignored package prefixes are specified relative to the workspace root
         // by definition of .bazelignore. So, we only use ignored paths when the
         // package root is equal to the workspace path.
-        if (workspacePath != null && workspacePath.equals(pathEntry.asPath())) {
+        if (workspacePath != null
+            && workspacePath.equals(pathEntry.asPath())
+            && ignoredPackagePrefixesValue != null) {
           ignoredPaths =
               ignoredPackagePrefixesValue.getPatterns().stream()
                   .map(pathEntry::getRelative)

--- a/src/test/shell/bazel/bazelignore_test.sh
+++ b/src/test/shell/bazel/bazelignore_test.sh
@@ -206,4 +206,15 @@ EOI
     assert_not_contains "ignoreme" output
 }
 
+test_invalid_path() {
+    rm -rf work && mkdir work && cd work
+    create_workspace_with_default_repos WORKSPACE
+    echo -e "foo/\0/bar" > .bazelignore
+    echo 'filegroup(name="f", srcs=glob(["**"]))' > BUILD
+    if bazel build //... 2> "$TEST_log"; then
+      fail "Bazel build should have failed"
+    fi
+    expect_log "java.nio.file.InvalidPathException: Nul character not allowed"
+}
+
 run_suite "Integration tests for .bazelignore"


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/20906.
cc @meteorcloudy

Closes #21170.

Commit https://github.com/bazelbuild/bazel/commit/026f493a5a403fa5d770cae0b3a3baf8dcf33488

PiperOrigin-RevId: 605291552
Change-Id: I8d42729f176b4325ee402c0c6143db9d534c5e0b