### PR TITLE
Update LibrariesToLinkCollector.java to

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
@@ -607,10 +607,10 @@ public class LibrariesToLinkCollector {
     // -lfoo -> libfoo.so
     // -l:foo -> foo.so
     // -l:libfoo.so.1 -> libfoo.so.1
-    boolean hasCompatibleName =
-        name.startsWith("lib") || (!name.endsWith(".so") && !name.endsWith(".dylib"));
+    // Stripping .dll added. Excess escape removed. hasCompatibleName logic corrected.
+    boolean hasCompatibleName = name.endsWith(".so") || name.endsWith(".dylib") || name.endsWith(".dll");
     if (CppFileTypes.SHARED_LIBRARY.matches(name) && hasCompatibleName) {
-      String libName = name.replaceAll("(^lib|\\.(so|dylib)$)", "");
+      String libName = name.replaceAll("(^lib|\.(so|dylib|dll)$)", "");
       librariesToLink.addValue(LibraryToLinkValue.forDynamicLibrary(libName));
     } else if (CppFileTypes.SHARED_LIBRARY.matches(name)
         || CppFileTypes.VERSIONED_SHARED_LIBRARY.matches(name)) {


### PR DESCRIPTION
If .dll library is built using GCC in Windows the name has to be stripped before passing as -l option.