### PR TITLE
DLL name stripping support for libraries built in Windows using GCC

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
@@ -607,10 +607,9 @@ public class LibrariesToLinkCollector {
     // -lfoo -> libfoo.so
     // -l:foo -> foo.so
     // -l:libfoo.so.1 -> libfoo.so.1
-    boolean hasCompatibleName =
-        name.startsWith("lib") || (!name.endsWith(".so") && !name.endsWith(".dylib"));
+    boolean hasCompatibleName = name.endsWith(".so") || name.endsWith(".dylib") || name.endsWith(".dll");
     if (CppFileTypes.SHARED_LIBRARY.matches(name) && hasCompatibleName) {
-      String libName = name.replaceAll("(^lib|\\.(so|dylib)$)", "");
+      String libName = name.replaceAll("(^lib|\\.(so|dylib|dll)$)", "");
       librariesToLink.addValue(LibraryToLinkValue.forDynamicLibrary(libName));
     } else if (CppFileTypes.SHARED_LIBRARY.matches(name)
         || CppFileTypes.VERSIONED_SHARED_LIBRARY.matches(name)) {


### PR DESCRIPTION
Fixes [#9696](https://github.com/bazelbuild/bazel/issues/19696#issue-1921625702)
.dll has to be stripped to enable linkage with DLL created by GCC in Windows