### PR TITLE
[7.1.0] Add `add_exports/add_opens` to bazel java_binary deploy jars

### DIFF
--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_deploy_jar.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_deploy_jar.bzl
@@ -55,6 +55,8 @@ def _bazel_deploy_jars_impl(ctx):
         info.strip_as_default,
         build_info_files,
         str(ctx.attr.binary.label),
+        add_exports = info.add_exports,
+        add_opens = info.add_opens,
         manifest_lines = info.manifest_lines,
     )
 

--- a/src/main/starlark/builtins_bzl/common/java/java_binary_deploy_jar.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary_deploy_jar.bzl
@@ -115,6 +115,8 @@ def create_deploy_archives(
             output = ctx.outputs.unstrippeddeployjar,
             multi_release = multi_release,
             hermetic = hermetic,
+            add_exports = add_exports,
+            add_opens = add_opens,
             extra_args = extra_args,
         )
     else:


### PR DESCRIPTION
Also propagates these in the unstripped case, which presumably was missed in unknown commit

Fixes: https://github.com/bazelbuild/bazel/issues/21243
Commit https://github.com/bazelbuild/bazel/commit/e16f11b18a51f0f02d647e371a34c02fa76c531b

PiperOrigin-RevId: 605543271
Change-Id: I57bc46074a289fa584acab147e11228e9dcf3eee