### PR TITLE
[7.1.0] Manipulate the local filesystem directly in the writeLocalFile test helper.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -1139,8 +1139,9 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
   @Override
   protected void writeLocalFile(FileSystem actionFs, PathFragment path, String content)
       throws IOException {
-    actionFs.getPath(path).getParentDirectory().createDirectoryAndParents();
-    FileSystemUtils.writeContent(actionFs.getPath(path), UTF_8, content);
+    FileSystem localFs = getLocalFileSystem(actionFs);
+    localFs.getPath(path).getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.writeContent(localFs.getPath(path), UTF_8, content);
   }
 
   /** Returns a remote artifact and puts its metadata into the action input map. */


### PR DESCRIPTION
To ensure that we're actually modifying the local filesystem, even if the RemoteActionFileSystem#getOutputStream implementation changes in the future.

PiperOrigin-RevId: 605539937
Change-Id: I1e17642153e2faec357a0778b9673c1f3fff0ea8