### PR TITLE
[7.1.0] Make it possible to toggle cache key scrubbing by rule kind

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.remote.RemoteScrubbing.Config;
@@ -104,6 +105,7 @@ public class Scrubber {
 
     private final Pattern mnemonicPattern;
     private final Pattern labelPattern;
+    private final Pattern kindPattern;
     private final boolean matchTools;
 
     private final ImmutableList<Pattern> omittedInputPatterns;
@@ -114,6 +116,7 @@ public class Scrubber {
       Config.Matcher matcherProto = ruleProto.getMatcher();
       this.mnemonicPattern = Pattern.compile(emptyToAll(matcherProto.getMnemonic()));
       this.labelPattern = Pattern.compile(emptyToAll(matcherProto.getLabel()));
+      this.kindPattern = Pattern.compile(emptyToAll(matcherProto.getKind()));
       this.matchTools = matcherProto.getMatchTools();
 
       Config.Transform transformProto = ruleProto.getTransform();
@@ -134,12 +137,15 @@ public class Scrubber {
     /** Whether this scrubber applies to the given {@link Spawn}. */
     private boolean matches(Spawn spawn) {
       String mnemonic = spawn.getMnemonic();
-      String label = spawn.getResourceOwner().getOwner().getLabel().getCanonicalForm();
-      boolean isForTool = spawn.getResourceOwner().getOwner().isBuildConfigurationForTool();
+      ActionOwner actionOwner = spawn.getResourceOwner().getOwner();
+      String label = actionOwner.getLabel().getCanonicalForm();
+      String kind = actionOwner.getTargetKind();
+      boolean isForTool = actionOwner.isBuildConfigurationForTool();
 
       return (!isForTool || matchTools)
           && mnemonicPattern.matcher(mnemonic).matches()
-          && labelPattern.matcher(label).matches();
+          && labelPattern.matcher(label).matches()
+          && kindPattern.matcher(kind).matches();
     }
 
     /** Whether the given input should be omitted from the cache key. */

--- a/src/main/protobuf/remote_scrubbing.proto
+++ b/src/main/protobuf/remote_scrubbing.proto
@@ -23,6 +23,10 @@ option java_package = "com.google.devtools.build.lib.remote";
 message Config {
   // Describes a set of actions. An action must pass all criteria to match.
   message Matcher {
+    // A regex matching the rule kind of the action owner.
+    // Use .* if a partial match is desired.
+    // If empty, matches every kind.
+    string kind = 4;
     // A regex matching the canonical label of the action owner.
     // Use .* if a partial match is desired.
     // If empty, matches every label.

--- a/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
@@ -43,7 +43,8 @@ import net.starlark.java.syntax.Location;
 public class FakeOwner implements ActionExecutionMetadata {
   private final String mnemonic;
   private final String progressMessage;
-  @Nullable private final String ownerLabel;
+  private final String ownerLabel;
+  private final String ownerRuleKind;
   @Nullable private final Artifact primaryOutput;
   @Nullable private final PlatformInfo platform;
   private final ImmutableMap<String, String> execProperties;
@@ -53,6 +54,7 @@ public class FakeOwner implements ActionExecutionMetadata {
       String mnemonic,
       String progressMessage,
       String ownerLabel,
+      String ownerRuleKind,
       @Nullable Artifact primaryOutput,
       @Nullable PlatformInfo platform,
       ImmutableMap<String, String> execProperties,
@@ -60,6 +62,7 @@ public class FakeOwner implements ActionExecutionMetadata {
     this.mnemonic = mnemonic;
     this.progressMessage = progressMessage;
     this.ownerLabel = checkNotNull(ownerLabel);
+    this.ownerRuleKind = checkNotNull(ownerRuleKind);
     this.primaryOutput = primaryOutput;
     this.platform = platform;
     this.execProperties = execProperties;
@@ -72,6 +75,7 @@ public class FakeOwner implements ActionExecutionMetadata {
         mnemonic,
         progressMessage,
         ownerLabel,
+        /* ownerRuleKind= */ "dummy-target-kind",
         /* primaryOutput= */ null,
         platform,
         ImmutableMap.of(),
@@ -87,7 +91,7 @@ public class FakeOwner implements ActionExecutionMetadata {
     return ActionOwner.createDummy(
         Label.parseCanonicalUnchecked(ownerLabel),
         new Location("dummy-file", 0, 0),
-        /* targetKind= */ "dummy-target-kind",
+        ownerRuleKind,
         mnemonic,
         /* configurationChecksum= */ "configurationChecksum",
         new BuildConfigurationEvent(

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -47,6 +47,7 @@ public final class SpawnBuilder {
   private String mnemonic = "Mnemonic";
   private String progressMessage = "progress message";
   private String ownerLabel = "//dummy:label";
+  private String ownerRuleKind = "dummy-target-kind";
   @Nullable private Artifact ownerPrimaryOutput;
   @Nullable private PlatformInfo platform;
   private final List<String> args;
@@ -96,6 +97,7 @@ public final class SpawnBuilder {
             mnemonic,
             progressMessage,
             ownerLabel,
+            ownerRuleKind,
             ownerPrimaryOutput,
             platform,
             execProperties,
@@ -137,6 +139,12 @@ public final class SpawnBuilder {
   @CanIgnoreReturnValue
   public SpawnBuilder withOwnerLabel(String ownerLabel) {
     this.ownerLabel = checkNotNull(ownerLabel);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public SpawnBuilder withOwnerRuleKind(String ownerRuleKind) {
+    this.ownerRuleKind = checkNotNull(ownerRuleKind);
     return this;
   }
 


### PR DESCRIPTION
Add the target kind (e.g. java_library) to the scrubbing matcher configuration. This is useful because different kinds may use the same mnemonic, and specifying an explicit set of labels is labor-intensive and error-prone.

Closes #21151.

Commit https://github.com/bazelbuild/bazel/commit/4bcf8552d32ee11e28fba1134c6ea2fd2e801e88

PiperOrigin-RevId: 605624773
Change-Id: Ib5748ca2dbb3fd6d30b27fc1b292d7cd826ced62