### PR TITLE
Move sandbox_stash to sandboxBase from outputBase

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
@@ -42,8 +42,8 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
   final Path sandboxExecRoot;
   private final ImmutableList<String> arguments;
   private final ImmutableMap<String, String> environment;
-  final SandboxInputs inputs;
-  final SandboxOutputs outputs;
+  protected final SandboxInputs inputs;
+  protected final SandboxOutputs outputs;
   private final Set<Path> writableDirs;
   protected final TreeDeleter treeDeleter;
   @Nullable private final Path sandboxDebugPath;

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AsynchronousTreeDeleter.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AsynchronousTreeDeleter.java
@@ -38,6 +38,9 @@ import javax.annotation.Nullable;
  * finished, this number should be raised to quickly go through any pending deletions.
  */
 public class AsynchronousTreeDeleter implements TreeDeleter {
+
+  public static final String MOVED_TRASH_DIR = "_moved_trash_dir";
+
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private final AtomicInteger trashCount = new AtomicInteger(0);

--- a/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -75,6 +75,7 @@ java_library(
         ":sandbox_helpers",
         ":sandbox_options",
         "//src/main/java/com/google/devtools/build/lib/exec:tree_deleter",
+        "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/util:command",
         "//src/main/java/com/google/devtools/build/lib/util:describable_execution_unit",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.sandbox;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.Subscribe;
@@ -55,6 +56,7 @@ import com.google.devtools.common.options.TriState;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -62,6 +64,9 @@ import javax.annotation.Nullable;
 
 /** This module provides the Sandbox spawn strategy. */
 public final class SandboxModule extends BlazeModule {
+
+  private static final Set<String> SANDBOX_BASE_PERSISTENT_DIRS = new HashSet<>(
+      Arrays.asList(SandboxStash.SANDBOX_STASH_BASE, AsynchronousTreeDeleter.MOVED_TRASH_DIR));
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
@@ -81,7 +86,7 @@ public final class SandboxModule extends BlazeModule {
    * completion but to avoid wiping the whole sandbox base itself, which could be problematic across
    * builds.
    */
-  private final Set<SpawnRunner> spawnRunners = new HashSet<>();
+  private final Set<SandboxFallbackSpawnRunner> spawnRunners = new HashSet<>();
 
   /**
    * Handler to process expensive tree deletions outside of the critical path.
@@ -193,7 +198,7 @@ public final class SandboxModule extends BlazeModule {
       throws IOException, InterruptedException {
     SandboxOptions options = checkNotNull(env.getOptions().getOptions(SandboxOptions.class));
     sandboxBase = computeSandboxBase(options, env);
-    Path trashBase = sandboxBase.getRelative("_moved_trash_dir");
+    Path trashBase = sandboxBase.getRelative(AsynchronousTreeDeleter.MOVED_TRASH_DIR);
 
     SandboxHelpers helpers = new SandboxHelpers();
 
@@ -221,8 +226,28 @@ public final class SandboxModule extends BlazeModule {
     // previous builds. However, on the very first build of an instance of the server, we must
     // wipe old contents to avoid reusing stale directories.
     if (firstBuild && sandboxBase.exists()) {
-      cmdEnv.getReporter().handle(Event.info("Deleting stale sandbox base " + sandboxBase));
-      sandboxBase.deleteTree();
+      if (trashBase.exists()) {
+        // Delete stale trash from a previous server instance.
+        Path staleTrash = getStaleTrashDir(trashBase);
+        trashBase.renameTo(staleTrash);
+        trashBase.createDirectory();
+        treeDeleter.deleteTree(staleTrash);
+      } else {
+        trashBase.createDirectory();
+      }
+      // We can delete other dirs asynchronously (if the flag is on).
+      for (Path entry : sandboxBase.getDirectoryEntries()) {
+        if (entry.getBaseName().equals(AsynchronousTreeDeleter.MOVED_TRASH_DIR)) {
+          continue;
+        }
+        if (entry.getBaseName().equals("inaccessibleHelperDir")) {
+          entry.deleteTree();
+        } else if (entry.isDirectory()) {
+          treeDeleter.deleteTree(entry);
+        } else {
+          entry.delete();
+        }
+      }
     }
     firstBuild = false;
     sandboxBase.createDirectoryAndParents();
@@ -247,7 +272,7 @@ public final class SandboxModule extends BlazeModule {
     // This works on most platforms, but isn't the best choice, so we put it first and let later
     // platform-specific sandboxing strategies become the default.
     if (processWrapperSupported) {
-      SpawnRunner spawnRunner =
+      SandboxFallbackSpawnRunner spawnRunner =
           withFallback(
               cmdEnv,
               new ProcessWrapperSandboxedSpawnRunner(
@@ -271,7 +296,7 @@ public final class SandboxModule extends BlazeModule {
       if (pathToDocker != null && DockerSandboxedSpawnRunner.isSupported(cmdEnv, pathToDocker)) {
         String defaultImage = options.dockerImage;
         boolean useCustomizedImages = options.dockerUseCustomizedImages;
-        SpawnRunner spawnRunner =
+        SandboxFallbackSpawnRunner spawnRunner =
             withFallback(
                 cmdEnv,
                 new DockerSandboxedSpawnRunner(
@@ -298,7 +323,7 @@ public final class SandboxModule extends BlazeModule {
 
     // This is the preferred sandboxing strategy on Linux.
     if (linuxSandboxSupported) {
-      SpawnRunner spawnRunner =
+      SandboxFallbackSpawnRunner spawnRunner =
           withFallback(
               cmdEnv,
               LinuxSandboxedStrategy.create(
@@ -316,7 +341,7 @@ public final class SandboxModule extends BlazeModule {
 
     // This is the preferred sandboxing strategy on macOS.
     if (darwinSandboxSupported) {
-      SpawnRunner spawnRunner =
+      SandboxFallbackSpawnRunner spawnRunner =
           withFallback(
               cmdEnv,
               new DarwinSandboxedSpawnRunner(
@@ -332,7 +357,7 @@ public final class SandboxModule extends BlazeModule {
     }
 
     if (windowsSandboxSupported) {
-      SpawnRunner spawnRunner =
+      SandboxFallbackSpawnRunner spawnRunner =
           withFallback(
               cmdEnv,
               new WindowsSandboxedSpawnRunner(
@@ -383,7 +408,7 @@ public final class SandboxModule extends BlazeModule {
     return null;
   }
 
-  private static SpawnRunner withFallback(
+  private static SandboxFallbackSpawnRunner withFallback(
       CommandEnvironment env, AbstractSandboxSpawnRunner sandboxSpawnRunner) {
     SandboxOptions sandboxOptions = env.getOptions().getOptions(SandboxOptions.class);
     return new SandboxFallbackSpawnRunner(
@@ -484,29 +509,27 @@ public final class SandboxModule extends BlazeModule {
         fallbackSpawnRunner.cleanupSandboxBase(sandboxBase, treeDeleter);
       }
     }
+
+    public SpawnRunner getSandboxSpawnRunner() {
+      return sandboxSpawnRunner;
+    }
   }
 
   @Subscribe
   public void cleanStarting(@SuppressWarnings("unused") CleanStartingEvent event) {
-    SandboxStash.clean(treeDeleter, env.getOutputBase());
+    SandboxStash.clean(treeDeleter, sandboxBase);
   }
 
   /**
-   * Best-effort cleanup of the sandbox base assuming all per-spawn contents have been removed.
-   *
-   * <p>When this gets called, the individual trees of each spawn should have been cleaned up but we
-   * may be left with the top-level subdirectories used by each sandboxed spawn runner (e.g. {@code
-   * darwin-sandbox}) and the sandbox base itself. Try to delete those so that a Bazel server
-   * restart doesn't print a spurious {@code Deleting stale sandbox base} message.
+   *  If there is anything other than SANDBOX_BASE_PERSISTENT_DIRS in sandboxBase when we hit
+   *  this precondition then there is a programming error somewhere (or I made a wrong assumption
+   *  that wasn't caught by any of our tests).
    */
-  private static void cleanupSandboxBaseTop(Path sandboxBase) {
+  private static void checkSandboxBaseTopOnlyContainsPersistentDirs(Path sandboxBase) {
     try {
-      // This might be called twice for a given sandbox base, so don't bother recording error
-      // messages if any of the files we try to delete don't exist.
-      for (Path leftover : sandboxBase.getDirectoryEntries()) {
-        leftover.delete();
-      }
-      sandboxBase.delete();
+      Preconditions.checkState(SANDBOX_BASE_PERSISTENT_DIRS.containsAll(
+          sandboxBase.getDirectoryEntries().stream().map(Path::getBaseName).collect(
+              ImmutableList.toImmutableList())), "Please report this in https://github.com/bazelbuild/bazel/issues.");
     } catch (IOException e) {
       logger.atWarning().withCause(e).log("Failed to clean up sandbox base %s", sandboxBase);
     }
@@ -533,8 +556,9 @@ public final class SandboxModule extends BlazeModule {
     if (shouldCleanupSandboxBase) {
       try {
         checkNotNull(sandboxBase, "shouldCleanupSandboxBase implies sandboxBase has been set");
-        for (SpawnRunner spawnRunner : spawnRunners) {
+        for (SandboxFallbackSpawnRunner spawnRunner : spawnRunners) {
           spawnRunner.cleanupSandboxBase(sandboxBase, treeDeleter);
+          sandboxBase.getChild(spawnRunner.getSandboxSpawnRunner().getName()).delete();
         }
       } catch (IOException e) {
         env.getReporter()
@@ -542,7 +566,7 @@ public final class SandboxModule extends BlazeModule {
       }
       shouldCleanupSandboxBase = false;
 
-      cleanupSandboxBaseTop(sandboxBase);
+      checkSandboxBaseTopOnlyContainsPersistentDirs(sandboxBase);
       // We intentionally keep sandboxBase around, without resetting it to null, in case we have
       // asynchronous deletions going on. In that case, we'd still want to retry this during
       // shutdown.
@@ -565,10 +589,6 @@ public final class SandboxModule extends BlazeModule {
         treeDeleter = null; // Avoid potential reexecution if we crash.
       }
     }
-
-    if (sandboxBase != null) {
-      cleanupSandboxBaseTop(sandboxBase);
-    }
   }
 
   @Override
@@ -579,5 +599,11 @@ public final class SandboxModule extends BlazeModule {
   @Override
   public void blazeShutdownOnCrash(DetailedExitCode exitCode) {
     commonShutdown();
+  }
+
+  private Path getStaleTrashDir(Path trashBase) {
+    int i = 0;
+    while (trashBase.getParentDirectory().getChild("stale-trash-" + i++).exists());
+    return trashBase.getParentDirectory().getChild("stale-trash-" + --i);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -214,7 +214,7 @@ public final class SandboxModule extends BlazeModule {
         treeDeleter = new AsynchronousTreeDeleter(trashBase);
       }
     }
-    SandboxStash.initialize(env.getWorkspaceName(), env.getOutputBase(), options);
+    SandboxStash.initialize(env.getWorkspaceName(), sandboxBase, options);
 
     // SpawnExecutionPolicy#getId returns unique base directories for each sandboxed action during
     // the life of a Bazel server instance so we don't need to worry about stale directories from

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -75,7 +75,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
   public void filterInputsAndDirsToCreate(
       Set<PathFragment> inputsToCreate, LinkedHashSet<PathFragment> dirsToCreate)
       throws IOException, InterruptedException {
-    boolean gotStash = SandboxStash.takeStashedSandbox(sandboxPath, mnemonic);
+    boolean gotStash = SandboxStash.takeStashedSandbox(sandboxPath, mnemonic, getEnvironment(), outputs);
     sandboxExecRoot.createDirectoryAndParents();
     if (gotStash) {
       // When reusing an old sandbox, we do a full traversal of the parent directory of
@@ -101,7 +101,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
 
   @Override
   public void delete() {
-    SandboxStash.stashSandbox(sandboxPath, mnemonic);
+    SandboxStash.stashSandbox(sandboxPath, mnemonic, getEnvironment(), outputs);
     super.delete();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -75,7 +75,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
   public void filterInputsAndDirsToCreate(
       Set<PathFragment> inputsToCreate, LinkedHashSet<PathFragment> dirsToCreate)
       throws IOException, InterruptedException {
-    boolean gotStash = SandboxStash.takeStashedSandbox(sandboxPath, mnemonic, getEnvironment(), outputs);
+    boolean gotStash = SandboxStash.takeStashedSandbox(sandboxPath, mnemonic);
     sandboxExecRoot.createDirectoryAndParents();
     if (gotStash) {
       // When reusing an old sandbox, we do a full traversal of the parent directory of
@@ -101,7 +101,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
 
   @Override
   public void delete() {
-    SandboxStash.stashSandbox(sandboxPath, mnemonic, getEnvironment(), outputs);
+    SandboxStash.stashSandbox(sandboxPath, mnemonic);
     super.delete();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
@@ -110,7 +110,7 @@ public class WorkerModule extends BlazeModule {
     } else {
       workerSandboxOptions = null;
     }
-    Path trashBase = workerDir.getRelative("_moved_trash_dir");
+    Path trashBase = workerDir.getRelative(AsynchronousTreeDeleter.MOVED_TRASH_DIR);
     if (treeDeleter == null) {
       treeDeleter = new AsynchronousTreeDeleter(trashBase);
     }

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -38,8 +38,6 @@ function tear_down() {
 }
 
 function test_sandbox_base_keeps_dirs_with_sandbox_debug {
-  local extra_args=( "${@}" )
-
   mkdir pkg
   cat >pkg/BUILD <<EOF
 genrule(name = "pkg", outs = ["pkg.out"], cmd = "echo >\$@")
@@ -47,7 +45,7 @@ EOF
 
   local output_base="$(bazel info output_base)"
 
-  bazel build --sandbox_debug "${extra_args[@]}" //pkg >"${TEST_log}" 2>&1 || fail "Expected build to succeed"
+  bazel build --sandbox_debug //pkg >"${TEST_log}" 2>&1 || fail "Expected build to succeed"
   find "${output_base}" >>"${TEST_log}" 2>&1 || true
 
   local sandbox_dir="$(echo "${output_base}/sandbox"/*-sandbox)"
@@ -200,7 +198,7 @@ EOF
   [[ -d "${sandbox_base}/_moved_trash_dir" ]] \
     || fail "${sandbox_base}/_moved_trash_dir directory not present"
 
-  [[ $(ls -1 ${sandbox_base} | wc -l) == 2 ]] \
+  [[ $(ls -1 ${sandbox_base} | wc -l | tr -d ' ') == 2 ]] \
     || fail "${sandbox_base} contains stale dirs"
 }
 


### PR DESCRIPTION
Because the sandbox_base can be set via the configuration flag `--sandbox_base`, it might be that the stashes end up in a different filesystem than the actual sandbox, which makes `reuse_sandbox_directories` inefficient.

Apart from making sure that the stash is under `sandboxBase, this change refactors the logic about which directories to delete from `sandboxBase` and when. The stash will persist between incremental builds but after a bazel server restart it will be deleted.

This change also refactors the tests since we had three different tests which weren't testing anything different. It also adds more spans for profiling.