### PR TITLE
[7.1.0] Canonicalize the parent path in RemoteActionFileSystem#delete.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -291,8 +291,24 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
     return "remoteActionFS";
   }
 
+  // Like resolveSymbolicLinks(), except that only the parent path is canonicalized.
+  private PathFragment resolveSymbolicLinksForParent(PathFragment path) throws IOException {
+    PathFragment parentPath = path.getParentDirectory();
+    if (parentPath != null) {
+      return resolveSymbolicLinks(parentPath).asFragment().getChild(path.getBaseName());
+    }
+    return path;
+  }
+
   @Override
   protected boolean delete(PathFragment path) throws IOException {
+    try {
+      path = resolveSymbolicLinksForParent(path);
+    } catch (FileNotFoundException ignored) {
+      // Failure to delete a nonexistent path is not an error.
+      return false;
+    }
+
     boolean deleted = localFs.getPath(path).delete();
     if (isOutput(path)) {
       deleted = remoteOutputTree.getPath(path).delete() || deleted;
@@ -462,10 +478,7 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   protected PathFragment readSymbolicLink(PathFragment path) throws IOException {
-    PathFragment parentPath = path.getParentDirectory();
-    if (parentPath != null) {
-      path = resolveSymbolicLinks(parentPath).asFragment().getChild(path.getBaseName());
-    }
+    path = resolveSymbolicLinksForParent(path);
 
     if (path.startsWith(execRoot)) {
       var execPath = path.relativeTo(execRoot);
@@ -497,10 +510,7 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
   @Override
   protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
-    PathFragment parentPath = linkPath.getParentDirectory();
-    if (parentPath != null) {
-      linkPath = resolveSymbolicLinks(parentPath).asFragment().getChild(linkPath.getBaseName());
-    }
+    linkPath = resolveSymbolicLinksForParent(linkPath);
 
     if (isOutput(linkPath)) {
       remoteOutputTree.getPath(linkPath).createSymbolicLink(targetFragment);


### PR DESCRIPTION
FileSystem#delete is documented as not following symlinks, but that refers to the last component only; we are still required to canonicalize the parent path, possibly taking into account symlinks that straddle underlying sources.

PiperOrigin-RevId: 605583053
Change-Id: Iaae6b433dd631de459ef0ecaf09736c79c710ba0