### PR TITLE
Maintain a separate lockfile for HEAD Bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,6 +26,7 @@ filegroup(
     srcs = glob(
         ["*"],
         exclude = [
+            "MODULE.bazel.lock",  # Use MODULE.bazel.lock.dist instead
             "WORKSPACE.bzlmod",  # Needs to be filtered.
             "bazel-*",  # convenience symlinks
             "out",  # IntelliJ with setup-intellij.sh
@@ -141,6 +142,7 @@ pkg_tar(
     ],
     # TODO(aiuto): Replace with pkg_filegroup when that is available.
     remap_paths = {
+        "MODULE.bazel.lock.dist": "MODULE.bazel.lock",
         "WORKSPACE.bzlmod.filtered": "WORKSPACE.bzlmod",
         # Rewrite paths coming from local repositories back into third_party.
         "external/googleapis~override": "third_party/googleapis",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 """Bazel build and test dependencies."""
 
-# NOTE: When editing this file, also update the lockfile.
+# NOTE: When editing this file, also update various lockfiles.
+#   bazel run //src/test/tools/bzlmod:update_default_lock_file
 #   bazel mod deps --lockfile_mode=update
 
 module(

--- a/MODULE.bazel.lock.dist
+++ b/MODULE.bazel.lock.dist
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 3,
+  "lockFileVersion": 4,
   "moduleFileHash": "03f4d52d627bfd8bef68fb6535c3cf7bea5a4a11faca14d3ef068f417e2289e7",
   "flags": {
     "cmdRegistries": [
@@ -13,7 +13,7 @@
     "compatibilityMode": "ERROR"
   },
   "localOverrideHashes": {
-    "bazel_tools": "922ea6752dc9105de5af957f7a99a6933c0a6a712d23df6aad16a9c399f7e787",
+    "bazel_tools": "636a67d715edf0b8975380e853efffced76dcf0ce2b15c31520f5202416f58d2",
     "googleapis": "89bad67656f73e953cbf62f12165f56e97cf2cc17d56974c593de76200fa3471",
     "remoteapis": "3862bfbe3d308e71852b8f025f4b33ea9c0dc8790829eda4a71425c5a2ca814e"
   },
@@ -653,10 +653,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_license~0.0.7",
           "urls": [
             "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz"
           ],
@@ -684,10 +683,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "bazel_skylib~1.5.0",
           "urls": [
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
           ],
@@ -764,10 +762,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "protobuf~21.7",
           "urls": [
             "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protobuf-all-21.7.zip"
           ],
@@ -845,10 +842,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "grpc~1.48.1.bcr.1",
           "urls": [
             "https://github.com/grpc/grpc/archive/refs/tags/v1.48.1.tar.gz"
           ],
@@ -875,10 +871,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "platforms",
           "urls": [
             "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
           ],
@@ -905,10 +900,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_pkg~0.9.1",
           "urls": [
             "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz"
           ],
@@ -935,10 +929,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "stardoc~0.5.6",
           "urls": [
             "https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz"
           ],
@@ -962,10 +955,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "zstd-jni~1.5.2-3.bcr.1",
           "urls": [
             "https://github.com/luben/zstd-jni/archive/refs/tags/v1.5.2-3.zip"
           ],
@@ -994,10 +986,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "blake3~1.3.3.bcr.1",
           "urls": [
             "https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/1.3.3.tar.gz"
           ],
@@ -1026,10 +1017,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "zlib~1.3",
           "urls": [
             "https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz"
           ],
@@ -1077,10 +1067,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_cc~0.0.9",
           "urls": [
             "https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"
           ],
@@ -1180,10 +1169,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_java~7.3.2",
           "urls": [
             "https://github.com/bazelbuild/rules_java/releases/download/7.3.2/rules_java-7.3.2.tar.gz"
           ],
@@ -1212,10 +1200,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_graalvm~0.10.3",
           "urls": [
             "https://github.com/sgammon/rules_graalvm/releases/download/v0.10.3/rules_graalvm-0.10.3.zip"
           ],
@@ -1242,10 +1229,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_proto~5.3.0-21.7",
           "urls": [
             "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz"
           ],
@@ -1283,7 +1269,7 @@
           "hasNonDevUseExtension": true
         },
         {
-          "extensionBzlFile": ":extensions.bzl",
+          "extensionBzlFile": "@rules_jvm_external//:extensions.bzl",
           "extensionName": "maven",
           "usingModule": "rules_jvm_external@6.0",
           "location": {
@@ -1562,10 +1548,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_jvm_external~6.0",
           "urls": [
             "https://github.com/bazelbuild/rules_jvm_external/releases/download/6.0/rules_jvm_external-6.0.tar.gz"
           ],
@@ -1576,7 +1561,7 @@
           },
           "remote_patch_strip": 0,
           "patches": [
-            "//third_party:rules_jvm_external_6.0.patch"
+            "@@//third_party:rules_jvm_external_6.0.patch"
           ],
           "patch_cmds": [],
           "patch_args": [
@@ -1680,10 +1665,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_python~0.28.0",
           "urls": [
             "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
           ],
@@ -1710,10 +1694,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_testing~0.0.4",
           "urls": [
             "https://github.com/bazelbuild/rules_testing/releases/download/v0.0.4/rules_testing-v0.0.4.tar.gz"
           ],
@@ -1742,10 +1725,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "googletest~1.14.0",
           "urls": [
             "https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"
           ],
@@ -1830,10 +1812,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "apple_support~1.8.1",
           "urls": [
             "https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"
           ],
@@ -1862,10 +1843,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "abseil-cpp~20230125.1",
           "urls": [
             "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.1.tar.gz"
           ],
@@ -1894,10 +1874,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "c-ares~1.15.0",
           "urls": [
             "https://github.com/c-ares/c-ares/releases/download/cares-1_15_0/c-ares-1.15.0.tar.gz"
           ],
@@ -2031,10 +2010,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_go~0.39.1",
           "urls": [
             "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"
           ],
@@ -2166,10 +2144,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_kotlin~1.9.0",
           "urls": [
             "https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.0/rules_kotlin-v1.9.0.tar.gz"
           ],
@@ -2200,10 +2177,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "upb~0.0.0-20220923-a547704",
           "urls": [
             "https://github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz"
           ],
@@ -2233,7 +2209,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 17,
+            "line": 18,
             "column": 29
           },
           "imports": {
@@ -2251,7 +2227,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 21,
+            "line": 22,
             "column": 32
           },
           "imports": {
@@ -2268,7 +2244,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 24,
+            "line": 25,
             "column": 32
           },
           "imports": {
@@ -2290,7 +2266,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 35,
+            "line": 36,
             "column": 39
           },
           "imports": {
@@ -2307,7 +2283,7 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 39,
+            "line": 40,
             "column": 48
           },
           "imports": {
@@ -2324,12 +2300,29 @@
           "usingModule": "bazel_tools@_",
           "location": {
             "file": "@@bazel_tools//:MODULE.bazel",
-            "line": 42,
+            "line": 43,
             "column": 42
           },
           "imports": {
             "android_gmaven_r8": "android_gmaven_r8",
             "android_tools": "android_tools"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@buildozer//:buildozer_binary.bzl",
+          "extensionName": "buildozer_binary",
+          "usingModule": "bazel_tools@_",
+          "location": {
+            "file": "@@bazel_tools//:MODULE.bazel",
+            "line": 47,
+            "column": 33
+          },
+          "imports": {
+            "buildozer_binary": "buildozer_binary"
           },
           "devImports": [],
           "tags": [],
@@ -2343,6 +2336,7 @@
         "rules_license": "rules_license@0.0.7",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "rules_python": "rules_python@0.28.0",
+        "buildozer": "buildozer@6.4.0.2",
         "platforms": "platforms@0.0.8",
         "com_google_protobuf": "protobuf@21.7",
         "zlib": "zlib@1.3",
@@ -2377,10 +2371,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "boringssl~0.0.0-20211025-d4f1ab9",
           "urls": [
             "https://github.com/google/boringssl/archive/d4f1ab983065e4616319f59c723c7b9870021fae.tar.gz"
           ],
@@ -2407,10 +2400,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "re2~2021-09-01",
           "urls": [
             "https://github.com/google/re2/archive/refs/tags/2021-09-01.zip"
           ],
@@ -2455,10 +2447,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "bazel_features~1.1.1",
           "urls": [
             "https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"
           ],
@@ -2580,10 +2571,9 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "gazelle~0.30.0",
           "urls": [
             "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"
           ],
@@ -2593,12 +2583,78 @@
           "remote_patch_strip": 0
         }
       }
+    },
+    "buildozer@6.4.0.2": {
+      "name": "buildozer",
+      "version": "6.4.0.2",
+      "key": "buildozer@6.4.0.2",
+      "repoName": "buildozer",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@buildozer//:buildozer_binary.bzl",
+          "extensionName": "buildozer_binary",
+          "usingModule": "buildozer@6.4.0.2",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/buildozer/6.4.0.2/MODULE.bazel",
+            "line": 7,
+            "column": 33
+          },
+          "imports": {
+            "buildozer_binary": "buildozer_binary"
+          },
+          "devImports": [],
+          "tags": [
+            {
+              "tagName": "buildozer",
+              "attributeValues": {
+                "sha256": {
+                  "darwin-amd64": "d29e347ecd6b5673d72cb1a8de05bf1b06178dd229ff5eb67fad5100c840cc8e",
+                  "darwin-arm64": "9b9e71bdbec5e7223871e913b65d12f6d8fa026684daf991f00e52ed36a6978d",
+                  "linux-amd64": "8dfd6345da4e9042daa738d7fdf34f699c5dfce4632f7207956fceedd8494119",
+                  "linux-arm64": "6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa",
+                  "windows-amd64": "e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b"
+                },
+                "version": "6.4.0"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/buildozer/6.4.0.2/MODULE.bazel",
+                "line": 8,
+                "column": 27
+              }
+            }
+          ],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "urls": [
+            "https://github.com/fmeum/buildozer/releases/download/v6.4.0.2/buildozer-v6.4.0.2.tar.gz"
+          ],
+          "integrity": "sha256-k7tFKQMR2AygxpmZfH0yEPnQmF3efFgD9rBPkj+Yz/8=",
+          "strip_prefix": "buildozer-6.4.0.2",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/buildozer/6.4.0.2/patches/module_dot_bazel_version.patch": "sha256-gKANF2HMilj7bWmuXs4lbBIAAansuWC4IhWGB/CerjU="
+          },
+          "remote_patch_strip": 1
+        }
+      }
     }
   },
   "moduleExtensions": {
     "//:extensions.bzl%bazel_android_deps": {
       "general": {
-        "bzlTransitiveDigest": "uzRwJ/aaGLzKqN69Hz+DktJFrVeKCjILtM+t4Hirz0M=",
+        "bzlTransitiveDigest": "t+ILJLlq7q0/p+k9yKj4bCrNS+xIVnuPdJ2Ji47/lsE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2606,7 +2662,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "_main~bazel_android_deps~desugar_jdk_libs",
               "sha256": "ef71be474fbb3b3b7bd70cda139f01232c63b9e1bbd08c058b00a8d538d4db17",
               "strip_prefix": "desugar_jdk_libs-24dcd1dead0b64aae3d7c89ca9646b5dc4068009",
               "url": "https://github.com/google/desugar_jdk_libs/archive/24dcd1dead0b64aae3d7c89ca9646b5dc4068009.zip"
@@ -2617,17 +2672,17 @@
           [
             "",
             "abseil-cpp",
-            "abseil-cpp~20230125.1"
+            "abseil-cpp~"
           ],
           [
             "",
             "apple_support",
-            "apple_support~1.8.1"
+            "apple_support~"
           ],
           [
             "",
             "bazel_skylib",
-            "bazel_skylib~1.5.0"
+            "bazel_skylib~"
           ],
           [
             "",
@@ -2637,27 +2692,27 @@
           [
             "",
             "blake3",
-            "blake3~1.3.3.bcr.1"
+            "blake3~"
           ],
           [
             "",
             "c-ares",
-            "c-ares~1.15.0"
+            "c-ares~"
           ],
           [
             "",
             "com_github_grpc_grpc",
-            "grpc~1.48.1.bcr.1"
+            "grpc~"
           ],
           [
             "",
             "com_google_protobuf",
-            "protobuf~21.7"
+            "protobuf~"
           ],
           [
             "",
             "io_bazel_skydoc",
-            "stardoc~0.5.6"
+            "stardoc~"
           ],
           [
             "",
@@ -2667,67 +2722,67 @@
           [
             "",
             "rules_cc",
-            "rules_cc~0.0.9"
+            "rules_cc~"
           ],
           [
             "",
             "rules_go",
-            "rules_go~0.39.1"
+            "rules_go~"
           ],
           [
             "",
             "rules_graalvm",
-            "rules_graalvm~0.10.3"
+            "rules_graalvm~"
           ],
           [
             "",
             "rules_java",
-            "rules_java~7.3.2"
+            "rules_java~"
           ],
           [
             "",
             "rules_jvm_external",
-            "rules_jvm_external~6.0"
+            "rules_jvm_external~"
           ],
           [
             "",
             "rules_kotlin",
-            "rules_kotlin~1.9.0"
+            "rules_kotlin~"
           ],
           [
             "",
             "rules_license",
-            "rules_license~0.0.7"
+            "rules_license~"
           ],
           [
             "",
             "rules_pkg",
-            "rules_pkg~0.9.1"
+            "rules_pkg~"
           ],
           [
             "",
             "rules_proto",
-            "rules_proto~5.3.0-21.7"
+            "rules_proto~"
           ],
           [
             "",
             "rules_python",
-            "rules_python~0.28.0"
+            "rules_python~"
           ],
           [
             "",
             "upb",
-            "upb~0.0.0-20220923-a547704"
+            "upb~"
           ],
           [
             "",
             "zlib",
-            "zlib~1.3"
+            "zlib~"
           ],
           [
             "",
             "zstd-jni",
-            "zstd-jni~1.5.2-3.bcr.1"
+            "zstd-jni~"
           ],
           [
             "bazel_tools",
@@ -2739,7 +2794,7 @@
     },
     "//:extensions.bzl%bazel_build_deps": {
       "general": {
-        "bzlTransitiveDigest": "uzRwJ/aaGLzKqN69Hz+DktJFrVeKCjILtM+t4Hirz0M=",
+        "bzlTransitiveDigest": "t+ILJLlq7q0/p+k9yKj4bCrNS+xIVnuPdJ2Ji47/lsE=",
         "accumulatedFileDigests": {
           "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "e591609d4999da0cac2aad19df3ff8a1e42f3f032fb16308037d0d9e555f369f",
           "@@//:MODULE.bazel": "03f4d52d627bfd8bef68fb6535c3cf7bea5a4a11faca14d3ef068f417e2289e7"
@@ -2750,7 +2805,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "_main~bazel_build_deps~openjdk_macos_aarch64_vanilla",
               "sha256": "2a7a99a3ea263dbd8d32a67d1e6e363ba8b25c645c826f5e167a02bbafaff1fa",
               "downloaded_file_path": "zulu-macos-aarch64-vanilla.tar.gz",
               "url": "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_aarch64.tar.gz"
@@ -2760,7 +2814,6 @@
             "bzlFile": "@@//:distdir.bzl",
             "ruleClassName": "repo_cache_tar",
             "attributes": {
-              "name": "_main~bazel_build_deps~bazel_tools_repo_cache",
               "repos": [
                 "rules_cc~0.0.9",
                 "rules_java~7.3.2",
@@ -2787,7 +2840,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "_main~bazel_build_deps~openjdk_linux_vanilla",
               "sha256": "0c0eadfbdc47a7ca64aeab51b9c061f71b6e4d25d2d87674512e9b6387e9e3a6",
               "downloaded_file_path": "zulu-linux-vanilla.tar.gz",
               "url": "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-linux_x64.tar.gz"
@@ -2797,7 +2849,6 @@
             "bzlFile": "@@//tools/distributions:system_repo.bzl",
             "ruleClassName": "system_repo",
             "attributes": {
-              "name": "_main~bazel_build_deps~debian_cc_deps",
               "symlinks": {},
               "build_file": "@@//tools/distributions/debian:debian_cc.BUILD"
             }
@@ -2806,7 +2857,6 @@
             "bzlFile": "@@//tools/distributions:system_repo.bzl",
             "ruleClassName": "system_repo",
             "attributes": {
-              "name": "_main~bazel_build_deps~debian_java_deps",
               "symlinks": {
                 "java": "/usr/share/java"
               },
@@ -2817,7 +2867,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "_main~bazel_build_deps~openjdk_linux_s390x_vanilla",
               "sha256": "0d5676c50821e0d0b951bf3ffd717e7a13be2a89d8848a5c13b4aedc6f982c78",
               "downloaded_file_path": "adoptopenjdk-s390x-vanilla.tar.gz",
               "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_s390x_linux_hotspot_21.0.2_13.tar.gz"
@@ -2827,38 +2876,37 @@
             "bzlFile": "@@//:distdir.bzl",
             "ruleClassName": "repo_cache_tar",
             "attributes": {
-              "name": "_main~bazel_build_deps~bootstrap_repo_cache",
               "repos": [
-                "abseil-cpp~20230125.1",
-                "apple_support~1.8.1",
-                "bazel_skylib~1.5.0",
-                "blake3~1.3.3.bcr.1",
-                "c-ares~1.15.0",
-                "grpc~1.48.1.bcr.1",
-                "protobuf~21.7",
-                "stardoc~0.5.6",
+                "abseil-cpp~",
+                "apple_support~",
+                "bazel_skylib~",
+                "blake3~",
+                "c-ares~",
+                "grpc~",
+                "protobuf~",
+                "stardoc~",
                 "platforms",
-                "rules_cc~0.0.9",
-                "rules_go~0.39.1",
-                "rules_java~7.3.2",
-                "rules_jvm_external~6.0",
-                "rules_kotlin~1.9.0",
-                "rules_graalvm~0.10.3",
-                "rules_license~0.0.7",
-                "rules_pkg~0.9.1",
-                "rules_proto~5.3.0-21.7",
-                "rules_python~0.28.0",
-                "upb~0.0.0-20220923-a547704",
-                "zlib~1.3",
-                "zstd-jni~1.5.2-3.bcr.1",
-                "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_gazelle",
-                "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_skylib",
-                "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate",
-                "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_github_cncf_udpa",
-                "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_google_googleapis",
-                "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~envoy_api",
-                "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~rules_cc",
-                "rules_kotlin~1.9.0~rules_kotlin_extensions~com_github_jetbrains_kotlin"
+                "rules_cc~",
+                "rules_go~",
+                "rules_java~",
+                "rules_jvm_external~",
+                "rules_kotlin~",
+                "rules_graalvm~",
+                "rules_license~",
+                "rules_pkg~",
+                "rules_proto~",
+                "rules_python~",
+                "upb~",
+                "zlib~",
+                "zstd-jni~",
+                "grpc~~grpc_repo_deps_ext~bazel_gazelle",
+                "grpc~~grpc_repo_deps_ext~bazel_skylib",
+                "grpc~~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate",
+                "grpc~~grpc_repo_deps_ext~com_github_cncf_udpa",
+                "grpc~~grpc_repo_deps_ext~com_google_googleapis",
+                "grpc~~grpc_repo_deps_ext~envoy_api",
+                "grpc~~grpc_repo_deps_ext~rules_cc",
+                "rules_kotlin~~rules_kotlin_extensions~com_github_jetbrains_kotlin"
               ],
               "dirname": "derived/repository_cache"
             }
@@ -2867,7 +2915,6 @@
             "bzlFile": "@@//tools/distributions:system_repo.bzl",
             "ruleClassName": "system_repo",
             "attributes": {
-              "name": "_main~bazel_build_deps~debian_bin_deps",
               "symlinks": {
                 "protoc": "/usr/bin/protoc",
                 "grpc_cpp_plugin": "/usr/bin/grpc_cpp_plugin",
@@ -2880,7 +2927,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "_main~bazel_build_deps~openjdk_win_arm64_vanilla",
               "sha256": "975603e684f2ec5a525b3b5336d6aa0b09b5b7d2d0d9e271bd6a9892ad550181",
               "downloaded_file_path": "zulu-win-arm64.zip",
               "url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-windows-aarch64.zip"
@@ -2890,7 +2936,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "_main~bazel_build_deps~openjdk_linux_ppc64le_vanilla",
               "sha256": "d08de863499d8851811c893e8915828f2cd8eb67ed9e29432a6b4e222d80a12f",
               "downloaded_file_path": "adoptopenjdk-ppc64le-vanilla.tar.gz",
               "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.2_13.tar.gz"
@@ -2900,7 +2945,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "_main~bazel_build_deps~openjdk_macos_x86_64_vanilla",
               "sha256": "9639b87db586d0c89f7a9892ae47f421e442c64b97baebdff31788fbe23265bd",
               "downloaded_file_path": "zulu-macos-vanilla.tar.gz",
               "url": "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_x64.tar.gz"
@@ -2910,7 +2954,6 @@
             "bzlFile": "@@//:distdir.bzl",
             "ruleClassName": "_distdir_tar",
             "attributes": {
-              "name": "_main~bazel_build_deps~workspace_repo_cache",
               "archives": [
                 "rules_cc-0.0.9.tar.gz",
                 "rules_java-7.3.2.tar.gz",
@@ -2968,7 +3011,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "_main~bazel_build_deps~openjdk_win_vanilla",
               "sha256": "e9959d500a0d9a7694ac243baf657761479da132f0f94720cbffd092150bd802",
               "downloaded_file_path": "zulu-win-vanilla.zip",
               "url": "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-win_x64.zip"
@@ -2978,7 +3020,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "_main~bazel_build_deps~openjdk_linux_aarch64_vanilla",
               "sha256": "1fb64b8036c5d463d8ab59af06bf5b6b006811e6012e3b0eb6bccf57f1c55835",
               "downloaded_file_path": "zulu-linux-aarch64-vanilla.tar.gz",
               "url": "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-linux_aarch64.tar.gz"
@@ -2988,7 +3029,6 @@
             "bzlFile": "@@//tools/distributions:system_repo.bzl",
             "ruleClassName": "system_repo",
             "attributes": {
-              "name": "_main~bazel_build_deps~debian_proto_deps",
               "symlinks": {
                 "google/protobuf": "/usr/include/google/protobuf"
               },
@@ -3000,17 +3040,17 @@
           [
             "",
             "abseil-cpp",
-            "abseil-cpp~20230125.1"
+            "abseil-cpp~"
           ],
           [
             "",
             "apple_support",
-            "apple_support~1.8.1"
+            "apple_support~"
           ],
           [
             "",
             "bazel_skylib",
-            "bazel_skylib~1.5.0"
+            "bazel_skylib~"
           ],
           [
             "",
@@ -3020,27 +3060,27 @@
           [
             "",
             "blake3",
-            "blake3~1.3.3.bcr.1"
+            "blake3~"
           ],
           [
             "",
             "c-ares",
-            "c-ares~1.15.0"
+            "c-ares~"
           ],
           [
             "",
             "com_github_grpc_grpc",
-            "grpc~1.48.1.bcr.1"
+            "grpc~"
           ],
           [
             "",
             "com_google_protobuf",
-            "protobuf~21.7"
+            "protobuf~"
           ],
           [
             "",
             "io_bazel_skydoc",
-            "stardoc~0.5.6"
+            "stardoc~"
           ],
           [
             "",
@@ -3050,67 +3090,67 @@
           [
             "",
             "rules_cc",
-            "rules_cc~0.0.9"
+            "rules_cc~"
           ],
           [
             "",
             "rules_go",
-            "rules_go~0.39.1"
+            "rules_go~"
           ],
           [
             "",
             "rules_graalvm",
-            "rules_graalvm~0.10.3"
+            "rules_graalvm~"
           ],
           [
             "",
             "rules_java",
-            "rules_java~7.3.2"
+            "rules_java~"
           ],
           [
             "",
             "rules_jvm_external",
-            "rules_jvm_external~6.0"
+            "rules_jvm_external~"
           ],
           [
             "",
             "rules_kotlin",
-            "rules_kotlin~1.9.0"
+            "rules_kotlin~"
           ],
           [
             "",
             "rules_license",
-            "rules_license~0.0.7"
+            "rules_license~"
           ],
           [
             "",
             "rules_pkg",
-            "rules_pkg~0.9.1"
+            "rules_pkg~"
           ],
           [
             "",
             "rules_proto",
-            "rules_proto~5.3.0-21.7"
+            "rules_proto~"
           ],
           [
             "",
             "rules_python",
-            "rules_python~0.28.0"
+            "rules_python~"
           ],
           [
             "",
             "upb",
-            "upb~0.0.0-20220923-a547704"
+            "upb~"
           ],
           [
             "",
             "zlib",
-            "zlib~1.3"
+            "zlib~"
           ],
           [
             "",
             "zstd-jni",
-            "zstd-jni~1.5.2-3.bcr.1"
+            "zstd-jni~"
           ],
           [
             "bazel_tools",
@@ -3122,29 +3162,24 @@
     },
     "//:extensions.bzl%bazel_test_deps": {
       "general": {
-        "bzlTransitiveDigest": "uzRwJ/aaGLzKqN69Hz+DktJFrVeKCjILtM+t4Hirz0M=",
+        "bzlTransitiveDigest": "t+ILJLlq7q0/p+k9yKj4bCrNS+xIVnuPdJ2Ji47/lsE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "local_config_winsdk": {
             "bzlFile": "@@//src/main/res:winsdk_configure.bzl",
             "ruleClassName": "winsdk_configure",
-            "attributes": {
-              "name": "_main~bazel_test_deps~local_config_winsdk"
-            }
+            "attributes": {}
           },
           "local_bazel_source_list": {
             "bzlFile": "@@//src/test/shell/bazel:list_source_repository.bzl",
             "ruleClassName": "list_source_repository",
-            "attributes": {
-              "name": "_main~bazel_test_deps~local_bazel_source_list"
-            }
+            "attributes": {}
           },
           "bazelci_rules": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "_main~bazel_test_deps~bazelci_rules",
               "sha256": "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
               "strip_prefix": "bazelci_rules-1.0.0",
               "url": "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz"
@@ -3155,17 +3190,17 @@
           [
             "",
             "abseil-cpp",
-            "abseil-cpp~20230125.1"
+            "abseil-cpp~"
           ],
           [
             "",
             "apple_support",
-            "apple_support~1.8.1"
+            "apple_support~"
           ],
           [
             "",
             "bazel_skylib",
-            "bazel_skylib~1.5.0"
+            "bazel_skylib~"
           ],
           [
             "",
@@ -3175,27 +3210,27 @@
           [
             "",
             "blake3",
-            "blake3~1.3.3.bcr.1"
+            "blake3~"
           ],
           [
             "",
             "c-ares",
-            "c-ares~1.15.0"
+            "c-ares~"
           ],
           [
             "",
             "com_github_grpc_grpc",
-            "grpc~1.48.1.bcr.1"
+            "grpc~"
           ],
           [
             "",
             "com_google_protobuf",
-            "protobuf~21.7"
+            "protobuf~"
           ],
           [
             "",
             "io_bazel_skydoc",
-            "stardoc~0.5.6"
+            "stardoc~"
           ],
           [
             "",
@@ -3205,67 +3240,67 @@
           [
             "",
             "rules_cc",
-            "rules_cc~0.0.9"
+            "rules_cc~"
           ],
           [
             "",
             "rules_go",
-            "rules_go~0.39.1"
+            "rules_go~"
           ],
           [
             "",
             "rules_graalvm",
-            "rules_graalvm~0.10.3"
+            "rules_graalvm~"
           ],
           [
             "",
             "rules_java",
-            "rules_java~7.3.2"
+            "rules_java~"
           ],
           [
             "",
             "rules_jvm_external",
-            "rules_jvm_external~6.0"
+            "rules_jvm_external~"
           ],
           [
             "",
             "rules_kotlin",
-            "rules_kotlin~1.9.0"
+            "rules_kotlin~"
           ],
           [
             "",
             "rules_license",
-            "rules_license~0.0.7"
+            "rules_license~"
           ],
           [
             "",
             "rules_pkg",
-            "rules_pkg~0.9.1"
+            "rules_pkg~"
           ],
           [
             "",
             "rules_proto",
-            "rules_proto~5.3.0-21.7"
+            "rules_proto~"
           ],
           [
             "",
             "rules_python",
-            "rules_python~0.28.0"
+            "rules_python~"
           ],
           [
             "",
             "upb",
-            "upb~0.0.0-20220923-a547704"
+            "upb~"
           ],
           [
             "",
             "zlib",
-            "zlib~1.3"
+            "zlib~"
           ],
           [
             "",
             "zstd-jni",
-            "zstd-jni~1.5.2-3.bcr.1"
+            "zstd-jni~"
           ],
           [
             "bazel_tools",
@@ -3285,12 +3320,17 @@
             "bzlFile": "@@_main~bazel_test_deps~bazelci_rules//:rbe_repo.bzl",
             "ruleClassName": "rbe_preconfig",
             "attributes": {
-              "name": "_main~bazel_rbe_deps~rbe_ubuntu2004_java11",
               "toolchain": "ubuntu2004-bazel-java11"
             }
           }
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazelci_rules",
+            "_main~bazel_test_deps~bazelci_rules"
+          ]
+        ]
       }
     },
     "//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
@@ -3303,7 +3343,6 @@
             "bzlFile": "@@//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "_main~remote_android_tools_extensions~android_tools",
               "sha256": "2b661a761a735b41c41b3a78089f4fc1982626c76ddb944604ae3ff8c545d3c2",
               "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.30.0.tar"
             }
@@ -3312,7 +3351,6 @@
             "bzlFile": "@@//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_jar",
             "attributes": {
-              "name": "_main~remote_android_tools_extensions~android_gmaven_r8",
               "sha256": "a1d7f902d56cfa8d1e8cd64aa250e63549359fcd096eb793286787b1a1e76db1",
               "url": "https://maven.google.com/com/android/tools/r8/8.2.42/r8-8.2.42.jar"
             }
@@ -3331,7 +3369,6 @@
             "bzlFile": "@@//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "_main~remote_coverage_tools_extension~remote_coverage_tools",
               "sha256": "7006375f6756819b7013ca875eab70a541cf7d89142d9c511ed78ea4fefa38af",
               "urls": [
                 "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"
@@ -3342,48 +3379,47 @@
         "recordedRepoMappingEntries": []
       }
     },
-    "@@apple_support~1.8.1//crosstool:setup.bzl%apple_cc_configure_extension": {
+    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "JFciz9+xRmE31CdyrcEUeZSKFxwiLTQ+PNMg6Bcc6s8=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "local_config_apple_cc": {
-            "bzlFile": "@@apple_support~1.8.1//crosstool:setup.bzl",
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
             "ruleClassName": "_apple_cc_autoconf",
-            "attributes": {
-              "name": "apple_support~1.8.1~apple_cc_configure_extension~local_config_apple_cc"
-            }
+            "attributes": {}
           },
           "local_config_apple_cc_toolchains": {
-            "bzlFile": "@@apple_support~1.8.1//crosstool:setup.bzl",
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
             "ruleClassName": "_apple_cc_autoconf_toolchains",
-            "attributes": {
-              "name": "apple_support~1.8.1~apple_cc_configure_extension~local_config_apple_cc_toolchains"
-            }
+            "attributes": {}
           }
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
-    "@@bazel_features~1.1.1//private:extensions.bzl%version_extension": {
+    "@@bazel_features~//private:extensions.bzl%version_extension": {
       "general": {
         "bzlTransitiveDigest": "xm7Skm1Las5saxzFWt2hbS+e68BWi+MXyt6+lKIhjPA=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "bazel_features_version": {
-            "bzlFile": "@@bazel_features~1.1.1//private:version_repo.bzl",
+            "bzlFile": "@@bazel_features~//private:version_repo.bzl",
             "ruleClassName": "version_repo",
-            "attributes": {
-              "name": "bazel_features~1.1.1~version_extension~bazel_features_version"
-            }
+            "attributes": {}
           },
           "bazel_features_globals": {
-            "bzlFile": "@@bazel_features~1.1.1//private:globals_repo.bzl",
+            "bzlFile": "@@bazel_features~//private:globals_repo.bzl",
             "ruleClassName": "globals_repo",
             "attributes": {
-              "name": "bazel_features~1.1.1~version_extension~bazel_features_globals",
               "globals": {
                 "RunEnvironmentInfo": "5.3.0",
                 "DefaultInfo": "0.0.1",
@@ -3397,7 +3433,7 @@
     },
     "@@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "4x/FXzwoadac6uV9ItZ4eGOyCculGHHrKUhLFNWo3lA=",
+        "bzlTransitiveDigest": "vsrPPBNf8OgywAYLMcIL1oNm2R8WtbCIL9wgQBUecpA=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3405,7 +3441,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "bazel_tools~remote_android_tools_extensions~android_tools",
               "sha256": "2b661a761a735b41c41b3a78089f4fc1982626c76ddb944604ae3ff8c545d3c2",
               "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.30.0.tar"
             }
@@ -3414,9 +3449,8 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_jar",
             "attributes": {
-              "name": "bazel_tools~remote_android_tools_extensions~android_gmaven_r8",
-              "sha256": "57a696749695a09381a87bc2f08c3a8ed06a717a5caa3ef878a3077e0d3af19d",
-              "url": "https://maven.google.com/com/android/tools/r8/8.1.56/r8-8.1.56.jar"
+              "sha256": "a1d7f902d56cfa8d1e8cd64aa250e63549359fcd096eb793286787b1a1e76db1",
+              "url": "https://maven.google.com/com/android/tools/r8/8.2.42/r8-8.2.42.jar"
             }
           }
         },
@@ -3425,23 +3459,19 @@
     },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "mcsWHq3xORJexV5/4eCvNOLxFOQKV6eli3fkr+tEaqE=",
+        "bzlTransitiveDigest": "XWy8pzw7/6RclAFWd6/VfUdoXn2SdSpmHOrbfEFJ1ao=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "local_config_cc": {
             "bzlFile": "@@bazel_tools//tools/cpp:cc_configure.bzl",
             "ruleClassName": "cc_autoconf",
-            "attributes": {
-              "name": "bazel_tools~cc_configure_extension~local_config_cc"
-            }
+            "attributes": {}
           },
           "local_config_cc_toolchains": {
             "bzlFile": "@@bazel_tools//tools/cpp:cc_configure.bzl",
             "ruleClassName": "cc_autoconf_toolchains",
-            "attributes": {
-              "name": "bazel_tools~cc_configure_extension~local_config_cc_toolchains"
-            }
+            "attributes": {}
           }
         },
         "recordedRepoMappingEntries": [
@@ -3463,7 +3493,6 @@
             "bzlFile": "@@bazel_tools//tools/osx:xcode_configure.bzl",
             "ruleClassName": "xcode_autoconf",
             "attributes": {
-              "name": "bazel_tools~xcode_configure_extension~local_config_xcode",
               "xcode_locator": "@bazel_tools//tools/osx:xcode_locator.m",
               "remote_xcode": ""
             }
@@ -3481,9 +3510,7 @@
           "local_config_sh": {
             "bzlFile": "@@bazel_tools//tools/sh:sh_configure.bzl",
             "ruleClassName": "sh_config",
-            "attributes": {
-              "name": "bazel_tools~sh_configure_extension~local_config_sh"
-            }
+            "attributes": {}
           }
         },
         "recordedRepoMappingEntries": []
@@ -3491,7 +3518,7 @@
     },
     "@@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "y48q5zUu2oMiYv7yUyi7rFB0wt14eqiF/RQcWT6vP7I=",
+        "bzlTransitiveDigest": "AL+K5m+GCP3XRzLPqpKAq4GsjIVDXgUveWm8nih4ju0=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3499,7 +3526,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "bazel_tools~remote_coverage_tools_extension~remote_coverage_tools",
               "sha256": "7006375f6756819b7013ca875eab70a541cf7d89142d9c511ed78ea4fefa38af",
               "urls": [
                 "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"
@@ -3510,22 +3536,45 @@
         "recordedRepoMappingEntries": []
       }
     },
-    "@@gazelle~0.30.0//:extensions.bzl%go_deps": {
+    "@@buildozer~//:buildozer_binary.bzl%buildozer_binary": {
       "general": {
-        "bzlTransitiveDigest": "qA0ex33bTMERZ7C8nXKz92cjvx42TwSWN1J1CSDT0K8=",
+        "bzlTransitiveDigest": "EleDU/FQ1+e/RgkW3aIDmdaxZEthvoWQhsqFTxiSgMI=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "buildozer_binary": {
+            "bzlFile": "@@buildozer~//private:buildozer_binary.bzl",
+            "ruleClassName": "_buildozer_binary_repo",
+            "attributes": {
+              "sha256": {
+                "darwin-amd64": "d29e347ecd6b5673d72cb1a8de05bf1b06178dd229ff5eb67fad5100c840cc8e",
+                "darwin-arm64": "9b9e71bdbec5e7223871e913b65d12f6d8fa026684daf991f00e52ed36a6978d",
+                "linux-amd64": "8dfd6345da4e9042daa738d7fdf34f699c5dfce4632f7207956fceedd8494119",
+                "linux-arm64": "6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa",
+                "windows-amd64": "e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b"
+              },
+              "version": "6.4.0"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@gazelle~//:extensions.bzl%go_deps": {
+      "general": {
+        "bzlTransitiveDigest": "V0I2A6HQbPqRuhGhygxjQV47OuSSxVaAXG5m+/637Zw=",
         "accumulatedFileDigests": {
-          "@@rules_go~0.39.1//:go.sum": "022d36c9ebcc7b5dee1e9b85b3da9c9f3a529ee6f979946d66e4955b8d54614a",
-          "@@rules_go~0.39.1//:go.mod": "a7143f329c2a3e0b983ce74a96c0c25b0d0c59d236d75f7e1b069aadd988d55e",
-          "@@gazelle~0.30.0//:go.sum": "c9624aa41e5ffd61a8581d57a3c4046e62b46630dddc8b191e65017f34ff12a5",
-          "@@gazelle~0.30.0//:go.mod": "5346019bf0673364b383d56ffbc9fced98b7b4ee921e865dfe905a1ebe82d326"
+          "@@gazelle~//:go.mod": "5346019bf0673364b383d56ffbc9fced98b7b4ee921e865dfe905a1ebe82d326",
+          "@@rules_go~//:go.sum": "022d36c9ebcc7b5dee1e9b85b3da9c9f3a529ee6f979946d66e4955b8d54614a",
+          "@@gazelle~//:go.sum": "c9624aa41e5ffd61a8581d57a3c4046e62b46630dddc8b191e65017f34ff12a5",
+          "@@rules_go~//:go.mod": "a7143f329c2a3e0b983ce74a96c0c25b0d0c59d236d75f7e1b069aadd988d55e"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
           "com_github_fsnotify_fsnotify": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_fsnotify_fsnotify",
               "importpath": "github.com/fsnotify/fsnotify",
               "sum": "h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=",
               "replace": "",
@@ -3534,10 +3583,9 @@
             }
           },
           "org_golang_x_text": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_x_text",
               "importpath": "golang.org/x/text",
               "sum": "h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=",
               "replace": "",
@@ -3546,10 +3594,9 @@
             }
           },
           "org_golang_google_protobuf": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_google_protobuf",
               "importpath": "google.golang.org/protobuf",
               "sum": "h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=",
               "replace": "",
@@ -3558,10 +3605,9 @@
             }
           },
           "com_github_bmatcuk_doublestar_v4": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_bmatcuk_doublestar_v4",
               "importpath": "github.com/bmatcuk/doublestar/v4",
               "sum": "h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=",
               "replace": "",
@@ -3570,10 +3616,9 @@
             }
           },
           "com_github_pmezard_go_difflib": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_pmezard_go_difflib",
               "importpath": "github.com/pmezard/go-difflib",
               "sum": "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
               "replace": "",
@@ -3582,10 +3627,9 @@
             }
           },
           "org_golang_x_mod": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_x_mod",
               "importpath": "golang.org/x/mod",
               "sum": "h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=",
               "replace": "",
@@ -3594,10 +3638,9 @@
             }
           },
           "org_golang_x_tools": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_x_tools",
               "importpath": "golang.org/x/tools",
               "sum": "h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=",
               "replace": "",
@@ -3606,10 +3649,9 @@
             }
           },
           "org_golang_x_net": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_x_net",
               "importpath": "golang.org/x/net",
               "sum": "h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=",
               "replace": "",
@@ -3618,10 +3660,9 @@
             }
           },
           "com_github_bazelbuild_buildtools": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_bazelbuild_buildtools",
               "importpath": "github.com/bazelbuild/buildtools",
               "sum": "h1:XmPu4mXICgdGnC5dXGjUGbwUD/kUmS0l5Aop3LaevBM=",
               "replace": "",
@@ -3630,10 +3671,9 @@
             }
           },
           "org_golang_google_genproto": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_google_genproto",
               "importpath": "google.golang.org/genproto",
               "sum": "h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=",
               "replace": "",
@@ -3642,10 +3682,9 @@
             }
           },
           "com_github_gogo_protobuf": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_gogo_protobuf",
               "importpath": "github.com/gogo/protobuf",
               "sum": "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=",
               "replace": "",
@@ -3656,10 +3695,9 @@
             }
           },
           "com_github_pelletier_go_toml": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_pelletier_go_toml",
               "importpath": "github.com/pelletier/go-toml",
               "sum": "h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=",
               "replace": "",
@@ -3668,10 +3706,9 @@
             }
           },
           "com_github_golang_protobuf": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_golang_protobuf",
               "importpath": "github.com/golang/protobuf",
               "sum": "h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=",
               "replace": "",
@@ -3680,10 +3717,9 @@
             }
           },
           "com_github_golang_mock": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_golang_mock",
               "importpath": "github.com/golang/mock",
               "sum": "h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=",
               "replace": "",
@@ -3692,10 +3728,9 @@
             }
           },
           "org_golang_x_sync": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_x_sync",
               "importpath": "golang.org/x/sync",
               "sum": "h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=",
               "replace": "",
@@ -3704,10 +3739,9 @@
             }
           },
           "bazel_gazelle_go_repository_config": {
-            "bzlFile": "@@gazelle~0.30.0//internal/bzlmod:go_deps.bzl",
+            "bzlFile": "@@gazelle~//internal/bzlmod:go_deps.bzl",
             "ruleClassName": "_go_repository_config",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~bazel_gazelle_go_repository_config",
               "importpaths": {
                 "com_github_gogo_protobuf": "github.com/gogo/protobuf",
                 "com_github_golang_mock": "github.com/golang/mock",
@@ -3732,10 +3766,9 @@
             }
           },
           "org_golang_google_grpc": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_google_grpc",
               "importpath": "google.golang.org/grpc",
               "sum": "h1:fPVVDxY9w++VjTZsYvXWqEf9Rqar/e+9zYfxKK+W+YU=",
               "replace": "",
@@ -3746,10 +3779,9 @@
             }
           },
           "org_golang_x_sys": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~org_golang_x_sys",
               "importpath": "golang.org/x/sys",
               "sum": "h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=",
               "replace": "",
@@ -3758,10 +3790,9 @@
             }
           },
           "com_github_google_go_cmp": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
             "ruleClassName": "go_repository",
             "attributes": {
-              "name": "gazelle~0.30.0~go_deps~com_github_google_go_cmp",
               "importpath": "github.com/google/go-cmp",
               "sum": "h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=",
               "replace": "",
@@ -3770,39 +3801,49 @@
             }
           }
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "gazelle~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
-    "@@gazelle~0.30.0//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
+    "@@gazelle~//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "30wev+wJfzc4s72MCfbP9U8W+3Js2b+Xbo5ofgZbHw8=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "bazel_gazelle_go_repository_tools": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository_tools.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository_tools.bzl",
             "ruleClassName": "go_repository_tools",
             "attributes": {
-              "name": "gazelle~0.30.0~non_module_deps~bazel_gazelle_go_repository_tools",
-              "go_cache": "@@gazelle~0.30.0~non_module_deps~bazel_gazelle_go_repository_cache//:go.env"
+              "go_cache": "@@gazelle~~non_module_deps~bazel_gazelle_go_repository_cache//:go.env"
             }
           },
           "bazel_gazelle_go_repository_cache": {
-            "bzlFile": "@@gazelle~0.30.0//internal:go_repository_cache.bzl",
+            "bzlFile": "@@gazelle~//internal:go_repository_cache.bzl",
             "ruleClassName": "go_repository_cache",
             "attributes": {
-              "name": "gazelle~0.30.0~non_module_deps~bazel_gazelle_go_repository_cache",
               "go_sdk_name": "go_default_sdk",
               "go_env": {}
             }
           }
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "gazelle~",
+            "bazel_gazelle_go_repository_cache",
+            "gazelle~~non_module_deps~bazel_gazelle_go_repository_cache"
+          ]
+        ]
       }
     },
-    "@@grpc~1.48.1.bcr.1//bazel:grpc_deps.bzl%grpc_repo_deps_ext": {
+    "@@grpc~//bazel:grpc_deps.bzl%grpc_repo_deps_ext": {
       "general": {
-        "bzlTransitiveDigest": "Vi/A+pHz0UslIVgXw0k4nRhXybndFcXR259m5TlMQXA=",
+        "bzlTransitiveDigest": "ENAlCD1yqO5dmn6dFK5cX3QI+mNQc8qRXPm4cZyAjDA=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3810,7 +3851,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~io_opencensus_cpp",
               "sha256": "90d6fafa8b1a2ea613bf662731d3086e1c2ed286f458a95c81744df2dbae41b1",
               "strip_prefix": "opencensus-cpp-c9a4da319bc669a772928ffc55af4a61be1a1176",
               "urls": [
@@ -3823,8 +3863,7 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_github_libuv_libuv",
-              "build_file": "@@grpc~1.48.1.bcr.1//third_party:libuv.BUILD",
+              "build_file": "@@grpc~//third_party:libuv.BUILD",
               "sha256": "5ca4e9091f3231d8ad8801862dc4e851c23af89c69141d27723157776f7291e7",
               "strip_prefix": "libuv-02a9e1be252b623ee032a3137c0b0c94afbe6809",
               "urls": [
@@ -3837,7 +3876,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_google_googleapis",
               "sha256": "5bb6b0253ccf64b53d6c7249625a7e3f6c3bc6402abd52d3778bfa48258703a0",
               "strip_prefix": "googleapis-2f9af297c84c55c8b871ba4495e01ade42476c92",
               "urls": [
@@ -3850,7 +3888,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~upb",
               "sha256": "d0fe259d650bf9547e75896a1307bfc7034195e4ae89f5139814d295991ba681",
               "strip_prefix": "upb-bef53686ec702607971bd3ea4d4fefd80c6cc6e8",
               "urls": [
@@ -3863,7 +3900,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~rules_cc",
               "sha256": "35f2fb4ea0b3e61ad64a369de284e4fbbdcdba71836a5555abb5e194cf119509",
               "strip_prefix": "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
               "urls": [
@@ -3876,7 +3912,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~boringssl",
               "sha256": "534fa658bd845fd974b50b10f444d392dfd0d93768c4a51b61263fd37d851c40",
               "strip_prefix": "boringssl-b9232f9e27e5668bc0414879dcdedb2a59ea75f2",
               "urls": [
@@ -3889,7 +3924,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_gazelle",
               "sha256": "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
               "urls": [
                 "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
@@ -3901,7 +3935,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~opencensus_proto",
               "sha256": "b7e13f0b4259e80c3070b583c2f39e53153085a6918718b1c710caf7037572b0",
               "strip_prefix": "opencensus-proto-0.3.0/src",
               "urls": [
@@ -3909,7 +3942,7 @@
                 "https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz"
               ],
               "patches": [
-                "@@grpc~1.48.1.bcr.1//third_party:opencensus-proto.patch"
+                "@@grpc~//third_party:opencensus-proto.patch"
               ],
               "patch_args": [
                 "-p2"
@@ -3920,7 +3953,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_googlesource_code_re2",
               "sha256": "319a58a58d8af295db97dfeecc4e250179c5966beaa2d842a82f0a013b6a239b",
               "strip_prefix": "re2-8e08f47b11b413302749c0d8b17a1c94777495d5",
               "urls": [
@@ -3933,7 +3965,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_skylib",
               "urls": [
                 "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
                 "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz"
@@ -3945,8 +3976,7 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_github_cares_cares",
-              "build_file": "@@grpc~1.48.1.bcr.1//third_party:cares/cares.BUILD",
+              "build_file": "@@grpc~//third_party:cares/cares.BUILD",
               "sha256": "ec76c5e79db59762776bece58b69507d095856c37b81fd35bfb0958e74b61d93",
               "strip_prefix": "c-ares-6654436a307a5a686b008c1d4c93b0085da6e6d8",
               "urls": [
@@ -3959,7 +3989,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~build_bazel_apple_support",
               "sha256": "76df040ade90836ff5543888d64616e7ba6c3a7b33b916aa3a4b68f342d1b447",
               "urls": [
                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/apple_support/releases/download/0.11.0/apple_support.0.11.0.tar.gz",
@@ -3971,8 +4000,7 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~zlib",
-              "build_file": "@@grpc~1.48.1.bcr.1//third_party:zlib.BUILD",
+              "build_file": "@@grpc~//third_party:zlib.BUILD",
               "sha256": "ef47b0fbe646d69a2fc5ba012cb278de8e8946a8e9649f83a807cc05559f0eff",
               "strip_prefix": "zlib-21767c654d31d2dccdde4330529775c6c5fd5389",
               "urls": [
@@ -3985,7 +4013,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_google_googletest",
               "sha256": "c8de6c60e12ad014a28225c5247ee735861d85cf906df617f6a29954ca05f547",
               "strip_prefix": "googletest-0e402173c97aea7a00749e825b194bfede4f2e45",
               "urls": [
@@ -3997,7 +4024,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~envoy_api",
               "sha256": "c5807010b67033330915ca5a20483e30538ae5e689aa14b3631d6284beca4630",
               "strip_prefix": "data-plane-api-9c42588c956220b48eb3099d186487c2f04d32ec",
               "urls": [
@@ -4010,7 +4036,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~build_bazel_rules_apple",
               "sha256": "0052d452af7742c8f3a4e0929763388a66403de363775db7e90adecb2ba4944b",
               "urls": [
                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/releases/download/0.31.3/rules_apple.0.31.3.tar.gz",
@@ -4022,7 +4047,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_github_cncf_udpa",
               "sha256": "5bc8365613fe2f8ce6cc33959b7667b13b7fe56cb9d16ba740c06e1a7c4242fc",
               "strip_prefix": "xds-cb28da3451f158a947dfc45090fe92b07b243bc1",
               "urls": [
@@ -4035,7 +4059,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_github_google_benchmark",
               "sha256": "0b921a3bc39e35f4275c8dcc658af2391c150fb966102341287b0401ff2e6f21",
               "strip_prefix": "benchmark-0baacde3618ca617da95375e0af13ce1baadea47",
               "urls": [
@@ -4048,14 +4071,13 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate",
               "strip_prefix": "protoc-gen-validate-4694024279bdac52b77e22dc87808bd0fd732b69",
               "sha256": "1e490b98005664d149b379a9529a6aa05932b8a11b76b4cd86f3d22d76346f47",
               "urls": [
                 "https://github.com/envoyproxy/protoc-gen-validate/archive/4694024279bdac52b77e22dc87808bd0fd732b69.tar.gz"
               ],
               "patches": [
-                "@@grpc~1.48.1.bcr.1//third_party:protoc-gen-validate.patch"
+                "@@grpc~//third_party:protoc-gen-validate.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4066,7 +4088,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_google_absl",
               "sha256": "4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602",
               "strip_prefix": "abseil-cpp-20220623.0",
               "urls": [
@@ -4079,7 +4100,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_toolchains",
               "sha256": "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
               "strip_prefix": "bazel-toolchains-4.1.0",
               "urls": [
@@ -4092,7 +4112,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_compdb",
               "sha256": "bcecfd622c4ef272fd4ba42726a52e140b961c4eac23025f18b346c968a8cfb4",
               "strip_prefix": "bazel-compilation-database-0.4.5",
               "urls": [
@@ -4104,29 +4123,28 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "grpc~1.48.1.bcr.1",
+            "grpc~",
             "bazel_tools",
             "bazel_tools"
           ],
           [
-            "grpc~1.48.1.bcr.1",
+            "grpc~",
             "com_github_grpc_grpc",
-            "grpc~1.48.1.bcr.1"
+            "grpc~"
           ]
         ]
       }
     },
-    "@@grpc~1.48.1.bcr.1//bazel:grpc_extra_deps.bzl%grpc_extra_deps_ext": {
+    "@@grpc~//bazel:grpc_extra_deps.bzl%grpc_extra_deps_ext": {
       "general": {
-        "bzlTransitiveDigest": "a/Diq7iDATaU2rBTMgcQ5R3n2KlPdis6c56UUe28yBU=",
+        "bzlTransitiveDigest": "ZRlq4e5NfO/c19V6wls6H+iNpKKhu2nQQwWLa94Lmc8=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "com_google_googleapis_imports": {
-            "bzlFile": "@@grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_google_googleapis//:repository_rules.bzl",
+            "bzlFile": "@@grpc~~grpc_repo_deps_ext~com_google_googleapis//:repository_rules.bzl",
             "ruleClassName": "switched_rules",
             "attributes": {
-              "name": "grpc~1.48.1.bcr.1~grpc_extra_deps_ext~com_google_googleapis_imports",
               "rules": {
                 "proto_library_with_info": [
                   "",
@@ -4270,89 +4288,88 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "grpc~1.48.1.bcr.1",
+            "grpc~",
             "com_envoyproxy_protoc_gen_validate",
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate"
+            "grpc~~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate"
           ],
           [
-            "grpc~1.48.1.bcr.1",
+            "grpc~",
             "com_google_googleapis",
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_google_googleapis"
+            "grpc~~grpc_repo_deps_ext~com_google_googleapis"
           ],
           [
-            "grpc~1.48.1.bcr.1",
+            "grpc~",
             "com_google_protobuf",
-            "protobuf~21.7"
+            "protobuf~"
           ],
           [
-            "grpc~1.48.1.bcr.1",
+            "grpc~",
             "envoy_api",
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~envoy_api"
+            "grpc~~grpc_repo_deps_ext~envoy_api"
           ],
           [
-            "grpc~1.48.1.bcr.1",
+            "grpc~",
             "io_bazel_rules_go",
-            "rules_go~0.39.1"
+            "rules_go~"
           ],
           [
-            "grpc~1.48.1.bcr.1",
+            "grpc~",
             "upb",
-            "upb~0.0.0-20220923-a547704"
+            "upb~"
           ],
           [
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_gazelle",
+            "grpc~~grpc_repo_deps_ext~bazel_gazelle",
             "bazel_gazelle",
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_gazelle"
+            "grpc~~grpc_repo_deps_ext~bazel_gazelle"
           ],
           [
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_gazelle",
+            "grpc~~grpc_repo_deps_ext~bazel_gazelle",
             "bazel_tools",
             "bazel_tools"
           ],
           [
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate",
+            "grpc~~grpc_repo_deps_ext~com_envoyproxy_protoc_gen_validate",
             "bazel_gazelle",
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~bazel_gazelle"
+            "grpc~~grpc_repo_deps_ext~bazel_gazelle"
           ],
           [
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~envoy_api",
+            "grpc~~grpc_repo_deps_ext~envoy_api",
             "bazel_tools",
             "bazel_tools"
           ],
           [
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~envoy_api",
+            "grpc~~grpc_repo_deps_ext~envoy_api",
             "envoy_api",
-            "grpc~1.48.1.bcr.1~grpc_repo_deps_ext~envoy_api"
+            "grpc~~grpc_repo_deps_ext~envoy_api"
           ],
           [
-            "protobuf~21.7",
+            "protobuf~",
             "bazel_tools",
             "bazel_tools"
           ],
           [
-            "rules_go~0.39.1",
+            "rules_go~",
             "bazel_tools",
             "bazel_tools"
           ],
           [
-            "upb~0.0.0-20220923-a547704",
+            "upb~",
             "bazel_tools",
             "bazel_tools"
           ]
         ]
       }
     },
-    "@@rules_go~0.39.1//go:extensions.bzl%go_sdk": {
+    "@@rules_go~//go:extensions.bzl%go_sdk": {
       "general": {
-        "bzlTransitiveDigest": "cvuDQzKTBy1BBsQPA+7jKTCEaEg3uqu2SQX9x2Z1vz4=",
+        "bzlTransitiveDigest": "g5EZCOP3bZMeEQ1ubaoKPfOJ376phuecoC0Cng8HQuQ=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "go_default_sdk": {
-            "bzlFile": "@@rules_go~0.39.1//go/private:sdk.bzl",
+            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
             "ruleClassName": "go_download_sdk_rule",
             "attributes": {
-              "name": "rules_go~0.39.1~go_sdk~go_default_sdk",
               "goos": "",
               "goarch": "",
               "sdks": {},
@@ -4363,10 +4380,9 @@
             }
           },
           "go_toolchains": {
-            "bzlFile": "@@rules_go~0.39.1//go/private:sdk.bzl",
+            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
             "ruleClassName": "go_multiple_toolchains",
             "attributes": {
-              "name": "rules_go~0.39.1~go_sdk~go_toolchains",
               "prefixes": [
                 "_0000_go_default_sdk_"
               ],
@@ -4390,16 +4406,16 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_go~0.39.1",
+            "rules_go~",
             "bazel_tools",
             "bazel_tools"
           ]
         ]
       }
     },
-    "@@rules_go~0.39.1//go/private:extensions.bzl%non_module_dependencies": {
+    "@@rules_go~//go/private:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "CamLV5C1Q66aY4Gu2ce5shMFpOJV/A+fmw4qzuGHmJk=",
+        "bzlTransitiveDigest": "oLq2n+NETjUQy2U9yXcFQY5oQEy5bn56tS8XtO8V7tA=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -4407,7 +4423,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~org_golang_x_xerrors",
               "urls": [
                 "https://mirror.bazel.build/github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip",
                 "https://github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip"
@@ -4415,7 +4430,7 @@
               "sha256": "ffad2b06ef2e09d040da2ff08077865e99ab95d4d0451737fc8e33706bb01634",
               "strip_prefix": "xerrors-04be3eba64a22a838cdb17b8dca15a52871c08b4",
               "patches": [
-                "@@rules_go~0.39.1//third_party:org_golang_x_xerrors-gazelle.patch"
+                "@@rules_go~//third_party:org_golang_x_xerrors-gazelle.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4423,17 +4438,14 @@
             }
           },
           "gogo_special_proto": {
-            "bzlFile": "@@rules_go~0.39.1//proto:gogo.bzl",
+            "bzlFile": "@@rules_go~//proto:gogo.bzl",
             "ruleClassName": "gogo_special_proto",
-            "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~gogo_special_proto"
-            }
+            "attributes": {}
           },
           "org_golang_google_protobuf": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~org_golang_google_protobuf",
               "sha256": "cb1a05581c33b3705ede6c08edf9b9c1dbc579559ba30f532704c324e42bf801",
               "urls": [
                 "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.30.0.zip",
@@ -4441,7 +4453,7 @@
               ],
               "strip_prefix": "protobuf-go-1.30.0",
               "patches": [
-                "@@rules_go~0.39.1//third_party:org_golang_google_protobuf-gazelle.patch"
+                "@@rules_go~//third_party:org_golang_google_protobuf-gazelle.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4452,7 +4464,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~com_github_mwitkow_go_proto_validators",
               "urls": [
                 "https://mirror.bazel.build/github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip",
                 "https://github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip"
@@ -4465,7 +4476,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~org_golang_x_tools",
               "urls": [
                 "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/v0.7.0.zip",
                 "https://github.com/golang/tools/archive/refs/tags/v0.7.0.zip"
@@ -4473,8 +4483,8 @@
               "sha256": "9f20a20f29f4008d797a8be882ef82b69cf8f7f2b96dbdfe3814c57d8280fa4b",
               "strip_prefix": "tools-0.7.0",
               "patches": [
-                "@@rules_go~0.39.1//third_party:org_golang_x_tools-deletegopls.patch",
-                "@@rules_go~0.39.1//third_party:org_golang_x_tools-gazelle.patch"
+                "@@rules_go~//third_party:org_golang_x_tools-deletegopls.patch",
+                "@@rules_go~//third_party:org_golang_x_tools-gazelle.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4485,7 +4495,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~go_googleapis",
               "urls": [
                 "https://mirror.bazel.build/github.com/googleapis/googleapis/archive/83c3605afb5a39952bf0a0809875d41cf2a558ca.zip",
                 "https://github.com/googleapis/googleapis/archive/83c3605afb5a39952bf0a0809875d41cf2a558ca.zip"
@@ -4493,9 +4502,9 @@
               "sha256": "ba694861340e792fd31cb77274eacaf6e4ca8bda97707898f41d8bebfd8a4984",
               "strip_prefix": "googleapis-83c3605afb5a39952bf0a0809875d41cf2a558ca",
               "patches": [
-                "@@rules_go~0.39.1//third_party:go_googleapis-deletebuild.patch",
-                "@@rules_go~0.39.1//third_party:go_googleapis-directives.patch",
-                "@@rules_go~0.39.1//third_party:go_googleapis-gazelle.patch"
+                "@@rules_go~//third_party:go_googleapis-deletebuild.patch",
+                "@@rules_go~//third_party:go_googleapis-directives.patch",
+                "@@rules_go~//third_party:go_googleapis-gazelle.patch"
               ],
               "patch_args": [
                 "-E",
@@ -4507,7 +4516,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~org_golang_google_genproto",
               "urls": [
                 "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/6ac7f18bb9d5eeeb13a9f1ae4f21e4374a1952f8.zip",
                 "https://github.com/googleapis/go-genproto/archive/6ac7f18bb9d5eeeb13a9f1ae4f21e4374a1952f8.zip"
@@ -4515,7 +4523,7 @@
               "sha256": "3470e7a89b24971b20c4bb8900a668df25279e4b741f72bc09418c1f22543215",
               "strip_prefix": "go-genproto-6ac7f18bb9d5eeeb13a9f1ae4f21e4374a1952f8",
               "patches": [
-                "@@rules_go~0.39.1//third_party:org_golang_google_genproto-gazelle.patch"
+                "@@rules_go~//third_party:org_golang_google_genproto-gazelle.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4526,7 +4534,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~bazel_skylib",
               "urls": [
                 "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
                 "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"
@@ -4539,7 +4546,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~com_github_gogo_protobuf",
               "urls": [
                 "https://mirror.bazel.build/github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
                 "https://github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip"
@@ -4547,7 +4553,7 @@
               "sha256": "f89f8241af909ce3226562d135c25b28e656ae173337b3e58ede917aa26e1e3c",
               "strip_prefix": "protobuf-1.3.2",
               "patches": [
-                "@@rules_go~0.39.1//third_party:com_github_gogo_protobuf-gazelle.patch"
+                "@@rules_go~//third_party:com_github_gogo_protobuf-gazelle.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4558,7 +4564,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~com_github_golang_protobuf",
               "urls": [
                 "https://mirror.bazel.build/github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip",
                 "https://github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip"
@@ -4566,7 +4571,7 @@
               "sha256": "2dced4544ae5372281e20f1e48ca76368355a01b31353724718c4d6e3dcbb430",
               "strip_prefix": "protobuf-1.5.3",
               "patches": [
-                "@@rules_go~0.39.1//third_party:com_github_golang_protobuf-gazelle.patch"
+                "@@rules_go~//third_party:com_github_golang_protobuf-gazelle.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4574,10 +4579,9 @@
             }
           },
           "io_bazel_rules_nogo": {
-            "bzlFile": "@@rules_go~0.39.1//go/private:nogo.bzl",
+            "bzlFile": "@@rules_go~//go/private:nogo.bzl",
             "ruleClassName": "go_register_nogo",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~io_bazel_rules_nogo",
               "nogo": "@io_bazel_rules_go//:default_nogo"
             }
           },
@@ -4585,13 +4589,12 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~com_github_golang_mock",
               "urls": [
                 "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",
                 "https://github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip"
               ],
               "patches": [
-                "@@rules_go~0.39.1//third_party:com_github_golang_mock-gazelle.patch"
+                "@@rules_go~//third_party:com_github_golang_mock-gazelle.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4604,7 +4607,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_go~0.39.1~non_module_dependencies~org_golang_x_sys",
               "urls": [
                 "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.6.0.zip",
                 "https://github.com/golang/sys/archive/refs/tags/v0.6.0.zip"
@@ -4612,7 +4614,7 @@
               "sha256": "7f2399398b2eb4f1f495cc754d6353566e0ad934ee0eb46505e55162e0def56d",
               "strip_prefix": "sys-0.6.0",
               "patches": [
-                "@@rules_go~0.39.1//third_party:org_golang_x_sys-gazelle.patch"
+                "@@rules_go~//third_party:org_golang_x_sys-gazelle.patch"
               ],
               "patch_args": [
                 "-p1"
@@ -4622,32 +4624,30 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_go~0.39.1",
+            "rules_go~",
             "bazel_tools",
             "bazel_tools"
           ]
         ]
       }
     },
-    "@@rules_graalvm~0.10.3//:extensions.bzl%graalvm": {
+    "@@rules_graalvm~//:extensions.bzl%graalvm": {
       "general": {
         "bzlTransitiveDigest": "RNOMan/EiPbz5i2nh2YxhbeTAOvTd9ReDe7arDK0PeY=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "graalvm_toolchains": {
-            "bzlFile": "@@rules_graalvm~0.10.3//internal:graalvm_bindist.bzl",
+            "bzlFile": "@@rules_graalvm~//internal:graalvm_bindist.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_graalvm~0.10.3~graalvm~graalvm_toolchains",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"graalvm_20\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"20\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"toolchain_gvm\",\n    actual = \"gvm\",\n    visibility = [\"//visibility:public\"],\n)\ntoolchain(\n    name = \"gvm\",\n    exec_compatible_with = [\n        \n    ],\n    target_compatible_with = [\n        \n    ],\n    toolchain = \"@graalvm//:gvm\",\n    toolchain_type = \"@rules_graalvm//graalvm/toolchain\",\n    visibility = [\"//visibility:public\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@graalvm//:jdk\",\n    visibility = [\"//visibility:public\"],\n)\n\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@graalvm//:jdk\",\n    visibility = [\"//visibility:public\"],\n)\n\n"
             }
           },
           "graalvm": {
-            "bzlFile": "@@rules_graalvm~0.10.3//internal:graalvm_bindist.bzl",
+            "bzlFile": "@@rules_graalvm~//internal:graalvm_bindist.bzl",
             "ruleClassName": "_graalvm_bindist_repository",
             "attributes": {
-              "name": "rules_graalvm~0.10.3~graalvm~graalvm",
               "version": "20.0.2",
               "java_version": "20",
               "distribution": "ce",
@@ -4658,52 +4658,53 @@
             }
           }
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "rules_graalvm~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ]
+        ]
       }
     },
-    "@@rules_java~7.3.2//java:extensions.bzl%toolchains": {
+    "@@rules_java~//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "VD4Sh110Jr4C8umSEo3aXDdF00rMCXKk8mH6XKBmpkw=",
+        "bzlTransitiveDigest": "Bm4ulErUcJjZtKeAt2etkB6sGO8evCgHQxbw4Px8q60=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "remotejdk21_linux_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_linux_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_linux//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_linux//:jdk\",\n)\n"
             }
           },
           "remotejdk17_linux_s390x_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_linux_s390x_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:s390x\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_s390x//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:s390x\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_s390x//:jdk\",\n)\n"
             }
           },
           "remotejdk17_macos_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_macos_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_macos//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_macos//:jdk\",\n)\n"
             }
           },
           "remotejdk21_macos_aarch64_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_macos_aarch64_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_macos_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_macos_aarch64//:jdk\",\n)\n"
             }
           },
           "remotejdk17_linux_aarch64_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_linux_aarch64_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_aarch64//:jdk\",\n)\n"
             }
           },
@@ -4711,7 +4712,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_macos_aarch64",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
               "sha256": "2a7a99a3ea263dbd8d32a67d1e6e363ba8b25c645c826f5e167a02bbafaff1fa",
               "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-macosx_aarch64",
@@ -4722,10 +4722,9 @@
             }
           },
           "remotejdk17_linux_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_linux_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux//:jdk\",\n)\n"
             }
           },
@@ -4733,7 +4732,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_macos_aarch64",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
               "sha256": "314b04568ec0ae9b36ba03c9cbd42adc9e1265f74678923b19297d66eb84dcca",
               "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-macosx_aarch64",
@@ -4747,7 +4745,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remote_java_tools_windows",
               "sha256": "8fc29a5e34e91c74815c4089ed0f481a7d728a5e886c4e5e3b9bcd79711fee3d",
               "urls": [
                 "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.3/java_tools_windows-v13.3.zip",
@@ -4759,7 +4756,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_win",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
               "sha256": "43408193ce2fa0862819495b5ae8541085b95660153f2adcf91a52d3a1710e83",
               "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-win_x64",
@@ -4770,10 +4766,9 @@
             }
           },
           "remotejdk11_win_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_win_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_win//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_win//:jdk\",\n)\n"
             }
           },
@@ -4781,7 +4776,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_linux_aarch64",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
               "sha256": "54174439f2b3fddd11f1048c397fe7bb45d4c9d66d452d6889b013d04d21c4de",
               "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-linux_aarch64",
@@ -4795,7 +4789,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_linux",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
               "sha256": "b9482f2304a1a68a614dfacddcf29569a72f0fac32e6c74f83dc1b9a157b8340",
               "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-linux_x64",
@@ -4806,18 +4799,16 @@
             }
           },
           "remotejdk11_linux_s390x_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_linux_s390x_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:s390x\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_s390x//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:s390x\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_s390x//:jdk\",\n)\n"
             }
           },
           "remotejdk11_linux_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_linux_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux//:jdk\",\n)\n"
             }
           },
@@ -4825,7 +4816,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_macos",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
               "sha256": "bcaab11cfe586fae7583c6d9d311c64384354fb2638eb9a012eca4c3f1a1d9fd",
               "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-macosx_x64",
@@ -4839,7 +4829,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_win_arm64",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
               "sha256": "b8a28e6e767d90acf793ea6f5bed0bb595ba0ba5ebdf8b99f395266161e53ec2",
               "strip_prefix": "jdk-11.0.13+8",
@@ -4852,7 +4841,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_macos",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
               "sha256": "640453e8afe8ffe0fb4dceb4535fb50db9c283c64665eebb0ba68b19e65f4b1f",
               "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-macosx_x64",
@@ -4866,7 +4854,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_macos",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
               "sha256": "9639b87db586d0c89f7a9892ae47f421e442c64b97baebdff31788fbe23265bd",
               "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-macosx_x64",
@@ -4877,18 +4864,16 @@
             }
           },
           "remotejdk21_macos_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_macos_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_macos//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_macos//:jdk\",\n)\n"
             }
           },
           "remotejdk17_macos_aarch64_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_macos_aarch64_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_macos_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_macos_aarch64//:jdk\",\n)\n"
             }
           },
@@ -4896,7 +4881,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_win",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
               "sha256": "192f2afca57701de6ec496234f7e45d971bf623ff66b8ee4a5c81582054e5637",
               "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-win_x64",
@@ -4907,18 +4891,16 @@
             }
           },
           "remotejdk11_macos_aarch64_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_macos_aarch64_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_macos_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_macos_aarch64//:jdk\",\n)\n"
             }
           },
           "remotejdk11_linux_ppc64le_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_linux_ppc64le_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:ppc\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_ppc64le//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:ppc\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_ppc64le//:jdk\",\n)\n"
             }
           },
@@ -4926,7 +4908,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_linux",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
               "sha256": "0c0eadfbdc47a7ca64aeab51b9c061f71b6e4d25d2d87674512e9b6387e9e3a6",
               "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-linux_x64",
@@ -4940,7 +4921,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remote_java_tools_linux",
               "sha256": "a781eb28bb28d1fd9eee129272f7f2eaf93cd272f974a5b3f6385889538d3408",
               "urls": [
                 "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.3/java_tools_linux-v13.3.zip",
@@ -4952,7 +4932,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_win",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
               "sha256": "e9959d500a0d9a7694ac243baf657761479da132f0f94720cbffd092150bd802",
               "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-win_x64",
@@ -4966,7 +4945,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_linux_aarch64",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
               "sha256": "1fb64b8036c5d463d8ab59af06bf5b6b006811e6012e3b0eb6bccf57f1c55835",
               "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-linux_aarch64",
@@ -4977,10 +4955,9 @@
             }
           },
           "remotejdk11_linux_aarch64_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_linux_aarch64_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_aarch64//:jdk\",\n)\n"
             }
           },
@@ -4988,7 +4965,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_linux_s390x",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
               "sha256": "a58fc0361966af0a5d5a31a2d8a208e3c9bb0f54f345596fd80b99ea9a39788b",
               "strip_prefix": "jdk-11.0.15+10",
@@ -5002,7 +4978,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_linux_aarch64",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
               "sha256": "6531cef61e416d5a7b691555c8cf2bdff689201b8a001ff45ab6740062b44313",
               "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-linux_aarch64",
@@ -5013,10 +4988,9 @@
             }
           },
           "remotejdk17_win_arm64_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_win_arm64_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:arm64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_win_arm64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:arm64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_win_arm64//:jdk\",\n)\n"
             }
           },
@@ -5024,7 +4998,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_linux",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
               "sha256": "a34b404f87a08a61148b38e1416d837189e1df7a040d949e743633daf4695a3c",
               "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-linux_x64",
@@ -5035,18 +5008,16 @@
             }
           },
           "remotejdk11_macos_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_macos_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_macos//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_macos//:jdk\",\n)\n"
             }
           },
           "remotejdk17_linux_ppc64le_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_linux_ppc64le_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:ppc\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_ppc64le//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:ppc\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_ppc64le//:jdk\",\n)\n"
             }
           },
@@ -5054,7 +5025,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_win_arm64",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
               "sha256": "6802c99eae0d788e21f52d03cab2e2b3bf42bc334ca03cbf19f71eb70ee19f85",
               "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-win_aarch64",
@@ -5068,7 +5038,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remote_java_tools_darwin_arm64",
               "sha256": "276bb552ee03341f93c0c218343295f60241fe1d32dccd97df89319c510c19a1",
               "urls": [
                 "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.3/java_tools_darwin_arm64-v13.3.zip",
@@ -5080,7 +5049,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_linux_ppc64le",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
               "sha256": "00a4c07603d0218cd678461b5b3b7e25b3253102da4022d31fc35907f21a2efd",
               "strip_prefix": "jdk-17.0.8.1+1",
@@ -5091,26 +5059,23 @@
             }
           },
           "remotejdk21_linux_aarch64_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_linux_aarch64_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_linux_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_linux_aarch64//:jdk\",\n)\n"
             }
           },
           "remotejdk11_win_arm64_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_win_arm64_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:arm64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_win_arm64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:arm64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_win_arm64//:jdk\",\n)\n"
             }
           },
           "local_jdk": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:local_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:local_java_repository.bzl",
             "ruleClassName": "_local_java_repository_rule",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~local_jdk",
               "java_home": "",
               "version": "",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = {RUNTIME_VERSION},\n)\n"
@@ -5120,7 +5085,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remote_java_tools_darwin_x86_64",
               "sha256": "55bd36bf2fad897d9107145f81e20a549a37e4d9d4c447b6915634984aa9f576",
               "urls": [
                 "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.3/java_tools_darwin_x86_64-v13.3.zip",
@@ -5132,7 +5096,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remote_java_tools",
               "sha256": "30a7d845bec3dd054ac45b5546c2fdf1922c0b1040b2a13b261fcc2e2d63a2f4",
               "urls": [
                 "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.3/java_tools-v13.3.zip",
@@ -5144,7 +5107,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_linux_s390x",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
               "sha256": "ffacba69c6843d7ca70d572489d6cc7ab7ae52c60f0852cedf4cf0d248b6fc37",
               "strip_prefix": "jdk-17.0.8.1+1",
@@ -5155,10 +5117,9 @@
             }
           },
           "remotejdk17_win_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk17_win_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_win//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_win//:jdk\",\n)\n"
             }
           },
@@ -5166,7 +5127,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_linux_ppc64le",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
               "sha256": "a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f",
               "strip_prefix": "jdk-11.0.15+10",
@@ -5180,7 +5140,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk11_macos_aarch64",
               "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
               "sha256": "7632bc29f8a4b7d492b93f3bc75a7b61630894db85d136456035ab2a24d38885",
               "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-macosx_aarch64",
@@ -5191,31 +5150,30 @@
             }
           },
           "remotejdk21_win_toolchain_config_repo": {
-            "bzlFile": "@@rules_java~7.3.2//toolchains:remote_java_repository.bzl",
+            "bzlFile": "@@rules_java~//toolchains:remote_java_repository.bzl",
             "ruleClassName": "_toolchain_config",
             "attributes": {
-              "name": "rules_java~7.3.2~toolchains~remotejdk21_win_toolchain_config_repo",
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_win//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_win//:jdk\",\n)\n"
             }
           }
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_java~7.3.2",
+            "rules_java~",
             "bazel_tools",
             "bazel_tools"
           ],
           [
-            "rules_java~7.3.2",
+            "rules_java~",
             "remote_java_tools",
-            "rules_java~7.3.2~toolchains~remote_java_tools"
+            "rules_java~~toolchains~remote_java_tools"
           ]
         ]
       }
     },
-    "@@rules_jvm_external~6.0//:MODULE.bazel%_repo_rules": {
+    "@@rules_jvm_external~//:MODULE.bazel%_repo_rules": {
       "general": {
-        "bzlTransitiveDigest": "nSp+oEsTv5DYy1r8s+aEwKWUHoJDhXelRNB5mFkZmdU=",
+        "bzlTransitiveDigest": "zJLwqQg1uLh8ImGrSMWJ3eK9A/g9h+BrTJBrFAwYF5g=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -5226,8 +5184,7 @@
               "sha256": "2b78bfdd3ef13fd1f42f158de0f029d7cbb1f4f652d51773445cf2b6f7918a87",
               "urls": [
                 "https://github.com/coursier/coursier/releases/download/v2.1.8/coursier.jar"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~coursier_cli"
+              ]
             }
           },
           "buildifier-linux-arm64": {
@@ -5237,8 +5194,7 @@
               "sha256": "917d599dbb040e63ae7a7e1adb710d2057811902fdc9e35cce925ebfd966eeb8",
               "urls": [
                 "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-arm64"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~buildifier-linux-arm64"
+              ]
             }
           },
           "buildifier-linux-x86_64": {
@@ -5248,8 +5204,7 @@
               "sha256": "52bf6b102cb4f88464e197caac06d69793fa2b05f5ad50a7e7bf6fbd656648a3",
               "urls": [
                 "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~buildifier-linux-x86_64"
+              ]
             }
           },
           "buildifier-macos-arm64": {
@@ -5259,8 +5214,7 @@
               "sha256": "745feb5ea96cb6ff39a76b2821c57591fd70b528325562486d47b5d08900e2e4",
               "urls": [
                 "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-arm64"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~buildifier-macos-arm64"
+              ]
             }
           },
           "buildifier-macos-x86_64": {
@@ -5270,8 +5224,7 @@
               "sha256": "c9378d9f4293fc38ec54a08fbc74e7a9d28914dae6891334401e59f38f6e65dc",
               "urls": [
                 "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-amd64"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~buildifier-macos-x86_64"
+              ]
             }
           },
           "com.google.ar.sceneform_rendering": {
@@ -5282,8 +5235,7 @@
               "sha256": "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
               "urls": [
                 "https://dl.google.com/android/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~com.google.ar.sceneform_rendering"
+              ]
             }
           },
           "hamcrest_core_for_test": {
@@ -5294,8 +5246,7 @@
               "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
               "urls": [
                 "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~hamcrest_core_for_test"
+              ]
             }
           },
           "hamcrest_core_srcs_for_test": {
@@ -5306,8 +5257,7 @@
               "sha256": "e223d2d8fbafd66057a8848cc94222d63c3cedd652cc48eddc0ab5c39c0f84df",
               "urls": [
                 "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~hamcrest_core_srcs_for_test"
+              ]
             }
           },
           "gson_for_test": {
@@ -5318,8 +5268,7 @@
               "sha256": "c96d60551331a196dac54b745aa642cd078ef89b6f267146b705f2c2cbef052d",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~gson_for_test"
+              ]
             }
           },
           "junit_platform_commons_for_test": {
@@ -5330,8 +5279,7 @@
               "sha256": "d2e015fca7130e79af2f4608dc54415e4b10b592d77333decb4b1a274c185050",
               "urls": [
                 "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.8.2/junit-platform-commons-1.8.2.jar"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~junit_platform_commons_for_test"
+              ]
             }
           },
           "google_api_services_compute_javadoc_for_test": {
@@ -5342,20 +5290,19 @@
               "sha256": "b03be5ee8effba3bfbaae53891a9c01d70e2e3bd82ad8889d78e641b22bd76c2",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/apis/google-api-services-compute/v1-rev235-1.25.0/google-api-services-compute-v1-rev235-1.25.0-javadoc.jar"
-              ],
-              "name": "rules_jvm_external~6.0~_repo_rules~google_api_services_compute_javadoc_for_test"
+              ]
             }
           }
         },
         "recordedRepoMappingEntries": []
       }
     },
-    "@@rules_jvm_external~6.0//:extensions.bzl%maven": {
+    "@@rules_jvm_external~//:extensions.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "ZfFFJr1eI3/nwAJgyEcYi9fjDDO/97v19BWbwVi0WeE=",
+        "bzlTransitiveDigest": "snNLjFwEomH8AkLvQ9Z06J2V4hWIE4sA4pLKVlFWKtk=",
         "accumulatedFileDigests": {
           "@@//:maven_install.json": "600f9d8ccad307e6c413a66a066844c6f6bb573c8178275de601e611a4cd3a82",
-          "@@rules_jvm_external~6.0//:rules_jvm_external_deps_install.json": "cafb5d2d8119391eb2b322ce3840d3352ea82d496bdb8cbd4b6779ec4d044dda",
+          "@@rules_jvm_external~//:rules_jvm_external_deps_install.json": "cafb5d2d8119391eb2b322ce3840d3352ea82d496bdb8cbd4b6779ec4d044dda",
           "@@//src/tools/android:maven_android_install.json": "09bff3e33d291336046f7c9201630fb5e014f0e60b78b6f09b84e4f5f73ed04f"
         },
         "envVariables": {},
@@ -5364,7 +5311,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_guava_guava_32_1_2_jre",
               "sha256": "bc65dea7cfd9e4dacf8419d8af0e741655857d27885bb35d943d7187fc3a8fce",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/guava/guava/32.1.2-jre/guava-32.1.2-jre.jar"
@@ -5376,7 +5322,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_errorprone_error_prone_type_annotations_2_23_0",
               "sha256": "97c4e41de140f9c5ba558afd1d1e9a8babdd46208266e19733a79795b817b5ec",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_type_annotations/2.23.0/error_prone_type_annotations-2.23.0.jar"
@@ -5388,7 +5333,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_netty_nio_client_2_20_128",
               "sha256": "d6117bf4c2f45c671e55ecdff60f364099ddc1cf9226c0c24601a7818b9a22ba",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/netty-nio-client/2.20.128/netty-nio-client-2.20.128.jar"
@@ -5400,7 +5344,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_sdk_core_2_20_128",
               "sha256": "19fd1e07de476f6b6c8342e254bf9b7df723dee65ac34002547789ec070d6a99",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/sdk-core/2.20.128/sdk-core-2.20.128.jar"
@@ -5412,7 +5355,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_ryanharter_auto_value_auto_value_gson_factory_1_3_1",
               "sha256": "5a76c3d401c984999d59868f08df05a15613d1428f7764fed80b722e2a277f6c",
               "urls": [
                 "https://repo1.maven.org/maven2/com/ryanharter/auto/value/auto-value-gson-factory/1.3.1/auto-value-gson-factory-1.3.1.jar"
@@ -5424,7 +5366,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_endpoints_spi_2_20_128",
               "sha256": "0b98f5553c1116520ef9022cebbde1b4dd7963c1c0f23b34137b64ccf17d0ff2",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/endpoints-spi/2.20.128/endpoints-spi-2.20.128.jar"
@@ -5436,7 +5377,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_gax_grpc_2_32_0",
               "sha256": "79e4c7910c74b3ca0e709665f36e061538f80d98b53e5168c301508d0159758d",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/gax-grpc/2.32.0/gax-grpc-2.32.0.jar"
@@ -5448,7 +5388,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_protobuf_1_48_1",
               "sha256": "6ab68b0a3bb3834af44208df058be4631425b56ef95f9b9412aa21df3311e8d3",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.48.1/grpc-protobuf-1.48.1.jar"
@@ -5460,7 +5399,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_jimfs_jimfs_1_1",
               "sha256": "c4828e28d7c0a930af9387510b3bada7daa5c04d7c25a75c7b8b081f1c257ddd",
               "urls": [
                 "https://dl.google.com/android/maven2/com/google/jimfs/jimfs/1.1/jimfs-1.1.jar",
@@ -5473,7 +5411,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_googlecode_json_simple_json_simple_1_1",
               "sha256": "2d9484f4c649f708f47f9a479465fc729770ee65617dca3011836602264f6439",
               "urls": [
                 "https://dl.google.com/android/maven2/com/googlecode/json-simple/json-simple/1.1/json-simple-1.1.jar",
@@ -5486,7 +5423,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_github_kevinstern_software_and_algorithms_1_0",
               "sha256": "61ab82439cef37343b14f53154c461619375373a56b9338e895709fb54e0864c",
               "urls": [
                 "https://repo1.maven.org/maven2/com/github/kevinstern/software-and-algorithms/1.0/software-and-algorithms-1.0.jar"
@@ -5498,7 +5434,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_jimfs_jimfs_1_2",
               "sha256": "de16d5c8489729a8512f1a02fbd81f58f89249b72066987da4cc5c87ecb9f72d",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/jimfs/jimfs/1.2/jimfs-1.2.jar"
@@ -5510,7 +5445,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_reactivestreams_reactive_streams_1_0_3",
               "sha256": "1dee0481072d19c929b623e155e14d2f6085dc011529a0a0dbefc84cf571d865",
               "urls": [
                 "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar"
@@ -5522,7 +5456,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_annotations_30_1_3",
               "sha256": "630ab4c6f211fa1c0f5c884152cb6311360f1b796442196c287a658645a99645",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/annotations/30.1.3/annotations-30.1.3.jar",
@@ -5535,7 +5468,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_api_1_56_1",
               "sha256": "b090b1bb5a3b066f7f2ef14b9ba68e3304de80ba34f90414aed3b519c30999e8",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-api/1.56.1/grpc-api-1.56.1.jar"
@@ -5547,7 +5479,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_util_9_1",
               "sha256": "380e2ecd16f7cc0f1a76ba9ba049179b5760a57b282a87a4c653caeff2cd5bd6",
               "urls": [
                 "https://dl.google.com/android/maven2/org/ow2/asm/asm-util/9.1/asm-util-9.1.jar",
@@ -5560,7 +5491,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_util_9_2",
               "sha256": "ff5b3cd331ae8a9a804768280da98f50f424fef23dd3c788bb320e08c94ee598",
               "urls": [
                 "https://repo1.maven.org/maven2/org/ow2/asm/asm-util/9.2/asm-util-9.2.jar"
@@ -5572,7 +5502,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_commons_commons_lang3_3_12_0",
               "sha256": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
               "urls": [
                 "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
@@ -5584,7 +5513,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_codec_http_4_1_94_Final",
               "sha256": "1ada4580f68cd17a534fb3c0337087073223a76cb77304dbe5a1b19df3d53c2f",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.94.Final/netty-codec-http-4.1.94.Final.jar"
@@ -5596,7 +5524,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~javax_activation_javax_activation_api_1_2_0",
               "sha256": "43fdef0b5b6ceb31b0424b208b930c74ab58fac2ceeb7b3f6fd3aeb8b5ca4393",
               "urls": [
                 "https://repo1.maven.org/maven2/javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar"
@@ -5608,7 +5535,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~it_unimi_dsi_fastutil_8_4_0",
               "sha256": "2ad2824a4a0a0eb836b52ee2fc84ba2134f44bce7bfa54015ae3f31c710a3071",
               "urls": [
                 "https://dl.google.com/android/maven2/it/unimi/dsi/fastutil/8.4.0/fastutil-8.4.0.jar",
@@ -5621,7 +5547,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_build_manifest_merger_30_1_3",
               "sha256": "fb04445bd588ccd27dacd5e139abed42246f55e6785eebf66659857233207fac",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/build/manifest-merger/30.1.3/manifest-merger-30.1.3.jar",
@@ -5634,7 +5559,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_glassfish_jaxb_jaxb_runtime_2_3_2",
               "sha256": "e6e0a1e89fb6ff786279e6a0082d5cef52dc2ebe67053d041800737652b4fd1b",
               "urls": [
                 "https://dl.google.com/android/maven2/org/glassfish/jaxb/jaxb-runtime/2.3.2/jaxb-runtime-2.3.2.jar",
@@ -5647,7 +5571,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_context_1_48_1",
               "sha256": "2fb9007e12f768e9c968f9db292be4ea9cba2ef40fb8d179f3f8746ebdc73c1b",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.48.1/grpc-context-1.48.1.jar"
@@ -5659,7 +5582,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_fasterxml_jackson_core_jackson_core_2_15_2",
               "sha256": "303c99e82b1faa91a0bae5d8fbeb56f7e2adf9b526a900dd723bf140d62bd4b4",
               "urls": [
                 "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2.jar"
@@ -5671,7 +5593,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_codec_4_1_93_Final",
               "sha256": "990c378168dc6364c6ff569701f4f2f122fffe8998b3e189eba4c4d868ed1084",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.93.Final/netty-codec-4.1.93.Final.jar"
@@ -5683,7 +5604,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_code_gson_gson_2_10_1",
               "sha256": "4241c14a7727c34feea6507ec801318a3d4a90f070e4525681079fb94ee4c593",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar"
@@ -5695,7 +5615,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_testparameterinjector_test_parameter_injector_1_15",
               "sha256": "a1ac1820becc772baaac57c4d2a4d49b6f7920e5dfd25b293ba8fb933a11dfe2",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/testparameterinjector/test-parameter-injector/1.15/test-parameter-injector-1.15.jar"
@@ -5707,7 +5626,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_grpc_proto_google_iam_v1_1_18_0",
               "sha256": "11ba274f3b23fae7985a51336ab45fcf24bf655604bdbfedc6d9701288fcc4cd",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.18.0/proto-google-iam-v1-1.18.0.jar"
@@ -5719,7 +5637,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_http_client_google_http_client_gson_1_43_3",
               "sha256": "e31a4edcb9c83954a2587e14fa2f3f8f4aad56152381b3321a3bd0bcae03fa26",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-gson/1.43.3/google-http-client-gson-1.43.3.jar"
@@ -5731,7 +5648,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_httpcomponents_httpcore_4_4_10",
               "sha256": "78ba1096561957db1b55200a159b648876430342d15d461277e62360da19f6fd",
               "urls": [
                 "https://dl.google.com/android/maven2/org/apache/httpcomponents/httpcore/4.4.10/httpcore-4.4.10.jar",
@@ -5744,7 +5660,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_build_builder_model_7_1_3",
               "sha256": "232604983a99b8372eb1a93e5183d48fc8fc69239e5e6229170be0e3320df430",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/build/builder-model/7.1.3/builder-model-7.1.3.jar",
@@ -5757,7 +5672,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_zipflinger_7_1_3",
               "sha256": "c6ed9458f3a85c847f168a7e3719bbd1e7484b97ec00096122ac8a9c4141665f",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/zipflinger/7.1.3/zipflinger-7.1.3.jar",
@@ -5770,7 +5684,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_turbine_turbine_0_4_0",
               "sha256": "1947490c23263ae1c0a95acceb7cb419724f236d14cfbbe5a558101e79842b28",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/turbine/turbine/0.4.0/turbine-0.4.0.jar"
@@ -5782,7 +5695,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_protobuf_lite_1_56_1",
               "sha256": "5605030f1668edf93ade7f24b0bfe5ecf943774e02cf0ac5cac02387ac910185",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.56.1/grpc-protobuf-lite-1.56.1.jar"
@@ -5794,7 +5706,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_httpcomponents_httpcore_4_4_16",
               "sha256": "6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f",
               "urls": [
                 "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar"
@@ -5806,7 +5717,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_grpc_gapic_google_cloud_storage_v2_2_26_1_alpha",
               "sha256": "4b1b414751ed08dfc9f5e7e93c3fa16b8c53de5d24bf2ded414240fa72842e09",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/grpc/gapic-google-cloud-storage-v2/2.26.1-alpha/gapic-google-cloud-storage-v2-2.26.1-alpha.jar"
@@ -5818,7 +5728,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_handler_proxy_4_1_93_Final",
               "sha256": "2ac5f7fbefa0b73ef783889069344d5515505a14b2303be693c5002c486df2b4",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.93.Final/netty-handler-proxy-4.1.93.Final.jar"
@@ -5830,7 +5739,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_build_builder_7_1_3",
               "sha256": "4b33ed3941563ffc67f8aeedc480aafd958ec6cd1fe661f0b2b5b0d9c1423649",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/build/builder/7.1.3/builder-7.1.3.jar",
@@ -5843,7 +5751,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_auth_2_20_128",
               "sha256": "aa12cf67a51d28a6f486e4818e5f0bd2c1398135df6705dd020af1f28a2bafec",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/auth/2.20.128/auth-2.20.128.jar"
@@ -5852,10 +5759,9 @@
             }
           },
           "maven_jar_migrator": {
-            "bzlFile": "@@rules_jvm_external~6.0//:coursier.bzl",
+            "bzlFile": "@@rules_jvm_external~//:coursier.bzl",
             "ruleClassName": "coursier_fetch",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~maven_jar_migrator",
               "user_provided_name": "maven_jar_migrator",
               "repositories": [
                 "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
@@ -5885,7 +5791,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_sun_istack_istack_commons_runtime_3_0_8",
               "sha256": "4ffabb06be454a05e4398e20c77fa2b6308d4b88dfbef7ca30a76b5b7d5505ef",
               "urls": [
                 "https://dl.google.com/android/maven2/com/sun/istack/istack-commons-runtime/3.0.8/istack-commons-runtime-3.0.8.jar",
@@ -5898,7 +5803,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_protobuf_protobuf_java_3_10_0",
               "sha256": "161d7d61a8cb3970891c299578702fd079646e032329d6c2cabf998d191437c9",
               "urls": [
                 "https://dl.google.com/android/maven2/com/google/protobuf/protobuf-java/3.10.0/protobuf-java-3.10.0.jar",
@@ -5911,7 +5815,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_netty_shaded_1_56_1",
               "sha256": "b15257e1137d609a7e8eb9bf4f0cec06b78ee69c030282db0a66d17cc9c3eaf1",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.56.1/grpc-netty-shaded-1.56.1.jar"
@@ -5923,7 +5826,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_kqueue_jar_osx_aarch_64_4_1_93_Final",
               "sha256": "6e9f04b5a16ba95b7371a735d60851602a3f3c549981edb74eeaf90e1b8fecce",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/4.1.93.Final/netty-transport-native-kqueue-4.1.93.Final-osx-aarch_64.jar"
@@ -5932,10 +5834,9 @@
             }
           },
           "kotlin_rules_maven": {
-            "bzlFile": "@@rules_jvm_external~6.0//:coursier.bzl",
+            "bzlFile": "@@rules_jvm_external~//:coursier.bzl",
             "ruleClassName": "coursier_fetch",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~kotlin_rules_maven",
               "user_provided_name": "kotlin_rules_maven",
               "repositories": [
                 "{ \"repo_url\": \"https://maven-central.storage.googleapis.com/repos/central/data/\" }",
@@ -5981,10 +5882,9 @@
             }
           },
           "unpinned_maven": {
-            "bzlFile": "@@rules_jvm_external~6.0//:coursier.bzl",
+            "bzlFile": "@@rules_jvm_external~//:coursier.bzl",
             "ruleClassName": "coursier_fetch",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~unpinned_maven",
               "user_provided_name": "maven",
               "repositories": [
                 "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
@@ -6134,7 +6034,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_testing_compile_compile_testing_0_18",
               "sha256": "92cfbee5ad356a403d36688ab7bae74be65db9a117478ace34ac3ab4d1f9feb9",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/testing/compile/compile-testing/0.18/compile-testing-0.18.jar"
@@ -6146,7 +6045,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_kqueue_jar_osx_x86_64_4_1_93_Final",
               "sha256": "bf3a21e503d26a600e2469e98f5acaadb57c18f207a51e8a7073b875c5f50e03",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/4.1.93.Final/netty-transport-native-kqueue-4.1.93.Final-osx-x86_64.jar"
@@ -6158,7 +6056,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_tomcat_tomcat_annotations_api_8_0_5",
               "sha256": "748677bebb1651a313317dfd93e984ed8f8c9e345538fa8b0ab0cbb804631953",
               "urls": [
                 "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-annotations-api/8.0.5/tomcat-annotations-api-8.0.5.jar"
@@ -6170,7 +6067,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_analytics_library_protos_30_1_3",
               "sha256": "6c7c2fc5ea590797db1532d7879b717cdd6328c8f74c0e32ddccdf392e94ffe6",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/analytics-library/protos/30.1.3/protos-30.1.3.jar",
@@ -6183,7 +6079,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_checkerframework_checker_qual_3_42_0",
               "sha256": "ccaedd33af0b7894d9f2f3b644f4d19e43928e32902e61ac4d10777830f5aac7",
               "urls": [
                 "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/3.42.0/checker-qual-3.42.0.jar"
@@ -6195,7 +6090,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_9_6",
               "sha256": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
               "urls": [
                 "https://repo1.maven.org/maven2/org/ow2/asm/asm/9.6/asm-9.6.jar"
@@ -6207,7 +6101,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_signflinger_7_1_3",
               "sha256": "899a4da318f83e6e8e64d3a51bf97add91b4c642a52f7162d3333c2f74ff4555",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/signflinger/7.1.3/signflinger-7.1.3.jar",
@@ -6220,7 +6113,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_gax_httpjson_2_32_0",
               "sha256": "5830038e076277d105cde00054c63926b98493d684634eb3c7f4318328d80ca0",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/gax-httpjson/2.32.0/gax-httpjson-2.32.0.jar"
@@ -6232,7 +6124,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_protobuf_protobuf_java_util_3_23_2",
               "sha256": "644975b780d7e8de542dda16d4ceb157b40a52a8be5645221e9fd026ef204b13",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.23.2/protobuf-java-util-3.23.2.jar"
@@ -6244,7 +6135,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_checkerframework_checker_compat_qual_2_5_3",
               "sha256": "d76b9afea61c7c082908023f0cbc1427fab9abd2df915c8b8a3e7a509bccbc6d",
               "urls": [
                 "https://repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/2.5.3/checker-compat-qual-2.5.3.jar"
@@ -6256,7 +6146,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_repository_30_1_3",
               "sha256": "11e2489f49f45b7709d080c2a82691ba42cfe8e13d3ac55487592fb550adb597",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/repository/30.1.3/repository-30.1.3.jar",
@@ -6269,7 +6158,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_apache_client_2_20_128",
               "sha256": "b35142b110c70ba0fd79f6f3e7633701d98424bcecc70d92eb336cb830244a09",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/apache-client/2.20.128/apache-client-2.20.128.jar"
@@ -6281,7 +6169,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_9_1",
               "sha256": "cda4de455fab48ff0bcb7c48b4639447d4de859a7afc30a094a986f0936beba2",
               "urls": [
                 "https://dl.google.com/android/maven2/org/ow2/asm/asm/9.1/asm-9.1.jar",
@@ -6294,7 +6181,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_stub_1_56_1",
               "sha256": "64ffca5dde4565c4c0f876deea3d105341d45ce605b29053e79dc86a22f7953b",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-stub/1.56.1/grpc-stub-1.56.1.jar"
@@ -6306,7 +6192,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_tcnative_boringssl_static_jar_linux_aarch_64_2_0_56_Final",
               "sha256": "8e5a30fc4a9514714367813f8027df4c9672746797b0699d83958d678e5cfeca",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.56.Final/netty-tcnative-boringssl-static-2.0.56.Final-linux-aarch_64.jar"
@@ -6318,7 +6203,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava",
               "sha256": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
@@ -6330,7 +6214,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_4_1_93_Final",
               "sha256": "a5a78019bc1cd43dbc3c7b7cdd3801912ca26d1f498fb560514fee497864ba96",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.93.Final/netty-transport-4.1.93.Final.jar"
@@ -6342,7 +6225,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_oauth_client_google_oauth_client_1_34_1",
               "sha256": "193edf97aefa28b93c5892bdc598bac34fa4c396588030084f290b1440e8b98a",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/oauth-client/google-oauth-client/1.34.1/google-oauth-client-1.34.1.jar"
@@ -6354,7 +6236,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_bouncycastle_bcprov_jdk15on_1_56",
               "sha256": "963e1ee14f808ffb99897d848ddcdb28fa91ddda867eb18d303e82728f878349",
               "urls": [
                 "https://dl.google.com/android/maven2/org/bouncycastle/bcprov-jdk15on/1.56/bcprov-jdk15on-1.56.jar",
@@ -6367,7 +6248,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_flogger_flogger_system_backend_0_5_1",
               "sha256": "685de33b53eb313049bbeee7f4b7a80dd09e8e754e96b048a3edab2cebb36442",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/flogger/flogger-system-backend/0.5.1/flogger-system-backend-0.5.1.jar"
@@ -6379,7 +6259,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_jetbrains_kotlin_kotlin_reflect_1_4_32",
               "sha256": "dbf19e9cdaa9c3c170f3f6f6ce3922f38dfc1d7fa1cab5b7c23a19da8b5eec5b",
               "urls": [
                 "https://dl.google.com/android/maven2/org/jetbrains/kotlin/kotlin-reflect/1.4.32/kotlin-reflect-1.4.32.jar",
@@ -6392,7 +6271,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_cloud_google_cloud_core_grpc_2_22_0",
               "sha256": "18eeb382b6cf83bfebd49a1c785a2474bb5937aeed15326c4e6d5595416dadf3",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core-grpc/2.22.0/google-cloud-core-grpc-2.22.0.jar"
@@ -6404,7 +6282,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~androidx_databinding_databinding_compiler_3_4_0_alpha10",
               "sha256": "2d741da6cc20a3f0136b6fdce6babf92d8b5115b37b05c61dd8ce6832499d629",
               "urls": [
                 "https://dl.google.com/android/maven2/androidx/databinding/databinding-compiler/3.4.0-alpha10/databinding-compiler-3.4.0-alpha10.jar",
@@ -6417,7 +6294,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~net_sf_jopt_simple_jopt_simple_4_9",
               "sha256": "26c5856e954b5f864db76f13b86919b59c6eecf9fd930b96baa8884626baf2f5",
               "urls": [
                 "https://dl.google.com/android/maven2/net/sf/jopt-simple/jopt-simple/4.9/jopt-simple-4.9.jar",
@@ -6430,7 +6306,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_cloud_google_cloud_storage_2_26_1",
               "sha256": "6a607268c51471280dc07176b46577951e0e198780a53c6a864fcb2a7acc9902",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-storage/2.26.1/google-cloud-storage-2.26.1.jar"
@@ -6442,7 +6317,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~jakarta_activation_jakarta_activation_api_1_2_1",
               "sha256": "8b0a0f52fa8b05c5431921a063ed866efaa41dadf2e3a7ee3e1961f2b0d9645b",
               "urls": [
                 "https://dl.google.com/android/maven2/jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1.jar",
@@ -6455,7 +6329,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_errorprone_error_prone_core_2_23_0",
               "sha256": "5f18d75490041ba6b446c9dc014f373b5eac1865463cdc6fd20f277e515fd9d7",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.23.0/error_prone_core-2.23.0.jar"
@@ -6467,7 +6340,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_http_client_spi_2_20_128",
               "sha256": "b09f1e0392975093ba0a2231e7057b673dacf05a798fe1b3f1446ba4f32e6a9b",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/http-client-spi/2.20.128/http-client-spi-2.20.128.jar"
@@ -6479,7 +6351,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_core_1_48_1",
               "sha256": "6d472ee6d2b60ef3f3e6801e7cd4dbec5fbbef81e883a0de1fbc55e6defe1cb7",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.48.1/grpc-core-1.48.1.jar"
@@ -6491,7 +6362,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_utils_2_20_128",
               "sha256": "ba635695d0046fae35740e9e64da9f0e34dab7cbc9a64813ce9ab49ed989f948",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/utils/2.20.128/utils-2.20.128.jar"
@@ -6503,7 +6373,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_codec_http_4_1_93_Final",
               "sha256": "dacf78ce78ab2d29570325db4cd2451ea589639807de95881a0fa7155a9e6b55",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.93.Final/netty-codec-http-4.1.93.Final.jar"
@@ -6515,7 +6384,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_common_30_1_3",
               "sha256": "194ea15f8b182cca975544fb97d92bc1c6ceb6059f35250a5971ac3c306ebdcc",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/common/30.1.3/common-30.1.3.jar",
@@ -6528,7 +6396,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_auth_1_48_1",
               "sha256": "ae63be5fe345ffdd5157284d90b783138eb31634e274182a8495242f9ad66a56",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-auth/1.48.1/grpc-auth-1.48.1.jar"
@@ -6540,7 +6407,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_httpcomponents_httpmime_4_5_6",
               "sha256": "0b2b1102c18d3c7e05a77214b9b7501a6f6056174ae5604e0e256776eda7553e",
               "urls": [
                 "https://dl.google.com/android/maven2/org/apache/httpcomponents/httpmime/4.5.6/httpmime-4.5.6.jar",
@@ -6553,7 +6419,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_resolver_dns_4_1_93_Final",
               "sha256": "2744ccc1bbd653c9f65f5764ab211f51cae56aa6c2e2288850a9add9c805be56",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.1.93.Final/netty-resolver-dns-4.1.93.Final.jar"
@@ -6565,7 +6430,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_resolver_4_1_94_Final",
               "sha256": "bd26e9bc5e94e2d3974a93fdf921658eff4f033bfd4c5208607760ab54298617",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.94.Final/netty-resolver-4.1.94.Final.jar"
@@ -6577,7 +6441,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_github_ben_manes_caffeine_caffeine_3_0_5",
               "sha256": "8a9b54d3506a3b92ee46b217bcee79196b21ca6d52dc2967c686a205fb2f9c15",
               "urls": [
                 "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/3.0.5/caffeine-3.0.5.jar"
@@ -6589,7 +6452,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_httpcomponents_httpclient_4_5_6",
               "sha256": "c03f813195e7a80e3608d0ddd8da80b21696a4c92a6a2298865bf149071551c7",
               "urls": [
                 "https://dl.google.com/android/maven2/org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar",
@@ -6602,7 +6464,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_tcnative_boringssl_static_jar_osx_aarch_64_2_0_56_Final",
               "sha256": "3b962ce1361b479ec7375f04e5d149e7b374a99ecf4f583c9aa0f0a92e5fa415",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.56.Final/netty-tcnative-boringssl-static-2.0.56.Final-osx-aarch_64.jar"
@@ -6614,7 +6475,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_threeten_threetenbp_1_6_8",
               "sha256": "e4b1eb3d90c38a54c7f3384fda957e0b5bf0b41b40672a44ae8b03cb6c87ce06",
               "urls": [
                 "https://repo1.maven.org/maven2/org/threeten/threetenbp/1.6.8/threetenbp-1.6.8.jar"
@@ -6626,7 +6486,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_guava_guava_33_0_0_jre",
               "sha256": "f4d85c3e4d411694337cb873abea09b242b664bb013320be6105327c45991537",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/guava/guava/33.0.0-jre/guava-33.0.0-jre.jar"
@@ -6638,7 +6497,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_errorprone_error_prone_check_api_2_23_0",
               "sha256": "4b0fc913b91d094221f1c7152fa74470eb8836cd6289b9f2de61411d72349290",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_check_api/2.23.0/error_prone_check_api-2.23.0.jar"
@@ -6650,7 +6508,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_errorprone_error_prone_annotations_2_3_4",
               "sha256": "baf7d6ea97ce606c53e11b6854ba5f2ce7ef5c24dddf0afa18d1260bd25b002c",
               "urls": [
                 "https://dl.google.com/android/maven2/com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.jar",
@@ -6663,7 +6520,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_re2j_re2j_1_7",
               "sha256": "4f657af51ab8bb0909bcc3eb40862d26125af8cbcf92aaaba595fed77f947bc0",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/re2j/re2j/1.7/re2j-1.7.jar"
@@ -6675,7 +6531,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_profiles_2_20_128",
               "sha256": "110a5a1bfa09b0be417d60bba97f9d8641d398ea36d72b942a97253066fd5fd0",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/profiles/2.20.128/profiles-2.20.128.jar"
@@ -6687,7 +6542,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auth_google_auth_library_oauth2_http_1_6_0",
               "sha256": "2220f02fcfc480e3798bab43b2618d158319f9fcb357c9eb04b4a68117699808",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/1.6.0/google-auth-library-oauth2-http-1.6.0.jar"
@@ -6699,7 +6553,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~javax_annotation_javax_annotation_api_1_3_2",
               "sha256": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
               "urls": [
                 "https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
@@ -6711,7 +6564,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auto_value_auto_value_annotations_1_10_2",
               "sha256": "3f3b7edfaf7fbbd88642f7bd5b09487b8dcf2b9e5f3a19f1eb7b3e53f20f14ba",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.10.2/auto-value-annotations-1.10.2.jar"
@@ -6723,7 +6575,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auto_value_auto_value_annotations_1_10_4",
               "sha256": "e1c45e6beadaef9797cb0d9afd5a45621ad061cd8632012f85582853a3887825",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.10.4/auto-value-annotations-1.10.4.jar"
@@ -6735,7 +6586,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_common_4_1_93_Final",
               "sha256": "443bb316599fb16e3baeba2fb58881814d7ff0b7af176fe76e38071a6e86f8c0",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.93.Final/netty-common-4.1.93.Final.jar"
@@ -6747,7 +6597,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_j2objc_j2objc_annotations_1_3",
               "sha256": "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b",
               "urls": [
                 "https://dl.google.com/android/maven2/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar",
@@ -6760,7 +6609,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_resolver_4_1_93_Final",
               "sha256": "e59770b66e81822e5d111ac4e544d7eb0c543e0a285f52628e53941acd8ed759",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.93.Final/netty-resolver-4.1.93.Final.jar"
@@ -6772,7 +6620,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_flogger_flogger_0_5_1",
               "sha256": "b5ecd1483e041197012786f749968a62063c1964d3ecfbf96ba92a95797bb8f5",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/flogger/flogger/0.5.1/flogger-0.5.1.jar"
@@ -6784,7 +6631,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_tcnative_boringssl_static_jar_linux_x86_64_2_0_56_Final",
               "sha256": "725c26b4dd58a1aa782020952ad949bdb607235dd20ee49e5a5875c15456ca86",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.56.Final/netty-tcnative-boringssl-static-2.0.56.Final-linux-x86_64.jar"
@@ -6796,7 +6642,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_http_client_google_http_client_apache_v2_1_43_3",
               "sha256": "4cc8485bdda05607c7d8b95b130168ac82ad80bb3618c608fbf941047a96ac3b",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-apache-v2/1.43.3/google-http-client-apache-v2-1.43.3.jar"
@@ -6808,7 +6653,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_ryanharter_auto_value_auto_value_gson_runtime_1_3_1",
               "sha256": "84ee23b7989d4bf19930b5bd3d03c0f2efb9e73bcee3a0208a9d1b2e1979c049",
               "urls": [
                 "https://repo1.maven.org/maven2/com/ryanharter/auto/value/auto-value-gson-runtime/1.3.1/auto-value-gson-runtime-1.3.1.jar"
@@ -6820,7 +6664,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_velocity_velocity_1_7",
               "sha256": "ec92dae810034f4b46dbb16ef4364a4013b0efb24a8c5dd67435cae46a290d8e",
               "urls": [
                 "https://repo1.maven.org/maven2/org/apache/velocity/velocity/1.7/velocity-1.7.jar"
@@ -6832,7 +6675,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_tree_9_2",
               "sha256": "aabf9bd23091a4ebfc109c1f3ee7cf3e4b89f6ba2d3f51c5243f16b3cffae011",
               "urls": [
                 "https://repo1.maven.org/maven2/org/ow2/asm/asm-tree/9.2/asm-tree-9.2.jar"
@@ -6844,7 +6686,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_classes_epoll_4_1_93_Final",
               "sha256": "23722fa366ba017137a68c5e92fc3ee27bbb341c681ac4790f61c6adb7289e26",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.93.Final/netty-transport-classes-epoll-4.1.93.Final.jar"
@@ -6856,7 +6697,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_tree_9_1",
               "sha256": "fd00afa49e9595d7646205b09cecb4a776a8ff0ba06f2d59b8f7bf9c704b4a73",
               "urls": [
                 "https://dl.google.com/android/maven2/org/ow2/asm/asm-tree/9.1/asm-tree-9.1.jar",
@@ -6869,7 +6709,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~androidx_databinding_databinding_compiler_common_3_4_0_alpha10",
               "sha256": "7e1ffef1c21064f2b065b17a69bc217270e14b6723311cf795f4276a05b83750",
               "urls": [
                 "https://dl.google.com/android/maven2/androidx/databinding/databinding-compiler-common/3.4.0-alpha10/databinding-compiler-common-3.4.0-alpha10.jar",
@@ -6882,7 +6721,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_client_google_api_client_2_2_0",
               "sha256": "58eca9fb0a869391689ffc828b3bd0b19ac76042ff9fab4881eddf7fde76903f",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api-client/google-api-client/2.2.0/google-api-client-2.2.0.jar"
@@ -6891,10 +6729,9 @@
             }
           },
           "rules_jvm_external_deps": {
-            "bzlFile": "@@rules_jvm_external~6.0//:coursier.bzl",
+            "bzlFile": "@@rules_jvm_external~//:coursier.bzl",
             "ruleClassName": "pinned_coursier_fetch",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~rules_jvm_external_deps",
               "user_provided_name": "rules_jvm_external_deps",
               "repositories": [
                 "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
@@ -6913,7 +6750,7 @@
               "fetch_sources": false,
               "fetch_javadoc": false,
               "generate_compat_repositories": false,
-              "maven_install_json": "@@rules_jvm_external~6.0//:rules_jvm_external_deps_install.json",
+              "maven_install_json": "@@rules_jvm_external~//:rules_jvm_external_deps_install.json",
               "override_targets": {},
               "strict_visibility": false,
               "strict_visibility_value": [
@@ -6932,7 +6769,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_commons_commons_compress_1_20",
               "sha256": "0aeb625c948c697ea7b205156e112363b59ed5e2551212cd4e460bdb72c7c06e",
               "urls": [
                 "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20.jar"
@@ -6944,7 +6780,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_checkerframework_checker_qual_3_5_0",
               "sha256": "729990b3f18a95606fc2573836b6958bcdb44cb52bfbd1b7aa9c339cff35a5a4",
               "urls": [
                 "https://dl.google.com/android/maven2/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.jar",
@@ -6957,7 +6792,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_crt_core_2_20_128",
               "sha256": "48d2b5c0102a234bf988da7e8ec5f36d51b41ae2b512df2cab29d99b6b7620eb",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/crt-core/2.20.128/crt-core-2.20.128.jar"
@@ -6969,7 +6803,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_http_client_google_http_client_appengine_1_43_3",
               "sha256": "66ade3c0e73566ed231032a2bda9f2f8e50e74911f6720bf0ee5233f6e5e033e",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-appengine/1.43.3/google-http-client-appengine-1.43.3.jar"
@@ -6981,7 +6814,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_auth_1_56_1",
               "sha256": "ac365e11532a4b779a2ac80ecc64dcbd3bafbdd666e08e22ffdb5c855069e3f9",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-auth/1.56.1/grpc-auth-1.56.1.jar"
@@ -6993,7 +6825,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_code_java_allocation_instrumenter_java_allocation_instrumenter_3_3_0",
               "sha256": "1ef5535a8bd41cf3072469f381b9ee6ab28275311a7499f53d6e52adf976fef0",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/code/java-allocation-instrumenter/java-allocation-instrumenter/3.3.0/java-allocation-instrumenter-3.3.0.jar"
@@ -7005,7 +6836,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_jetbrains_kotlin_kotlin_stdlib_jdk7_1_4_32",
               "sha256": "5f801e75ca27d8791c14b07943c608da27620d910a8093022af57f543d5d98b6",
               "urls": [
                 "https://dl.google.com/android/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.4.32/kotlin-stdlib-jdk7-1.4.32.jar",
@@ -7015,10 +6845,9 @@
             }
           },
           "maven_android": {
-            "bzlFile": "@@rules_jvm_external~6.0//:coursier.bzl",
+            "bzlFile": "@@rules_jvm_external~//:coursier.bzl",
             "ruleClassName": "pinned_coursier_fetch",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~maven_android",
               "user_provided_name": "maven_android",
               "repositories": [
                 "{ \"repo_url\": \"https://dl.google.com/android/maven2\" }",
@@ -7056,7 +6885,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_code_gson_gson_2_8_6",
               "sha256": "c8fb4839054d280b3033f800d1f5a97de2f028eb8ba2eb458ad287e536f3f25f",
               "urls": [
                 "https://dl.google.com/android/maven2/com/google/code/gson/gson/2.8.6/gson-2.8.6.jar",
@@ -7069,7 +6897,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auto_service_auto_service_annotations_1_0_1",
               "sha256": "c7bec54b7b5588b5967e870341091c5691181d954cf2039f1bf0a6eeb837473b",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auto/service/auto-service-annotations/1.0.1/auto-service-annotations-1.0.1.jar"
@@ -7081,7 +6908,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_unix_common_jar_linux_aarch_64_4_1_93_Final",
               "sha256": "29675f1d9a2f09e426c0016e5fb89328d38afad0403f1bd1b98f985253d96ad8",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.93.Final/netty-transport-native-unix-common-4.1.93.Final-linux-aarch_64.jar"
@@ -7093,7 +6919,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_jetbrains_kotlin_kotlin_stdlib_1_4_32",
               "sha256": "13e9fd3e69dc7230ce0fc873a92a4e5d521d179bcf1bef75a6705baac3bfecba",
               "urls": [
                 "https://dl.google.com/android/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.4.32/kotlin-stdlib-1.4.32.jar",
@@ -7106,7 +6931,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_layoutlib_layoutlib_api_30_1_3",
               "sha256": "14d7ffdcedeea701c7316d6eba58ae32d329293de215c3b7218d14711ecfffaf",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/layoutlib/layoutlib-api/30.1.3/layoutlib-api-30.1.3.jar",
@@ -7119,7 +6943,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_classes_kqueue_4_1_93_Final",
               "sha256": "453fe595c3e12b9228b930b845140aaed93a9fb87d1a5d829c55b31d670def9f",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-kqueue/4.1.93.Final/netty-transport-classes-kqueue-4.1.93.Final.jar"
@@ -7131,7 +6954,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~junit_junit_4_13_2",
               "sha256": "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
               "urls": [
                 "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar"
@@ -7143,7 +6965,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_sdklib_30_1_3",
               "sha256": "edf456a67ada3154c9fd23f9829699e8b654dc7f33f2430b50839d6904760b48",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/sdklib/30.1.3/sdklib-30.1.3.jar",
@@ -7156,7 +6977,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_grpc_proto_google_cloud_storage_v2_2_26_1_alpha",
               "sha256": "e1c33f066db9189f09d1b7ec698f939eb4591f937fcd1ca1cbd4f05f1eb0e25c",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-storage-v2/2.26.1-alpha/proto-google-cloud-storage-v2-2.26.1-alpha.jar"
@@ -7168,7 +6988,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_tukaani_xz_1_9",
               "sha256": "211b306cfc44f8f96df3a0a3ddaf75ba8c5289eed77d60d72f889bb855f535e5",
               "urls": [
                 "https://repo1.maven.org/maven2/org/tukaani/xz/1.9/xz-1.9.jar"
@@ -7180,7 +6999,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_http_client_google_http_client_1_42_0",
               "sha256": "82ca0e08171846d1768d5ac3f13244d6fe5a54102c14735ef40bf15d57d478e5",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/http-client/google-http-client/1.42.0/google-http-client-1.42.0.jar"
@@ -7192,7 +7010,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_sdk_common_30_1_3",
               "sha256": "6c44d6ffa3b1b34505fcb05422f08bd293391648dc974cc252ddc541fd9b27f5",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/sdk-common/30.1.3/sdk-common-30.1.3.jar",
@@ -7205,7 +7022,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_checkerframework_checker_qual_3_33_0",
               "sha256": "e316255bbfcd9fe50d165314b85abb2b33cb2a66a93c491db648e498a82c2de1",
               "urls": [
                 "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar"
@@ -7217,7 +7033,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_hamcrest_hamcrest_core_1_3",
               "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
               "urls": [
                 "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
@@ -7229,7 +7044,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_unix_common_jar_osx_aarch_64_4_1_93_Final",
               "sha256": "6c6ecf73016d360e09a1cac31acd953f508309612f1b97d73db2ed0813d8bf14",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.93.Final/netty-transport-native-unix-common-4.1.93.Final-osx-aarch_64.jar"
@@ -7241,7 +7055,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_sweers_autotransient_autotransient_1_0_0",
               "sha256": "914ce84508410ee1419514925f93b1855a9f7a7b5b5d02fc07f411d2a45f1bba",
               "urls": [
                 "https://repo1.maven.org/maven2/io/sweers/autotransient/autotransient/1.0.0/autotransient-1.0.0.jar"
@@ -7250,10 +7063,9 @@
             }
           },
           "unpinned_rules_jvm_external_deps": {
-            "bzlFile": "@@rules_jvm_external~6.0//:coursier.bzl",
+            "bzlFile": "@@rules_jvm_external~//:coursier.bzl",
             "ruleClassName": "coursier_fetch",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~unpinned_rules_jvm_external_deps",
               "user_provided_name": "rules_jvm_external_deps",
               "repositories": [
                 "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
@@ -7280,7 +7092,7 @@
               "strict_visibility_value": [
                 "@@//visibility:private"
               ],
-              "maven_install_json": "@@rules_jvm_external~6.0//:rules_jvm_external_deps_install.json",
+              "maven_install_json": "@@rules_jvm_external~//:rules_jvm_external_deps_install.json",
               "resolve_timeout": 600,
               "use_starlark_android_rules": false,
               "aar_import_bzl_label": "@build_bazel_rules_android//android:rules.bzl",
@@ -7292,7 +7104,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_rls_1_56_1",
               "sha256": "ff56fa9750087f9deea2d00e08f46c7a3fd40f1032c3f5b44a702c595ddb7f55",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-rls/1.56.1/grpc-rls-1.56.1.jar"
@@ -7304,7 +7115,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auth_google_auth_library_credentials_1_6_0",
               "sha256": "153fa3cdc153ac3ee25649e8037aeda4438256153d35acf3c27e83e4ee6165a4",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/1.6.0/google-auth-library-credentials-1.6.0.jar"
@@ -7316,7 +7126,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_tcnative_boringssl_static_jar_windows_x86_64_2_0_56_Final",
               "sha256": "b0d9505b09427ab655369506a802358966762edcb7cf08fc162dc2b368a2041c",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.56.Final/netty-tcnative-boringssl-static-2.0.56.Final-windows-x86_64.jar"
@@ -7328,7 +7137,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_classes_epoll_4_1_94_Final",
               "sha256": "9d5d51eb42081d6fc13f4dca6855cd30d098a5b1d0b06d5644a1342bd1e50a44",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.94.Final/netty-transport-classes-epoll-4.1.94.Final.jar"
@@ -7340,7 +7148,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_googlecode_juniversalchardet_juniversalchardet_1_0_3",
               "sha256": "757bfe906193b8b651e79dc26cd67d6b55d0770a2cdfb0381591504f779d4a76",
               "urls": [
                 "https://dl.google.com/android/maven2/com/googlecode/juniversalchardet/juniversalchardet/1.0.3/juniversalchardet-1.0.3.jar",
@@ -7353,7 +7160,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_opencensus_opencensus_contrib_http_util_0_31_1",
               "sha256": "3ea995b55a4068be22989b70cc29a4d788c2d328d1d50613a7a9afd13fdd2d0a",
               "urls": [
                 "https://repo1.maven.org/maven2/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.jar"
@@ -7365,7 +7171,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_alts_1_56_1",
               "sha256": "04317f8835b3a8736ba12a7a25e474430c7f2d8c0b7afc433c2abc4cb2f0d4e8",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-alts/1.56.1/grpc-alts-1.56.1.jar"
@@ -7377,7 +7182,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_flogger_google_extensions_0_5_1",
               "sha256": "8b0862cad85b9549f355fe383c6c63816d2f19529634e033ae06d0107ab110b9",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/flogger/google-extensions/0.5.1/google-extensions-0.5.1.jar"
@@ -7389,7 +7193,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_sun_activation_javax_activation_1_2_0",
               "sha256": "993302b16cd7056f21e779cc577d175a810bb4900ef73cd8fbf2b50f928ba9ce",
               "urls": [
                 "https://dl.google.com/android/maven2/com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar",
@@ -7402,7 +7205,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auth_google_auth_library_oauth2_http_1_19_0",
               "sha256": "01bdf5c5cd85e10b794e401775d9909b56a38ffce313fbd39510a5d87ed56f58",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/1.19.0/google-auth-library-oauth2-http-1.19.0.jar"
@@ -7414,7 +7216,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_ryanharter_auto_value_auto_value_gson_extension_1_3_1",
               "sha256": "261be84be30a56994e132d718a85efcd579197a2edb9426b84c5722c56955eca",
               "urls": [
                 "https://repo1.maven.org/maven2/com/ryanharter/auto/value/auto-value-gson-extension/1.3.1/auto-value-gson-extension-1.3.1.jar"
@@ -7426,7 +7227,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_guava_guava_30_1_jre",
               "sha256": "e6dd072f9d3fe02a4600688380bd422bdac184caf6fe2418cfdd0934f09432aa",
               "urls": [
                 "https://dl.google.com/android/maven2/com/google/guava/guava/30.1-jre/guava-30.1-jre.jar",
@@ -7439,7 +7239,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~net_bytebuddy_byte_buddy_agent_1_14_5",
               "sha256": "55f19862b870f5d85890ba5386b1b45e9bbc88d5fe1f819abe0c788b4929fa6b",
               "urls": [
                 "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.14.5/byte-buddy-agent-1.14.5.jar"
@@ -7451,7 +7250,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_cloud_google_cloud_core_http_2_22_0",
               "sha256": "eba963e2d7aee9cb7dd71872f634d4418c7dffc260f740431b9f577b09417c03",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core-http/2.22.0/google-cloud-core-http-2.22.0.jar"
@@ -7463,7 +7261,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_j2objc_j2objc_annotations_2_8",
               "sha256": "f02a95fa1a5e95edb3ed859fd0fb7df709d121a35290eff8b74dce2ab7f4d6ed",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar"
@@ -7475,7 +7272,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auth_google_auth_library_credentials_1_19_0",
               "sha256": "095984b0594888a47f311b3c9dcf6da9ed86feeea8f78140c55e14c27b0593e5",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/1.19.0/google-auth-library-credentials-1.19.0.jar"
@@ -7487,7 +7283,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~net_java_dev_jna_jna_platform_5_6_0",
               "sha256": "9ecea8bf2b1b39963939d18b70464eef60c508fed8820f9dcaba0c35518eabf7",
               "urls": [
                 "https://dl.google.com/android/maven2/net/java/dev/jna/jna-platform/5.6.0/jna-platform-5.6.0.jar",
@@ -7500,7 +7295,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_xds_1_56_1",
               "sha256": "688950e2dc79c2b227fcad553f4e4c8faf8de324eeccb3a591ff679929bbfa24",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-xds/1.56.1/grpc-xds-1.56.1.jar"
@@ -7512,7 +7306,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_analytics_library_shared_30_1_3",
               "sha256": "7c7d19727641e1fbbb61e8569712b3a0229e4e0352636b5745049d41e1a71e00",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/analytics-library/shared/30.1.3/shared-30.1.3.jar",
@@ -7525,7 +7318,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_code_findbugs_jsr305_3_0_2",
               "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
@@ -7537,7 +7329,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_aws_core_2_20_128",
               "sha256": "105f5d4a204a6a759ab502922df4cd5aa2a6d1b0c5f53ce88713f60abd4650e9",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/aws-core/2.20.128/aws-core-2.20.128.jar"
@@ -7549,7 +7340,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_apis_google_api_services_storage_v1_rev20230617_2_0_0",
               "sha256": "43484b32b410b2b8ff32ac9ab1b89c039c727c2e37465e375ce2846d5a804645",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/apis/google-api-services-storage/v1-rev20230617-2.0.0/google-api-services-storage-v1-rev20230617-2.0.0.jar"
@@ -7561,7 +7351,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_http_client_google_http_client_gson_1_42_0",
               "sha256": "cb852272c1cb0c8449d8b1a70f3e0f2c1efb2063e543183faa43078fb446f540",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-gson/1.42.0/google-http-client-gson-1.42.0.jar"
@@ -7573,7 +7362,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_googlejavaformat_google_java_format_1_17_0",
               "sha256": "631ba54c39f6c20df027dc1420736df2e5e43c581880efdd1e46ddb4ce050e3e",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/googlejavaformat/google-java-format/1.17.0/google-java-format-1.17.0.jar"
@@ -7585,7 +7373,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_mockito_mockito_core_5_4_0",
               "sha256": "b1689b06617ea01fd777bfaedbdde512faf083d639a049f79b388d5a4e96d2e5",
               "urls": [
                 "https://repo1.maven.org/maven2/org/mockito/mockito-core/5.4.0/mockito-core-5.4.0.jar"
@@ -7597,7 +7384,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_guava_failureaccess_1_0_2",
               "sha256": "8a8f81cf9b359e3f6dfa691a1e776985c061ef2f223c9b2c80753e1b458e8064",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar"
@@ -7609,7 +7395,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_opencensus_opencensus_api_0_31_1",
               "sha256": "f1474d47f4b6b001558ad27b952e35eda5cc7146788877fc52938c6eba24b382",
               "urls": [
                 "https://repo1.maven.org/maven2/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.jar"
@@ -7621,7 +7406,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_guava_failureaccess_1_0_1",
               "sha256": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
               "urls": [
                 "https://dl.google.com/android/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
@@ -7634,7 +7418,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_perfmark_perfmark_api_0_26_0",
               "sha256": "b7d23e93a34537ce332708269a0d1404788a5b5e1949e82f5535fce51b3ea95b",
               "urls": [
                 "https://repo1.maven.org/maven2/io/perfmark/perfmark-api/0.26.0/perfmark-api-0.26.0.jar"
@@ -7646,7 +7429,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_context_1_56_1",
               "sha256": "3d442ce08bfb1b487edf76d12e2dfd991c3877af32cf772a83c73d06f89743bc",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.56.1/grpc-context-1.56.1.jar"
@@ -7658,7 +7440,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_objenesis_objenesis_3_3",
               "sha256": "02dfd0b0439a5591e35b708ed2f5474eb0948f53abf74637e959b8e4ef69bfeb",
               "urls": [
                 "https://repo1.maven.org/maven2/org/objenesis/objenesis/3.3/objenesis-3.3.jar"
@@ -7670,7 +7451,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_guava_guava_testlib_33_0_0_jre",
               "sha256": "79626019fed282b70eef91f645a9febd5f6b9f7be46484b6b328313a481f05f0",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar"
@@ -7682,7 +7462,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_maven_maven_artifact_3_9_4",
               "sha256": "7dd352fd9f8ff86a1d0a7d89e6289d8d3cd346ac9b214ed85868d585be05ab78",
               "urls": [
                 "https://repo1.maven.org/maven2/org/apache/maven/maven-artifact/3.9.4/maven-artifact-3.9.4.jar"
@@ -7694,7 +7473,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_truth_truth_1_4_0",
               "sha256": "235c28e96ee6701ab01cc852fb294cb0f34756f636a8154b9aef08fb1215bbc4",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/truth/truth/1.4.0/truth-1.4.0.jar"
@@ -7706,7 +7484,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_build_apksig_7_1_3",
               "sha256": "095885c56af3e52e9c7d2ac9b6cf07a8e3bf7fedfbab3914c75c39677d346ada",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/build/apksig/7.1.3/apksig-7.1.3.jar",
@@ -7719,7 +7496,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_beust_jcommander_1_82",
               "sha256": "deeac157c8de6822878d85d0c7bc8467a19cc8484d37788f7804f039dde280b1",
               "urls": [
                 "https://repo1.maven.org/maven2/com/beust/jcommander/1.82/jcommander-1.82.jar"
@@ -7731,7 +7507,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~it_unimi_dsi_fastutil_7_2_1",
               "sha256": "d73dec5ec18f973f380869b6125d60f5cda77cf6e40e321bd06e0308ed0a40b7",
               "urls": [
                 "https://repo1.maven.org/maven2/it/unimi/dsi/fastutil/7.2.1/fastutil-7.2.1.jar"
@@ -7743,7 +7518,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_metrics_spi_2_20_128",
               "sha256": "5fcbfe4d10d0814ea1caa963d66129b1dfcf5e2f7c3a8298596676985234f94c",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/metrics-spi/2.20.128/metrics-spi-2.20.128.jar"
@@ -7755,7 +7529,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~androidx_databinding_databinding_common_3_4_0_alpha10",
               "sha256": "1b2cfc3beaf6139e1851dd4a888cda8192ba0ad4be3de43450d5f30569845303",
               "urls": [
                 "https://dl.google.com/android/maven2/androidx/databinding/databinding-common/3.4.0-alpha10/databinding-common-3.4.0-alpha10.jar",
@@ -7768,7 +7541,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_codehaus_mojo_animal_sniffer_annotations_1_23",
               "sha256": "9ffe526bf43a6348e9d8b33b9cd6f580a7f5eed0cf055913007eda263de974d0",
               "urls": [
                 "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.23/animal-sniffer-annotations-1.23.jar"
@@ -7780,7 +7552,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_eventstream_eventstream_1_0_1",
               "sha256": "0c37d8e696117f02c302191b8110b0d0eb20fa412fce34c3a269ec73c16ce822",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar"
@@ -7792,7 +7563,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_threeten_threeten_extra_1_5_0",
               "sha256": "e7def554536188fbaf8aac1a0a2f956b039cbbb5696edc3b8336c442c56ae445",
               "urls": [
                 "https://repo1.maven.org/maven2/org/threeten/threeten-extra/1.5.0/threeten-extra-1.5.0.jar"
@@ -7804,7 +7574,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_codec_dns_4_1_93_Final",
               "sha256": "10a278b19d6393d5637f745007cb26d47dd16d468898dcc4a43e26d39c6cdd29",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.1.93.Final/netty-codec-dns-4.1.93.Final.jar"
@@ -7816,7 +7585,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_unix_common_jar_linux_x86_64_4_1_93_Final",
               "sha256": "8923a73ba8a373f7b994906f5902ba9f6bb59d181d4ad01576a6e0c5abb09b67",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.93.Final/netty-transport-native-unix-common-4.1.93.Final-linux-x86_64.jar"
@@ -7828,7 +7596,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_handler_4_1_93_Final",
               "sha256": "4e5f563ae14ed713381816d582f5fcfd0615aefb29203486cdfb782d8a00a02b",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.93.Final/netty-handler-4.1.93.Final.jar"
@@ -7840,7 +7607,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_databinding_baseLibrary_3_4_0_alpha10",
               "sha256": "1aed4f3e46bf83c80a1722ce6cc64a8133c4554a668c483f6b3d0f2c06dd7461",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/databinding/baseLibrary/3.4.0-alpha10/baseLibrary-3.4.0-alpha10.jar",
@@ -7853,7 +7619,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_codehaus_mojo_animal_sniffer_annotations_1_21",
               "sha256": "2f25841c937e24959a57b630e2c4b8525b3d0f536f2e511c9b2bed30b1651d54",
               "urls": [
                 "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.21/animal-sniffer-annotations-1.21.jar"
@@ -7865,7 +7630,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_json_utils_2_20_128",
               "sha256": "82a05550dcf9538d878d9d26e8c97913aa34600f7614cd7fd3b6e1f3f67c13cd",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/json-utils/2.20.128/json-utils-2.20.128.jar"
@@ -7877,7 +7641,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_errorprone_error_prone_annotation_2_23_0",
               "sha256": "64eef5d9f2cd58459221f0a664e3add6d22abe7ecf5293601f1044555f5224f1",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotation/2.23.0/error_prone_annotation-2.23.0.jar"
@@ -7889,7 +7652,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_codec_http2_4_1_93_Final",
               "sha256": "d96cc09045a1341c6d47494352aa263b87b72fb1d2ea9eca161aa73820bfe8bb",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.93.Final/netty-codec-http2-4.1.93.Final.jar"
@@ -7901,7 +7663,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_protobuf_1_56_1",
               "sha256": "46185731a718d723d853723610a77e9062da9a6fc8b4ff14f370ba10cf097893",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.56.1/grpc-protobuf-1.56.1.jar"
@@ -7913,7 +7674,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_buffer_4_1_93_Final",
               "sha256": "007c7d9c378df02d390567d0d7ddf542ffddb021b7313dbf502392113ffabb08",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.93.Final/netty-buffer-4.1.93.Final.jar"
@@ -7925,7 +7685,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~commons_lang_commons_lang_2_6",
               "sha256": "50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c",
               "urls": [
                 "https://repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6.jar"
@@ -7937,7 +7696,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_antlr_antlr4_4_5_3",
               "sha256": "a32de739cfdf515774e696f91aa9697d2e7731e5cb5045ca8a4b657f8b1b4fb4",
               "urls": [
                 "https://dl.google.com/android/maven2/org/antlr/antlr4/4.5.3/antlr4-4.5.3.jar",
@@ -7950,7 +7708,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_tcnative_classes_2_0_56_Final",
               "sha256": "eede807f0dd5eb1ad74ea1ae1094430631da63fcde00d4dc20eb0cd048bb0ac3",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-tcnative-classes/2.0.56.Final/netty-tcnative-classes-2.0.56.Final.jar"
@@ -7962,7 +7719,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_grpc_proto_google_common_protos_2_23_0",
               "sha256": "ff880ec7fae731bed60377871fa3138ad6ea6fd31d0c6055c2e70ea47917402b",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.23.0/proto-google-common-protos-2.23.0.jar"
@@ -7974,7 +7730,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_http_client_google_http_client_apache_v2_1_42_0",
               "sha256": "1fc4964236b67cf3c5651d7ac1dff668f73b7810c7f1dc0862a0e5bc01608785",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-apache-v2/1.42.0/google-http-client-apache-v2-1.42.0.jar"
@@ -7986,7 +7741,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_perfmark_perfmark_api_0_25_0",
               "sha256": "2044542933fcdf40ad18441bec37646d150c491871157f288847e29cb81de4cb",
               "urls": [
                 "https://repo1.maven.org/maven2/io/perfmark/perfmark-api/0.25.0/perfmark-api-0.25.0.jar"
@@ -7998,7 +7752,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_4_1_94_Final",
               "sha256": "a75afa84ca35a50225991b39e6b6278186e612f7a2a0c0e981de523aaac516a4",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.94.Final/netty-transport-4.1.94.Final.jar"
@@ -8010,7 +7763,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_api_1_48_1",
               "sha256": "aeb8d7a1361aa3d8f5a191580fa7f8cbc5ceb53137a4a698590f612f791e2c45",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-api/1.48.1/grpc-api-1.48.1.jar"
@@ -8022,7 +7774,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_analysis_9_2",
               "sha256": "878fbe521731c072d14d2d65b983b1beae6ad06fda0007b6a8bae81f73f433c4",
               "urls": [
                 "https://repo1.maven.org/maven2/org/ow2/asm/asm-analysis/9.2/asm-analysis-9.2.jar"
@@ -8034,7 +7785,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_common_4_1_94_Final",
               "sha256": "cb8d84a3e63aea90d0d7a333a02e50ac751d2b05db55745d981b5eff893f647b",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.94.Final/netty-common-4.1.94.Final.jar"
@@ -8046,7 +7796,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_aws_xml_protocol_2_20_128",
               "sha256": "085f9e55c26daa7d38b17795d0e767e159da595892b95a60a6be4e76936ea68f",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/aws-xml-protocol/2.20.128/aws-xml-protocol-2.20.128.jar"
@@ -8058,7 +7807,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_analysis_9_1",
               "sha256": "81a88041b1b8beda5a8a99646098046c48709538270c49def68abff25ac3be34",
               "urls": [
                 "https://dl.google.com/android/maven2/org/ow2/asm/asm-analysis/9.1/asm-analysis-9.1.jar",
@@ -8071,7 +7819,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_squareup_javapoet_1_12_0",
               "sha256": "2b70cdfa8c9e997b4007035a266c273c0df341f9c57c9d0b45a680ae3fd882db",
               "urls": [
                 "https://repo1.maven.org/maven2/com/squareup/javapoet/1.12.0/javapoet-1.12.0.jar"
@@ -8080,10 +7827,9 @@
             }
           },
           "unpinned_maven_android": {
-            "bzlFile": "@@rules_jvm_external~6.0//:coursier.bzl",
+            "bzlFile": "@@rules_jvm_external~//:coursier.bzl",
             "ruleClassName": "coursier_fetch",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~unpinned_maven_android",
               "user_provided_name": "maven_android",
               "repositories": [
                 "{ \"repo_url\": \"https://dl.google.com/android/maven2\" }",
@@ -8122,7 +7868,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_s3_2_20_128",
               "sha256": "9b8f061683e06703d5728f22379c31d39bcb1bdcb418e38957cdea886c2aea00",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/s3/2.20.128/s3-2.20.128.jar"
@@ -8134,7 +7879,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_squareup_javapoet_1_8_0",
               "sha256": "8e108c92027bb428196f10fa11cffbe589f7648a6af2016d652279385fdfd789",
               "urls": [
                 "https://dl.google.com/android/maven2/com/squareup/javapoet/1.8.0/javapoet-1.8.0.jar",
@@ -8147,7 +7891,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_codec_http2_4_1_94_Final",
               "sha256": "8fbd2e95abec6155b60ed3c9c1600ed4e17ffe3f053cd5a40677d879c0af961f",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.94.Final/netty-codec-http2-4.1.94.Final.jar"
@@ -8159,7 +7902,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_protocol_core_2_20_128",
               "sha256": "59107235409e9af0ec2f68aaad0d6cfe78b79e23600a59081a3f2af83e81c3c2",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/protocol-core/2.20.128/protocol-core-2.20.128.jar"
@@ -8171,7 +7913,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_arns_2_20_128",
               "sha256": "db6e5c582aaafcbe2e1804090505c6dbd76188b2a1661ecfd06afb7e949985b9",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/arns/2.20.128/arns-2.20.128.jar"
@@ -8183,7 +7924,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_protobuf_lite_1_48_1",
               "sha256": "0a4c735bb80e342d418c0ef7d2add7793aaf72b91c449bde2769ea81f1869737",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.48.1/grpc-protobuf-lite-1.48.1.jar"
@@ -8195,7 +7935,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_third_party_jackson_core_2_20_128",
               "sha256": "5487638bb3033b4de5f9cc04d97c4b5ec48533f2617803818e6263edc58b37cc",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/third-party-jackson-core/2.20.128/third-party-jackson-core-2.20.128.jar"
@@ -8207,7 +7946,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_squareup_javawriter_2_5_0",
               "sha256": "fcfb09fb0ea0aa97d3cfe7ea792398081348e468f126b3603cb3803f240197f0",
               "urls": [
                 "https://dl.google.com/android/maven2/com/squareup/javawriter/2.5.0/javawriter-2.5.0.jar",
@@ -8220,7 +7958,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_httpcomponents_httpclient_4_5_14",
               "sha256": "c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6",
               "urls": [
                 "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar"
@@ -8232,7 +7969,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_api_common_2_15_0",
               "sha256": "8c56f69021f1e6dc5bbf5597459220df176d78278456c5a80b47369c83af251b",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/api-common/2.15.0/api-common-2.15.0.jar"
@@ -8244,7 +7980,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~net_sf_kxml_kxml2_2_3_0",
               "sha256": "f264dd9f79a1fde10ce5ecc53221eff24be4c9331c830b7d52f2f08a7b633de2",
               "urls": [
                 "https://dl.google.com/android/maven2/net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar",
@@ -8257,7 +7992,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_core_1_56_1",
               "sha256": "fddeafc25019b7e5600028d6398e9ed7383056d9aecaf95aec5c39c5085a4830",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.56.1/grpc-core-1.56.1.jar"
@@ -8269,7 +8003,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_services_1_56_1",
               "sha256": "0d14ece28e97b30aa9ef1b63782d48261dd63738ef1c5615afefb8b963c121c8",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-services/1.56.1/grpc-services-1.56.1.jar"
@@ -8281,7 +8014,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_code_gson_gson_2_9_0",
               "sha256": "c96d60551331a196dac54b745aa642cd078ef89b6f267146b705f2c2cbef052d",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar"
@@ -8293,7 +8025,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_regions_2_20_128",
               "sha256": "79ac0d6a19daf4b5cb480a955bc36ed083e728fd2d0fb78efde2bcaaed0fce9f",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/regions/2.20.128/regions-2.20.128.jar"
@@ -8305,7 +8036,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~jakarta_xml_bind_jakarta_xml_bind_api_2_3_2",
               "sha256": "69156304079bdeed9fc0ae3b39389f19b3cc4ba4443bc80508995394ead742ea",
               "urls": [
                 "https://dl.google.com/android/maven2/jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2.jar",
@@ -8318,7 +8048,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_errorprone_error_prone_annotations_2_24_1",
               "sha256": "19fe2f7155d20ea093168527999da98108103ee546d1e8b726bc4b27c31a3c30",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.24.1/error_prone_annotations-2.24.1.jar"
@@ -8330,7 +8059,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_grpc_grpc_google_cloud_storage_v2_2_26_1_alpha",
               "sha256": "c5fa3121300bf3558248792ca8279f13208b395f6ba5e004ae32fcb2964810bd",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-storage-v2/2.26.1-alpha/grpc-google-cloud-storage-v2-2.26.1-alpha.jar"
@@ -8342,7 +8070,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_pcollections_pcollections_3_1_4",
               "sha256": "34f579ba075c8da2c8a0fedd0f04e21eac2fb6c660d90d0fabb573e8b4dc6918",
               "urls": [
                 "https://repo1.maven.org/maven2/org/pcollections/pcollections/3.1.4/pcollections-3.1.4.jar"
@@ -8354,7 +8081,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~xerces_xercesImpl_2_12_0",
               "sha256": "b50d3a4ca502faa4d1c838acb8aa9480446953421f7327e338c5dda3da5e76d0",
               "urls": [
                 "https://dl.google.com/android/maven2/xerces/xercesImpl/2.12.0/xercesImpl-2.12.0.jar",
@@ -8367,7 +8093,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_codehaus_plexus_plexus_utils_3_5_1",
               "sha256": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
               "urls": [
                 "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar"
@@ -8379,7 +8104,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_handler_4_1_94_Final",
               "sha256": "8e50719a9ab89e33ef85c5f36d780e0d7056b3f768b07d261d87baed7094eb3c",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.94.Final/netty-handler-4.1.94.Final.jar"
@@ -8391,7 +8115,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_analytics_library_tracker_30_1_3",
               "sha256": "c30e3634f83d524680f3aba2861078fb14bd347e6f9f0e5c079fba6142eec7e9",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/analytics-library/tracker/30.1.3/tracker-30.1.3.jar",
@@ -8404,7 +8127,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_tcnative_boringssl_static_jar_osx_x86_64_2_0_56_Final",
               "sha256": "9a77e8910af04becbdb535592c6a1e1a9accecde522aa1bb925a023c2c59d6dc",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.56.Final/netty-tcnative-boringssl-static-2.0.56.Final-osx-x86_64.jar"
@@ -8416,7 +8138,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_http_client_google_http_client_1_43_3",
               "sha256": "60aca7428c5a1ff3655b70541a98ff3d70dded48ac1324dae1af39f1b61914af",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/http-client/google-http-client/1.43.3/google-http-client-1.43.3.jar"
@@ -8428,7 +8149,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_truth_extensions_truth_proto_extension_1_4_0",
               "sha256": "99e6cede45cb1fe962e6ae4e95fb045df8038b01eee03eee362bb073e42f54fc",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/truth/extensions/truth-proto-extension/1.4.0/truth-proto-extension-1.4.0.jar"
@@ -8440,7 +8160,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_stub_1_48_1",
               "sha256": "6436f19cef264fd949fb7a41e11424e373aa3b1096cad0b7e518f1c81aa60f23",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-stub/1.48.1/grpc-stub-1.48.1.jar"
@@ -8452,7 +8171,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_opencensus_opencensus_proto_0_2_0",
               "sha256": "0c192d451e9dd74e98721b27d02f0e2b6bca44b51563b5dabf2e211f7a3ebf13",
               "urls": [
                 "https://repo1.maven.org/maven2/io/opencensus/opencensus-proto/0.2.0/opencensus-proto-0.2.0.jar"
@@ -8464,7 +8182,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_slf4j_slf4j_api_1_7_30",
               "sha256": "cdba07964d1bb40a0761485c6b1e8c2f8fd9eb1d19c53928ac0d7f9510105c57",
               "urls": [
                 "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar"
@@ -8476,7 +8193,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_jetbrains_annotations_13_0",
               "sha256": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
               "urls": [
                 "https://dl.google.com/android/maven2/org/jetbrains/annotations/13.0/annotations-13.0.jar",
@@ -8489,7 +8205,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_jvnet_staxex_stax_ex_1_8_1",
               "sha256": "20522549056e9e50aa35ef0b445a2e47a53d06be0b0a9467d704e2483ffb049a",
               "urls": [
                 "https://dl.google.com/android/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.jar",
@@ -8502,7 +8217,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~commons_logging_commons_logging_1_2",
               "sha256": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
               "urls": [
                 "https://dl.google.com/android/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
@@ -8515,7 +8229,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_client_google_api_client_gson_1_35_2",
               "sha256": "54e5be675e5c2ab0958647fcaa35c14bd8f7c08358c634f5ab786e4ed7268576",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api-client/google-api-client-gson/1.35.2/google-api-client-gson-1.35.2.jar"
@@ -8527,7 +8240,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_sun_xml_fastinfoset_FastInfoset_1_2_16",
               "sha256": "056f3a1e144409f21ed16afc26805f58e9a21f3fce1543c42d400719d250c511",
               "urls": [
                 "https://dl.google.com/android/maven2/com/sun/xml/fastinfoset/FastInfoset/1.2.16/FastInfoset-1.2.16.jar",
@@ -8540,7 +8252,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_errorprone_error_prone_annotations_2_18_0",
               "sha256": "9e6814cb71816988a4fd1b07a993a8f21bb7058d522c162b1de849e19bea54ae",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.jar"
@@ -8552,7 +8263,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~commons_io_commons_io_2_4",
               "sha256": "cc6a41dc3eaacc9e440a6bd0d2890b20d36b4ee408fe2d67122f328bb6e01581",
               "urls": [
                 "https://dl.google.com/android/maven2/commons-io/commons-io/2.4/commons-io-2.4.jar",
@@ -8565,7 +8275,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_codec_4_1_94_Final",
               "sha256": "91243776ad68b4d8e39eafb9ec115e1b8fa9aecd147b12ef15bb691639498328",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.94.Final/netty-codec-4.1.94.Final.jar"
@@ -8577,7 +8286,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_epoll_jar_linux_x86_64_4_1_93_Final",
               "sha256": "f87a502f3d257bc41f80bd0b90c19e6b4a48d0600fb26e7b5d6c2c675680fa0e",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.93.Final/netty-transport-native-epoll-4.1.93.Final-linux-x86_64.jar"
@@ -8589,7 +8297,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_conscrypt_conscrypt_openjdk_uber_2_5_2",
               "sha256": "eaf537d98e033d0f0451cd1b8cc74e02d7b55ec882da63c88060d806ba89c348",
               "urls": [
                 "https://repo1.maven.org/maven2/org/conscrypt/conscrypt-openjdk-uber/2.5.2/conscrypt-openjdk-uber-2.5.2.jar"
@@ -8601,7 +8308,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_github_stephenc_jcip_jcip_annotations_1_0_1",
               "sha256": "4fccff8382aafc589962c4edb262f6aa595e34f1e11e61057d1c6a96e8fc7323",
               "urls": [
                 "https://repo1.maven.org/maven2/com/github/stephenc/jcip/jcip-annotations/1.0-1/jcip-annotations-1.0-1.jar"
@@ -8613,7 +8319,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_client_google_api_client_1_35_2",
               "sha256": "f195cd6228d3f99fa7e30ff2dee60ad0f2c7923be31399a7dcdc1abd679aa22e",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api-client/google-api-client/1.35.2/google-api-client-1.35.2.jar"
@@ -8625,7 +8330,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_commons_9_2",
               "sha256": "be4ce53138a238bb522cd781cf91f3ba5ce2f6ca93ec62d46a162a127225e0a6",
               "urls": [
                 "https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/9.2/asm-commons-9.2.jar"
@@ -8637,7 +8341,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_protobuf_protobuf_java_3_23_2",
               "sha256": "18a057f5e0f828daa92b71c19df91f6bcc2aad067ca2cdd6b5698055ca7bcece",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.23.2/protobuf-java-3.23.2.jar"
@@ -8649,7 +8352,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_ow2_asm_asm_commons_9_1",
               "sha256": "afcb26dc1fc12c0c4a99ada670908dd82e18dfc488caf5ee92546996b470c00c",
               "urls": [
                 "https://dl.google.com/android/maven2/org/ow2/asm/asm-commons/9.1/asm-commons-9.1.jar",
@@ -8662,7 +8364,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_dvlib_30_1_3",
               "sha256": "50886691517d30762c571f585a07f384e6a8cca5fcbea9d46660ba078b613bfa",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/dvlib/30.1.3/dvlib-30.1.3.jar",
@@ -8675,7 +8376,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_buffer_4_1_94_Final",
               "sha256": "8066ee7c49f9f29da96ee62f7cb13bee022cb4b68e51437b33da3b6d01398f13",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.94.Final/netty-buffer-4.1.94.Final.jar"
@@ -8687,7 +8387,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_yaml_snakeyaml_2_0",
               "sha256": "880c9d896e4b74a06c549c15ca496450165d6909fa15d7e662bee8f6a66d7afa",
               "urls": [
                 "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar"
@@ -8699,7 +8398,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_reactivex_rxjava3_rxjava_3_1_2",
               "sha256": "8d784075bec0b7c55042c109a4de8923b3b6d2ebd2e00912d518f07240f9c23a",
               "urls": [
                 "https://repo1.maven.org/maven2/io/reactivex/rxjava3/rxjava/3.1.2/rxjava-3.1.2.jar"
@@ -8711,7 +8409,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_build_apkzlib_7_1_3",
               "sha256": "5c10846c4a325b4313cdfcb236505ce1defa68f55d1a4259b503be115453c661",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/build/apkzlib/7.1.3/apkzlib-7.1.3.jar",
@@ -8724,7 +8421,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_github_java_diff_utils_java_diff_utils_4_12",
               "sha256": "9990a2039778f6b4cc94790141c2868864eacee0620c6c459451121a901cd5b5",
               "urls": [
                 "https://repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar"
@@ -8736,7 +8432,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_netty_1_48_1",
               "sha256": "2a51593342a2ee4f8f1b946dc48d06b02d0721493238e4ae83d1ad66f8b0c9f4",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-netty/1.48.1/grpc-netty-1.48.1.jar"
@@ -8745,10 +8440,9 @@
             }
           },
           "maven": {
-            "bzlFile": "@@rules_jvm_external~6.0//:coursier.bzl",
+            "bzlFile": "@@rules_jvm_external~//:coursier.bzl",
             "ruleClassName": "pinned_coursier_fetch",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~maven",
               "user_provided_name": "maven",
               "repositories": [
                 "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
@@ -8897,7 +8591,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_cloud_google_cloud_core_2_22_0",
               "sha256": "5bc01f00878cb5bf2dcd596cc577979357460f311807aee65aaa6837bdf0eef9",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core/2.22.0/google-cloud-core-2.22.0.jar"
@@ -8909,7 +8602,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auto_service_auto_service_1_0",
               "sha256": "4ae44dd05b49a1109a463c0d2aaf920c24f76d1e996bb89f29481c4ff75ec526",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auto/service/auto-service/1.0/auto-service-1.0.jar"
@@ -8921,7 +8613,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_aws_query_protocol_2_20_128",
               "sha256": "dddab4ee63ad1bbc42bfcb3a9085917983ff4b5db71bc60b7ba6c5c17cbe5256",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/aws-query-protocol/2.20.128/aws-query-protocol-2.20.128.jar"
@@ -8933,7 +8624,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~aopalliance_aopalliance_1_0",
               "sha256": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
               "urls": [
                 "https://repo1.maven.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
@@ -8945,7 +8635,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_bouncycastle_bcpkix_jdk15on_1_56",
               "sha256": "7043dee4e9e7175e93e0b36f45b1ec1ecb893c5f755667e8b916eb8dd201c6ca",
               "urls": [
                 "https://dl.google.com/android/maven2/org/bouncycastle/bcpkix-jdk15on/1.56/bcpkix-jdk15on-1.56.jar",
@@ -8958,7 +8647,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_unix_common_jar_osx_x86_64_4_1_93_Final",
               "sha256": "deded602209c23f624e9d91f3d4c27cbba9b303e35ea9b4693090d54ac245b6c",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.93.Final/netty-transport-native-unix-common-4.1.93.Final-osx-x86_64.jar"
@@ -8970,7 +8658,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_build_builder_test_api_7_1_3",
               "sha256": "6259c32a8602d9a18fc9a5abb274b915dbba32837c5ce91ac07a2d229460078a",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/build/builder-test-api/7.1.3/builder-test-api-7.1.3.jar",
@@ -8983,7 +8670,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_http_client_google_http_client_jackson2_1_43_3",
               "sha256": "8157f93ce7b51a013ea8c514413db6647056e39d7acb829bfc5da5b3bd25db3e",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-jackson2/1.43.3/google-http-client-jackson2-1.43.3.jar"
@@ -8995,7 +8681,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_googleapis_1_56_1",
               "sha256": "39b880dc2da28695984bdb77c1fb052e2d3e446d1fbd902e00ea27bebf5f7860",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-googleapis/1.56.1/grpc-googleapis-1.56.1.jar"
@@ -9007,7 +8692,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_gax_2_32_0",
               "sha256": "eedeceb93a8d92e3b5d9781c87db1deb3d72eb545ae4e27a18cddde4100a5173",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/gax/2.32.0/gax-2.32.0.jar"
@@ -9019,7 +8703,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~commons_collections_commons_collections_3_2_2",
               "sha256": "eeeae917917144a68a741d4c0dff66aa5c5c5fd85593ff217bced3fc8ca783b8",
               "urls": [
                 "https://repo1.maven.org/maven2/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar"
@@ -9031,7 +8714,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_github_eisop_dataflow_errorprone_3_34_0_eisop1",
               "sha256": "89b4f5d2bd5059f067c5982a0e5988b87dfc8a8234795d68c6f3178846de3319",
               "urls": [
                 "https://repo1.maven.org/maven2/io/github/eisop/dataflow-errorprone/3.34.0-eisop1/dataflow-errorprone-3.34.0-eisop1.jar"
@@ -9043,7 +8725,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_api_grpc_proto_google_common_protos_2_9_0",
               "sha256": "0d830380ec66bd7e25eee63aa0a5a08578e46ad187fb72d99b44d9ba22827f91",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.9.0/proto-google-common-protos-2.9.0.jar"
@@ -9055,7 +8736,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_ddms_ddmlib_30_1_3",
               "sha256": "b88ba88a1a8f0156c9a056eb0c83a181321541bdbb78e834bf837fd1dd07e4f3",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/ddms/ddmlib/30.1.3/ddmlib-30.1.3.jar",
@@ -9068,7 +8748,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_apache_commons_commons_pool2_2_8_0",
               "sha256": "5efa9fbb54a58b1a12205a5fac565f6982abfeb0ff45bdbc318748ef5fd3a3ff",
               "urls": [
                 "https://repo1.maven.org/maven2/org/apache/commons/commons-pool2/2.8.0/commons-pool2-2.8.0.jar"
@@ -9080,7 +8759,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_grpc_grpc_grpclb_1_56_1",
               "sha256": "6ba786cc5271c7355cb0cdb57660d807cbf0f082b50edae15232e8c354228496",
               "urls": [
                 "https://repo1.maven.org/maven2/io/grpc/grpc-grpclb/1.56.1/grpc-grpclb-1.56.1.jar"
@@ -9092,7 +8770,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_inject_guice_5_1_0",
               "sha256": "4130e50bfac48099c860f0d903b91860c81a249c90f38245f8fed58fc817bc26",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/inject/guice/5.1.0/guice-5.1.0.jar"
@@ -9104,7 +8781,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_codec_socks_4_1_93_Final",
               "sha256": "0ea47b5ba23ca1da8eb9146c8fc755c1271414633b1e2be2ce1df764ba0fff2a",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.93.Final/netty-codec-socks-4.1.93.Final.jar"
@@ -9116,7 +8792,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auto_value_auto_value_1_8_2",
               "sha256": "2067b788d4c1c96fd621ad861053a5c4d8a801cfafc77fec20d49a6e9340a745",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auto/value/auto-value/1.8.2/auto-value-1.8.2.jar"
@@ -9128,7 +8803,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_auto_auto_common_1_2_1",
               "sha256": "f43f29fe2a6ebaf04b2598cdeec32a4e346d49a9404e990f5fc19c19f3a28d0e",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/auto/auto-common/1.2.1/auto-common-1.2.1.jar"
@@ -9140,7 +8814,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_unix_common_4_1_93_Final",
               "sha256": "774165a1c4dbaacb17f9c1ad666b3569a6a59715ae828e7c3d47703f479a53e7",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.93.Final/netty-transport-native-unix-common-4.1.93.Final.jar"
@@ -9152,7 +8825,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_truth_extensions_truth_liteproto_extension_1_4_0",
               "sha256": "2445c955286b8bc58903a853d4b9166000c94e4b95aea6ac9da3e1fdc3e08f10",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/truth/extensions/truth-liteproto-extension/1.4.0/truth-liteproto-extension-1.4.0.jar"
@@ -9164,7 +8836,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~net_bytebuddy_byte_buddy_1_14_5",
               "sha256": "e99761a526df0fefbbd3fe14436b0f953000cdfa5151dc63c0b18d37d9c46f1c",
               "urls": [
                 "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.14.5/byte-buddy-1.14.5.jar"
@@ -9176,7 +8847,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_jetbrains_kotlin_kotlin_stdlib_common_1_4_32",
               "sha256": "e1ff6f55ee9e7591dcc633f7757bac25a7edb1cc7f738b37ec652f10f66a4145",
               "urls": [
                 "https://dl.google.com/android/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.4.32/kotlin-stdlib-common-1.4.32.jar",
@@ -9189,7 +8859,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_truth_extensions_truth_java8_extension_1_4_0",
               "sha256": "293f4e4c59ce48e8b68651321d2d9f2355534412b221369b2af8ff76e6acf381",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/truth/extensions/truth-java8-extension/1.4.0/truth-java8-extension-1.4.0.jar"
@@ -9201,7 +8870,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_jetbrains_intellij_deps_trove4j_1_0_20181211",
               "sha256": "affb7c85a3c87bdcf69ff1dbb84de11f63dc931293934bc08cd7ab18de083601",
               "urls": [
                 "https://dl.google.com/android/maven2/org/jetbrains/intellij/deps/trove4j/1.0.20181211/trove4j-1.0.20181211.jar",
@@ -9214,7 +8882,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_jetbrains_kotlin_kotlin_stdlib_jdk8_1_4_32",
               "sha256": "adc43e54757b106e0cd7b3b7aa257dff471b61efdabe067fc02b2f57e2396262",
               "urls": [
                 "https://dl.google.com/android/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.4.32/kotlin-stdlib-jdk8-1.4.32.jar",
@@ -9227,7 +8894,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~javax_inject_javax_inject_1",
               "sha256": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
               "urls": [
                 "https://repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar"
@@ -9239,7 +8905,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~tools_profiler_async_profiler_2_9",
               "sha256": "6c4e993c28cf2882964cac82a0f96e81a325840043884526565017b2f62c5ba4",
               "urls": [
                 "https://repo1.maven.org/maven2/tools/profiler/async-profiler/2.9/async-profiler-2.9.jar"
@@ -9251,7 +8916,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~commons_codec_commons_codec_1_10",
               "sha256": "4241dfa94e711d435f29a4604a3e2de5c4aa3c165e23bd066be6fc1fc4309569",
               "urls": [
                 "https://dl.google.com/android/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10.jar",
@@ -9264,7 +8928,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_google_android_annotations_4_1_1_4",
               "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
               "urls": [
                 "https://repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
@@ -9276,7 +8939,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~commons_codec_commons_codec_1_15",
               "sha256": "b3e9f6d63a790109bf0d056611fbed1cf69055826defeb9894a71369d246ed63",
               "urls": [
                 "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.15/commons-codec-1.15.jar"
@@ -9288,7 +8950,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~xml_apis_xml_apis_1_4_01",
               "sha256": "a840968176645684bb01aed376e067ab39614885f9eee44abe35a5f20ebe7fad",
               "urls": [
                 "https://dl.google.com/android/maven2/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01.jar",
@@ -9301,7 +8962,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_build_jetifier_jetifier_core_1_0_0_beta02",
               "sha256": "ef61f84302f8b41dce3858c1fc7e7a90ec74a263a0213b1f65e80c56145a4793",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/build/jetifier/jetifier-core/1.0.0-beta02/jetifier-core-1.0.0-beta02.jar",
@@ -9314,7 +8974,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~org_glassfish_jaxb_txw2_2_3_2",
               "sha256": "4a6a9f483388d461b81aa9a28c685b8b74c0597993bf1884b04eddbca95f48fe",
               "urls": [
                 "https://dl.google.com/android/maven2/org/glassfish/jaxb/txw2/2.3.2/txw2-2.3.2.jar",
@@ -9327,7 +8986,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_epoll_jar_linux_aarch_64_4_1_93_Final",
               "sha256": "cca126fd095563fa67288300b6ac2ef4a92e623600e9a3273382211de364695d",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.93.Final/netty-transport-native-epoll-4.1.93.Final-linux-aarch_64.jar"
@@ -9339,7 +8997,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~com_android_tools_build_aapt2_proto_7_0_0_beta04_7396180",
               "sha256": "1ca4f1b0f550c6c25f63c1916da84f6e7a92c66b7ad38ab1d5d49a20552a5984",
               "urls": [
                 "https://dl.google.com/android/maven2/com/android/tools/build/aapt2-proto/7.0.0-beta04-7396180/aapt2-proto-7.0.0-beta04-7396180.jar",
@@ -9352,7 +9009,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~software_amazon_awssdk_annotations_2_20_128",
               "sha256": "4eeddb1848a90c73b8ce85d7b556f0be36f0f97c780f1715b9cb59a93620eae2",
               "urls": [
                 "https://repo1.maven.org/maven2/software/amazon/awssdk/annotations/2.20.128/annotations-2.20.128.jar"
@@ -9364,7 +9020,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~io_netty_netty_transport_native_unix_common_4_1_94_Final",
               "sha256": "27d0dff1cd743190279becacfb372fe4d45b266edafad9f1c6c01b04d00280eb",
               "urls": [
                 "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.94.Final/netty-transport-native-unix-common-4.1.94.Final.jar"
@@ -9376,7 +9031,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_jvm_external~6.0~maven~net_java_dev_jna_jna_5_6_0",
               "sha256": "5557e235a8aa2f9766d5dc609d67948f2a8832c2d796cea9ef1d6cbe0b3b7eaf",
               "urls": [
                 "https://dl.google.com/android/maven2/net/java/dev/jna/jna/5.6.0/jna-5.6.0.jar",
@@ -9388,16 +9042,16 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_jvm_external~6.0",
+            "rules_jvm_external~",
             "bazel_tools",
             "bazel_tools"
           ]
         ]
       }
     },
-    "@@rules_kotlin~1.9.0//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+    "@@rules_kotlin~//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "i+Zxd+SgLbZqTLF+shombR5Pmc99aednkh48BQE7r3s=",
+        "bzlTransitiveDigest": "1u6jpTI2bXdvJ5g8S0Dqjt88MVYoUdKGTD7sXrG1PcE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -9405,7 +9059,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_kotlin~1.9.0~rules_kotlin_extensions~rules_android",
               "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
               "strip_prefix": "rules_android-0.1.1",
               "urls": [
@@ -9417,7 +9070,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_kotlin~1.9.0~rules_kotlin_extensions~com_github_pinterest_ktlint",
               "sha256": "2b3f6f674a944d25bb8d283c3539947bbe86074793012909a55de4b771f74bcc",
               "urls": [
                 "https://github.com/pinterest/ktlint/releases/download/0.49.1/ktlint"
@@ -9429,17 +9081,15 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_kotlin~1.9.0~rules_kotlin_extensions~buildkite_config",
               "urls": [
                 "https://storage.googleapis.com/rbe-toolchain/bazel-configs/rbe-ubuntu1604/latest/rbe_default.tar"
               ]
             }
           },
           "com_github_jetbrains_kotlin": {
-            "bzlFile": "@@rules_kotlin~1.9.0//src/main/starlark/core/repositories:compiler.bzl",
+            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:compiler.bzl",
             "ruleClassName": "kotlin_compiler_repository",
             "attributes": {
-              "name": "rules_kotlin~1.9.0~rules_kotlin_extensions~com_github_jetbrains_kotlin",
               "urls": [
                 "https://github.com/JetBrains/kotlin/releases/download/v1.9.10/kotlin-compiler-1.9.10.zip"
               ],
@@ -9448,10 +9098,9 @@
             }
           },
           "com_github_google_ksp": {
-            "bzlFile": "@@rules_kotlin~1.9.0//src/main/starlark/core/repositories:ksp.bzl",
+            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:ksp.bzl",
             "ruleClassName": "ksp_compiler_plugin_repository",
             "attributes": {
-              "name": "rules_kotlin~1.9.0~rules_kotlin_extensions~com_github_google_ksp",
               "urls": [
                 "https://github.com/google/ksp/releases/download/1.9.10-1.0.13/artifacts.zip"
               ],
@@ -9463,7 +9112,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_file",
             "attributes": {
-              "name": "rules_kotlin~1.9.0~rules_kotlin_extensions~kt_java_stub_template",
               "urls": [
                 "https://raw.githubusercontent.com/bazelbuild/bazel/6.2.1/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt"
               ],
@@ -9473,26 +9121,25 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_kotlin~1.9.0",
+            "rules_kotlin~",
             "bazel_tools",
             "bazel_tools"
           ]
         ]
       }
     },
-    "@@rules_python~0.28.0//python/extensions:pip.bzl%pip": {
+    "@@rules_python~//python/extensions:pip.bzl%pip": {
       "os:osx,arch:aarch64": {
-        "bzlTransitiveDigest": "/exydCN1l0BSvhKnxv7/6d3E1s5VSyZJSChu9rJo7u0=",
+        "bzlTransitiveDigest": "Zu8fxD3gfeoyFgvSL+v6YHQaQdGVOOefO/bzWRW1X0c=",
         "accumulatedFileDigests": {
           "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
           "bazel_pip_dev_deps": {
-            "bzlFile": "@@rules_python~0.28.0//python/private/bzlmod:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/private/bzlmod:pip_repository.bzl",
             "ruleClassName": "pip_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps",
               "repo_name": "bazel_pip_dev_deps",
               "whl_map": {
                 "bazel_runfiles": [
@@ -9503,17 +9150,16 @@
             }
           },
           "bazel_pip_dev_deps_38_bazel_runfiles": {
-            "bzlFile": "@@rules_python~0.28.0//python/pip_install:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps_38_bazel_runfiles",
               "requirement": "bazel-runfiles==0.24.0",
               "repo": "bazel_pip_dev_deps_38",
               "repo_prefix": "bazel_pip_dev_deps_38_",
               "whl_patches": {},
               "experimental_target_platforms": [],
               "python_interpreter": "",
-              "python_interpreter_target": "@@rules_python~0.28.0~python~python_3_8_aarch64-apple-darwin//:bin/python3",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_aarch64-apple-darwin//:bin/python3",
               "quiet": true,
               "timeout": 600,
               "isolated": true,
@@ -9527,10 +9173,9 @@
             }
           },
           "bazel_pip_dev_deps_38__groups": {
-            "bzlFile": "@@rules_python~0.28.0//python/pip_install:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
             "ruleClassName": "group_library",
             "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps_38__groups",
               "repo_prefix": "bazel_pip_dev_deps_38_",
               "groups": {}
             }
@@ -9538,653 +9183,133 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "bazel_features~1.1.1",
+            "bazel_features~",
             "bazel_features_globals",
-            "bazel_features~1.1.1~version_extension~bazel_features_globals"
+            "bazel_features~~version_extension~bazel_features_globals"
           ],
           [
-            "bazel_features~1.1.1",
+            "bazel_features~",
             "bazel_features_version",
-            "bazel_features~1.1.1~version_extension~bazel_features_version"
+            "bazel_features~~version_extension~bazel_features_version"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "bazel_features",
-            "bazel_features~1.1.1"
+            "bazel_features~"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "bazel_skylib",
-            "bazel_skylib~1.5.0"
+            "bazel_skylib~"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "bazel_tools",
             "bazel_tools"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__build",
-            "rules_python~0.28.0~internal_deps~pypi__build"
+            "rules_python~~internal_deps~pypi__build"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__click",
-            "rules_python~0.28.0~internal_deps~pypi__click"
+            "rules_python~~internal_deps~pypi__click"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__colorama",
-            "rules_python~0.28.0~internal_deps~pypi__colorama"
+            "rules_python~~internal_deps~pypi__colorama"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__importlib_metadata",
-            "rules_python~0.28.0~internal_deps~pypi__importlib_metadata"
+            "rules_python~~internal_deps~pypi__importlib_metadata"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__installer",
-            "rules_python~0.28.0~internal_deps~pypi__installer"
+            "rules_python~~internal_deps~pypi__installer"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__more_itertools",
-            "rules_python~0.28.0~internal_deps~pypi__more_itertools"
+            "rules_python~~internal_deps~pypi__more_itertools"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__packaging",
-            "rules_python~0.28.0~internal_deps~pypi__packaging"
+            "rules_python~~internal_deps~pypi__packaging"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__pep517",
-            "rules_python~0.28.0~internal_deps~pypi__pep517"
+            "rules_python~~internal_deps~pypi__pep517"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__pip",
-            "rules_python~0.28.0~internal_deps~pypi__pip"
+            "rules_python~~internal_deps~pypi__pip"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__pip_tools",
-            "rules_python~0.28.0~internal_deps~pypi__pip_tools"
+            "rules_python~~internal_deps~pypi__pip_tools"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__pyproject_hooks",
-            "rules_python~0.28.0~internal_deps~pypi__pyproject_hooks"
+            "rules_python~~internal_deps~pypi__pyproject_hooks"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__setuptools",
-            "rules_python~0.28.0~internal_deps~pypi__setuptools"
+            "rules_python~~internal_deps~pypi__setuptools"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__tomli",
-            "rules_python~0.28.0~internal_deps~pypi__tomli"
+            "rules_python~~internal_deps~pypi__tomli"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__wheel",
-            "rules_python~0.28.0~internal_deps~pypi__wheel"
+            "rules_python~~internal_deps~pypi__wheel"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pypi__zipp",
-            "rules_python~0.28.0~internal_deps~pypi__zipp"
+            "rules_python~~internal_deps~pypi__zipp"
           ],
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "pythons_hub",
-            "rules_python~0.28.0~python~pythons_hub"
+            "rules_python~~python~pythons_hub"
           ],
           [
-            "rules_python~0.28.0~python~pythons_hub",
+            "rules_python~~python~pythons_hub",
             "python_3_11_aarch64-apple-darwin",
-            "rules_python~0.28.0~python~python_3_11_aarch64-apple-darwin"
+            "rules_python~~python~python_3_11_aarch64-apple-darwin"
           ],
           [
-            "rules_python~0.28.0~python~pythons_hub",
+            "rules_python~~python~pythons_hub",
             "python_3_8_aarch64-apple-darwin",
-            "rules_python~0.28.0~python~python_3_8_aarch64-apple-darwin"
-          ]
-        ]
-      },
-      "os:osx,arch:x86_64": {
-        "bzlTransitiveDigest": "FWc08SaZYQ2jhaaA8W5XRTAZFevdO03Yy9Web2WHI7o=",
-        "accumulatedFileDigests": {
-          "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
-        },
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "bazel_pip_dev_deps": {
-            "bzlFile": "@@rules_python~0.28.0//python/private/bzlmod:pip_repository.bzl",
-            "ruleClassName": "pip_repository",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps",
-              "repo_name": "bazel_pip_dev_deps",
-              "whl_map": {
-                "bazel_runfiles": [
-                  "3.8.18"
-                ]
-              },
-              "default_version": "3.8.18"
-            }
-          },
-          "bazel_pip_dev_deps_38_bazel_runfiles": {
-            "bzlFile": "@@rules_python~0.28.0//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps_38_bazel_runfiles",
-              "requirement": "bazel-runfiles==0.24.0",
-              "repo": "bazel_pip_dev_deps_38",
-              "repo_prefix": "bazel_pip_dev_deps_38_",
-              "whl_patches": {},
-              "experimental_target_platforms": [],
-              "python_interpreter": "",
-              "python_interpreter_target": "@@rules_python~0.28.0~python~python_3_8_x86_64-apple-darwin//:bin/python3",
-              "quiet": true,
-              "timeout": 600,
-              "isolated": true,
-              "extra_pip_args": [],
-              "download_only": false,
-              "pip_data_exclude": [],
-              "enable_implicit_namespace_pkgs": false,
-              "environment": {},
-              "group_name": "",
-              "group_deps": []
-            }
-          },
-          "bazel_pip_dev_deps_38__groups": {
-            "bzlFile": "@@rules_python~0.28.0//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "group_library",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps_38__groups",
-              "repo_prefix": "bazel_pip_dev_deps_38_",
-              "groups": {}
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "bazel_features~1.1.1",
-            "bazel_features_globals",
-            "bazel_features~1.1.1~version_extension~bazel_features_globals"
-          ],
-          [
-            "bazel_features~1.1.1",
-            "bazel_features_version",
-            "bazel_features~1.1.1~version_extension~bazel_features_version"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_features",
-            "bazel_features~1.1.1"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_skylib",
-            "bazel_skylib~1.5.0"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__build",
-            "rules_python~0.28.0~internal_deps~pypi__build"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__click",
-            "rules_python~0.28.0~internal_deps~pypi__click"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__colorama",
-            "rules_python~0.28.0~internal_deps~pypi__colorama"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__importlib_metadata",
-            "rules_python~0.28.0~internal_deps~pypi__importlib_metadata"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__installer",
-            "rules_python~0.28.0~internal_deps~pypi__installer"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__more_itertools",
-            "rules_python~0.28.0~internal_deps~pypi__more_itertools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__packaging",
-            "rules_python~0.28.0~internal_deps~pypi__packaging"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pep517",
-            "rules_python~0.28.0~internal_deps~pypi__pep517"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pip",
-            "rules_python~0.28.0~internal_deps~pypi__pip"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pip_tools",
-            "rules_python~0.28.0~internal_deps~pypi__pip_tools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pyproject_hooks",
-            "rules_python~0.28.0~internal_deps~pypi__pyproject_hooks"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__setuptools",
-            "rules_python~0.28.0~internal_deps~pypi__setuptools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__tomli",
-            "rules_python~0.28.0~internal_deps~pypi__tomli"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__wheel",
-            "rules_python~0.28.0~internal_deps~pypi__wheel"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__zipp",
-            "rules_python~0.28.0~internal_deps~pypi__zipp"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pythons_hub",
-            "rules_python~0.28.0~python~pythons_hub"
-          ],
-          [
-            "rules_python~0.28.0~python~pythons_hub",
-            "python_3_11_x86_64-apple-darwin",
-            "rules_python~0.28.0~python~python_3_11_x86_64-apple-darwin"
-          ],
-          [
-            "rules_python~0.28.0~python~pythons_hub",
-            "python_3_8_x86_64-apple-darwin",
-            "rules_python~0.28.0~python~python_3_8_x86_64-apple-darwin"
-          ]
-        ]
-      },
-      "os:linux,arch:amd64": {
-        "bzlTransitiveDigest": "d0OVLoT963/iZQXemI1/pGQEP82W1vQNRYD9S6qm6MQ=",
-        "accumulatedFileDigests": {
-          "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
-        },
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "bazel_pip_dev_deps": {
-            "bzlFile": "@@rules_python~0.28.0//python/private/bzlmod:pip_repository.bzl",
-            "ruleClassName": "pip_repository",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps",
-              "repo_name": "bazel_pip_dev_deps",
-              "whl_map": {
-                "bazel_runfiles": [
-                  "3.8.18"
-                ]
-              },
-              "default_version": "3.8.18"
-            }
-          },
-          "bazel_pip_dev_deps_38_bazel_runfiles": {
-            "bzlFile": "@@rules_python~0.28.0//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps_38_bazel_runfiles",
-              "requirement": "bazel-runfiles==0.24.0",
-              "repo": "bazel_pip_dev_deps_38",
-              "repo_prefix": "bazel_pip_dev_deps_38_",
-              "whl_patches": {},
-              "experimental_target_platforms": [],
-              "python_interpreter": "",
-              "python_interpreter_target": "@@rules_python~0.28.0~python~python_3_8_x86_64-unknown-linux-gnu//:bin/python3",
-              "quiet": true,
-              "timeout": 600,
-              "isolated": true,
-              "extra_pip_args": [],
-              "download_only": false,
-              "pip_data_exclude": [],
-              "enable_implicit_namespace_pkgs": false,
-              "environment": {},
-              "group_name": "",
-              "group_deps": []
-            }
-          },
-          "bazel_pip_dev_deps_38__groups": {
-            "bzlFile": "@@rules_python~0.28.0//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "group_library",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps_38__groups",
-              "repo_prefix": "bazel_pip_dev_deps_38_",
-              "groups": {}
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "bazel_features~1.1.1",
-            "bazel_features_globals",
-            "bazel_features~1.1.1~version_extension~bazel_features_globals"
-          ],
-          [
-            "bazel_features~1.1.1",
-            "bazel_features_version",
-            "bazel_features~1.1.1~version_extension~bazel_features_version"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_features",
-            "bazel_features~1.1.1"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_skylib",
-            "bazel_skylib~1.5.0"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__build",
-            "rules_python~0.28.0~internal_deps~pypi__build"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__click",
-            "rules_python~0.28.0~internal_deps~pypi__click"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__colorama",
-            "rules_python~0.28.0~internal_deps~pypi__colorama"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__importlib_metadata",
-            "rules_python~0.28.0~internal_deps~pypi__importlib_metadata"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__installer",
-            "rules_python~0.28.0~internal_deps~pypi__installer"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__more_itertools",
-            "rules_python~0.28.0~internal_deps~pypi__more_itertools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__packaging",
-            "rules_python~0.28.0~internal_deps~pypi__packaging"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pep517",
-            "rules_python~0.28.0~internal_deps~pypi__pep517"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pip",
-            "rules_python~0.28.0~internal_deps~pypi__pip"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pip_tools",
-            "rules_python~0.28.0~internal_deps~pypi__pip_tools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pyproject_hooks",
-            "rules_python~0.28.0~internal_deps~pypi__pyproject_hooks"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__setuptools",
-            "rules_python~0.28.0~internal_deps~pypi__setuptools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__tomli",
-            "rules_python~0.28.0~internal_deps~pypi__tomli"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__wheel",
-            "rules_python~0.28.0~internal_deps~pypi__wheel"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__zipp",
-            "rules_python~0.28.0~internal_deps~pypi__zipp"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pythons_hub",
-            "rules_python~0.28.0~python~pythons_hub"
-          ],
-          [
-            "rules_python~0.28.0~python~pythons_hub",
-            "python_3_11_x86_64-unknown-linux-gnu",
-            "rules_python~0.28.0~python~python_3_11_x86_64-unknown-linux-gnu"
-          ],
-          [
-            "rules_python~0.28.0~python~pythons_hub",
-            "python_3_8_x86_64-unknown-linux-gnu",
-            "rules_python~0.28.0~python~python_3_8_x86_64-unknown-linux-gnu"
-          ]
-        ]
-      },
-      "os:windows,arch:amd64": {
-        "bzlTransitiveDigest": "bziIBZXe9Fgta0vqgJCnSrWLkgI9pGWtj6wUEqi/JSU=",
-        "accumulatedFileDigests": {
-          "@@//:requirements.txt": "ff12967a755bb8e9b4c92524f6471a99e14c30474a3d428547c55745ec8f23a0"
-        },
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "bazel_pip_dev_deps": {
-            "bzlFile": "@@rules_python~0.28.0//python/private/bzlmod:pip_repository.bzl",
-            "ruleClassName": "pip_repository",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps",
-              "repo_name": "bazel_pip_dev_deps",
-              "whl_map": {
-                "bazel_runfiles": [
-                  "3.8.18"
-                ]
-              },
-              "default_version": "3.8.18"
-            }
-          },
-          "bazel_pip_dev_deps_38_bazel_runfiles": {
-            "bzlFile": "@@rules_python~0.28.0//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps_38_bazel_runfiles",
-              "requirement": "bazel-runfiles==0.24.0",
-              "repo": "bazel_pip_dev_deps_38",
-              "repo_prefix": "bazel_pip_dev_deps_38_",
-              "whl_patches": {},
-              "experimental_target_platforms": [],
-              "python_interpreter": "",
-              "python_interpreter_target": "@@rules_python~0.28.0~python~python_3_8_x86_64-pc-windows-msvc//:python.exe",
-              "quiet": true,
-              "timeout": 600,
-              "isolated": true,
-              "extra_pip_args": [],
-              "download_only": false,
-              "pip_data_exclude": [],
-              "enable_implicit_namespace_pkgs": false,
-              "environment": {},
-              "group_name": "",
-              "group_deps": []
-            }
-          },
-          "bazel_pip_dev_deps_38__groups": {
-            "bzlFile": "@@rules_python~0.28.0//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "group_library",
-            "attributes": {
-              "name": "rules_python~0.28.0~pip~bazel_pip_dev_deps_38__groups",
-              "repo_prefix": "bazel_pip_dev_deps_38_",
-              "groups": {}
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "bazel_features~1.1.1",
-            "bazel_features_globals",
-            "bazel_features~1.1.1~version_extension~bazel_features_globals"
-          ],
-          [
-            "bazel_features~1.1.1",
-            "bazel_features_version",
-            "bazel_features~1.1.1~version_extension~bazel_features_version"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_features",
-            "bazel_features~1.1.1"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_skylib",
-            "bazel_skylib~1.5.0"
-          ],
-          [
-            "rules_python~0.28.0",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__build",
-            "rules_python~0.28.0~internal_deps~pypi__build"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__click",
-            "rules_python~0.28.0~internal_deps~pypi__click"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__colorama",
-            "rules_python~0.28.0~internal_deps~pypi__colorama"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__importlib_metadata",
-            "rules_python~0.28.0~internal_deps~pypi__importlib_metadata"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__installer",
-            "rules_python~0.28.0~internal_deps~pypi__installer"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__more_itertools",
-            "rules_python~0.28.0~internal_deps~pypi__more_itertools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__packaging",
-            "rules_python~0.28.0~internal_deps~pypi__packaging"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pep517",
-            "rules_python~0.28.0~internal_deps~pypi__pep517"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pip",
-            "rules_python~0.28.0~internal_deps~pypi__pip"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pip_tools",
-            "rules_python~0.28.0~internal_deps~pypi__pip_tools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__pyproject_hooks",
-            "rules_python~0.28.0~internal_deps~pypi__pyproject_hooks"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__setuptools",
-            "rules_python~0.28.0~internal_deps~pypi__setuptools"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__tomli",
-            "rules_python~0.28.0~internal_deps~pypi__tomli"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__wheel",
-            "rules_python~0.28.0~internal_deps~pypi__wheel"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pypi__zipp",
-            "rules_python~0.28.0~internal_deps~pypi__zipp"
-          ],
-          [
-            "rules_python~0.28.0",
-            "pythons_hub",
-            "rules_python~0.28.0~python~pythons_hub"
-          ],
-          [
-            "rules_python~0.28.0~python~pythons_hub",
-            "python_3_11_x86_64-pc-windows-msvc",
-            "rules_python~0.28.0~python~python_3_11_x86_64-pc-windows-msvc"
-          ],
-          [
-            "rules_python~0.28.0~python~pythons_hub",
-            "python_3_8_x86_64-pc-windows-msvc",
-            "rules_python~0.28.0~python~python_3_8_x86_64-pc-windows-msvc"
+            "rules_python~~python~python_3_8_aarch64-apple-darwin"
           ]
         ]
       }
     },
-    "@@rules_python~0.28.0//python/extensions:python.bzl%python": {
+    "@@rules_python~//python/extensions:python.bzl%python": {
       "general": {
-        "bzlTransitiveDigest": "R+uhsqnIakelms6fx4bxX5QATrwO+kf97NPNyDFrYA4=",
+        "bzlTransitiveDigest": "uURpKYgS4UiuvrQO+LOmvl+XMsGF0duP1/0rFCueoDk=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "python_3_11_s390x-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_11_s390x-unknown-linux-gnu",
               "sha256": "f9f19823dba3209cedc4647b00f46ed0177242917db20fb7fb539970e384531c",
               "patches": [],
               "platform": "s390x-unknown-linux-gnu",
@@ -10200,10 +9325,9 @@
             }
           },
           "python_3_8_aarch64-apple-darwin": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_8_aarch64-apple-darwin",
               "sha256": "1825b1f7220bc93ff143f2e70b5c6a79c6469e0eeb40824e07a7277f59aabfda",
               "patches": [],
               "platform": "aarch64-apple-darwin",
@@ -10219,10 +9343,9 @@
             }
           },
           "python_3_11_aarch64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_11_aarch64-unknown-linux-gnu",
               "sha256": "3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec",
               "patches": [],
               "platform": "aarch64-unknown-linux-gnu",
@@ -10238,10 +9361,9 @@
             }
           },
           "python_3_11_aarch64-apple-darwin": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_11_aarch64-apple-darwin",
               "sha256": "916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990",
               "patches": [],
               "platform": "aarch64-apple-darwin",
@@ -10257,10 +9379,9 @@
             }
           },
           "pythons_hub": {
-            "bzlFile": "@@rules_python~0.28.0//python/private/bzlmod:pythons_hub.bzl",
+            "bzlFile": "@@rules_python~//python/private/bzlmod:pythons_hub.bzl",
             "ruleClassName": "hub_repo",
             "attributes": {
-              "name": "rules_python~0.28.0~python~pythons_hub",
               "default_python_version": "3.8",
               "toolchain_prefixes": [
                 "_0000_python_3_11_",
@@ -10281,10 +9402,9 @@
             }
           },
           "python_3_8_aarch64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_8_aarch64-unknown-linux-gnu",
               "sha256": "236a300f386ead02ca98dbddbc026ff4ef4de6701a394106e291ff8b75445ee1",
               "patches": [],
               "platform": "aarch64-unknown-linux-gnu",
@@ -10300,10 +9420,9 @@
             }
           },
           "python_3_8": {
-            "bzlFile": "@@rules_python~0.28.0//python/private:toolchains_repo.bzl",
+            "bzlFile": "@@rules_python~//python/private:toolchains_repo.bzl",
             "ruleClassName": "toolchain_aliases",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_8",
               "python_version": "3.8.18",
               "user_repository_name": "python_3_8",
               "platforms": [
@@ -10316,10 +9435,9 @@
             }
           },
           "python_3_11_x86_64-pc-windows-msvc": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_11_x86_64-pc-windows-msvc",
               "sha256": "3933545e6d41462dd6a47e44133ea40995bc6efeed8c2e4cbdf1a699303e95ea",
               "patches": [],
               "platform": "x86_64-pc-windows-msvc",
@@ -10335,10 +9453,9 @@
             }
           },
           "python_3_8_x86_64-apple-darwin": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_8_x86_64-apple-darwin",
               "sha256": "fcf04532e644644213977242cd724fe5e84c0a5ac92ae038e07f1b01b474fca3",
               "patches": [],
               "platform": "x86_64-apple-darwin",
@@ -10354,10 +9471,9 @@
             }
           },
           "python_3_8_x86_64-pc-windows-msvc": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_8_x86_64-pc-windows-msvc",
               "sha256": "a9d203e78caed94de368d154e841610cef6f6b484738573f4ae9059d37e898a5",
               "patches": [],
               "platform": "x86_64-pc-windows-msvc",
@@ -10373,10 +9489,9 @@
             }
           },
           "python_3_11": {
-            "bzlFile": "@@rules_python~0.28.0//python/private:toolchains_repo.bzl",
+            "bzlFile": "@@rules_python~//python/private:toolchains_repo.bzl",
             "ruleClassName": "toolchain_aliases",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_11",
               "python_version": "3.11.6",
               "user_repository_name": "python_3_11",
               "platforms": [
@@ -10391,10 +9506,9 @@
             }
           },
           "python_3_11_ppc64le-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_11_ppc64le-unknown-linux-gnu",
               "sha256": "7937035f690a624dba4d014ffd20c342e843dd46f89b0b0a1e5726b85deb8eaf",
               "patches": [],
               "platform": "ppc64le-unknown-linux-gnu",
@@ -10410,10 +9524,9 @@
             }
           },
           "python_3_11_x86_64-apple-darwin": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_11_x86_64-apple-darwin",
               "sha256": "178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371",
               "patches": [],
               "platform": "x86_64-apple-darwin",
@@ -10429,10 +9542,9 @@
             }
           },
           "python_versions": {
-            "bzlFile": "@@rules_python~0.28.0//python/private:toolchains_repo.bzl",
+            "bzlFile": "@@rules_python~//python/private:toolchains_repo.bzl",
             "ruleClassName": "multi_toolchain_aliases",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_versions",
               "python_versions": {
                 "3.8": "python_3_8",
                 "3.11": "python_3_11"
@@ -10440,10 +9552,9 @@
             }
           },
           "python_3_8_x86_64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_8_x86_64-unknown-linux-gnu",
               "sha256": "1e8a3babd1500111359b0f5675d770984bcbcb2cc8890b117394f0ed342fb9ec",
               "patches": [],
               "platform": "x86_64-unknown-linux-gnu",
@@ -10459,10 +9570,9 @@
             }
           },
           "python_3_11_x86_64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~0.28.0//python:repositories.bzl",
+            "bzlFile": "@@rules_python~//python:repositories.bzl",
             "ruleClassName": "python_repository",
             "attributes": {
-              "name": "rules_python~0.28.0~python~python_3_11_x86_64-unknown-linux-gnu",
               "sha256": "ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8",
               "patches": [],
               "platform": "x86_64-unknown-linux-gnu",
@@ -10480,16 +9590,16 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "bazel_tools",
             "bazel_tools"
           ]
         ]
       }
     },
-    "@@rules_python~0.28.0//python/private/bzlmod:internal_deps.bzl%internal_deps": {
+    "@@rules_python~//python/private/bzlmod:internal_deps.bzl%internal_deps": {
       "general": {
-        "bzlTransitiveDigest": "95pxBpvVs3b2XQbNMlIpXDvvfBYeQYrJz5wy4YprQaY=",
+        "bzlTransitiveDigest": "+J2GzTTi/IHtm7gEs/JNj3b67cbw6ynj8yBeq4xjI0Y=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -10497,7 +9607,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__wheel",
               "url": "https://files.pythonhosted.org/packages/b8/8b/31273bf66016be6ad22bb7345c37ff350276cfd46e389a0c2ac5da9d9073/wheel-0.41.2-py3-none-any.whl",
               "sha256": "75909db2664838d015e3d9139004ee16711748a52c8f336b52882266540215d8",
               "type": "zip",
@@ -10508,7 +9617,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__click",
               "url": "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl",
               "sha256": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
               "type": "zip",
@@ -10519,7 +9627,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__importlib_metadata",
               "url": "https://files.pythonhosted.org/packages/cc/37/db7ba97e676af155f5fcb1a35466f446eadc9104e25b83366e8088c9c926/importlib_metadata-6.8.0-py3-none-any.whl",
               "sha256": "3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb",
               "type": "zip",
@@ -10530,7 +9637,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__pyproject_hooks",
               "url": "https://files.pythonhosted.org/packages/d5/ea/9ae603de7fbb3df820b23a70f6aff92bf8c7770043254ad8d2dc9d6bcba4/pyproject_hooks-1.0.0-py3-none-any.whl",
               "sha256": "283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8",
               "type": "zip",
@@ -10541,7 +9647,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__pep517",
               "url": "https://files.pythonhosted.org/packages/ee/2f/ef63e64e9429111e73d3d6cbee80591672d16f2725e648ebc52096f3d323/pep517-0.13.0-py3-none-any.whl",
               "sha256": "4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b",
               "type": "zip",
@@ -10552,7 +9657,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__packaging",
               "url": "https://files.pythonhosted.org/packages/ab/c3/57f0601a2d4fe15de7a553c00adbc901425661bf048f2a22dfc500caf121/packaging-23.1-py3-none-any.whl",
               "sha256": "994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
               "type": "zip",
@@ -10563,7 +9667,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__pip_tools",
               "url": "https://files.pythonhosted.org/packages/e8/df/47e6267c6b5cdae867adbdd84b437393e6202ce4322de0a5e0b92960e1d6/pip_tools-7.3.0-py3-none-any.whl",
               "sha256": "8717693288720a8c6ebd07149c93ab0be1fced0b5191df9e9decd3263e20d85e",
               "type": "zip",
@@ -10574,7 +9677,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__setuptools",
               "url": "https://files.pythonhosted.org/packages/4f/ab/0bcfebdfc3bfa8554b2b2c97a555569c4c1ebc74ea288741ea8326c51906/setuptools-68.1.2-py3-none-any.whl",
               "sha256": "3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b",
               "type": "zip",
@@ -10585,7 +9687,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__zipp",
               "url": "https://files.pythonhosted.org/packages/8c/08/d3006317aefe25ea79d3b76c9650afabaf6d63d1c8443b236e7405447503/zipp-3.16.2-py3-none-any.whl",
               "sha256": "679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0",
               "type": "zip",
@@ -10596,7 +9697,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__colorama",
               "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
               "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
               "type": "zip",
@@ -10607,7 +9707,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__build",
               "url": "https://files.pythonhosted.org/packages/58/91/17b00d5fac63d3dca605f1b8269ba3c65e98059e1fd99d00283e42a454f0/build-0.10.0-py3-none-any.whl",
               "sha256": "af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171",
               "type": "zip",
@@ -10615,17 +9714,14 @@
             }
           },
           "rules_python_internal": {
-            "bzlFile": "@@rules_python~0.28.0//python/private:internal_config_repo.bzl",
+            "bzlFile": "@@rules_python~//python/private:internal_config_repo.bzl",
             "ruleClassName": "internal_config_repo",
-            "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~rules_python_internal"
-            }
+            "attributes": {}
           },
           "pypi__pip": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__pip",
               "url": "https://files.pythonhosted.org/packages/50/c2/e06851e8cc28dcad7c155f4753da8833ac06a5c704c109313b8d5a62968a/pip-23.2.1-py3-none-any.whl",
               "sha256": "7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be",
               "type": "zip",
@@ -10636,7 +9732,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__installer",
               "url": "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl",
               "sha256": "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53",
               "type": "zip",
@@ -10647,7 +9742,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__more_itertools",
               "url": "https://files.pythonhosted.org/packages/5a/cb/6dce742ea14e47d6f565589e859ad225f2a5de576d7696e0623b784e226b/more_itertools-10.1.0-py3-none-any.whl",
               "sha256": "64e0735fcfdc6f3464ea133afe8ea4483b1c5fe3a3d69852e6503b43a0b222e6",
               "type": "zip",
@@ -10658,7 +9752,6 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_python~0.28.0~internal_deps~pypi__tomli",
               "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
               "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
               "type": "zip",
@@ -10668,7 +9761,7 @@
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_python~0.28.0",
+            "rules_python~",
             "bazel_tools",
             "bazel_tools"
           ]

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -43,7 +43,7 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain \
       --enable_bzlmod \
       --check_direct_dependencies=error \
-      --lockfile_mode=update \
+      --lockfile_mode=error \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -250,15 +250,8 @@ if [ -z "${BAZEL_SKIP_JAVA_COMPILATION}" ]; then
 workspace(name = 'bazel_tools')
 EOF
 
-  # Set up the MODULE.bazel file for `bazel_tools` and update the hash in the lockfile.
+  # Set up the MODULE.bazel file for `bazel_tools`
   link_file "${PWD}/src/MODULE.tools" "${BAZEL_TOOLS_REPO}/MODULE.bazel"
-  new_hash=$(shasum -a 256 "${BAZEL_TOOLS_REPO}/MODULE.bazel" | awk '{print $1}')
-  sed -i.bak "/\"bazel_tools\":/s/\"[a-f0-9]*\"/\"$new_hash\"/" MODULE.bazel.lock
-  # TODO: Temporary hack for lockfile version mismatch, remove these lines after updating to 7.1.0
-  sed -i.bak 's/"lockFileVersion": 3/"lockFileVersion": 4/' MODULE.bazel.lock
-  # Replace canonical repository names and parts thereof of the form rules_foo~1.2.3 with rules_foo~
-  sed -i.bak -E 's/([a-z]([a-z0-9._-]*[a-z0-9]){0,1})~[a-zA-Z0-9.]{1,}(-[0-9.-]{1,}){0,1}(\+[0-9.-]{1,}){0,1}/\1/g' MODULE.bazel.lock
-  rm MODULE.bazel.lock.bak
 
   mkdir -p "${BAZEL_TOOLS_REPO}/src/conditions"
   link_file "${PWD}/src/conditions/BUILD.tools" \

--- a/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
+++ b/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
@@ -103,7 +103,7 @@ function test_bootstrap() {
     JAVABASE=$(echo reduced*)
 
     env EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk" ./compile.sh \
-        || fail "Expected to be able to bootstrap bazel. If you updated MODULE.bazel, see the NOTE in that file."
+        || fail 'Expected to be able to bootstrap bazel. If the error complains about an out-of-date lockfile, try running `bazel run //src/test/tools/bzlmod:update_default_lock_file` first'
 
     ./output/bazel \
       --server_javabase=$JAVABASE --host_jvm_args=--add-opens=java.base/java.nio=ALL-UNNAMED \

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -69,18 +69,6 @@ function test_determinism()  {
     # Set up the maven repository properly.
     cp derived/maven/BUILD.vendor derived/maven/BUILD
 
-    # Update the hash of bazel_tools in lockfile to avoid rerunning module resolution.
-    new_hash=$(shasum -a 256 "src/MODULE.tools" | awk '{print $1}')
-    sed -i.bak "/\"bazel_tools\":/s/\"[a-f0-9]*\"/\"$new_hash\"/" MODULE.bazel.lock
-    # TODO: Temporary hack for lockfile version mismatch, remove these lines after updating to 7.1.0
-    sed -i.bak 's/"lockFileVersion": 3/"lockFileVersion": 4/' MODULE.bazel.lock
-    # Replace canonical repository names and parts thereof of the form rules_foo~1.2.3 with rules_foo~
-    sed -i.bak -E 's/([a-z]([a-z0-9._-]*[a-z0-9]){0,1})~[a-zA-Z0-9.]{1,}(-[0-9.-]{1,}){0,1}(\+[0-9.-]{1,}){0,1}/\1/g' MODULE.bazel.lock
-    rm MODULE.bazel.lock.bak
-
-    # Use @bazel_tools//tools/python:autodetecting_toolchain to avoid
-    # downloading python toolchain.
-
     # Build Bazel once.
     bazel \
       --output_base="${TEST_TMPDIR}/out1" \
@@ -88,7 +76,7 @@ function test_determinism()  {
       --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain \
       --enable_bzlmod \
       --check_direct_dependencies=error \
-      --lockfile_mode=update \
+      --lockfile_mode=error \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       --nostamp \
       //src:bazel
@@ -103,7 +91,7 @@ function test_determinism()  {
       --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain \
       --enable_bzlmod \
       --check_direct_dependencies=error \
-      --lockfile_mode=update \
+      --lockfile_mode=error \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       --nostamp \
       //src:bazel

--- a/src/test/tools/bzlmod/update_default_lock_file.sh
+++ b/src/test/tools/bzlmod/update_default_lock_file.sh
@@ -38,9 +38,22 @@ function generate_lock_file() {
   touch MODULE.bazel
   bazel=$(rlocation io_bazel/src/bazel)
 
-  echo "Running: $bazel mod deps $@"
+  echo "Generating default lockfile: $bazel mod deps $@"
   $bazel mod deps "$@"
   cp ./MODULE.bazel.lock $BUILD_WORKSPACE_DIRECTORY/src/test/tools/bzlmod/MODULE.bazel.lock
 }
 
+function generate_bazel_dist_lock_file() {
+  cd "${BUILD_WORKSPACE_DIRECTORY}"
+  bazel=$(rlocation io_bazel/src/bazel)
+
+  cp ./MODULE.bazel.lock ./MODULE.bazel.lock.bak
+  trap 'mv -f ./MODULE.bazel.lock.bak ./MODULE.bazel.lock' EXIT
+
+  echo "Generating the lockfile for the distribution archive: $bazel mod deps $@"
+  $bazel mod deps "$@"
+  cp ./MODULE.bazel.lock ./MODULE.bazel.lock.dist
+}
+
 generate_lock_file "$@"
+generate_bazel_dist_lock_file "$@"


### PR DESCRIPTION
The MODULE.bazel.lock file we have in our source tree is generated by the version of Bazel specified in the .bazelversion file. We currently use this lockfile for our distribution archives, which means whenever we increment the lockfile version, we need to manually transform the checked-in lockfile to make it work with HEAD Bazel too.

This commit just checks in a lockfile for HEAD Bazel and removes that hack. This separate lockfile is updated by running `bazel run //src/test/tools/bzlmod:update_default_lock_file`. If it goes out of date, the distfile tests will complain.