### PR TITLE
[7.1.0] Canonicalize the parent path in RemoteActionFileSystem#renameTo.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -734,20 +734,23 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat {
   }
 
   @Override
-  public void renameTo(PathFragment sourcePath, PathFragment targetPath) throws IOException {
-    checkArgument(isOutput(sourcePath), "sourcePath must be an output path");
-    checkArgument(isOutput(targetPath), "targetPath must be an output path");
+  public void renameTo(PathFragment srcPath, PathFragment dstPath) throws IOException {
+    srcPath = resolveSymbolicLinksForParent(srcPath);
+    dstPath = resolveSymbolicLinksForParent(dstPath);
+
+    checkArgument(isOutput(srcPath), "srcPath must be an output path");
+    checkArgument(isOutput(dstPath), "dstPath must be an output path");
 
     FileNotFoundException remoteException = null;
     try {
-      remoteOutputTree.renameTo(sourcePath, targetPath);
+      remoteOutputTree.renameTo(srcPath, dstPath);
     } catch (FileNotFoundException e) {
       remoteException = e;
     }
 
     FileNotFoundException localException = null;
     try {
-      localFs.renameTo(sourcePath, targetPath);
+      localFs.renameTo(srcPath, dstPath);
     } catch (FileNotFoundException e) {
       localException = e;
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTestBase.java
@@ -161,10 +161,20 @@ public abstract class RemoteActionFileSystemTestBase {
   }
 
   @Test
-  public void renameTo_fileDoesNotExist_throwError() throws Exception {
+  public void renameTo_sourceFileDoesNotExist_throwError() throws Exception {
     FileSystem actionFs = createActionFileSystem();
     PathFragment path = getOutputPath("file");
     PathFragment newPath = getOutputPath("file-new");
+
+    assertThrows(FileNotFoundException.class, () -> actionFs.renameTo(path, newPath));
+  }
+
+  @Test
+  public void renameTo_targetDirectoryDoesNotExist_throwError() throws Exception {
+    FileSystem actionFs = createActionFileSystem();
+    PathFragment path = getOutputPath("file");
+    PathFragment newPath = getOutputPath("dir/file-new");
+    writeLocalFile(actionFs, path, "local-content");
 
     assertThrows(FileNotFoundException.class, () -> actionFs.renameTo(path, newPath));
   }


### PR DESCRIPTION
FileSystem#renameTo is documented as not following symlinks, but that refers to the last component only; we are still required to canonicalize the parent path, possibly taking into account symlinks that straddle underlying sources.

PiperOrigin-RevId: 605606357
Change-Id: I6508c07413ceccc9947e0a03cce93d769b31f2b9