### PR TITLE
Allow locally build actions with scrubber

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -341,7 +341,8 @@ public class RemoteExecutionService {
   public boolean mayBeExecutedRemotely(Spawn spawn) {
     return remoteCache instanceof RemoteExecutionCache
         && remoteExecutor != null
-        && Spawns.mayBeExecutedRemotely(spawn);
+        && Spawns.mayBeExecutedRemotely(spawn)
+        && !scrubbedSpawn(spawn, scrubber);
   }
 
   @VisibleForTesting
@@ -1593,6 +1594,11 @@ public class RemoteExecutionService {
       reportedErrors.add(evt.getMessage());
       reporter.handle(evt);
     }
+  }
+
+  private static boolean scrubbedSpawn(Spawn spawn, @Nullable Scrubber scrubber) {
+    return scrubber != null
+        && scrubber.forSpawn(spawn) != null;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -313,10 +313,7 @@ public final class RemoteModule extends BlazeModule {
 
     boolean enableScrubbing = remoteOptions.scrubber != null;
     if (enableScrubbing && enableRemoteExecution) {
-
-      throw createOptionsExitException(
-          "Cannot combine remote cache key scrubbing with remote execution",
-          FailureDetails.RemoteOptions.Code.EXECUTION_WITH_SCRUBBING);
+      env.getReporter().handle(Event.warn("Cannot combine remote cache key scrubbing with remote execution. All actions with cache key scrubbing will be executed locally"));
     }
 
     // TODO(bazel-team): Consider adding a warning or more validation if the remoteDownloadRegex is


### PR DESCRIPTION
Since cannot run remote cache key scrubbing action with remote execution, run this actions only locally. Actions without scrubber can still be executed remotely.

The part from https://github.com/bazelbuild/bazel/pull/20070 that didn't cause much rejection.