### PR TITLE
Add closing tag in repo rule docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/WorkspaceBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/WorkspaceBaseRule.java
@@ -50,7 +50,7 @@ public class WorkspaceBaseRule implements RuleDefinition {
         <p>For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this
         repository depends on <code>"@foo"</code> (such as a dependency on
         <code>"@foo//some:target"</code>), it should actually resolve that dependency within
-        globally-declared <code>"@bar"</code> (<code>"@bar//some:target"</code>).
+        globally-declared <code>"@bar"</code> (<code>"@bar//some:target"</code>).</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("repo_mapping", STRING_DICT))
         .build();

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/FakeRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/FakeRepositoryModule.java
@@ -56,7 +56,7 @@ public class FakeRepositoryModule implements RepositoryModuleApi {
                   + "<p>For example, an entry `\"@foo\": \"@bar\"` declares that, for any time "
                   + "this repository depends on `@foo` (such as a dependency on "
                   + "`@foo//some:target`, it should actually resolve that dependency within "
-                  + "globally-declared `@bar` (`@bar//some:target`)."),
+                  + "globally-declared `@bar` (`@bar//some:target`).</p>"),
           true,
           ImmutableList.of(),
           "");

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/repo_rules_test/golden.textproto
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/repo_rules_test/golden.textproto
@@ -9,7 +9,7 @@ rule_info {
   }
   attribute {
     name: "repo_mapping"
-    doc_string: "A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<p>For example, an entry `\"@foo\": \"@bar\"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`)."
+    doc_string: "A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<p>For example, an entry `\"@foo\": \"@bar\"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).</p>"
     type: STRING_DICT
     mandatory: true
   }


### PR DESCRIPTION
A missing closing tags seems to cause problems when translating the docs with stardoc:

https://github.com/aspect-build/bazel-lib/blob/3f4e1889948e3e933ed68108d05a4cb3b38fb360/docs/host_repo.md?plain=1#L21C215-L21C224

which renders as `<p>`.

Other tags like `code`, that are closed properly, work fine.