### PR TITLE
Generate a lockfile for the distribution archive on the fly

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -96,8 +96,11 @@ genrule(
         "//third_party/remoteapis:MODULE.bazel",
     ],
     outs = ["MODULE.bazel.lock.dist"],
-    cmd = "touch BUILD && trap 'rm -rf tmp_bazel_root' EXIT && $(location //src:bazel) --output_user_root=$$PWD/tmp_bazel_root query --check_direct_dependencies=error --lockfile_mode=update :all && mv MODULE.bazel.lock $@",
-    tags = ["allow-network"],
+    cmd = "touch BUILD && " +
+          "trap 'rm -rf tmp_bazel_root' EXIT && " +
+          "$(location //src:bazel) --batch --output_user_root=$$PWD/tmp_bazel_root query --check_direct_dependencies=error --lockfile_mode=update :all && " +
+          "mv MODULE.bazel.lock $@",
+    tags = ["requires-network"],
     tools = ["//src:bazel"],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -96,7 +96,7 @@ genrule(
         "//third_party/remoteapis:MODULE.bazel",
     ],
     outs = ["MODULE.bazel.lock.dist"],
-    cmd = "touch BUILD && $(location //src:bazel) query --check_direct_dependencies=error --lockfile_mode=update :all && mv MODULE.bazel.lock $@",
+    cmd = "touch BUILD && $(location //src:bazel) --output_user_root=$$PWD/tmp_bazel_root query --check_direct_dependencies=error --lockfile_mode=update :all && mv MODULE.bazel.lock $@",
     tools = ["//src:bazel"],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -96,7 +96,8 @@ genrule(
         "//third_party/remoteapis:MODULE.bazel",
     ],
     outs = ["MODULE.bazel.lock.dist"],
-    cmd = "touch BUILD && $(location //src:bazel) --output_user_root=$$PWD/tmp_bazel_root query --check_direct_dependencies=error --lockfile_mode=update :all && mv MODULE.bazel.lock $@",
+    cmd = "touch BUILD && trap 'rm -rf tmp_bazel_root' EXIT && $(location //src:bazel) --output_user_root=$$PWD/tmp_bazel_root query --check_direct_dependencies=error --lockfile_mode=update :all && mv MODULE.bazel.lock $@",
+    tags = ["allow-network"],
     tools = ["//src:bazel"],
 )
 

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -250,15 +250,8 @@ if [ -z "${BAZEL_SKIP_JAVA_COMPILATION}" ]; then
 workspace(name = 'bazel_tools')
 EOF
 
-  # Set up the MODULE.bazel file for `bazel_tools` and update the hash in the lockfile.
+  # Set up the MODULE.bazel file for `bazel_tools`
   link_file "${PWD}/src/MODULE.tools" "${BAZEL_TOOLS_REPO}/MODULE.bazel"
-  new_hash=$(shasum -a 256 "${BAZEL_TOOLS_REPO}/MODULE.bazel" | awk '{print $1}')
-  sed -i.bak "/\"bazel_tools\":/s/\"[a-f0-9]*\"/\"$new_hash\"/" MODULE.bazel.lock
-  # TODO: Temporary hack for lockfile version mismatch, remove these lines after updating to 7.1.0
-  sed -i.bak 's/"lockFileVersion": 3/"lockFileVersion": 4/' MODULE.bazel.lock
-  # Replace canonical repository names and parts thereof of the form rules_foo~1.2.3 with rules_foo~
-  sed -i.bak -E 's/([a-z]([a-z0-9._-]*[a-z0-9]){0,1})~[a-zA-Z0-9.]{1,}(-[0-9.-]{1,}){0,1}(\+[0-9.-]{1,}){0,1}/\1/g' MODULE.bazel.lock
-  rm MODULE.bazel.lock.bak
 
   mkdir -p "${BAZEL_TOOLS_REPO}/src/conditions"
   link_file "${PWD}/src/conditions/BUILD.tools" \

--- a/src/BUILD
+++ b/src/BUILD
@@ -293,6 +293,7 @@ genrule(
     executable = 1,
     output_to_bindir = 1,
     visibility = [
+        "//:__pkg__",  # For distribution archive lockfile generation
         "//scripts:__pkg__",  # For bash completion generation
         "//scripts/packages:__pkg__",  # For installer generation
         "//src/java:__subpackages__",  # For command line reference generation

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -69,18 +69,6 @@ function test_determinism()  {
     # Set up the maven repository properly.
     cp derived/maven/BUILD.vendor derived/maven/BUILD
 
-    # Update the hash of bazel_tools in lockfile to avoid rerunning module resolution.
-    new_hash=$(shasum -a 256 "src/MODULE.tools" | awk '{print $1}')
-    sed -i.bak "/\"bazel_tools\":/s/\"[a-f0-9]*\"/\"$new_hash\"/" MODULE.bazel.lock
-    # TODO: Temporary hack for lockfile version mismatch, remove these lines after updating to 7.1.0
-    sed -i.bak 's/"lockFileVersion": 3/"lockFileVersion": 4/' MODULE.bazel.lock
-    # Replace canonical repository names and parts thereof of the form rules_foo~1.2.3 with rules_foo~
-    sed -i.bak -E 's/([a-z]([a-z0-9._-]*[a-z0-9]){0,1})~[a-zA-Z0-9.]{1,}(-[0-9.-]{1,}){0,1}(\+[0-9.-]{1,}){0,1}/\1/g' MODULE.bazel.lock
-    rm MODULE.bazel.lock.bak
-
-    # Use @bazel_tools//tools/python:autodetecting_toolchain to avoid
-    # downloading python toolchain.
-
     # Build Bazel once.
     bazel \
       --output_base="${TEST_TMPDIR}/out1" \

--- a/third_party/googleapis/BUILD.bazel
+++ b/third_party/googleapis/BUILD.bazel
@@ -20,7 +20,10 @@ license(
     license_text = "LICENSE",
 )
 
-exports_files(["LICENSE"])
+exports_files([
+    "LICENSE",
+    "MODULE.bazel",
+])
 
 filegroup(
     name = "srcs",

--- a/third_party/remoteapis/BUILD.bazel
+++ b/third_party/remoteapis/BUILD.bazel
@@ -5,7 +5,10 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-exports_files(["LICENSE"])
+exports_files([
+    "LICENSE",
+    "MODULE.bazel",
+])
 
 load("@io_bazel//third_party/grpc:build_defs.bzl", "java_grpc_library")
 load("@io_bazel//tools/build_rules:utilities.bzl", "java_library_srcs")


### PR DESCRIPTION
The MODULE.bazel.lock file we have in our source tree is generated by the version of Bazel specified in the .bazelversion file. We currently use this lockfile for our distribution archives, which means whenever we increment the lockfile version, we need to manually transform the checked-in lockfile to make it work with HEAD Bazel too.

This commit generates a lockfile for HEAD Bazel on the fly and uses that for the distribution archive. This lockfile doesn't have any module extension content, since we only need to make sure that no network access happens during tests that use the distribution archive. See https://github.com/bazelbuild/bazel/pull/21283#issuecomment-1938398252 for more context.