### PR TITLE
[7.1.0] Introduce --default_test_resources flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -2734,7 +2734,10 @@ java_library(
 
 java_library(
     name = "test/test_configuration",
-    srcs = ["test/TestConfiguration.java"],
+    srcs = [
+        "test/TestConfiguration.java",
+        "test/TestResourcesConverter.java",
+    ],
     deps = [
         ":config/build_options",
         ":config/core_option_converters",
@@ -2747,6 +2750,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:resource_converter",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -28,7 +28,9 @@ import com.google.devtools.build.lib.analysis.config.RequiresOptions;
 import com.google.devtools.build.lib.analysis.test.CoverageConfiguration.CoverageOptions;
 import com.google.devtools.build.lib.analysis.test.TestShardingStrategy.ShardingStrategyConverter;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.packages.TestSize;
 import com.google.devtools.build.lib.packages.TestTimeout;
+import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDefinition;
@@ -83,6 +85,26 @@ public class TestConfiguration extends Fragment {
                 + "short, moderate, long and eternal (in that order). In either form, a value of "
                 + "-1 tells blaze to use its default timeouts for that category.")
     public Map<TestTimeout, Duration> testTimeout;
+
+    @Option(
+        name = "default_test_resources",
+        defaultValue = "null",
+        converter = TestResourcesConverter.class,
+        allowMultiple = true,
+        documentationCategory = OptionDocumentationCategory.TESTING,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        help =
+            "Override the default resources amount for tests. The expected format is"
+                + " <resource>=<value>. If a single positive number is specified as <value>"
+                + " it will override the default resources for all test sizes. If 4"
+                + " comma-separated numbers are specified, they will override the resource"
+                + " amount for respectively the small, medium, large, enormous test sizes."
+                + " Values can also be HOST_RAM/HOST_CPU, optionally followed"
+                + " by [-|*]<float> (eg. memory=HOST_RAM*.1,HOST_RAM*.2,HOST_RAM*.3,HOST_RAM*.4)."
+                + " The default test resources specified by this flag are overridden by explicit"
+                + " resources specified in tags.")
+    // We need to store these as Pair(s) instead of Map.Entry(s) so that they are serializable.
+    public List<Pair<String, Map<TestSize, Double>>> testResources;
 
     @Option(
       name = "test_filter",
@@ -320,6 +342,7 @@ public class TestConfiguration extends Fragment {
   private final TestOptions options;
   private final ImmutableMap<TestTimeout, Duration> testTimeout;
   private final boolean shouldInclude;
+  private final ImmutableMap<TestSize, ImmutableMap<String, Double>> testResources;
 
   public TestConfiguration(BuildOptions buildOptions) {
     this.shouldInclude = buildOptions.contains(TestOptions.class);
@@ -327,9 +350,20 @@ public class TestConfiguration extends Fragment {
       TestOptions options = buildOptions.get(TestOptions.class);
       this.options = options;
       this.testTimeout = ImmutableMap.copyOf(options.testTimeout);
+      ImmutableMap.Builder<TestSize, ImmutableMap<String, Double>> testResources =
+          ImmutableMap.builderWithExpectedSize(TestSize.values().length);
+      for (TestSize size : TestSize.values()) {
+        ImmutableMap.Builder<String, Double> resources = ImmutableMap.builder();
+        for (Pair<String, Map<TestSize, Double>> resource : options.testResources) {
+          resources.put(resource.getFirst(), resource.getSecond().get(size));
+        }
+        testResources.put(size, resources.buildKeepingLast());
+      }
+      this.testResources = testResources.buildOrThrow();
     } else {
       this.options = null;
       this.testTimeout = null;
+      this.testResources = ImmutableMap.of();
     }
   }
 
@@ -341,6 +375,11 @@ public class TestConfiguration extends Fragment {
   /** Returns test timeout mapping as set by --test_timeout options. */
   public ImmutableMap<TestTimeout, Duration> getTestTimeout() {
     return testTimeout;
+  }
+
+  /** Returns test resource mapping as set by --default_test_resources options. */
+  public ImmutableMap<String, Double> getTestResources(TestSize size) {
+    return testResources.getOrDefault(size, ImmutableMap.of());
   }
 
   public String getTestFilter() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestResourcesConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestResourcesConverter.java
@@ -1,0 +1,67 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.analysis.test;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.packages.TestSize;
+import com.google.devtools.build.lib.util.Pair;
+import com.google.devtools.build.lib.util.ResourceConverter;
+import com.google.devtools.common.options.Converter;
+import com.google.devtools.common.options.Converters;
+import com.google.devtools.common.options.OptionsParsingException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.Map;
+
+public class TestResourcesConverter
+    extends Converter.Contextless<Pair<String, Map<TestSize, Double>>> {
+  private static final Converters.AssignmentConverter assignmentConverter =
+      new Converters.AssignmentConverter();
+  private static final ResourceConverter.DoubleConverter resourceConverter =
+      new ResourceConverter.DoubleConverter(
+          /* keywords= */ ImmutableMap.of(
+              ResourceConverter.HOST_CPUS_KEYWORD,
+                  () -> (double) ResourceConverter.HOST_CPUS_SUPPLIER.get(),
+              ResourceConverter.HOST_RAM_KEYWORD,
+                  () -> (double) ResourceConverter.HOST_RAM_SUPPLIER.get()),
+          /* minValue= */ 0.0,
+          /* maxValue= */ Double.MAX_VALUE);
+
+  @Override
+  public String getTypeDescription() {
+    return "a resource name followed by equal and 1 float or 4 float, e.g memory=10,30,60,100";
+  }
+
+  @Override
+  public Pair<String, Map<TestSize, Double>> convert(String input) throws OptionsParsingException {
+    Map.Entry<String, String> assignment = assignmentConverter.convert(input);
+    ArrayList<Double> values = new ArrayList<>(TestSize.values().length);
+    for (String s : Splitter.on(",").splitToList(assignment.getValue())) {
+      values.add(resourceConverter.convert(s));
+    }
+
+    if (values.size() != 1 && values.size() != TestSize.values().length) {
+      throw new OptionsParsingException("Invalid number of comma-separated entries in " + input);
+    }
+
+    EnumMap<TestSize, Double> amounts = Maps.newEnumMap(TestSize.class);
+    for (TestSize size : TestSize.values()) {
+      amounts.put(size, values.get(Math.min(values.size() - 1, size.ordinal())));
+    }
+    return Pair.of(assignment.getKey(), amounts);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
@@ -71,6 +71,7 @@ public class TestTargetProperties {
   private final boolean isExternal;
   private final String language;
   private final ImmutableMap<String, String> executionInfo;
+  private final TestConfiguration testConfiguration;
 
   /**
    * Creates test target properties instance. Constructor expects that it will be called only for
@@ -93,7 +94,7 @@ public class TestTargetProperties {
 
     boolean incompatibleExclusiveTestSandboxed = false;
 
-    TestConfiguration testConfiguration = ruleContext.getFragment(TestConfiguration.class);
+    testConfiguration = ruleContext.getFragment(TestConfiguration.class);
     if (testConfiguration != null) {
       incompatibleExclusiveTestSandboxed = testConfiguration.incompatibleExclusiveTestSandboxed();
     }
@@ -201,11 +202,21 @@ public class TestTargetProperties {
       return LOCAL_TEST_JOBS_BASED_RESOURCES;
     }
 
-    Map<String, Double> resources = parseTags(label, executionInfo);
-    ResourceSet testResourcesFromSize = TestTargetProperties.getResourceSetFromSize(size);
-    testResourcesFromSize.getResources().forEach(resources::putIfAbsent);
+    ResourceSet defaultResources = getResourceSetFromSize(size);
+    Map<String, Double> resourcesFromTags = parseTags(label, executionInfo);
+    Map<String, Double> configResources =
+        testConfiguration == null ? ImmutableMap.of() : testConfiguration.getTestResources(size);
+    if (resourcesFromTags.isEmpty() && configResources.isEmpty()) {
+      return defaultResources;
+    }
+
     return ResourceSet.create(
-        ImmutableMap.copyOf(resources), testResourcesFromSize.getLocalTestCount());
+        ImmutableMap.<String, Double>builder()
+            .putAll(defaultResources.getResources())
+            .putAll(configResources)
+            .putAll(resourcesFromTags)
+            .buildKeepingLast(),
+        defaultResources.getLocalTestCount());
   }
 
   private static FailureDetail createFailureDetail(String message, Code detailedCode) {


### PR DESCRIPTION
Add `--default_test_resources=<resource>=<value(s)>` that allows setting the default resource utilization for tests. The flag follow a syntax simialar to `--local_resources=<resource>=<value>`, in that it allow assigning different resource types, and `--test_timeout=<value(s)>`, which accepts either 1 or 4 intergers to assign to all test sizes or to each individually.

Relates to #19679

Closes #20839.

Commit https://github.com/bazelbuild/bazel/commit/0c5b6e818a069bb61f2fc078eb8d1200002dc540

PiperOrigin-RevId: 606233269
Change-Id: Ia53e42820ba9aa646b0600fe4e9f95f146d7b2b9