### PR TITLE
[7.1.0] Add `Label.to_display_form()`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -373,13 +373,9 @@ public abstract class AbstractAction extends ActionKeyCacher implements Action, 
   private String replaceProgressMessagePlaceholders(
       String progressMessage, @Nullable RepositoryMapping mainRepositoryMapping) {
     if (progressMessage.contains("%{label}") && owner.getLabel() != null) {
-      String labelString;
-      if (mainRepositoryMapping != null) {
-        labelString = owner.getLabel().getDisplayForm(mainRepositoryMapping);
-      } else {
-        labelString = owner.getLabel().toString();
-      }
-      progressMessage = progressMessage.replace("%{label}", labelString);
+      progressMessage =
+          progressMessage.replace(
+              "%{label}", owner.getLabel().getDisplayForm(mainRepositoryMapping));
     }
     if (progressMessage.contains("%{output}") && getPrimaryOutput() != null) {
       progressMessage =

--- a/src/main/java/com/google/devtools/build/lib/cmdline/BazelModuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/BazelModuleContext.java
@@ -44,6 +44,13 @@ public abstract class BazelModuleContext {
   /** The repository mapping applicable to the repo where the .bzl file is located in. */
   public abstract RepositoryMapping repoMapping();
 
+  /**
+   * The repository mapping applicable to the main repository, possibly without WORKSPACE repos or
+   * null. This is purely meant to support {@link Label#getDisplayFormForStarlark(StarlarkThread)}.
+   */
+  @Nullable
+  public abstract RepositoryMapping bestEffortMainRepoMapping();
+
   /** Returns the name of the module's .bzl file, as provided to the parser. */
   public abstract String filename();
 
@@ -160,11 +167,12 @@ public abstract class BazelModuleContext {
   public static BazelModuleContext create(
       Label label,
       RepositoryMapping repoMapping,
+      @Nullable RepositoryMapping bestEffortMainRepoMapping,
       String filename,
       ImmutableList<Module> loads,
       byte[] bzlTransitiveDigest) {
     return new AutoValue_BazelModuleContext(
-        label, repoMapping, filename, loads, bzlTransitiveDigest);
+        label, repoMapping, bestEffortMainRepoMapping, filename, loads, bzlTransitiveDigest);
   }
 
   public final Label.PackageContext packageContext() {

--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -437,8 +437,26 @@ public final class Label implements Comparable<Label>, StarlarkValue, SkyKey, Co
    * @param mainRepositoryMapping the {@link RepositoryMapping} of the main repository
    * @return analogous to {@link PackageIdentifier#getDisplayForm(RepositoryMapping)}
    */
-  public String getDisplayForm(RepositoryMapping mainRepositoryMapping) {
+  public String getDisplayForm(@Nullable RepositoryMapping mainRepositoryMapping) {
     return packageIdentifier.getDisplayForm(mainRepositoryMapping) + ":" + name;
+  }
+
+  @StarlarkMethod(
+      name = "to_display_form",
+      useStarlarkThread = true,
+      doc =
+          "Returns a string representation of this label that is optimized for human readability."
+              + " Use this to format a <code>Label</code> for use in BUILD files. <p>The exact form"
+              + " of the return value is explicitly unspecified and subject to change. The"
+              + " following properties are guaranteed for a <code>Label</code> <code>l</code>:<ul> "
+              + " <li><code>l.to_display_form()</code> has no repository part if and only if"
+              + " <code>l</code> references the main repository;</li> "
+              + " <li><code>Label(l.to_display_form()) == l</code> if the call to"
+              + " <code>Label</code> occurs in the main repository.</li></ul>")
+  public String getDisplayFormForStarlark(StarlarkThread starlarkThread) throws EvalException {
+    checkRepoVisibilityForStarlark("to_display_form");
+    return getDisplayForm(
+        BazelModuleContext.ofInnermostBzlOrThrow(starlarkThread).bestEffortMainRepoMapping());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/cmdline/PackageIdentifier.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/PackageIdentifier.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.util.HashCodes;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -215,7 +216,7 @@ public final class PackageIdentifier implements SkyKey, Comparable<PackageIdenti
    *       <dd>only with Bzlmod if the current package belongs to a repository that is not visible
    *           from the main module
    */
-  public String getDisplayForm(RepositoryMapping mainRepositoryMapping) {
+  public String getDisplayForm(@Nullable RepositoryMapping mainRepositoryMapping) {
     return repository.getDisplayForm(mainRepositoryMapping) + "//" + pkgName;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -247,19 +247,24 @@ public final class RepositoryName {
    *       <dt><code>@protobuf</code>
    *       <dd>if this repository is a WORKSPACE dependency and its <code>name</code> is "protobuf",
    *           or if this repository is a Bzlmod dependency of the main module and its apparent name
-   *           is "protobuf"
+   *           is "protobuf" (in both cases only if mainRepositoryMapping is not null)
    *       <dt><code>@@protobuf~3.19.2</code>
    *       <dd>only with Bzlmod, if this a repository that is not visible from the main module
    */
-  public String getDisplayForm(RepositoryMapping mainRepositoryMapping) {
+  public String getDisplayForm(@Nullable RepositoryMapping mainRepositoryMapping) {
     Preconditions.checkArgument(
-        mainRepositoryMapping.ownerRepo() == null || mainRepositoryMapping.ownerRepo().isMain());
+        mainRepositoryMapping == null
+            || mainRepositoryMapping.ownerRepo() == null
+            || mainRepositoryMapping.ownerRepo().isMain());
     if (!isVisible()) {
       return getNameWithAt();
     }
     if (isMain()) {
       // Packages in the main repository can always use repo-relative form.
       return "";
+    }
+    if (mainRepositoryMapping == null) {
+      return getNameWithAt();
     }
     if (!mainRepositoryMapping.usesStrictDeps()) {
       // If the main repository mapping is not using strict visibility, then Bzlmod is certainly

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -68,6 +68,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -765,6 +766,11 @@ public class BzlLoadFunction implements SkyFunction {
     if (repoMapping == null) {
       return null;
     }
+    Optional<RepositoryMapping> mainRepoMapping =
+        getMainRepositoryMapping(key, builtins.starlarkSemantics, env);
+    if (mainRepoMapping == null) {
+      return null;
+    }
     Label.RepoMappingRecorder repoMappingRecorder = new Label.RepoMappingRecorder();
     ImmutableList<Pair<String, Location>> programLoads = getLoadsFromProgram(prog);
     ImmutableList<Label> loadLabels =
@@ -843,6 +849,7 @@ public class BzlLoadFunction implements SkyFunction {
         BazelModuleContext.create(
             label,
             repoMapping,
+            mainRepoMapping.orElse(null),
             prog.getFilename(),
             ImmutableList.copyOf(loadMap.values()),
             transitiveDigest);
@@ -975,6 +982,34 @@ public class BzlLoadFunction implements SkyFunction {
       return null;
     }
     return repositoryMappingValue.getRepositoryMapping();
+  }
+
+  @Nullable
+  private static Optional<RepositoryMapping> getMainRepositoryMapping(
+      BzlLoadValue.Key key, StarlarkSemantics starlarkSemantics, Environment env)
+      throws InterruptedException {
+    if (!starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_BZLMOD)) {
+      return Optional.empty();
+    }
+    RepositoryMappingValue.Key repoMappingKey;
+    // When adding cases for other key types such as WORKSPACE or Bzlmod, make sure to track the
+    // usages of the repo mapping in persistent caches, such as repository marker files and the
+    // MODULE.bazel.lock file.
+    if (key instanceof BzlLoadValue.KeyForBuild) {
+      repoMappingKey = RepositoryMappingValue.key(RepositoryName.MAIN);
+    } else if (key instanceof BzlLoadValue.KeyForBuiltins) {
+      // Using the full main repo mapping here results in a cycle as it depends on WORKSPACE, but
+      // builtins are injected into WORKSPACE. Fixing this fully would require adding a new key type
+      // for builtins (transitively) loaded from WORKSPACE.
+      repoMappingKey = RepositoryMappingValue.KEY_FOR_ROOT_MODULE_WITHOUT_WORKSPACE_REPOS;
+    } else {
+      return Optional.empty();
+    }
+    var mainRepositoryMappingValue = (RepositoryMappingValue) env.getValue(repoMappingKey);
+    if (mainRepositoryMappingValue == null) {
+      return null;
+    }
+    return Optional.of(mainRepositoryMappingValue.getRepositoryMapping());
   }
 
   /**

--- a/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
@@ -297,7 +297,7 @@ def _init_cc_compilation_context(
         if not module_map:
             module_map = cc_common.create_module_map(
                 file = actions.declare_file(label.name + ".cppmap"),
-                name = label.workspace_name + "//" + label.package + ":" + label.name,
+                name = label.to_display_form(),
             )
 
         # There are different modes for module compilation:

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/BuildInfoFileWriteActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/BuildInfoFileWriteActionTest.java
@@ -78,6 +78,7 @@ public class BuildInfoFileWriteActionTest extends BuildViewTestCase {
               BazelModuleContext.create(
                   Label.parseCanonicalUnchecked("//test:label"),
                   RepositoryMapping.ALWAYS_FALLBACK,
+                  /* bestEffortMainRepoMapping= */ null,
                   "test/label.bzl",
                   /* loads= */ ImmutableList.of(),
                   /* bzlTransitiveDigest= */ new byte[0])),

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2533,4 +2533,37 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             "//:repo.bzl does not export a repository_rule called data_repo, yet its use is"
                 + " requested at /ws/MODULE.bazel");
   }
+
+  @Test
+  public void labelToDisplayForm() throws Exception {
+    scratch.file(
+        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "bazel_dep(name='data_repo', version='1.0')",
+        "ext = use_extension('//:defs.bzl', 'ext')",
+        "use_repo(ext, 'foo', 'bar', 'baz')");
+    scratch.file(
+        workspaceRoot.getRelative("defs.bzl").getPathString(),
+        "load('@data_repo//:defs.bzl','data_repo')",
+        "def _ext_impl(ctx):",
+        "  data_repo(name='foo',data=Label('//:foo').to_display_form())",
+        "  data_repo(name='bar',data=Label('@data_repo//:bar').to_display_form())",
+        "  data_repo(name='baz',data=Label('@@canonical_name//:baz').to_display_form())",
+        "ext = module_extension(implementation=_ext_impl)");
+    scratch.file(workspaceRoot.getRelative("BUILD").getPathString());
+    scratch.file(
+        workspaceRoot.getRelative("data.bzl").getPathString(),
+        "load('@foo//:data.bzl', foo_data='data')",
+        "load('@bar//:data.bzl', bar_data='data')",
+        "load('@baz//:data.bzl', baz_data='data')",
+        "data = 'foo:'+foo_data+' bar:'+bar_data+' baz:'+baz_data");
+
+    SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
+    EvaluationResult<BzlLoadValue> result =
+        evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
+    if (result.hasError()) {
+      throw result.getError().getException();
+    }
+    assertThat(result.get(skyKey).getModule().getGlobal("data"))
+        .isEqualTo("foo://:foo bar:@@data_repo~//:bar baz:@@canonical_name//:baz");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/cmdline/LabelTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/LabelTest.java
@@ -418,6 +418,12 @@ public class LabelTest {
         .isEqualTo("@unremapped//:unremapped");
   }
 
+  @Test
+  public void testDisplayFormNullMapping() throws Exception {
+    assertThat(displayFormFor("//foo/bar:bar", null)).isEqualTo("//foo/bar:bar");
+    assertThat(displayFormFor("@@foo//bar:bar", null)).isEqualTo("@@foo//bar:bar");
+  }
+
   private static String shorthandDisplayFormFor(
       String rawLabel, RepositoryMapping repositoryMapping) throws Exception {
     return Label.parseCanonical(rawLabel).getShorthandDisplayForm(repositoryMapping);

--- a/src/test/java/com/google/devtools/build/lib/cmdline/PackageIdentifierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/PackageIdentifierTest.java
@@ -120,6 +120,7 @@ public class PackageIdentifierTest {
                 RepositoryMapping.create(
                     ImmutableMap.of("foo", RepositoryName.create("bar")), RepositoryName.MAIN)))
         .isEqualTo("//some/pkg");
+    assertThat(pkg.getDisplayForm(null)).isEqualTo("//some/pkg");
   }
 
   @Test
@@ -139,5 +140,6 @@ public class PackageIdentifierTest {
                     ImmutableMap.of("local", RepositoryName.create("other_repo")),
                     RepositoryName.MAIN)))
         .isEqualTo("@@canonical//some/pkg");
+    assertThat(pkg.getDisplayForm(null)).isEqualTo("@@canonical//some/pkg");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryNameTest.java
@@ -105,4 +105,21 @@ public class RepositoryNameTest {
                 .getDisplayForm(repositoryMapping))
         .isEqualTo("@@[unknown repo 'local' requested from @@owner]");
   }
+
+  @Test
+  public void testGetDisplayFormWithNullMapping() throws Exception {
+    assertThat(RepositoryName.create("").getDisplayForm(null)).isEmpty();
+    assertThat(RepositoryName.create("canonical").getDisplayForm(null)).isEqualTo("@@canonical");
+
+    assertThat(
+            RepositoryName.create("")
+                .toNonVisible(RepositoryName.create("owner"))
+                .getDisplayForm(null))
+        .isEqualTo("@@[unknown repo '' requested from @@owner]");
+    assertThat(
+            RepositoryName.create("canonical")
+                .toNonVisible(RepositoryName.create("owner"))
+                .getDisplayForm(null))
+        .isEqualTo("@@[unknown repo 'canonical' requested from @@owner]");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -4824,6 +4824,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
             bzlLabel,
             RepositoryMapping.create(
                 ImmutableMap.of("my_module", currentRepo, "dep", otherRepo), currentRepo),
+            /* bestEffortMainRepoMapping= */ null,
             "lib/label.bzl",
             /* loads= */ ImmutableList.of(),
             /* bzlTransitiveDigest= */ new byte[0]);

--- a/src/test/java/com/google/devtools/build/lib/starlark/util/BazelEvaluationTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/util/BazelEvaluationTestCase.java
@@ -175,6 +175,7 @@ public final class BazelEvaluationTestCase {
     return BazelModuleContext.create(
         label,
         RepositoryMapping.ALWAYS_FALLBACK,
+        /* bestEffortMainRepoMapping= */ null,
         "test/label.bzl",
         /* loads= */ ImmutableList.of(),
         /* bzlTransitiveDigest= */ new byte[0]);

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -844,6 +844,141 @@ class BazelModuleTest(test_base.TestBase):
 
     self.RunBazel(['build', '@my_jar//jar'])
 
+  def testLabelToDisplayForm(self):
+    self.main_registry.setModuleBasePath('projects')
+    projects_dir = self.main_registry.projects
+
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'module(name="root",version="0.1")',
+            'bazel_dep(name="foo",version="1.0")',
+            'ext = use_extension("@foo//:ext.bzl", "ext")',
+            'use_repo(ext, "ext_repo")',
+        ],
+    )
+    self.ScratchFile(
+        'WORKSPACE.bzlmod',
+        [
+            'local_repository(name="quux",path="quux")',
+            'load("@foo//:ext.bzl", "ext_repo")',
+            'ext_repo(name="workspace_repo")',
+        ],
+    )
+    self.ScratchFile(
+        'BUILD',
+        [
+            'load("@foo//:defs.bzl", "my_macro", "my_rule")',
+            'my_macro(name="main_macro")',
+            'my_rule(name="main_rule")',
+        ],
+    )
+    self.main_registry.createLocalPathModule('foo', '1.0', 'foo')
+    scratchFile(
+        projects_dir.joinpath('foo', 'BUILD'),
+        [
+            'load(":defs.bzl", "my_macro", "my_rule")',
+            'my_macro(name="foo_macro")',
+            'my_rule(name="foo_rule")',
+        ],
+    )
+    scratchFile(
+        projects_dir.joinpath('foo', 'defs.bzl'),
+        [
+            'print("init => " + Label("@foo//:init").to_display_form())',
+            'def my_macro(name):',
+            '  label = native.package_relative_label(name)',
+            '  print(name + " => " + label.to_display_form())',
+            '',
+            'def _my_rule(ctx):',
+            '  print(ctx.attr.name + " => " + ctx.label.to_display_form())',
+            '  out = ctx.actions.declare_file(ctx.attr.name)',
+            '  ctx.actions.write(out, "")',
+            '  return [DefaultInfo(files = depset([out]))]',
+            'my_rule = rule(implementation = _my_rule)',
+        ],
+    )
+    scratchFile(
+        projects_dir.joinpath('foo', 'ext.bzl'),
+        [
+            'def _ext_repo(rctx):',
+            '  name = rctx.attr.name',
+            '  if "~" in name:',
+            '    name = name.rpartition("~")[-1]',
+            (
+                '  print(name + "_impl => " +'
+                ' Label("@foo//:repo_impl").to_display_form())'
+            ),
+            '  rctx.file("BUILD",',
+            (
+                '    ("load(\\"@foo//:defs.bzl\\", \\"my_macro\\",'
+                ' \\"my_rule\\")\\n" +'
+            ),
+            '    "my_macro(name=\\"{name}_macro\\")\\n" +',
+            '    "my_rule(name=\\"{name}_rule\\")").format(name = str(name)))',
+            'ext_repo = repository_rule(_ext_repo)',
+            'def _ext(mctx):',
+            (
+                '  print("ext_impl => " +'
+                ' Label("@foo//:ext_impl").to_display_form())'
+            ),
+            '  ext_repo(name="ext_repo")',
+            'ext = module_extension(_ext)',
+        ],
+    )
+
+    self.ScratchFile('quux/REPO.bazel')
+    self.ScratchFile(
+        'quux/BUILD',
+        [
+            'load("@foo//:defs.bzl", "my_macro", "my_rule")',
+            'my_macro(name="quux_macro")',
+            'my_rule(name="quux_rule")',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(
+        [
+            'build',
+            '--enable_workspace',
+            '//:all',
+            '@foo//:all',
+            '@ext_repo//:all',
+            '@quux//:all',
+            '@workspace_repo//:all',
+        ],
+    )
+    stderr = '\n'.join(stderr)
+
+    # Display form of labels in global constants uses apparent names.
+    self.assertIn('init => @foo//:init', stderr)
+
+    # Display form of labels in rule implementation functions uses
+    # apparent names.
+    self.assertIn('main_rule => //:main_rule', stderr)
+    self.assertIn('foo_rule => @foo//:foo_rule', stderr)
+    self.assertIn('ext_repo_rule => @ext_repo//:ext_repo_rule', stderr)
+    self.assertIn('quux_rule => @quux//:quux_rule', stderr)
+    self.assertIn(
+        'workspace_repo_rule => @workspace_repo//:workspace_repo_rule', stderr
+    )
+
+    # Display form of labels in macros uses apparent names.
+    self.assertIn('main_macro => //:main_macro', stderr)
+    self.assertIn('foo_macro => @foo//:foo_macro', stderr)
+    self.assertIn('ext_repo_macro => @ext_repo//:ext_repo_macro', stderr)
+    self.assertIn('quux_macro => @quux//:quux_macro', stderr)
+    self.assertIn(
+        'workspace_repo_macro => @workspace_repo//:workspace_repo_macro', stderr
+    )
+
+    # Display form of labels in extensions uses canonical names.
+    self.assertIn('ext_impl => @@foo~//:ext_impl', stderr)
+    self.assertIn('ext_repo_impl => @@foo~//:repo_impl', stderr)
+
+    # Display form of labels in WORKSPACE loaded files uses canonical names.
+    self.assertIn('workspace_repo_impl => @@foo~//:repo_impl', stderr)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -634,6 +634,7 @@ sh_test(
     data = [":test-deps"],
     tags = [
         "no_windows",
+        "requires-network",  # Allow this test to access the BCR
     ],
 )
 

--- a/src/test/shell/bazel/bazel_layering_check_test.sh
+++ b/src/test/shell/bazel/bazel_layering_check_test.sh
@@ -167,4 +167,59 @@ function test_bazel_layering_check() {
     "'base.h'"
 }
 
+function test_bazel_layering_check_external_repo() {
+  if is_darwin; then
+    echo "This test doesn't run on Darwin. Skipping."
+    return
+  fi
+
+  local -r clang_tool=$(which clang)
+  if [[ ! -x ${clang_tool:-/usr/bin/clang_tool} ]]; then
+    echo "clang not installed. Skipping test."
+    return
+  fi
+
+  cat << 'EOF' > MODULE.bazel
+bazel_dep(
+    name = "lib",
+    repo_name = "my_lib",
+)
+local_path_override(
+    module_name = "lib",
+    path = "lib",
+)
+EOF
+
+  mkdir -p lib
+  cat << 'EOF' > lib/MODULE.bazel
+module(name = "lib")
+EOF
+  mkdir -p lib/pkg
+  cat << 'EOF' > lib/pkg/BUILD
+cc_library(name = "a", srcs = ["a.cc"], deps = [":b"])
+cc_library(name = "b", srcs = ["b.cc"], hdrs = ["b.h"], deps = [":c"])
+cc_library(name = "c", srcs = ["c.cc"], hdrs = ["c.h"])
+EOF
+  cat << 'EOF' > lib/pkg/a.cc
+#include "b.h"
+#include "c.h"
+EOF
+  cat << 'EOF' > lib/pkg/b.cc
+#include "b.h"
+#include "c.h"
+EOF
+  cat << 'EOF' > lib/pkg/b.h
+#include "c.h"
+EOF
+  cat << 'EOF' > lib/pkg/c.cc
+#include "c.h"
+EOF
+  touch lib/pkg/c.h
+
+  CC="${clang_tool}" bazel build @my_lib//pkg:a --features=layering_check \
+    -s \
+    &> $TEST_log && fail "Build should have failed"
+  expect_log "module @my_lib//pkg:a does not depend on a module exporting 'c.h'"
+}
+
 run_suite "test layering_check"


### PR DESCRIPTION
Fixes #20486

While `to_display_form()` can be called in all contexts, it only returns apparent names for BUILD threads, which are the most common use case for display form labels. Support for module extensions can be added later, but requires explicit tracking of inverse mappings in the lockfile.

Also use `to_display_form()` to generate Clang module names in the correct form for external repositories. `java_*` rules require more delicate handling and will be migrated in a follow-up change.

RELNOTES: The `to_display_form()` method on `Label` returns a string representation of a label optimized for readability by humans.

Closes #21179.

PiperOrigin-RevId: 606330539
Change-Id: Id6a4ad79fd3d50319320789b88c618aad28db28b