### PR TITLE
[7.1.0] Allow `@repo_name` labels in override attributes

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2293,7 +2293,7 @@
       "general": {
         "bzlTransitiveDigest": "TaEUQXsOyJBUS1hp5pqPajfzBJlceug58PemF8nCEa8=",
         "accumulatedFileDigests": {
-          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "764150deafd5a0f7ab16ce189e9cc616b0f667f3bd8704c1f5049782bb1193b1",
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "50cae33efeced92457f02701d6d43ffbef4629533788a59dae209e0b50bfd8b0",
           "@@//:MODULE.bazel": "f0f6c040c50ad1d3555157b29dea32260bdaf5cc7205dfc346d4b1b6b008baca"
         },
         "envVariables": {},

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveOverride.java
@@ -25,7 +25,7 @@ public abstract class ArchiveOverride implements NonRegistryOverride {
 
   public static ArchiveOverride create(
       ImmutableList<String> urls,
-      ImmutableList<String> patches,
+      ImmutableList<Object> patches,
       ImmutableList<String> patchCmds,
       String integrity,
       String stripPrefix,
@@ -37,8 +37,8 @@ public abstract class ArchiveOverride implements NonRegistryOverride {
   /** The URLs pointing at the archives. Can be HTTP(S) or file URLs. */
   public abstract ImmutableList<String> getUrls();
 
-  /** The patches to apply after extracting the archive. Should be a list of labels. */
-  public abstract ImmutableList<String> getPatches();
+  /** The labels of patches to apply after extracting the archive. */
+  public abstract ImmutableList<Object> getPatches();
 
   /** The patch commands to execute after extracting the archive. Should be a list of commands. */
   public abstract ImmutableList<String> getPatchCmds();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveRepoSpecBuilder.java
@@ -27,7 +27,7 @@ import net.starlark.java.eval.StarlarkInt;
  */
 public class ArchiveRepoSpecBuilder {
 
-  public static final String HTTP_ARCHIVE_PATH = "@bazel_tools//tools/build_defs/repo:http.bzl";
+  public static final String HTTP_ARCHIVE_PATH = "@@bazel_tools//tools/build_defs/repo:http.bzl";
 
   private final ImmutableMap.Builder<String, Object> attrBuilder;
 
@@ -54,7 +54,7 @@ public class ArchiveRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
-  public ArchiveRepoSpecBuilder setPatches(ImmutableList<String> patches) {
+  public ArchiveRepoSpecBuilder setPatches(ImmutableList<Object> patches) {
     attrBuilder.put("patches", patches);
     return this;
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitOverride.java
@@ -25,7 +25,7 @@ public abstract class GitOverride implements NonRegistryOverride {
   public static GitOverride create(
       String remote,
       String commit,
-      ImmutableList<String> patches,
+      ImmutableList<Object> patches,
       ImmutableList<String> patchCmds,
       int patchStrip,
       boolean initSubmodules) {
@@ -39,8 +39,8 @@ public abstract class GitOverride implements NonRegistryOverride {
   /** The commit hash to use. */
   public abstract String getCommit();
 
-  /** The patches to apply after fetching from Git. Should be a list of labels. */
-  public abstract ImmutableList<String> getPatches();
+  /** The labels of patches to apply after fetching from Git. */
+  public abstract ImmutableList<Object> getPatches();
 
   /** The patch commands to execute after fetching from Git. Should be a list of commands. */
   public abstract ImmutableList<String> getPatchCmds();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 public class GitRepoSpecBuilder {
 
-  public static final String GIT_REPO_PATH = "@bazel_tools//tools/build_defs/repo:git.bzl";
+  public static final String GIT_REPO_PATH = "@@bazel_tools//tools/build_defs/repo:git.bzl";
 
   private final ImmutableMap.Builder<String, Object> attrBuilder;
 
@@ -71,7 +71,7 @@ public class GitRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
-  public GitRepoSpecBuilder setPatches(List<String> patches) {
+  public GitRepoSpecBuilder setPatches(List<Object> patches) {
     return setAttr("patches", patches);
   }
 
@@ -113,7 +113,7 @@ public class GitRepoSpecBuilder {
   }
 
   @CanIgnoreReturnValue
-  private GitRepoSpecBuilder setAttr(String name, List<String> value) {
+  private GitRepoSpecBuilder setAttr(String name, List<?> value) {
     if (value != null && !value.isEmpty()) {
       attrBuilder.put(name, value);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpec.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RepoSpec.java
@@ -29,7 +29,8 @@ import javax.annotation.Nullable;
 public abstract class RepoSpec implements SkyValue {
 
   /**
-   * The label string for the bzl file this repository rule is defined in, empty for native rule.
+   * The unambiguous canonical label string for the bzl file this repository rule is defined in,
+   * empty for native rule.
    */
   @Nullable
   public abstract String bzlFile();
@@ -51,6 +52,8 @@ public abstract class RepoSpec implements SkyValue {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setBzlFile(String bzlFile);
+
+    abstract String bzlFile();
 
     public abstract Builder setRuleClassName(String name);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleVersionOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleVersionOverride.java
@@ -33,7 +33,7 @@ public abstract class SingleVersionOverride implements RegistryOverride {
   public static SingleVersionOverride create(
       Version version,
       String registry,
-      ImmutableList<String> patches,
+      ImmutableList<Object> patches,
       ImmutableList<String> patchCmds,
       int patchStrip) {
     return new AutoValue_SingleVersionOverride(version, registry, patches, patchCmds, patchStrip);
@@ -48,8 +48,8 @@ public abstract class SingleVersionOverride implements RegistryOverride {
   @Override
   public abstract String getRegistry();
 
-  /** The patches to apply after retrieving per the registry. Should be a list of labels. */
-  public abstract ImmutableList<String> getPatches();
+  /** The labels of patches to apply after retrieving per the registry. */
+  public abstract ImmutableList<Object> getPatches();
 
   /**
    * The patch commands to execute after retrieving per the registry. Should be a list of commands.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
@@ -70,14 +70,11 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
   private final BlazeDirectories directories;
 
   /**
-   * An empty repo mapping anchored to the main repo.
-   *
-   * <p>None of the labels present in RepoSpecs can point to any repo other than the main repo
-   * or @bazel_tools, because at this point we don't know how any other repo is defined yet. The
-   * RepoSpecs processed by this class can only contain labels from the MODULE.bazel file (from
-   * overrides). In the future, they might contain labels from the lockfile, but those will need to
-   * be canonical label literals, which bypass repo mapping anyway.
+   * An empty repo mapping anchored to the main repo. Label strings in {@link RepoSpec}s are always
+   * in unambiguous canonical form and thus require no mapping, except instances read from old
+   * lockfiles.
    */
+  // TODO(fmeum): Make this mapping truly empty after bumping LOCK_FILE_VERSION.
   private static final RepositoryMapping EMPTY_MAIN_REPO_MAPPING =
       RepositoryMapping.create(
           ImmutableMap.of("", RepositoryName.MAIN, "bazel_tools", RepositoryName.BAZEL_TOOLS),

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -143,22 +143,84 @@ class BazelOverridesTest(test_base.TestBase):
     self.writeMainProjectFiles()
     archive_aaa_1_0 = self.main_registry.archives.joinpath('aaa.1.0.zip')
     self.ScratchFile(
+        'aaa2.patch',
+        [
+            '--- a/aaa.cc',
+            '+++ b/aaa.cc',
+            '@@ -1,6 +1,6 @@',
+            ' #include <stdio.h>',
+            ' #include "aaa.h"',
+            ' void hello_aaa(const std::string& caller) {',
+            '-    std::string lib_name = "aaa@1.0 (locally patched)";',
+            '+    std::string lib_name = "aaa@1.0 (locally patched again)";',
+            '     printf("%s => %s\\n", caller.c_str(), lib_name.c_str());',
+            ' }',
+        ],
+    )
+    self.ScratchFile(
+        'aaa3.patch',
+        [
+            '--- a/aaa.cc',
+            '+++ b/aaa.cc',
+            '@@ -1,6 +1,6 @@',
+            ' #include <stdio.h>',
+            ' #include "aaa.h"',
+            ' void hello_aaa(const std::string& caller) {',
+            '-    std::string lib_name = "aaa@1.0 (locally patched again)";',
+            (
+                '+    std::string lib_name = "aaa@1.0 (locally patched again'
+                ' and again)";'
+            ),
+            '     printf("%s => %s\\n", caller.c_str(), lib_name.c_str());',
+            ' }',
+        ],
+    )
+    self.ScratchFile(
+        'aaa4.patch',
+        [
+            '--- a/aaa.cc',
+            '+++ b/aaa.cc',
+            '@@ -1,6 +1,6 @@',
+            ' #include <stdio.h>',
+            ' #include "aaa.h"',
+            ' void hello_aaa(const std::string& caller) {',
+            (
+                '-    std::string lib_name = "aaa@1.0 (locally patched again'
+                ' and again)";'
+            ),
+            (
+                '+    std::string lib_name = "aaa@1.0 (locally patched all over'
+                ' again)";'
+            ),
+            '     printf("%s => %s\\n", caller.c_str(), lib_name.c_str());',
+            ' }',
+        ],
+    )
+    self.ScratchFile(
         'MODULE.bazel',
         [
+            'module(name = "main", repo_name = "my_main")',
             'bazel_dep(name = "aaa", version = "1.1")',
             'bazel_dep(name = "bbb", version = "1.1")',
             'archive_override(',
             '  module_name = "aaa",',
             '  urls = ["%s"],' % archive_aaa_1_0.as_uri(),
-            '  patches = ["//:aaa.patch"],',
+            '  patches = [',
+            '    "//:aaa.patch",',
+            '    "@//:aaa2.patch",',
+            '    "@my_main//:aaa3.patch",',
+            '    ":aaa4.patch",',
+            '  ],',
             '  patch_strip = 1,',
             ')',
         ],
     )
     _, stdout, _ = self.RunBazel(['run', '//:main'])
-    self.assertIn('main function => aaa@1.0 (locally patched)', stdout)
+    self.assertIn(
+        'main function => aaa@1.0 (locally patched all over again)', stdout
+    )
     self.assertIn('main function => bbb@1.1', stdout)
-    self.assertIn('bbb@1.1 => aaa@1.0 (locally patched)', stdout)
+    self.assertIn('bbb@1.1 => aaa@1.0 (locally patched all over again)', stdout)
 
   def testGitOverride(self):
     self.writeMainProjectFiles()

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -228,7 +228,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -330,7 +330,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -356,7 +356,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -385,7 +385,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -489,7 +489,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -555,7 +555,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -584,7 +584,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -663,7 +663,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -696,7 +696,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -748,7 +748,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -778,7 +778,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -807,7 +807,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -837,7 +837,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -870,7 +870,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -956,7 +956,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -985,7 +985,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
@@ -1015,7 +1015,7 @@
         "local_config_platform": "local_config_platform@_"
       },
       "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [


### PR DESCRIPTION
This is made possible by a refactoring that moves the label parsing of `RepoSpec` attributes coming from module overrides as well as `.bzl` file labels containing repo rules from `BzlmodRepoRuleFunction` into `ModuleFileGlobals`. Also adds a TODO to `BzlmodRepoRuleFunction` to further simplify the logic after the next lockfile version bumps, as old lockfiles are now the only source of non-canonical labels in `RepoSpec`s.

Work towards #19301

Closes #21188.

PiperOrigin-RevId: 605517195
Change-Id: Id34c81fa9474fef2354ff1fbc898e518a9044640