### PR TITLE
Initialize buildEventArtifactUploaderFactoryDelegate for http caches

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -392,6 +392,19 @@ public final class RemoteModule extends BlazeModule {
 
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
       initHttpAndDiskCache(env, credentials, authAndTlsOptions, remoteOptions, digestUtil);
+      buildEventArtifactUploaderFactoryDelegate.init(
+        new ByteStreamBuildEventArtifactUploaderFactory(
+          executorService,
+          env.getReporter(),
+          verboseFailures,
+          actionContextProvider.getRemoteCache(),
+          remoteOptions.remoteInstanceName,
+          remoteOptions.remoteBytestreamUriPrefix,
+          buildRequestId,
+          invocationId,
+          remoteOptions.remoteBuildEventUploadMode
+        )
+      );
       return;
     }
 


### PR DESCRIPTION
This PR addresses issue [#21320](https://github.com/bazelbuild/bazel/issues/21320). 

This was discovered after testing a service that relies on trace profiles being uploaded stopped working when HTTP remote cache is used instead of GRPC. 
This is due to the lack of a `ByteStreamBuildEventArtifactUploaderFactory` in the `delegate` since that codepath is only executed if the remote cache is GRPC. 

With this change, all files referenced in BEP events are uploaded to the remote cache if the [--build_event_upload_strategy](https://bazel.build/reference/command-line-reference#flag--experimental_build_event_upload_strategy) flag is set to `remote`
