### PR TITLE
[7.1.0] Make SpawnLogConvert an abstract class instead of an interface.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -14,11 +14,6 @@
 package com.google.devtools.build.lib.exec;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.computeDigest;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.getEnvironmentVariables;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.getPlatform;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.getSpawnMetricsProto;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.isInputDirectory;
 
 import com.github.luben.zstd.ZstdOutputStream;
 import com.google.common.collect.ImmutableList;
@@ -58,7 +53,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 /** A {@link SpawnLogContext} implementation that produces a log in compact format. */
-public class CompactSpawnLogContext implements SpawnLogContext {
+public class CompactSpawnLogContext extends SpawnLogContext {
 
   private interface ExecLogEntrySupplier {
     ExecLogEntry.Builder get() throws IOException;

--- a/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
@@ -13,12 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.exec;
 
-import static com.google.devtools.build.lib.exec.SpawnLogContext.computeDigest;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.getEnvironmentVariables;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.getPlatform;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.getSpawnMetricsProto;
-import static com.google.devtools.build.lib.exec.SpawnLogContext.isInputDirectory;
-
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -62,7 +56,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 /** A {@link SpawnLogContext} implementation that produces a log in expanded format. */
-public class ExpandedSpawnLogContext implements SpawnLogContext {
+public class ExpandedSpawnLogContext extends SpawnLogContext {
 
   /** The log encoding. */
   public enum Encoding {

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -50,7 +50,7 @@ import java.util.SortedMap;
 import javax.annotation.Nullable;
 
 /** An {@link ActionContext} providing the ability to log executed spawns. */
-public interface SpawnLogContext extends ActionContext {
+public abstract class SpawnLogContext implements ActionContext {
   /**
    * Logs an executed spawn.
    *
@@ -64,7 +64,7 @@ public interface SpawnLogContext extends ActionContext {
    * @param timeout the timeout the spawn was run under
    * @param result the spawn result
    */
-  void logSpawn(
+  public abstract void logSpawn(
       Spawn spawn,
       InputMetadataProvider inputMetadataProvider,
       SortedMap<PathFragment, ActionInput> inputMap,
@@ -74,10 +74,10 @@ public interface SpawnLogContext extends ActionContext {
       throws IOException, ExecException;
 
   /** Finishes writing the log and performs any required post-processing. */
-  void close() throws IOException;
+  public abstract void close() throws IOException;
 
   /** Computes the environment variables. */
-  static ImmutableList<EnvironmentVariable> getEnvironmentVariables(Spawn spawn) {
+  protected ImmutableList<EnvironmentVariable> getEnvironmentVariables(Spawn spawn) {
     ImmutableMap<String, String> environment = spawn.getEnvironment();
     ImmutableList.Builder<EnvironmentVariable> builder =
         ImmutableList.builderWithExpectedSize(environment.size());
@@ -93,7 +93,8 @@ public interface SpawnLogContext extends ActionContext {
 
   /** Computes the execution platform. */
   @Nullable
-  static Platform getPlatform(Spawn spawn, RemoteOptions remoteOptions) throws UserExecException {
+  protected Platform getPlatform(Spawn spawn, RemoteOptions remoteOptions)
+      throws UserExecException {
     var execPlatform = PlatformUtils.getPlatformProto(spawn, remoteOptions);
     if (execPlatform == null) {
       return null;
@@ -110,7 +111,7 @@ public interface SpawnLogContext extends ActionContext {
    *
    * <p>Do not call for action outputs.
    */
-  static boolean isInputDirectory(ActionInput input, InputMetadataProvider inputMetadataProvider)
+  protected boolean isInputDirectory(ActionInput input, InputMetadataProvider inputMetadataProvider)
       throws IOException {
     if (input.isDirectory()) {
       return true;
@@ -134,7 +135,7 @@ public interface SpawnLogContext extends ActionContext {
    * <p>Will try to obtain the digest from cached metadata first, falling back to digesting the
    * contents manually.
    */
-  static Digest computeDigest(
+  protected Digest computeDigest(
       @Nullable ActionInput input,
       Path path,
       InputMetadataProvider inputMetadataProvider,
@@ -183,7 +184,7 @@ public interface SpawnLogContext extends ActionContext {
         .build();
   }
 
-  static Protos.SpawnMetrics getSpawnMetricsProto(SpawnResult result) {
+  protected static Protos.SpawnMetrics getSpawnMetricsProto(SpawnResult result) {
     SpawnMetrics metrics = result.getMetrics();
     Protos.SpawnMetrics.Builder builder = Protos.SpawnMetrics.newBuilder();
     if (metrics.totalTimeInMs() != 0L) {


### PR DESCRIPTION
It has accumulated a lot of shared logic, so it's starting to look weird.

PiperOrigin-RevId: 606251379
Change-Id: I961d8ae1b5b836bbef6b6e759e94ccc6337b125f