### PR TITLE
[7.1.0] Document --cache_computed_file_digests.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -358,7 +358,7 @@ public class ExecutionOptions extends OptionsBase {
   @Option(
       name = "cache_computed_file_digests",
       defaultValue = "50000",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "If greater than 0, configures Bazel to cache file digests in memory based on their "


### PR DESCRIPTION
It seems pretty important to document the existence of this flag, as it has implications for both performance and correctness.

See https://github.com/bazelbuild/bazel/issues/14401 for prior discussion.

PiperOrigin-RevId: 606545000
Change-Id: I3aa9d311c805ebf9fb7401b79f320e1ba11d2179