### PR TITLE
[7.1.0] Mark `use_repo_rule` extension as reproducible

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -122,7 +122,7 @@ public class BazelLockFileModule extends BlazeModule {
     // Add the new resolved extensions
     for (var event : extensionResolutionEventsMap.values()) {
       LockFileModuleExtension extension = event.getModuleExtension();
-      if (!extension.shouldLockExtesnsion()) {
+      if (!extension.shouldLockExtension()) {
         continue;
       }
 
@@ -169,7 +169,7 @@ public class BazelLockFileModule extends BlazeModule {
     // If there is a new event for this extension, compare it with the existing ones
     ModuleExtensionResolutionEvent extEvent = extensionResolutionEventsMap.get(extensionId);
     if (extEvent != null) {
-      boolean doNotLockExtension = !extEvent.getModuleExtension().shouldLockExtesnsion();
+      boolean doNotLockExtension = !extEvent.getModuleExtension().shouldLockExtension();
       boolean dependencyOnOsChanged =
           lockedExtensionKey.getOs().isEmpty() != extEvent.getExtensionFactors().getOs().isEmpty();
       boolean dependencyOnArchChanged =

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
@@ -54,7 +54,7 @@ public abstract class LockFileModuleExtension implements Postable {
 
   public abstract Builder toBuilder();
 
-  public boolean shouldLockExtesnsion() {
+  public boolean shouldLockExtension() {
     return getModuleExtensionMetadata().isEmpty()
         || !getModuleExtensionMetadata().get().getReproducible();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionMetadata.java
@@ -55,6 +55,14 @@ import net.starlark.java.syntax.Location;
 @AutoValue
 @GenerateTypeAdapter
 public abstract class ModuleExtensionMetadata implements StarlarkValue {
+
+  static final ModuleExtensionMetadata REPRODUCIBLE =
+      create(
+          /* explicitRootModuleDirectDeps= */ null,
+          /* explicitRootModuleDirectDevDeps= */ null,
+          UseAllRepos.NO,
+          /* reproducible= */ true);
+
   @Nullable
   abstract ImmutableSet<String> getExplicitRootModuleDirectDeps();
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -713,7 +713,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
         ModuleExtensionId extensionId)
         throws InterruptedException, SingleExtensionEvalFunctionException {
       var generatedRepoSpecs = ImmutableMap.<String, RepoSpec>builderWithExpectedSize(repos.size());
-      // Instiantiate the repos one by one.
+      // Instantiate the repos one by one.
       for (InnateExtensionRepo repo : repos) {
         Object exported = repo.loadedBzl().getModule().getGlobal(repo.ruleName());
         if (exported == null) {
@@ -790,7 +790,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       return RunModuleExtensionResult.create(
           ImmutableMap.of(),
           generatedRepoSpecs.buildOrThrow(),
-          Optional.empty(),
+          Optional.of(ModuleExtensionMetadata.REPRODUCIBLE),
           ImmutableTable.of());
     }
   }


### PR DESCRIPTION
This ensures that the attributes of repo rules used with `use_repo_rule` are not duplicated in the locked extension entry in the lockfile. They are still duplicated in the usages section of the lockfile.

Also fix two typos.

Closes #21304.

Commit https://github.com/bazelbuild/bazel/commit/0523461ffdc5c0d2f8e55c66df824e1efbba1cf7

PiperOrigin-RevId: 606660953
Change-Id: I5f7fa50dbacfafae22e4ea3fdb92e6bfb2beffc6