### PR TITLE
[7.1.0] Make SpawnLogContext interruptible.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -71,7 +71,7 @@ public abstract class SpawnLogContext implements ActionContext {
       FileSystem fileSystem,
       Duration timeout,
       SpawnResult result)
-      throws IOException, ExecException;
+      throws IOException, InterruptedException, ExecException;
 
   /** Finishes writing the log and performs any required post-processing. */
   public abstract void close() throws IOException;

--- a/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
@@ -99,7 +99,7 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
 
   @Override
   protected SpawnLogContext createSpawnLogContext(ImmutableMap<String, String> platformProperties)
-      throws IOException {
+      throws IOException, InterruptedException {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.remoteDefaultExecProperties = platformProperties.entrySet().asList();
 
@@ -113,7 +113,7 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
 
   @Override
   protected void closeAndAssertLog(SpawnLogContext context, SpawnExec... expected)
-      throws IOException {
+      throws IOException, InterruptedException {
     context.close();
 
     ArrayList<SpawnExec> actual = new ArrayList<>();

--- a/src/test/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContextTest.java
@@ -37,7 +37,7 @@ public final class ExpandedSpawnLogContextTest extends SpawnLogContextTestBase {
 
   @Override
   protected SpawnLogContext createSpawnLogContext(ImmutableMap<String, String> platformProperties)
-      throws IOException {
+      throws IOException, InterruptedException {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.remoteDefaultExecProperties = platformProperties.entrySet().asList();
 
@@ -54,7 +54,7 @@ public final class ExpandedSpawnLogContextTest extends SpawnLogContextTestBase {
 
   @Override
   protected void closeAndAssertLog(SpawnLogContext context, SpawnExec... expected)
-      throws IOException {
+      throws IOException, InterruptedException {
     context.close();
 
     ArrayList<SpawnExec> actual = new ArrayList<>();

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -957,12 +957,12 @@ public abstract class SpawnLogContextTestBase {
     return builder.build();
   }
 
-  protected SpawnLogContext createSpawnLogContext() throws IOException {
+  protected SpawnLogContext createSpawnLogContext() throws IOException, InterruptedException {
     return createSpawnLogContext(ImmutableSortedMap.of());
   }
 
   protected abstract SpawnLogContext createSpawnLogContext(
-      ImmutableMap<String, String> platformProperties) throws IOException;
+      ImmutableMap<String, String> platformProperties) throws IOException, InterruptedException;
 
   protected Digest getDigest(String content) {
     return Digest.newBuilder()
@@ -982,5 +982,5 @@ public abstract class SpawnLogContextTestBase {
   }
 
   protected abstract void closeAndAssertLog(SpawnLogContext context, SpawnExec... expected)
-      throws IOException;
+      throws IOException, InterruptedException;
 }


### PR DESCRIPTION
To simplify a followup change.

PiperOrigin-RevId: 606551475
Change-Id: I1a6b32352fce3beeb4f903079a50f6a5429d44d6