### PR TITLE
Support watching a path even if it's a directory or nonexistent

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkPath.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkPath.java
@@ -77,7 +77,6 @@ public final class StarlarkPath implements StarlarkValue {
 
   @StarlarkMethod(
       name = "readdir",
-      structField = false,
       doc = "The list of entries in the directory denoted by this path.")
   public ImmutableList<StarlarkPath> readdir() throws IOException {
     ImmutableList.Builder<StarlarkPath> builder = ImmutableList.builder();
@@ -118,9 +117,25 @@ public final class StarlarkPath implements StarlarkValue {
   @StarlarkMethod(
       name = "exists",
       structField = true,
-      doc = "Returns true if the file denoted by this path exists.")
+      doc =
+          "Returns true if the file or directory denoted by this path exists.<p>Note that "
+              + "accessing this field does <em>not</em> cause the path to be watched. If you'd "
+              + "like the repo rule or module extension to be sensitive to the path's existence, "
+              + "use the <code>watch()</code> method on the context object.")
   public boolean exists() {
     return path.exists();
+  }
+
+  @StarlarkMethod(
+      name = "is_dir",
+      structField = true,
+      doc =
+          "Returns true if this path points to a directory.<p>Note that accessing this field does "
+              + "<em>not</em> cause the path to be watched. If you'd like the repo rule or module "
+              + "extension to be sensitive to whether the path is a directory or a file, use the "
+              + "<code>watch()</code> method on the context object.")
+  public boolean isDir() {
+    return path.isDirectory();
   }
 
   @StarlarkMethod(

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
@@ -194,12 +194,16 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
 
     /**
      * Convert to a {@link com.google.devtools.build.lib.actions.FileValue} to a String appropriate
-     * for placing in a repository marker file.
-     *
-     * @param fileValue The value to convert. It must correspond to a regular file.
+     * for placing in a repository marker file. The file need not exist, and can be a file or a
+     * directory.
      */
     public static String fileValueToMarkerValue(FileValue fileValue) throws IOException {
-      Preconditions.checkArgument(fileValue.isFile() && !fileValue.isSpecialFile());
+      if (fileValue.isDirectory()) {
+        return "DIR";
+      }
+      if (!fileValue.exists()) {
+        return "ENOENT";
+      }
       // Return the file content digest in hex. fileValue may or may not have the digest available.
       byte[] digest = fileValue.realFileStateValue().getDigest();
       if (digest == null) {

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -93,7 +93,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
 
   // The marker file version is inject in the rule key digest so the rule key is always different
   // when we decide to update the format.
-  private static final int MARKER_FILE_VERSION = 5;
+  private static final int MARKER_FILE_VERSION = 6;
 
   // Mapping of rule class name to RepositoryFunction.
   private final ImmutableMap<String, RepositoryFunction> handlers;

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -327,7 +327,7 @@ public final class StarlarkRepositoryContextTest {
     StarlarkPath patchFile = context.path("my.patch");
     context.createFile(
         context.path("my.patch"), "--- foo\n+++ foo\n" + ONE_LINE_PATCH, false, true, thread);
-    context.patch(patchFile, StarlarkInt.of(0), thread);
+    context.patch(patchFile, StarlarkInt.of(0), "auto", thread);
     testOutputFile(foo.getPath(), "line one\nline two\n");
   }
 
@@ -338,7 +338,7 @@ public final class StarlarkRepositoryContextTest {
     context.createFile(
         context.path("my.patch"), "--- foo\n+++ foo\n" + ONE_LINE_PATCH, false, true, thread);
     try {
-      context.patch(patchFile, StarlarkInt.of(0), thread);
+      context.patch(patchFile, StarlarkInt.of(0), "auto", thread);
       fail("Expected RepositoryFunctionException");
     } catch (RepositoryFunctionException ex) {
       assertThat(ex)
@@ -361,7 +361,7 @@ public final class StarlarkRepositoryContextTest {
         true,
         thread);
     try {
-      context.patch(patchFile, StarlarkInt.of(0), thread);
+      context.patch(patchFile, StarlarkInt.of(0), "auto", thread);
       fail("Expected RepositoryFunctionException");
     } catch (RepositoryFunctionException ex) {
       assertThat(ex)
@@ -382,7 +382,7 @@ public final class StarlarkRepositoryContextTest {
     context.createFile(
         context.path("my.patch"), "--- foo\n+++ foo\n" + ONE_LINE_PATCH, false, true, thread);
     try {
-      context.patch(patchFile, StarlarkInt.of(0), thread);
+      context.patch(patchFile, StarlarkInt.of(0), "auto", thread);
       fail("Expected RepositoryFunctionException");
     } catch (RepositoryFunctionException ex) {
       assertThat(ex)
@@ -459,7 +459,7 @@ public final class StarlarkRepositoryContextTest {
     setUpContextForRule("test");
     context.createFile(context.path("foo"), "foobar", true, true, thread);
 
-    context.symlink(context.path("foo"), context.path("bar"), thread);
+    context.symlink(context.path("foo"), context.path("bar"), "auto", thread);
     testOutputFile(outputDirectory.getChild("bar"), "foobar");
 
     assertThat(context.path("bar").realpath()).isEqualTo(context.path("foo"));

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -17,6 +17,7 @@
 import os
 import tempfile
 from absl.testing import absltest
+
 from src.test.py.bazel import test_base
 from src.test.py.bazel.bzlmod.test_utils import BazelRegistry
 

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -501,7 +501,7 @@ function test_starlark_repository_environ() {
 def _impl(repository_ctx):
   print(repository_ctx.os.environ["FOO"])
   # Symlink so a repository is created
-  repository_ctx.symlink(repository_ctx.path("$repo2"), repository_ctx.path(""))
+  repository_ctx.symlink(repository_ctx.path("$repo2"), repository_ctx.path(""), watch_target="no")
 repo = repository_rule(implementation=_impl, local=False)
 EOF
 
@@ -544,7 +544,7 @@ EOF
 def _impl(repository_ctx):
   print(repository_ctx.os.environ["BAR"])
   # Symlink so a repository is created
-  repository_ctx.symlink(repository_ctx.path("$repo2"), repository_ctx.path(""))
+  repository_ctx.symlink(repository_ctx.path("$repo2"), repository_ctx.path(""), watch_target="no")
 repo = repository_rule(implementation=_impl, local=True)
 EOF
   BAR=BEZ bazel build @foo//:bar >& $TEST_log || fail "Failed to build"
@@ -556,7 +556,7 @@ EOF
 def _impl(repository_ctx):
   print(repository_ctx.os.environ["BAZ"])
   # Symlink so a repository is created
-  repository_ctx.symlink(repository_ctx.path("$repo2"), repository_ctx.path(""))
+  repository_ctx.symlink(repository_ctx.path("$repo2"), repository_ctx.path(""), watch_target="no")
 repo = repository_rule(implementation=_impl, local=True)
 EOF
   BAZ=BOZ bazel build @foo//:bar >& $TEST_log || fail "Failed to build"
@@ -2755,7 +2755,7 @@ EOF
 
 function test_file_watching_outside_workspace() {
   # when reading a file outside the Bazel workspace, we should watch it.
-  local outside_dir="${TEST_TMPDIR}/outside_dir"
+  local outside_dir=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
   mkdir -p "${outside_dir}"
   echo nothing > ${outside_dir}/data.txt
 
@@ -2852,6 +2852,152 @@ EOF
 
   bazel build @foo >& $TEST_log && fail "expected bazel to fail!"
   expect_log "Circular definition of repositories"
+}
+
+function test_watch_file_status_change() {
+  local outside_dir=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  mkdir -p "${outside_dir}"
+  echo something > ${outside_dir}/data.txt
+
+  create_new_workspace
+  cat > MODULE.bazel <<EOF
+r = use_repo_rule("//:r.bzl", "r")
+r(name = "r")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _r(rctx):
+  rctx.file("BUILD", "filegroup(name='r')")
+  data_file = rctx.path("${outside_dir}/data.txt")
+  rctx.watch(data_file)
+  if not data_file.exists:
+    print("I see nothing")
+  elif data_file.is_dir:
+    print("I see a directory")
+  else:
+    print("I see: " + rctx.read(data_file))
+r=repository_rule(_r)
+EOF
+
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: something"
+
+  # test that all kinds of transitions between file, dir, and noent are watched
+
+  rm ${outside_dir}/data.txt
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see nothing"
+
+  mkdir ${outside_dir}/data.txt
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see a directory"
+
+  rm -r ${outside_dir}/data.txt
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see nothing"
+
+  echo something again > ${outside_dir}/data.txt
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: something again"
+
+  rm ${outside_dir}/data.txt
+  mkdir ${outside_dir}/data.txt
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see a directory"
+
+  rm -r ${outside_dir}/data.txt
+  echo something yet again > ${outside_dir}/data.txt
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: something yet again"
+}
+
+function test_watch_file_status_change_dangling_symlink() {
+  if "$is_windows"; then
+    # symlinks on Windows... annoying
+    return
+  fi
+  local outside_dir=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  mkdir -p "${outside_dir}"
+  ln -s ${outside_dir}/pointee ${outside_dir}/pointer
+
+  create_new_workspace
+  cat > MODULE.bazel <<EOF
+r = use_repo_rule("//:r.bzl", "r")
+r(name = "r")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _r(rctx):
+  rctx.file("BUILD", "filegroup(name='r')")
+  data_file = rctx.path("${outside_dir}/pointer")
+  rctx.watch(data_file)
+  if not data_file.exists:
+    print("I see nothing")
+  elif data_file.is_dir:
+    print("I see a directory")
+  else:
+    print("I see: " + rctx.read(data_file))
+r=repository_rule(_r)
+EOF
+
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see nothing"
+
+  echo haha > ${outside_dir}/pointee
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: haha"
+
+  rm ${outside_dir}/pointee
+  mkdir ${outside_dir}/pointee
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see a directory"
+}
+
+function test_watch_file_status_change_symlink_parent() {
+  if "$is_windows"; then
+    # symlinks on Windows... annoying
+    return
+  fi
+  local outside_dir=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  mkdir -p "${outside_dir}/a"
+
+  create_new_workspace
+  cat > MODULE.bazel <<EOF
+r = use_repo_rule("//:r.bzl", "r")
+r(name = "r")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _r(rctx):
+  rctx.file("BUILD", "filegroup(name='r')")
+  data_file = rctx.path("${outside_dir}/a/b/c")
+  rctx.watch(data_file)
+  if not data_file.exists:
+    print("I see nothing")
+  elif data_file.is_dir:
+    print("I see a directory")
+  else:
+    print("I see: " + rctx.read(data_file))
+r=repository_rule(_r)
+EOF
+
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see nothing"
+
+  mkdir -p ${outside_dir}/a/b
+  echo blah > ${outside_dir}/a/b/c
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: blah"
+
+  rm -rf ${outside_dir}/a/b
+  ln -s ${outside_dir}/d ${outside_dir}/a/b
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see nothing"
+
+  mkdir ${outside_dir}/d
+  echo bleh > ${outside_dir}/d/c
+  bazel build @r >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: bleh"
 }
 
 run_suite "local repository tests"


### PR DESCRIPTION
- `rctx.watch()` now supports watching a path even if it's a directory or nonexistent.
  - a path's status changing counts triggers a refetch.
- added `path.is_dir` so that users can tell whether a path points to a directory or a file.
- added `watch_X` parameters to the following methods, with behavior similar to the `watch` parameter in `rctx.read()`
  - `rctx.extract()`, `rctx.patch()`, `rctx.template()` (for the template file), `rctx.symlink()` (for the symlink target)

Work towards #20952.