### PR TITLE
[7.1.0] Clear the file digests cache on clean.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.shell.CommandResult;
 import com.google.devtools.build.lib.util.CommandBuilder;
 import com.google.devtools.build.lib.util.InterruptedFailureDetails;
 import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -213,6 +214,7 @@ public final class CleanCommand implements BlazeCommand {
       CommandEnvironment env, Path outputBase, boolean expunge, boolean async, String symlinkPrefix)
       throws CleanException, InterruptedException {
     BlazeRuntime runtime = env.getRuntime();
+
     if (env.getOutputService() != null) {
       try {
         env.getOutputService().clean();
@@ -220,11 +222,15 @@ public final class CleanCommand implements BlazeCommand {
         throw new CleanException(Code.OUTPUT_SERVICE_CLEAN_FAILURE, e);
       }
     }
+
     try {
       env.getBlazeWorkspace().clearCaches();
     } catch (IOException e) {
       throw new CleanException(Code.ACTION_CACHE_CLEAN_FAILURE, e);
     }
+
+    DigestUtils.clearCache();
+
     if (expunge && !async) {
       logger.atInfo().log("Expunging...");
       runtime.prepareForAbruptShutdown();

--- a/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
@@ -130,6 +130,16 @@ public class DigestUtils {
   }
 
   /**
+   * Clears the cache contents without changing its size. No-op if the cache hasn't yet been
+   * initialized.
+   */
+  public static void clearCache() {
+    if (globalCache != null) {
+      globalCache.invalidateAll();
+    }
+  }
+
+  /**
    * Obtains cache statistics.
    *
    * <p>The cache must have previously been enabled by a call to {@link #configureCache(long)}.

--- a/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
@@ -122,14 +122,21 @@ public final class DigestUtilsTest {
     Path file = tracingFileSystem.getPath("/file.txt");
     FileSystemUtils.writeContentAsLatin1(file, "some contents");
 
-    byte[] digest1 = DigestUtils.getDigestWithManualFallback(file, SyscallCache.NO_CACHE);
+    byte[] digest = DigestUtils.getDigestWithManualFallback(file, SyscallCache.NO_CACHE);
     assertThat(getFastDigestCounter.get()).isEqualTo(1);
     assertThat(getDigestCounter.get()).isEqualTo(1);
 
     assertThat(DigestUtils.getDigestWithManualFallback(file, SyscallCache.NO_CACHE))
-        .isEqualTo(digest1);
+        .isEqualTo(digest);
     assertThat(getFastDigestCounter.get()).isEqualTo(2);
     assertThat(getDigestCounter.get()).isEqualTo(1); // Cached.
+
+    DigestUtils.clearCache();
+
+    assertThat(DigestUtils.getDigestWithManualFallback(file, SyscallCache.NO_CACHE))
+        .isEqualTo(digest);
+    assertThat(getFastDigestCounter.get()).isEqualTo(3);
+    assertThat(getDigestCounter.get()).isEqualTo(2); // Not cached.
   }
 
   @Test


### PR DESCRIPTION
Failure to do so compromises benchmarking results, as digest computations can still hit the cache despite the expectation of starting from a clean slate.

PiperOrigin-RevId: 606620638
Change-Id: I60b066da4b50992f57a6b5e2d37db3b04ea31e93