### PR TITLE
[7.1.0] Parallelize TreeArtifactValue.visitTree across files instead of subdirectories.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -283,10 +283,6 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       return TreeArtifactValue.MISSING_TREE_ARTIFACT;
     }
 
-    if (chmod) {
-      setPathPermissions(treeDir);
-    }
-
     AtomicBoolean anyRemote = new AtomicBoolean(false);
 
     TreeArtifactValue.Builder tree = TreeArtifactValue.newBuilder(parent);


### PR DESCRIPTION
This performs better when the subdirectories are unbalanced (and doesn't degrade catastrophically for a flat hierarchy). Most tree artifacts are too small for this to matter, but some users have very large ones (with hundreds of thousands of files) for which this can reduce the overall traversal time by 30% or more (after other, more important optimizations such as https://github.com/bazelbuild/bazel/commit/f2512a0718f3a652ec536b513be82324361bbe77 have been made).

Also remove the edge case for the root directory; the code is cleaner that way.

Related to https://github.com/bazelbuild/bazel/issues/17009.

PiperOrigin-RevId: 606897861
Change-Id: I143d55a844ac191543a856f73849a95560199468