### PR TITLE
[7.1.0] Make it possible to avoid an extra stat() when obtaining a digest from the cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.exec.Protos.Platform;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.DigestUtils;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -172,14 +173,13 @@ public abstract class SpawnLogContext implements ActionContext {
       }
     }
 
-    long fileSize = path.getFileSize();
-
-    // Try to obtain a digest from the filesystem.
+    // Obtain a digest from the filesystem.
+    FileStatus status = path.stat();
     return builder
         .setHash(
-            HashCode.fromBytes(DigestUtils.getDigestWithManualFallback(path, xattrProvider))
+            HashCode.fromBytes(DigestUtils.getDigestWithManualFallback(path, xattrProvider, status))
                 .toString())
-        .setSizeBytes(fileSize)
+        .setSizeBytes(status.getSize())
         .build();
   }
 


### PR DESCRIPTION
For now, it's only used to optimize out a stat() required by the execution log, which adds up for very large tree artifacts. However, there are other callsites that could be refactored to benefit from it.

PiperOrigin-RevId: 606891771
Change-Id: Ib2f6428009b86e609f4e46c4ac0ac4b2714414ff