### PR TITLE
[7.1.0] Remove unnecessary test assertions to fix flakiness.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
@@ -476,20 +476,10 @@ public final class TreeArtifactValueTest {
     Path treeDir = scratch.dir("tree");
     scratch.file("outside");
     scratch.resolve("tree/link").createSymbolicLink(PathFragment.create("../outside"));
-    List<Pair<PathFragment, Dirent.Type>> children = new ArrayList<>();
 
     Exception e =
         assertThrows(
-            IOException.class,
-            () ->
-                TreeArtifactValue.visitTree(
-                    treeDir,
-                    (child, type) -> {
-                      synchronized (children) {
-                        children.add(Pair.of(child, type));
-                      }
-                    }));
-    assertThat(children).containsExactly(Pair.of(PathFragment.create(""), Dirent.Type.DIRECTORY));
+            IOException.class, () -> TreeArtifactValue.visitTree(treeDir, (child, type) -> {}));
     assertThat(e).hasMessageThat().contains("/tree/link pointing to ../outside");
   }
 
@@ -498,23 +488,10 @@ public final class TreeArtifactValueTest {
     Path treeDir = scratch.dir("tree");
     scratch.file("tree/file");
     scratch.resolve("tree/link").createSymbolicLink(PathFragment.create("../tree/file"));
-    List<Pair<PathFragment, Dirent.Type>> children = new ArrayList<>();
 
     Exception e =
         assertThrows(
-            IOException.class,
-            () ->
-                TreeArtifactValue.visitTree(
-                    treeDir,
-                    (child, type) -> {
-                      synchronized (children) {
-                        children.add(Pair.of(child, type));
-                      }
-                    }));
-    assertThat(children)
-        .containsExactly(
-            Pair.of(PathFragment.create(""), Dirent.Type.DIRECTORY),
-            Pair.of(PathFragment.create("file"), Dirent.Type.FILE));
+            IOException.class, () -> TreeArtifactValue.visitTree(treeDir, (child, type) -> {}));
     assertThat(e).hasMessageThat().contains("/tree/link pointing to ../tree/file");
   }
 


### PR DESCRIPTION
After https://github.com/bazelbuild/bazel/commit/df07d275ce17f14224af0f1a5862755a7db44397, the tree artifact contents are traversed in nondeterministic order. These test cases only care whether the exception was propagated.

PiperOrigin-RevId: 606983523
Change-Id: I62441b5a0ae48d202947684f87f8928a63b9d070