### PR TITLE
[7.1.0] Temporarily hardcode rules_java repository name

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1,6 +1,5 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//:workspace_deps.bzl", "gen_workspace_stanza")
-load("//src/tools/bzlmod:utils.bzl", "get_canonical_repo_name")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -221,7 +220,9 @@ sh_test(
 write_file(
     name = "gen_rules_java_repo_name",
     out = "RULES_JAVA_REPO_NAME",
-    content = [get_canonical_repo_name("@rules_java")],
+    # TODO: Revert to the following when building with Bazel 7.1.0.
+    # content = [get_canonical_repo_name("@rules_java")],
+    content = ["rules_java~"],
 )
 
 sh_test(


### PR DESCRIPTION
Fixes #21350

Closes #21351.

Commit https://github.com/bazelbuild/bazel/commit/eee416bdd76a487f6b2b8713fb1444cf6f99473d

PiperOrigin-RevId: 607063055
Change-Id: Ia80ba907d04718205658c3ad5d5fc801caf94535