### PR TITLE
Use strip_files matching CppHelper on strip action

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -132,7 +132,7 @@ def _create_strip_action(ctx, cc_toolchain, cpp_config, input, output, feature_c
     ctx.actions.run(
         inputs = depset(
             direct = [input],
-            transitive = [cc_toolchain.all_files],
+            transitive = [cc_toolchain._strip_files],
         ),
         outputs = [output],
         use_default_shell_env = True,


### PR DESCRIPTION
With native cc rules, bazel only specified strip_files as input to the automatically generated {name}.stripped action for a cc_binary target. This change makes the starlark cc rules consistent with native behavior.