### PR TITLE
[7.1.0] python: rules_python 0.22.0 -> 0.22.1 soas to register Python toolchain by default

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2293,7 +2293,7 @@
       "general": {
         "bzlTransitiveDigest": "ViQGEDr/pPfdaylbQ9kIMC61dAyi2clQRXxliJle+HM=",
         "accumulatedFileDigests": {
-          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "69df266de27085a01662606690412507656529aa965f177330f46eafea22c456",
+          "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "0493425c35cde8310abe79cfbe790ea6b209c7cf68ec80d48ba7dd8cc8170ca5",
           "@@//:MODULE.bazel": "f0f6c040c50ad1d3555157b29dea32260bdaf5cc7205dfc346d4b1b6b008baca"
         },
         "envVariables": {},
@@ -2318,7 +2318,7 @@
                 "rules_java~7.1.0",
                 "rules_license~0.0.7",
                 "rules_proto~5.3.0-21.7",
-                "rules_python~0.22.0",
+                "rules_python~0.22.1",
                 "buildozer~6.4.0.2",
                 "platforms",
                 "protobuf~21.7",

--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -8,7 +8,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_java", version = "7.1.0")
 bazel_dep(name = "rules_license", version = "0.0.3")
 bazel_dep(name = "rules_proto", version = "4.0.0")
-bazel_dep(name = "rules_python", version = "0.22.0")
+bazel_dep(name = "rules_python", version = "0.22.1")
 
 bazel_dep(name = "buildozer", version = "6.4.0.2")
 bazel_dep(name = "platforms", version = "0.0.7")

--- a/src/test/shell/bazel/python_version_test.sh
+++ b/src/test/shell/bazel/python_version_test.sh
@@ -89,6 +89,34 @@ EOF
   expect_log "I am Python 3"
 }
 
+# Verify that a bzlmod without any workspace interference is able to
+# run Python rules.
+# This test is obsolete once the Python rules are removed from Bazel itself.
+function test_pure_bzlmod_can_build_py_binary() {
+  mkdir -p test
+
+  cat > test/BUILD << EOF
+py_binary(
+    name = "main3",
+    python_version = "PY3",
+    srcs = ["main3.py"],
+)
+EOF
+
+  touch test/main3.py
+
+  # Tell bzlmod to ignore workspace entirely
+  touch WORKSPACE.bzlmod
+  # Also clear out workspace, just to be safe. If workspace is triggered at all,
+  # then internal logic as part of the Python rules registration will trigger
+  # registering a Python toolchain, which we explicitly want to avoid.
+  cat > WORKSPACE
+
+  # Build instead of run. The autodetecting toolchain may not produce something
+  # that actually works (it could be a fake or some arbitrary system python).
+  bazel build --enable_bzlmod //test:main3 &> $TEST_log || fail "unable to build py binary"
+}
+
 # Test that access to runfiles works (in general, and under our test environment
 # specifically).
 function test_can_access_runfiles() {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -13,7 +13,7 @@
     "compatibilityMode": "ERROR"
   },
   "localOverrideHashes": {
-    "bazel_tools": "75309ca8f012966e1226d3b90b5f86671f5910980be0100d1e254df59880d0ec"
+    "bazel_tools": "8903a871e52ee1ae96141198b51b2d163059212613fa77a7b520ee771baf9e50"
   },
   "moduleDepGraph": {
     "<root>": {
@@ -172,7 +172,7 @@
         "rules_java": "rules_java@7.1.0",
         "rules_license": "rules_license@0.0.7",
         "rules_proto": "rules_proto@5.3.0-21.7",
-        "rules_python": "rules_python@0.22.0",
+        "rules_python": "rules_python@0.22.1",
         "buildozer": "buildozer@6.4.0.2",
         "platforms": "platforms@0.0.7",
         "com_google_protobuf": "protobuf@21.7",
@@ -398,20 +398,22 @@
         }
       }
     },
-    "rules_python@0.22.0": {
+    "rules_python@0.22.1": {
       "name": "rules_python",
-      "version": "0.22.0",
-      "key": "rules_python@0.22.0",
+      "version": "0.22.1",
+      "key": "rules_python@0.22.1",
       "repoName": "rules_python",
       "executionPlatformsToRegister": [],
-      "toolchainsToRegister": [],
+      "toolchainsToRegister": [
+        "@bazel_tools//tools/python:autodetecting_toolchain"
+      ],
       "extensionUsages": [
         {
           "extensionBzlFile": "@rules_python//python/extensions/private:internal_deps.bzl",
           "extensionName": "internal_deps",
-          "usingModule": "rules_python@0.22.0",
+          "usingModule": "rules_python@0.22.1",
           "location": {
-            "file": "https://bcr.bazel.build/modules/rules_python/0.22.0/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel",
             "line": 14,
             "column": 30
           },
@@ -453,7 +455,7 @@
               "attributeValues": {},
               "devDependency": false,
               "location": {
-                "file": "https://bcr.bazel.build/modules/rules_python/0.22.0/MODULE.bazel",
+                "file": "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel",
                 "line": 15,
                 "column": 22
               }
@@ -465,9 +467,9 @@
         {
           "extensionBzlFile": "@rules_python//python/extensions:python.bzl",
           "extensionName": "python",
-          "usingModule": "rules_python@0.22.0",
+          "usingModule": "rules_python@0.22.1",
           "location": {
-            "file": "https://bcr.bazel.build/modules/rules_python/0.22.0/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel",
             "line": 50,
             "column": 23
           },
@@ -493,14 +495,14 @@
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
-            "https://github.com/bazelbuild/rules_python/releases/download/0.22.0/rules_python-0.22.0.tar.gz"
+            "https://github.com/bazelbuild/rules_python/releases/download/0.22.1/rules_python-0.22.1.tar.gz"
           ],
-          "integrity": "sha256-hjug+pRDGffj1pVxFCfZrYC6ksbt0LfHRDuE6QRolTk=",
-          "strip_prefix": "rules_python-0.22.0",
+          "integrity": "sha256-pWQP3dS+sD6MH95e1xYMC6a9R359BIZhwwwGk2om/WM=",
+          "strip_prefix": "rules_python-0.22.1",
           "remote_patches": {
-            "https://bcr.bazel.build/modules/rules_python/0.22.0/patches/module_dot_bazel_version.patch": "sha256-vkTKvRF90qu2osevlH+kcbaag0gQ7KFz9MWoRW14TZ4="
+            "https://bcr.bazel.build/modules/rules_python/0.22.1/patches/module_dot_bazel_version.patch": "sha256-3+VLDH9gYDzNI4eOW7mABC/LKxh1xqF6NhacLbNTucs="
           },
-          "remote_patch_strip": 0
+          "remote_patch_strip": 1
         }
       }
     },
@@ -649,7 +651,7 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.3.0",
-        "rules_python": "rules_python@0.22.0",
+        "rules_python": "rules_python@0.22.1",
         "rules_cc": "rules_cc@0.0.9",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "rules_java": "rules_java@7.1.0",
@@ -800,7 +802,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "rules_python": "rules_python@0.22.0",
+        "rules_python": "rules_python@0.22.1",
         "bazel_skylib": "bazel_skylib@1.3.0",
         "rules_license": "rules_license@0.0.7",
         "bazel_tools": "bazel_tools@_",


### PR DESCRIPTION
A regression from upgrading to rules_python 0.22.0 is that a Python toolchain is no longer registered by default (the prior 0.4.0 version registered the "autodetecting" toolchain). Subsequent versions of rules_python (0.23.0 or later) register a toolchain by default again, but it's a downloaded runtime, which makes upgrading more involved.

To fix, upgrade to 0.22.1, which registers the autodetecting toolchain. This restores the rules_python 0.4.0 behavior and should suffice until bazel_tools is upgraded to 0.23.0 or later.

Fixes https://github.com/bazelbuild/bazel/issues/20458

Closes https://github.com/bazelbuild/bazel/pull/20514

PiperOrigin-RevId: 592578175
Change-Id: I707a4c96829063536f81cc10e144652102da1e7e

Fixes https://github.com/bazelbuild/bazel/issues/21348