### PR TITLE
[7.1.0] Set the executable bit on files in output directories uploaded to a disk or remote cache.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -640,7 +640,12 @@ public class GrpcCacheClientTest {
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("bar/qux"), "abc");
     final Directory testDirMessage =
         Directory.newBuilder()
-            .addFiles(FileNode.newBuilder().setName("wobble").setDigest(wobbleDigest).build())
+            .addFiles(
+                FileNode.newBuilder()
+                    .setName("wobble")
+                    .setDigest(wobbleDigest)
+                    .setIsExecutable(true)
+                    .build())
             .build();
     final Digest testDigest = DIGEST_UTIL.compute(testDirMessage);
     final Tree barTree =
@@ -649,9 +654,9 @@ public class GrpcCacheClientTest {
                 Directory.newBuilder()
                     .addFiles(
                         FileNode.newBuilder()
-                            .setIsExecutable(true)
                             .setName("qux")
-                            .setDigest(quxDigest))
+                            .setDigest(quxDigest)
+                            .setIsExecutable(true))
                     .addDirectories(
                         DirectoryNode.newBuilder().setName("test").setDigest(testDigest)))
             .addChildren(testDirMessage)

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -306,7 +306,11 @@ public class RemoteExecutionServiceTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("bar").setDigest(barDigest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("bar")
+                            .setDigest(barDigest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = cache.addContents(remoteActionExecutionContext, tree.toByteArray());
     ActionResult.Builder builder = ActionResult.newBuilder();
@@ -401,8 +405,16 @@ public class RemoteExecutionServiceTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("foo").setDigest(fooDigest))
-                    .addFiles(FileNode.newBuilder().setName("subdir/bar").setDigest(barDigest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("foo")
+                            .setDigest(fooDigest)
+                            .setIsExecutable(true))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("subdir/bar")
+                            .setDigest(barDigest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = cache.addContents(remoteActionExecutionContext, tree.toByteArray());
     ActionResult.Builder builder = ActionResult.newBuilder();
@@ -469,7 +481,8 @@ public class RemoteExecutionServiceTest {
     Digest quxDigest = cache.addContents(remoteActionExecutionContext, "qux-contents");
     Directory wobbleDirMessage =
         Directory.newBuilder()
-            .addFiles(FileNode.newBuilder().setName("qux").setDigest(quxDigest))
+            .addFiles(
+                FileNode.newBuilder().setName("qux").setDigest(quxDigest).setIsExecutable(true))
             .build();
     Digest wobbleDirDigest =
         cache.addContents(remoteActionExecutionContext, wobbleDirMessage.toByteArray());
@@ -477,7 +490,11 @@ public class RemoteExecutionServiceTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("qux").setDigest(quxDigest))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("qux")
+                            .setDigest(quxDigest)
+                            .setIsExecutable(true))
                     .addDirectories(
                         DirectoryNode.newBuilder().setName("wobble").setDigest(wobbleDirDigest)))
             .addChildren(wobbleDirMessage)
@@ -518,8 +535,16 @@ public class RemoteExecutionServiceTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("foo").setDigest(fooDigest))
-                    .addFiles(FileNode.newBuilder().setName("bar").setDigest(barDigest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("foo")
+                            .setDigest(fooDigest)
+                            .setIsExecutable(true))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("bar")
+                            .setDigest(barDigest)
+                            .setIsExecutable(true)))
             .build();
     Digest subdirTreeDigest =
         cache.addContents(remoteActionExecutionContext, subdirTreeMessage.toByteArray());
@@ -559,7 +584,8 @@ public class RemoteExecutionServiceTest {
 
     // arrange
     Digest fileDigest = cache.addContents(remoteActionExecutionContext, "file");
-    FileNode file = FileNode.newBuilder().setName("file").setDigest(fileDigest).build();
+    FileNode file =
+        FileNode.newBuilder().setName("file").setDigest(fileDigest).setIsExecutable(true).build();
     Directory fooDir = Directory.newBuilder().addFiles(file).build();
     Digest fooDigest = cache.addContents(remoteActionExecutionContext, fooDir.toByteArray());
     DirectoryNode fooDirNode =
@@ -815,7 +841,11 @@ public class RemoteExecutionServiceTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("bar").setDigest(barDigest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("bar")
+                            .setDigest(barDigest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = cache.addContents(remoteActionExecutionContext, tree.toByteArray());
     ActionResult.Builder builder = ActionResult.newBuilder();
@@ -850,7 +880,10 @@ public class RemoteExecutionServiceTest {
             .setRoot(
                 Directory.newBuilder()
                     .addFiles(
-                        FileNode.newBuilder().setName("outputfile").setDigest(treeFileDigest)))
+                        FileNode.newBuilder()
+                            .setName("outputfile")
+                            .setDigest(treeFileDigest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = cache.addContents(remoteActionExecutionContext, tree.toByteArray());
     Digest otherFileDigest =
@@ -1201,8 +1234,10 @@ public class RemoteExecutionServiceTest {
     // dir/a/file2
     Digest d1 = cache.addContents(remoteActionExecutionContext, "content1");
     Digest d2 = cache.addContents(remoteActionExecutionContext, "content2");
-    FileNode file1 = FileNode.newBuilder().setName("file1").setDigest(d1).build();
-    FileNode file2 = FileNode.newBuilder().setName("file2").setDigest(d2).build();
+    FileNode file1 =
+        FileNode.newBuilder().setName("file1").setDigest(d1).setIsExecutable(true).build();
+    FileNode file2 =
+        FileNode.newBuilder().setName("file2").setDigest(d2).setIsExecutable(true).build();
     Directory a = Directory.newBuilder().addFiles(file2).build();
     Digest da = cache.addContents(remoteActionExecutionContext, a);
     Directory root =
@@ -1251,8 +1286,10 @@ public class RemoteExecutionServiceTest {
     // dir/a/file2
     Digest d1 = cache.addContents(remoteActionExecutionContext, "content1");
     Digest d2 = cache.addContents(remoteActionExecutionContext, "content2");
-    FileNode file1 = FileNode.newBuilder().setName("file1").setDigest(d1).build();
-    FileNode file2 = FileNode.newBuilder().setName("file2").setDigest(d2).build();
+    FileNode file1 =
+        FileNode.newBuilder().setName("file1").setDigest(d1).setIsExecutable(true).build();
+    FileNode file2 =
+        FileNode.newBuilder().setName("file2").setDigest(d2).setIsExecutable(true).build();
     Directory a = Directory.newBuilder().addFiles(file2).build();
     Digest da = cache.addContents(remoteActionExecutionContext, a);
     Directory root =
@@ -1303,8 +1340,10 @@ public class RemoteExecutionServiceTest {
     // dir/a/file2
     Digest d1 = cache.addContents(remoteActionExecutionContext, "content1");
     Digest d2 = cache.addContents(remoteActionExecutionContext, "content2");
-    FileNode file1 = FileNode.newBuilder().setName("file1").setDigest(d1).build();
-    FileNode file2 = FileNode.newBuilder().setName("file2").setDigest(d2).build();
+    FileNode file1 =
+        FileNode.newBuilder().setName("file1").setDigest(d1).setIsExecutable(true).build();
+    FileNode file2 =
+        FileNode.newBuilder().setName("file2").setDigest(d2).setIsExecutable(true).build();
     Directory a = Directory.newBuilder().addFiles(file2).build();
     Digest da = cache.addContents(remoteActionExecutionContext, a);
     Directory root =
@@ -1577,9 +1616,9 @@ public class RemoteExecutionServiceTest {
                     Directory.newBuilder()
                         .addFiles(
                             FileNode.newBuilder()
-                                .setIsExecutable(true)
                                 .setName("qux")
                                 .setDigest(quxDigest)
+                                .setIsExecutable(true)
                                 .build())
                         .build())
                 .build());
@@ -1680,7 +1719,12 @@ public class RemoteExecutionServiceTest {
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("outputs/bar/qux"), "abc");
     final Directory testDirMessage =
         Directory.newBuilder()
-            .addFiles(FileNode.newBuilder().setName("wobble").setDigest(wobbleDigest).build())
+            .addFiles(
+                FileNode.newBuilder()
+                    .setName("wobble")
+                    .setDigest(wobbleDigest)
+                    .setIsExecutable(true)
+                    .build())
             .build();
     final Digest testDigest = digestUtil.compute(testDirMessage);
     final Tree barTree =
@@ -1689,9 +1733,9 @@ public class RemoteExecutionServiceTest {
                 Directory.newBuilder()
                     .addFiles(
                         FileNode.newBuilder()
-                            .setIsExecutable(true)
                             .setName("qux")
-                            .setDigest(quxDigest))
+                            .setDigest(quxDigest)
+                            .setIsExecutable(true))
                     .addDirectories(
                         DirectoryNode.newBuilder().setName("test").setDigest(testDigest)))
             .addChildren(testDirMessage)

--- a/src/test/java/com/google/devtools/build/lib/remote/UploadManifestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/UploadManifestTest.java
@@ -247,7 +247,11 @@ public class UploadManifestTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("foo")
+                            .setDigest(digest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = digestUtil.compute(tree);
 
@@ -311,7 +315,11 @@ public class UploadManifestTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("foo")
+                            .setDigest(digest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = digestUtil.compute(tree);
 
@@ -375,7 +383,11 @@ public class UploadManifestTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("foo")
+                            .setDigest(digest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = digestUtil.compute(tree);
 
@@ -631,7 +643,11 @@ public class UploadManifestTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("link").setDigest(digest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("link")
+                            .setDigest(digest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = digestUtil.compute(tree);
 
@@ -671,7 +687,7 @@ public class UploadManifestTest {
 
     Directory barDir =
         Directory.newBuilder()
-            .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest))
+            .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest).setIsExecutable(true))
             .build();
     Digest barDigest = digestUtil.compute(barDir);
     Tree tree =
@@ -720,7 +736,11 @@ public class UploadManifestTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("link").setDigest(digest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("link")
+                            .setDigest(digest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = digestUtil.compute(tree);
 
@@ -760,7 +780,7 @@ public class UploadManifestTest {
 
     Directory barDir =
         Directory.newBuilder()
-            .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest))
+            .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest).setIsExecutable(true))
             .build();
     Digest barDigest = digestUtil.compute(barDir);
     Tree tree =
@@ -808,7 +828,11 @@ public class UploadManifestTest {
         Tree.newBuilder()
             .setRoot(
                 Directory.newBuilder()
-                    .addFiles(FileNode.newBuilder().setName("link").setDigest(digest)))
+                    .addFiles(
+                        FileNode.newBuilder()
+                            .setName("link")
+                            .setDigest(digest)
+                            .setIsExecutable(true)))
             .build();
     Digest treeDigest = digestUtil.compute(tree);
 
@@ -848,7 +872,7 @@ public class UploadManifestTest {
 
     Directory barDir =
         Directory.newBuilder()
-            .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest))
+            .addFiles(FileNode.newBuilder().setName("foo").setDigest(digest).setIsExecutable(true))
             .build();
     Digest barDigest = digestUtil.compute(barDir);
     Tree tree =
@@ -1278,7 +1302,10 @@ public class UploadManifestTest {
     Directory root =
         Directory.newBuilder()
             .addFiles(
-                FileNode.newBuilder().setName("file").setDigest(digestUtil.compute(fileContents)))
+                FileNode.newBuilder()
+                    .setName("file")
+                    .setDigest(digestUtil.compute(fileContents))
+                    .setIsExecutable(true))
             .build();
     for (int depth = 0; depth < 3; depth++) {
       Directory.Builder b = Directory.newBuilder();


### PR DESCRIPTION
Bazel doesn't preserve executable bits for outputs; all files in the output tree are chmodded to either 0555 or 0755 after action execution, depending on --experimental_writable_outputs.

With respect to the disk/remote cache protocol, Bazel always marks uploaded inputs as executable and always ignores the executable bit on downloaded outputs. For uploaded outputs, the behavior currently differs between directories and non-directories; this CL makes the behavior consistent.

This makes it more likely that the input Merkle tree to a remote action can hit a cache populated by a previous local action. (See unknown commit where the behavior was changed for non-directory outputs, with the same rationale.)

As a minor effect, it also avoids additional I/O to obtain the permission bits from the filesystem, which adds up for very large tree artifacts.

PiperOrigin-RevId: 607367059
Change-Id: Ib507a98f32c0a5c89b1ed0f1ec3777f1c6430e28