### PR TITLE
[7.1.0] Call out that TreeArtifactVisitor.visit is called in a nondeterministic order.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java
@@ -483,7 +483,8 @@ public class TreeArtifactValue implements HasDigest, SkyValue {
   @FunctionalInterface
   public interface TreeArtifactVisitor {
     /**
-     * Called for every directory entry encountered during tree traversal.
+     * Called for every directory entry encountered during tree traversal, in a nondeterministic
+     * order.
      *
      * <p>Symlinks are not followed during traversal and are simply reported as {@link
      * Dirent.Type#SYMLINK} regardless of whether they point to a file, directory, or are dangling.


### PR DESCRIPTION
PiperOrigin-RevId: 607649229
Change-Id: I7c3cc7f750bbba1c90d1b3e033ca9b7493f401f8