### PR TITLE
[7.1.0] Optimize out a stat call.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -40,10 +40,12 @@ import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.util.io.AsynchronousMessageOutputStream;
 import com.google.devtools.build.lib.util.io.MessageOutputStream;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.IORuntimeException;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.XattrProvider;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
@@ -101,8 +103,9 @@ public class CompactSpawnLogContext extends SpawnLogContext {
 
     private void visitSubdirectory(Path dir) {
       try {
-        for (Path child : dir.getDirectoryEntries()) {
-          if (child.isDirectory()) {
+        for (Dirent dirent : dir.readdir(Symlinks.FOLLOW)) {
+          Path child = dir.getChild(dirent.getName());
+          if (dirent.getType() == Dirent.Type.DIRECTORY) {
             execute(() -> visitSubdirectory(child));
             continue;
           }


### PR DESCRIPTION
Calling isDirectory on a Path requires an extra system call. In most Unix filesystems, readdir is able to return the type directly (see the implementation in NativePosixFiles).

PiperOrigin-RevId: 607678196
Change-Id: I5d09f11d6aa4702a6f7a0310cca26616cfbac6d1