### PR TITLE
Do not record or check repo mapping entries for repos defined in WORKSPACE

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -319,12 +319,17 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
             new RepoRecordedInput.EnvVar(envKey), clientEnvironment.get(envKey));
       }
 
-      for (Table.Cell<RepositoryName, String, RepositoryName> repoMappings :
-          repoMappingRecorder.recordedEntries().cellSet()) {
-        recordedInputValues.put(
-            new RepoRecordedInput.RecordedRepoMapping(
-                repoMappings.getRowKey(), repoMappings.getColumnKey()),
-            repoMappings.getValue().getName());
+      // For repos defined in Bzlmod, record any used repo mappings in the marker file.
+      // Repos defined in WORKSPACE are impossible to verify given the chunked loading (we'd have to
+      // record which chunk the repo mapping was used in, and ain't nobody got time for that).
+      if (!isWorkspaceRepo(rule)) {
+        for (Table.Cell<RepositoryName, String, RepositoryName> repoMappings :
+            repoMappingRecorder.recordedEntries().cellSet()) {
+          recordedInputValues.put(
+              new RepoRecordedInput.RecordedRepoMapping(
+                  repoMappings.getRowKey(), repoMappings.getColumnKey()),
+              repoMappings.getValue().getName());
+        }
       }
 
       env.getListener().post(resolved);

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
@@ -559,7 +559,12 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
 
     @Override
     public SkyKey getSkyKey(BlazeDirectories directories) {
-      return RepositoryMappingValue.key(sourceRepo);
+      // Since we only record repo mapping entries for repos defined in Bzlmod, we can request the
+      // WORKSPACE-less version of the main repo mapping (as no repos defined in Bzlmod can see
+      // stuff from WORKSPACE).
+      return sourceRepo.isMain()
+          ? RepositoryMappingValue.KEY_FOR_ROOT_MODULE_WITHOUT_WORKSPACE_REPOS
+          : RepositoryMappingValue.key(sourceRepo);
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -15,7 +15,6 @@
 
 package com.google.devtools.build.lib.rules.repository;
 
-import static com.google.devtools.build.lib.cmdline.LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -394,12 +393,9 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
   }
 
   private boolean shouldExcludeRepoFromVendoring(RepositoryFunction handler, Rule rule) {
-    return handler.isLocal(rule) || handler.isConfigure(rule) || isWorkspaceRepo(rule);
-  }
-
-  private boolean isWorkspaceRepo(Rule rule) {
-    // All workspace repos are under //external, while bzlmod repo rules are not
-    return rule.getPackage().getPackageIdentifier().equals(EXTERNAL_PACKAGE_IDENTIFIER);
+    return handler.isLocal(rule)
+        || handler.isConfigure(rule)
+        || RepositoryFunction.isWorkspaceRepo(rule);
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.rules.repository;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.devtools.build.lib.cmdline.LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -135,6 +136,11 @@ public abstract class RepositoryFunction {
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
     }
+  }
+
+  public static boolean isWorkspaceRepo(Rule rule) {
+    // All workspace repos are under //external, while bzlmod repo rules are not
+    return rule.getPackage().getPackageIdentifier().equals(EXTERNAL_PACKAGE_IDENTIFIER);
   }
 
   protected void setupRepoRootBeforeFetching(Path repoRoot) throws RepositoryFunctionException {

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2627,10 +2627,12 @@ bazel_dep(name="bar")
 local_path_override(module_name="bar", path="bar")
 EOF
   touch BUILD
+  echo 'load("@r//:r.bzl", "pi"); print(pi)' > WORKSPACE.bzlmod
   cat > r.bzl <<EOF
 def _r(rctx):
   print("I see: " + str(Label("@data")))
   rctx.file("BUILD", "filegroup(name='r')")
+  rctx.file("r.bzl", "pi=3.14")
 r=repository_rule(_r)
 EOF
   mkdir foo
@@ -2671,11 +2673,13 @@ bazel_dep(name="bar")
 local_path_override(module_name="bar", path="bar")
 EOF
   touch BUILD
+  echo 'load("@r//:r.bzl", "pi"); print(pi)' > WORKSPACE.bzlmod
   cat > r.bzl <<EOF
 CONSTANT = Label("@data")
 def _r(rctx):
   print("I see: " + str(CONSTANT))
   rctx.file("BUILD", "filegroup(name='r')")
+  rctx.file("r.bzl", "pi=3.14")
 r=repository_rule(_r)
 EOF
   mkdir foo


### PR DESCRIPTION
Mappings for repos defined in WORKSPACE are extremely annoying to verify given the chunked loading (we'd have to record which chunk the repo mapping was used in, and then load that chunk while verifying). This is extremely not worth the effort (especially since nobody really uses repo mappings in WORKSPACE) so we just don't record it.

This also means, during verification, we can safely use the main repo mapping without WORKSPACE (since repos defined in Bzlmod can't see stuff from WORKSPACE anyway).

Fixes #21289.