### PR TITLE
[7.1.0] Avoid a superfluous stat() in DigestUtil.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -240,7 +240,7 @@ public class UploadManifest {
         continue;
       }
       if (statNoFollow.isFile() && !statNoFollow.isSpecialFile()) {
-        Digest digest = digestUtil.compute(file, statNoFollow.getSize());
+        Digest digest = digestUtil.compute(file, statNoFollow);
         addFile(digest, file);
         continue;
       }
@@ -264,7 +264,7 @@ public class UploadManifest {
         if (statFollow.isFile() && !statFollow.isSpecialFile()) {
           if (followSymlinks || target.isAbsolute()) {
             // Symlink to file uploaded as a file.
-            addFile(digestUtil.compute(file), file);
+            addFile(digestUtil.compute(file, statFollow), file);
           } else {
             // Symlink to file uploaded as a symlink.
             if (target.isAbsolute()) {

--- a/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.DigestUtils;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.XattrProvider;
 import com.google.protobuf.Message;
@@ -67,12 +68,27 @@ public class DigestUtil {
     return buildDigest(hashFn.getHashFunction().hashBytes(blob).toString(), blob.length);
   }
 
-  public Digest compute(Path file) throws IOException {
-    return compute(file, file.getFileSize());
+  /**
+   * Computes a digest for a file.
+   *
+   * <p>Prefer calling {@link #compute(Path, FileStatus)} when a recently obtained {@link
+   * FileStatus} is available.
+   *
+   * @param path the file path
+   */
+  public Digest compute(Path path) throws IOException {
+    return compute(path, path.stat());
   }
 
-  public Digest compute(Path file, long fileSize) throws IOException {
-    return buildDigest(DigestUtils.getDigestWithManualFallback(file, xattrProvider), fileSize);
+  /**
+   * Computes a digest for a file.
+   *
+   * @param path the file path
+   * @param status a recently obtained file status, if available
+   */
+  public Digest compute(Path path, FileStatus status) throws IOException {
+    return buildDigest(
+        DigestUtils.getDigestWithManualFallback(path, xattrProvider, status), status.getSize());
   }
 
   public Digest compute(VirtualActionInput input) throws IOException {


### PR DESCRIPTION
Similar in spirit to https://github.com/bazelbuild/bazel/commit/bb8031989397633326520720013f23eff91d8a42. DigestUtil wraps DigestUtils, trading in Digests instead of byte arrays.

There are probably other callsites that would benefit from the optimization, but I'm focused on UploadManifest at the moment.

PiperOrigin-RevId: 607695005
Change-Id: Iaa9b1f07b26f05482cb6f3fe8dfaacf50e0c07f5