### PR TITLE
Update LibrariesToLinkCollector.java for .dll suffix stripping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
@@ -608,9 +608,9 @@ public class LibrariesToLinkCollector {
     // -l:foo -> foo.so
     // -l:libfoo.so.1 -> libfoo.so.1
     boolean hasCompatibleName =
-        name.startsWith("lib") || (!name.endsWith(".so") && !name.endsWith(".dylib"));
+        name.startsWith("lib") || (!name.endsWith(".so") && !name.endsWith(".dylib") && !name.endsWith(".dll"));
     if (CppFileTypes.SHARED_LIBRARY.matches(name) && hasCompatibleName) {
-      String libName = name.replaceAll("(^lib|\\.(so|dylib)$)", "");
+      String libName = name.replaceAll("(^lib|\\.(so|dylib|dll)$)", "");
       librariesToLink.addValue(LibraryToLinkValue.forDynamicLibrary(libName));
     } else if (CppFileTypes.SHARED_LIBRARY.matches(name)
         || CppFileTypes.VERSIONED_SHARED_LIBRARY.matches(name)) {


### PR DESCRIPTION
Fixes #19696

Allow automatic linkage of DLL libraries when GNU toolchain used in Windows. .dll suffix has to be stripped before passing library name to `ld.exe` with `-l` option.

This [case](https://github.com/vvviktor/bazel_sandbox.git) was successfully tested :

Workspace structure:
```
D:.
│   .bazelrc
│   BUILD
│   MODULE.bazel
│   MODULE.bazel.lock
│   WORKSPACE
│
├───Main
│       BUILD
│       main.cpp
│       math.cpp
│       math.h
│       math_dll_interface.cpp
│       math_dll_interface.h
│       math_import_defs.h
│
└───toolchain
        BUILD
        toolchain_config.bzl
```

BUILD file:
```
# //Main/BUILD

DLL_HDRS = ["math_import_defs.h", "math_dll_interface.h"]

cc_binary(
    name = "sum_numbers_mingw",
    srcs = ["main.cpp"],
    deps = [":math_d_shared"]
)

cc_import(
    name = "math_d_shared",
    hdrs = DLL_HDRS,
    shared_library = ":libmath_d.dll"
)

cc_binary(
    name = "libmath_d.dll",
    srcs = ["math_dll_interface.cpp"] + DLL_HDRS,
    deps = [":math"],
    defines = ["MATH_DLL"],
    linkshared = 1
)

cc_library(
    name = "math",
    srcs = ["math.cpp"],
    hdrs = ["math.h"],
    copts = ["-std=c++17"]
)
```
Without patch applied `bazel build //main:sum_numbers_mingw --verbose_failures` fails with error: 
`C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: cannot find -lmath_d.dll: No such file or directory`
Then after patch was applied it builds all targets as expected.

This approach also works fine with patch applied:
```
# //Main/BUILD

DLL_HDRS = ["math_import_defs.h", "math_dll_interface.h"]

cc_binary(
    name = "sum_numbers_mingw",
    srcs = ["main.cpp"] + DLL_HDRS,
    dynamic_deps = [":math_d_shared"]
)

cc_shared_library(
    name = "math_d_shared",
    shared_lib_name = "libmath_d.dll",
    deps = [":math_dll_interface"]
)

cc_library(
    name = "math_dll_interface",
    srcs = ["math_dll_interface.cpp"],
    hdrs = DLL_HDRS,
    deps = [":math"],
    defines = ["MATH_DLL"]
)

cc_library(
    name = "math",
    srcs = ["math.cpp"],
    hdrs = ["math.h"],
    copts = ["-std=c++17"]
)
```
 

