### PR TITLE
[7.1.0] [credentialhelper] Respect `expires` field from helper

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -180,10 +180,8 @@ public class AuthAndTLSOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "The duration for which credentials supplied by a credential helper are cached.\n\n"
-              + "Invoking with a different value will adjust the lifetime of preexisting entries;"
-              + " pass zero to clear the cache. A clean command always clears the cache, regardless"
-              + " of this flag.")
+          "The default duration for which credentials supplied by a credential helper are cached if"
+              + " the helper does not provide when the credentials expire.")
   public Duration credentialHelperCacheTimeout;
 
   /** One of the values of the `--credential_helper` flag. */

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -20,11 +20,10 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperCredentials;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperEnvironment;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperProvider;
+import com.google.devtools.build.lib.authandtls.credentialhelper.GetCredentialsResponse;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.runtime.CommandLinePathFactory;
 import com.google.devtools.build.lib.vfs.FileSystem;
@@ -252,7 +251,7 @@ public final class GoogleAuthUtils {
    */
   public static Credentials newCredentials(
       CredentialHelperEnvironment credentialHelperEnvironment,
-      Cache<URI, ImmutableMap<String, ImmutableList<String>>> credentialCache,
+      Cache<URI, GetCredentialsResponse> credentialCache,
       CommandLinePathFactory commandLinePathFactory,
       FileSystem fileSystem,
       AuthAndTLSOptions authAndTlsOptions)

--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/BUILD
@@ -18,6 +18,7 @@ java_library(
         "SystemMillisTicker.java",
     ],
     deps = [
+        ":credentialhelper",
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib/authandtls",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialCacheExpiry.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialCacheExpiry.java
@@ -1,0 +1,74 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.authandtls.credentialhelper;
+
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+
+final class CredentialCacheExpiry implements Expiry<URI, GetCredentialsResponse> {
+  private Duration defaultCacheDuration = Duration.ZERO;
+
+  /**
+   * Sets the default cache duration for {@link GetCredentialsResponse}s that don't set {@code
+   * expiry}.
+   */
+  public void setDefaultCacheDuration(Duration duration) {
+    this.defaultCacheDuration = Preconditions.checkNotNull(duration);
+  }
+
+  private Duration getExpirationTime(GetCredentialsResponse response) {
+    Preconditions.checkNotNull(response);
+
+    var expires = response.getExpires();
+    if (expires.isEmpty()) {
+      return defaultCacheDuration;
+    }
+
+    var now = Instant.now();
+    return Duration.between(expires.get(), now);
+  }
+
+  @Override
+  public long expireAfterCreate(URI uri, GetCredentialsResponse response, long currentTime) {
+    Preconditions.checkNotNull(uri);
+    Preconditions.checkNotNull(response);
+
+    return getExpirationTime(response).toNanos();
+  }
+
+  @Override
+  public long expireAfterUpdate(
+      URI uri, GetCredentialsResponse response, long currentTime, long currentDuration) {
+    Preconditions.checkNotNull(uri);
+    Preconditions.checkNotNull(response);
+
+    return getExpirationTime(response).toNanos();
+  }
+
+  @CanIgnoreReturnValue
+  @Override
+  public long expireAfterRead(
+      URI uri, GetCredentialsResponse response, long currentTime, long currentDuration) {
+    Preconditions.checkNotNull(uri);
+    Preconditions.checkNotNull(response);
+
+    // We don't extend the duration on access.
+    return currentDuration;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/GetCredentialsResponse.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/GetCredentialsResponse.java
@@ -26,21 +26,39 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Response from the {@code get} command of the <a
  * href="https://github.com/bazelbuild/proposals/blob/main/designs/2022-06-07-bazel-credential-helpers.md#proposal">Credential
  * Helper Protocol</a>.
+ *
+ * <p>See the <a
+ * href="https://github.com/EngFlow/credential-helper-spec/blob/main/schemas/get-credentials-response.schema.json">specification</a>.
  */
 @AutoValue
 @AutoValue.CopyAnnotations
 @Immutable
 @JsonAdapter(GetCredentialsResponse.GsonTypeAdapter.class)
 public abstract class GetCredentialsResponse {
+  public static final DateTimeFormatter RFC_3339_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX")
+          .withZone(ZoneId.from(ZoneOffset.UTC))
+          .withResolverStyle(ResolverStyle.LENIENT);
+
   /** Returns the headers to attach to the request. */
   public abstract ImmutableMap<String, ImmutableList<String>> getHeaders();
+
+  /** Returns the time the credentials expire and must be revalidated. */
+  public abstract Optional<Instant> getExpires();
 
   /** Returns a new builder for {@link GetCredentialsRequest}. */
   public static Builder newBuilder() {
@@ -51,6 +69,8 @@ public abstract class GetCredentialsResponse {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract ImmutableMap.Builder<String, ImmutableList<String>> headersBuilder();
+
+    public abstract Builder setExpires(Instant instant);
 
     /** Returns the newly constructed {@link GetCredentialsResponse}. */
     public abstract GetCredentialsResponse build();
@@ -80,6 +100,13 @@ public abstract class GetCredentialsResponse {
         }
         writer.endObject();
       }
+
+      var expires = response.getExpires();
+      if (expires.isPresent()) {
+        writer.name("expires");
+        writer.value(RFC_3339_FORMATTER.format(expires.get()));
+      }
+
       writer.endObject();
     }
 
@@ -139,6 +166,25 @@ public abstract class GetCredentialsResponse {
             }
 
             reader.endObject();
+            break;
+
+          case "expires":
+            if (reader.peek() != JsonToken.STRING) {
+              throw new JsonSyntaxException(
+                  String.format(
+                      Locale.US,
+                      "Expected value of 'expires' to be a string, got %s",
+                      reader.peek()));
+            }
+            try {
+              response.setExpires(Instant.from(RFC_3339_FORMATTER.parse(reader.nextString())));
+            } catch (DateTimeException e) {
+              throw new JsonSyntaxException(
+                  String.format(
+                      Locale.US,
+                      "Expected value of 'expires' to be a RFC 3339 formatted timestamp: %s",
+                      e.getMessage()));
+            }
             break;
 
           default:

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -44,6 +43,7 @@ import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperEnvironment;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
+import com.google.devtools.build.lib.authandtls.credentialhelper.GetCredentialsResponse;
 import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
@@ -1098,7 +1098,7 @@ public final class RemoteModule extends BlazeModule {
   @VisibleForTesting
   static Credentials createCredentials(
       CredentialHelperEnvironment credentialHelperEnvironment,
-      Cache<URI, ImmutableMap<String, ImmutableList<String>>> credentialCache,
+      Cache<URI, GetCredentialsResponse> credentialCache,
       CommandLinePathFactory commandLinePathFactory,
       FileSystem fileSystem,
       AuthAndTLSOptions authAndTlsOptions,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperEnvironment;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
+import com.google.devtools.build.lib.authandtls.credentialhelper.GetCredentialsResponse;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.exec.BinTools;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
@@ -384,8 +385,7 @@ public final class RemoteModuleTest {
     Scratch scratch = new Scratch(fileSystem);
     scratch.file(netrc, "machine foo.example.org login baruser password barpass");
     AuthAndTLSOptions authAndTLSOptions = Options.getDefaults(AuthAndTLSOptions.class);
-    Cache<URI, ImmutableMap<String, ImmutableList<String>>> credentialCache =
-        Caffeine.newBuilder().build();
+    Cache<URI, GetCredentialsResponse> credentialCache = Caffeine.newBuilder().build();
 
     Credentials credentials =
         RemoteModule.createCredentials(


### PR DESCRIPTION
This was recently specified in https://github.com/EngFlow/credential-helper-spec/pull/2.

RELNOTES[NEW]: Bazel now respects `expires` from Credential Helpers.

Closes #21249.

Commit https://github.com/bazelbuild/bazel/commit/f7601aa2aef78e6badc8338ac979be2d7cf69fcd

PiperOrigin-RevId: 608208538
Change-Id: Id168f654093c7491a40364e3988af66ad1767443