### PR TITLE
Fix genrule autostamping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRule.java
@@ -15,6 +15,8 @@
 package com.google.devtools.build.lib.bazel.rules.genrule;
 
 import com.google.devtools.build.lib.analysis.RuleContext;
+import com.google.devtools.build.lib.packages.BuildType;
+import com.google.devtools.build.lib.packages.TriState;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.rules.genrule.GenRuleBase;
 
@@ -25,9 +27,11 @@ public class BazelGenRule extends GenRuleBase {
 
   @Override
   protected boolean isStampingEnabled(RuleContext ruleContext) {
-    if (!ruleContext.attributes().has("stamp", Type.BOOLEAN)) {
+    if (!ruleContext.attributes().has("stamp", BuildType.TRISTATE)) {
       return false;
     }
-    return ruleContext.attributes().get("stamp", Type.BOOLEAN);
+    TriState stamp = ruleContext.attributes().get("stamp", BuildType.TRISTATE);
+    return stamp.equals(TriState.YES) ||
+        (stamp.equals(TriState.AUTO) && ruleContext.getConfiguration().stampBinaries());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRuleRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRuleRule.java
@@ -15,12 +15,14 @@ package com.google.devtools.build.lib.bazel.rules.genrule;
 
 import static com.google.devtools.build.lib.packages.Attribute.attr;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL;
+import static com.google.devtools.build.lib.packages.BuildType.TRISTATE;
 import static com.google.devtools.build.lib.packages.Type.BOOLEAN;
 
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
 import com.google.devtools.build.lib.packages.RuleClass;
+import com.google.devtools.build.lib.packages.TriState;
 import com.google.devtools.build.lib.rules.genrule.GenRuleBaseRule;
 
 /**
@@ -43,9 +45,7 @@ public final class BazelGenRuleRule implements RuleDefinition {
             attr("$genrule_setup", LABEL)
                 .cfg(ExecutionTransitionFactory.createFactory())
                 .value(env.getToolsLabel(GENRULE_SETUP_LABEL)))
-
-        // TODO(bazel-team): stamping doesn't seem to work. Fix it or remove attribute.
-        .add(attr("stamp", BOOLEAN).value(false))
+        .add(attr("stamp", TRISTATE).value(TriState.NO))
         .build();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
@@ -530,6 +530,7 @@ public final class GenRuleConfiguredTargetTest extends BuildViewTestCase {
         "u/BUILD",
         "genrule(name='foo_stamp', srcs=[], outs=['uu'], stamp=1, cmd='')",
         "genrule(name='foo_nostamp', srcs=[], outs=['vv'], stamp=0, cmd='')",
+        "genrule(name='foo_autostamp', srcs=[], outs=['aa'], stamp=-1, cmd='')",
         "genrule(name='foo_default', srcs=[], outs=['xx'], cmd='')");
   }
 
@@ -562,6 +563,8 @@ public final class GenRuleConfiguredTargetTest extends BuildViewTestCase {
     assertStamped(getExecConfiguredTarget("//u:foo_stamp"));
     assertNotStamped("//u:foo_nostamp");
     assertNotStamped(getExecConfiguredTarget("//u:foo_nostamp"));
+    assertNotStamped("//u:foo_autostamp");
+    assertNotStamped(getExecConfiguredTarget("//u:foo_autostamp"));
     assertNotStamped("//u:foo_default");
   }
 
@@ -571,8 +574,10 @@ public final class GenRuleConfiguredTargetTest extends BuildViewTestCase {
     createStampingTargets();
     assertStamped("//u:foo_stamp");
     assertStamped(getExecConfiguredTarget("//u:foo_stamp"));
-    // assertStamped("//u:foo_nostamp");
+    assertNotStamped("//u:foo_nostamp");
     assertNotStamped(getExecConfiguredTarget("//u:foo_nostamp"));
+    assertStamped("//u:foo_autostamp");
+    assertNotStamped(getExecConfiguredTarget("//u:foo_autostamp"));
     assertNotStamped("//u:foo_default");
   }
 


### PR DESCRIPTION
Genrule does not support conditional stamping based on the value of the `--stamp` flag. This is because genrule treats the `stamp` attribute as `boolean`, while all other rules use the `tristate` type. After this change, the stamp attribute in genrule can be set to `-1` to request conditional stamping.