### PR TITLE
Stop stashing tmp directories for tests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
@@ -132,10 +132,7 @@ public class SandboxStash {
     if (sandboxes == null || isTestXmlGenerationOrCoverageSpawn(mnemonic, outputs)) {
       return;
     }
-    String stashName;
-    synchronized (stash) {
-      stashName = Integer.toString(stash.incrementAndGet());
-    }
+    String stashName = Integer.toString(stash.incrementAndGet());
     Path stashPath = sandboxes.getChild(stashName);
     if (!path.exists()) {
       return;

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -102,7 +102,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
 
   @Override
   public void delete() {
-    SandboxStash.stashSandbox(sandboxPath, mnemonic, getEnvironment(), outputs);
+    SandboxStash.stashSandbox(sandboxPath, mnemonic, getEnvironment(), outputs, treeDeleter);
     super.delete();
   }
 

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -951,7 +951,7 @@ EOF
   bazel shutdown
 }
 
-function test_runfiles_from_tests_get_reused() {
+function test_runfiles_from_tests_get_reused_and_tmp_clean() {
   mkdir pkg
   touch pkg/file.txt
   cat >pkg/reusing_test.bzl <<'EOF'
@@ -1012,6 +1012,13 @@ EOF
   fi
   dir_inode_a=$(awk '/The directory inode is/ {print $5}' ${test_output})
   file_inode_a=$(awk '/The file inode is/ {print $5}' ${test_output})
+
+  local output_base="$(bazel info output_base)"
+  local stashed_test_dir="${output_base}/sandbox/sandbox_stash/TestRunner/6/execroot/$WORKSPACE_NAME"
+  [[ -d "${stashed_test_dir}/bazel-out" ]] \
+    || fail "${stashed_test_dir}/bazel-out directory not present"
+  [[ -d "${stashed_test_dir}/_tmp" ]] \
+      && fail "${stashed_test_dir}/_tmp directory is present"
 
   if is_bazel; then
     bazel coverage --test_output=streamed //pkg:b \


### PR DESCRIPTION
Test actions create a `_tmp` directory that doesn't make sense to stash between different test actions when using `--reuse_sandbox_directories`. This change makes sure that doesn't happen by deleting the directory before stashing.