### PR TITLE
[7.1.0] Traverse symlinks to directories while collecting a TreeArtifactValue.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -289,26 +289,19 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
 
     TreeArtifactValue.visitTree(
         treeDir,
-        (parentRelativePath, type) -> {
-          if (chmod && type != Dirent.Type.SYMLINK) {
+        (parentRelativePath, type, traversedSymlink) -> {
+          checkState(type == Dirent.Type.FILE || type == Dirent.Type.DIRECTORY);
+          // Set the output permissions when the execution mode requires it, unless at least one
+          // symlink was traversed on the way to this entry, as it might have led outside of the
+          // root directory.
+          if (chmod && !traversedSymlink) {
             setPathPermissions(treeDir.getRelative(parentRelativePath));
           }
           if (type == Dirent.Type.DIRECTORY) {
             return; // The final TreeArtifactValue does not contain child directories.
           }
           TreeFileArtifact child = TreeFileArtifact.createTreeOutput(parent, parentRelativePath);
-          FileArtifactValue metadata;
-          try {
-            metadata = constructFileArtifactValueFromFilesystem(child);
-          } catch (FileNotFoundException e) {
-            String errorMessage =
-                String.format(
-                    "Failed to resolve relative path %s inside TreeArtifact %s. "
-                        + "The associated file is either missing or is an invalid symlink.",
-                    parentRelativePath, treeDir);
-            throw new IOException(errorMessage, e);
-          }
-
+          FileArtifactValue metadata = constructFileArtifactValueFromFilesystem(child);
           // visitTree() uses multiple threads and putChild() is not thread-safe
           synchronized (tree) {
             if (metadata.isRemote()) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -464,7 +464,7 @@ public class FilesystemValueChecker {
     try {
       TreeArtifactValue.visitTree(
           path,
-          (child, type) -> {
+          (child, type, traversedSymlink) -> {
             if (type != Dirent.Type.DIRECTORY) {
               currentChildren.add(child);
             }

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -1647,7 +1647,7 @@ public class ActionCacheCheckerTest {
       if (treeDir.exists()) {
         TreeArtifactValue.visitTree(
             treeDir,
-            (parentRelativePath, type) -> {
+            (parentRelativePath, type, traversedSymlink) -> {
               if (type == Dirent.Type.DIRECTORY) {
                 return;
               }

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -957,7 +957,7 @@ public abstract class SpawnLogContextTestBase {
     TreeArtifactValue.Builder builder = TreeArtifactValue.newBuilder((SpecialArtifact) tree);
     TreeArtifactValue.visitTree(
         tree.getPath(),
-        (parentRelativePath, type) -> {
+        (parentRelativePath, type, traversedSymlink) -> {
           if (type.equals(Dirent.Type.DIRECTORY)) {
             return;
           }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.Artifact.ArchivedTreeArtifact;
@@ -32,9 +33,9 @@ import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifac
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue.ArchivedRepresentation;
 import com.google.devtools.build.lib.testutil.Scratch;
-import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.Dirent;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -43,9 +44,11 @@ import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,6 +60,21 @@ public final class TreeArtifactValueTest {
   private final ArtifactRoot root =
       ArtifactRoot.asDerivedRoot(
           scratch.resolve("root"), RootType.Output, PathFragment.create("bin"));
+
+  @AutoValue
+  abstract static class VisitTreeArgs {
+    abstract PathFragment getParentRelativePath();
+
+    abstract Dirent.Type getType();
+
+    abstract boolean getTraversedSymlink();
+
+    static VisitTreeArgs of(
+        PathFragment parentRelativePath, Dirent.Type type, boolean traversedSymlink) {
+      return new AutoValue_TreeArtifactValueTest_VisitTreeArgs(
+          parentRelativePath, type, traversedSymlink);
+    }
+  }
 
   @Test
   public void createsCorrectValue() {
@@ -368,46 +386,146 @@ public final class TreeArtifactValueTest {
     scratch.file("tree/a/file2");
     scratch.file("tree/a/b/file3");
     scratch.resolve("tree/file_link").createSymbolicLink(PathFragment.create("file1"));
-    scratch.resolve("tree/a/dir_link").createSymbolicLink(PathFragment.create("c"));
-    scratch.resolve("tree/a/b/dangling_link").createSymbolicLink(PathFragment.create("?"));
-    List<Pair<PathFragment, Dirent.Type>> children = new ArrayList<>();
+    scratch.resolve("tree/a/dir_link").createSymbolicLink(PathFragment.create("b"));
+    List<VisitTreeArgs> children = new ArrayList<>();
 
     TreeArtifactValue.visitTree(
         treeDir,
-        (child, type) -> {
+        (child, type, traversedSymlink) -> {
           synchronized (children) {
-            children.add(Pair.of(child, type));
+            children.add(VisitTreeArgs.of(child, type, traversedSymlink));
           }
         });
 
     assertThat(children)
         .containsExactly(
-            Pair.of(PathFragment.create(""), Dirent.Type.DIRECTORY),
-            Pair.of(PathFragment.create("a"), Dirent.Type.DIRECTORY),
-            Pair.of(PathFragment.create("a/b"), Dirent.Type.DIRECTORY),
-            Pair.of(PathFragment.create("file1"), Dirent.Type.FILE),
-            Pair.of(PathFragment.create("a/file2"), Dirent.Type.FILE),
-            Pair.of(PathFragment.create("a/b/file3"), Dirent.Type.FILE),
-            Pair.of(PathFragment.create("file_link"), Dirent.Type.SYMLINK),
-            Pair.of(PathFragment.create("a/dir_link"), Dirent.Type.SYMLINK),
-            Pair.of(PathFragment.create("a/b/dangling_link"), Dirent.Type.SYMLINK));
+            VisitTreeArgs.of(PathFragment.create(""), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("a"), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("a/b"), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("file1"), Dirent.Type.FILE, false),
+            VisitTreeArgs.of(PathFragment.create("a/file2"), Dirent.Type.FILE, false),
+            VisitTreeArgs.of(PathFragment.create("a/b/file3"), Dirent.Type.FILE, false),
+            VisitTreeArgs.of(PathFragment.create("file_link"), Dirent.Type.FILE, true),
+            VisitTreeArgs.of(PathFragment.create("a/dir_link"), Dirent.Type.DIRECTORY, true),
+            VisitTreeArgs.of(PathFragment.create("a/dir_link/file3"), Dirent.Type.FILE, true));
   }
 
   @Test
-  public void visitTree_throwsOnUnknownDirentType() {
+  public void visitTree_throwsOnDanglingSymlink() throws Exception {
+    Path treeDir = scratch.dir("tree");
+    scratch.resolve("tree/symlink").createSymbolicLink(PathFragment.create("/does_not_exist"));
+
+    Exception e =
+        assertThrows(
+            IOException.class,
+            () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Child symlink of tree artifact /tree is a dangling symbolic link");
+  }
+
+  @Test
+  public void visitTree_throwsOnSymlinkLoop() throws Exception {
+    Path treeDir = scratch.dir("tree");
+    scratch.resolve("tree/symlink").createSymbolicLink(scratch.resolve(treeDir.asFragment()));
+
+    Exception e =
+        assertThrows(
+            IOException.class,
+            () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
+    assertThat(e).hasMessageThat().contains("tree/symlink");
+    assertThat(e).hasMessageThat().contains("Too many levels of symbolic links");
+  }
+
+  @Test
+  public void visitTree_throwsOnUnknownDirentType() throws Exception {
     FileSystem fs =
         new InMemoryFileSystem(DigestHashFunction.SHA256) {
           @Override
-          public ImmutableList<Dirent> readdir(PathFragment path, boolean followSymlinks) {
-            return ImmutableList.of(new Dirent("?", Dirent.Type.UNKNOWN));
+          public Collection<Dirent> readdir(PathFragment path, boolean followSymlinks)
+              throws IOException {
+            if (path.equals(PathFragment.create("/tree"))) {
+              return ImmutableList.of(new Dirent("unknown", Dirent.Type.UNKNOWN));
+            }
+            return super.readdir(path, followSymlinks);
           }
         };
     Path treeDir = fs.getPath("/tree");
 
     Exception e =
         assertThrows(
-            IOException.class, () -> TreeArtifactValue.visitTree(treeDir, (child, type) -> {}));
-    assertThat(e).hasMessageThat().contains("Could not determine type of file for /tree/?");
+            IOException.class,
+            () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Child unknown of tree artifact /tree has an unsupported type");
+  }
+
+  @Test
+  public void visitTree_throwsOnSymlinkToSpecialFile() throws Exception {
+    FileSystem fs =
+        new InMemoryFileSystem(DigestHashFunction.SHA256) {
+          @Override
+          @Nullable
+          public FileStatus statIfFound(PathFragment path, boolean followSymlinks)
+              throws IOException {
+            if (path.equals(PathFragment.create("/tree/sym"))) {
+              return new FileStatus() {
+                @Override
+                public boolean isFile() {
+                  return true;
+                }
+
+                @Override
+                public boolean isDirectory() {
+                  return false;
+                }
+
+                @Override
+                public boolean isSymbolicLink() {
+                  return false;
+                }
+
+                @Override
+                public boolean isSpecialFile() {
+                  return true;
+                }
+
+                @Override
+                public long getLastChangeTime() {
+                  return 0;
+                }
+
+                @Override
+                public long getLastModifiedTime() {
+                  return 0;
+                }
+
+                @Override
+                public long getNodeId() {
+                  return 0;
+                }
+
+                @Override
+                public long getSize() {
+                  return 0;
+                }
+              };
+            }
+            return super.statIfFound(path, followSymlinks);
+          }
+        };
+    Path treeDir = fs.getPath("/tree");
+    treeDir.createDirectory();
+    treeDir.getChild("sym").createSymbolicLink(PathFragment.create("/special"));
+
+    Exception e =
+        assertThrows(
+            IOException.class,
+            () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Child sym of tree artifact /tree has an unsupported type");
   }
 
   @Test
@@ -421,7 +539,7 @@ public final class TreeArtifactValueTest {
             () ->
                 TreeArtifactValue.visitTree(
                     treeDir,
-                    (child, type) -> {
+                    (child, type, traversedSymlink) -> {
                       throw e;
                     }));
     assertThat(thrown).isSameInstanceAs(e);
@@ -433,42 +551,47 @@ public final class TreeArtifactValueTest {
     scratch.file("tree/file");
     scratch.dir("tree/a");
     scratch.resolve("tree/a/up_link").createSymbolicLink(PathFragment.create("../file"));
-    List<Pair<PathFragment, Dirent.Type>> children = new ArrayList<>();
+    List<VisitTreeArgs> children = new ArrayList<>();
 
     TreeArtifactValue.visitTree(
         treeDir,
-        (child, type) -> {
+        (child, type, traversedSymlink) -> {
           synchronized (children) {
-            children.add(Pair.of(child, type));
+            children.add(VisitTreeArgs.of(child, type, traversedSymlink));
           }
         });
 
     assertThat(children)
         .containsExactly(
-            Pair.of(PathFragment.create(""), Dirent.Type.DIRECTORY),
-            Pair.of(PathFragment.create("file"), Dirent.Type.FILE),
-            Pair.of(PathFragment.create("a"), Dirent.Type.DIRECTORY),
-            Pair.of(PathFragment.create("a/up_link"), Dirent.Type.SYMLINK));
+            VisitTreeArgs.of(PathFragment.create(""), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("file"), Dirent.Type.FILE, false),
+            VisitTreeArgs.of(PathFragment.create("a"), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("a/up_link"), Dirent.Type.FILE, true));
   }
 
   @Test
   public void visitTree_permitsAbsoluteSymlink() throws Exception {
     Path treeDir = scratch.dir("tree");
-    scratch.resolve("tree/absolute_link").createSymbolicLink(PathFragment.create("/tmp"));
-    List<Pair<PathFragment, Dirent.Type>> children = new ArrayList<>();
+    Path targetFile = scratch.file("target_file");
+    Path targetDir = scratch.dir("target_dir");
+    scratch.resolve("tree/absolute_file_link").createSymbolicLink(targetFile.asFragment());
+    scratch.resolve("tree/absolute_dir_link").createSymbolicLink(targetDir.asFragment());
+    List<VisitTreeArgs> children = new ArrayList<>();
 
     TreeArtifactValue.visitTree(
         treeDir,
-        (child, type) -> {
+        (child, type, traversedSymlink) -> {
           synchronized (children) {
-            children.add(Pair.of(child, type));
+            children.add(VisitTreeArgs.of(child, type, traversedSymlink));
           }
         });
 
     assertThat(children)
         .containsExactly(
-            Pair.of(PathFragment.create(""), Dirent.Type.DIRECTORY),
-            Pair.of(PathFragment.create("absolute_link"), Dirent.Type.SYMLINK));
+            VisitTreeArgs.of(PathFragment.create(""), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("absolute_file_link"), Dirent.Type.FILE, true),
+            VisitTreeArgs.of(
+                PathFragment.create("absolute_dir_link"), Dirent.Type.DIRECTORY, true));
   }
 
   @Test
@@ -479,7 +602,8 @@ public final class TreeArtifactValueTest {
 
     Exception e =
         assertThrows(
-            IOException.class, () -> TreeArtifactValue.visitTree(treeDir, (child, type) -> {}));
+            IOException.class,
+            () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
     assertThat(e).hasMessageThat().contains("/tree/link pointing to ../outside");
   }
 
@@ -491,7 +615,8 @@ public final class TreeArtifactValueTest {
 
     Exception e =
         assertThrows(
-            IOException.class, () -> TreeArtifactValue.visitTree(treeDir, (child, type) -> {}));
+            IOException.class,
+            () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
     assertThat(e).hasMessageThat().contains("/tree/link pointing to ../tree/file");
   }
 


### PR DESCRIPTION
As explained in https://github.com/bazelbuild/bazel/issues/20418, when a tree artifact contains a symlink to a directory, it is collected as a single TreeFileArtifact with DirectoryArtifactValue metadata. With this change, the symlink is followed and the directory expanded into its contents, which is more incrementally correct and removes a special case that tree artifact consumers would otherwise have to be aware of.

This also addresses https://github.com/bazelbuild/bazel/issues/21171, which is due to the metadata for the directory contents not being available when building without the bytes, causing the input Merkle tree builder to fail. (While I could have fixed this by falling back to reading the directory contents from the filesystem, I prefer to abide by the principle that input metadata should be collected before execution; source directories are the other case where this isn't true, which I also regard as a bug.)

Fixes https://github.com/bazelbuild/bazel/issues/20418.
Fixes https://github.com/bazelbuild/bazel/issues/21171.

Commit https://github.com/bazelbuild/bazel/commit/4247c20f1daeeb787e9b5cb64848d398467effb1

PiperOrigin-RevId: 608389141
Change-Id: I956f3f8a4b1bfd279091e179d1cba3cdd0e5019b