### PR TITLE
[credentialhelper] Support paths relative to `%install_base%`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
@@ -74,7 +74,6 @@ public final class CommandLinePathFactory {
     var installBase = directories.getInstallBase();
     if (installBase != null) {
       wellKnownRoots.put("install_base", installBase);
-      System.err.println(installBase);
     }
 
     return new CommandLinePathFactory(fileSystem, wellKnownRoots.buildOrThrow());

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
@@ -66,9 +66,15 @@ public final class CommandLinePathFactory {
     ImmutableMap.Builder<String, Path> wellKnownRoots = ImmutableMap.builder();
 
     // This is necessary because some tests don't have a workspace set.
-    Path workspace = directories.getWorkspace();
+    var workspace = directories.getWorkspace();
     if (workspace != null) {
       wellKnownRoots.put("workspace", workspace);
+    }
+
+    var installBase = directories.getInstallBase();
+    if (installBase != null) {
+      wellKnownRoots.put("install_base", installBase);
+      System.err.println(installBase);
     }
 
     return new CommandLinePathFactory(fileSystem, wellKnownRoots.buildOrThrow());


### PR DESCRIPTION
This allows us to ship built-in credential helpers (e.g., for `.netrc`) and move them out of Bazel core.