### PR TITLE
[7.1.0] Correctly handle file inputs/outputs with directory contents in the execution log.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -216,7 +216,8 @@ public class CompactSpawnLogContext extends SpawnLogContext {
           builder.addOutputs(
               ExecLogEntry.Output.newBuilder()
                   .setFileId(logFile(output, path, inputMetadataProvider)));
-        } else if (output.isDirectory() && path.isDirectory()) {
+        } else if (!output.isSymlink() && path.isDirectory()) {
+          // TODO(tjgq): Tighten once --incompatible_disallow_unsound_directory_outputs is gone.
           builder.addOutputs(
               ExecLogEntry.Output.newBuilder()
                   .setDirectoryId(logDirectory(output, path, inputMetadataProvider)));
@@ -360,7 +361,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
               continue;
             }
             Path path = fileSystem.getPath(execRoot.getRelative(input.getExecPath()));
-            if (isInputDirectory(input, inputMetadataProvider)) {
+            if (isInputDirectory(input, path, inputMetadataProvider)) {
               builder.addDirectoryIds(logDirectory(input, path, inputMetadataProvider));
             } else if (input.isSymlink()) {
               builder.addUnresolvedSymlinkIds(logUnresolvedSymlink(input, path));
@@ -468,7 +469,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
 
             Path path = fileSystem.getPath(execRoot.getRelative(input.getExecPath()));
 
-            if (isInputDirectory(input, inputMetadataProvider)) {
+            if (isInputDirectory(input, path, inputMetadataProvider)) {
               builder.addAllFiles(expandDirectory(path, runfilesPath, inputMetadataProvider));
               continue;
             }

--- a/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExpandedSpawnLogContext.java
@@ -168,7 +168,7 @@ public class ExpandedSpawnLogContext extends SpawnLogContext {
 
           Path contentPath = fileSystem.getPath(execRoot.getRelative(input.getExecPathString()));
 
-          if (isInputDirectory(input, inputMetadataProvider)) {
+          if (isInputDirectory(input, contentPath, inputMetadataProvider)) {
             listDirectoryContents(
                 displayPath, contentPath, builder::addInputs, inputMetadataProvider, isTool);
             continue;
@@ -225,7 +225,8 @@ public class ExpandedSpawnLogContext extends SpawnLogContext {
                           xattrProvider,
                           digestHashFunction,
                           /* includeHashFunctionName= */ true));
-            } else if (output.isDirectory() && path.isDirectory()) {
+            } else if (!output.isSymlink() && path.isDirectory()) {
+              // TODO(tjgq): Tighten once --incompatible_disallow_unsound_directory_outputs is gone.
               listDirectoryContents(
                   output.getExecPath(),
                   path,


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/commit/9fd9aa57c456f5324383528c4094995f19124889 was a little too conservative: it didn't account for inputs/outputs declared as a file but materialized as a directory, which are still permitted by --noincompatible_disallow_unsound_directory_outputs.

Also fall back to the filesystem if input metadata isn't available to make the determination. This shouldn't happen most of the time, as metadata should already be available for most inputs, but there are some hard-to-fix edge cases where it doesn't hold.

PiperOrigin-RevId: 608584354
Change-Id: If9a4c6df4319ef66f487068dd89b382eea1b425e