### PR TITLE
Sandboxes: cleanup: Hide Set implementation detail for "dirsToCreate"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
@@ -114,7 +114,7 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
     // First compute all the inputs and directories that we need. This is based only on
     // `workerFiles`, `inputs` and `outputs` and won't do any I/O.
     Set<PathFragment> inputsToCreate = new LinkedHashSet<>();
-    LinkedHashSet<PathFragment> dirsToCreate = new LinkedHashSet<>();
+    Set<PathFragment> dirsToCreate = new LinkedHashSet<>();
     Set<PathFragment> writableSandboxDirs =
         writableDirs.stream()
             .filter(p -> p.startsWith(sandboxExecRoot))
@@ -145,7 +145,7 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
   }
 
   protected void filterInputsAndDirsToCreate(
-      Set<PathFragment> inputsToCreate, LinkedHashSet<PathFragment> dirsToCreate)
+      Set<PathFragment> inputsToCreate, Set<PathFragment> dirsToCreate)
       throws IOException, InterruptedException {}
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -55,7 +55,6 @@ import com.google.devtools.common.options.OptionsParsingResult;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -262,7 +261,7 @@ public final class SandboxHelpers {
   public static void populateInputsAndDirsToCreate(
       Set<PathFragment> writableDirs,
       Set<PathFragment> inputsToCreate,
-      LinkedHashSet<PathFragment> dirsToCreate,
+      Set<PathFragment> dirsToCreate,
       Iterable<PathFragment> inputFiles,
       SandboxOutputs outputs) {
     // Add all worker files, input files, and the parent directories.

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -26,7 +26,6 @@ import com.google.devtools.build.lib.util.CommandFailureUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
-import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -73,7 +72,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
 
   @Override
   public void filterInputsAndDirsToCreate(
-      Set<PathFragment> inputsToCreate, LinkedHashSet<PathFragment> dirsToCreate)
+      Set<PathFragment> inputsToCreate, Set<PathFragment> dirsToCreate)
       throws IOException, InterruptedException {
     boolean gotStash =
         SandboxStash.takeStashedSandbox(sandboxPath, mnemonic, getEnvironment(), outputs);


### PR DESCRIPTION
The `LinkedHashSet` implementation detail needs to only be known at construction time. All further users can just rely on the `Set` interface definition.