### PR TITLE
[7.1.0] Clarify the meaning of Dirent.Type.UNKNOWN.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -895,9 +895,6 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat
     }
     PathFragment path = dirPath.getChild(entry.getName());
     FileStatus st = statNullable(path, /* followSymlinks= */ true);
-    if (st == null) {
-      return new Dirent(entry.getName(), Dirent.Type.UNKNOWN);
-    }
     return new Dirent(entry.getName(), direntFromStat(st));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/unix/NativePosixFiles.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/NativePosixFiles.java
@@ -255,15 +255,23 @@ public final class NativePosixFiles {
 
     /** The names of the entries in a directory. */
     private final String[] names;
+
     /**
-     * An optional (nullable) array of entry types, corresponding positionally
-     * to the "names" field.  The types are:
-     *   'd': a subdirectory
-     *   'f': a regular file
-     *   's': a symlink (only returned with {@code NOFOLLOW})
-     *   '?': anything else
-     * Note that unlike libc, this implementation of readdir() follows
-     * symlinks when determining these types.
+     * An optional (nullable) array of entry types, corresponding positionally to the "names" field.
+     * The possible types are:
+     *
+     * <ul>
+     *   <li>'d': a subdirectory
+     *   <li>'f': a regular file
+     *   <li>'s': a symlink, only returned for {@link ReadTypes.NOFOLLOW}
+     *   <li>'?': anything else, including:
+     *       <ul>
+     *         <li>a special file
+     *         <li>a nonexistent symlink target
+     *         <li>an error occurred while determining the file type, for example because of a
+     *             symlink loop
+     *       </ul>
+     * </ul>
      *
      * <p>This is intentionally a byte array rather than a array of enums to save memory.
      */

--- a/src/main/java/com/google/devtools/build/lib/vfs/Dirent.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Dirent.java
@@ -26,7 +26,8 @@ public final class Dirent implements Comparable<Dirent> {
     DIRECTORY,
     // A symlink.
     SYMLINK,
-    // Not one of the above. For example, a special file.
+    // None of the above.
+    // For example, a special file, or a path that could not be resolved while following symlinks.
     UNKNOWN;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -618,7 +618,7 @@ public abstract class FileSystem {
    */
   protected abstract Collection<String> getDirectoryEntries(PathFragment path) throws IOException;
 
-  protected static Dirent.Type direntFromStat(FileStatus stat) {
+  protected static Dirent.Type direntFromStat(@Nullable FileStatus stat) {
     if (stat == null) {
       return Dirent.Type.UNKNOWN;
     } else if (stat.isSpecialFile()) {

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -1768,29 +1769,68 @@ public abstract class FileSystemTest {
 
   @Test
   public void testResolveSymlinks() throws Exception {
-    if (testFS.supportsSymbolicLinksNatively(xLink.asFragment())) {
-      createSymbolicLink(xLink, xFile);
-      FileSystemUtils.createEmptyFile(xFile);
-      assertThat(testFS.resolveOneLink(xLink.asFragment())).isEqualTo(xFile.asFragment());
-      assertThat(xLink.resolveSymbolicLinks()).isEqualTo(xFile);
-    }
+    assumeTrue(testFS.supportsSymbolicLinksNatively(xLink.asFragment()));
+
+    createSymbolicLink(xLink, xFile);
+    FileSystemUtils.createEmptyFile(xFile);
+    assertThat(testFS.resolveOneLink(xLink.asFragment())).isEqualTo(xFile.asFragment());
+    assertThat(xLink.resolveSymbolicLinks()).isEqualTo(xFile);
   }
 
   @Test
   public void testResolveDanglingSymlinks() throws Exception {
-    if (testFS.supportsSymbolicLinksNatively(xLink.asFragment())) {
-      createSymbolicLink(xLink, xNothing);
-      assertThat(testFS.resolveOneLink(xLink.asFragment())).isEqualTo(xNothing.asFragment());
-      assertThrows(IOException.class, () -> xLink.resolveSymbolicLinks());
-    }
+    assumeTrue(testFS.supportsSymbolicLinksNatively(xLink.asFragment()));
+
+    createSymbolicLink(xLink, xNothing);
+    assertThat(testFS.resolveOneLink(xLink.asFragment())).isEqualTo(xNothing.asFragment());
+    assertThrows(IOException.class, () -> xLink.resolveSymbolicLinks());
   }
 
   @Test
   public void testResolveNonSymlinks() throws Exception {
-    if (testFS.supportsSymbolicLinksNatively(xFile.asFragment())) {
-      assertThat(testFS.resolveOneLink(xFile.asFragment())).isNull();
-      assertThat(xFile.resolveSymbolicLinks()).isEqualTo(xFile);
-    }
+    assertThat(testFS.resolveOneLink(xFile.asFragment())).isNull();
+    assertThat(xFile.resolveSymbolicLinks()).isEqualTo(xFile);
+  }
+
+  @Test
+  public void testReaddir() throws Exception {
+    Path dir = workingDir.getChild("readdir");
+
+    assumeTrue(testFS.supportsSymbolicLinksNatively(dir.asFragment()));
+
+    dir.getChild("dir").createDirectoryAndParents();
+    FileSystemUtils.createEmptyFile(dir.getChild("file"));
+    dir.getChild("file_link").createSymbolicLink(dir.getChild("file"));
+    dir.getChild("dir_link").createSymbolicLink(dir.getChild("dir"));
+    dir.getChild("looping_link").createSymbolicLink(dir.getChild("looping_link"));
+    dir.getChild("dangling_link").createSymbolicLink(testFS.getPath("/does_not_exist"));
+
+    assertThat(dir.getDirectoryEntries())
+        .containsExactly(
+            dir.getChild("file"),
+            dir.getChild("dir"),
+            dir.getChild("file_link"),
+            dir.getChild("dir_link"),
+            dir.getChild("looping_link"),
+            dir.getChild("dangling_link"));
+
+    assertThat(dir.readdir(Symlinks.NOFOLLOW))
+        .containsExactly(
+            new Dirent("file", Dirent.Type.FILE),
+            new Dirent("dir", Dirent.Type.DIRECTORY),
+            new Dirent("file_link", Dirent.Type.SYMLINK),
+            new Dirent("dir_link", Dirent.Type.SYMLINK),
+            new Dirent("looping_link", Dirent.Type.SYMLINK),
+            new Dirent("dangling_link", Dirent.Type.SYMLINK));
+
+    assertThat(dir.readdir(Symlinks.FOLLOW))
+        .containsExactly(
+            new Dirent("file", Dirent.Type.FILE),
+            new Dirent("dir", Dirent.Type.DIRECTORY),
+            new Dirent("file_link", Dirent.Type.FILE),
+            new Dirent("dir_link", Dirent.Type.DIRECTORY),
+            new Dirent("looping_link", Dirent.Type.UNKNOWN),
+            new Dirent("dangling_link", Dirent.Type.UNKNOWN));
   }
 
   @Test


### PR DESCRIPTION
Also add some tests to verify that all filesystem implementations follow the readdir spec. (RemoteActionFileSystemTest needs its own because it doesn't inherit from FileSystemTest. UnixFileSystemTest needs its own because it's the only implementation supporting special files.)

PiperOrigin-RevId: 608529008
Change-Id: I73dbbe8f218779b76d8879f4d4f5dfb228835157