### PR TITLE
toolchain_resolution_debug logging: fix typo in 'plaform'

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionFunction.java
@@ -216,7 +216,7 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
       debugMessage(
           resolutionTrace,
           IndentLevel.TOOLCHAIN_LEVEL,
-          "Toolchain %s is compatible with target plaform, searching for execution platforms:",
+          "Toolchain %s is compatible with target platform, searching for execution platforms:",
           toolchain.toolchainLabel());
 
       boolean done = true;

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkExecGroupTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkExecGroupTest.java
@@ -195,7 +195,7 @@ public class StarlarkExecGroupTest extends BuildViewTestCase {
     BuildConfigurationValue passthruDepConfig =
         getConfiguration((ConfiguredTarget) ((StructImpl) dep.get(key)).getValue("dep"));
 
-    // Action will be executed on '//platform:platform_1' plaform.
+    // Action will be executed on '//platform:platform_1' platform.
     assertThat(
             getGeneratingAction(target, "test/parent.out")
                 .getOwner()

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -690,7 +690,7 @@ EOF
     --platform_mappings= \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
   expect_log "Performing resolution of //${pkg}/toolchain:test_toolchain for target platform ${default_host_platform}"
-  expect_log "Toolchain //register/${pkg}:test_toolchain_impl_1 is compatible with target plaform, searching for execution platforms:"
+  expect_log "Toolchain //register/${pkg}:test_toolchain_impl_1 is compatible with target platform, searching for execution platforms:"
   expect_log "Compatible execution platform ${default_host_platform}"
   expect_log "Recap of selected //${pkg}/toolchain:test_toolchain toolchains for target platform ${default_host_platform}:"
   expect_log "Selected //register/${pkg}:test_toolchain_impl_1 to run on execution platform ${default_host_platform}"
@@ -721,7 +721,7 @@ EOF
     --platform_mappings= \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
   expect_log "Performing resolution of //${pkg}/toolchain:test_toolchain for target platform ${default_host_platform}"
-  expect_log "Toolchain //register/${pkg}:test_toolchain_impl_1 is compatible with target plaform, searching for execution platforms:"
+  expect_log "Toolchain //register/${pkg}:test_toolchain_impl_1 is compatible with target platform, searching for execution platforms:"
   expect_log "Compatible execution platform ${default_host_platform}"
   expect_log "Recap of selected //${pkg}/toolchain:test_toolchain toolchains for target platform ${default_host_platform}:"
   expect_log "Selected //register/${pkg}:test_toolchain_impl_1 to run on execution platform ${default_host_platform}"


### PR DESCRIPTION
I noticed while debugging toolchain resolution logic in a random project with `--toolchain_resolution_debug=<regex>` that some log messages output `plaform` instead of `platform`.
