### PR TITLE
[7.1.0] Remove the restriction that relative symlinks in a tree artifact may not point outside the tree.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
@@ -546,7 +546,7 @@ public final class TreeArtifactValueTest {
   }
 
   @Test
-  public void visitTree_pemitsUpLevelSymlinkInsideTree() throws Exception {
+  public void visitTree_permitsUpLevelSymlinkInsideTree() throws Exception {
     Path treeDir = scratch.dir("tree");
     scratch.file("tree/file");
     scratch.dir("tree/a");
@@ -567,6 +567,33 @@ public final class TreeArtifactValueTest {
             VisitTreeArgs.of(PathFragment.create("file"), Dirent.Type.FILE, false),
             VisitTreeArgs.of(PathFragment.create("a"), Dirent.Type.DIRECTORY, false),
             VisitTreeArgs.of(PathFragment.create("a/up_link"), Dirent.Type.FILE, true));
+  }
+
+  @Test
+  public void visitTree_permitsUpLevelSymlinkOutsideTree() throws Exception {
+    Path treeDir = scratch.dir("tree");
+    scratch.file("tree/file");
+    scratch.dir("tree/a");
+    scratch.file("other_tree/file");
+    scratch
+        .resolve("tree/a/uplink")
+        .createSymbolicLink(PathFragment.create("../../other_tree/file"));
+    List<VisitTreeArgs> children = new ArrayList<>();
+
+    TreeArtifactValue.visitTree(
+        treeDir,
+        (child, type, traversedSymlink) -> {
+          synchronized (children) {
+            children.add(VisitTreeArgs.of(child, type, traversedSymlink));
+          }
+        });
+
+    assertThat(children)
+        .containsExactly(
+            VisitTreeArgs.of(PathFragment.create(""), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("file"), Dirent.Type.FILE, false),
+            VisitTreeArgs.of(PathFragment.create("a"), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("a/uplink"), Dirent.Type.FILE, true));
   }
 
   @Test
@@ -595,29 +622,27 @@ public final class TreeArtifactValueTest {
   }
 
   @Test
-  public void visitTree_throwsOnSymlinkPointingOutsideTree() throws Exception {
-    Path treeDir = scratch.dir("tree");
-    scratch.file("outside");
-    scratch.resolve("tree/link").createSymbolicLink(PathFragment.create("../outside"));
-
-    Exception e =
-        assertThrows(
-            IOException.class,
-            () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
-    assertThat(e).hasMessageThat().contains("/tree/link pointing to ../outside");
-  }
-
-  @Test
-  public void visitTree_throwsOnSymlinkTraversingOutsideThenBackInsideTree() throws Exception {
+  public void visitTree_permitsUplevelSymlinkTraversingOutsideThenBackInsideTree()
+      throws Exception {
     Path treeDir = scratch.dir("tree");
     scratch.file("tree/file");
     scratch.resolve("tree/link").createSymbolicLink(PathFragment.create("../tree/file"));
 
-    Exception e =
-        assertThrows(
-            IOException.class,
-            () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
-    assertThat(e).hasMessageThat().contains("/tree/link pointing to ../tree/file");
+    List<VisitTreeArgs> children = new ArrayList<>();
+
+    TreeArtifactValue.visitTree(
+        treeDir,
+        (child, type, traversedSymlink) -> {
+          synchronized (children) {
+            children.add(VisitTreeArgs.of(child, type, traversedSymlink));
+          }
+        });
+
+    assertThat(children)
+        .containsExactly(
+            VisitTreeArgs.of(PathFragment.create(""), Dirent.Type.DIRECTORY, false),
+            VisitTreeArgs.of(PathFragment.create("file"), Dirent.Type.FILE, false),
+            VisitTreeArgs.of(PathFragment.create("link"), Dirent.Type.FILE, true));
   }
 
   @Test


### PR DESCRIPTION
As discussed in https://github.com/bazelbuild/bazel/issues/20891, the restriction is pointless, as it can already be bypassed with an absolute symlink. Note that the symlinks are still required not to dangle in all cases.

Also rename and reorganize the tests in TreeArtifactBuildTest in a more logical manner.

Fixes https://github.com/bazelbuild/bazel/issues/20891.

Closes #21263.

Commit https://github.com/bazelbuild/bazel/commit/5506a0fa81c8f122ee635f9866d891ac885051ef

PiperOrigin-RevId: 608926604
Change-Id: I967a383b9891360700f868abd5c2d292e0e7974e