### PR TITLE
Add %home% support for bazelrc imports

### DIFF
--- a/src/main/cpp/rc_file.cc
+++ b/src/main/cpp/rc_file.cc
@@ -103,6 +103,9 @@ RcFile::ParseError RcFile::ParseFile(const string& filename,
                             workspace_layout_->WorkspacePrefix) == 0 &&
            !workspace_layout_->WorkspaceRelativizeRcFilePath(workspace_,
                                                              &words[1]) &&
+           command == kCommandImport) ||
+           (words[1].compare(0, HomePrefixLength_, HomePrefix_) == 0 &&
+           !this->HomeRelativizeRcFilePath(&words[1]) &&
            command == kCommandImport)) {
         blaze_util::StringPrintf(
             error_text,
@@ -151,6 +154,14 @@ RcFile::ParseError RcFile::ParseFile(const string& filename,
   }
 
   return ParseError::NONE;
+}
+
+bool RcFile::HomeRelativizeRcFilePath(string *path_fragment) const {
+  // Strip off the "%home%/" prefix and prepend the true home path.
+  // In theory this could use alternate search paths for blazerc files.
+  path_fragment->assign(blaze_util::JoinPath(blaze::GetHomeDir(),
+                          path_fragment->substr(HomePrefixLength_)));
+  return true;
 }
 
 }  // namespace blaze

--- a/src/main/cpp/rc_file.h
+++ b/src/main/cpp/rc_file.h
@@ -78,6 +78,17 @@ class RcFile {
   std::vector<std::string> canonical_rcfile_paths_;
   // All options parsed from the file.
   OptionMap options_;
+
+  // Turn a %home%-relative import into its true name in the filesystem.
+  // path_fragment is modified in place.
+  // Unlike FindCandidateBlazercPaths, it is an error if no import file
+  // exists.
+  bool HomeRelativizeRcFilePath(std::string* path_fragment) const;
+
+  // Prefix that will be expanded to the value
+  // of the HOME environment variable.
+  static constexpr const char HomePrefix_[] = "%home%/";
+  static const int HomePrefixLength_ = sizeof HomePrefix_ - 1;
 };
 
 }  // namespace blaze

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -826,6 +826,17 @@ TEST_F(BlazercImportTest, BazelRcTryImportDoesNotFailForUnreadableFile) {
   ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
 }
 
+TEST_F(BlazercImportTest, SimpleTryImportUsingHomePrefix) {
+   const std::string home_rc_path =
+      blaze_util::JoinPath(home_, "startup_foo.bazelrc");
+  blaze_util::WriteFile("startup --max_idle_secs=123", home_rc_path, 0755);
+  std::string workspace_rc;
+  ASSERT_TRUE(
+      SetUpWorkspaceRcFile("try-import %home%/startup_foo.bazelrc", &workspace_rc));
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
+}
+
 #if defined(_WIN32)
 TEST_F(BlazercImportTest,
        BazelRcTryImportDoesNotFailForInvalidPosixPathOnWindows) {


### PR DESCRIPTION
In CI environments with multiple bazel versions running on the same machine it is sometimes not possible to share ~/.bazelrc files between the versions.

This commit adds support for the %home% prefix when using import or try-import and allows the user to specify any bazelrc file relative to $HOME/.

Example workspace .bazelrc file:
try-import %home%/.bazelrc_bazel_7
