### PR TITLE
Unblock Bazel JDK 21 upgrade by patching RJE with upstream commit 5a78bc62

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,9 +24,9 @@ bazel_dep(name = "blake3", version = "1.3.3.bcr.1")
 bazel_dep(name = "zlib", version = "1.3")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_java", version = "7.4.0")
+bazel_dep(name = "rules_jvm_external", version = "6.0")
 bazel_dep(name = "rules_graalvm", version = "0.10.3")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
-bazel_dep(name = "rules_jvm_external", version = "6.0")
 bazel_dep(name = "rules_python", version = "0.28.0")
 bazel_dep(name = "rules_testing", version = "0.0.4")
 bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
@@ -38,7 +38,13 @@ bazel_dep(name = "googleapis", version = "")
 single_version_override(
     module_name = "rules_jvm_external",
     patch_strip = 1,
-    patches = ["//third_party:rules_jvm_external_6.0.patch"],
+    patches = [
+        "//third_party:rules_jvm_external_6.0.patch",
+        # Temporary patch until RJE publishes a bzlmod release with 5a78bc6, a
+        # fix that allows Bazel to be built with JDK 21 toolchain.
+        # https://github.com/bazelbuild/rules_jvm_external/issues/895#issuecomment-1959720142
+        "//third_party:rules_jvm_external_jre_right_version.patch",
+    ],
 )
 
 local_path_override(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "bca9cd3cd122e30c880e8133807c924d2457f7f1c3c258ef5cb4d3f18027a857",
+  "moduleFileHash": "e211c1383330081a3bd7128daa08ee102a28df172ff4b2b0779b5f2e30bfe37e",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -39,7 +39,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 67,
+            "line": 73,
             "column": 22
           },
           "imports": {
@@ -168,7 +168,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 68,
+                "line": 74,
                 "column": 14
               }
             },
@@ -183,7 +183,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -198,7 +198,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -213,7 +213,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -228,7 +228,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -243,7 +243,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -258,7 +258,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -273,7 +273,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -288,7 +288,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -303,7 +303,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 191,
+                "line": 197,
                 "column": 19
               }
             },
@@ -331,7 +331,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 331,
+                "line": 337,
                 "column": 22
               }
             }
@@ -345,7 +345,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 212,
+            "line": 218,
             "column": 32
           },
           "imports": {
@@ -385,7 +385,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 246,
+            "line": 252,
             "column": 23
           },
           "imports": {},
@@ -399,7 +399,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 247,
+                "line": 253,
                 "column": 17
               }
             }
@@ -413,7 +413,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 249,
+            "line": 255,
             "column": 20
           },
           "imports": {
@@ -431,7 +431,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 250,
+                "line": 256,
                 "column": 10
               }
             }
@@ -445,7 +445,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 261,
+            "line": 267,
             "column": 33
           },
           "imports": {
@@ -476,7 +476,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 282,
+            "line": 288,
             "column": 29
           },
           "imports": {
@@ -493,7 +493,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 285,
+            "line": 291,
             "column": 20
           },
           "imports": {
@@ -512,7 +512,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 286,
+                "line": 292,
                 "column": 12
               }
             }
@@ -526,7 +526,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 298,
+            "line": 304,
             "column": 32
           },
           "imports": {
@@ -545,7 +545,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 306,
+            "line": 312,
             "column": 31
           },
           "imports": {
@@ -562,7 +562,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 309,
+            "line": 315,
             "column": 48
           },
           "imports": {
@@ -579,7 +579,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 353,
+            "line": 359,
             "column": 35
           },
           "imports": {
@@ -596,7 +596,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 356,
+            "line": 362,
             "column": 42
           },
           "imports": {
@@ -622,9 +622,9 @@
         "zlib": "zlib@1.3",
         "rules_cc": "rules_cc@0.0.9",
         "rules_java": "rules_java@7.4.0",
+        "rules_jvm_external": "rules_jvm_external@6.0",
         "rules_graalvm": "rules_graalvm@0.10.3",
         "rules_proto": "rules_proto@5.3.0-21.7",
-        "rules_jvm_external": "rules_jvm_external@6.0",
         "rules_python": "rules_python@0.28.0",
         "rules_testing": "rules_testing@0.0.4",
         "com_google_googletest": "googletest@1.14.0",
@@ -1194,68 +1194,6 @@
         }
       }
     },
-    "rules_graalvm@0.10.3": {
-      "name": "rules_graalvm",
-      "version": "0.10.3",
-      "key": "rules_graalvm@0.10.3",
-      "repoName": "rules_graalvm",
-      "executionPlatformsToRegister": [],
-      "toolchainsToRegister": [],
-      "extensionUsages": [],
-      "deps": {
-        "platforms": "platforms@0.0.8",
-        "bazel_features": "bazel_features@1.1.1",
-        "rules_java": "rules_java@7.4.0",
-        "bazel_skylib": "bazel_skylib@1.5.0",
-        "build_bazel_apple_support": "apple_support@1.8.1",
-        "bazel_tools": "bazel_tools@_",
-        "local_config_platform": "local_config_platform@_"
-      },
-      "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
-        "ruleClassName": "http_archive",
-        "attributes": {
-          "name": "rules_graalvm~0.10.3",
-          "urls": [
-            "https://github.com/sgammon/rules_graalvm/releases/download/v0.10.3/rules_graalvm-0.10.3.zip"
-          ],
-          "integrity": "sha256-H0uZeedQMwQt9OlAWgqUmqXdlCfnLIqv2Ikdj2dOdeQ=",
-          "strip_prefix": "rules_graalvm-0.10.3",
-          "remote_patches": {},
-          "remote_patch_strip": 0
-        }
-      }
-    },
-    "rules_proto@5.3.0-21.7": {
-      "name": "rules_proto",
-      "version": "5.3.0-21.7",
-      "key": "rules_proto@5.3.0-21.7",
-      "repoName": "rules_proto",
-      "executionPlatformsToRegister": [],
-      "toolchainsToRegister": [],
-      "extensionUsages": [],
-      "deps": {
-        "bazel_skylib": "bazel_skylib@1.5.0",
-        "com_google_protobuf": "protobuf@21.7",
-        "rules_cc": "rules_cc@0.0.9",
-        "bazel_tools": "bazel_tools@_",
-        "local_config_platform": "local_config_platform@_"
-      },
-      "repoSpec": {
-        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
-        "ruleClassName": "http_archive",
-        "attributes": {
-          "name": "rules_proto~5.3.0-21.7",
-          "urls": [
-            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz"
-          ],
-          "integrity": "sha256-3D+yBqLLNEG0heseQjFlsjEjWh6psDG0Qzz3vB+kYN0=",
-          "strip_prefix": "rules_proto-5.3.0-21.7",
-          "remote_patches": {},
-          "remote_patch_strip": 0
-        }
-      }
-    },
     "rules_jvm_external@6.0": {
       "name": "rules_jvm_external",
       "version": "6.0",
@@ -1576,12 +1514,75 @@
           },
           "remote_patch_strip": 0,
           "patches": [
-            "//third_party:rules_jvm_external_6.0.patch"
+            "//third_party:rules_jvm_external_6.0.patch",
+            "//third_party:rules_jvm_external_jre_right_version.patch"
           ],
           "patch_cmds": [],
           "patch_args": [
             "-p1"
           ]
+        }
+      }
+    },
+    "rules_graalvm@0.10.3": {
+      "name": "rules_graalvm",
+      "version": "0.10.3",
+      "key": "rules_graalvm@0.10.3",
+      "repoName": "rules_graalvm",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "platforms": "platforms@0.0.8",
+        "bazel_features": "bazel_features@1.1.1",
+        "rules_java": "rules_java@7.4.0",
+        "bazel_skylib": "bazel_skylib@1.5.0",
+        "build_bazel_apple_support": "apple_support@1.8.1",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_graalvm~0.10.3",
+          "urls": [
+            "https://github.com/sgammon/rules_graalvm/releases/download/v0.10.3/rules_graalvm-0.10.3.zip"
+          ],
+          "integrity": "sha256-H0uZeedQMwQt9OlAWgqUmqXdlCfnLIqv2Ikdj2dOdeQ=",
+          "strip_prefix": "rules_graalvm-0.10.3",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "rules_proto@5.3.0-21.7": {
+      "name": "rules_proto",
+      "version": "5.3.0-21.7",
+      "key": "rules_proto@5.3.0-21.7",
+      "repoName": "rules_proto",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "bazel_skylib": "bazel_skylib@1.5.0",
+        "com_google_protobuf": "protobuf@21.7",
+        "rules_cc": "rules_cc@0.0.9",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_proto~5.3.0-21.7",
+          "urls": [
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz"
+          ],
+          "integrity": "sha256-3D+yBqLLNEG0heseQjFlsjEjWh6psDG0Qzz3vB+kYN0=",
+          "strip_prefix": "rules_proto-5.3.0-21.7",
+          "remote_patches": {},
+          "remote_patch_strip": 0
         }
       }
     },
@@ -2742,7 +2743,7 @@
         "bzlTransitiveDigest": "r8gQnSLwon27gWD77J8mb3DIe4v3gtn7J/rsic53Qyw=",
         "accumulatedFileDigests": {
           "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "90bec989ef7d229ef67c24ad140987a20c64343695a944fc04c7266815f89ade",
-          "@@//:MODULE.bazel": "bca9cd3cd122e30c880e8133807c924d2457f7f1c3c258ef5cb4d3f18027a857"
+          "@@//:MODULE.bazel": "e211c1383330081a3bd7128daa08ee102a28df172ff4b2b0779b5f2e30bfe37e"
         },
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/third_party/rules_jvm_external_jre_right_version.patch
+++ b/third_party/rules_jvm_external_jre_right_version.patch
@@ -1,0 +1,69 @@
+diff --git a/private/rules/jvm_import.bzl b/private/rules/jvm_import.bzl
+index 26292ae..00ef163 100644
+--- a/private/rules/jvm_import.bzl
++++ b/private/rules/jvm_import.bzl
+@@ -23,17 +23,22 @@ def _jvm_import_impl(ctx):
+         workspace_name = visible_name,
+     )
+ 
++    java_runtime = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"].java_runtime
++    add_jar_manifest_entry_jar = ctx.file._add_jar_manifest_entry
++
+     injar = ctx.files.jars[0]
+     if ctx.attr._stamp_manifest[StampManifestProvider].stamp_enabled:
+         outjar = ctx.actions.declare_file("processed_" + injar.basename, sibling = injar)
+         args = ctx.actions.args()
++        args.add_all(["-jar", add_jar_manifest_entry_jar])
+         args.add_all(["--source", injar, "--output", outjar])
+         args.add_all(["--manifest-entry", "Target-Label:{target_label}".format(target_label = label)])
+         ctx.actions.run(
+-            executable = ctx.executable._add_jar_manifest_entry,
++            executable = java_runtime.java_executable_exec_path,
+             arguments = [args],
+-            inputs = [injar],
++            inputs = [injar, add_jar_manifest_entry_jar],
+             outputs = [outjar],
++            tools = java_runtime.files,
+             mnemonic = "StampJarManifest",
+             progress_message = "Stamping the manifest of %s" % ctx.label,
+         )
+@@ -42,6 +47,7 @@ def _jvm_import_impl(ctx):
+ 
+     compilejar = ctx.actions.declare_file("header_" + injar.basename, sibling = injar)
+     args = ctx.actions.args()
++    args.add_all(["-jar", add_jar_manifest_entry_jar])
+     args.add_all(["--source", outjar, "--output", compilejar])
+ 
+     # We need to remove the `Class-Path` entry since bazel 4.0.0 forces `javac`
+@@ -56,10 +62,11 @@ def _jvm_import_impl(ctx):
+     args.add("--make-safe")
+ 
+     ctx.actions.run(
+-        executable = ctx.executable._add_jar_manifest_entry,
++        executable = java_runtime.java_executable_exec_path,
+         arguments = [args],
+-        inputs = [outjar],
++        inputs = [outjar, add_jar_manifest_entry_jar],
+         outputs = [compilejar],
++        tools = java_runtime.files,
+         mnemonic = "CreateCompileJar",
+         progress_message = "Creating compile jar for %s" % ctx.label,
+     )
+@@ -101,9 +108,9 @@ jvm_import = rule(
+             default = False,
+         ),
+         "_add_jar_manifest_entry": attr.label(
+-            executable = True,
++            allow_single_file = True,
+             cfg = "exec",
+-            default = "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:AddJarManifestEntry",
++            default = "//private/tools/java/com/github/bazelbuild/rules_jvm_external/jar:AddJarManifestEntry_deploy.jar",
+         ),
+         "_stamp_manifest": attr.label(
+             default = "@rules_jvm_external//settings:stamp_manifest",
+@@ -111,4 +118,5 @@ jvm_import = rule(
+     },
+     implementation = _jvm_import_impl,
+     provides = [JavaInfo],
++    toolchains = ["@bazel_tools//tools/jdk:runtime_toolchain_type"],
+ )


### PR DESCRIPTION
Context: https://github.com/bazelbuild/rules_jvm_external/issues/895#issuecomment-1959720142

This updates RJE to unblock building Bazel itself with Java 21.