### PR TITLE
Fixes _module_repo_name when building with Bazel@HEAD or Bazel 7.1

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2598,7 +2598,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_android_deps": {
       "general": {
-        "bzlTransitiveDigest": "uzRwJ/aaGLzKqN69Hz+DktJFrVeKCjILtM+t4Hirz0M=",
+        "bzlTransitiveDigest": "qF4MUyoxY7fCY0kaWtM87qFtK+boKcqviSosJqqpaDI=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2739,7 +2739,7 @@
     },
     "//:extensions.bzl%bazel_build_deps": {
       "general": {
-        "bzlTransitiveDigest": "uzRwJ/aaGLzKqN69Hz+DktJFrVeKCjILtM+t4Hirz0M=",
+        "bzlTransitiveDigest": "qF4MUyoxY7fCY0kaWtM87qFtK+boKcqviSosJqqpaDI=",
         "accumulatedFileDigests": {
           "@@//src/test/tools/bzlmod:MODULE.bazel.lock": "e591609d4999da0cac2aad19df3ff8a1e42f3f032fb16308037d0d9e555f369f",
           "@@//:MODULE.bazel": "f291782aef1d2989f49c0e884b32ec8d7814ae48c598b6f3060870ccb3f5c0b6"
@@ -3122,7 +3122,7 @@
     },
     "//:extensions.bzl%bazel_test_deps": {
       "general": {
-        "bzlTransitiveDigest": "uzRwJ/aaGLzKqN69Hz+DktJFrVeKCjILtM+t4Hirz0M=",
+        "bzlTransitiveDigest": "qF4MUyoxY7fCY0kaWtM87qFtK+boKcqviSosJqqpaDI=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/src/tools/bzlmod/utils.bzl
+++ b/src/tools/bzlmod/utils.bzl
@@ -137,4 +137,9 @@ def _module_repo_name(module):
     module_name = module["name"]
     if module_name in _WELL_KNOWN_MODULES:
         return module_name
+
+    # TODO(pcloudy): Simplify the following logic after we upgrade to 7.1
+    if get_canonical_repo_name("rules_cc").endswith("~"):
+        return "{}~".format(module_name)
+
     return "{}~{}".format(module_name, module["version"])


### PR DESCRIPTION
If `get_canonical_repo_name` no longer returns the repo name with version due to containing https://github.com/bazelbuild/bazel/commit/a54a393d209ab9c8cf5e80b2a0ef092196c17df3, the `_module_repo_name` should not either.

Fixes: https://github.com/bazelbuild/bazel/issues/21292

Closes #21324.

PiperOrigin-RevId: 606646238
Change-Id: I8835a84842c2c66929586b39156eb9f5a541652f