### PR TITLE
[7.1.0] Fix vendor existing repo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -199,7 +199,9 @@ public final class VendorCommand implements BlazeCommand {
     for (Entry<RepositoryName, RepositoryDirectoryValue> entry :
         repositoryNamesAndValues.entrySet()) {
       if (entry.getValue().repositoryExists()) {
-        reposToVendor.add(entry.getKey());
+        if (!entry.getValue().excludeFromVendoring()) {
+          reposToVendor.add(entry.getKey());
+        }
       } else {
         notFoundRepoErrors.add(entry.getValue().getErrorMsg());
       }


### PR DESCRIPTION
If a repo is already vendored & up-to-date, we shouldn't vendor it again. As it may not exist under the external cache and this causes vendoring to fail.

PiperOrigin-RevId: 609728367
Change-Id: I5d0df83f254e860110a734270e25f8ce2193e437