### PR TITLE
[7.1.0] [test][windows] Export BAZEL_TEST=1 on windows

### DIFF
--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -628,6 +628,11 @@ bool ExportGtestVariables(const Path& test_tmpdir) {
 }
 
 bool ExportMiscEnvvars(const Path& cwd) {
+  // Add BAZEL_TEST environment variable.
+  if (!SetEnv(L"BAZEL_TEST", L"1")) {
+    return false;
+  }
+
   for (const wchar_t* name :
        {L"TEST_INFRASTRUCTURE_FAILURE_FILE", L"TEST_LOGSPLITTER_OUTPUT_FILE",
         L"TEST_PREMATURE_EXIT_FILE", L"TEST_UNUSED_RUNFILES_LOG_FILE",


### PR DESCRIPTION
This was an oversight from when exporting BAZEL_TEST on Linux.

fixes: https://github.com/bazelbuild/bazel/issues/21420

Closes #21444.

Commit https://github.com/bazelbuild/bazel/commit/0a9d61206cbd2d6e6a070b612cb3e9c4b4838aad

PiperOrigin-RevId: 610338496
Change-Id: Icbbdc42b6ea92a2de2b0c558aea47a24493c9d8a