### PR TITLE
[7.1.0] Enable aar_import JNI libs to work with --android_platforms.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AarImportBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AarImportBaseRule.java
@@ -21,6 +21,7 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
 import com.google.devtools.build.lib.packages.StarlarkProviderIdentifier;
@@ -92,6 +93,18 @@ public class AarImportBaseRule implements RuleDefinition {
                 .cfg(ExecutionTransitionFactory.createFactory())
                 .exec()
                 .value(env.getToolsLabel("//tools/zip:zipper")))
+        .add(
+            attr("$constraint_arm64", LABEL)
+                .value(Label.parseCanonicalUnchecked("@platforms//cpu:arm64")))
+        .add(
+            attr("$constraint_armv7", LABEL)
+                .value(Label.parseCanonicalUnchecked("@platforms//cpu:armv7")))
+        .add(
+            attr("$constraint_x86", LABEL)
+                .value(Label.parseCanonicalUnchecked("@platforms//cpu:x86_32")))
+        .add(
+            attr("$constraint_x86_64", LABEL)
+                .value(Label.parseCanonicalUnchecked("@platforms//cpu:x86_64")))
         .advertiseStarlarkProvider(StarlarkProviderIdentifier.forKey(JavaInfo.PROVIDER.getKey()))
         .requiresConfigurationFragments(AndroidConfiguration.class, JavaConfiguration.class)
         .build();

--- a/src/test/shell/bazel/android/aar_integration_test.sh
+++ b/src/test/shell/bazel/android/aar_integration_test.sh
@@ -83,6 +83,8 @@ EOF
 function test_android_binary_depends_on_aar() {
   create_new_workspace
   setup_android_sdk_support
+  setup_android_platforms
+
   cat > AndroidManifest.xml <<EOF
 <manifest package="com.example"/>
 EOF
@@ -91,9 +93,15 @@ EOF
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" />
 EOF
+
   mkdir assets
   echo "some asset" > assets/a
-  zip example.aar AndroidManifest.xml res/layout/mylayout.xml assets/a
+
+  mkdir -p jni/armeabi-v7a
+  echo "an armeabi-v7a so" > jni/armeabi-v7a/libjni.so
+
+  zip example.aar AndroidManifest.xml res/layout/mylayout.xml assets/a jni/armeabi-v7a/libjni.so
+
   cat > BUILD <<EOF
 aar_import(
   name = "example",
@@ -106,10 +114,12 @@ android_binary(
   deps = [":example"],
 )
 EOF
-  assert_build :app
+
+  assert_build :app --android_platforms=//test_android_platforms:simple
   apk_contents="$(zipinfo -1 bazel-bin/app.apk)"
   assert_one_of $apk_contents "assets/a"
   assert_one_of $apk_contents "res/layout/mylayout.xml"
+  assert_one_of $apk_contents "lib/armeabi-v7a/libjni.so"
 }
 
 function test_android_binary_fat_apk_contains_all_shared_libraries() {

--- a/src/test/shell/bazel/android/android_sdk_integration_test.sh
+++ b/src/test/shell/bazel/android/android_sdk_integration_test.sh
@@ -85,12 +85,15 @@ function test_specifying_android_sdk_flag() {
   create_new_workspace
   setup_android_sdk_support
   create_android_binary
+  setup_android_platforms
+
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
 android_sdk_repository(
     name = "a",
 )
 EOF
   ANDROID_HOME=$ANDROID_SDK bazel build --android_sdk=@a//:sdk-24 \
+    --android_platforms=//test_android_platforms:simple \
     //java/bazel:bin || fail "build with --android_sdk failed"
 }
 


### PR DESCRIPTION
Fixes #21225

Commit https://github.com/bazelbuild/bazel/commit/1e77944386a6c8a5fbdde6738be43859decfd19e

PiperOrigin-RevId: 610551472
Change-Id: I7e62919dd41d0d4e2b923df1942920162f554809