### PR TITLE
[7.1.0] Passthrough HTTP headers to remote downloader service

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -351,7 +351,10 @@ public class GrpcRemoteDownloaderTest {
             Optional.<Checksum>of(
                 Checksum.fromSubresourceIntegrity(
                     "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),
-            "canonical ID");
+            "canonical ID",
+            ImmutableMap.of(
+                "Authorization", ImmutableList.of("Basic Zm9vOmJhcg=="),
+                "X-Custom-Token", ImmutableList.of("foo", "bar")));
 
     assertThat(request)
         .isEqualTo(
@@ -366,6 +369,14 @@ public class GrpcRemoteDownloaderTest {
                         .setValue("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
                 .addQualifiers(
                     Qualifier.newBuilder().setName("bazel.canonical_id").setValue("canonical ID"))
+                .addQualifiers(
+                    Qualifier.newBuilder()
+                        .setName("http_header:Authorization")
+                        .setValue("Basic Zm9vOmJhcg=="))
+                .addQualifiers(
+                    Qualifier.newBuilder()
+                        .setName("http_header:X-Custom-Token")
+                        .setValue("foo,bar"))
                 .build());
   }
 }


### PR DESCRIPTION
Related to https://github.com/bazelbuild/bazel/issues/17829 and https://github.com/bazelbuild/bazel/commit/2697e0c7d798184cf80f8a5c16db3f0022d63256

I don't love this design but according to the Remote Asset API spec, this is an intended use of qualifiers: https://docs.google.com/document/d/10ari9WtTTSv9bqB_UU-oe2gBtaAA7HyQgkpP-RFP80c/edit#heading=h.sixrlhdnkfoa.

cc @Wyverald @jmillikin

Closes #21490.

Commit https://github.com/bazelbuild/bazel/commit/2195baabe7fc23be325d12159606e63e739b0ced

PiperOrigin-RevId: 610688317
Change-Id: I272f63a6bc4ea432503003ee907ca012f6d641cf