### PR TITLE
[7.1.0] Fix genrule autostamping in bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BUILD
@@ -15,11 +15,16 @@ java_library(
     name = "genrule",
     srcs = glob(["*.java"]),
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/execution_transition_factory",
+        "//src/main/java/com/google/devtools/build/lib/analysis:file_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis:rule_definition_environment",
+        "//src/main/java/com/google/devtools/build/lib/analysis:transitive_info_collection",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/rules/genrule",
-        "//src/main/java/com/google/devtools/build/lib/util:filetype",
+        "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRule.java
@@ -18,24 +18,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.AliasProvider;
 import com.google.devtools.build.lib.analysis.FileProvider;
-import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
-import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.rules.genrule.GenRuleBase;
 import java.util.List;
 
 /** An implementation of genrule for Bazel. */
 public final class BazelGenRule extends GenRuleBase {
-
-  @Override
-  protected boolean isStampingEnabled(RuleContext ruleContext) {
-    if (!ruleContext.attributes().has("stamp", Type.BOOLEAN)) {
-      return false;
-    }
-    return ruleContext.attributes().get("stamp", Type.BOOLEAN);
-  }
 
   @Override
   protected ImmutableMap<Label, NestedSet<Artifact>> collectSources(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRule.java
@@ -14,14 +14,20 @@
 
 package com.google.devtools.build.lib.bazel.rules.genrule;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.AliasProvider;
+import com.google.devtools.build.lib.analysis.FileProvider;
 import com.google.devtools.build.lib.analysis.RuleContext;
+import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.rules.genrule.GenRuleBase;
+import java.util.List;
 
-/**
- * An implementation of genrule for Bazel.
- */
-public class BazelGenRule extends GenRuleBase {
+/** An implementation of genrule for Bazel. */
+public final class BazelGenRule extends GenRuleBase {
 
   @Override
   protected boolean isStampingEnabled(RuleContext ruleContext) {
@@ -29,5 +35,19 @@ public class BazelGenRule extends GenRuleBase {
       return false;
     }
     return ruleContext.attributes().get("stamp", Type.BOOLEAN);
+  }
+
+  @Override
+  protected ImmutableMap<Label, NestedSet<Artifact>> collectSources(
+      List<? extends TransitiveInfoCollection> srcs) {
+    ImmutableMap.Builder<Label, NestedSet<Artifact>> labelMap =
+        ImmutableMap.builderWithExpectedSize(srcs.size());
+
+    for (TransitiveInfoCollection dep : srcs) {
+      NestedSet<Artifact> files = dep.getProvider(FileProvider.class).getFilesToBuild();
+      labelMap.put(AliasProvider.getDependencyLabel(dep), files);
+    }
+
+    return labelMap.buildOrThrow();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRuleRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRuleRule.java
@@ -15,19 +15,20 @@ package com.google.devtools.build.lib.bazel.rules.genrule;
 
 import static com.google.devtools.build.lib.packages.Attribute.attr;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL;
-import static com.google.devtools.build.lib.packages.Type.BOOLEAN;
+import static com.google.devtools.build.lib.packages.BuildType.TRISTATE;
 
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
 import com.google.devtools.build.lib.packages.RuleClass;
+import com.google.devtools.build.lib.packages.TriState;
 import com.google.devtools.build.lib.rules.genrule.GenRuleBaseRule;
 
 /**
  * Rule definition for genrule for Bazel.
  */
 public final class BazelGenRuleRule implements RuleDefinition {
-  public static final String GENRULE_SETUP_LABEL = "//tools/genrule:genrule-setup.sh";
+  private static final String GENRULE_SETUP_LABEL = "//tools/genrule:genrule-setup.sh";
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -43,9 +44,7 @@ public final class BazelGenRuleRule implements RuleDefinition {
             attr("$genrule_setup", LABEL)
                 .cfg(ExecutionTransitionFactory.createFactory())
                 .value(env.getToolsLabel(GENRULE_SETUP_LABEL)))
-
-        // TODO(bazel-team): stamping doesn't seem to work. Fix it or remove attribute.
-        .add(attr("stamp", BOOLEAN).value(false))
+        .add(attr("stamp", TRISTATE).value(TriState.NO))
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
@@ -45,7 +45,9 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.AttributeMap;
+import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.TargetUtils;
+import com.google.devtools.build.lib.packages.TriState;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import com.google.devtools.build.lib.util.OnDemandString;
@@ -58,7 +60,7 @@ import javax.annotation.Nullable;
 
 /**
  * A base implementation of genrule, to be used by specific implementing rules which can change the
- * semantics of {@link #isStampingEnabled} and {@link #collectSources}.
+ * semantics of {@link #collectSources}.
  */
 public abstract class GenRuleBase implements RuleConfiguredTargetFactory {
 
@@ -231,19 +233,19 @@ public abstract class GenRuleBase implements RuleConfiguredTargetFactory {
         .build();
   }
 
-  /**
-   * Returns {@code true} if the rule should be stamped.
-   *
-   * <p>Genrule implementations can set this based on the rule context, including by defining their
-   * own attributes over and above what is present in {@link GenRuleBaseRule}.
-   */
-  @ForOverride
-  protected abstract boolean isStampingEnabled(RuleContext ruleContext);
-
   /** Collects sources from src attribute. */
   @ForOverride
   protected abstract ImmutableMap<Label, NestedSet<Artifact>> collectSources(
       List<? extends TransitiveInfoCollection> srcs) throws RuleErrorException;
+
+  private static boolean isStampingEnabled(RuleContext ruleContext) {
+    // This intentionally does not call AnalysisUtils.isStampingEnabled(). That method returns false
+    // in the exec configuration (regardless of the attribute value), which is the behavior for
+    // binaries, but not genrules.
+    TriState stamp = ruleContext.attributes().get("stamp", BuildType.TRISTATE);
+    return stamp == TriState.YES
+        || (stamp == TriState.AUTO && ruleContext.getConfiguration().stampBinaries());
+  }
 
   private enum CommandType {
     BASH,

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
@@ -530,6 +530,7 @@ public final class GenRuleConfiguredTargetTest extends BuildViewTestCase {
         "u/BUILD",
         "genrule(name='foo_stamp', srcs=[], outs=['uu'], stamp=1, cmd='')",
         "genrule(name='foo_nostamp', srcs=[], outs=['vv'], stamp=0, cmd='')",
+        "genrule(name='foo_autostamp', srcs=[], outs=['aa'], stamp=-1, cmd='')",
         "genrule(name='foo_default', srcs=[], outs=['xx'], cmd='')");
   }
 
@@ -562,6 +563,8 @@ public final class GenRuleConfiguredTargetTest extends BuildViewTestCase {
     assertStamped(getExecConfiguredTarget("//u:foo_stamp"));
     assertNotStamped("//u:foo_nostamp");
     assertNotStamped(getExecConfiguredTarget("//u:foo_nostamp"));
+    assertNotStamped("//u:foo_autostamp");
+    assertNotStamped(getExecConfiguredTarget("//u:foo_autostamp"));
     assertNotStamped("//u:foo_default");
   }
 
@@ -571,8 +574,10 @@ public final class GenRuleConfiguredTargetTest extends BuildViewTestCase {
     createStampingTargets();
     assertStamped("//u:foo_stamp");
     assertStamped(getExecConfiguredTarget("//u:foo_stamp"));
-    // assertStamped("//u:foo_nostamp");
+    assertNotStamped("//u:foo_nostamp");
     assertNotStamped(getExecConfiguredTarget("//u:foo_nostamp"));
+    assertStamped("//u:foo_autostamp");
+    assertNotStamped(getExecConfiguredTarget("//u:foo_autostamp"));
     assertNotStamped("//u:foo_default");
   }
 


### PR DESCRIPTION
Genrule does not support conditional stamping based on the value of the `--stamp` flag. This is because genrule treats the `stamp` attribute as `boolean`, while all other rules use the `tristate` type. After this change, the stamp attribute in genrule can be set to `-1` to request conditional stamping.

RELNOTES: `genrule` now supports setting `stamp = -1` to request conditional stamping (based on the value of the build's `--stamp` flag).

Closes https://github.com/bazelbuild/bazel/pull/21407.

Commit https://github.com/bazelbuild/bazel/commit/cb901b71b4beb57b263bcb5551d0d45afc2e38c5, https://github.com/bazelbuild/bazel/commit/ee57d991ccb56b78e8af0185f266e9a39554b1d4

PiperOrigin-RevId: 609085052
Change-Id: I873941e9aaae3760a545c1900cd13cb60a9ada39