### PR TITLE
Allow filtering files to instrument for coverage

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -265,6 +265,18 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public RegexFilter instrumentationFilter;
 
   @Option(
+      name = "experimental_instrumentation_file_filter",
+      converter = RegexFilter.RegexFilterConverter.class,
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      help =
+          "When coverage is enabled, only source and class files matched by the "
+              + "specified regex-based filter will be instrumented. Patterns prefixed "
+              + "with '-' are excluded instead.")
+  public RegexFilter instrumentationFileFilter;
+
+  @Option(
       name = "instrument_test_targets",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -36,6 +36,7 @@ import com.google.devtools.build.lib.analysis.actions.LazyWritePathsFileAction;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.StrictDepsMode;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.test.InstrumentedFilesCollector;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -48,6 +49,7 @@ import com.google.devtools.build.lib.rules.java.JavaConfiguration.JavaClasspathM
 import com.google.devtools.build.lib.rules.java.JavaPluginInfo.JavaPluginData;
 import com.google.devtools.build.lib.rules.java.JavaRuleOutputJarsProvider.JavaOutput;
 import com.google.devtools.build.lib.rules.java.JavaToolchainProvider.JspecifyInfo;
+import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.ArrayList;
@@ -165,6 +167,19 @@ public final class JavaCompilationHelper {
 
   private JavaConfiguration getJavaConfiguration() {
     return ruleContext.getFragment(JavaConfiguration.class);
+  }
+
+  private ImmutableSet<Artifact> filterCoverage(ImmutableSet<Artifact> sourceFiles) {
+    ImmutableSet.Builder<Artifact> builder = ImmutableSet.builder();
+    CoreOptions coreOptions = getConfiguration().getOptions().get(CoreOptions.class);
+    RegexFilter filter = coreOptions.instrumentationFileFilter;
+
+    for (Artifact sourceFile : sourceFiles) {
+      if (filter.isIncluded(sourceFile.getExecPath().toString())) {
+        builder.add(sourceFile);
+      }
+    }
+    return builder.build();
   }
 
   public JavaCompileOutputs<Artifact> createOutputs(Artifact output) {
@@ -376,11 +391,12 @@ public final class JavaCompilationHelper {
     builder.setInjectingRuleKind(attributes.getInjectingRuleKind());
 
     if (coverageArtifact != null) {
+      ImmutableSet<Artifact> filteredSourceFiles = filterCoverage(sourceFiles);
       ruleContext.registerAction(
           new LazyWritePathsFileAction(
               ruleContext.getActionOwner(execGroup),
               coverageArtifact,
-              NestedSetBuilder.<Artifact>stableOrder().addAll(sourceFiles).build(),
+              NestedSetBuilder.<Artifact>stableOrder().addAll(filteredSourceFiles).build(),
               /* filesToIgnore= */ ImmutableSet.of(),
               false));
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.actions.extra.JavaCompileInfo;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.StrictDepsMode;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -335,9 +336,12 @@ public final class JavaCompileActionBuilder {
     if (coverageArtifact != null) {
       result.add("--post_processor");
       result.addExecPath(JACOCO_INSTRUMENTATION_PROCESSOR, coverageArtifact);
-      result.addPath(ruleContext.getCoverageMetadataDirectory().getExecPath());
-      result.add("-*Test");
-      result.add("-*TestCase");
+
+      CoreOptions coreOptions = ruleContext.getConfiguration().getOptions().get(CoreOptions.class);
+      String inclusionRegex = coreOptions.instrumentationFileFilter.getInclusionRegex();
+      result.addDynamicString(inclusionRegex == null ? ".*" : inclusionRegex);
+      String exclusionRegex = coreOptions.instrumentationFileFilter.getExclusionRegex();
+      result.addDynamicString(exclusionRegex == null ? "^$" : exclusionRegex);
     }
     return result.build();
   }

--- a/src/main/java/com/google/devtools/build/lib/util/RegexFilter.java
+++ b/src/main/java/com/google/devtools/build/lib/util/RegexFilter.java
@@ -146,6 +146,16 @@ public final class RegexFilter implements Predicate<String> {
     return isIncluded(value);
   }
 
+  @Nullable
+  public String getInclusionRegex() {
+    return inclusionPattern == null ? null : inclusionPattern.pattern();
+  }
+
+  @Nullable
+  public String getExclusionRegex() {
+    return exclusionPattern == null ? null : exclusionPattern.pattern();
+  }
+
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
Bazel currently has a mechanism to skip targets from coverage instrumentation via the --instrumentation_filter flag.  Unfortunately, there are cases where individual _files_ within a target need to be excluded.

This happens when a build contains gigantic targets with lots of source files in them, some of which are problematic (e.g. because they contain very large methods), and there is no way to easily build those files as separate targets.

To resolve this, introduce --experimental_instrumentation_file_filter, a new flag that applies filtering at the file level.

By looking at the code, it *seems* as if older versions of the Java builder did have filtering as well, but such feature was lost at some point in time.

Fixes #21520.