### PR TITLE
[7.1.0] [credentialhelper] Support paths relative to `%install_base%`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
@@ -66,9 +66,14 @@ public final class CommandLinePathFactory {
     ImmutableMap.Builder<String, Path> wellKnownRoots = ImmutableMap.builder();
 
     // This is necessary because some tests don't have a workspace set.
-    Path workspace = directories.getWorkspace();
+    var workspace = directories.getWorkspace();
     if (workspace != null) {
       wellKnownRoots.put("workspace", workspace);
+    }
+
+    var installBase = directories.getInstallBase();
+    if (installBase != null) {
+      wellKnownRoots.put("install_base", installBase);
     }
 
     return new CommandLinePathFactory(fileSystem, wellKnownRoots.buildOrThrow());


### PR DESCRIPTION
This allows us to ship built-in credential helpers (e.g., for `.netrc`) and move them out of Bazel core.

Closes #21419.

Commit https://github.com/bazelbuild/bazel/commit/ed5d444ed447061d7ef9e44c5a9a6da047486159

PiperOrigin-RevId: 611551189
Change-Id: I89c036ef87d4a1eac11c2eff5076e7884d274bb9