### PR TITLE
[7.1.0] Lazily open files to be uploaded to an HTTP cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileInputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileInputStream.java
@@ -1,0 +1,78 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.common;
+
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Creates an {@link InputStream} backed by a file that isn't actually opened until the first data
+ * is read. This is useful to only have as many open file descriptors as necessary at a time to
+ * avoid running into system limits.
+ *
+ * <p>The markSupported(), mark() and reset() methods need not be overridden, as they're unsupported
+ * by the base implementation.
+ */
+public class LazyFileInputStream extends InputStream {
+
+  private final Path path;
+  private InputStream in;
+
+  public LazyFileInputStream(Path path) {
+    this.path = path;
+  }
+
+  @Override
+  public int available() throws IOException {
+    ensureOpen();
+    return in.available();
+  }
+
+  @Override
+  public int read() throws IOException {
+    ensureOpen();
+    return in.read();
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    ensureOpen();
+    return in.read(b);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    ensureOpen();
+    return in.read(b, off, len);
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    ensureOpen();
+    return in.skip(n);
+  }
+
+  @Override
+  public void close() throws IOException {
+    ensureOpen();
+    in.close();
+  }
+
+  private void ensureOpen() throws IOException {
+    if (in == null) {
+      in = path.getInputStream();
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileOutputStream.java
@@ -19,9 +19,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * Creates an {@link OutputStream} that isn't actually opened until the first data is written. This
- * is useful to only have as many open file descriptors as necessary at a time to avoid running into
- * system limits.
+ * Creates an {@link OutputStream} backed by a file that isn't actually opened until the first data
+ * is written. This is useful to only have as many open file descriptors as necessary at a time to
+ * avoid running into system limits.
  */
 public class LazyFileOutputStream extends OutputStream {
 

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.exec.SpawnCheckingCacheEvent;
 import com.google.devtools.build.lib.remote.RemoteRetrier;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.LazyFileInputStream;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
@@ -725,18 +726,12 @@ public final class HttpCacheClient implements RemoteCacheClient {
   public ListenableFuture<Void> uploadFile(
       RemoteActionExecutionContext context, Digest digest, Path file) {
     return retrier.executeAsync(
-        () -> {
-          try {
-            return uploadAsync(
+        () ->
+            uploadAsync(
                 digest.getHash(),
                 digest.getSizeBytes(),
-                file.getInputStream(),
-                /* casUpload= */ true);
-          } catch (IOException e) {
-            // Can be thrown from file.getInputStream.
-            return Futures.immediateFailedFuture(e);
-          }
-        });
+                new LazyFileInputStream(file),
+                /* casUpload= */ true));
   }
 
   @Override


### PR DESCRIPTION
This reduces the chance of running out of file descriptors when uploading a large number of files simultaneously.

PiperOrigin-RevId: 612410120
Change-Id: I2573c26e60042a5867e7d23748fcb8d74ebe7e68