### PR TITLE
[7.1.0] Move the disk cache reads and writes into a thread pool.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -217,7 +217,8 @@ public final class RemoteModule extends BlazeModule {
       Credentials credentials,
       AuthAndTLSOptions authAndTlsOptions,
       RemoteOptions remoteOptions,
-      DigestUtil digestUtil) {
+      DigestUtil digestUtil,
+      ExecutorService executorService) {
     RemoteCacheClient cacheClient;
     try {
       cacheClient =
@@ -227,6 +228,7 @@ public final class RemoteModule extends BlazeModule {
               authAndTlsOptions,
               Preconditions.checkNotNull(env.getWorkingDirectory(), "workingDirectory"),
               digestUtil,
+              executorService,
               new RemoteRetrier(
                   remoteOptions, RETRIABLE_HTTP_ERRORS, retryScheduler, Retrier.ALLOW_ALL_CALLS));
     } catch (IOException e) {
@@ -391,7 +393,8 @@ public final class RemoteModule extends BlazeModule {
     }
 
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
-      initHttpAndDiskCache(env, credentials, authAndTlsOptions, remoteOptions, digestUtil);
+      initHttpAndDiskCache(
+          env, credentials, authAndTlsOptions, remoteOptions, digestUtil, executorService);
       return;
     }
 
@@ -524,8 +527,9 @@ public final class RemoteModule extends BlazeModule {
               RemoteCacheClientFactory.createDiskAndRemoteClient(
                   env.getWorkingDirectory(),
                   remoteOptions.diskCache,
-                  remoteOptions.remoteVerifyDownloads,
                   digestUtil,
+                  executorService,
+                  remoteOptions.remoteVerifyDownloads,
                   cacheClient);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
@@ -583,8 +587,9 @@ public final class RemoteModule extends BlazeModule {
               RemoteCacheClientFactory.createDiskAndRemoteClient(
                   env.getWorkingDirectory(),
                   remoteOptions.diskCache,
-                  remoteOptions.remoteVerifyDownloads,
                   digestUtil,
+                  executorService,
+                  remoteOptions.remoteVerifyDownloads,
                   cacheClient);
         } catch (Exception e) {
           handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactoryTest.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +46,8 @@ import org.junit.runners.JUnit4;
 public class RemoteCacheClientFactoryTest {
   private final DigestUtil digestUtil =
       new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256);
+  private static final ExecutorService executorService =
+      MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
 
   private RemoteOptions remoteOptions;
   private final AuthAndTLSOptions authAndTlsOptions = Options.getDefaults(AuthAndTLSOptions.class);
@@ -79,6 +82,7 @@ public class RemoteCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
+            executorService,
             retrier);
 
     assertThat(blobStore).isInstanceOf(DiskAndRemoteCacheClient.class);
@@ -97,6 +101,7 @@ public class RemoteCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
+            executorService,
             retrier);
 
     assertThat(blobStore).isInstanceOf(DiskAndRemoteCacheClient.class);
@@ -118,6 +123,7 @@ public class RemoteCacheClientFactoryTest {
                 authAndTlsOptions,
                 /* workingDirectory= */ null,
                 digestUtil,
+                executorService,
                 retrier));
   }
 
@@ -133,6 +139,7 @@ public class RemoteCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
+            executorService,
             retrier);
 
     assertThat(blobStore).isInstanceOf(HttpCacheClient.class);
@@ -153,6 +160,7 @@ public class RemoteCacheClientFactoryTest {
                         authAndTlsOptions,
                         workingDirectory,
                         digestUtil,
+                        executorService,
                         retrier)))
         .hasMessageThat()
         .contains("Remote cache proxy unsupported: bad-proxy");
@@ -169,6 +177,7 @@ public class RemoteCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
+            executorService,
             retrier);
 
     assertThat(blobStore).isInstanceOf(HttpCacheClient.class);
@@ -185,6 +194,7 @@ public class RemoteCacheClientFactoryTest {
             authAndTlsOptions,
             workingDirectory,
             digestUtil,
+            executorService,
             retrier);
 
     assertThat(blobStore).isInstanceOf(DiskCacheClient.class);

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -26,6 +26,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
         "//src/test/java/com/google/devtools/build/lib:test_runner",
+        "//third_party:guava",
         "//third_party:junit4",
         "//third_party:mockito",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import build.bazel.remote.execution.v2.RequestMetadata;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.exec.SpawnCheckingCacheEvent;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
@@ -28,6 +29,8 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +41,8 @@ import org.junit.runners.JUnit4;
 public class DiskCacheClientTest {
   private static final DigestUtil DIGEST_UTIL =
       new DigestUtil(SyscallCache.NO_CACHE, DigestHashFunction.SHA256);
+  private static final ExecutorService executorService =
+      MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
 
   private final FileSystem fs = new InMemoryFileSystem(DigestHashFunction.SHA256);
   private final Path root = fs.getPath("/");
@@ -46,7 +51,7 @@ public class DiskCacheClientTest {
 
   @Before
   public void setUp() throws Exception {
-    client = new DiskCacheClient(root, /* verifyDownloads= */ true, DIGEST_UTIL);
+    client = new DiskCacheClient(root, DIGEST_UTIL, executorService, /* verifyDownloads= */ true);
     context =
         RemoteActionExecutionContext.create(
             mock(Spawn.class),

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.FileNode;
 import build.bazel.remote.execution.v2.SymlinkNode;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.remote.RemoteCache;
 import com.google.devtools.build.lib.remote.Store;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
@@ -31,13 +32,18 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /** A {@link RemoteCache} backed by an {@link DiskCacheClient}. */
 class OnDiskBlobStoreCache extends RemoteCache {
+  private static final ExecutorService executorService =
+      MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
+
   public OnDiskBlobStoreCache(RemoteOptions options, Path cacheDir, DigestUtil digestUtil)
       throws IOException {
     super(
-        new DiskCacheClient(cacheDir, /* verifyDownloads= */ true, digestUtil),
+        new DiskCacheClient(cacheDir, digestUtil, executorService, /* verifyDownloads= */ true),
         options,
         digestUtil);
   }


### PR DESCRIPTION
So that disk cache uploads or downloads that are collectively waited upon can make progress concurrently instead of sequentially. This provides a significant performance boost for actions that download or upload a large number of files.

PiperOrigin-RevId: 612432619
Change-Id: Id4e88b239a5475c49aecb1219045b047c9f5c319