### PR TITLE
[7.1.0] StarlarkBaseExternalContext.java: propagate error message when deleting temporary directory failed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -970,7 +970,11 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
     } catch (IOException e) {
       throw new RepositoryFunctionException(
           new IOException(
-              "Couldn't delete temporary directory (" + downloadDirectory.getPathString() + ")", e),
+              "Couldn't delete temporary directory ("
+                  + downloadDirectory.getPathString()
+                  + "): "
+                  + e.getMessage(),
+              e),
           Transience.TRANSIENT);
     }
     return downloadResult;


### PR DESCRIPTION
Related: https://github.com/bazelbuild/bazel/issues/20013
Commit https://github.com/bazelbuild/bazel/commit/5b4ba3e9b5a3d2532e96812ed7f1fd87c263a467

PiperOrigin-RevId: 585046630
Change-Id: Ifdf098e7d54c1d5dca85a39afd7694dc828331a4