### PR TITLE
Remove --host_jvm_args=-Djava.net.preferIPv6Addresses=true

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -107,7 +107,7 @@ genrule(
         # Instead of `bazel mod deps`, we run a simpler command like `bazel query :all` here
         # so that we only trigger module resolution, not extension eval.
         # Also use `--batch` so that Bazel doesn't keep a server process alive.
-        "$$ROOT/$(location //src:bazel) --batch --host_jvm_args=-Djava.net.preferIPv6Addresses=true --output_user_root=$$TMPDIR/output_user_root query --check_direct_dependencies=error --lockfile_mode=update :all",
+        "$$ROOT/$(location //src:bazel) --batch --output_user_root=$$TMPDIR/output_user_root query --check_direct_dependencies=error --lockfile_mode=update :all",
         "mv MODULE.bazel.lock $$ROOT/$@",
     ]),
     tags = ["requires-network"],

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -708,12 +708,16 @@ exit 1
 EOF
   chmod +x true.sh flaky.sh false.sh
 
-  # The next two lines ensure that the test passes in IPv6-only networks.
-  export JAVA_TOOL_OPTIONS="-Djava.net.preferIPv6Addresses=true"
-  export STARTUP_OPTS="--host_jvm_args=-Djava.net.preferIPv6Addresses=true"
+  # The next line ensures that the test passes in IPv6-only networks on macOS.
+  if is_darwin; then
+    export JAVA_TOOL_OPTIONS="-Djava.net.preferIPv6Addresses=true"
+    export STARTUP_OPTS="--host_jvm_args=-Djava.net.preferIPv6Addresses=true"
+  else
+    export STARTUP_OPTS=""
+  fi
 
   # We do not use sandboxing so we can trick to be deterministically flaky
-  bazel --ignore_all_rc_files "$STARTUP_OPTS" test --experimental_ui_debug_all_events \
+  bazel --ignore_all_rc_files $STARTUP_OPTS test --experimental_ui_debug_all_events \
       --spawn_strategy=standalone //:flaky &> $TEST_log \
       || fail "//:flaky should have passed with flaky support"
   [ -f "${FLAKE_FILE}" ] || fail "Flaky test should have created the flake-file!"
@@ -727,7 +731,7 @@ EOF
   cat bazel-testlogs/flaky/test.log &> $TEST_log
   assert_equals "pass" "$(awk "NR == $(wc -l < $TEST_log)" $TEST_log)"
 
-  bazel --ignore_all_rc_files "$STARTUP_OPTS" test --experimental_ui_debug_all_events //:pass \
+  bazel --ignore_all_rc_files $STARTUP_OPTS test --experimental_ui_debug_all_events //:pass \
       &> $TEST_log || fail "//:pass should have passed"
   expect_log_once "PASS.*: //:pass"
   expect_log_once "PASSED"
@@ -736,7 +740,7 @@ EOF
   cat bazel-testlogs/flaky/test.log &> $TEST_log
   assert_equals "pass" "$(tail -1 bazel-testlogs/flaky/test.log)"
 
-  bazel --ignore_all_rc_files "$STARTUP_OPTS" test --experimental_ui_debug_all_events //:fail \
+  bazel --ignore_all_rc_files $STARTUP_OPTS test --experimental_ui_debug_all_events //:fail \
       &> $TEST_log && fail "//:fail should have failed" \
       || true
   expect_log_n "FAIL.*: //:fail (.*/fail/test_attempts/attempt_..log)" 2


### PR DESCRIPTION
Bazel cannot reach to bcr.bazel.build from a ipv4 only machine with --host_jvm_args=-Djava.net.preferIPv6Addresses=true set. Our GCP VMs are ipv4 only and we recently enabled ipv6 for bcr.bazel.build.

Related https://github.com/bazelbuild/bazel/issues/21525

PiperOrigin-RevId: 611465054
Change-Id: I0c3d144d12ab167a18075e6719ff8597161798d1