### PR TITLE
[7.1.0] Fix watching paths in undefined repos in repo rules

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -456,7 +456,7 @@ public final class StarlarkRepositoryContextTest {
     setUpContextForRule("test");
     context.createFile(context.path("foo"), "foobar", true, true, thread);
 
-    context.symlink(context.path("foo"), context.path("bar"), "auto", thread);
+    context.symlink(context.path("foo"), context.path("bar"), thread);
     testOutputFile(outputDirectory.getChild("bar"), "foobar");
 
     assertThat(context.path("bar").realpath()).isEqualTo(context.path("foo"));


### PR DESCRIPTION
Watching a path in an undefined repo (eg. `$output_base/external/i_am_undefined/blah`) currently causes an NPE because we expect it to need a skyframe restart when it actually doesn't. The underlying reason is rather convoluted, but the gist is that we request `RepositoryDirectoryValue.Key(@@i_am_undefined)` explicitly, when we don't actually have to -- we can simply use `FileValue.Key($output_base/external/i_am_undefined/blah` directly, and rely on the fact that `FileFunction` knows to request the corresponding `RepositoryDirectoryValue` and behave appropriately when the repo is undefined. (This is due to logic in `ExternalFilesHelper.maybeHandleExternalFile`.)

Additionally, this PR removes the `rctx.symlink(watch_target=)` parameter. The symlink target's existence and its contents should not affect the creation of the symlink at all, so there's no reason to ever watch it.

Fixes #21483.

Closes #21562.

Commit https://github.com/bazelbuild/bazel/commit/aba1186aa25ed1ef585cbe4b690434b2f59422a8

PiperOrigin-RevId: 612898526
Change-Id: I30deb9d9b2d19e0869517f4b6b126078446745b4