### PR TITLE
[7.1.0] Implicit dependencies should be visible to rule/aspect definitions in `.bzl` files in the same package

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -658,6 +658,7 @@ java_library(
         ":visibility_provider",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -655,9 +655,9 @@ java_library(
     deps = [
         ":analysis_cluster",
         ":rule_error_consumer",
+        ":visibility_provider",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",
-        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.FunctionSplitTransitionAllowlist;
 import com.google.devtools.build.lib.packages.InputFile;
 import com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper;
+import com.google.devtools.build.lib.packages.PackageSpecification.PackageGroupContents;
 import com.google.devtools.build.lib.packages.RawAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
@@ -80,13 +81,6 @@ public abstract class CommonPrerequisiteValidator implements PrerequisiteValidat
 
     checkVisibilityAttributeContents(context, prerequisite, attribute, attrName, rule);
 
-    if (isSameLogicalPackage(
-        rule.getLabel().getPackageIdentifier(),
-        AliasProvider.getDependencyLabel(prerequisite.getConfiguredTarget())
-            .getPackageIdentifier())) {
-      return;
-    }
-
     // We don't check the visibility of late-bound attributes, because it would break some
     // features.
     if (Attribute.isLateBound(attrName)) {
@@ -121,7 +115,7 @@ public abstract class CommonPrerequisiteValidator implements PrerequisiteValidat
         || attribute.getName().equals(RuleClass.CONFIG_SETTING_DEPS_ATTRIBUTE)
         || !context.isStarlarkRuleOrAspect()) {
       // Default check: The attribute must be visible from the target.
-      if (!context.isVisible(prerequisite.getConfiguredTarget())) {
+      if (!isVisible(rule.getLabel(), prerequisite)) {
         handleVisibilityConflict(context, prerequisite, rule.getLabel());
       }
     } else {
@@ -142,13 +136,35 @@ public abstract class CommonPrerequisiteValidator implements PrerequisiteValidat
       // prerequisite is visible from the target so that adopting this new style of checking
       // visibility is not a breaking change.
       if (implicitDefinition != null
-          && !RuleContext.isVisible(implicitDefinition, prerequisite.getConfiguredTarget())
-          && !context.isVisible(prerequisite.getConfiguredTarget())) {
+          && !isVisible(implicitDefinition, prerequisite)
+          && !isVisible(rule.getLabel(), prerequisite)) {
         // In the error message, always suggest making the prerequisite visible from the definition,
         // not the target.
         handleVisibilityConflict(context, prerequisite, implicitDefinition);
       }
     }
+  }
+
+  private boolean isVisible(Label target, ConfiguredTargetAndData prerequisite) {
+    if (isSameLogicalPackage(
+        target.getPackageIdentifier(),
+        AliasProvider.getDependencyLabel(prerequisite.getConfiguredTarget())
+            .getPackageIdentifier())) {
+      return true;
+    }
+    // Check visibility attribute
+    for (PackageGroupContents specification :
+        prerequisite
+            .getConfiguredTarget()
+            .getProvider(VisibilityProvider.class)
+            .getVisibility()
+            .toList()) {
+      if (specification.containsPackage(target.getPackageIdentifier())) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private void checkVisibilityAttributeContents(

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -1527,34 +1527,6 @@ public final class RuleContext extends TargetContext
   }
 
   /**
-   * Returns true if {@code label} is visible from {@code prerequisite}.
-   *
-   * <p>This only computes the logic as implemented by the visibility system. The final decision
-   * whether a dependency is allowed is made by {@link PrerequisiteValidator}.
-   */
-  public static boolean isVisible(Label label, TransitiveInfoCollection prerequisite) {
-    // Check visibility attribute
-    for (PackageGroupContents specification :
-        prerequisite.getProvider(VisibilityProvider.class).getVisibility().toList()) {
-      if (specification.containsPackage(label.getPackageIdentifier())) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * Returns true if {@code rule} is visible from {@code prerequisite}.
-   *
-   * <p>This only computes the logic as implemented by the visibility system. The final decision
-   * whether a dependency is allowed is made by {@link PrerequisiteValidator}.
-   */
-  public static boolean isVisible(Rule rule, TransitiveInfoCollection prerequisite) {
-    return isVisible(rule.getLabel(), prerequisite);
-  }
-
-  /**
    * @return the set of features applicable for the current rule.
    */
   public ImmutableSet<String> getFeatures() {
@@ -1975,17 +1947,6 @@ public final class RuleContext extends TargetContext
 
     public BuildConfigurationValue getConfiguration() {
       return configuration;
-    }
-
-    /**
-     * @return true if {@code rule} is visible from {@code prerequisite}.
-     *     <p>This only computes the logic as implemented by the visibility system. The final
-     *     decision whether a dependency is allowed is made by {@link PrerequisiteValidator}, who is
-     *     supposed to call this method to determine whether a dependency is allowed as per
-     *     visibility rules.
-     */
-    public boolean isVisible(TransitiveInfoCollection prerequisite) {
-      return RuleContext.isVisible(target.getAssociatedRule(), prerequisite);
     }
 
     @Nullable


### PR DESCRIPTION
Fixes: []
Commit https://github.com/bazelbuild/bazel/commit/f4c9c88bae15b1586f13412c72160d057ad98971

PiperOrigin-RevId: 612579829
Change-Id: I429ca24931482cc94543692532ea4c08692020e3