### PR TITLE
[7.1.0] Disable some tests because of JDK21

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -47,6 +47,15 @@ tasks:
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:AllTests"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:antxmlresultwriter_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:junit4_testbridge_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:utf8_test_log_test"
+      # --
     include_json_profile:
       - build
       - test
@@ -95,7 +104,15 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
-      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:AllTests"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:antxmlresultwriter_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:junit4_testbridge_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:utf8_test_log_test"
+      # --
     include_json_profile:
       - build
       - test
@@ -154,6 +171,15 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:AllTests"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:antxmlresultwriter_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:junit4_testbridge_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:utf8_test_log_test"
+      # --
     include_json_profile:
       - build
       - test
@@ -205,6 +231,15 @@ tasks:
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:AllTests"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:antxmlresultwriter_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:junit4_testbridge_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:utf8_test_log_test"
+      # --
     include_json_profile:
       - build
       - test
@@ -296,6 +331,8 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/remote:RemoteTests"
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      - "-//src/test/java/com/google/devtools/build/lib/bazel/repository/downloader:DownloaderTestSuite"
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,6 +48,15 @@ tasks:
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:AllTests"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:antxmlresultwriter_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:junit4_testbridge_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:utf8_test_log_test"
+      # --
     include_json_profile:
       - build
       - test
@@ -97,6 +106,15 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:AllTests"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:antxmlresultwriter_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:junit4_testbridge_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:utf8_test_log_test"
+      # --
     include_json_profile:
       - build
       - test
@@ -156,6 +174,15 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:AllTests"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:antxmlresultwriter_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:junit4_testbridge_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:utf8_test_log_test"
+      # --
     include_json_profile:
       - build
       - test
@@ -243,13 +270,20 @@ tasks:
       - "-//src/test/shell/bazel:bazel_java_test"
       - "-//src/test/py/bazel:bzlmod_query_test"
       # - "-//src/test/shell/bazel/android:desugarer_integration_test"
-      # - "-//src/test/shell/bazel/android:android_local_test_integration_test"
       # - "-//src/test/shell/bazel/android:desugarer_integration_test_with_head_android_tools"
       - "-//src/test/py/bazel:bazel_external_repository_test"
       # - "-//src/test/shell/bazel/android:resource_processing_integration_test"
       - "-//src/test/shell/bazel:bazel_coverage_java_jdk11_toolchain_released_test"
       # - "-//src/test/shell/bazel/android:aar_integration_test_with_head_android_tools"
-      # - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:AllTests"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:antxmlresultwriter_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:junit4_testbridge_integration_test"
+      - "-//src/java_tools/junitrunner/javatests/com/google/testing/junit/runner:utf8_test_log_test"
+      # --
       - "-//src/tools/singlejar:zip64_test"
       - "-//src/test/py/bazel:launcher_test"
       - "-//src/test/shell/integration:bazel_worker_test"
@@ -357,6 +391,8 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/remote:RemoteTests"
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      - "-//src/test/java/com/google/devtools/build/lib/bazel/repository/downloader:DownloaderTestSuite"
     include_json_profile:
       - build
       - test


### PR DESCRIPTION
Related: https://github.com/bazelbuild/bazel/issues/21593
PiperOrigin-RevId: 613199006
Change-Id: Id2ff16950a666545437fa9d6044f7c798cbf6ad2