### PR TITLE
[7.1.0] Expose AndroidIdeInfo in android_common

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkCommon.java
@@ -23,8 +23,10 @@ import com.google.devtools.build.lib.packages.Info;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.rules.java.JavaCompilationArgsProvider;
 import com.google.devtools.build.lib.rules.java.JavaInfo;
+import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidIdeInfoProviderApi;
 import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidSplitTransitionApi;
 import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidStarlarkCommonApi;
+import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Sequence;
 
@@ -93,5 +95,10 @@ public class AndroidStarlarkCommon
         (SpecialArtifact) input,
         Sequence.cast(dexopts, String.class, "dexopts"),
         dexmerger);
+  }
+
+  @StarlarkMethod(name = AndroidIdeInfoProviderApi.NAME, structField = true, documented = false)
+  public AndroidIdeInfoProvider.Provider getAndroidIdeInfoProvider() {
+    return AndroidIdeInfoProvider.PROVIDER;
   }
 }


### PR DESCRIPTION
Previously https://github.com/bazelbuild/bazel/commit/916c3f5a649926f07a8390893539b560646a192e exposed the provider on top-level to support IntelliJ aspects. Exposing it over android_common, makes it possible to detect its presence in Starlark code via `getattr(android_common, "AndroidIdeInfo")`. With this detection it's easier to support older Bazel versions.

Without exposing it via android_common, detecting AndroidIdeInfo presence in Bazel world is only possible using a new dependency on @bazel_features in IntelliJ aspects.

Addresses: https://github.com/bazelbuild/bazel/issues/21544
PiperOrigin-RevId: 613580552
Change-Id: I214024facbdc9ac7742bf98575101bd624d4a6a7