### PR TITLE
Fix CommandLine class initialization deadlock.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/CommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CommandLine.java
@@ -25,11 +25,13 @@ import javax.annotation.Nullable;
 /** A representation of a list of arguments. */
 public abstract class CommandLine {
 
-  public static final CommandLine EMPTY = new EmptyCommandLine();
+  public static CommandLine empty() {
+    return EmptyCommandLine.INSTANCE;
+  }
 
   /** Returns a {@link CommandLine} backed by the given list of arguments. */
   public static CommandLine of(ImmutableList<String> arguments) {
-    return arguments.isEmpty() ? CommandLine.EMPTY : new SimpleCommandLine(arguments);
+    return arguments.isEmpty() ? empty() : new SimpleCommandLine(arguments);
   }
 
   /**
@@ -40,7 +42,7 @@ public abstract class CommandLine {
     if (args.isEmpty()) {
       return commandLine;
     }
-    if (commandLine == EMPTY) {
+    if (commandLine == EmptyCommandLine.INSTANCE) {
       return CommandLine.of(args);
     }
     return new SuffixedCommandLine(args, commandLine);
@@ -126,6 +128,8 @@ public abstract class CommandLine {
       throws CommandLineExpansionException, InterruptedException;
 
   private static final class EmptyCommandLine extends AbstractCommandLine {
+    private static final EmptyCommandLine INSTANCE = new EmptyCommandLine();
+
     @Override
     public ImmutableList<String> arguments() {
       return ImmutableList.of();

--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
@@ -526,10 +526,10 @@ public final class RunfilesSupport {
     if (!ruleContext.getRule().isAttrDefined("args", Type.STRING_LIST)) {
       // Some non-_binary rules create RunfilesSupport instances; it is fine to not have an args
       // attribute here.
-      return CommandLine.EMPTY;
+      return CommandLine.empty();
     }
     ImmutableList<String> args = ruleContext.getExpander().withDataLocations().tokenized("args");
-    return args.isEmpty() ? CommandLine.EMPTY : CommandLine.of(args);
+    return args.isEmpty() ? CommandLine.empty() : CommandLine.of(args);
   }
 
   private static ActionEnvironment computeActionEnvironment(RuleContext ruleContext)

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -756,7 +756,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
 
     CommandLine build(boolean flagPerLine) {
       if (arguments.isEmpty()) {
-        return CommandLine.EMPTY;
+        return CommandLine.empty();
       }
       Object[] args = arguments.toArray();
       return flagPerLine


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/21566#issuecomment-1983242695 shows a deadlock when initializing static variable `CommandLine.EMPTY` and another thread is initializing `CommandLine`'s subclass `AbstractCommandLine` because `CommandLine.EMPTY` is an instance of `AbstractCommandLine`.

Fixes https://github.com/bazelbuild/bazel/issues/21566.