### PR TITLE
[C++] Allow controlling PDB file generation on Windows using no_pdb_file feature

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
@@ -322,6 +322,13 @@ public class CppRuleClasses {
   public static final String GENERATE_PDB_FILE = "generate_pdb_file";
 
   /**
+   * A string constant used to disable PDB file generation. This is needed since generate_pdb_file
+   * is implied when building under fastbuild or dbg modes, making it impossible to disable it
+   * directly.
+   */
+  public static final String NO_PDB_FILE = "no_pdb_file";
+
+  /**
    * A string constant for a feature that automatically exporting symbols on Windows. Bazel
    * generates a DEF file for object files of a cc_library, then use it at linking time. This
    * feature should only be used for toolchains targeting Windows, and the toolchain should support

--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -713,7 +713,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
     # On Windows, if GENERATE_PDB_FILE feature is enabled
     # then a pdb file will be built along with the executable.
     pdb_file = None
-    if cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "generate_pdb_file"):
+    if cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "generate_pdb_file") and not cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "no_pdb_file"):
         pdb_file = ctx.actions.declare_file(_strip_extension(binary) + ".pdb", sibling = binary)
 
     extra_link_time_libraries = deps_cc_linking_context.extra_link_time_libraries()

--- a/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
@@ -684,7 +684,7 @@ def _cc_shared_library_impl(ctx):
         main_output = ctx.actions.declare_file(ctx.attr.shared_lib_name)
 
     pdb_file = None
-    if cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "generate_pdb_file"):
+    if cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "generate_pdb_file") and not cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "no_pdb_file"):
         if ctx.attr.shared_lib_name:
             pdb_file = ctx.actions.declare_file(paths.replace_extension(ctx.attr.shared_lib_name, ".pdb"))
         else:

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/cc_toolchain_config.bzl
@@ -33,6 +33,7 @@ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
 _FEATURE_NAMES = struct(
     generate_pdb_file = "generate_pdb_file",
+    no_pdb_file = "no_pdb_file",
     no_legacy_features = "no_legacy_features",
     do_not_split_linking_cmdline = "do_not_split_linking_cmdline",
     supports_dynamic_linker = "supports_dynamic_linker",
@@ -814,6 +815,10 @@ _generate_pdb_file_feature = feature(
     name = _FEATURE_NAMES.generate_pdb_file,
 )
 
+_no_pdb_file_feature = feature(
+    name = _FEATURE_NAMES.no_pdb_file,
+)
+
 _supports_start_end_lib_feature = feature(
     name = _FEATURE_NAMES.supports_start_end_lib,
     enabled = True,
@@ -1388,6 +1393,7 @@ _feature_name_to_feature = {
     _FEATURE_NAMES.optional_cc_flags_feature: _optional_cc_flags_feature,
     _FEATURE_NAMES.cpp_compile_with_requirements: _cpp_compile_with_requirements,
     _FEATURE_NAMES.generate_pdb_file: _generate_pdb_file_feature,
+    _FEATURE_NAMES.no_pdb_file: _no_pdb_file_feature,
     "header_modules_feature_configuration": _header_modules_feature_configuration,
     "env_var_feature_configuration": _env_var_feature_configuration,
     "host_and_nonhost_configuration": _host_and_nonhost_configuration,

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -126,6 +126,15 @@ function test_cpp() {
   assert_build -c opt ${cpp_pkg}:hello-world --output_groups=pdb_file
   test -f ./bazel-bin/${cpp_pkg}/hello-world.pdb \
     && fail "PDB file should not be generated in OPT mode"
+  # Check that no_pdb_file/generate_pdb_file can be used to control PDB file
+  # behavior.
+  assert_build_output ./bazel-bin/${cpp_pkg}/hello-world.pdb -c opt \
+    --features=generate_pdb_file ${cpp_pkg}:hello-world \
+    --output_groups=pdb_file
+  assert_build --features=no_pdb_file ${cpp_pkg}:hello-world \
+    --output_groups=pdb_file
+  test -f ./bazel-bin/${cpp_pkg}/hello-world.pdb \
+    && fail "PDB file should not be generated under no_pdb_file"
   assert_build ${cpp_pkg}:hello-world
   ./bazel-bin/${cpp_pkg}/hello-world foo >& $TEST_log \
     || fail "./bazel-bin/${cpp_pkg}/hello-world foo execution failed"


### PR DESCRIPTION
See #21615 for a description of the underlying problem. So far we cannot disable PDB file creation in the fastbuild and dbg configurations as described in the issue. At the same time, it is difficult to generate PDB files properly in the opt configuration; doing so would require manually enabling debug information, passing the debug flag to the linker and enabling the feature.

This resolves the issue by moving the flags used to generate debug information at compile time and generate the PDB file at link time to the `generate_pdb_file` feature, and adds a `no_pdb_file` feature to disable PDB file generation. The behavior is unchanged when no additional features are being passed, but adding `no_pdb_file` in fastbuild/dbg or `generate_pdb_file` in opt can be used to easily control PDB file generation.

This is based on the assumption that bazel does not enable features that do not have their requirements met, even if other features imply them as stated in [FeatureSelection.java](https://github.com/bazelbuild/bazel/blob/42611f9/src/main/java/com/google/devtools/build/lib/rules/cpp/FeatureSelection.java#L40).

Note that I do not use Windows and therefore was unable to test this locally unfortunately. ~~It would be helpful if a reviewer could confirm that the behavior has not changed if no feature flags are enabled, that for fastbuild and dbg --features=no_pdb_file disables debug info generation and PDB file creation and that for release --features=generate_pdb_file enables those instead.~~ Addressed by adding some test cases

Closes #21615

RELNOTES: Allow disabling PDB file generation using the `no_pdb_file` feature in the Windows C++ toolchain.