### PR TITLE
Apply repo mapping to `cc_shared_library`'s `exports_filter`

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -19,7 +19,7 @@ load(":common/cc/cc_common.bzl", "cc_common")
 load(":common/cc/cc_debug_helper.bzl", "create_debug_packager_actions")
 load(":common/cc/cc_helper.bzl", "cc_helper", "linker_mode")
 load(":common/cc/cc_info.bzl", "CcInfo")
-load(":common/cc/cc_shared_library.bzl", "GraphNodeInfo", "add_unused_dynamic_deps", "build_exports_map_from_only_dynamic_deps", "build_link_once_static_libs_map", "cc_shared_library_initializer", "merge_cc_shared_library_infos", "separate_static_and_dynamic_link_libraries", "sort_linker_inputs", "throw_linked_but_not_exported_errors")
+load(":common/cc/cc_shared_library.bzl", "GraphNodeInfo", "add_unused_dynamic_deps", "build_exports_map_from_only_dynamic_deps", "build_link_once_static_libs_map", "dynamic_deps_initializer", "merge_cc_shared_library_infos", "separate_static_and_dynamic_link_libraries", "sort_linker_inputs", "throw_linked_but_not_exported_errors")
 load(":common/cc/semantics.bzl", "semantics")
 
 DebugPackageInfo = _builtins.toplevel.DebugPackageInfo
@@ -791,7 +791,7 @@ def _impl(ctx):
 
 cc_binary = rule(
     implementation = _impl,
-    initializer = cc_shared_library_initializer,
+    initializer = dynamic_deps_initializer,
     doc = """
 <p>It produces an executable binary.</p>
 

--- a/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
@@ -843,8 +843,31 @@ graph_structure_aspect = aspect(
     implementation = _graph_structure_aspect_impl,
 )
 
+def _cc_shared_library_initializer(**kwargs):
+    """Converts labels in exports_filter into canonical form relative to the current repository.
+
+    This conversion can only be done in a macro as it requires access to the repository mapping of
+    the repository containing the cc_shared_library target. This mapping is automatically
+    applied to label attributes, but exports_filter is a list of strings attribute.
+    """
+    if "exports_filter" not in kwargs:
+        return kwargs
+
+    raw_exports_filter = kwargs["exports_filter"]
+    if type(raw_exports_filter) != type([]):
+        # TODO: Also canonicalize labels in selects once macros can operate on them.
+        # https://github.com/bazelbuild/bazel/issues/14157
+        return kwargs
+
+    canonical_exports_filter = [
+        str(_builtins.native.package_relative_label(s))
+        for s in raw_exports_filter
+    ]
+    return kwargs | {"exports_filter": canonical_exports_filter}
+
 cc_shared_library = rule(
     implementation = _cc_shared_library_impl,
+    initializer = _cc_shared_library_initializer,
     doc = """
 <p>It produces a shared library.</p>
 
@@ -1073,7 +1096,7 @@ following:
     fragments = ["cpp"] + semantics.additional_fragments(),
 )
 
-def cc_shared_library_initializer(**kwargs):
+def dynamic_deps_initializer(**kwargs):
     """Initializes dynamic_deps_attrs"""
     if "dynamic_deps" in kwargs and cc_helper.is_non_empty_list_or_select(kwargs["dynamic_deps"], "dynamic_deps"):
         # Propagate an aspect if dynamic_deps attribute is specified.

--- a/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl
@@ -17,7 +17,7 @@
 load(":common/cc/attrs.bzl", "cc_binary_attrs", "linkstatic_doc", "stamp_doc")
 load(":common/cc/cc_binary.bzl", "cc_binary_impl")
 load(":common/cc/cc_helper.bzl", "cc_helper")
-load(":common/cc/cc_shared_library.bzl", "cc_shared_library_initializer")
+load(":common/cc/cc_shared_library.bzl", "dynamic_deps_initializer")
 load(":common/cc/semantics.bzl", "semantics")
 load(":common/paths.bzl", "paths")
 
@@ -113,7 +113,7 @@ def cc_test_initializer(**kwargs):
     if "linkstatic" not in kwargs:
         kwargs["linkstatic"] = semantics.get_linkstatic_default_for_test()
 
-    return cc_shared_library_initializer(**kwargs)
+    return dynamic_deps_initializer(**kwargs)
 
 cc_test = rule(
     initializer = cc_test_initializer,

--- a/src/main/starlark/tests/builtins_bzl/BUILD
+++ b/src/main/starlark/tests/builtins_bzl/BUILD
@@ -26,6 +26,9 @@ sh_test(
         "@rules_testing//lib:truth_bzl",
         "@rules_testing//lib:util_bzl",
     ],
+    tags = [
+        "requires-network", # for Bzlmod
+    ],
 )
 
 sh_library(

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
@@ -286,7 +286,7 @@ cc_shared_library(
         "bar",
         "bar2",
     ] + select({
-        ":is_bazel": ["@test_repo//:bar"],
+        ":is_bazel": ["@my_test_repo//:bar"],
         "//conditions:default": [],
     }),
 )
@@ -296,7 +296,7 @@ cc_library(
     srcs = ["barX.cc"],
     hdrs = ["barX.h"],
     deps = select({
-        ":is_bazel": ["@test_repo//:bar"],
+        ":is_bazel": ["@my_test_repo//:bar"],
         "//conditions:default": [],
     }),
 )
@@ -473,6 +473,21 @@ cc_library(
     hdrs = [":hdr_only_hdr"],
 )
 
+cc_library(
+    name = "external_export",
+    deps = ["@my_test_repo//:bar"],
+)
+
+cc_shared_library(
+    name = "external_export_so",
+    exports_filter = [
+        "@my_test_repo//:__pkg__",
+    ],
+    deps = [
+        ":external_export",
+    ],
+)
+
 build_failure_test(
     name = "two_dynamic_deps_same_export_in_so_test",
     message = "Two shared libraries in dependencies export the same symbols",
@@ -533,6 +548,15 @@ exports_test(
        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library:nocode_cc_lib",
        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library:should_not_be_linked_cc_lib",
        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library:a_suffix",
+    ],
+)
+
+exports_test(
+    name = "external_export_exports_test",
+    target = "external_export_so",
+    targets_that_should_be_claimed_to_be_exported = [
+        "@@test_repo~//:bar",
+        "//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library:external_export",
     ],
 )
 

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/starlark_tests.bzl
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/starlark_tests.bzl
@@ -353,9 +353,9 @@ nocode_cc_lib = rule(
 def _exports_test_impl(env, target):
     actual = list(target[CcSharedLibraryInfo].exports)
 
-    # Remove the @@ prefix on Bazel
+    # Remove the @@ prefix for main repo labels on Bazel
     for i in range(len(actual)):
-        if actual[i].startswith("@@"):
+        if actual[i].startswith("@@//"):
             actual[i] = actual[i][2:]
     expected = env.ctx.attr._targets_that_should_be_claimed_to_be_exported
     env.expect.where(

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library2/MODULE.bazel
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library2/MODULE.bazel
@@ -1,0 +1,1 @@
+module(name = "test_repo")

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library2/WORKSPACE
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library2/WORKSPACE
@@ -1,1 +1,0 @@
-workspace(name = "test_repo")

--- a/src/main/starlark/tests/builtins_bzl/cc_builtin_tests.sh
+++ b/src/main/starlark/tests/builtins_bzl/cc_builtin_tests.sh
@@ -56,9 +56,10 @@ function test_starlark_cc() {
   mkdir -p "src/conditions"
   cp "$(rlocation "io_bazel/src/conditions/BUILD")" "src/conditions/BUILD"
 
-  cat >> WORKSPACE<<EOF
-local_repository(
-    name = "test_repo",
+  cat >> MODULE.bazel<<EOF
+bazel_dep(name = "test_repo", repo_name = "my_test_repo")
+local_path_override(
+    module_name = "test_repo",
     path = "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library2",
 )
 EOF


### PR DESCRIPTION
This is required for `exports_filter` to match any external repositories with Bzlmod enabled.

`native.package_relative_label` is used to convert the user-specified filter strings, which are always valid labels, to canonical label literals that are then passed to the actual `cc_shared_library` rule.

Fixes #21872 