### PR TITLE
Create remoteOutputService within beforeCommand method

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -49,6 +49,7 @@ final class RemoteActionContextProvider {
   private RemoteExecutionService remoteExecutionService;
   @Nullable private RemoteActionInputFetcher actionInputFetcher;
   @Nullable private final RemoteOutputChecker remoteOutputChecker;
+  @Nullable private final RemoteOutputService remoteOutputService;
 
   private RemoteActionContextProvider(
       Executor executor,
@@ -58,7 +59,8 @@ final class RemoteActionContextProvider {
       @Nullable ListeningScheduledExecutorService retryScheduler,
       DigestUtil digestUtil,
       @Nullable Path logDir,
-      @Nullable RemoteOutputChecker remoteOutputChecker) {
+      @Nullable RemoteOutputChecker remoteOutputChecker,
+      @Nullable RemoteOutputService remoteOutputService) {
     this.executor = executor;
     this.env = Preconditions.checkNotNull(env, "env");
     this.remoteCache = remoteCache;
@@ -67,6 +69,7 @@ final class RemoteActionContextProvider {
     this.digestUtil = digestUtil;
     this.logDir = logDir;
     this.remoteOutputChecker = remoteOutputChecker;
+    this.remoteOutputService = remoteOutputService;
   }
 
   public static RemoteActionContextProvider createForPlaceholder(
@@ -81,7 +84,8 @@ final class RemoteActionContextProvider {
         retryScheduler,
         digestUtil,
         /* logDir= */ null,
-        /* remoteOutputChecker= */ null);
+        /* remoteOutputChecker= */ null,
+        /* remoteOutputService= */ null);
   }
 
   public static RemoteActionContextProvider createForRemoteCaching(
@@ -90,7 +94,8 @@ final class RemoteActionContextProvider {
       RemoteCache remoteCache,
       ListeningScheduledExecutorService retryScheduler,
       DigestUtil digestUtil,
-      @Nullable RemoteOutputChecker remoteOutputChecker) {
+      @Nullable RemoteOutputChecker remoteOutputChecker,
+      RemoteOutputService remoteOutputService) {
     return new RemoteActionContextProvider(
         executor,
         env,
@@ -99,7 +104,8 @@ final class RemoteActionContextProvider {
         retryScheduler,
         digestUtil,
         /* logDir= */ null,
-        remoteOutputChecker);
+        remoteOutputChecker,
+        checkNotNull(remoteOutputService));
   }
 
   public static RemoteActionContextProvider createForRemoteExecution(
@@ -110,7 +116,8 @@ final class RemoteActionContextProvider {
       ListeningScheduledExecutorService retryScheduler,
       DigestUtil digestUtil,
       Path logDir,
-      @Nullable RemoteOutputChecker remoteOutputChecker) {
+      @Nullable RemoteOutputChecker remoteOutputChecker,
+      RemoteOutputService remoteOutputService) {
     return new RemoteActionContextProvider(
         executor,
         env,
@@ -119,7 +126,8 @@ final class RemoteActionContextProvider {
         retryScheduler,
         digestUtil,
         logDir,
-        remoteOutputChecker);
+        remoteOutputChecker,
+        checkNotNull(remoteOutputService));
   }
 
   private RemotePathResolver createRemotePathResolver() {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -245,7 +245,8 @@ public final class RemoteModule extends BlazeModule {
             remoteCache,
             /* retryScheduler= */ null,
             digestUtil,
-            remoteOutputChecker);
+            remoteOutputChecker,
+            remoteOutputService);
   }
 
   @Override
@@ -266,6 +267,7 @@ public final class RemoteModule extends BlazeModule {
     Preconditions.checkState(this.env == null, "env must be null");
     Preconditions.checkState(tempPathGenerator == null, "tempPathGenerator must be null");
     Preconditions.checkState(remoteOutputChecker == null, "remoteOutputChecker must be null");
+    Preconditions.checkState(remoteOutputService == null, "remoteOutputService must be null");
 
     RemoteOptions remoteOptions = env.getOptions().getOptions(RemoteOptions.class);
     if (remoteOptions == null) {
@@ -393,6 +395,8 @@ public final class RemoteModule extends BlazeModule {
       handleInitFailure(env, e, Code.CREDENTIALS_INIT_FAILURE);
       return;
     }
+
+    remoteOutputService = new RemoteOutputService(env);
 
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
       initHttpAndDiskCache(
@@ -572,7 +576,8 @@ public final class RemoteModule extends BlazeModule {
               retryScheduler,
               digestUtil,
               logDir,
-              remoteOutputChecker);
+              remoteOutputChecker,
+              remoteOutputService);
       repositoryRemoteExecutorFactoryDelegate.init(
           new RemoteRepositoryRemoteExecutorFactory(
               remoteCache,
@@ -602,7 +607,13 @@ public final class RemoteModule extends BlazeModule {
       RemoteCache remoteCache = new RemoteCache(cacheClient, remoteOptions, digestUtil);
       actionContextProvider =
           RemoteActionContextProvider.createForRemoteCaching(
-              executorService, env, remoteCache, retryScheduler, digestUtil, remoteOutputChecker);
+              executorService,
+              env,
+              remoteCache,
+              retryScheduler,
+              digestUtil,
+              remoteOutputChecker,
+              remoteOutputService);
     }
 
     buildEventArtifactUploaderFactoryDelegate.init(
@@ -960,6 +971,7 @@ public final class RemoteModule extends BlazeModule {
 
     if (actionContextProvider.getRemoteCache() != null) {
       Preconditions.checkNotNull(remoteOutputChecker, "remoteOutputChecker must not be null");
+      Preconditions.checkNotNull(remoteOutputService, "remoteOutputService must not be null");
 
       actionInputFetcher =
           new RemoteActionInputFetcher(
@@ -1003,10 +1015,6 @@ public final class RemoteModule extends BlazeModule {
 
   @Override
   public OutputService getOutputService() {
-    Preconditions.checkState(remoteOutputService == null, "remoteOutputService must be null");
-    if (actionContextProvider.getRemoteCache() != null) {
-      remoteOutputService = new RemoteOutputService(env);
-    }
     return remoteOutputService;
   }
 


### PR DESCRIPTION
so that other objects can acquire a reference to it.

This change doesn't change the condition when remoteOutputService is created, i.e. we create remoteOutputService whenever remoteCache is used.

Working towards #21630.