### PR TITLE
Generate error-prone patches

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
@@ -51,6 +51,7 @@ java_library(
     name = "errorprone",
     srcs = glob(["errorprone/*.java"]),
     javacopts = [
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",


### PR DESCRIPTION
The current error-prone integration doesn't generate patches: https://github.com/bazelbuild/bazel/issues/5729#issuecomment-1877875315

This PR enables error-prone patch generation and relies on making some existing error-prone members public: https://github.com/google/error-prone/pull/4318

Error-prone requires the caller to specify the location of the generated error-prone.patch files: https://errorprone.info/docs/patching, callers can handle this by for example dynamically generating a javacopts with a different -XepPatchLocation for each java target rule. Another option is to use the [IN_PLACE](https://github.com/google/error-prone/blob/master/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java#L451) option: `-XepPatchLocation:IN_PLACE`