### PR TITLE
Fix `bazel mod tidy` failure with no changes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
@@ -589,7 +589,7 @@ public final class ModCommand implements BlazeCommand {
     } catch (InterruptedException | CommandException e) {
       String suffix = "";
       if (e instanceof AbnormalTerminationException) {
-        if ((AbnormalTerminationException) e).getResult().getTerminationStatus().getRawExitCode() == 3) {
+        if (((AbnormalTerminationException) e).getResult().getTerminationStatus().getRawExitCode() == 3) {
           // Buildozer exits with exit code 3 if it didn't make any changes.
           return BlazeCommandResult.success();
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
@@ -589,6 +589,10 @@ public final class ModCommand implements BlazeCommand {
     } catch (InterruptedException | CommandException e) {
       String suffix = "";
       if (e instanceof AbnormalTerminationException) {
+        if ((AbnormalTerminationException) e).getResult().getTerminationStatus().getRawExitCode() == 3) {
+          // Buildozer exits with exit code 3 if it didn't make any changes.
+          return BlazeCommandResult.success();
+        }
         suffix =
             ":\n" + new String(((AbnormalTerminationException) e).getResult().getStderr(), UTF_8);
       }

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -739,6 +739,7 @@ class ModCommandTest(test_base.TestBase):
           [
               'ext = use_extension("//:extension.bzl", "ext")',
               'use_repo(ext, "dep")',
+              # This newline is from ScratchFile.
               '',
           ],
           module_file.read().split('\n'),
@@ -781,6 +782,7 @@ class ModCommandTest(test_base.TestBase):
           [
               'ext = use_extension("//:extension.bzl", "ext")',
               'use_repo(ext, "dep")',
+              # This newline is from ScratchFile.
               '',
           ],
           module_file.read().split('\n'),

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -743,6 +743,48 @@ class ModCommandTest(test_base.TestBase):
           ],
           module_file.read().split('\n'),
       )
+      
+  def testModTidyNoop(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'ext = use_extension("//:extension.bzl", "ext")',
+            'use_repo(ext, "dep")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def _repo_rule_impl(ctx):',
+            '    ctx.file("WORKSPACE")',
+            '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
+            '',
+            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            '',
+            'def _ext_impl(ctx):',
+            '    repo_rule(name="dep")',
+            '    return ctx.extension_metadata(',
+            '        root_module_direct_deps=["dep"],',
+            '        root_module_direct_dev_deps=[],',
+            '    )',
+            '',
+            'ext = module_extension(implementation=_ext_impl)',
+        ],
+    )
+
+    # Verify that bazel mod tidy doesn't fail or change the file.
+    self.RunBazel(['mod', 'tidy'])
+
+    with open('MODULE.bazel', 'r') as module_file:
+      self.assertEqual(
+          [
+              'ext = use_extension("//:extension.bzl", "ext")',
+              'use_repo(ext, "dep")',
+              '',
+          ],
+          module_file.read().split('\n'),
+      )
 
   def testModTidyFailsOnExtensionFailure(self):
     self.ScratchFile(


### PR DESCRIPTION
Buildozer has a non-zero exit code if it didn't make any changes.

Work towards #21651