### PR TITLE
[7.1.1] Fix `bazel mod tidy` failure with no changes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
@@ -589,6 +589,11 @@ public final class ModCommand implements BlazeCommand {
     } catch (InterruptedException | CommandException e) {
       String suffix = "";
       if (e instanceof AbnormalTerminationException) {
+        if (((AbnormalTerminationException) e).getResult().getTerminationStatus().getRawExitCode()
+            == 3) {
+          // Buildozer exits with exit code 3 if it didn't make any changes.
+          return BlazeCommandResult.success();
+        }
         suffix =
             ":\n" + new String(((AbnormalTerminationException) e).getResult().getStderr(), UTF_8);
       }


### PR DESCRIPTION
Buildozer has a non-zero exit code if it didn't make any changes.

Work towards #21651

Closes #21657.

Commit https://github.com/bazelbuild/bazel/commit/98f29db0ac47b4b3c75bccdcfda20ffd50521597

PiperOrigin-RevId: 615184752
Change-Id: Ib89928974e2cd014cec968193d35fd74e2d01261