### PR TITLE
[7.1.1] Let native Turbine image find `ct.sym` with non-hermetic `java_runtime`

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_toolchain.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_toolchain.bzl
@@ -81,6 +81,10 @@ def _java_toolchain_impl(ctx):
     if java_runtime and java_runtime.lib_ct_sym:
         header_compiler_direct_data = [java_runtime.lib_ct_sym]
         header_compiler_direct_jvm_opts = ["-Dturbine.ctSymPath=" + java_runtime.lib_ct_sym.path]
+    elif java_runtime and java_runtime.java_home:
+        # Turbine finds ct.sym relative to java.home.
+        header_compiler_direct_data = []
+        header_compiler_direct_jvm_opts = ["-Djava.home=" + java_runtime.java_home]
     else:
         header_compiler_direct_data = []
         header_compiler_direct_jvm_opts = []


### PR DESCRIPTION
Work towards #21604

Closes #21610.

Commit https://github.com/bazelbuild/bazel/commit/061ddebac2511f78dcd77fa5e76b72ffe6727949

PiperOrigin-RevId: 613912980
Change-Id: Ibc620120b783c990d08b84ea6cd8ae224333ed8a