### PR TITLE
[7.1.1] Actually use shouldPublish() to determine whether to publish the execution log to the BEP.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -181,7 +181,9 @@ public final class SpawnLogModule extends BlazeModule {
 
     try {
       spawnLogContext.close();
-      event.getResult().getBuildToolLogCollection().addLocalFile("execution.log", outputPath);
+      if (spawnLogContext.shouldPublish()) {
+        event.getResult().getBuildToolLogCollection().addLocalFile("execution.log", outputPath);
+      }
     } catch (IOException e) {
       abruptExit =
           new AbruptExitException(


### PR DESCRIPTION
This was the original intent in https://github.com/bazelbuild/bazel/commit/9eb3b0a340c620a8bbcfa930bf4711ec64686099.

PiperOrigin-RevId: 614986613
Change-Id: I356788d82a6d36a7a465a1bb828e4074aad11385