### PR TITLE
Local repo rules in Starlark

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -376,7 +376,18 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
           new IOException(rule + " must create a directory"), Transience.TRANSIENT);
     }
 
+    // Make sure the fetched repo has a boundary file.
     if (!WorkspaceFileHelper.isValidRepoRoot(outputDirectory)) {
+      if (outputDirectory.isSymbolicLink()) {
+        // The created repo is actually just a symlink to somewhere else (think local_repository).
+        // In this case, we shouldn't try to create the repo boundary file ourselves, but report an
+        // error instead.
+        throw new RepositoryFunctionException(
+            new IOException(
+                "No MODULE.bazel, REPO.bazel, or WORKSPACE file found in " + outputDirectory),
+            Transience.TRANSIENT);
+      }
+      // Otherwise, we can just create an empty REPO.bazel file.
       try {
         FileSystemUtils.createEmptyFile(outputDirectory.getRelative(LabelConstants.REPO_FILE_NAME));
         if (starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)) {

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/LocalRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/LocalRepositoryFunction.java
@@ -46,6 +46,8 @@ public class LocalRepositoryFunction extends RepositoryFunction {
       Map<RepoRecordedInput, String> recordedInputValues,
       SkyKey key)
       throws InterruptedException, RepositoryFunctionException {
+    // DO NOT MODIFY THIS! It's being deprecated in favor of Starlark counterparts.
+    // See https://github.com/bazelbuild/bazel/issues/18285
     String userDefinedPath = RepositoryFunction.getPathAttr(rule);
     Path targetPath = directories.getWorkspace().getRelative(userDefinedPath);
     RepositoryDirectoryValue.Builder result =

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/LocalRepositoryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/LocalRepositoryRule.java
@@ -31,6 +31,8 @@ public class LocalRepositoryRule implements RuleDefinition {
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment environment) {
+    // DO NOT MODIFY THIS! It's being deprecated in favor of Starlark counterparts.
+    // See https://github.com/bazelbuild/bazel/issues/18285
     return builder
         /* <!-- #BLAZE_RULE(local_repository).ATTRIBUTE(path) -->
         The path to the local repository's directory.

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
@@ -62,6 +62,8 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
       Map<RepoRecordedInput, String> recordedInputValues,
       SkyKey key)
       throws InterruptedException, RepositoryFunctionException {
+    // DO NOT MODIFY THIS! It's being deprecated in favor of Starlark counterparts.
+    // See https://github.com/bazelbuild/bazel/issues/18285
 
     NewRepositoryFileHandler fileHandler = new NewRepositoryFileHandler(directories.getWorkspace());
     if (!fileHandler.prepareFile(rule, env)) {

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryRule.java
@@ -31,6 +31,8 @@ public class NewLocalRepositoryRule implements RuleDefinition {
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment environment) {
+    // DO NOT MODIFY THIS! It's being deprecated in favor of Starlark counterparts.
+    // See https://github.com/bazelbuild/bazel/issues/18285
     return builder
         /* <!-- #BLAZE_RULE(new_local_repository).ATTRIBUTE(path) -->
         A path on the local filesystem.

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -241,6 +241,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     """Regression test for https://github.com/bazelbuild/bazel/issues/7063."""
     rule_definition = [
         'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
+        'load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")',
         'new_local_repository(',
         '    name = "r",',
         '    path = "./repo",',
@@ -281,6 +282,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.ScratchFile('other_repo/pkg/ignore/file')
     work_dir = self.ScratchDir('my_repo')
     self.ScratchFile('my_repo/WORKSPACE', [
+        'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         "local_repository(name = 'other_repo', path='../other_repo')",
     ])
 
@@ -318,6 +320,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.ScratchFile('other_repo/pkg/ignore/file.txt')
     work_dir = self.ScratchDir('my_repo')
     self.ScratchFile('my_repo/WORKSPACE', [
+        'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         'local_repository(name = "other_repo", path="../other_repo")',
     ])
 
@@ -369,6 +372,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
 
     work_dir = self.ScratchDir('my_repo')
     self.ScratchFile('my_repo/WORKSPACE', [
+        'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         'local_repository(name = "other_repo", path="../other_repo")',
     ])
 
@@ -396,6 +400,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
 
     work_dir = self.ScratchDir('my_repo')
     self.ScratchFile('my_repo/WORKSPACE', [
+        'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         'local_repository(name = "other_repo", path="../other_repo")',
     ])
     # This should not exclude @other_repo//foo/bar
@@ -421,6 +426,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     ])
     self.ScratchFile('my_repo/foo/bar/file.txt')
     self.ScratchFile('my_repo/WORKSPACE', [
+        'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         'local_repository(name = "other_repo", path="../other_repo")',
     ])
 
@@ -439,6 +445,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
 
     work_dir = self.ScratchDir('my_repo')
     self.ScratchFile('my_repo/WORKSPACE', [
+        'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         'local_repository(name = "other_repo", path="../other_repo")',
     ])
     # This should not exclude @other_repo//foo/bar, because .bazelignore doesn't
@@ -471,6 +478,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
 
     work_dir = self.ScratchDir('my_repo')
     self.ScratchFile('my_repo/WORKSPACE', [
+        'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         'local_repository(name = "other_repo", path="../other_repo")',
         'local_repository(name = "third_repo", path="../third_repo")',
     ])

--- a/src/test/py/bazel/bazel_workspace_test.py
+++ b/src/test/py/bazel/bazel_workspace_test.py
@@ -15,6 +15,7 @@
 
 import os
 from absl.testing import absltest
+
 from src.test.py.bazel import test_base
 
 
@@ -58,7 +59,9 @@ class BazelWorkspaceTest(test_base.TestBase):
     # Test WORKSPACE.bazel takes priority over WORKSPACE
     self.ScratchFile("B/WORKSPACE")
     workspace_dot_bazel = self.ScratchFile(
-        "B/WORKSPACE.bazel", ["local_repository(name = 'A', path='../A')"])
+        "B/WORKSPACE.bazel", [
+            'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
+            "local_repository(name = 'A', path='../A')"])
     self.ScratchFile("B/bin.py")
     self.ScratchFile("B/BUILD", [
         "py_binary(",
@@ -79,7 +82,9 @@ class BazelWorkspaceTest(test_base.TestBase):
 
     # Test a WORKSPACE.bazel directory won't confuse Bazel
     self.ScratchFile("B/WORKSPACE",
-                     ["local_repository(name = 'A', path='../A')"])
+                     [
+                         'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
+                         "local_repository(name = 'A', path='../A')"])
     self.ScratchDir("B/WORKSPACE.bazel")
     self.RunBazel(args=["build", ":bin"], cwd=work_dir)
 

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -436,6 +436,7 @@ class BazelModuleTest(test_base.TestBase):
     self.ScratchFile(
         'WORKSPACE.bzlmod',
         [
+            'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
             'local_repository(name="foo", path="foo", repo_mapping={',
             '  "@bar":"@baz",',
             '  "@my_aaa":"@aaa",',
@@ -497,6 +498,7 @@ class BazelModuleTest(test_base.TestBase):
     self.ScratchFile(
         'WORKSPACE',
         [
+            'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
             'local_repository(name="hello", path="hello")',
             'load("@hello//:world.bzl", "message")',
             'print(message)',
@@ -562,7 +564,9 @@ class BazelModuleTest(test_base.TestBase):
         ],
     )
     self.ScratchFile(
-        'WORKSPACE.bzlmod', ['local_repository(name="quux",path="quux")']
+        'WORKSPACE.bzlmod', [
+            'load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
+            'local_repository(name="quux",path="quux")']
     )
     self.ScratchFile(
         'BUILD',

--- a/src/test/shell/bazel/check_external_files_test.sh
+++ b/src/test/shell/bazel/check_external_files_test.sh
@@ -104,6 +104,7 @@ setup_local() {
   mkdir main
   cd main
   cat >> "$(create_workspace_with_default_repos WORKSPACE)" <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name="local_rep",
   path="../local_rep",
@@ -205,7 +206,8 @@ test_no_fetch_then_fetch() {
     --noexperimental_check_output_files \
     --watchfs \
     @remote//:g >& "$TEST_log" && fail "Expected build to fail" || true
-  expect_log "no such package '@@bazel_tools//tools/build_defs/repo'"
+  expect_log "no such package"
+  expect_log "fetching repositories is disabled"
   bazel build \
     --fetch \
     --noexperimental_check_external_repository_files \

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -1113,6 +1113,7 @@ EOF
 
 function test_use_bind_as_repository() {
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<'EOF'
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'foobar', path = 'foo')
 bind(name = 'foo', actual = '@foobar//:test')
 EOF
@@ -1163,6 +1164,7 @@ function test_flip_flopping() {
   cd -
 
   cat > local_ws <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "repo",
     path = "$REPO_PATH",
@@ -2840,6 +2842,7 @@ function test_external_java_target_depends_on_external_resources() {
   mkdir -p $test_repo2
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'repo1', path='$test_repo1')
 local_repository(name = 'repo2', path='$test_repo2')
 EOF

--- a/src/test/shell/bazel/external_starlark_load_test.sh
+++ b/src/test/shell/bazel/external_starlark_load_test.sh
@@ -48,6 +48,7 @@ function run_external_starlark_load_test() {
   external_repo=${new_workspace_dir}
 
   cat > ${WORKSPACE_DIR}/WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = "external_repo", path = "${external_repo}")
 EOF
 
@@ -126,6 +127,7 @@ remote_rule = rule(
 EOF
 
   cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r",
     path = "$repo2",
@@ -158,6 +160,7 @@ function test_starlark_repository_nested_relative_label() {
 
   # local
   cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r1",
     path = "$repo1",

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -37,6 +37,7 @@ EOF
   touch $r/fg/file
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name="r", path="$r")
 bind(name="e", actual="@r//:fg")
 EOF
@@ -83,6 +84,7 @@ EOF
   cd ${WORKSPACE_DIR}
   mkdir -p {zoo,red}
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'pandas', path = '${repo2}')
 EOF
 
@@ -142,6 +144,7 @@ EOF
 
   cd ${WORKSPACE_DIR}
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'endangered', path = '$repo2')
 EOF
 
@@ -223,6 +226,7 @@ EOF
   if [ "$1" == "build_file" ] ; then
     touch BUILD
     cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = 'endangered',
     path = '$project_dir',
@@ -239,6 +243,7 @@ java_library(
 EOF
   else
     cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = 'endangered',
     path = '$project_dir',
@@ -333,6 +338,7 @@ cc_binary(
 )
 EOF
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "greet_ws",
     path = "$external_ws",
@@ -368,6 +374,7 @@ cc_library(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "clib_repo",
     path = "$clib",
@@ -403,19 +410,23 @@ function test_external_query() {
   mkdir -p $external_dir
   create_workspace_with_default_repos $external_dir/WORKSPACE
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "my_repo",
     path = "$external_dir",
 )
 EOF
-  bazel fetch //external:my_repo || fail "Fetch failed"
+  bazel fetch --repo=@@my_repo || fail "Fetch failed"
   bazel query 'deps(//external:my_repo)' >& $TEST_log || fail "query failed"
   expect_log "//external:my_repo"
 }
 
 function test_repository_package_query() {
   mkdir a b b/b
-  echo "local_repository(name='b', path='b')" > WORKSPACE
+  cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(name='b', path='b')
+EOF
   echo "sh_library(name='a', deps=['@b//b'])" > a/BUILD
   create_workspace_with_default_repos b/WORKSPACE
   echo "sh_library(name='b')" > b/b/BUILD
@@ -426,7 +437,10 @@ function test_repository_package_query() {
 
 function test_repository_buildfiles_package_query() {
   mkdir a b b/b b/c
-  echo "local_repository(name='b', path='b')" > WORKSPACE
+  cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(name='b', path='b')
+EOF
   echo "sh_library(name='a', deps=['@b//b'])" > a/BUILD
   touch b/WORKSPACE b/c/BUILD
   cat > b/b/BUILD <<EOF
@@ -446,10 +460,12 @@ function test_override_workspace_file() {
   local bar=$TEST_TMPDIR/bar
   mkdir -p "$bar"
   cat > "$bar/WORKSPACE" <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 workspace(name = "foo")
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "bar",
     path = "$bar",
@@ -464,6 +480,7 @@ EOF
 
 function test_missing_path_reported_as_user_defined_it() {
   cat >WORKSPACE <<eof
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository", "new_local_repository")
 local_repository(name = "foo1", path = "./missing")
 
 new_local_repository(name = "foo2", path = "./missing", build_file_content = "")
@@ -505,6 +522,7 @@ eof
 
 function test_path_looking_like_home_directory_is_reported_as_user_defined_it() {
   cat >WORKSPACE <<eof
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository", "new_local_repository")
 local_repository(name = "foo1", path = "~/missing")
 
 new_local_repository(name = "foo2", path = "~/missing", build_file_content = "")
@@ -555,6 +573,7 @@ function test_overlaid_build_file() {
   mkdir $mutant
   create_workspace_with_default_repos $mutant/WORKSPACE
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "mutant",
     path = "$mutant",
@@ -597,6 +616,7 @@ function test_external_deps_in_remote_repo() {
   mkdir -p $r
   create_workspace_with_default_repos $r/WORKSPACE
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 local_repository(
     name = "r",
     path = "$r",
@@ -657,6 +677,7 @@ genrule(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r",
     path = "$r",
@@ -684,6 +705,7 @@ EOF
   touch $r/b/{BUILD,b}
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r",
     path = "$r",
@@ -710,6 +732,7 @@ int main() { return 0; };
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r",
     path = "$r",
@@ -734,6 +757,7 @@ genrule(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name="r", path="$r")
 EOF
 
@@ -755,6 +779,7 @@ EOF
 exports_files(["a/b"])
 EOF
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "other",
     path = "$other_ws",
@@ -815,6 +840,7 @@ genrule(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r",
     path = "$r",
@@ -874,6 +900,7 @@ EOF
   touch $r/rfgf
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name="r", path="$r")
 EOF
 
@@ -914,6 +941,7 @@ def User():
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name="r", path="$r")
 EOF
 
@@ -936,6 +964,7 @@ exports_files(["g", "h"])
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name="r", path="$r")
 EOF
 
@@ -984,6 +1013,7 @@ genrule(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name='r', path='$r')
 EOF
 
@@ -1009,6 +1039,7 @@ int main() { return 0; };
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r/a",
     path = "$r/a",
@@ -1044,6 +1075,7 @@ int getNum();
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r",
     path = "$remote",
@@ -1079,6 +1111,7 @@ int b() { return 42; }
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name="r",
     path="$r",
@@ -1116,6 +1149,7 @@ genrule(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name="r",
     path="$r",
@@ -1137,6 +1171,7 @@ EOF
 function test_local_repository_path_does_not_exist() {
   rm -rf $TEST_TMPDIR/r
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r",
     path = "$TEST_TMPDIR/r",
@@ -1160,6 +1195,7 @@ genrule(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "r",
     path = "$TEST_TMPDIR/r",
@@ -1190,6 +1226,7 @@ genrule(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "r",
     path = "$TEST_TMPDIR/r",
@@ -1210,6 +1247,7 @@ function test_new_local_repository_path_not_existing() {
   local r=$TEST_TMPDIR/r
   rm -rf $r
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "r",
     path = "$TEST_TMPDIR/r",
@@ -1231,6 +1269,7 @@ function test_new_local_repository_path_not_directory() {
   rm -rf $r
   touch $r
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "r",
     path = "$TEST_TMPDIR/r",
@@ -1256,6 +1295,7 @@ function test_new_local_repository_path_symlink_to_dir() {
   ln -s $s $r
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "r",
     path = "$TEST_TMPDIR/r",
@@ -1280,6 +1320,7 @@ function test_new_local_repository_path_symlink_to_file() {
   ln -s $s $r
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "r",
     path = "$TEST_TMPDIR/r",
@@ -1361,6 +1402,7 @@ java_library(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "x_repo",
     path = "$external_dir",
@@ -1413,6 +1455,7 @@ EOF
   cd ${WORKSPACE_DIR}
   mkdir -p green
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'blue', path = "${repo2}")
 EOF
   cat > green/BUILD <<EOF
@@ -1444,6 +1487,7 @@ EOF
   cd ${WORKSPACE_DIR}
   mkdir -p green
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'blue', path = "${repo2}")
 EOF
   cat > green/BUILD <<EOF

--- a/src/test/shell/bazel/new_local_repo_test.sh
+++ b/src/test/shell/bazel/new_local_repo_test.sh
@@ -62,25 +62,6 @@ if "$is_windows"; then
   export MSYS2_ARG_CONV_EXCL="*"
 fi
 
-function test_build_file_label_repo_mapping() {
-  mkdir subdir
-  cat > WORKSPACE <<'eof'
-workspace(name='myws')
-# add a `load` to force a new workspace chunk, adding "myws" to the mapping
-load('@bazel_tools//tools/build_defs/repo:http.bzl', 'http_archive')
-new_local_repository(
-  name = "heh",
-  path = "subdir",
-  build_file = "@myws//:thing",
-)
-eof
-  touch BUILD
-  echo 'filegroup(name="a-ma-bob")' > thing
-  write_default_lockfile MODULE.bazel.lock
-
-  bazel build @heh//:a-ma-bob &> $TEST_log || fail "don't fail!"
-}
-
 # Regression test for GitHub issue #6351, see
 # https://github.com/bazelbuild/bazel/issues/6351#issuecomment-465488344
 function test_glob_in_synthesized_build_file() {
@@ -90,6 +71,7 @@ function test_glob_in_synthesized_build_file() {
   mkdir $pkg/B || fail "mkdir $pkg/B"
 
   cat >$pkg/A/WORKSPACE <<'eof'
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "B",
     build_file_content = """
@@ -143,6 +125,7 @@ function test_recursive_glob_in_new_local_repository() {
   touch "$pkg/B/subdir/outer.txt"
   touch "$pkg/B/subdir/inner/inner.txt"
   cat >"$pkg/A/WORKSPACE" <<eof
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "myext",
     path = "../B",

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Test the local_repository binding
-#
 
 # --- begin runfiles.bash initialization ---
 # Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
@@ -100,41 +98,29 @@ EOF
 
   # Our macro
   cat >test.bzl <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 def macro(path):
   print('bleh')
-  native.local_repository(name='endangered', path=path)
-  native.bind(name='mongoose', actual='@endangered//carnivore:mongoose')
+  local_repository(name='endangered', path=path)
 EOF
   mkdir -p zoo
   cat > zoo/BUILD <<'EOF'
 genrule(
-    name = "ball-pit1",
+    name = "ball-pit",
     srcs = ["@endangered//carnivore:mongoose"],
-    outs = ["ball-pit1.txt"],
-    cmd = "cat $< >$@",
-)
-
-genrule(
-    name = "ball-pit2",
-    srcs = ["//external:mongoose"],
-    outs = ["ball-pit2.txt"],
+    outs = ["ball-pit.txt"],
     cmd = "cat $< >$@",
 )
 EOF
 
-  bazel build //zoo:ball-pit1 >& $TEST_log || fail "Failed to build"
+  bazel build //zoo:ball-pit >& $TEST_log || fail "Failed to build"
   expect_log "bleh"
   expect_log "Tra-la!"  # Invalidation
-  cat bazel-bin/zoo/ball-pit1.txt >$TEST_log
+  cat bazel-bin/zoo/ball-pit.txt >$TEST_log
   expect_log "Tra-la!"
 
-  bazel build //zoo:ball-pit1 >& $TEST_log || fail "Failed to build"
+  bazel build //zoo:ball-pit >& $TEST_log || fail "Failed to build"
   expect_not_log "Tra-la!"  # No invalidation
-
-  bazel build //zoo:ball-pit2 >& $TEST_log || fail "Failed to build"
-  expect_not_log "Tra-la!"  # No invalidation
-  cat bazel-bin/zoo/ball-pit2.txt >$TEST_log
-  expect_log "Tra-la!"
 
   # Test invalidation of the WORKSPACE file
   create_new_workspace
@@ -151,24 +137,19 @@ genrule(
 EOF
   cd ${WORKSPACE_DIR}
   cat >test.bzl <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 def macro(path):
   print('blah')
-  native.local_repository(name='endangered', path='$repo2')
-  native.bind(name='mongoose', actual='@endangered//carnivore:mongoose')
+  local_repository(name='endangered', path='$repo2')
 EOF
-  bazel build //zoo:ball-pit1 >& $TEST_log || fail "Failed to build"
+  bazel build //zoo:ball-pit >& $TEST_log || fail "Failed to build"
   expect_log "blah"
   expect_log "Tra-la-la!"  # Invalidation
-  cat bazel-bin/zoo/ball-pit1.txt >$TEST_log
+  cat bazel-bin/zoo/ball-pit.txt >$TEST_log
   expect_log "Tra-la-la!"
 
-  bazel build //zoo:ball-pit1 >& $TEST_log || fail "Failed to build"
+  bazel build //zoo:ball-pit >& $TEST_log || fail "Failed to build"
   expect_not_log "Tra-la-la!"  # No invalidation
-
-  bazel build //zoo:ball-pit2 >& $TEST_log || fail "Failed to build"
-  expect_not_log "Tra-la-la!"  # No invalidation
-  cat bazel-bin/zoo/ball-pit2.txt >$TEST_log
-  expect_log "Tra-la-la!"
 }
 
 function test_load_from_symlink_to_outside_of_workspace() {
@@ -211,9 +192,10 @@ EOF
   # Our macro
   cat >WORKSPACE
   cat >test.bzl <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 def macro(path):
   print('bleh')
-  native.local_repository(name='endangered', path=path)
+  local_repository(name='endangered', path=path)
 EOF
   cat >BUILD <<'EOF'
 exports_files(["test.bzl"])
@@ -221,6 +203,7 @@ EOF
 
   cd ${WORKSPACE_DIR}
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name='proxy', path='$repo3')
 load('@proxy//:test.bzl', 'macro')
 macro('$repo2')
@@ -254,6 +237,7 @@ EOF
 
   cd ${WORKSPACE_DIR}
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name='foo', path='$repo2')
 load("@foo//:ext.bzl", "macro")
 macro()
@@ -289,6 +273,7 @@ EOF
   cd ${WORKSPACE_DIR}
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
 load("@foo//:ext.bzl", "macro")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 macro()
 local_repository(name='foo', path='$repo2')
 EOF
@@ -359,7 +344,6 @@ EOF
 
   bazel build @foo//:bar >& $TEST_log || fail "Failed to build"
   expect_log "foo"
-  expect_not_log "Workspace name in .*/WORKSPACE (.*) does not match the name given in the repository's definition (@foo)"
   cat bazel-bin/external/foo/bar.txt >$TEST_log
   expect_log "foo"
 }
@@ -1389,9 +1373,10 @@ EOF
 
   # Our macro
   cat >test.bzl <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 def macro(path):
   print(native.bazel_version)
-  native.local_repository(name='test', path=path)
+  local_repository(name='test', path=path)
 EOF
 
   local version="$(bazel info release)"
@@ -1415,6 +1400,7 @@ function test_existing_rule() {
   cat > BUILD
 
   cat >> WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'existing', path='$repo2')
 load('//:test.bzl', 'macro')
 
@@ -2378,6 +2364,7 @@ function test_disable_download_should_allow_local_repository() {
   mkdir main
   cd main
   cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name="ext",
   path="../x",

--- a/src/test/shell/bazel/workspace_test.sh
+++ b/src/test/shell/bazel/workspace_test.sh
@@ -44,6 +44,7 @@ function test_workspace_changes() {
   setup_repo $repo_b bye
 
   cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "x",
     path = "$repo_a",
@@ -54,6 +55,7 @@ EOF
   assert_contains "hi" bazel-genfiles/external/x/out
 
   cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "x",
     path = "$repo_b",
@@ -92,6 +94,7 @@ function test_middleman_conflict() {
   create_workspace_with_default_repos $test_repo2/WORKSPACE
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = 'repo1', path='$test_repo1')
 local_repository(name = 'repo2', path='$test_repo2')
 EOF
@@ -125,6 +128,7 @@ EOF
 
 function test_no_select() {
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 new_local_repository(
     name = "foo",
     path = "/path/to/foo",
@@ -144,8 +148,9 @@ foo_repo()
 EOF
   touch BUILD
   cat > foo.bzl <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 def foo_repo():
-  native.new_local_repository(
+  new_local_repository(
       name = "foo",
       path = "/path/to/foo",
       build_file = select({
@@ -214,6 +219,7 @@ function test_workspace_name() {
   cat > foo/WORKSPACE <<EOF
 workspace(name = "foo")
 
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "bar",
     path = "$PWD/bar",
@@ -260,6 +266,7 @@ genrule(
 EOF
 
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "o",
     path = "original",
@@ -401,6 +408,7 @@ function test_package_loading_with_remapping_changes() {
   mkdir -p tree/oak
   cat > tree/WORKSPACE <<EOF
 workspace(name="tree")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "flower",
     path="../flower",
@@ -425,6 +433,7 @@ EOF
   # Change mapping in tree/WORKSPACE
   cat > WORKSPACE <<EOF
 workspace(name="tree")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "flower",
     path="../flower",
@@ -451,6 +460,7 @@ function test_repository_mapping_in_build_file_load() {
   cat > main/WORKSPACE <<EOF
 workspace(name = "main")
 
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = "a", path="../a", repo_mapping = {"@x" : "@y"})
 local_repository(name = "y", path="../y")
 EOF
@@ -488,6 +498,7 @@ function test_remapping_from_bzl_file_load() {
   cat > main/WORKSPACE <<EOF
 workspace(name = "main")
 
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = "a", path="../a", repo_mapping = {"@x" : "@y"})
 local_repository(name = "y", path="../y")
 EOF
@@ -547,6 +558,7 @@ EOF
   cat > main/WORKSPACE <<EOF
 workspace(name = "main")
 
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = "a", path="../a", repo_mapping = {"@x" : "@b"})
 local_repository(name = "b", path="../b")
 EOF
@@ -583,6 +595,7 @@ EOF
   cat > main/WORKSPACE <<EOF
 workspace(name = "main")
 
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = "a", path="../a", repo_mapping = {"@x" : "@b"})
 local_repository(name = "b", path="../b")
 EOF
@@ -629,6 +642,7 @@ http_archive(
   urls=["file://${EXTREPODIR}/a.zip"],
   repo_mapping = {"@x" : "@b"}
 )
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = "b", path="../b")
 EOF
   touch main/BUILD
@@ -660,6 +674,7 @@ EOF
   mkdir -p main
   cat >main/WORKSPACE <<EOF
 workspace(name = "main")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = "foo", path="../foo", repo_mapping = {"@a" : "@b"})
 local_repository(name = "b", path="../b")
 EOF
@@ -694,6 +709,7 @@ EOF
   mkdir -p main
   cat >main/WORKSPACE <<EOF
 workspace(name = "main")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(name = "foo", path="../foo", repo_mapping = {"@a" : "@b"})
 local_repository(name = "b", path="../b")
 EOF
@@ -801,6 +817,7 @@ function test_mainrepo_name_remapped_properly() {
   touch mainrepo/BUILD
   cat > mainrepo/WORKSPACE<<EOF
 workspace(name = "mainrepo")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name = "a",
   path = "../a"
@@ -826,6 +843,7 @@ EOF
   cd ..
   cat > mainrepo/WORKSPACE<<EOF
 workspace(name = "mainrepo")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name = "a",
   path = "../a",
@@ -848,15 +866,14 @@ function test_external_subpacakge() {
   touch local/BUILD
   mkdir main
   cd main
-  echo 'local_repository(name="local", path="../local")' > WORKSPACE
-  bazel build //external:local --build_event_json_file=bep.json \
-        > "${TEST_log}" 2>&1 \
-      || fail "Accessing a repo through the //extern package should not fail"
+  cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(name="local", path="../local")
+EOF
+  bazel build //external:local > "${TEST_log}" 2>&1 \
+      && fail "building a thing under //external shouldn't work"
   expect_not_log 'IllegalArgumentException'
-  grep '"id".*"targetCompleted".*"label".*"//external:local"' bep.json > completion.json \
-      || fail "expected completion of //external:local being reported"
-  grep '"success".*true' completion.json \
-      || fail "Success of //external:local expected"
+  expect_log "Found reference to a workspace rule in a context where a build rule was expected"
 }
 
 function test_external_rule() {
@@ -883,6 +900,7 @@ http_archive(
   strip_prefix="true",
 )
 
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name="extref",
   path="../extref",
@@ -1065,6 +1083,7 @@ EOF
     mkdir mainrepo
     cd mainrepo
     cat > WORKSPACE <<'EOF'
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name = "source",
   path = "../local_a",
@@ -1080,6 +1099,7 @@ EOF
 
    # Now, verify the same with for renamed to bar.
    cat > WORKSPACE <<'EOF'
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name = "source",
   path = "../local_a",
@@ -1096,6 +1116,7 @@ EOF
 
    # Finally, verify the same with a renaming in the other repository
    cat > WORKSPACE <<'EOF'
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name = "origin",
   path = "../local_a",
@@ -1126,6 +1147,7 @@ EOF
     cd mainrepo
    cat > WORKSPACE <<'EOF'
 workspace(name="foo")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name = "source",
   path = "../local_a",
@@ -1159,6 +1181,7 @@ EOF
     cd mainrepo
    cat > WORKSPACE <<'EOF'
 workspace(name="foo")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name = "source",
   path = "../local_a",
@@ -1198,25 +1221,6 @@ data(name="it")
 EOF
     echo; echo remapping main repo; echo
     bazel build @foo//:it || fail "Expected success"
-}
-
-function test_cannot_define_repo_named_builtins() {
-    # The name "@_builtins" is reserved for use by builtins injection.
-    # It should be disallowed as a user repo name anyway because it doesn't
-    # begin with a letter.
-    cat > WORKSPACE <<'EOF'
-local_repository(
-  name = "_builtins",
-  path = "subrepo",
-)
-EOF
-    mkdir -p subrepo
-    touch subrepo/WORKSPACE
-    touch BUILD
-
-    bazel build //:BUILD \
-        && fail "Expected to be unable to define a repo named @_builtins" \
-        || true
 }
 
 run_suite "workspace tests"

--- a/tools/build_defs/repo/BUILD
+++ b/tools/build_defs/repo/BUILD
@@ -42,6 +42,7 @@ genrule(
 REPO_BZL_FILES = [
     "git",
     "http",
+    "local",
     "utils",
 ]
 

--- a/tools/build_defs/repo/index.md
+++ b/tools/build_defs/repo/index.md
@@ -5,6 +5,7 @@ Book: /_book.yaml
 
 * [Rules related to git](git)
 * [Rules related to http](http)
+* [Rules related to local directories](local)
 
 # Generic functions for repository rule authors
 

--- a/tools/build_defs/repo/local.bzl
+++ b/tools/build_defs/repo/local.bzl
@@ -1,0 +1,133 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WARNING:
+# https://github.com/bazelbuild/bazel/issues/17713
+# .bzl files in this package (tools/build_defs/repo) are evaluated
+# in a Starlark environment without "@_builtins" injection, and must not refer
+# to symbols associated with build/workspace .bzl files
+
+"""Rules for making directories in the local filesystem available as repos.
+
+### Setup
+
+To use these rules in a module extension, load them in your .bzl file and then call them from your
+extension's implementation function. For example, to use `local_repository`:
+
+```python
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+
+def _my_extension_impl(mctx):
+  local_repository(name = "foo", path = "foo")
+
+my_extension = module_extension(implementation = _my_extension_impl)
+```
+
+Alternatively, you can directly call these repo rules in your MODULE.bazel file with
+`use_repo_rule`:
+
+```python
+local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(name = "foo", path = "foo")
+```
+"""
+
+# The default value for the string attr `build_file_content`. String attrs default to the empty
+# string by default, but we need another default because the empty string is perfectly valid build
+# file content and we need to know whether the attribute is actually set.
+_UNSET = "_UNSET"
+
+def _get_dir_path(rctx):
+    """Turns the string attr `path` into a path object, ensuring that it's a directory."""
+    path = rctx.workspace_root.get_child(rctx.attr.path)
+    if not path.is_dir:
+        fail(
+            ("The repository's path is \"%s\" (absolute: \"%s\") but it does not exist or is not " +
+             "a directory.") % (rctx.attr.path, path),
+        )
+    return path
+
+def _local_repository_impl(rctx):
+    rctx.symlink(_get_dir_path(rctx), ".")
+
+local_repository = repository_rule(
+    implementation = _local_repository_impl,
+    attrs = {
+        "path": attr.string(
+            doc =
+                "The path to the directory to make available as a repo. <p>The path can be " +
+                "either absolute, or relative to the workspace root.",
+            mandatory = True,
+        ),
+    },
+    doc =
+        "Makes a local directory that already contains Bazel files available as a repo. This " +
+        "directory should contain Bazel BUILD files and a repo boundary file already. If it " +
+        "doesn't contain these files, consider using <a " +
+        "href=\"#new_local_repository\"><code>new_local_repository</code></a> instead.",
+    local = True,
+)
+
+def _new_local_repository_impl(rctx):
+    if (rctx.attr.build_file == None) == (rctx.attr.build_file_content == _UNSET):
+        fail("exactly one of `build_file` and `build_file_content` must be specified")
+
+    children = _get_dir_path(rctx).readdir()
+    for child in children:
+        rctx.symlink(child, child.basename)
+
+        # On Windows, `rctx.symlink` actually does a copy for files (for directories, it uses
+        # junctions which basically behave like symlinks as far as we're concerned). So we need to
+        # watch the symlink target as well.
+        if rctx.os.name.startswith("windows") and not child.is_dir:
+            rctx.watch(child)
+
+    if rctx.attr.build_file != None:
+        rctx.symlink(rctx.attr.build_file, "BUILD.bazel")
+        if rctx.os.name.startswith("windows"):
+            rctx.watch(rctx.attr.build_file)  # same reason as above
+    else:
+        rctx.file("BUILD.bazel", rctx.attr.build_file_content)
+
+new_local_repository = repository_rule(
+    implementation = _new_local_repository_impl,
+    attrs = {
+        "path": attr.string(
+            doc =
+                "The path to the directory to make available as a repo. <p>The path can be " +
+                "either absolute, or relative to the workspace root.",
+            mandatory = True,
+        ),
+        "build_file": attr.label(
+            doc =
+                "A file to use as a BUILD file for this repo. <p>Exactly one of " +
+                "<code>build_file</code> and <code>build_file_content</code> must be specified. " +
+                "<p>The file addressed by this label does not need to be named BUILD, but can " +
+                "be. Something like <code>BUILD.new-repo-name</code> may work well to " +
+                "distinguish it from actual BUILD files.",
+        ),
+        "build_file_content": attr.string(
+            doc =
+                "The content of the BUILD file to be created for this repo. <p>Exactly one of " +
+                "<code>build_file</code> and <code>build_file_content</code> must be specified.",
+            default = _UNSET,
+        ),
+    },
+    doc =
+        "Makes a local directory that doesn't contain Bazel files available as a repo. This " +
+        "directory need not contain Bazel BUILD files or a repo boundary file; they will be " +
+        "created by this repo rule. If the directory already contains Bazel files, consider " +
+        "using <a href=\"#local_repository\"><code>local_repository</code></a> instead.",
+    local = True,
+)


### PR DESCRIPTION
Added `local_repository` and `new_local_repository` as Starlark repo rules under `@bazel_tools//tools/build_defs/repo:local.bzl`. They're drop-in replacements for their native counterparts.

Work towards https://github.com/bazelbuild/bazel/issues/18285.

RELNOTES: The `local_repository` and `new_local_repository` repository rules are now available as Starlark rules under `@bazel_tools//tools/build_defs/repo:local.bzl`. They are drop-in replacements for their native counterparts, and can be used in module extensions.