### PR TITLE
[7.1.1] Also inject a failure for createWritableDirectory when testing that ActionOutputDirectoryHelper propagates exceptions.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/actions/ActionOutputDirectoryHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionOutputDirectoryHelperTest.java
@@ -265,6 +265,14 @@ public class ActionOutputDirectoryHelperTest {
       }
 
       @Override
+      public boolean createWritableDirectory(PathFragment path) throws IOException {
+        if (path.equals(failingPath)) {
+          throw injectedException;
+        }
+        return super.createWritableDirectory(path);
+      }
+
+      @Override
       public void createDirectoryAndParents(PathFragment path) throws IOException {
         if (path.equals(failingPath)) {
           throw injectedException;


### PR DESCRIPTION
Failure to do causes a flaky test failure when simulating an IOException while the `knownDirectories` cache is disabled. The reason is that `ActionOutputDirectoryHelper#forceCreateDirectoryAndParents` calls either `createDirectory` or `createWritableDirectory`, depending on whether the parent directory is in the cache or not. However, "disabling" the cache sets its size to zero, which doesn't prevent insertion; rather, it causes inserted entries to be almost immediately deleted by a background thread. Thus, if only one of `createDirectory` and `createWritableDirectory` throws, the test outcome depends on how fast the background thread runs.

(We could make the zero-sized cache an actual no-op, but it's unlikely that anyone would want to set it to zero outside of test code, so it's not worth the trouble.)

Fixes https://github.com/bazelbuild/bazel/issues/21471.

Commit https://github.com/bazelbuild/bazel/commit/f9243382bb21485d5dce6a0c80f3bdcb225cb70a

PiperOrigin-RevId: 615513608
Change-Id: Id2247596c6af0e5d5142072de8309227a1d1cbd1