### PR TITLE
Fix two `bazel mod tidy` crashes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -132,7 +132,14 @@ public abstract class BazelLockFileValue implements SkyValue, Postable {
     newDepGraph.putAll(getModuleDepGraph());
     newDepGraph.put(
         ModuleKey.ROOT,
-        toModule(value.getModule(), /* override= */ null, /* remoteRepoSpec= */ null));
+        toModule(
+            value
+                .getModule()
+                .withDepSpecsTransformed(
+                    InterimModule.applyOverrides(
+                        value.getOverrides(), value.getModule().getName())),
+            /* override= */ null,
+            /* remoteRepoSpec= */ null));
     return toBuilder()
         .setModuleFileHash(value.getModuleFileHash())
         .setModuleDepGraph(newDepGraph.buildKeepingLast())

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModTidyFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModTidyFunction.java
@@ -21,6 +21,7 @@ import static com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction.IGNO
 import static com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction.MODULE_OVERRIDES;
 import static com.google.devtools.build.lib.skyframe.PrecomputedValue.STARLARK_SEMANTICS;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
@@ -81,7 +82,12 @@ public class BazelModTidyFunction implements SkyFunction {
     }
 
     ImmutableSet<SkyKey> extensionsUsedByRootModule =
-        depGraphValue.getExtensionUsagesTable().columnMap().get(ModuleKey.ROOT).keySet().stream()
+        depGraphValue
+            .getExtensionUsagesTable()
+            .columnMap()
+            .getOrDefault(ModuleKey.ROOT, ImmutableMap.of())
+            .keySet()
+            .stream()
             .map(SingleExtensionEvalValue::key)
             .collect(toImmutableSet());
     SkyframeLookupResult result = env.getValuesAndExceptions(extensionsUsedByRootModule);

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -846,7 +846,10 @@ class ModCommandTest(test_base.TestBase):
     with open('MODULE.bazel', 'r') as module_file:
       self.assertEqual(
         [
-          'module(name = "foo", version = "1.2.3")',
+          'module(',
+          '    name = "foo",',
+          '    version = "1.2.3",',
+          ')',
           # This newline is from ScratchFile.
           '',
         ],

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -788,6 +788,71 @@ class ModCommandTest(test_base.TestBase):
           module_file.read().split('\n'),
       )
 
+  def testModTidyWithNonRegistryOverride(self):
+    self.ScratchFile(
+      'MODULE.bazel',
+      [
+        'bazel_dep(name = "foo", version = "1.2.3")',
+        'local_path_override(module_name = "foo", path = "foo")',
+        'ext = use_extension("//:extension.bzl", "ext")',
+        'use_repo(ext, "dep")',
+      ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+      'extension.bzl',
+      [
+        'def _ext_impl(ctx):',
+        '    pass',
+        '',
+        'ext = module_extension(implementation=_ext_impl)',
+      ],
+    )
+    self.ScratchFile('foo/MODULE.bazel', ['module(name = "foo", version = "1.2.3")'])
+
+    # Verify that bazel mod tidy doesn't fail without the lockfile.
+    self.RunBazel(['mod', 'tidy'])
+
+    with open('MODULE.bazel', 'r') as module_file:
+      self.assertEqual(
+        [
+          'bazel_dep(name = "foo", version = "1.2.3")',
+          'local_path_override(',
+          '    module_name = "foo",',
+          '    path = "foo",',
+          ')',
+          '',
+          'ext = use_extension("//:extension.bzl", "ext")',
+          'use_repo(ext, "dep")',
+          # This newline is from ScratchFile.
+          '',
+        ],
+        module_file.read().split('\n'),
+      )
+
+    # Verify that bazel mod tidy doesn't fail with the lockfile.
+    self.RunBazel(['mod', 'tidy'])
+
+  def testModTidyWithoutUsages(self):
+    self.ScratchFile(
+      'MODULE.bazel',
+      [
+        'module(  name = "foo", version = "1.2.3")',
+      ],
+    )
+
+    self.RunBazel(['mod', 'tidy'])
+
+    with open('MODULE.bazel', 'r') as module_file:
+      self.assertEqual(
+        [
+          'module(name = "foo", version = "1.2.3")',
+          # This newline is from ScratchFile.
+          '',
+        ],
+        module_file.read().split('\n'),
+      )
+
   def testModTidyFailsOnExtensionFailure(self):
     self.ScratchFile(
         'MODULE.bazel',


### PR DESCRIPTION
* Fixes a crash when using a non-registry override with a specified version:

```
Caused by: java.lang.NullPointerException: null value in entry: foo=null
	at com.google.common.collect.CollectPreconditions.checkEntryNotNull(CollectPreconditions.java:33)
	at com.google.common.collect.ImmutableMapEntry.<init>(ImmutableMapEntry.java:54)
	at com.google.common.collect.ImmutableMap.entryOf(ImmutableMap.java:345)
	at com.google.common.collect.ImmutableMap$Builder.put(ImmutableMap.java:454)
	at com.google.devtools.build.lib.bazel.bzlmod.Module.getRepoMappingWithBazelDepsOnly(Module.java:67)
	at com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphFunction.getExtensionUsagesById(BazelDepGraphFunction.java:233)
	at com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphFunction.compute(BazelDepGraphFunction.java:126)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:464)
```

* Fixes a crash for root modules with no extension usages:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.keySet()" because the return value of "com.google.common.collect.ImmutableMap.get(Object)" is null
	at com.google.devtools.build.lib.bazel.bzlmod.BazelModTidyFunction.compute(BazelModTidyFunction.java:85)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:464)
```

Fixes #21651 