### PR TITLE
[7.1.1] Allow any canonical repo name to be used with `bazel mod show_repo`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArg.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArg.java
@@ -334,18 +334,7 @@ public interface ModuleArg {
         ImmutableMap<String, ImmutableSet<ModuleKey>> modulesIndex,
         ImmutableMap<ModuleKey, AugmentedModule> depGraph,
         ImmutableMap<ModuleKey, RepositoryName> moduleKeyToCanonicalNames,
-        RepositoryMapping mapping)
-        throws InvalidArgumentException {
-      if (depGraph.values().stream()
-          .filter(m -> moduleKeyToCanonicalNames.get(m.getKey()).equals(repoName()) && m.isUsed())
-          .findAny()
-          .isEmpty()) {
-        throw new InvalidArgumentException(
-            String.format(
-                "No module with the canonical repo name @@%s exists in the dependency graph",
-                repoName().getName()),
-            Code.INVALID_ARGUMENTS);
-      }
+        RepositoryMapping mapping) {
       return ImmutableMap.of(toString(), repoName());
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
@@ -94,6 +94,7 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
@@ -494,6 +495,14 @@ public final class ModCommand implements BlazeCommand {
                         e ->
                             (BzlmodRepoRuleValue)
                                 result.get(BzlmodRepoRuleValue.key(e.getValue()))));
+        for (Map.Entry<String, BzlmodRepoRuleValue> entry : targetRepoRuleValues.entrySet()) {
+          if (entry.getValue() == BzlmodRepoRuleValue.REPO_RULE_NOT_FOUND_VALUE) {
+            return reportAndCreateFailureResult(
+                env,
+                String.format("In repo argument %s: no such repo", entry.getKey()),
+                Code.INVALID_ARGUMENTS);
+          }
+        }
       }
     } catch (InterruptedException e) {
       String errorMessage = "mod command interrupted: " + e.getMessage();

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArgTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArgTest.java
@@ -303,10 +303,10 @@ public class ModuleArgTest {
                 baseModuleUnusedDeps,
                 /* includeUnused= */ true,
                 /* warnUnused= */ true));
-    assertThrows(
-        InvalidArgumentException.class,
-        () ->
-            arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping));
+    // The repo need not exist in the "repo -> repo" case.
+    assertThat(
+            arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping))
+        .containsExactly("@@bar~1.0", RepositoryName.create("bar~1.0"));
   }
 
   @Test
@@ -341,9 +341,8 @@ public class ModuleArgTest {
         .containsExactly(foo1);
 
     // resolving to repo names doesn't care about unused deps.
-    assertThrows(
-        InvalidArgumentException.class,
-        () ->
-            arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping));
+    assertThat(
+            arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping))
+        .containsExactly("@@foo~1.0", RepositoryName.create("foo~1.0"));
   }
 }

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -465,6 +465,18 @@ class ModCommandTest(test_base.TestBase):
         stderr,
     )
 
+  def testShowRepoThrowsNonexistentRepo(self):
+    _, _, stderr = self.RunBazel(
+        ['mod', 'show_repo', '@@lol'],
+        allow_failure=True,
+        rstrip=True,
+    )
+    self.assertIn(
+        "ERROR: In repo argument @@lol: no such repo. Type 'bazel help mod' "
+        'for syntax and help.',
+        stderr,
+    )
+
   def testDumpRepoMapping(self):
     _, stdout, _ = self.RunBazel(
         [


### PR DESCRIPTION
Previously we enforced that the canonical repo name had to correspond to a module (i.e. not an extension-generated repo). This makes no sense, so this change simple deletes that enforcement.

To compensate for the lack of checks whether the repo exists at all, we add an additional check after requesting the BzlmodRepoRuleValues that all requested repos must exist.

Fixes https://github.com/bazelbuild/bazel/issues/21621

Commit https://github.com/bazelbuild/bazel/commit/5c2b37e56e77e9c96b1e5a6c99d803e31e17a03c

PiperOrigin-RevId: 615733963
Change-Id: Icf706b36f0e8d3c775bc26528948e5102910d4a0