### PR TITLE
Declare support for `gcc_quoting_for_param_files` feature in Unix cc_toolchain

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -218,6 +218,11 @@ def _impl(ctx):
         enabled = True,
     )
 
+    gcc_quoting_for_param_files_feature = feature(
+        name = "gcc_quoting_for_param_files",
+        enabled = True,
+    )
+
     static_link_cpp_runtimes_feature = feature(
         name = "static_link_cpp_runtimes",
         enabled = False,
@@ -1399,6 +1404,7 @@ def _impl(ctx):
             asan_feature,
             tsan_feature,
             ubsan_feature,
+            gcc_quoting_for_param_files_feature,
             static_link_cpp_runtimes_feature,
         ] + (
             [
@@ -1439,6 +1445,7 @@ def _impl(ctx):
             asan_feature,
             tsan_feature,
             ubsan_feature,
+            gcc_quoting_for_param_files_feature,
             static_link_cpp_runtimes_feature,
         ] + (
             [


### PR DESCRIPTION
This was missed with a9e5a32b9c0de2ade15be67bd1b80c3ec8e6b472. Without this change, `gcc_quoting_for_param_files` does nothing, because `FeatureConfiguration.isEnabled()` will always return false. Without `gcc_quoting_for_param_files`, linking can fail for files with spaces in them.