### PR TITLE
[7.1.1] Disable //src/test/shell/bazel:srcs_test on Intel macOS

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -226,6 +226,8 @@ tasks:
       - "-//src/test/shell/bazel:bazel_determinism_test"
       # https://github.com/bazelbuild/bazel/issues/17457
       - "-//src/test/shell/bazel:jdeps_test"
+      # https://github.com/bazelbuild/bazel/issues/21495
+      - "-//src/test/shell/bazel:srcs_test"
       # Macs can't find python, so these fail: https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -230,6 +230,8 @@ tasks:
       - "-//src/test/shell/bazel:bazel_determinism_test"
       # https://github.com/bazelbuild/bazel/issues/17457
       - "-//src/test/shell/bazel:jdeps_test"
+      # https://github.com/bazelbuild/bazel/issues/21495
+      - "-//src/test/shell/bazel:srcs_test"
       # Macs can't find python, so these fail: https://github.com/bazelbuild/bazel/issues/18776
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"


### PR DESCRIPTION
This tests is very flaky in postsubmit on macOS Intel machines.

https://github.com/bazelbuild/bazel/issues/21495

Commit https://github.com/bazelbuild/bazel/commit/548bf4db56696557f2d1b732c56497e8098d3565

PiperOrigin-RevId: 610376373
Change-Id: Id215898317e8b1f1485e5dbaf72e9555307b83db