### PR TITLE
Fix links to Protobufs on GitHub on the BEP docs page

### DIFF
--- a/site/en/remote/bep.md
+++ b/site/en/remote/bep.md
@@ -24,15 +24,15 @@ a set of child event identifiers, and a payload.
 
 *  __Build Event Identifier:__ Depending on the kind of build event, it might be
 an [opaque
-string](https://github.com/bazelbuild/bazel/blob/16a107d/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L91){: .external}
+string](https://github.com/bazelbuild/bazel/blob/7.1.0/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L131-L140){: .external}
 or [structured
-information](https://github.com/bazelbuild/bazel/blob/16a107d/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L123){: .external}
+information](https://github.com/bazelbuild/bazel/blob/7.1.0/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L194-L205){: .external}
 revealing more about the build event. A build event identifier is unique within
 a build.
 
 *  __Children:__ A build event may announce other build events, by including
 their build event identifiers in its [children
-field](https://github.com/bazelbuild/bazel/blob/16a107d/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L469){: .external}.
+field](https://github.com/bazelbuild/bazel/blob/7.1.0/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L1276){: .external}.
 For example, the `PatternExpanded` build event announces the targets it expands
 to as children. The protocol guarantees that all events, except for the first
 event, are announced by a previous event.


### PR DESCRIPTION
A few links on [this page](https://bazel.build/remote/bep) are broken (the commit SHA for each is shortened, which apparently the GitHub UI doesn't accept). Since I was around, I thought it might have made sense to also update those pointers to a more recent version of the Protobufs in case someone uses it for reference.

The original pointers were supposed to go at the following locations

https://github.com/bazelbuild/bazel/blob/16a107dca10c49d2365886df4a06f50ce2e4aeb1/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L91
https://github.com/bazelbuild/bazel/blob/16a107dca10c49d2365886df4a06f50ce2e4aeb1/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L123
https://github.com/bazelbuild/bazel/blob/16a107dca10c49d2365886df4a06f50ce2e4aeb1/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L469