### PR TITLE
Make `RepositoryCache#put` resistant to concurrent file system operations

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
@@ -217,7 +217,13 @@ public class RepositoryCache {
     Path tmpName = cacheEntry.getRelative(TMP_PREFIX + UUID.randomUUID());
     cacheEntry.createDirectoryAndParents();
     FileSystemUtils.copyFile(sourcePath, tmpName);
-    tmpName.renameTo(cacheValue);
+    try {
+      tmpName.renameTo(cacheValue);
+    } catch (java.nio.file.AccessDeniedException e) {
+      if (!cacheValue.exists()) {
+        throw e;
+      }
+    }
 
     if (!Strings.isNullOrEmpty(canonicalId)) {
       String idHash = keyType.newHasher().putBytes(canonicalId.getBytes(UTF_8)).hash().toString();

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
@@ -22,6 +22,7 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
+import com.google.devtools.build.lib.vfs.FileAccessException;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
@@ -219,7 +220,13 @@ public class RepositoryCache {
     FileSystemUtils.copyFile(sourcePath, tmpName);
     try {
       tmpName.renameTo(cacheValue);
-    } catch (java.nio.file.AccessDeniedException e) {
+    } catch (FileAccessException e) {
+      // On Windows, atomically replacing a file that is currently opened (e.g. due to a concurrent
+      // get on the cache) results in renameTo throwing this exception, which wraps an
+      // AccessDeniedException. This case is benign since if the target path already exists, we know
+      // that another thread won the race to place the file in the cache. As the exception is rather
+      // generic and could result from other failure types, we rethrow the exception if the cache
+      // entry hasn't been created.
       if (!cacheValue.exists()) {
         throw e;
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
@@ -217,7 +217,7 @@ public class RepositoryCache {
     Path tmpName = cacheEntry.getRelative(TMP_PREFIX + UUID.randomUUID());
     cacheEntry.createDirectoryAndParents();
     FileSystemUtils.copyFile(sourcePath, tmpName);
-    FileSystemUtils.moveFile(tmpName, cacheValue);
+    tmpName.renameTo(cacheValue);
 
     if (!Strings.isNullOrEmpty(canonicalId)) {
       String idHash = keyType.newHasher().putBytes(canonicalId.getBytes(UTF_8)).hash().toString();

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -186,7 +186,6 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
           recordedInputValues.putAll(state.recordedInputValues);
           return result;
         } catch (ExecutionException e) {
-          e.printStackTrace();
           Throwables.throwIfInstanceOf(e.getCause(), RepositoryFunctionException.class);
           Throwables.throwIfUnchecked(e.getCause());
           throw new IllegalStateException(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -186,6 +186,7 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
           recordedInputValues.putAll(state.recordedInputValues);
           return result;
         } catch (ExecutionException e) {
+          e.printStackTrace();
           Throwables.throwIfInstanceOf(e.getCause(), RepositoryFunctionException.class);
           Throwables.throwIfUnchecked(e.getCause());
           throw new IllegalStateException(

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -773,6 +773,11 @@ public abstract class FileSystem {
   /**
    * Renames the file denoted by "sourceNode" to the location "targetNode". See {@link
    * Path#renameTo} for specification.
+   *
+   * <p>Implementations must be atomic.</p>
+   *
+   * @throws java.nio.file.AccessDeniedException if the target file cannot be replaced due to
+   *     concurrent file system operations on Windows (and possibly other reasons)
    */
   public abstract void renameTo(PathFragment sourcePath, PathFragment targetPath)
       throws IOException;

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -775,9 +775,6 @@ public abstract class FileSystem {
    * Path#renameTo} for specification.
    *
    * <p>Implementations must be atomic.</p>
-   *
-   * @throws java.nio.file.AccessDeniedException if the target file cannot be replaced due to
-   *     concurrent file system operations on Windows (and possibly other reasons)
    */
   public abstract void renameTo(PathFragment sourcePath, PathFragment targetPath)
       throws IOException;

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -429,6 +429,8 @@ public class FileSystemUtils {
    * "to". If "from" is a regular file, its last modified time, executable and writable bits are
    * also preserved. Symlinks are also supported but not directories or special files.
    *
+   * <p>This method is not guaranteed to be atomic. Use {@link Path#renameTo(Path)} instead.
+   *
    * <p>If the move fails (usually because the "from" and "to" live in different file systems), this
    * falls back to copying the file. Note that these two operations have very different performance
    * characteristics and is why this operation reports back to the caller what actually happened.

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -319,9 +319,7 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   public void renameTo(PathFragment sourcePath, PathFragment targetPath) throws IOException {
     java.nio.file.Path source = getNioPath(sourcePath);
     java.nio.file.Path target = getNioPath(targetPath);
-    try {
-    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
-    } catch (java.nio.file.FileAlreadyExistsException e) {}
+    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyAction.REPLACE_EXISTING);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -319,7 +319,9 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   public void renameTo(PathFragment sourcePath, PathFragment targetPath) throws IOException {
     java.nio.file.Path source = getNioPath(sourcePath);
     java.nio.file.Path target = getNioPath(targetPath);
-    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    try {
+    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+    } catch (java.nio.file.FileAlreadyExistsException e) {}
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -316,26 +317,9 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   public void renameTo(PathFragment sourcePath, PathFragment targetPath) throws IOException {
-    File sourceFile = getIoFile(sourcePath);
-    File targetFile = getIoFile(targetPath);
-    if (!sourceFile.renameTo(targetFile)) {
-      if (!sourceFile.exists()) {
-        throw new FileNotFoundException(sourcePath + ERR_NO_SUCH_FILE_OR_DIR);
-      }
-      if (targetFile.exists()) {
-        if (targetFile.isDirectory() && targetFile.list().length > 0) {
-          throw new IOException(targetPath + ERR_DIRECTORY_NOT_EMPTY);
-        } else if (sourceFile.isDirectory() && targetFile.isFile()) {
-          throw new IOException(sourcePath + " -> " + targetPath + ERR_NOT_A_DIRECTORY);
-        } else if (sourceFile.isFile() && targetFile.isDirectory()) {
-          throw new IOException(sourcePath + " -> " + targetPath + ERR_IS_DIRECTORY);
-        } else {
-          throw new IOException(sourcePath + " -> " + targetPath  + ERR_PERMISSION_DENIED);
-        }
-      } else {
-        throw new FileAccessException(sourcePath + " -> " + targetPath + ERR_PERMISSION_DENIED);
-      }
-    }
+    java.nio.file.Path source = getNioPath(sourcePath);
+    java.nio.file.Path target = getNioPath(targetPath);
+    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -322,6 +322,8 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   public void renameTo(PathFragment sourcePath, PathFragment targetPath) throws IOException {
     java.nio.file.Path source = getNioPath(sourcePath);
     java.nio.file.Path target = getNioPath(targetPath);
+    // Replace NIO exceptions with the types used by the native Unix filesystem implementation where
+    // necessary.
     try {
       Files.move(
           source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
@@ -336,6 +338,9 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
       newException.initCause(originalException);
       throw newException;
     } catch (FileSystemException originalException) {
+      // Rewrite exception messages to be identical to the ones produced by the native Unix
+      // filesystem implementation. Bazel forces the root locale for the JVM, so the error messages
+      // can be expected to be stable.
       if (originalException.getMessage().endsWith(": Directory not empty")) {
         String originalMessage = originalException.getMessage();
         throw new IOException(

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -319,7 +319,7 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   public void renameTo(PathFragment sourcePath, PathFragment targetPath) throws IOException {
     java.nio.file.Path source = getNioPath(sourcePath);
     java.nio.file.Path target = getNioPath(targetPath);
-    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyAction.REPLACE_EXISTING);
+    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -533,12 +533,14 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   }
 
   /**
-   * Renames the file denoted by the current path to the location "target", not following symbolic
-   * links.
+   * Atomically renames the file denoted by the current path to the location "target", not following
+   * symbolic links.
    *
    * <p>Files cannot be atomically renamed across devices; copying is required. Use {@link
-   * FileSystemUtils#copyFile} followed by {@link Path#delete}.
+   * FileSystemUtils#moveFile(Path, Path)} instead.
    *
+   * @throws java.nio.file.AccessDeniedException if the target file cannot be replaced due to
+   *     concurrent file system operations on Windows (and possibly other reasons)
    * @throws IOException if the rename failed for any reason
    */
   public void renameTo(Path target) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -539,8 +539,6 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
    * <p>Files cannot be atomically renamed across devices; copying is required. Use {@link
    * FileSystemUtils#moveFile(Path, Path)} instead.
    *
-   * @throws java.nio.file.AccessDeniedException if the target file cannot be replaced due to
-   *     concurrent file system operations on Windows (and possibly other reasons)
    * @throws IOException if the rename failed for any reason
    */
   public void renameTo(Path target) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -70,13 +70,6 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  public void renameTo(PathFragment sourcePath, PathFragment targetPath) throws IOException {
-    // Make sure the target path doesn't exist to avoid permission denied error on Windows.
-    delete(targetPath);
-    super.renameTo(sourcePath, targetPath);
-  }
-
-  @Override
   protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
     PathFragment targetPath =

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3200,9 +3200,13 @@ filegroup(
   srcs = ["@repo{}//file".format(i) for i in range(100)],
 )
 EOF
-
+  
   mkdir repo_cache
-  bazel build --repository_cache="$(cygpath -w "$PWD"/repo_cache)" \
+  cache="$PWD"/repo_cache
+  if "$is_windows"; then
+    cache="$(cygpath -w "$cache")"
+  fi
+  bazel build --repository_cache="$cache" \
     //:files >& $TEST_log || fail "expected bazel to succeed"
 }
 
@@ -3226,7 +3230,11 @@ filegroup(
 EOF
 
   mkdir repo_cache
-  bazel build --repository_cache="$(cygpath -w "$PWD"/repo_cache)" \
+  cache="$PWD"/repo_cache
+  if "$is_windows"; then
+    cache="$(cygpath -w "$cache")"
+  fi
+  bazel build --repository_cache="$cache" \
     //:files >& $TEST_log || fail "expected bazel to succeed"
 }
 

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3202,7 +3202,7 @@ filegroup(
 EOF
 
   mkdir repo_cache
-  bazel build --repository_cache="$PWD"/repo_cache \
+  bazel build --repository_cache="$(cygpath -w "$PWD"/repo_cache)" \
     //:files >& $TEST_log || fail "expected bazel to succeed"
 }
 
@@ -3226,7 +3226,7 @@ filegroup(
 EOF
 
   mkdir repo_cache
-  bazel build --repository_cache="$PWD"/repo_cache \
+  bazel build --repository_cache="$(cygpath -w "$PWD"/repo_cache)" \
     //:files >& $TEST_log || fail "expected bazel to succeed"
 }
 


### PR DESCRIPTION
This requires making the implementation of `renameTo` in `JavaIoFileSystem` and `WindowsFileSystem` atomic.

Fixes https://github.com/bazelbuild/bazel/issues/21823