### PR TITLE
Hard-wire --experimental_sibling_repository_layout to false.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -74,7 +74,6 @@ import com.google.devtools.build.lib.exec.RemoteLocalFallbackRegistry;
 import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
 import com.google.devtools.build.lib.exec.SpawnStrategyResolver;
 import com.google.devtools.build.lib.exec.SymlinkTreeStrategy;
-import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.GoogleAutoProfilerUtils;
 import com.google.devtools.build.lib.profiler.ProfilePhase;
@@ -281,7 +280,7 @@ public class ExecutionTool {
               env.getEventBus(),
               env.getDirectories().getProductName() + "-",
               skyframeExecutor.getIgnoredPaths(),
-              request.getOptions(BuildLanguageOptions.class).experimentalSiblingRepositoryLayout,
+              false,
               runtime.getWorkspace().doesAllowExternalRepositories());
       if (shouldSymlinksBePlanted) {
         incrementalPackageRoots.eagerlyPlantSymlinksToSingleSourceRoot();
@@ -648,11 +647,7 @@ public class ExecutionTool {
       // Plant the symlink forest.
       try (SilentCloseable c = Profiler.instance().profile("plantSymlinkForest")) {
         SymlinkForest symlinkForest =
-            new SymlinkForest(
-                packageRootMap.get(),
-                getExecRoot(),
-                runtime.getProductName(),
-                request.getOptions(BuildLanguageOptions.class).experimentalSiblingRepositoryLayout);
+            new SymlinkForest(packageRootMap.get(), getExecRoot(), runtime.getProductName(), false);
         symlinkForest.plantSymlinkForest();
       } catch (IOException e) {
         String message = String.format("Source forest creation failed: %s", e.getMessage());

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -761,7 +761,7 @@ public final class BuildLanguageOptions extends OptionsBase {
             .setBool(EXPERIMENTAL_CC_SHARED_LIBRARY, experimentalCcSharedLibrary)
             .setBool(EXPERIMENTAL_REPO_REMOTE_EXEC, experimentalRepoRemoteExec)
             .setBool(EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE, experimentalDisableExternalPackage)
-            .setBool(EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, experimentalSiblingRepositoryLayout)
+            .setBool(EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, false)
             .setBool(
                 INCOMPATIBLE_DISABLE_TARGET_PROVIDER_FIELDS,
                 incompatibleDisableTargetProviderFields)

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -22,11 +22,9 @@ import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.ModuleActionContextRegistry;
 import com.google.devtools.build.lib.exec.SpawnCache;
 import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
-import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver.DefaultRemotePathResolver;
-import com.google.devtools.build.lib.remote.common.RemotePathResolver.SiblingRepositoryLayoutResolver;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TempPathGenerator;
@@ -133,17 +131,8 @@ final class RemoteActionContextProvider {
 
   private RemotePathResolver createRemotePathResolver() {
     Path execRoot = env.getExecRoot();
-    BuildLanguageOptions buildLanguageOptions =
-        env.getOptions().getOptions(BuildLanguageOptions.class);
     RemotePathResolver remotePathResolver;
-    if (buildLanguageOptions != null && buildLanguageOptions.experimentalSiblingRepositoryLayout) {
-      RemoteOptions remoteOptions = checkNotNull(env.getOptions().getOptions(RemoteOptions.class));
-      remotePathResolver =
-          new SiblingRepositoryLayoutResolver(
-              execRoot, remoteOptions.incompatibleRemoteOutputPathsRelativeToInputRoot);
-    } else {
-      remotePathResolver = new DefaultRemotePathResolver(execRoot);
-    }
+    remotePathResolver = new DefaultRemotePathResolver(execRoot);
     return remotePathResolver;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -66,7 +66,6 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
 import com.google.devtools.build.lib.exec.SpawnStrategyResolver;
-import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -518,11 +517,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       }
       commandLineKey = computeCommandLineKey(options);
       ImmutableList<PathFragment> systemIncludeDirs = getSystemIncludeDirs(options);
-      boolean siblingLayout =
-          actionExecutionContext
-              .getOptions()
-              .getOptions(BuildLanguageOptions.class)
-              .experimentalSiblingRepositoryLayout;
+      boolean siblingLayout = false;
       if (!shouldScanIncludes) {
         // When not actually doing include scanning, add all prunable headers to additionalInputs.
         // This is necessary because the inputs that can be pruned by .d file parsing must be
@@ -1394,11 +1389,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     CppIncludeExtractionContext scanningContext =
         actionExecutionContext.getContext(CppIncludeExtractionContext.class);
     Path execRoot = actionExecutionContext.getExecRoot();
-    boolean siblingRepositoryLayout =
-        actionExecutionContext
-            .getOptions()
-            .getOptions(BuildLanguageOptions.class)
-            .experimentalSiblingRepositoryLayout;
+    boolean siblingRepositoryLayout = false;
 
     if (shouldParseShowIncludes()) {
       NestedSet<Artifact> discoveredInputs =

--- a/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderIntegrationTest.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.ModifiedFileSet;
 import com.google.devtools.build.lib.vfs.Root;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -217,6 +218,7 @@ public class LocationExpanderIntegrationTest extends BuildViewTestCase {
   }
 
   @Test
+  @Ignore
   public void otherPathExternalExpansionNoLegacyExternalRunfilesSiblingRepositoryLayout()
       throws Exception {
     scratch.file("expansion/BUILD", "sh_library(name='lib', srcs=['@r//p:foo'])");

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -118,7 +118,7 @@ public class ConsistencyTest {
     return parseOptions(
         // <== Add new options here in alphabetic order ==>
         "--experimental_disable_external_package=" + rand.nextBoolean(),
-        "--experimental_sibling_repository_layout=" + rand.nextBoolean(),
+        "--experimental_sibling_repository_layout=" + "false",
         "--experimental_builtins_bzl_path=" + rand.nextDouble(),
         "--experimental_builtins_dummy=" + rand.nextBoolean(),
         "--experimental_bzl_visibility=" + rand.nextBoolean(),
@@ -162,7 +162,7 @@ public class ConsistencyTest {
     return StarlarkSemantics.builder()
         // <== Add new options here in alphabetic order ==>
         .setBool(BuildLanguageOptions.EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE, rand.nextBoolean())
-        .setBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, rand.nextBoolean())
+        .setBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, false)
         .set(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_BZL_PATH, String.valueOf(rand.nextDouble()))
         .setBool(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_DUMMY, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_BZL_VISIBILITY, rand.nextBoolean())

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollectorTest.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -85,6 +86,7 @@ public final class LibrariesToLinkCollectorTest extends BuildViewTestCase {
   /* TODO: Add an integration test (maybe in cc_integration_test.sh) when a modular toolchain config
   is available.*/
   @Test
+  @Ignore
   public void dynamicLink_siblingLayout_externalBinary_rpath() throws Exception {
     FileSystemUtils.appendIsoLatin1(
         scratch.resolve("WORKSPACE"), "local_repository(name = 'src', path = 'src')");
@@ -179,6 +181,7 @@ public final class LibrariesToLinkCollectorTest extends BuildViewTestCase {
   }
 
   @Test
+  @Ignore
   public void dynamicLink_siblingLayout_externalToolchain_rpath() throws Exception {
     FileSystemUtils.appendIsoLatin1(
         scratch.resolve("WORKSPACE"), "local_repository(name = 'toolchain', path = 'toolchain')");

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -63,6 +63,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.util.Collection;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -745,6 +746,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   }
 
   @Test
+  @Ignore
   public void testIncludesDirs_inExternalRepo_resolvesSiblingLayout() throws Exception {
     FileSystemUtils.appendIsoLatin1(
         scratch.resolve("WORKSPACE"),

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoCommonTest.java
@@ -505,7 +505,7 @@ public class BazelProtoCommonTest extends BuildViewTestCase {
   public void generateCode_externalProtoLibrary(
       boolean sibling, boolean generated, List<String> expectedFlags) throws Exception {
     if (sibling) {
-      setBuildLanguageOptions("--experimental_sibling_repository_layout");
+      return;
     }
     scratch.appendFile("WORKSPACE", "local_repository(name = 'foo', path = '/foo')");
     invalidatePackages();

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryTest.java
@@ -468,6 +468,7 @@ public class BazelProtoLibraryTest extends BuildViewTestCase {
   }
 
   @Test
+  @Ignore
   public void test_siblingRepoLayout_externalRepoWithGeneratedProto() throws Exception {
     testExternalRepoWithGeneratedProto(/* siblingRepoLayout= */ true);
   }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
@@ -71,6 +71,7 @@ import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkList;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -170,6 +171,7 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
   }
 
   @Test
+  @Ignore
   public void testExternalRepoLabelWorkspaceRoot_siblingRepoLayout() throws Exception {
     scratch.overwriteFile(
         "WORKSPACE",

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -980,7 +980,7 @@ EOF
   expect_log "cannot run local tests with --nobuild_runfile_manifests"
 }
 
-function test_run_from_external_repo_sibling_repository_layout() {
+function DISABLED_test_run_from_external_repo_sibling_repository_layout() {
   cat <<EOF > WORKSPACE
 local_repository(
     name = "a",

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -989,7 +989,7 @@ function test_execroot_subdir_layout_fails_for_external_subpackages() {
   expect_log "Target //baz:binary failed to build"
 }
 
-function test_execroot_sibling_layout_null_build_for_external_subpackages() {
+function DISABLED_test_execroot_sibling_layout_null_build_for_external_subpackages() {
   setup_workspace_layout_with_external_directory
   bazel build --experimental_sibling_repository_layout //baz:binary \
     || fail "expected build success"
@@ -1000,7 +1000,7 @@ function test_execroot_sibling_layout_null_build_for_external_subpackages() {
   expect_log "INFO: 1 process: 1 internal"
 }
 
-function test_execroot_sibling_layout_header_scanning_in_external_subpackage() {
+function DISABLED_test_execroot_sibling_layout_header_scanning_in_external_subpackage() {
   setup_workspace_layout_with_external_directory
   cat << 'EOF' > external/foo/BUILD
 cc_library(
@@ -1018,7 +1018,7 @@ EOF
      "could not find 'undeclared inclusion' error message in bazel output"
 }
 
-function test_sibling_repository_layout_include_external_repo_output() {
+function DISABLED_test_sibling_repository_layout_include_external_repo_output() {
   mkdir test
   cat > test/BUILD <<'EOF'
 cc_library(
@@ -1396,7 +1396,7 @@ function test_external_cc_test_sandboxed() {
       @other_repo//test >& $TEST_log || fail "Test should pass"
 }
 
-function test_external_cc_test_sandboxed_sibling_repository_layout() {
+function DISABLED_test_external_cc_test_sandboxed_sibling_repository_layout() {
   [ "$PLATFORM" != "windows" ] || return 0
 
   external_cc_test_setup
@@ -1417,7 +1417,7 @@ function test_external_cc_test_local() {
       @other_repo//test >& $TEST_log || fail "Test should pass"
 }
 
-function test_external_cc_test_local_sibling_repository_layout() {
+function DISABLED_test_external_cc_test_local_sibling_repository_layout() {
   external_cc_test_setup
 
   bazel test \

--- a/src/test/shell/bazel/execroot_test.sh
+++ b/src/test/shell/bazel/execroot_test.sh
@@ -70,7 +70,7 @@ EOF
   assert_contains "$(dirname $execroot)/_main/bazel-out" out
 }
 
-function test_sibling_repository_layout() {
+function DISABLED_test_sibling_repository_layout() {
     touch WORKSPACE
 
     mkdir -p external/foo
@@ -95,7 +95,7 @@ EOF
 }
 
 # Regression test for b/149771751
-function test_sibling_repository_layout_indirect_dependency() {
+function DISABLED_test_sibling_repository_layout_indirect_dependency() {
     touch WORKSPACE
 
     mkdir external
@@ -170,7 +170,7 @@ EOF
 
 }
 
-function test_external_directory_globs() {
+function DISABLED_test_external_directory_globs() {
   touch WORKSPACE
   touch MODULE.bazel
 
@@ -194,7 +194,7 @@ EOF
   assert_contains file_e bazel-bin/go
 }
 
-function test_cc_smoke_with_new_layouts() {
+function DISABLED_test_cc_smoke_with_new_layouts() {
   touch WORKSPACE
   mkdir -p external/a
   cat > external/a/BUILD <<EOF
@@ -213,7 +213,7 @@ EOF
     || fail "build failed"
 }
 
-function test_java_smoke_with_new_layouts() {
+function DISABLED_test_java_smoke_with_new_layouts() {
   touch WORKSPACE
   mkdir -p external/java/a
   cat > external/java/a/BUILD <<EOF

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -2890,7 +2890,7 @@ EOF
   bazel build a_bin >& $TEST_log  || fail "Expected build/run to succeed"
 }
 
-function test_query_external_packages() {
+function DISABLED_test_query_external_packages() {
   setup_skylib_support
 
   mkdir -p external/nested
@@ -2929,7 +2929,7 @@ EOF
   expect_log "//external/nested:a2"
 }
 
-function test_query_external_all_targets() {
+function DISABLED_test_query_external_all_targets() {
   setup_skylib_support
 
   mkdir -p external/nested


### PR DESCRIPTION
According to the discussion
https://github.com/bazelbuild/bazel/discussions/20500, no one is too attached to it and the project, sadly, failed: given the current climate, it doesn't look like we'll ever have enough political will to go through with the necessary migration to flip the default value of the flag, as good an idea as it is on its own merits.

This change is designed to minimize the number of lines changed so that it's easy to roll back if need be.