### PR TITLE
[7.2.0] cpp/blaze_util: handle clock_gettime failure

### DIFF
--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -148,7 +148,10 @@ string GetSelfPath(const char* argv0) {
 
 uint64_t GetMillisecondsMonotonic() {
   struct timespec ts = {};
-  clock_gettime(CLOCK_MONOTONIC, &ts);
+  if (clock_gettime(CLOCK_MONOTONIC, &ts)) {
+    BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
+        << "error calling clock_gettime: " << GetLastErrorString();
+  }
   return ts.tv_sec * 1000LL + (ts.tv_nsec / 1000000LL);
 }
 

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -84,7 +84,10 @@ void WarnFilesystemType(const blaze_util::Path &output_base) {
 
 uint64_t GetMillisecondsMonotonic() {
   struct timespec ts = {};
-  clock_gettime(CLOCK_MONOTONIC, &ts);
+  if (clock_gettime(CLOCK_MONOTONIC, &ts)) {
+    BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
+        << "error calling clock_gettime: " << GetLastErrorString();
+  }
   return ts.tv_sec * 1000LL + (ts.tv_nsec / 1000000LL);
 }
 


### PR DESCRIPTION
Capture the exit code of this syscall and terminate Bazel accordingly. Otherwise, an incorrect value will be used as the time.

Closes #21246.

PiperOrigin-RevId: 611531510
Change-Id: I4b5f755d7292eafcf8eab882482d9dbc2d85d8d0

Commit https://github.com/bazelbuild/bazel/commit/5c8c4e9bf6c8213bb40ad211d0419d6b0feccc4b