### PR TITLE
Attempt to fix bazel shell integration tests

### DIFF
--- a/src/test/shell/testenv.sh.tmpl
+++ b/src/test/shell/testenv.sh.tmpl
@@ -265,6 +265,7 @@ function setup_localjdk_javabase() {
 }
 
 function setup_bazelrc() {
+  mkdir -p /tmp/bazel_tmp_sandbox
   cat >$TEST_TMPDIR/bazelrc <<EOF
 # Set the user root properly for this test invocation.
 startup --output_user_root=${bazel_root}
@@ -276,7 +277,7 @@ common --show_progress_rate_limit=-1
 common --color=no --curses=no
 
 # Prevent SIGBUS during JVM actions.
-build --sandbox_tmpfs_path=/tmp
+build --sandbox_tmpfs_path=/tmp/bazel_tmp_sandbox
 
 build --incompatible_skip_genfiles_symlink=false
 


### PR DESCRIPTION
There seems to be a problem with putting the tmpfs directly at /tmp. Let's try putting it one level down. This seems to fix the Android shell integration tests.