### PR TITLE
[7.2.0] Ensure output root is an absolute path even if $HOME or $XDG_CACHE_HOME are relative

### DIFF
--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/blaze_util_platform.h"
 #include "src/main/cpp/util/errors.h"
 #include "src/main/cpp/util/exit_code.h"

--- a/src/test/cpp/BUILD
+++ b/src/test/cpp/BUILD
@@ -91,7 +91,10 @@ cc_test(
         "//src/main/cpp:startup_options",
         "//src/main/cpp:workspace_layout",
         "@com_google_googletest//:gtest_main",
-    ],
+    ] + select({
+        "//src/conditions:linux": ["//src/main/cpp/util"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_test(

--- a/src/test/cpp/startup_options_test.cc
+++ b/src/test/cpp/startup_options_test.cc
@@ -19,6 +19,9 @@
 #include <memory>
 
 #include "src/main/cpp/blaze_util_platform.h"
+#ifdef __linux
+#include "src/main/cpp/util/file_platform.h"
+#endif  // __linux
 #include "src/main/cpp/workspace_layout.h"
 #include "src/test/cpp/test_util.h"
 #include "googletest/include/gtest/gtest.h"
@@ -104,6 +107,26 @@ TEST_F(StartupOptionsTest, OutputRootUseHomeDirectory) {
   ReinitStartupOptions();
 
   ASSERT_EQ("/nonexistent/home/.cache/bazel", startup_options_->output_root);
+}
+
+TEST_F(StartupOptionsTest, OutputRootIsAbsoluteAndNotShellExpanded) {
+  SetEnv("TEST_TMPDIR", "~/\"$foo/test\"");
+  SetEnv("XDG_CACHE_HOME", "~/cache${bar}");
+  SetEnv("HOME", "~/home$(echo baz)");
+
+  ReinitStartupOptions();
+  ASSERT_EQ(blaze_util::GetCwd() + "/~/\"$foo/test\"",
+            startup_options_->output_root);
+
+  UnsetEnv("TEST_TMPDIR");
+  ReinitStartupOptions();
+  ASSERT_EQ(blaze_util::GetCwd() + "/~/cache${bar}/bazel",
+            startup_options_->output_root);
+
+  UnsetEnv("XDG_CACHE_HOME");
+  ReinitStartupOptions();
+  ASSERT_EQ(blaze_util::GetCwd() + "/~/home$(echo baz)/.cache/bazel",
+            startup_options_->output_root);
 }
 #endif  // __linux
 


### PR DESCRIPTION
The Bazel server pre-processes the output root via PathFragmentConverter,
which absolutizes paths and expands leading "~" as the home directory. This
can cause the server and the client to treat different directories as output
root, leading to a server crash.

Thus, the client must make the output root absolute. We already do so when
the output root derives from $TEST_TMPDIR (without tilde expansion) in
StartupOptions::StartupOptions. And we do so (with tilde expansion, for
legacy reasons) when the output root derives from the --output_user_root
startup flag passed to the client, see StartupOptions::ProcessArg.

We must do the same when the output root derives from $HOME or
$XDG_CACHE_HOME - without tilde expansion, since it's generally expected
that tools do not perform tilde expansion on paths derived from env
variables (and since tilde expansion on $HOME is meaningless and a
recursive explosion).

Fixes https://github.com/bazelbuild/bazel/issues/21660

PiperOrigin-RevId: 615506594
Change-Id: Ice67c8be43cef2812b6dce591bd65b9813e82f5c

Commit https://github.com/bazelbuild/bazel/commit/f12fc134ef34d3b845f8aefad361298134d4f224