### PR TITLE
Set the default value of -check_direct_dependencies to error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -266,7 +266,7 @@ public class RepositoryOptions extends OptionsBase {
 
   @Option(
       name = "check_direct_dependencies",
-      defaultValue = "warning",
+      defaultValue = "error",
       converter = CheckDirectDepsMode.Converter.class,
       documentationCategory = OptionDocumentationCategory.BZLMOD,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},


### PR DESCRIPTION
# What
Change the default value of --check_direct_dependencies from "warning" to "error":

>[`--check_direct_dependencies`](https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies) = `<off, warning or error>` default: "warning"
> Check if the direct `bazel_dep` dependencies declared in the root module are the same versions you get in the resolved dependency graph. Valid values are `off` to disable the check, `warning` to print a warning when mismatch detected or `error` to escalate it to a resolution failure.

# Why
This feature has the potential to protect users from unexpected package upgrades and the unintended side effects that they can bring along, but it's not doing as much good as it can be by being a warning rather than an error. This is the sort of thing you don't know you need until it's already bitten you—setting it to an error will give people protection by default, and it's easy for them to opt out into a less safe mode of operation if they need to.

Here's the exact situation that I encountered last week:
- my project uses `rules_python` 0.26.0
- I pulled in a new dependency, `rules_multirun`, which happens to use `rules_python` 0.27.1
- this had the unintended side effect of upgrading my project to `rules_python` 0.27.1, which broke some of our internal tooling and was unfortunately not caught prior to deployment

This was arguably my fault: a warning _was_ emitted, but I didn't happen to notice it in time. Even once I did see it, it was not clear what what had introduced the issue—the message doesn't explain _why_ the resolved dependency graph didn't match the root module:

````
WARNING: For repository 'rules_python', the root module requires module version rules_python@0.26.0, but got rules_python@0.27.1 in the resolved dependency graph.
````

The good news is that `--check_direct_dependencies=error` already exists and solves this problem completely; when set, we get an error instead:

````
ERROR: For repository 'rules_python', the root module requires module version rules_python@0.26.0, but got rules_python@0.27.1 in the resolved dependency graph.
````

If this had been an error, the source of the discrepancy would've been immediately obvious. Unless there are other implications to this change, I believe that changing the default value to `error` makes a lot of sense and would make Bazel safer and easier to operate, particularly in larger repositories with many dependencies and many contributors, not all of whom are necessarily Bazel experts.

# See also
Issue https://github.com/bazelbuild/bazel/issues/21794 (reported by me; included for completeness)
[Slack conversation](https://bazelbuild.slack.com/archives/CA31HN1T3/p1711391497929079)