### PR TITLE
[7.2.0] Add --experimental_remote_output_service flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -392,6 +392,13 @@ public final class RemoteModule extends BlazeModule {
       return;
     }
 
+    if (!Strings.isNullOrEmpty(remoteOptions.remoteOutputService)) {
+      throw createExitException(
+          "Remote Output Service is still WIP",
+          ExitCode.REMOTE_ERROR,
+          Code.REMOTE_EXECUTION_UNKNOWN);
+    }
+
     if ((enableHttpCache || enableDiskCache) && !enableGrpcCache) {
       initHttpAndDiskCache(
           env, credentials, authAndTlsOptions, remoteOptions, digestUtil, executorService);

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -752,6 +752,18 @@ public final class RemoteOptions extends CommonRemoteOptions {
               + " smart enough about the RAM/CPU usages, this flag will be removed.")
   public boolean throttleRemoteActionBuilding;
 
+  @Option(
+      name = "experimental_remote_output_service",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "HOST or HOST:PORT of a remote output service endpoint. The supported schemas are grpc, "
+              + "grpcs (grpc with TLS enabled) and unix (local UNIX sockets). If no schema is "
+              + "provided Bazel will default to grpcs. Specify grpc:// or unix: schema to "
+              + "disable TLS.")
+  public String remoteOutputService;
+
   private static final class ScrubberConverter extends Converter.Contextless<Scrubber> {
 
     @Override


### PR DESCRIPTION
which accept an endpoint pointing to the local output service daemon.

Since the feature is still WIP, Bazel exits and prints an error if this flag is set.

Working towards #21630.

Closes #21649.

PiperOrigin-RevId: 615357528
Change-Id: Ie4cc3a1636b1cf0e710d23883f6bb7b22de7d6c3