### PR TITLE
[7.2.0] java_binary: superfluous dependency on MANIFEST from runfiles

### DIFF
--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_deploy_jar.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_deploy_jar.bzl
@@ -34,21 +34,12 @@ def _get_build_info(ctx, stamp):
 def _bazel_deploy_jars_impl(ctx):
     info = ctx.attr.binary[InternalDeployJarInfo]
 
-    runfiles_manifest = ctx.attr.binary.files_to_run.runfiles_manifest
-    if runfiles_manifest:
-        runfiles = depset(
-            [runfiles_manifest],
-        )
-    else:
-        runfiles = depset()
-
     build_info_files = _get_build_info(ctx, info.stamp)
 
     create_deploy_archives(
         ctx,
         info.java_attrs,
         info.launcher_info,
-        runfiles,
         info.main_class,
         info.coverage_main_class,
         info.strip_as_default,

--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_deploy_jar.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary_deploy_jar.bzl
@@ -38,7 +38,6 @@ def _bazel_deploy_jars_impl(ctx):
     if runfiles_manifest:
         runfiles = depset(
             [runfiles_manifest],
-            transitive = [ctx.attr.binary[OutputGroupInfo]._hidden_top_level_INTERNAL_],
         )
     else:
         runfiles = depset()

--- a/src/main/starlark/builtins_bzl/common/java/java_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary.bzl
@@ -528,7 +528,6 @@ def _auto_create_deploy_jar(ctx, info):
     create_deploy_archive(
         ctx,
         launcher = info.launcher_info.launcher,
-        runfiles = depset(),
         main_class = info.main_class,
         coverage_main_class = info.coverage_main_class,
         resources = java_attrs.resources,

--- a/src/main/starlark/builtins_bzl/common/java/java_binary_deploy_jar.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary_deploy_jar.bzl
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Auxiliary rule to create the deploy archives for java_binary
-
-This needs to be a separate rule because we need to add the runfiles manifest as an input to
-the generating actions, so that the runfiles symlink tree is staged for the deploy jars.
-"""
+"""Auxiliary rule to create the deploy archives for java_binary"""
 
 load(":common/cc/cc_helper.bzl", "cc_helper")
 load(":common/java/java_common.bzl", "java_common")
@@ -29,7 +25,6 @@ def create_deploy_archives(
         ctx,
         java_attrs,
         launcher_info,
-        runfiles,
         main_class,
         coverage_main_class,
         strip_as_default,
@@ -49,7 +44,6 @@ def create_deploy_archives(
         ctx: (RuleContext) The rule context
         java_attrs: (Struct) Struct of (classpath_resources, runtime_jars, runtime_classpath_for_archive, resources)
         launcher_info: (Struct) Struct of (runtime_jars, launcher, unstripped_launcher)
-        runfiles: (Depset) the runfiles for the deploy jar
         main_class: (String) FQN of the entry point for execution
         coverage_main_class: (String) FQN of the entry point for coverage collection
         build_target: (String) Name of the build target for stamping
@@ -79,7 +73,6 @@ def create_deploy_archives(
     create_deploy_archive(
         ctx,
         launcher_info.launcher,
-        runfiles,
         main_class,
         coverage_main_class,
         java_attrs.resources,
@@ -103,7 +96,6 @@ def create_deploy_archives(
         create_deploy_archive(
             ctx,
             launcher_info.unstripped_launcher,
-            runfiles,
             main_class,
             coverage_main_class,
             java_attrs.resources,
@@ -125,7 +117,6 @@ def create_deploy_archives(
 def create_deploy_archive(
         ctx,
         launcher,
-        runfiles,
         main_class,
         coverage_main_class,
         resources,
@@ -150,7 +141,6 @@ def create_deploy_archive(
     Args:
         ctx: (RuleContext) The rule context
         launcher: (File) the launcher artifact
-        runfiles: (Depset) the runfiles for the deploy jar
         main_class: (String) FQN of the entry point for execution
         coverage_main_class: (String) FQN of the entry point for coverage collection
         resources: (Depset) resource inputs
@@ -177,7 +167,6 @@ def create_deploy_archive(
         resources,
         classpath_resources,
         runtime_classpath,
-        runfiles,
     ]
 
     single_jar = semantics.find_java_toolchain(ctx).single_jar

--- a/src/test/shell/integration/java_integration_test.sh
+++ b/src/test/shell/integration/java_integration_test.sh
@@ -373,7 +373,7 @@ function test_compiles_hello_library_from_deploy_jar() {
   mkdir "$pkg" || fail "mkdir $pkg"
   write_hello_library_files "$pkg"
 
-  bazel build //$pkg/java/main:main_deploy.jar || fail "build failed"
+  bazel build //$pkg/java/main:{main,main_deploy.jar} || fail "build failed"
   ${PRODUCT_NAME}-bin/$pkg/java/main/main --singlejar \
       | grep -q "Hello, Library!;Hello, World!" || fail "comparison failed"
 


### PR DESCRIPTION
This contains two commits
1) Do not add the runfiles middleman to the inputs of the deploy jar action.

Before https://github.com/bazelbuild/bazel/commit/a6d839d0d0c602bca94fe8b4ed0b208564db4fcf, it was useless because it did not actually make the runfiles appear on the inputs of the action. After that change, it does, thereby adding a large number of unnecessary inputs to the deploy jar actios (unnecessary because they worked before https://github.com/bazelbuild/bazel/commit/a6d839d0d0c602bca94fe8b4ed0b208564db4fcf...)

RELNOTES: None.
PiperOrigin-RevId: 603638505
Change-Id: I1a9d59e361fcad3c6cf4362b4251fd03dd521e22
Commit https://github.com/bazelbuild/bazel/commit/6a4d61ebf2dc2214ffe6abc807e4f597175e1a6c

2) Do not build the runfiles tree when creating deploy jars.

I missed this from https://github.com/bazelbuild/bazel/commit/6a4d61ebf2dc2214ffe6abc807e4f597175e1a6c and as it is, Bazel at HEAD builds the runfiles tree, but not the artifacts in it, thus resulting in the runfiles tree being made of broken symlinks.

RELNOTES: None.
PiperOrigin-RevId: 604583234
Change-Id: I5d106719c269a4b145a5f43ded0de749f55da3b0
Commit https://github.com/bazelbuild/bazel/commit/cff79d0aa6f2d470b8648f2b89beeefd0867e177