### PR TITLE
Show display form labels in `java_*` buildozer fixups

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
@@ -767,6 +767,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>Prefer this over its dynamic cousin, as using static strings saves memory.
      */
+    @CanIgnoreReturnValue
     public Builder add(@CompileTimeConstant String value) {
       return addObjectInternal(value);
     }
@@ -776,6 +777,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If the value is null, neither the arg nor the value is added.
      */
+    @CanIgnoreReturnValue
     public Builder add(@CompileTimeConstant String arg, @Nullable String value) {
       return addObjectInternal(arg, value);
     }
@@ -812,6 +814,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      * <p>There are many other ways you can try to avoid calling this. In general, try to use
      * constants or objects that are already on the heap elsewhere.
      */
+    @CanIgnoreReturnValue
     public Builder addDynamicString(@Nullable String value) {
       return addObjectInternal(value);
     }
@@ -822,6 +825,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      * <p>Prefer this over manually calling {@link Label#getCanonicalForm}, as it avoids a copy of
      * the label value.
      */
+    @CanIgnoreReturnValue
     public Builder addLabel(@Nullable Label value) {
       return addObjectInternal(value);
     }
@@ -834,6 +838,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If the value is null, neither the arg nor the value is added.
      */
+    @CanIgnoreReturnValue
     public Builder addLabel(@CompileTimeConstant String arg, @Nullable Label value) {
       return addObjectInternal(arg, value);
     }
@@ -844,6 +849,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      * <p>Prefer this over manually calling {@link PathFragment#getPathString}, as it avoids storing
      * a copy of the path string.
      */
+    @CanIgnoreReturnValue
     public Builder addPath(@Nullable PathFragment value) {
       return addObjectInternal(value);
     }
@@ -856,6 +862,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If the value is null, neither the arg nor the value is added.
      */
+    @CanIgnoreReturnValue
     public Builder addPath(@CompileTimeConstant String arg, @Nullable PathFragment value) {
       return addObjectInternal(arg, value);
     }
@@ -866,6 +873,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      * <p>Prefer this over manually calling {@link Artifact#getExecPath}, as it avoids storing a
      * copy of the artifact path string.
      */
+    @CanIgnoreReturnValue
     public Builder addExecPath(@Nullable Artifact value) {
       return addObjectInternal(value);
     }
@@ -878,16 +886,19 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If the value is null, neither the arg nor the value is added.
      */
+    @CanIgnoreReturnValue
     public Builder addExecPath(@CompileTimeConstant String arg, @Nullable Artifact value) {
       return addObjectInternal(arg, value);
     }
 
     /** Adds a lazily expanded string. */
+    @CanIgnoreReturnValue
     public Builder addLazyString(@Nullable OnDemandString value) {
       return addObjectInternal(value);
     }
 
     /** Adds a lazily expanded string. */
+    @CanIgnoreReturnValue
     public Builder addLazyString(@CompileTimeConstant String arg, @Nullable OnDemandString value) {
       return addObjectInternal(arg, value);
     }
@@ -902,6 +913,7 @@ public class CustomCommandLine extends AbstractCommandLine {
     }
 
     /** Concatenates the passed prefix string and the string. */
+    @CanIgnoreReturnValue
     public Builder addPrefixed(@CompileTimeConstant String prefix, @Nullable String arg) {
       return addPrefixedInternal(prefix, arg, /* mainRepoMapping= */ null);
     }
@@ -910,6 +922,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      * Concatenates the passed prefix string and the label using {@link Label#getDisplayForm}, which
      * is identical to {@link Label#getCanonicalForm()} for main repo labels.
      */
+    @CanIgnoreReturnValue
     public Builder addPrefixedLabel(
         @CompileTimeConstant String prefix,
         @Nullable Label arg,
@@ -918,11 +931,13 @@ public class CustomCommandLine extends AbstractCommandLine {
     }
 
     /** Concatenates the passed prefix string and the path. */
+    @CanIgnoreReturnValue
     public Builder addPrefixedPath(@CompileTimeConstant String prefix, @Nullable PathFragment arg) {
       return addPrefixedInternal(prefix, arg, /* mainRepoMapping= */ null);
     }
 
     /** Concatenates the passed prefix string and the artifact's exec path. */
+    @CanIgnoreReturnValue
     public Builder addPrefixedExecPath(@CompileTimeConstant String prefix, @Nullable Artifact arg) {
       return addPrefixedInternal(prefix, arg, /* mainRepoMapping= */ null);
     }
@@ -933,6 +948,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      * <p>If you are converting long lists or nested sets of a different type to string lists,
      * please try to use a different method that supports what you are trying to do directly.
      */
+    @CanIgnoreReturnValue
     public Builder addAll(@Nullable Collection<String> values) {
       return addCollectionInternal(values);
     }
@@ -943,6 +959,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      * <p>If you are converting long lists or nested sets of a different type to string lists,
      * please try to use a different method that supports what you are trying to do directly.
      */
+    @CanIgnoreReturnValue
     public Builder addAll(@Nullable NestedSet<String> values) {
       return addNestedSetInternal(values);
     }
@@ -955,6 +972,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addAll(@CompileTimeConstant String arg, @Nullable Collection<String> values) {
       return addCollectionInternal(arg, values);
     }
@@ -964,11 +982,13 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addAll(@CompileTimeConstant String arg, @Nullable NestedSet<String> values) {
       return addNestedSetInternal(arg, values);
     }
 
     /** Adds the passed vector arg. See {@link VectorArg}. */
+    @CanIgnoreReturnValue
     public Builder addAll(VectorArg<String> vectorArg) {
       return addVectorArgInternal(vectorArg);
     }
@@ -978,16 +998,19 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addAll(@CompileTimeConstant String arg, VectorArg<String> vectorArg) {
       return addVectorArgInternal(arg, vectorArg);
     }
 
     /** Adds the passed paths to the command line. */
+    @CanIgnoreReturnValue
     public Builder addPaths(@Nullable Collection<PathFragment> values) {
       return addCollectionInternal(values);
     }
 
     /** Adds the passed paths to the command line. */
+    @CanIgnoreReturnValue
     public Builder addPaths(@Nullable NestedSet<PathFragment> values) {
       return addNestedSetInternal(values);
     }
@@ -997,6 +1020,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addPaths(
         @CompileTimeConstant String arg, @Nullable Collection<PathFragment> values) {
       return addCollectionInternal(arg, values);
@@ -1007,12 +1031,14 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addPaths(
         @CompileTimeConstant String arg, @Nullable NestedSet<PathFragment> values) {
       return addNestedSetInternal(arg, values);
     }
 
     /** Adds the passed vector arg. See {@link VectorArg}. */
+    @CanIgnoreReturnValue
     public Builder addPaths(VectorArg<PathFragment> vectorArg) {
       return addVectorArgInternal(vectorArg);
     }
@@ -1022,6 +1048,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addPaths(@CompileTimeConstant String arg, VectorArg<PathFragment> vectorArg) {
       return addVectorArgInternal(arg, vectorArg);
     }
@@ -1032,11 +1059,13 @@ public class CustomCommandLine extends AbstractCommandLine {
      * <p>Do not use this method if the list is derived from a flattened nested set. Instead, figure
      * out how to avoid flattening the set and use {@link #addExecPaths(NestedSet)}.
      */
+    @CanIgnoreReturnValue
     public Builder addExecPaths(@Nullable Collection<Artifact> values) {
       return addCollectionInternal(values);
     }
 
     /** Adds the artifacts' exec paths to the command line. */
+    @CanIgnoreReturnValue
     public Builder addExecPaths(@Nullable NestedSet<Artifact> values) {
       return addNestedSetInternal(values);
     }
@@ -1049,6 +1078,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addExecPaths(
         @CompileTimeConstant String arg, @Nullable Collection<Artifact> values) {
       return addCollectionInternal(arg, values);
@@ -1059,12 +1089,14 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addExecPaths(
         @CompileTimeConstant String arg, @Nullable NestedSet<Artifact> values) {
       return addNestedSetInternal(arg, values);
     }
 
     /** Adds the passed vector arg. See {@link VectorArg}. */
+    @CanIgnoreReturnValue
     public Builder addExecPaths(VectorArg<Artifact> vectorArg) {
       return addVectorArgInternal(vectorArg);
     }
@@ -1074,6 +1106,7 @@ public class CustomCommandLine extends AbstractCommandLine {
      *
      * <p>If values is empty, the arg isn't added.
      */
+    @CanIgnoreReturnValue
     public Builder addExecPaths(@CompileTimeConstant String arg, VectorArg<Artifact> vectorArg) {
       return addVectorArgInternal(arg, vectorArg);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -208,7 +208,8 @@ public final class JavaCompilationHelper {
     return builder.build();
   }
 
-  public void createCompileAction(JavaCompileOutputs<Artifact> outputs) throws RuleErrorException {
+  public void createCompileAction(JavaCompileOutputs<Artifact> outputs)
+      throws RuleErrorException, InterruptedException {
     if (outputs.genClass() != null) {
       createGenJarAction(
           outputs.output(),
@@ -542,7 +543,7 @@ public final class JavaCompilationHelper {
    * @param headerDeps the .jdeps output of this java compilation
    */
   public void createHeaderCompilationAction(Artifact headerJar, Artifact headerDeps)
-      throws RuleErrorException {
+      throws RuleErrorException, InterruptedException {
 
     JavaTargetAttributes attributes = getAttributes();
 
@@ -687,7 +688,8 @@ public final class JavaCompilationHelper {
    * @return the header jar (if requested), or ijar (if requested), or else the class jar
    */
   public Artifact createCompileTimeJarAction(
-      Artifact runtimeJar, JavaCompilationArtifacts.Builder builder) throws RuleErrorException {
+      Artifact runtimeJar, JavaCompilationArtifacts.Builder builder)
+      throws RuleErrorException, InterruptedException {
     Artifact jar;
     boolean isFullJar = false;
     if (shouldUseHeaderCompilation()) {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -171,7 +171,7 @@ public final class JavaCompileActionBuilder {
     this.execGroup = execGroup;
   }
 
-  public JavaCompileAction build() throws RuleErrorException {
+  public JavaCompileAction build() throws RuleErrorException, InterruptedException {
     // TODO(bazel-team): all the params should be calculated before getting here, and the various
     // aggregation code below should go away.
 
@@ -271,7 +271,7 @@ public final class JavaCompileActionBuilder {
   }
 
   private CustomCommandLine buildParamFileContents(ImmutableList<String> javacOpts)
-      throws RuleErrorException {
+      throws RuleErrorException, InterruptedException {
 
     CustomCommandLine.Builder result = CustomCommandLine.builder();
 
@@ -304,7 +304,8 @@ public final class JavaCompileActionBuilder {
       } else {
         // @-prefixed strings will be assumed to be filenames and expanded by
         // {@link JavaLibraryBuildRequest}, so add an extra &at; to escape it.
-        result.addPrefixedLabel("@", targetLabel);
+        result.addPrefixedLabel(
+            "@", targetLabel, ruleContext.getAnalysisEnvironment().getMainRepoMapping());
       }
     }
     result.add("--injecting_rule_kind", injectingRuleKind);

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -368,7 +368,8 @@ public final class JavaHeaderCompileAction extends SpawnAction {
     }
 
     /** Builds and registers the action for a header compilation. */
-    public void build(JavaToolchainProvider javaToolchain) throws RuleErrorException {
+    public void build(JavaToolchainProvider javaToolchain)
+        throws RuleErrorException, InterruptedException {
       checkNotNull(outputDepsProto, "outputDepsProto must not be null");
       checkNotNull(sourceFiles, "sourceFiles must not be null");
       checkNotNull(sourceJars, "sourceJars must not be null");
@@ -478,7 +479,8 @@ public final class JavaHeaderCompileAction extends SpawnAction {
         } else {
           // @-prefixed strings will be assumed to be params filenames and expanded,
           // so add an extra @ to escape it.
-          commandLine.addPrefixedLabel("@", targetLabel);
+          commandLine.addPrefixedLabel(
+              "@", targetLabel, ruleContext.getAnalysisEnvironment().getMainRepoMapping());
         }
       }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -134,7 +134,11 @@ public class JavaStarlarkCommon
       Object injectingRuleKind,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs)
-      throws EvalException, TypeException, RuleErrorException, LabelSyntaxException {
+      throws EvalException,
+          TypeException,
+          RuleErrorException,
+          LabelSyntaxException,
+          InterruptedException {
     checkJavaToolchainIsDeclaredOnRule(ctx.getRuleContext());
     JavaTargetAttributes.Builder attributesBuilder =
         new JavaTargetAttributes.Builder(javaSemantics)
@@ -199,7 +203,11 @@ public class JavaStarlarkCommon
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
       Sequence<?> additionalOutputs)
-      throws EvalException, TypeException, RuleErrorException, LabelSyntaxException {
+      throws EvalException,
+          TypeException,
+          RuleErrorException,
+          LabelSyntaxException,
+          InterruptedException {
     checkJavaToolchainIsDeclaredOnRule(ctx.getRuleContext());
     JavaCompileOutputs<Artifact> outputs =
         JavaCompileOutputs.builder()

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -523,7 +523,11 @@ public interface JavaCommonApi<
       Object injectingRuleKind,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs)
-      throws EvalException, TypeException, RuleErrorException, LabelSyntaxException;
+      throws EvalException,
+          TypeException,
+          RuleErrorException,
+          LabelSyntaxException,
+          InterruptedException;
 
   @StarlarkMethod(
       name = "create_compilation_action",
@@ -587,7 +591,11 @@ public interface JavaCommonApi<
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
       Sequence<?> additionalOutputs)
-      throws EvalException, TypeException, RuleErrorException, LabelSyntaxException;
+      throws EvalException,
+          TypeException,
+          RuleErrorException,
+          LabelSyntaxException,
+          InterruptedException;
 
   @StarlarkMethod(
       name = "default_javac_opts",

--- a/src/test/java/com/google/devtools/build/lib/actions/CustomCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/CustomCommandLineTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
@@ -28,6 +29,8 @@ import com.google.devtools.build.lib.analysis.actions.CustomCommandLine;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine.VectorArg;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine.VectorArg.SimpleVectorArg;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -126,7 +129,8 @@ public final class CustomCommandLineTest {
         .containsExactly("prefix-foo");
     assertThat(
             builder()
-                .addPrefixedLabel("prefix-", Label.parseCanonical("//a:b"))
+                .addPrefixedLabel(
+                    "prefix-", Label.parseCanonical("//a:b"), /* mainRepoMapping= */ null)
                 .build()
                 .arguments())
         .containsExactly("prefix-//a:b");
@@ -135,6 +139,22 @@ public final class CustomCommandLineTest {
         .containsExactly("prefix-path");
     assertThat(builder().addPrefixedExecPath("prefix-", artifact1).build().arguments())
         .containsExactly("prefix-dir/file1.txt");
+  }
+
+  @Test
+  public void addPrefixedLabel_emitsExternalLabelInDisplayForm() throws Exception {
+    assertThat(
+            builder()
+                .addPrefixedLabel(
+                    "prefix-",
+                    Label.parseCanonical("@@canonical_name//a:b"),
+                    RepositoryMapping.create(
+                        ImmutableMap.of(
+                            "apparent_name", RepositoryName.createUnvalidated("canonical_name")),
+                        RepositoryName.MAIN))
+                .build()
+                .arguments())
+        .containsExactly("prefix-@apparent_name//a:b");
   }
 
   @Test
@@ -527,7 +547,7 @@ public final class CustomCommandLineTest {
             .addExecPath("foo", null)
             .addLazyString("foo", null)
             .addPrefixed("prefix", null)
-            .addPrefixedLabel("prefix", null)
+            .addPrefixedLabel("prefix", null, /* mainRepoMapping= */ null)
             .addPrefixedPath("prefix", null)
             .addPrefixedExecPath("prefix", null)
             .addAll((ImmutableList<String>) null)

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1998,4 +1998,90 @@ EOF
   expect_log "buildozer 'add deps @c//:c' //pkg:a"
 }
 
+function test_strict_deps_error_external_repo_header_compile_action() {
+  cat << 'EOF' > MODULE.bazel
+bazel_dep(
+    name = "lib_c",
+    repo_name = "c",
+)
+local_path_override(
+    module_name = "lib_c",
+    path = "lib_c",
+)
+EOF
+
+  mkdir -p pkg
+  cat << 'EOF' > pkg/BUILD
+java_binary(name = "Main", srcs = ["Main.java"], deps = [":a"])
+java_library(name = "a", srcs = ["A.java"], deps = [":b"])
+java_library(name = "b", srcs = ["B.java"], deps = ["@c"])
+EOF
+  cat << 'EOF' > pkg/Main.java
+public class Main extends A {}
+EOF
+  cat << 'EOF' > pkg/A.java
+public class A extends B implements C {}
+EOF
+  cat << 'EOF' > pkg/B.java
+public class B implements C {}
+EOF
+
+  mkdir -p lib_c
+  cat << 'EOF' > lib_c/MODULE.bazel
+module(name = "lib_c")
+EOF
+  cat << 'EOF' > lib_c/BUILD
+java_library(name = "c", srcs = ["C.java"], visibility = ["//visibility:public"])
+EOF
+  cat << 'EOF' > lib_c/C.java
+public interface C {}
+EOF
+
+  bazel build //pkg:a >& $TEST_log && fail "build should fail"
+  expect_log "buildozer 'add deps @c//:c' //pkg:a"
+}
+
+function test_strict_deps_error_external_repo_compile_action() {
+  cat << 'EOF' > MODULE.bazel
+bazel_dep(
+    name = "lib_c",
+    repo_name = "c",
+)
+local_path_override(
+    module_name = "lib_c",
+    path = "lib_c",
+)
+EOF
+
+  mkdir -p pkg
+  cat << 'EOF' > pkg/BUILD
+java_library(name = "a", srcs = ["A.java"], deps = [":b"])
+java_library(name = "b", srcs = ["B.java"], deps = ["@c"])
+EOF
+  cat << 'EOF' > pkg/A.java
+public class A extends B {
+  boolean foo() {
+    return this instanceof C;
+  }
+}
+EOF
+  cat << 'EOF' > pkg/B.java
+public class B implements C {}
+EOF
+
+  mkdir -p lib_c
+  cat << 'EOF' > lib_c/MODULE.bazel
+module(name = "lib_c")
+EOF
+  cat << 'EOF' > lib_c/BUILD
+java_library(name = "c", srcs = ["C.java"], visibility = ["//visibility:public"])
+EOF
+  cat << 'EOF' > lib_c/C.java
+public interface C {}
+EOF
+
+  bazel build //pkg:a >& $TEST_log && fail "build should fail"
+  expect_log "buildozer 'add deps @c//:c' //pkg:a"
+}
+
 run_suite "Java integration tests"

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -1411,7 +1411,7 @@ EOF
 
   bazel build @x_repo//a >& $TEST_log && fail "Building @x_repo//a should error out"
   expect_log "** Please add the following dependencies:"
-  expect_log "@@x_repo//x to @@x_repo//a"
+  expect_log " @x_repo//x to @x_repo//a"
 }
 
 # This test verifies that the `public` pattern includes external dependencies.


### PR DESCRIPTION
The change in #21702 only fixed the buildozer fixup messages for `java_*` actions entirely defined in Starlark. This commit makes the analogous change to the remaining native actions.

Related to #20486 and #21702