### PR TITLE
Add path mapping test for multiplex sandboxing

### DIFF
--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -148,6 +148,54 @@ function test_path_stripping_singleplex_worker() {
   expect_not_log '[0-9] worker'
 }
 
+function test_path_stripping_multiplex_worker() {
+  if is_windows; then
+    echo "Skipping test_path_stripping_multiplex_worker on Windows as it requires sandboxing"
+    return
+  fi
+
+  mkdir toolchain
+  cat > toolchain/BUILD <<'EOF'
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+default_java_toolchain(
+    name = "java_toolchain",
+    source_version = "17",
+    target_version = "17",
+    javac_supports_worker_multiplex_sandboxing = True,
+)
+EOF
+
+  cache_dir=$(mktemp -d)
+
+  bazel run -c fastbuild \
+    --disk_cache=$cache_dir \
+    --experimental_output_paths=strip \
+    --strategy=Javac=worker \
+    --experimental_worker_multiplex_sandboxing \
+    --extra_toolchains=//toolchain:java_toolchain_definition \
+    --java_language_version=17 \
+    //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"
+  expect_log 'Hello, World!'
+  # JavaToolchainCompileBootClasspath, JavaToolchainCompileClasses and header compilation.
+  expect_log '3 \(linux\|darwin\|processwrapper\)-sandbox'
+  # Actual compilation actions.
+  expect_log '2 worker'
+  expect_not_log 'disk cache hit'
+
+  bazel run -c opt \
+    --disk_cache=$cache_dir \
+    --experimental_output_paths=strip \
+    --strategy=Javac=worker \
+    --experimental_worker_multiplex_sandboxing \
+    --extra_toolchains=//toolchain:java_toolchain_definition \
+    --java_language_version=17 \
+    //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"
+  expect_log 'Hello, World!'
+  expect_log '5 disk cache hit'
+  expect_not_log '[0-9] \(linux\|darwin\|processwrapper\)-sandbox'
+  expect_not_log '[0-9] worker'
+}
+
 function test_path_stripping_remote() {
   bazel run -c fastbuild \
     --experimental_output_paths=strip \


### PR DESCRIPTION
Javac actions gained support for multiplex sandboxing with rules_java 7.5.0, which makes it possible to test path mapping in this mode.

Fixes #21091