### PR TITLE
Use XattrProvider from OutputService to check filesystem values

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
@@ -66,6 +66,7 @@ import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.repository.ExternalPackageHelper;
 import com.google.devtools.build.lib.skyframe.AspectKeyCreator.AspectKey;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.ExternalFileAction;
+import com.google.devtools.build.lib.skyframe.FilesystemValueChecker.XattrProviderOverrider;
 import com.google.devtools.build.lib.skyframe.PackageFunction.ActionOnIOExceptionReadingBuildFile;
 import com.google.devtools.build.lib.skyframe.PackageLookupFunction.CrossRepositoryLabelViolationStrategy;
 import com.google.devtools.build.lib.skyframe.actiongraph.v2.ActionGraphDump;
@@ -460,7 +461,12 @@ public class SequencedSkyframeExecutor extends SkyframeExecutor {
     long startTime = System.nanoTime();
     FilesystemValueChecker fsvc =
         new FilesystemValueChecker(
-            Preconditions.checkNotNull(tsgm.get()), syscallCache, fsvcThreads);
+            Preconditions.checkNotNull(tsgm.get()),
+            syscallCache,
+            outputService == null
+                ? XattrProviderOverrider.IDENTICAL
+                : outputService::getXattrProvider,
+            fsvcThreads);
     BatchStat batchStatter = outputService == null ? null : outputService.getBatchStatter();
     recordingDiffer.invalidate(
         fsvc.getDirtyActionValues(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -183,6 +183,7 @@ import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.ExternalFileAc
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.ExternalFilesKnowledge;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.FileType;
 import com.google.devtools.build.lib.skyframe.FilesystemValueChecker.ImmutableBatchDirtyResult;
+import com.google.devtools.build.lib.skyframe.FilesystemValueChecker.XattrProviderOverrider;
 import com.google.devtools.build.lib.skyframe.MetadataConsumerForMetrics.FilesMetricConsumer;
 import com.google.devtools.build.lib.skyframe.PackageFunction.ActionOnIOExceptionReadingBuildFile;
 import com.google.devtools.build.lib.skyframe.PackageFunction.GlobbingStrategy;
@@ -3386,7 +3387,14 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
       invalidateValuesMarkedForInvalidation(eventHandler);
 
-      FilesystemValueChecker fsvc = new FilesystemValueChecker(tsgm, syscallCache, fsvcThreads);
+      FilesystemValueChecker fsvc =
+          new FilesystemValueChecker(
+              tsgm,
+              syscallCache,
+              outputService == null
+                  ? XattrProviderOverrider.IDENTICAL
+                  : outputService::getXattrProvider,
+              fsvcThreads);
 
       Set<Root> diffPackageRootsUnderWhichToCheck =
           getDiffPackageRootsUnderWhichToCheck(pathEntriesWithoutDiffInformation);
@@ -3450,7 +3458,14 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       logger.atInfo().log(
           "About to scan %d external files",
           externalFilesKnowledge.nonOutputExternalFilesSeen.size());
-      FilesystemValueChecker fsvc = new FilesystemValueChecker(tsgm, syscallCache, fsvcThreads);
+      FilesystemValueChecker fsvc =
+          new FilesystemValueChecker(
+              tsgm,
+              syscallCache,
+              outputService == null
+                  ? XattrProviderOverrider.IDENTICAL
+                  : outputService::getXattrProvider,
+              fsvcThreads);
       ImmutableBatchDirtyResult batchDirtyResult;
       try (SilentCloseable c = Profiler.instance().profile("fsvc.getDirtyExternalKeys")) {
         Map<SkyKey, SkyValue> externalDirtyNodes = new ConcurrentHashMap<>();
@@ -3897,7 +3912,13 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     Differencer.Diff diff;
     if (modifiedFileSet.treatEverythingAsModified()) {
       diff =
-          new FilesystemValueChecker(tsgm, syscallCache, /* numThreads= */ 200)
+          new FilesystemValueChecker(
+                  tsgm,
+                  syscallCache,
+                  outputService == null
+                      ? XattrProviderOverrider.IDENTICAL
+                      : outputService::getXattrProvider,
+                  /* numThreads= */ 200)
               .getDirtyKeys(
                   memoizingEvaluator.getValues(),
                   DirtinessCheckerUtils.createBasicFilesystemDirtinessChecker());


### PR DESCRIPTION
If `--experimental_remote_output_service` is set, a `XattrProvider` which uses `BatchStat` RPC to get the digest of a file will be used for Bazel to invalidate stale output files during the start of incremental builds.

Working towards https://github.com/bazelbuild/bazel/issues/21630.