### PR TITLE
[7.2.0] Make `RepositoryCache#put` resistant to concurrent file system operations

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -785,6 +785,8 @@ public abstract class FileSystem {
   /**
    * Renames the file denoted by "sourceNode" to the location "targetNode". See {@link
    * Path#renameTo} for specification.
+   *
+   * <p>Implementations must be atomic.
    */
   public abstract void renameTo(PathFragment sourcePath, PathFragment targetPath)
       throws IOException;

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -429,6 +429,8 @@ public class FileSystemUtils {
    * "to". If "from" is a regular file, its last modified time, executable and writable bits are
    * also preserved. Symlinks are also supported but not directories or special files.
    *
+   * <p>This method is not guaranteed to be atomic. Use {@link Path#renameTo(Path)} instead.
+   *
    * <p>If the move fails (usually because the "from" and "to" live in different file systems), this
    * falls back to copying the file. Note that these two operations have very different performance
    * characteristics and is why this operation reports back to the caller what actually happened.

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -534,11 +534,11 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   }
 
   /**
-   * Renames the file denoted by the current path to the location "target", not following symbolic
-   * links.
+   * Atomically renames the file denoted by the current path to the location "target", not following
+   * symbolic links.
    *
    * <p>Files cannot be atomically renamed across devices; copying is required. Use {@link
-   * FileSystemUtils#copyFile} followed by {@link Path#delete}.
+   * FileSystemUtils#moveFile(Path, Path)} instead.
    *
    * @throws IOException if the rename failed for any reason
    */

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -70,13 +70,6 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  public void renameTo(PathFragment sourcePath, PathFragment targetPath) throws IOException {
-    // Make sure the target path doesn't exist to avoid permission denied error on Windows.
-    delete(targetPath);
-    super.renameTo(sourcePath, targetPath);
-  }
-
-  @Override
   protected void createSymbolicLink(PathFragment linkPath, PathFragment targetFragment)
       throws IOException {
     PathFragment targetPath =

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3196,4 +3196,51 @@ EOF
   bazel build @r >& $TEST_log || fail "expected bazel to succeed"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/21823.
+function test_repository_cache_concurrency() {
+  sha=cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94
+
+  cat > MODULE.bazel <<EOF
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+[
+  http_file(
+    name = "repo" + str(i),
+    url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+    sha256 = "$sha",
+  )
+  for i in range(100)
+]
+EOF
+  cat > BUILD <<'EOF'
+FILES = ["@repo{}//file".format(i) for i in range(100)]
+filegroup(
+  name = "files",
+  srcs = FILES,
+)
+genrule(
+  name = "unique_hashes",
+  srcs = [":files"],
+  outs = ["unique_hashes"],
+  cmd = """
+# Get the unique sha256 hashes of the files.
+sha256sum $(execpaths :files) |
+  cut -d' ' -f1 |
+  sort |
+  uniq > $@
+""".format(),
+)
+EOF
+
+  repo_cache_dir=$TEST_TMPDIR/repository_cache
+  trap 'rm -rf ${repo_cache_dir}' EXIT
+  bazel build --repository_cache="$repo_cache_dir" \
+    //:unique_hashes >& $TEST_log || fail "expected bazel to succeed"
+  assert_equals 1 "$(wc -l < bazel-bin/unique_hashes | tr -d ' ')"
+  assert_equals $sha "$(cat bazel-bin/unique_hashes)"
+
+  # Verify that the repository cache entry has been created.
+  cache_entry="$repo_cache_dir/content_addressable/sha256/$sha/file"
+  echo "$sha $cache_entry" | sha256sum --check || fail "sha256 mismatch"
+}
+
 run_suite "local repository tests"


### PR DESCRIPTION
This requires making the implementation of `renameTo` in `JavaIoFileSystem` and `WindowsFileSystem` atomic.

Fixes https://github.com/bazelbuild/bazel/issues/21823

Closes #21779.

PiperOrigin-RevId: 620719510
Change-Id: Id3ff4baa56c6ef693196e8268614b483713542a5

Commit https://github.com/bazelbuild/bazel/commit/753dc9750714af581147f6aa338adeb07a9dcb57