### PR TITLE
Make `cc_shared_library` runnable standalone

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
@@ -754,10 +754,7 @@ def _cc_shared_library_impl(ctx):
         # precompiled_dynamic_library.dynamic_library could be None if the library to link just contains
         # an interface library which is valid if the actual library is obtained from the system.
         if precompiled_dynamic_library.dynamic_library != None:
-            if precompiled_dynamic_library.resolved_symlink_dynamic_library != None:
-                precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.resolved_symlink_dynamic_library)
-            else:
-                precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.dynamic_library)
+            precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.dynamic_library)
 
     runfiles = runfiles.merge(ctx.runfiles(files = precompiled_only_dynamic_libraries_runfiles))
 

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
@@ -33,6 +33,8 @@ py_test(
     name = "python_test",
     srcs = ["python_test.py"],
     data = ["foo_so"],
+    env = {"FOO_SO": "$(rlocationpath foo_so)"},
+    deps = ["@rules_python//python/runfiles"],
 )
 
 cc_test(

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/python_test.py
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/python_test.py
@@ -11,3 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Load the shared library from data and call the "foo" function defined by it to
+# verify that its runfiles are sufficient to run the shared library.
+import ctypes
+import os
+import unittest
+import python.runfiles as runfiles
+
+
+class TestStandaloneSharedLibrary(unittest.TestCase):
+
+  def test_call_foo(self):
+    lib_path = runfiles.Create().Rlocation(os.getenv("FOO_SO"))
+    lib = ctypes.CDLL(lib_path)
+    if lib_path.endswith(".dll"):
+      self.assertEqual(getattr(lib, "?foo@@YAHXZ")(), 42)
+    else:
+      self.assertEqual(lib._Z3foov(), 42)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/python_test.py
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/python_test.py
@@ -17,7 +17,7 @@
 import ctypes
 import os
 import unittest
-import python.runfiles as runfiles
+from python import runfiles
 
 
 class TestStandaloneSharedLibrary(unittest.TestCase):

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/starlark_tests.bzl
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/starlark_tests.bzl
@@ -194,13 +194,13 @@ def _runfiles_test_impl(env, target):
     env.expect.that_collection(runfiles).contains_exactly_predicates([
         matching.str_endswith(path_suffix + "/libfoo_so.so"),
         matching.str_endswith(path_suffix + "/libbar_so.so"),
-        matching.str_endswith(path_suffix + "/libdirect_so_file.so"),
         matching.str_endswith(path_suffix + "/libprivate_lib_so.so"),
-        matching.str_endswith(path_suffix + "/renamed_so_file_copy.so"),
         matching.str_endswith(path_suffix + "3/libdiff_pkg_so.so"),
         matching.str_endswith("Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary/libbar_so.so"),
+        matching.str_endswith("Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary/libdirect_so_file.so"),
         matching.str_endswith("Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary/libfoo_so.so"),
         matching.str_endswith("Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary/libprivate_lib_so.so"),
+        matching.str_endswith("Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary/renamed_so_file_copy.so"),
         matching.str_endswith("Smain_Sstarlark_Stests_Sbuiltins_Ubzl_Scc_Scc_Ushared_Ulibrary_Stest_Ucc_Ushared_Ulibrary3/libdiff_pkg_so.so"),
     ])
 


### PR DESCRIPTION
When loaded as a `data` dependency (e.g. for `dlopen`), the runfiles of a `cc_shared_library` now contain the `_solib` symlinks of precompiled dynamic library dependencies instead of the symlink targets.

Work towards #21833 