### PR TITLE
[7.1.2] Implement RemoteActionFileSystem#statIfFound correctly when the path cannot be canonicalized

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -630,13 +630,17 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat
   private FileStatus statInternal(PathFragment path, FollowMode followMode, StatSources statSources)
       throws IOException {
     // Canonicalize the path.
-    if (followMode == FollowMode.FOLLOW_ALL) {
-      path = resolveSymbolicLinks(path).asFragment();
-    } else if (followMode == FollowMode.FOLLOW_PARENT) {
-      PathFragment parent = path.getParentDirectory();
-      if (parent != null) {
-        path = resolveSymbolicLinks(parent).asFragment().getChild(path.getBaseName());
+    try {
+      if (followMode == FollowMode.FOLLOW_ALL) {
+        path = resolveSymbolicLinks(path).asFragment();
+      } else if (followMode == FollowMode.FOLLOW_PARENT) {
+        PathFragment parent = path.getParentDirectory();
+        if (parent != null) {
+          path = resolveSymbolicLinks(parent).asFragment().getChild(path.getBaseName());
+        }
       }
+    } catch (FileNotFoundException e) {
+      return null;
     }
 
     // Since the path has been canonicalized, the operations below never need to follow symlinks.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -1488,11 +1488,12 @@ public final class SkyframeActionExecutor {
       Action action, Artifact output, Reporter reporter, IOException e) {
     String errorMessage;
     if (e instanceof FileNotFoundException) {
-      errorMessage = String.format("TreeArtifact %s was not created", output.prettyPrint());
+      errorMessage = String.format("output tree artifact %s was not created", output.prettyPrint());
     } else {
       errorMessage =
           String.format(
-              "Error while validating output TreeArtifact %s : %s", output, e.getMessage());
+              "error while validating output tree artifact %s: %s",
+              output.prettyPrint(), e.getMessage());
     }
 
     reporter.handle(Event.error(action.getOwner().getLocation(), errorMessage));

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java
@@ -558,9 +558,7 @@ public class TreeArtifactValue implements HasDigest, SkyValue {
 
           if (statFollow == null) {
             throw new IOException(
-                String.format(
-                    "Child %s of tree artifact %s is a dangling symbolic link",
-                    parentRelativePath, parentDir));
+                String.format("child %s is a dangling symbolic link", parentRelativePath));
           }
 
           if (statFollow.isFile() && !statFollow.isSpecialFile()) {
@@ -574,9 +572,7 @@ public class TreeArtifactValue implements HasDigest, SkyValue {
 
         if (type == Dirent.Type.UNKNOWN) {
           throw new IOException(
-              String.format(
-                  "Child %s of tree artifact %s has an unsupported type",
-                  parentRelativePath, parentDir));
+              String.format("child %s has an unsupported type", parentRelativePath));
         }
 
         visitor.visit(parentRelativePath, type, traversedSymlink);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactBuildTest.java
@@ -505,9 +505,7 @@ public final class TreeArtifactBuildTest extends TimestampBuilderTestCase {
 
     ImmutableList<Event> errors = ImmutableList.copyOf(eventCollector);
     assertThat(errors).hasSize(2);
-    assertThat(errors.get(0).getMessage())
-        .contains(
-            "Child links/link of tree artifact " + out.getPath() + " is a dangling symbolic link");
+    assertThat(errors.get(0).getMessage()).contains("child links/link is a dangling symbolic link");
     assertThat(errors.get(1).getMessage()).contains("not all outputs were created or valid");
   }
 
@@ -555,9 +553,7 @@ public final class TreeArtifactBuildTest extends TimestampBuilderTestCase {
 
     ImmutableList<Event> errors = ImmutableList.copyOf(eventCollector);
     assertThat(errors).hasSize(2);
-    assertThat(errors.get(0).getMessage())
-        .contains(
-            "Child links/link of tree artifact " + out.getPath() + " is a dangling symbolic link");
+    assertThat(errors.get(0).getMessage()).contains("child links/link is a dangling symbolic link");
     assertThat(errors.get(1).getMessage()).contains("not all outputs were created or valid");
   }
 
@@ -607,9 +603,7 @@ public final class TreeArtifactBuildTest extends TimestampBuilderTestCase {
 
     ImmutableList<Event> errors = ImmutableList.copyOf(eventCollector);
     assertThat(errors).hasSize(2);
-    assertThat(errors.get(0).getMessage())
-        .contains(
-            "Child links/link of tree artifact " + out.getPath() + " is a dangling symbolic link");
+    assertThat(errors.get(0).getMessage()).contains("child links/link is a dangling symbolic link");
     assertThat(errors.get(1).getMessage()).contains("not all outputs were created or valid");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
@@ -419,9 +419,7 @@ public final class TreeArtifactValueTest {
         assertThrows(
             IOException.class,
             () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
-    assertThat(e)
-        .hasMessageThat()
-        .contains("Child symlink of tree artifact /tree is a dangling symbolic link");
+    assertThat(e).hasMessageThat().contains("child symlink is a dangling symbolic link");
   }
 
   @Test
@@ -456,9 +454,7 @@ public final class TreeArtifactValueTest {
         assertThrows(
             IOException.class,
             () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
-    assertThat(e)
-        .hasMessageThat()
-        .contains("Child unknown of tree artifact /tree has an unsupported type");
+    assertThat(e).hasMessageThat().contains("child unknown has an unsupported type");
   }
 
   @Test
@@ -523,9 +519,7 @@ public final class TreeArtifactValueTest {
         assertThrows(
             IOException.class,
             () -> TreeArtifactValue.visitTree(treeDir, (child, type, traversedSymlink) -> {}));
-    assertThat(e)
-        .hasMessageThat()
-        .contains("Child sym of tree artifact /tree has an unsupported type");
+    assertThat(e).hasMessageThat().contains("child sym has an unsupported type");
   }
 
   @Test


### PR DESCRIPTION
This improves the error message for a tree artifact containing a dangling symlink, which regressed in https://github.com/bazelbuild/bazel/commit/4247c20f1daeeb787e9b5cb64848d398467effb1 (see https://github.com/bazelbuild/bazel/issues/15454#issuecomment-2011456094).

PiperOrigin-RevId: 617870632
Change-Id: I6847084a52b1e4bb7d8a9384ad6cd5d015dddf1b

Commit https://github.com/bazelbuild/bazel/commit/b78d73fab1f01e2e8ae29bed667865a42800b626