### PR TITLE
[7.2.0] Revert "Add -Djava.security.manager=allow to BazelAndroidLoca…

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -394,6 +394,10 @@ tasks:
       - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/py/bazel:mod_command_test"
       - "-//src/test/shell/bazel:verify_workspace"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
     include_json_profile:
       - build
       - test

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -47,6 +47,11 @@ tasks:
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # --
     include_json_profile:
       - build
       - test
@@ -95,6 +100,11 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # --
     include_json_profile:
       - build
       - test
@@ -153,6 +163,11 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # --
     include_json_profile:
       - build
       - test
@@ -206,6 +221,11 @@ tasks:
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # --
     include_json_profile:
       - build
       - test

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -449,6 +449,10 @@ tasks:
       - "-//src/test/py/bazel:bzlmod_query_test"
       - "-//src/test/py/bazel:mod_command_test"
       - "-//src/test/shell/bazel:verify_workspace"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
       # Flaky on rbe_ubuntu2004
       # https://github.com/bazelbuild/continuous-integration/issues/1631
       - "-//src/test/shell/bazel:bazel_sandboxing_networking_test"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,6 +48,11 @@ tasks:
       - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
       - "-//src/test/shell/bazel/android:aapt_integration_test"
       - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # --
     include_json_profile:
       - build
       - test
@@ -97,6 +102,11 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # --
     include_json_profile:
       - build
       - test
@@ -156,6 +166,11 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # --
     include_json_profile:
       - build
       - test
@@ -247,6 +262,11 @@ tasks:
       - "-//src/test/py/bazel:bazel_external_repository_test"
       # - "-//src/test/shell/bazel/android:resource_processing_integration_test"
       # - "-//src/test/shell/bazel/android:aar_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      # --
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_local_test_integration_test_with_head_android_tools"
+      # --
       - "-//src/tools/singlejar:zip64_test"
       - "-//src/test/py/bazel:launcher_test"
       - "-//src/test/shell/integration:bazel_worker_test"

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidLocalTest.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidLocalTest.java
@@ -27,7 +27,6 @@ import com.google.devtools.build.lib.rules.android.AndroidSemantics;
 import com.google.devtools.build.lib.rules.java.JavaCommon;
 import com.google.devtools.build.lib.rules.java.JavaCompilationArtifacts;
 import com.google.devtools.build.lib.rules.java.JavaCompilationHelper;
-import com.google.devtools.build.lib.rules.java.JavaRuntimeInfo;
 import com.google.devtools.build.lib.rules.java.JavaSemantics;
 import com.google.devtools.build.lib.rules.java.JavaTargetAttributes;
 import com.google.devtools.build.lib.util.ShellEscaper;
@@ -58,25 +57,16 @@ public class BazelAndroidLocalTest extends AndroidLocalTestBase {
       throws RuleErrorException, InterruptedException {
     Artifact androidAllJarsPropertiesFile = getAndroidAllJarsPropertiesFile(ruleContext);
 
-    ImmutableList.Builder<String> builder =
-        ImmutableList.<String>builder()
-            .addAll(JavaCommon.getJvmFlags(ruleContext))
-            .add("-ea")
-            .add("-Dbazel.test_suite=" + ShellEscaper.escapeString(testClass))
-            .add("-Drobolectric.offline=true")
-            .add(
-                "-Drobolectric-deps.properties="
-                    + androidAllJarsPropertiesFile.getRunfilesPathString())
-            .add("-Duse_framework_manifest_parser=true")
-            .add("-Dorg.robolectric.packagesToNotAcquire=com.google.testing.junit.runner.util");
-
-    if (JavaRuntimeInfo.from(ruleContext, createJavaSemantics().getJavaRuntimeToolchainType())
-            .version()
-        >= 17) {
-      builder.add("-Djava.security.manager=allow");
-    }
-
-    return builder.build();
+    return ImmutableList.<String>builder()
+        .addAll(JavaCommon.getJvmFlags(ruleContext))
+        .add("-ea")
+        .add("-Dbazel.test_suite=" + ShellEscaper.escapeString(testClass))
+        .add("-Drobolectric.offline=true")
+        .add(
+            "-Drobolectric-deps.properties=" + androidAllJarsPropertiesFile.getRunfilesPathString())
+        .add("-Duse_framework_manifest_parser=true")
+        .add("-Dorg.robolectric.packagesToNotAcquire=com.google.testing.junit.runner.util")
+        .build();
   }
 
   @Override


### PR DESCRIPTION
…lTest to prevent breakage when running on JDK 21."

Amazingly, this fixes the build for release-7.2.0.

For some reason, without this PR, BazelAndroidLocalTestTest fails with some sort of "artifact does not have generating action" error: https://storage.googleapis.com/bazel-untrusted-buildkite-artifacts/018ea0c4-55df-44fe-8f65-cc40d8f29482/src/test/java/com/google/devtools/build/lib/bazel/rules/android/AndroidTests/test.log

But that error goes away as soon as I delete the `if` block at line 73.

This reverts commit c70a4b75dc1d9eb00c52434ac5035e0333d5c914.