### PR TITLE
Forcibly use the bundled version of `@platforms` for loading the host platform repo rule

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/local_config_platform.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/local_config_platform.WORKSPACE
@@ -7,11 +7,17 @@ maybe(
 )
 
 maybe(
+    local_repository,
+    "internal_platforms_do_not_use",
+    path = __embedded_dir__ + "/platforms",
+)
+
+maybe(
     local_config_platform,
     "local_config_platform",
 )
 
-load("@platforms//host:extension.bzl", "host_platform_repo")
+load("@internal_platforms_do_not_use//host:extension.bzl", "host_platform_repo")
 maybe(
     host_platform_repo,
     "host_platform",

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -81,6 +81,9 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "bind(name = 'has_androidsdk', actual = '@bazel_tools//tools/android:always_false')",
         "local_repository(name = 'bazel_tools', path = '" + bazelToolWorkspace + "')",
         "local_repository(name = 'platforms', path = '" + bazelPlatformsWorkspace + "')",
+        "local_repository(name = 'internal_platforms_do_not_use', path = '"
+            + bazelPlatformsWorkspace
+            + "')",
         "local_repository(name = 'local_config_xcode', path = '" + xcodeWorkspace + "')",
         "local_repository(name = 'com_google_protobuf', path = '" + protobufWorkspace + "')",
         "local_repository(name = 'rules_java', path = '" + rulesJavaWorkspace + "')",
@@ -108,6 +111,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "com_google_protobuf",
         "local_config_xcode",
         "platforms",
+        "internal_platforms_do_not_use",
         "rules_java",
         "rules_java_builtin",
         "build_bazel_apple_support");


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/21877 happened because, even though we define `@platforms` to be the bundled version shipped with Bazel (which is 0.0.9 on HEAD), people tend to define their own versions of `@platforms` in WORKSPACE. If this ends up being a lower version (very likely), the subsequent `load` to use the `host_platform_repo` repo rule (which is a Starlark version of `local_config_platform`) will fail because that repo rule was only introduced in `platforms` version 0.0.9.

To resolve this conundrum, we define a new repo `@internal_platforms_do_not_use` that _also_ points to the bundled version of `@platforms`. Nobody is likely to define this repo, so we can fairly reliably get the Starlark repo rule, and also still allow people to override the actual `@platforms` targets they use.

This only affects WORKSPACE users; if `--enable_bzlmod` is set, the `@host_platform` seen by `@bazel_tools` will come from the module extension instead.

Work towards https://github.com/bazelbuild/bazel/issues/18285.

Fixes https://github.com/bazelbuild/bazel/issues/21877.