### PR TITLE
Extract yanked versions into a SkyFunction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -50,6 +50,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.RegistryFactoryImpl;
 import com.google.devtools.build.lib.bazel.bzlmod.RepoSpecFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.SingleExtensionEvalFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.SingleExtensionUsagesFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.commands.FetchCommand;
 import com.google.devtools.build.lib.bazel.commands.ModCommand;
@@ -271,6 +272,7 @@ public class BazelRepositoryModule extends BlazeModule {
         .addSkyFunction(SkyFunctions.SINGLE_EXTENSION_EVAL, singleExtensionEvalFunction)
         .addSkyFunction(SkyFunctions.SINGLE_EXTENSION_USAGES, new SingleExtensionUsagesFunction())
         .addSkyFunction(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+        .addSkyFunction(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(registryFactory))
         .addSkyFunction(
             SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
             new ModuleExtensionRepoMappingEntriesFunction());

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -144,6 +144,7 @@ java_library(
         "SingleExtensionEvalValue.java",
         "SingleExtensionUsagesValue.java",
         "SingleVersionOverride.java",
+        "YankedVersionsValue.java",
     ],
     deps = [
         ":common",
@@ -196,6 +197,7 @@ java_library(
         "SingleExtensionUsagesFunction.java",
         "StarlarkBazelModule.java",
         "TypeCheckedTag.java",
+        "YankedVersionsFunction.java",
         "YankedVersionsUtil.java",
     ],
     deps = [

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsFunction.java
@@ -19,9 +19,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
-import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.skyframe.SkyFunction;
-import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
@@ -42,8 +40,7 @@ public class YankedVersionsFunction implements SkyFunction {
 
   @Override
   @Nullable
-  public SkyValue compute(SkyKey skyKey, Environment env)
-      throws InterruptedException, YankedVersionsException {
+  public SkyValue compute(SkyKey skyKey, Environment env) throws InterruptedException {
     var key = (YankedVersionsValue.Key) skyKey.argument();
     try (SilentCloseable c =
         Profiler.instance()
@@ -66,13 +63,6 @@ public class YankedVersionsFunction implements SkyFunction {
       // This should never happen since we obtain the registry URL from an already constructed
       // registry.
       throw new IllegalStateException(e);
-    }
-  }
-
-  static final class YankedVersionsException extends SkyFunctionException {
-
-    YankedVersionsException(ExternalDepsException cause) {
-      super(cause, Transience.TRANSIENT);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsFunction.java
@@ -1,0 +1,78 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.devtools.build.lib.bazel.bzlmod;
+
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.profiler.Profiler;
+import com.google.devtools.build.lib.profiler.ProfilerTask;
+import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.server.FailureDetails;
+import com.google.devtools.build.skyframe.SkyFunction;
+import com.google.devtools.build.skyframe.SkyFunctionException;
+import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.SkyValue;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * A simple SkyFunction that computes a {@link RepoSpec} for the given {@link InterimModule} by
+ * fetching required information from its {@link Registry}.
+ */
+public class YankedVersionsFunction implements SkyFunction {
+  private final RegistryFactory registryFactory;
+
+  public YankedVersionsFunction(RegistryFactory registryFactory) {
+    this.registryFactory = registryFactory;
+  }
+
+  @Override
+  @Nullable
+  public SkyValue compute(SkyKey skyKey, Environment env)
+      throws InterruptedException, YankedVersionsException {
+    var key = (YankedVersionsValue.Key) skyKey.argument();
+    try (SilentCloseable c =
+        Profiler.instance()
+            .profile(
+                ProfilerTask.BZLMOD, () -> "getting yanked versions: " + key.getModuleName())) {
+      return YankedVersionsValue.create(
+          registryFactory
+              .getRegistryWithUrl(key.getRegistryUrl())
+              .getYankedVersions(key.getModuleName(), env.getListener()));
+    } catch (IOException e) {
+      env.getListener()
+          .handle(
+              Event.warn(
+                  String.format(
+                      "Could not read metadata file for module %s: %s", key, e.getMessage())));
+      // This is failing open: If we can't read the metadata file, we allow yanked modules to be
+      // fetched.
+      return YankedVersionsValue.create(Optional.empty());
+    } catch (URISyntaxException e) {
+      // This should never happen since we obtain the registry URL from an already constructed
+      // registry.
+      throw new IllegalStateException(e);
+    }
+  }
+
+  static final class YankedVersionsException extends SkyFunctionException {
+
+    YankedVersionsException(ExternalDepsException cause) {
+      super(cause, Transience.TRANSIENT);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsUtil.java
@@ -15,14 +15,10 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
-import com.google.devtools.build.lib.events.Event;
-import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,39 +59,20 @@ public final class YankedVersionsUtil {
     return Optional.of(allowedYankedVersionBuilder.build());
   }
 
-  /**
-   * Returns the reason for the given module being yanked, or {@code Optional.empty()} if the module
-   * is not yanked or explicitly allowed despite being yanked.
-   */
   static Optional<String> getYankedInfo(
-      Registry registry,
-      ModuleKey key,
-      Optional<ImmutableSet<ModuleKey>> allowedYankedVersions,
-      ExtendedEventHandler eventHandler)
-      throws InterruptedException {
-    Optional<ImmutableMap<Version, String>> yankedVersions;
-    try {
-      yankedVersions = registry.getYankedVersions(key.getName(), eventHandler);
-    } catch (IOException e) {
-      eventHandler.handle(
-          Event.warn(
-              String.format(
-                  "Could not read metadata file for module %s: %s", key, e.getMessage())));
-      // This is failing open: If we can't read the metadata file, we allow yanked modules to be
-      // fetched.
-      return Optional.empty();
-    }
-    if (yankedVersions.isEmpty()) {
-      return Optional.empty();
-    }
-    String yankedInfo = yankedVersions.get().get(key.getVersion());
-    if (yankedInfo != null
-        && allowedYankedVersions.isPresent()
-        && !allowedYankedVersions.get().contains(key)) {
-      return Optional.of(yankedInfo);
-    } else {
-      return Optional.empty();
-    }
+          ModuleKey key,
+          YankedVersionsValue yankedVersionsValue,
+          Optional<ImmutableSet<ModuleKey>> allowedYankedVersions) {
+    return yankedVersionsValue.yankedVersions().flatMap(yankedVersions -> {
+      String yankedInfo = yankedVersions.get(key.getVersion());
+      if (yankedInfo != null
+              && allowedYankedVersions.isPresent()
+              && !allowedYankedVersions.get().contains(key)) {
+        return Optional.of(yankedInfo);
+      } else {
+        return Optional.empty();
+      }
+    });
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsValue.java
@@ -1,0 +1,63 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.bzlmod;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.skyframe.SkyFunctions;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
+import com.google.devtools.build.skyframe.SkyFunctionName;
+import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.SkyValue;
+
+import java.util.Optional;
+
+/** A class holding information about the versions of a particular module that have been yanked. */
+@AutoValue
+public abstract class YankedVersionsValue implements SkyValue {
+
+  public abstract Optional<ImmutableMap<Version, String>> yankedVersions();
+
+  public static YankedVersionsValue create(Optional<ImmutableMap<Version, String>> yankedVersions) {
+    return new AutoValue_YankedVersionsValue(yankedVersions);
+  }
+
+  /** The key for {@link YankedVersionsFunction}. */
+  @AutoCodec
+  @AutoValue
+  abstract static class Key implements SkyKey {
+    private static final SkyKeyInterner<Key> interner = SkyKey.newInterner();
+
+    abstract String getModuleName();
+
+    abstract String getRegistryUrl();
+
+    @AutoCodec.Instantiator
+    static Key create(String moduleName, String registryUrl) {
+      return interner.intern(new AutoValue_YankedVersionsValue_Key(moduleName, registryUrl));
+    }
+
+    @Override
+    public SkyFunctionName functionName() {
+      return SkyFunctions.YANKED_VERSIONS;
+    }
+
+    @Override
+    public SkyKeyInterner<Key> getSkyKeyInterner() {
+      return interner;
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyFunctions.java
@@ -163,6 +163,8 @@ public final class SkyFunctions {
   public static final SkyFunctionName BAZEL_FETCH_ALL =
       SkyFunctionName.createHermetic("BAZEL_FETCH_ALL");
   public static final SkyFunctionName REPO_SPEC = SkyFunctionName.createNonHermetic("REPO_SPEC");
+  public static final SkyFunctionName YANKED_VERSIONS =
+      SkyFunctionName.createNonHermetic("YANKED_VERSIONS");
 
   public static final SkyFunctionName MODULE_EXTENSION_REPO_MAPPING_ENTRIES =
       SkyFunctionName.createHermetic("MODULE_EXTENSION_REPO_MAPPING_ENTRIES");

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.NonRegistryOverride;
 import com.google.devtools.build.lib.bazel.bzlmod.RepoSpecFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.SingleExtensionEvalFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.SingleExtensionUsagesFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
@@ -180,6 +181,7 @@ public abstract class AnalysisMock extends LoadingMock {
             new SingleExtensionEvalFunction(directories, ImmutableMap::of, downloadManager))
         .put(SkyFunctions.SINGLE_EXTENSION_USAGES, new SingleExtensionUsagesFunction())
         .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(FakeRegistry.DEFAULT_FACTORY))
+        .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(FakeRegistry.DEFAULT_FACTORY))
         .put(
             SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
             new ModuleExtensionRepoMappingEntriesFunction())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -135,6 +135,7 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                 .put(SkyFunctions.BAZEL_DEP_GRAPH, new BazelDepGraphFunction())
                 .put(SkyFunctions.BAZEL_MODULE_RESOLUTION, resolutionFunctionMock)
                 .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+                .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(registryFactory))
                 .put(
                     SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
                     new ModuleExtensionRepoMappingEntriesFunction())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunctionTest.java
@@ -160,6 +160,7 @@ public class BazelLockFileFunctionTest extends FoundationTestCase {
                         ImmutableMap.of()))
                 .put(SkyFunctions.BAZEL_LOCK_FILE, new BazelLockFileFunction(rootDirectory))
                 .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+                .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(registryFactory))
                 .put(
                     SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
                     new ModuleExtensionRepoMappingEntriesFunction())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
@@ -121,6 +121,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
                 .put(SkyFunctions.BAZEL_LOCK_FILE, new BazelLockFileFunction(rootDirectory))
                 .put(SkyFunctions.BAZEL_MODULE_RESOLUTION, new BazelModuleResolutionFunction())
                 .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+                .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(registryFactory))
                 .put(
                     SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
                     new ModuleExtensionRepoMappingEntriesFunction())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleFunctionTest.java
@@ -135,6 +135,7 @@ public final class BzlmodRepoRuleFunctionTest extends FoundationTestCase {
                         workspaceRoot,
                         ImmutableMap.of()))
                 .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+                .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(registryFactory))
                 .put(
                     SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
                     new ModuleExtensionRepoMappingEntriesFunction())
@@ -301,5 +302,4 @@ public final class BzlmodRepoRuleFunctionTest extends FoundationTestCase {
     BzlmodRepoRuleValue bzlmodRepoRuleValue = result.get(BzlmodRepoRuleValue.key(repo));
     assertThat(bzlmodRepoRuleValue).isEqualTo(BzlmodRepoRuleValue.REPO_RULE_NOT_FOUND_VALUE);
   }
-
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -189,6 +189,7 @@ public class DiscoveryTest extends FoundationTestCase {
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))
                 .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+                .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(registryFactory))
                 .put(
                     SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
                     new ModuleExtensionRepoMappingEntriesFunction())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -272,6 +272,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
                 .put(SkyFunctions.SINGLE_EXTENSION_USAGES, new SingleExtensionUsagesFunction())
                 .put(SkyFunctions.SINGLE_EXTENSION_EVAL, singleExtensionEvalFunction)
                 .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+                .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(registryFactory))
                 .put(
                     SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
                     new ModuleExtensionRepoMappingEntriesFunction())

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -158,6 +158,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))
                 .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+                .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction(registryFactory))
                 .put(
                     SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
                     new ModuleExtensionRepoMappingEntriesFunction())

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleExtensionRepoMappingEntriesFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.RepoSpecFunction;
+import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsFunction;
 import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
@@ -136,8 +137,8 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
         new RepositoryDelegatorFunction(
             repositoryHandlers,
             new StarlarkRepositoryFunction(downloader),
-            /*isFetch=*/ new AtomicBoolean(true),
-            /*clientEnvironmentSupplier=*/ ImmutableMap::of,
+            /* isFetch= */ new AtomicBoolean(true),
+            /* clientEnvironmentSupplier= */ ImmutableMap::of,
             directories,
             BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER);
     AtomicReference<PathPackageLocator> pkgLocator =
@@ -247,6 +248,9 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
                     BzlmodRepoRuleValue.BZLMOD_REPO_RULE,
                     new BzlmodRepoRuleFunction(ruleClassProvider, directories))
                 .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction(registryFactory))
+                .put(
+                    SkyFunctions.YANKED_VERSIONS,
+                    new YankedVersionsFunction(registryFactory))
                 .put(
                     SkyFunctions.MODULE_EXTENSION_REPO_MAPPING_ENTRIES,
                     new ModuleExtensionRepoMappingEntriesFunction())


### PR DESCRIPTION
Ensures that yanked version information is only downloaded once per module name, which reduces the number of files fetched during module resolution. On my machine, this reduces `bazel mod deps` runtime on Bazel itself by ~15%.

This also prepares for storing yanked version information in the lockfile.

Work towards https://github.com/bazelbuild/bazel/issues/20369