### PR TITLE
[7.2.0] Use an HTTP registry in Bzlmod tests

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -29,6 +29,7 @@ class BazelFetchTest(test_base.TestBase):
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main')
     )
+    self.main_registry.start()
     self.ScratchFile(
         '.bazelrc',
         [
@@ -47,6 +48,10 @@ class BazelFetchTest(test_base.TestBase):
     )
     self.ScratchFile('MODULE.bazel')
     self.generatBuiltinModules()
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def generatBuiltinModules(self):
     self.ScratchFile('platforms_mock/BUILD')

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -32,6 +32,7 @@ class BazelLockfileTest(test_base.TestBase):
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main')
     )
+    self.main_registry.start()
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(
         'aaa', '1.1'
     ).createCcModule('bbb', '1.0', {'aaa': '1.0'}).createCcModule(
@@ -58,6 +59,10 @@ class BazelLockfileTest(test_base.TestBase):
     # TODO(pcloudy): investigate why this is needed, MODULE.bazel.lock is not
     # deterministic?
     os.remove(self.Path('MODULE.bazel.lock'))
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def testChangeModuleInRegistryWithoutLockfile(self):
     # Add module 'sss' to the registry with dep on 'aaa'
@@ -1277,66 +1282,70 @@ class BazelLockfileTest(test_base.TestBase):
 
   def testLockfileWithNoUserSpecificPath(self):
     self.my_registry = BazelRegistry(os.path.join(self._test_cwd, 'registry'))
-    self.my_registry.setModuleBasePath('projects')
-    patch_file = self.ScratchFile(
-        'ss.patch',
-        [
-            '--- a/aaa.cc',
-            '+++ b/aaa.cc',
-            '@@ -1,6 +1,6 @@',
-            ' #include <stdio.h>',
-            ' #include "aaa.h"',
-            ' void hello_aaa(const std::string& caller) {',
-            '-    std::string lib_name = "aaa@1.1-1";',
-            '+    std::string lib_name = "aaa@1.1-1 (remotely patched)";',
-            '     printf("%s => %s\\n", caller.c_str(), lib_name.c_str());',
-            ' }',
-        ],
-    )
-    # Module with a local patch & extension
-    self.my_registry.createCcModule(
-        'ss',
-        '1.3-1',
-        {'ext': '1.0'},
-        patches=[patch_file],
-        patch_strip=1,
-        extra_module_file_contents=[
-            'my_ext = use_extension("@ext//:ext.bzl", "ext")',
-            'use_repo(my_ext, "justRepo")',
-        ],
-    )
-    ext_src = [
-        'def _repo_impl(ctx): ctx.file("BUILD")',
-        'repo = repository_rule(_repo_impl)',
-        'def _ext_impl(ctx): repo(name=justRepo)',
-        'ext=module_extension(_ext_impl)',
-    ]
-    self.my_registry.createLocalPathModule('ext', '1.0', 'ext')
-    scratchFile(self.my_registry.projects.joinpath('ext', 'BUILD'))
-    scratchFile(self.my_registry.projects.joinpath('ext', 'ext.bzl'), ext_src)
+    self.my_registry.start()
+    try:
+      self.my_registry.setModuleBasePath('projects')
+      patch_file = self.ScratchFile(
+          'ss.patch',
+          [
+              '--- a/aaa.cc',
+              '+++ b/aaa.cc',
+              '@@ -1,6 +1,6 @@',
+              ' #include <stdio.h>',
+              ' #include "aaa.h"',
+              ' void hello_aaa(const std::string& caller) {',
+              '-    std::string lib_name = "aaa@1.1-1";',
+              '+    std::string lib_name = "aaa@1.1-1 (remotely patched)";',
+              '     printf("%s => %s\\n", caller.c_str(), lib_name.c_str());',
+              ' }',
+          ],
+      )
+      # Module with a local patch & extension
+      self.my_registry.createCcModule(
+          'ss',
+          '1.3-1',
+          {'ext': '1.0'},
+          patches=[patch_file],
+          patch_strip=1,
+          extra_module_file_contents=[
+              'my_ext = use_extension("@ext//:ext.bzl", "ext")',
+              'use_repo(my_ext, "justRepo")',
+          ],
+      )
+      ext_src = [
+          'def _repo_impl(ctx): ctx.file("BUILD")',
+          'repo = repository_rule(_repo_impl)',
+          'def _ext_impl(ctx): repo(name=justRepo)',
+          'ext=module_extension(_ext_impl)',
+      ]
+      self.my_registry.createLocalPathModule('ext', '1.0', 'ext')
+      scratchFile(self.my_registry.projects.joinpath('ext', 'BUILD'))
+      scratchFile(self.my_registry.projects.joinpath('ext', 'ext.bzl'), ext_src)
 
-    self.ScratchFile(
-        'MODULE.bazel',
-        [
-            'bazel_dep(name = "ss", version = "1.3-1")',
-        ],
-    )
-    self.ScratchFile('BUILD.bazel', ['filegroup(name = "lala")'])
-    self.RunBazel(
-        ['build', '--registry=file:///%workspace%/registry', '//:lala']
-    )
+      self.ScratchFile(
+          'MODULE.bazel',
+          [
+              'bazel_dep(name = "ss", version = "1.3-1")',
+          ],
+      )
+      self.ScratchFile('BUILD.bazel', ['filegroup(name = "lala")'])
+      self.RunBazel(
+          ['build', '--registry=file:///%workspace%/registry', '//:lala']
+      )
 
-    with open('MODULE.bazel.lock', 'r') as json_file:
-      lockfile = json.load(json_file)
-    ss_dep = lockfile['moduleDepGraph']['ss@1.3-1']
-    remote_patches = ss_dep['repoSpec']['attributes']['remote_patches']
-    ext_usage_location = ss_dep['extensionUsages'][0]['location']['file']
+      with open('MODULE.bazel.lock', 'r') as json_file:
+        lockfile = json.load(json_file)
+      ss_dep = lockfile['moduleDepGraph']['ss@1.3-1']
+      remote_patches = ss_dep['repoSpec']['attributes']['remote_patches']
+      ext_usage_location = ss_dep['extensionUsages'][0]['location']['file']
 
-    self.assertNotIn(self.my_registry.getURL(), ext_usage_location)
-    self.assertIn('%workspace%', ext_usage_location)
-    for key in remote_patches.keys():
-      self.assertNotIn(self.my_registry.getURL(), key)
-      self.assertIn('%workspace%', key)
+      self.assertNotIn(self.my_registry.getURL(), ext_usage_location)
+      self.assertIn('%workspace%', ext_usage_location)
+      for key in remote_patches.keys():
+        self.assertNotIn(self.my_registry.getURL(), key)
+        self.assertIn('%workspace%', key)
+    finally:
+      self.my_registry.stop()
 
   def testExtensionEvaluationRerunsIfDepGraphOrderChanges(self):
     self.ScratchFile(

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -32,6 +32,7 @@ class BazelModuleTest(test_base.TestBase):
     self.registries_work_dir = tempfile.mkdtemp(dir=self._test_cwd)
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main'))
+    self.main_registry.start()
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(
         'aaa', '1.1'
     ).createCcModule(
@@ -59,6 +60,10 @@ class BazelModuleTest(test_base.TestBase):
             'build --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain'  # fmt: skip pylint: disable=line-too-long
         ],
     )
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def writeMainProjectFiles(self):
     self.ScratchFile('aaa.patch', [

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -29,6 +29,7 @@ class BazelOverridesTest(test_base.TestBase):
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main')
     )
+    self.main_registry.start()
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(
         'aaa', '1.1'
     ).createCcModule('bbb', '1.0', {'aaa': '1.0'}).createCcModule(
@@ -53,6 +54,10 @@ class BazelOverridesTest(test_base.TestBase):
             'build --lockfile_mode=update',
         ],
     )
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def writeMainProjectFiles(self):
     self.ScratchFile(
@@ -122,22 +127,26 @@ class BazelOverridesTest(test_base.TestBase):
         os.path.join(self.registries_work_dir, 'another'),
         ' from another registry',
     )
-    another_registry.createCcModule('aaa', '1.0')
-    self.ScratchFile(
-        'MODULE.bazel',
-        [
-            'bazel_dep(name = "aaa", version = "1.0")',
-            'bazel_dep(name = "bbb", version = "1.0")',
-            'single_version_override(',
-            '  module_name = "aaa",',
-            '  registry = "%s",' % another_registry.getURL(),
-            ')',
-        ],
-    )
-    _, stdout, _ = self.RunBazel(['run', '//:main'])
-    self.assertIn('main function => aaa@1.0 from another registry', stdout)
-    self.assertIn('main function => bbb@1.0', stdout)
-    self.assertIn('bbb@1.0 => aaa@1.0 from another registry', stdout)
+    another_registry.start()
+    try:
+      another_registry.createCcModule('aaa', '1.0')
+      self.ScratchFile(
+          'MODULE.bazel',
+          [
+              'bazel_dep(name = "aaa", version = "1.0")',
+              'bazel_dep(name = "bbb", version = "1.0")',
+              'single_version_override(',
+              '  module_name = "aaa",',
+              '  registry = "%s",' % another_registry.getURL(),
+              ')',
+          ],
+      )
+      _, stdout, _ = self.RunBazel(['run', '//:main'])
+      self.assertIn('main function => aaa@1.0 from another registry', stdout)
+      self.assertIn('main function => bbb@1.0', stdout)
+      self.assertIn('bbb@1.0 => aaa@1.0 from another registry', stdout)
+    finally:
+      another_registry.stop()
 
   def testArchiveOverride(self):
     self.writeMainProjectFiles()

--- a/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py
@@ -30,6 +30,7 @@ class BazelRepoMappingTest(test_base.TestBase):
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main')
     )
+    self.main_registry.start()
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(
         'aaa', '1.1'
     ).createCcModule('bbb', '1.0', {'aaa': '1.0'}).createCcModule(
@@ -55,6 +56,10 @@ class BazelRepoMappingTest(test_base.TestBase):
             'build --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain'  # fmt: skip pylint: disable=line-too-long
         ],
     )
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def testRunfilesRepoMappingManifest(self):
     self.main_registry.setModuleBasePath('projects')

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -29,6 +29,7 @@ class BazelVendorTest(test_base.TestBase):
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main')
     )
+    self.main_registry.start()
     self.ScratchFile(
         '.bazelrc',
         [
@@ -48,6 +49,10 @@ class BazelVendorTest(test_base.TestBase):
     )
     self.ScratchFile('MODULE.bazel')
     self.generateBuiltinModules()
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def generateBuiltinModules(self):
     self.ScratchFile('platforms_mock/BUILD')

--- a/src/test/py/bazel/bzlmod/bazel_yanked_versions_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_yanked_versions_test.py
@@ -29,6 +29,7 @@ class BazelYankedVersionsTest(test_base.TestBase):
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main')
     )
+    self.main_registry.start()
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(
         'aaa', '1.1'
     ).createCcModule('bbb', '1.0', {'aaa': '1.0'}).createCcModule(
@@ -49,6 +50,10 @@ class BazelYankedVersionsTest(test_base.TestBase):
         'yanked2', yanked_versions={'1.0': 'sketchy'}
     )
     self.writeBazelrcFile()
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def writeBazelrcFile(self, allow_yanked_versions=True):
     self.ScratchFile(

--- a/src/test/py/bazel/bzlmod/bzlmod_query_test.py
+++ b/src/test/py/bazel/bzlmod/bzlmod_query_test.py
@@ -30,6 +30,7 @@ class BzlmodQueryTest(test_base.TestBase):
     self.registries_work_dir = tempfile.mkdtemp(dir=self._test_cwd)
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main'))
+    self.main_registry.start()
     self.main_registry.createCcModule('aaa', '1.0', {'ccc': '1.2'}) \
       .createCcModule('aaa', '1.1') \
       .createCcModule('bbb', '1.0', {'aaa': '1.0'}, {'aaa': 'com_foo_bar_aaa'}) \
@@ -49,6 +50,10 @@ class BzlmodQueryTest(test_base.TestBase):
             'common --allow_yanked_versions=all',
         ],
     )
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def testQueryModuleRepoTargetsBelow(self):
     self.ScratchFile('MODULE.bazel', [

--- a/src/test/py/bazel/bzlmod/external_repo_completion_test.py
+++ b/src/test/py/bazel/bzlmod/external_repo_completion_test.py
@@ -37,6 +37,7 @@ class ExternalRepoCompletionTest(test_base.TestBase):
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main')
     )
+    self.main_registry.start()
     self.main_registry.setModuleBasePath('projects')
     self.projects_dir = self.main_registry.projects
     self.maxDiff = None  # there are some long diffs in this test
@@ -156,6 +157,10 @@ class ExternalRepoCompletionTest(test_base.TestBase):
         ['cc_library(name="lib_ext2", visibility = ["//visibility:public"])'],
     )
     scratchFile(self.projects_dir.joinpath('ext2', 'ext.bzl'), ext_src)
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def complete(self, bazel_args):
     """Get the bash completions for the given "bazel" command line."""

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -32,6 +32,7 @@ class ModCommandTest(test_base.TestBase):
     self.main_registry = BazelRegistry(
         os.path.join(self.registries_work_dir, 'main')
     )
+    self.main_registry.start()
     self.main_registry.setModuleBasePath('projects')
     self.projects_dir = self.main_registry.projects
     self.maxDiff = None  # there are some long diffs in this test
@@ -132,6 +133,10 @@ class ModCommandTest(test_base.TestBase):
     self.main_registry.createLocalPathModule('ext2', '1.0', 'ext2')
     scratchFile(self.projects_dir.joinpath('ext2', 'BUILD'))
     scratchFile(self.projects_dir.joinpath('ext2', 'ext.bzl'), ext_src)
+
+  def tearDown(self):
+    self.main_registry.stop()
+    test_base.TestBase.tearDown(self)
 
   def testFailWithoutBzlmod(self):
     _, _, stderr = self.RunBazel(

--- a/src/test/py/bazel/bzlmod/test_utils.py
+++ b/src/test/py/bazel/bzlmod/test_utils.py
@@ -98,17 +98,28 @@ class BazelRegistry:
     self.archives = self.root.joinpath('archives')
     self.archives.mkdir(parents=True, exist_ok=True)
     self.registry_suffix = registry_suffix
+    self.http_server = StaticHTTPServer(self.root)
 
   def setModuleBasePath(self, module_base_path):
     bazel_registry = {
-        'module_base_path': module_base_path,
+        'module_base_path': (
+            self.root.joinpath(module_base_path).resolve().as_posix()
+        ),
     }
     with self.root.joinpath('bazel_registry.json').open('w') as f:
       json.dump(bazel_registry, f, indent=4, sort_keys=True)
 
+  def start(self):
+    """Start an HTTP server serving the registry."""
+    self.http_server.__enter__()
+
+  def stop(self):
+    """Stop the HTTP server."""
+    self.http_server.__exit__(None, None, None)
+
   def getURL(self):
     """Return the URL of this registry."""
-    return self.root.resolve().as_uri()
+    return self.http_server.getURL()
 
   def generateCcSource(
       self,


### PR DESCRIPTION
This is in preparation for tracking the hashes of remote (non-`file:` URL) files in the lockfile. If the tests use local registries, they wouldn't be representative of the default situation.

Work towards #20369

Closes #21906.

PiperOrigin-RevId: 622290283
Change-Id: Ibe825d2bede84c1b0672dbb699aaf3ee5168a813

Commit https://github.com/bazelbuild/bazel/commit/3f9d80c35d88a280c2d53682f3d201b4733a3fff