### PR TITLE
[7.2.0] Implement StageArtifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1267,6 +1267,7 @@ public class RemoteExecutionService {
     }
 
     if (hasBazelOutputService) {
+      // TODO(chiwang): Stage directories directly
       ((BazelOutputService) outputService).stageArtifacts(finishedDownloads);
     } else {
       moveOutputsToFinalLocation(finishedDownloads, realToTmpPath);


### PR DESCRIPTION
If `--experimental_remote_output_service` is set, Bazel issue StageArtifacts RPC to the output service after hitting the remote cache or executing action remotely.

Working towards https://github.com/bazelbuild/bazel/issues/21630.

Closes #21746.

PiperOrigin-RevId: 617834441
Change-Id: I85fb544a69d0ca779a793038ff0e6a4b755dd637

Commit https://github.com/bazelbuild/bazel/commit/4484f86ca43a874d5a28e59e6a1ecc77c6249ae3