### PR TITLE
Include Bzlmod globals in `builtin.proto`

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/ApiExporter.java
+++ b/src/main/java/com/google/devtools/build/docgen/ApiExporter.java
@@ -375,6 +375,12 @@ public class ApiExporter {
           builtins, symbols.getGlobals(), globalToDoc, typeNameToConstructor, ApiContext.ALL);
       appendGlobals(
           builtins, symbols.getBzlGlobals(), globalToDoc, typeNameToConstructor, ApiContext.BZL);
+      appendGlobals(
+          builtins,
+          symbols.getModuleFileGlobals(),
+          globalToDoc,
+          typeNameToConstructor,
+          ApiContext.MODULE);
       appendNativeRules(builtins, symbols.getNativeRules());
       writeBuiltins(options.outputFile, builtins);
 

--- a/src/main/java/com/google/devtools/build/docgen/BUILD
+++ b/src/main/java/com/google/devtools/build/docgen/BUILD
@@ -77,6 +77,7 @@ java_binary(
     srcs = ["ApiExporter.java"],
     main_class = "com.google.devtools.build.docgen.ApiExporter",
     runtime_deps = [
+        "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository",
         "//src/main/java/net/starlark/java/syntax",
     ],

--- a/src/main/java/com/google/devtools/build/docgen/SymbolFamilies.java
+++ b/src/main/java/com/google/devtools/build/docgen/SymbolFamilies.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.docgen.starlark.StarlarkDocPage;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.util.Classpath.ClassPathException;
 import com.google.devtools.build.skydoc.fakebuildapi.FakeStarlarkNativeModuleApi;
+import com.google.devtools.build.skydoc.fakebuildapi.repository.FakeRepositoryModule;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -114,6 +115,7 @@ public class SymbolFamilies {
     // annotations, whereas the real "native" object is just a bare struct.
     ImmutableMap.Builder<String, Object> env = ImmutableMap.builder();
     env.put("native", new FakeStarlarkNativeModuleApi());
+    Starlark.addMethods(env, new FakeRepositoryModule(ImmutableList.of()));
     for (Map.Entry<String, Object> entry :
         provider.getBazelStarlarkEnvironment().getUninjectedBuildBzlEnv().entrySet()) {
       if (entry.getKey().equals("native")) {

--- a/src/main/protobuf/builtin.proto
+++ b/src/main/protobuf/builtin.proto
@@ -57,6 +57,7 @@ enum ApiContext {
   ALL = 0;
   BZL = 1;
   BUILD = 2;
+  MODULE = 3;
 }
 
 // Generic representation for a Starlark object. If the object is callable

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -149,3 +149,15 @@ test_suite(
     name = "others",
     tags = ["-" + n for n in TEST_SUITES],
 )
+
+java_test(
+    name = "BuiltinProtoSmokeTest",
+    srcs = ["BuiltinProtoSmokeTest.java"],
+    data = ["//src/main/java/com/google/devtools/build/lib:gen_api_proto"],
+    env = {"BUILTIN_PROTO": "$(rlocationpath //src/main/java/com/google/devtools/build/lib:gen_api_proto)"},
+    deps = [
+        "//src/main/protobuf:builtin_java_proto",
+        "//third_party:truth",
+        "@bazel_tools//tools/java/runfiles",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/BuiltinProtoSmokeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/BuiltinProtoSmokeTest.java
@@ -30,7 +30,7 @@ public final class BuiltinProtoSmokeTest {
   }
 
   @Test
-  public void hasGlobalCallableFromEachApiContext() {
+  public void wellKnownCallablesAreDocumented() {
     assertThat(
             builtins.getGlobalList().stream()
                 .filter(BuiltinProtos.Value::hasCallable)
@@ -40,6 +40,7 @@ public final class BuiltinProtoSmokeTest {
             "range", BuiltinProtos.ApiContext.ALL,
             "glob", BuiltinProtos.ApiContext.BUILD,
             "DefaultInfo", BuiltinProtos.ApiContext.BZL,
+            "module_extension", BuiltinProtos.ApiContext.BZL,
             "bazel_dep", BuiltinProtos.ApiContext.MODULE);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/BuiltinProtoSmokeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/BuiltinProtoSmokeTest.java
@@ -1,0 +1,45 @@
+package com.google.devtools.build.lib;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toMap;
+
+import com.google.devtools.build.docgen.builtin.BuiltinProtos;
+import com.google.devtools.build.runfiles.Runfiles;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class BuiltinProtoSmokeTest {
+  static BuiltinProtos.Builtins builtins;
+
+  @BeforeClass
+  public static void loadProto() throws IOException {
+    Path protoPath =
+        Path.of(Runfiles.preload().unmapped().rlocation(System.getenv("BUILTIN_PROTO")));
+    try (InputStream inputStream = Files.newInputStream(protoPath);
+        BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream)) {
+      builtins = BuiltinProtos.Builtins.parseFrom(bufferedInputStream);
+    }
+  }
+
+  @Test
+  public void hasGlobalCallableFromEachApiContext() {
+    assertThat(
+            builtins.getGlobalList().stream()
+                .filter(BuiltinProtos.Value::hasCallable)
+                .filter(global -> !global.getCallable().getParamList().isEmpty())
+                .collect(toMap(BuiltinProtos.Value::getName, BuiltinProtos.Value::getApiContext)))
+        .containsAtLeast(
+            "range", BuiltinProtos.ApiContext.ALL,
+            "glob", BuiltinProtos.ApiContext.BUILD,
+            "DefaultInfo", BuiltinProtos.ApiContext.BZL,
+            "bazel_dep", BuiltinProtos.ApiContext.MODULE);
+  }
+}


### PR DESCRIPTION
This allows consumers of the proto to learn about globals only available in `MODULE.bazel` under a new `ApiContext` `MODULE`. 

Also adds the `ApiContext.BZL` globals for repository rule and module extension definition.

A new smoke test verifies that common symbols are contained in the proto for each API context.

Work towards bazelbuild/vscode-bazel#1