### PR TITLE
[7.2.0] Implement FinalizeArtifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BazelOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/BazelOutputService.java
@@ -22,8 +22,12 @@ import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.events.EventHandler;
+import com.google.devtools.build.lib.remote.BazelOutputServiceProto.StageArtifactsRequest;
+import com.google.devtools.build.lib.remote.BazelOutputServiceProto.StageArtifactsRequest.Artifact;
+import com.google.devtools.build.lib.remote.BazelOutputServiceProto.StageArtifactsResponse;
 import com.google.devtools.build.lib.remote.BazelOutputServiceProto.StartBuildRequest;
 import com.google.devtools.build.lib.remote.BazelOutputServiceProto.StartBuildResponse;
+import com.google.devtools.build.lib.remote.BazelOutputServiceREv2Proto.FileArtifactLocator;
 import com.google.devtools.build.lib.remote.BazelOutputServiceREv2Proto.StartBuildArgs;
 import com.google.devtools.build.lib.remote.RemoteExecutionService.ActionResultMetadata.FileMetadata;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -41,6 +45,7 @@ import com.google.devtools.build.lib.vfs.OutputService;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.protobuf.Any;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.util.List;
@@ -225,8 +230,49 @@ public class BazelOutputService implements OutputService {
                 }));
   }
 
-  protected void stageArtifacts(List<FileMetadata> files) {
-    // TODO(chiwang): implement this
+  protected void stageArtifacts(List<FileMetadata> files) throws IOException, InterruptedException {
+    var outputPath = outputPathSupplier.get();
+    var request = StageArtifactsRequest.newBuilder();
+    request.setBuildId(buildId);
+    for (var file : files) {
+      request.addArtifacts(
+          Artifact.newBuilder()
+              .setPath(file.path().relativeTo(outputPath).toString())
+              .setLocator(
+                  Any.pack(FileArtifactLocator.newBuilder().setDigest(file.digest()).build()))
+              .build());
+    }
+    var response = stageArtifacts(request.build());
+    if (response.getResponsesCount() != files.size()) {
+      throw new IOException(
+          String.format(
+              "StageArtifacts failed: expect %s responses from StageArtifactsResponse, got %s",
+              files.size(), response.getResponsesCount()));
+    }
+
+    for (var i = 0; i < files.size(); ++i) {
+      var fileResponse = response.getResponses(i);
+      if (fileResponse.getStatus().getCode() != Status.Code.OK.value()) {
+        throw new IOException(
+            String.format(
+                "Failed to stage %s, code: %s",
+                files.get(i).path().relativeTo(outputPath), fileResponse.getStatus()));
+      }
+    }
+  }
+
+  private StageArtifactsResponse stageArtifacts(StageArtifactsRequest request)
+      throws IOException, InterruptedException {
+    return retrier.execute(
+        () ->
+            channel.withChannelBlocking(
+                channel -> {
+                  try {
+                    return BazelOutputServiceGrpc.newBlockingStub(channel).stageArtifacts(request);
+                  } catch (StatusRuntimeException e) {
+                    throw new IOException(e);
+                  }
+                }));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1267,6 +1267,7 @@ public class RemoteExecutionService {
     }
 
     if (hasBazelOutputService) {
+      // TODO(chiwang): Stage directories directly
       ((BazelOutputService) outputService).stageArtifacts(finishedDownloads);
     } else {
       moveOutputsToFinalLocation(finishedDownloads, realToTmpPath);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -446,6 +446,7 @@ public final class RemoteModule extends BlazeModule {
       outputService =
           new BazelOutputService(
               env.getOutputBase(),
+              env::getExecRoot,
               () -> env.getDirectories().getOutputPath(env.getWorkspaceName()),
               digestUtil.getDigestFunction(),
               remoteOptions,


### PR DESCRIPTION
This includes two commits

1) Implement StageArtifacts
If `--experimental_remote_output_service` is set, Bazel issue StageArtifacts RPC to the output service after hitting the remote cache or executing action remotely.

Working towards https://github.com/bazelbuild/bazel/issues/21630.

Closes https://github.com/bazelbuild/bazel/pull/21746.

PiperOrigin-RevId: 617834441
Change-Id: I85fb544a69d0ca779a793038ff0e6a4b755dd637
Commit https://github.com/bazelbuild/bazel/commit/4484f86ca43a874d5a28e59e6a1ecc77c6249ae3

2) Implement FinalizeArtifacts
If `--experimental_remote_output_service` is set, Bazel issues a FinalizeArtifacts RPC to the output service after an action has been executed.

Working towards https://github.com/bazelbuild/bazel/issues/21630.

Closes https://github.com/bazelbuild/bazel/pull/21759.

PiperOrigin-RevId: 618190373
Change-Id: I8ed981fcea7ebe146de0b1c48b1933392c86253f
Commit https://github.com/bazelbuild/bazel/commit/586bd13179636350a2d0f156dc95a4acc820bae2