### PR TITLE
[7.2.0] Implement XattrProvider which uses BatchStat to getFastDigest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -217,7 +217,7 @@ public final class SkyframeActionExecutor {
   @Nullable private ActionCompletedReceiver completionReceiver;
 
   private final AtomicReference<ActionExecutionStatusReporter> statusReporterRef;
-  private OutputService outputService;
+  @Nullable private OutputService outputService;
   private boolean finalizeActions;
   private boolean rewindingEnabled;
   private final Supplier<ImmutableList<Root>> sourceRootSupplier;
@@ -283,7 +283,7 @@ public final class SkyframeActionExecutor {
       OptionsProvider options,
       ActionCacheChecker actionCacheChecker,
       ActionOutputDirectoryHelper outputDirectoryHelper,
-      OutputService outputService,
+      @Nullable OutputService outputService,
       boolean trackIncrementalState) {
     this.reporter = checkNotNull(reporter);
     this.executorEngine = checkNotNull(executor);
@@ -361,6 +361,10 @@ public final class SkyframeActionExecutor {
   }
 
   XattrProvider getXattrProvider() {
+    if (outputService != null) {
+      return checkNotNull(outputService.getXattrProvider(syscallCache));
+    }
+
     return syscallCache;
   }
 
@@ -369,14 +373,15 @@ public final class SkyframeActionExecutor {
       String relativeOutputPath,
       ActionInputMap inputArtifactData,
       Iterable<Artifact> outputArtifacts) {
-    return outputService.createActionFileSystem(
-        executorEngine.getFileSystem(),
-        executorEngine.getExecRoot().asFragment(),
-        relativeOutputPath,
-        sourceRootSupplier.get(),
-        inputArtifactData,
-        outputArtifacts,
-        rewindingEnabled);
+    return checkNotNull(outputService)
+        .createActionFileSystem(
+            executorEngine.getFileSystem(),
+            executorEngine.getExecRoot().asFragment(),
+            relativeOutputPath,
+            sourceRootSupplier.get(),
+            inputArtifactData,
+            outputArtifacts,
+            rewindingEnabled);
   }
 
   private void updateActionFileSystemContext(
@@ -385,8 +390,8 @@ public final class SkyframeActionExecutor {
       Environment env,
       MetadataInjector metadataInjector,
       ImmutableMap<Artifact, ImmutableList<FilesetOutputSymlink>> filesets) {
-    outputService.updateActionFileSystemContext(
-        action, actionFileSystem, env, metadataInjector, filesets);
+    checkNotNull(outputService)
+        .updateActionFileSystemContext(action, actionFileSystem, env, metadataInjector, filesets);
   }
 
   void executionOver() {

--- a/src/main/java/com/google/devtools/build/lib/vfs/OutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OutputService.java
@@ -241,4 +241,8 @@ public interface OutputService {
   default BulkDeleter bulkDeleter() {
     return null;
   }
+
+  default XattrProvider getXattrProvider(XattrProvider delegate) {
+    return delegate;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/vfs/XattrProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/XattrProvider.java
@@ -38,4 +38,29 @@ public interface XattrProvider {
   default byte[] getxattr(Path path, String xattrName, Symlinks followSymlinks) throws IOException {
     return path.getxattr(xattrName, followSymlinks);
   }
+
+  /** Delegates to another {@link XattrProvider}. */
+  class DelegatingXattrProvider implements XattrProvider {
+    private final XattrProvider delegate;
+
+    public DelegatingXattrProvider(XattrProvider delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public byte[] getFastDigest(Path path) throws IOException {
+      return delegate.getFastDigest(path);
+    }
+
+    @Override
+    public byte[] getxattr(Path path, String xattrName) throws IOException {
+      return delegate.getxattr(path, xattrName);
+    }
+
+    @Override
+    public byte[] getxattr(Path path, String xattrName, Symlinks followSymlinks)
+        throws IOException {
+      return delegate.getxattr(path, xattrName, followSymlinks);
+    }
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/OutputsInvalidationIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/OutputsInvalidationIntegrationTest.java
@@ -57,6 +57,7 @@ public final class OutputsInvalidationIntegrationTest extends BuildIntegrationTe
     when(outputService.getFilesSystemName()).thenReturn("fileSystemName");
     when(outputService.startBuild(any(), any(), anyBoolean()))
         .thenReturn(ModifiedFileSet.EVERYTHING_MODIFIED);
+    when(outputService.getXattrProvider(any())).thenAnswer(i -> i.getArgument(0));
   }
 
   @Override


### PR DESCRIPTION
If `--experimental_remote_output_service` is set, a `XattrProvider` which uses `BatchStat` RPC to get the digest of a file will be used for Bazel to get digests for outputs.

Working towards https://github.com/bazelbuild/bazel/issues/21630.

Closes #21812.

PiperOrigin-RevId: 619539349
Change-Id: I71364e78c45c37e834c71e120a109c8de602db77

Commit https://github.com/bazelbuild/bazel/commit/30aa5d0e7e5782703b4ac1fd980fb6cabd408c3c