### PR TITLE
Add `bazel help builtin-symbols-as-proto`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -213,6 +213,13 @@ java_library(
     ],
 )
 
+java_library(
+    name = "builtin_symbols_proto",
+    resources = [
+        "//src/main/java/com/google/devtools/build/lib:gen_api_proto",
+    ],
+)
+
 java_binary(
     name = "BazelServer",
     javacopts = [
@@ -220,6 +227,7 @@ java_binary(
     ],
     main_class = "com.google.devtools.build.lib.bazel.Bazel",
     runtime_deps = [
+        ":builtin_symbols_proto",  # Adding this to :main would create a cycle
         ":main",
         "//src/main/java/com/google/devtools/build/lib/server",
         "//src/main/java/com/google/devtools/build/lib/util:simple_log_handler",  # See startup_options.cc

--- a/src/test/java/com/google/devtools/build/lib/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BUILD
@@ -16,6 +16,7 @@ java_library(
         exclude = [
             "commands/ConfigCommandTest.java",
             "commands/DumpCommandTest.java",
+            "commands/HelpCommandTest.java",
         ],
     ),
     deps = [
@@ -154,6 +155,23 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/runtime/commands",
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
+        "//src/test/java/com/google/devtools/build/lib/buildtool/util",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
+    name = "HelpCommandTest",
+    srcs = ["commands/HelpCommandTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib:runtime/blaze_command_result",
+        "//src/main/java/com/google/devtools/build/lib/bazel:builtin_symbols_proto",
+        "//src/main/java/com/google/devtools/build/lib/runtime/commands",
+        "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
+        "//src/main/protobuf:builtin_java_proto",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
         "//third_party:guava",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/runtime/commands/HelpCommandTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/commands/HelpCommandTest.java
@@ -1,0 +1,77 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.runtime.commands;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toMap;
+
+import com.google.common.collect.Lists;
+import com.google.devtools.build.docgen.builtin.BuiltinProtos;
+import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
+import com.google.devtools.build.lib.runtime.BlazeCommandDispatcher;
+import com.google.devtools.build.lib.runtime.BlazeCommandResult;
+import com.google.devtools.build.lib.runtime.BlazeRuntime;
+import com.google.devtools.build.lib.util.io.RecordingOutErr;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link HelpCommand}. */
+@RunWith(JUnit4.class)
+public final class HelpCommandTest extends BuildIntegrationTestCase {
+  private BlazeCommandDispatcher dispatcher;
+  private RecordingOutErr recordingOutErr;
+
+  @Before
+  public void createDispatcher() {
+    BlazeRuntime runtime = getRuntime();
+    runtime.getCommandMap().put("help", new HelpCommand());
+    dispatcher = new BlazeCommandDispatcher(runtime);
+  }
+
+  @Before
+  public void createRecording() {
+    recordingOutErr = new RecordingOutErr();
+  }
+
+  private BlazeCommandResult help(String... args) throws InterruptedException {
+    List<String> params = Lists.newArrayList("help");
+    Collections.addAll(params, args);
+    return dispatcher.exec(params, "test", recordingOutErr);
+  }
+
+  @Test
+  public void wellKnownCallablesInBuiltinSymbolsProto() throws Exception {
+    assertThat(help("builtin-symbols-as-proto").isSuccess()).isTrue();
+    assertThat(recordingOutErr.errAsLatin1()).isEmpty();
+    String base64Proto = recordingOutErr.outAsLatin1();
+    byte[] rawProto = Base64.getDecoder().decode(base64Proto);
+    var builtins = BuiltinProtos.Builtins.parseFrom(rawProto);
+
+    assertThat(
+            builtins.getGlobalList().stream()
+                .filter(BuiltinProtos.Value::hasCallable)
+                .filter(global -> !global.getCallable().getParamList().isEmpty())
+                .collect(toMap(BuiltinProtos.Value::getName, BuiltinProtos.Value::getApiContext)))
+        .containsAtLeast(
+            "range", BuiltinProtos.ApiContext.ALL,
+            "glob", BuiltinProtos.ApiContext.BUILD,
+            "DefaultInfo", BuiltinProtos.ApiContext.BZL);
+  }
+}


### PR DESCRIPTION
Work towards bazelbuild/vscode-bazel#1

RELNOTES: The new `bazel help builtin-symbols-as-proto` subcommand emits a base64-encoded proto message describing the built-in Starlark types and global symbols. See `src/main/protobuf/builtin.proto` for the message definition.