### PR TITLE
[7.2.0] Show display form labels in `java_*` buildozer fixups

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -211,7 +211,8 @@ public final class JavaCompilationHelper {
     return builder.build();
   }
 
-  public void createCompileAction(JavaCompileOutputs<Artifact> outputs) throws RuleErrorException {
+  public void createCompileAction(JavaCompileOutputs<Artifact> outputs)
+      throws RuleErrorException, InterruptedException {
     if (outputs.genClass() != null) {
       createGenJarAction(
           outputs.output(),
@@ -544,7 +545,7 @@ public final class JavaCompilationHelper {
    * @param headerDeps the .jdeps output of this java compilation
    */
   public void createHeaderCompilationAction(Artifact headerJar, Artifact headerDeps)
-      throws RuleErrorException {
+      throws RuleErrorException, InterruptedException {
 
     JavaTargetAttributes attributes = getAttributes();
 
@@ -689,7 +690,8 @@ public final class JavaCompilationHelper {
    * @return the header jar (if requested), or ijar (if requested), or else the class jar
    */
   public Artifact createCompileTimeJarAction(
-      Artifact runtimeJar, JavaCompilationArtifacts.Builder builder) throws RuleErrorException {
+      Artifact runtimeJar, JavaCompilationArtifacts.Builder builder)
+      throws RuleErrorException, InterruptedException {
     Artifact jar;
     boolean isFullJar = false;
     if (shouldUseHeaderCompilation()) {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -171,7 +171,7 @@ public final class JavaCompileActionBuilder {
     this.execGroup = execGroup;
   }
 
-  public JavaCompileAction build() throws RuleErrorException {
+  public JavaCompileAction build() throws RuleErrorException, InterruptedException {
     // TODO(bazel-team): all the params should be calculated before getting here, and the various
     // aggregation code below should go away.
 
@@ -271,7 +271,7 @@ public final class JavaCompileActionBuilder {
   }
 
   private CustomCommandLine buildParamFileContents(ImmutableList<String> javacOpts)
-      throws RuleErrorException {
+      throws RuleErrorException, InterruptedException {
 
     CustomCommandLine.Builder result = CustomCommandLine.builder();
 
@@ -304,7 +304,8 @@ public final class JavaCompileActionBuilder {
       } else {
         // @-prefixed strings will be assumed to be filenames and expanded by
         // {@link JavaLibraryBuildRequest}, so add an extra &at; to escape it.
-        result.addPrefixedLabel("@", targetLabel);
+        result.addPrefixedLabel(
+            "@", targetLabel, ruleContext.getAnalysisEnvironment().getMainRepoMapping());
       }
     }
     result.add("--injecting_rule_kind", injectingRuleKind);

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -372,7 +372,8 @@ public final class JavaHeaderCompileAction extends SpawnAction {
     }
 
     /** Builds and registers the action for a header compilation. */
-    public void build(JavaToolchainProvider javaToolchain) throws RuleErrorException {
+    public void build(JavaToolchainProvider javaToolchain)
+        throws RuleErrorException, InterruptedException {
       checkNotNull(outputDepsProto, "outputDepsProto must not be null");
       checkNotNull(sourceFiles, "sourceFiles must not be null");
       checkNotNull(sourceJars, "sourceJars must not be null");
@@ -482,7 +483,8 @@ public final class JavaHeaderCompileAction extends SpawnAction {
         } else {
           // @-prefixed strings will be assumed to be params filenames and expanded,
           // so add an extra @ to escape it.
-          commandLine.addPrefixedLabel("@", targetLabel);
+          commandLine.addPrefixedLabel(
+              "@", targetLabel, ruleContext.getAnalysisEnvironment().getMainRepoMapping());
         }
       }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -136,7 +136,11 @@ public class JavaStarlarkCommon
       Object injectingRuleKind,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs)
-      throws EvalException, TypeException, RuleErrorException, LabelSyntaxException {
+      throws EvalException,
+          TypeException,
+          RuleErrorException,
+          LabelSyntaxException,
+          InterruptedException {
     checkJavaToolchainIsDeclaredOnRule(ctx.getRuleContext());
     JavaTargetAttributes.Builder attributesBuilder =
         new JavaTargetAttributes.Builder(javaSemantics)
@@ -200,7 +204,11 @@ public class JavaStarlarkCommon
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
       Sequence<?> additionalOutputs)
-      throws EvalException, TypeException, RuleErrorException, LabelSyntaxException {
+      throws EvalException,
+          TypeException,
+          RuleErrorException,
+          LabelSyntaxException,
+          InterruptedException {
     checkJavaToolchainIsDeclaredOnRule(ctx.getRuleContext());
     JavaCompileOutputs<Artifact> outputs =
         JavaCompileOutputs.builder()

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -523,7 +523,11 @@ public interface JavaCommonApi<
       Object injectingRuleKind,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs)
-      throws EvalException, TypeException, RuleErrorException, LabelSyntaxException;
+      throws EvalException,
+          TypeException,
+          RuleErrorException,
+          LabelSyntaxException,
+          InterruptedException;
 
   @StarlarkMethod(
       name = "create_compilation_action",
@@ -585,7 +589,11 @@ public interface JavaCommonApi<
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
       Sequence<?> additionalOutputs)
-      throws EvalException, TypeException, RuleErrorException, LabelSyntaxException;
+      throws EvalException,
+          TypeException,
+          RuleErrorException,
+          LabelSyntaxException,
+          InterruptedException;
 
   @StarlarkMethod(
       name = "default_javac_opts",

--- a/src/test/java/com/google/devtools/build/lib/actions/CustomCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/CustomCommandLineTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
@@ -28,6 +29,8 @@ import com.google.devtools.build.lib.analysis.actions.CustomCommandLine;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine.VectorArg;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine.VectorArg.SimpleVectorArg;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -126,7 +129,8 @@ public final class CustomCommandLineTest {
         .containsExactly("prefix-foo");
     assertThat(
             builder()
-                .addPrefixedLabel("prefix-", Label.parseCanonical("//a:b"))
+                .addPrefixedLabel(
+                    "prefix-", Label.parseCanonical("//a:b"), /* mainRepoMapping= */ null)
                 .build()
                 .arguments())
         .containsExactly("prefix-//a:b");
@@ -135,6 +139,22 @@ public final class CustomCommandLineTest {
         .containsExactly("prefix-path");
     assertThat(builder().addPrefixedExecPath("prefix-", artifact1).build().arguments())
         .containsExactly("prefix-dir/file1.txt");
+  }
+
+  @Test
+  public void addPrefixedLabel_emitsExternalLabelInDisplayForm() throws Exception {
+    assertThat(
+            builder()
+                .addPrefixedLabel(
+                    "prefix-",
+                    Label.parseCanonical("@@canonical_name//a:b"),
+                    RepositoryMapping.create(
+                        ImmutableMap.of(
+                            "apparent_name", RepositoryName.createUnvalidated("canonical_name")),
+                        RepositoryName.MAIN))
+                .build()
+                .arguments())
+        .containsExactly("prefix-@apparent_name//a:b");
   }
 
   @Test
@@ -527,7 +547,7 @@ public final class CustomCommandLineTest {
             .addExecPath("foo", null)
             .addLazyString("foo", null)
             .addPrefixed("prefix", null)
-            .addPrefixedLabel("prefix", null)
+            .addPrefixedLabel("prefix", null, /* mainRepoMapping= */ null)
             .addPrefixedPath("prefix", null)
             .addPrefixedExecPath("prefix", null)
             .addAll((ImmutableList<String>) null)

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1981,4 +1981,90 @@ EOF
     >& $TEST_log || fail "build failed"
 }
 
+function test_strict_deps_error_external_repo_header_compile_action() {
+  cat << 'EOF' > MODULE.bazel
+bazel_dep(
+    name = "lib_c",
+    repo_name = "c",
+)
+local_path_override(
+    module_name = "lib_c",
+    path = "lib_c",
+)
+EOF
+
+  mkdir -p pkg
+  cat << 'EOF' > pkg/BUILD
+java_binary(name = "Main", srcs = ["Main.java"], deps = [":a"])
+java_library(name = "a", srcs = ["A.java"], deps = [":b"])
+java_library(name = "b", srcs = ["B.java"], deps = ["@c"])
+EOF
+  cat << 'EOF' > pkg/Main.java
+public class Main extends A {}
+EOF
+  cat << 'EOF' > pkg/A.java
+public class A extends B implements C {}
+EOF
+  cat << 'EOF' > pkg/B.java
+public class B implements C {}
+EOF
+
+  mkdir -p lib_c
+  cat << 'EOF' > lib_c/MODULE.bazel
+module(name = "lib_c")
+EOF
+  cat << 'EOF' > lib_c/BUILD
+java_library(name = "c", srcs = ["C.java"], visibility = ["//visibility:public"])
+EOF
+  cat << 'EOF' > lib_c/C.java
+public interface C {}
+EOF
+
+  bazel build //pkg:a >& $TEST_log && fail "build should fail"
+  expect_log "buildozer 'add deps @c//:c' //pkg:a"
+}
+
+function test_strict_deps_error_external_repo_compile_action() {
+  cat << 'EOF' > MODULE.bazel
+bazel_dep(
+    name = "lib_c",
+    repo_name = "c",
+)
+local_path_override(
+    module_name = "lib_c",
+    path = "lib_c",
+)
+EOF
+
+  mkdir -p pkg
+  cat << 'EOF' > pkg/BUILD
+java_library(name = "a", srcs = ["A.java"], deps = [":b"])
+java_library(name = "b", srcs = ["B.java"], deps = ["@c"])
+EOF
+  cat << 'EOF' > pkg/A.java
+public class A extends B {
+  boolean foo() {
+    return this instanceof C;
+  }
+}
+EOF
+  cat << 'EOF' > pkg/B.java
+public class B implements C {}
+EOF
+
+  mkdir -p lib_c
+  cat << 'EOF' > lib_c/MODULE.bazel
+module(name = "lib_c")
+EOF
+  cat << 'EOF' > lib_c/BUILD
+java_library(name = "c", srcs = ["C.java"], visibility = ["//visibility:public"])
+EOF
+  cat << 'EOF' > lib_c/C.java
+public interface C {}
+EOF
+
+  bazel build //pkg:a >& $TEST_log && fail "build should fail"
+  expect_log "buildozer 'add deps @c//:c' //pkg:a"
+}
+
 run_suite "Java integration tests"

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -1367,7 +1367,7 @@ EOF
 
   bazel build @x_repo//a >& $TEST_log && fail "Building @x_repo//a should error out"
   expect_log "** Please add the following dependencies:"
-  expect_log "@@x_repo//x to @@x_repo//a"
+  expect_log " @x_repo//x to @x_repo//a"
 }
 
 # This test verifies that the `public` pattern includes external dependencies.


### PR DESCRIPTION
The change in #21702 only fixed the buildozer fixup messages for `java_*` actions entirely defined in Starlark. This commit makes the analogous change to the remaining native actions.

Related to #20486 and #21702

Closes #21827.

PiperOrigin-RevId: 623253302
Change-Id: Iadc2b0d8ce64f359b921ad7a7c489111a3a29997

Commit https://github.com/bazelbuild/bazel/commit/1c9986613a83ed9d8bd037bd9bcec3fc775bad9f