### PR TITLE
feat(cc toolchain): support external_include_paths on macos

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -1477,6 +1477,7 @@ def _impl(ctx):
             default_link_flags_feature,
             user_link_flags_feature,
             default_link_libs_feature,
+            external_include_paths_feature,
             fdo_optimize_feature,
             dbg_feature,
             opt_feature,


### PR DESCRIPTION
The external_include_paths feature enables specifying include paths locally with -I and with -isystem when the project is included as an external repo.

This makes it possible to set -Werror against your own headers for development without propagating this to consumers of your libraries.

For some reason this was only previously enabled on linux. I do not see a reason for not also enabling it on macos.