### PR TITLE
Flip `--experimental_skip_ttvs_for_genquery` and limit Skyframe state dropping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryConfiguration.java
@@ -30,7 +30,7 @@ public class GenQueryConfiguration extends Fragment {
   public static class GenQueryOptions extends FragmentOptions {
     @Option(
         name = "experimental_skip_ttvs_for_genquery",
-        defaultValue = "false",
+        defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
         help =


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/14169#issuecomment-2048460661

RELNOTES: `genquery` now handles cycles gracefully in the same way as a `bazel query` invocation instead of failing.