### PR TITLE
Add the projectview file to default path for IntelliJ recognition

### DIFF
--- a/tools/intellij/.managed.bazelproject
+++ b/tools/intellij/.managed.bazelproject
@@ -1,0 +1,1 @@
+import scripts/ij.bazelproject


### PR DESCRIPTION
It could make the initial import a bit more convenient

Following the change implemented in https://github.com/bazelbuild/intellij/pull/5227#issuecomment-1701571663, the IntelliJ plugin recognizes the "default" project view file.