### PR TITLE
Disallow comma in a feature name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/FeatureSet.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/FeatureSet.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis.config;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -44,6 +45,11 @@ public abstract class FeatureSet {
 
   /** Parses a {@link FeatureSet} instance from a list of strings. */
   public static FeatureSet parse(Iterable<String> features) {
+    for (String feature : features) {
+      Preconditions.checkArgument(
+          !feature.contains(","),
+          String.format("Feature %s contains a comma `,`. If provided via the command-line, use multiple --features instead.", feature));
+    }
     Map<String, Boolean> featureToState = new HashMap<>();
     for (String feature : features) {
       if (feature.startsWith("-")) {


### PR DESCRIPTION
Part of an improvement related to #21957 Bazel should disallow features that have a comma.

Ideally, a better place would be to put this in CoreOptions parsing but I don't see a clean way unless I expand Option.class to have a new _Validator_ type interface.

You can see the output here below.
```
❯ ./bazel-bin/src/bazel //src:bazel  --features foo,bar
Extracting Bazel installation...
Running host JVM under debugger (listening on TCP port 5005).
Starting local Bazel server and connecting to it...
Analyzing: target //src:bazel (1 packages loaded)
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.IllegalStateException: java.lang.RuntimeException: Unrecoverable error while evaluating node 'BuildConfigurationKey[f1120607d8a0ac705875df48ea01d277e85fa924b2a4775aec46706b2aff2331]' (requested by nodes )
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.evaluateSkyKeys(SkyframeExecutor.java:2021)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.getConfiguration(SkyframeExecutor.java:1881)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.createConfiguration(SkyframeExecutor.java:1633)
	at com.google.devtools.build.lib.analysis.BuildView.update(BuildView.java:254)
	at com.google.devtools.build.lib.buildtool.AnalysisAndExecutionPhaseRunner.runAnalysisAndExecutionPhase(AnalysisAndExecutionPhaseRunner.java:227)
	at com.google.devtools.build.lib.buildtool.AnalysisAndExecutionPhaseRunner.execute(AnalysisAndExecutionPhaseRunner.java:125)
	at com.google.devtools.build.lib.buildtool.BuildTool.buildTargetsWithMergedAnalysisExecution(BuildTool.java:354)
	at com.google.devtools.build.lib.buildtool.BuildTool.buildTargets(BuildTool.java:190)
	at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:561)
	at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:529)
	at com.google.devtools.build.lib.runtime.commands.BuildCommand.exec(BuildCommand.java:105)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:676)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:250)
	at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:604)
	at com.google.devtools.build.lib.server.GrpcServerImpl.lambda$run$1(GrpcServerImpl.java:676)
	at io.grpc.Context$1.run(Context.java:566)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.RuntimeException: Unrecoverable error while evaluating node 'BuildConfigurationKey[f1120607d8a0ac705875df48ea01d277e85fa924b2a4775aec46706b2aff2331]' (requested by nodes )
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:557)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:414)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.IllegalArgumentException: Feature foo,bar contains a comma `,`. If provided via the command-line, use multiple --features instead.
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:143)
	at com.google.devtools.build.lib.analysis.config.FeatureSet.parse(FeatureSet.java:49)
	at com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.<init>(BuildConfigurationValue.java:307)
	at com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.create(BuildConfigurationValue.java:197)
	at com.google.devtools.build.lib.skyframe.config.BuildConfigurationFunction.compute(BuildConfigurationFunction.java:77)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:468)
	... 7 more
```