### PR TITLE
windows: use default msys64 root

### DIFF
--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -60,7 +60,7 @@ Bazel has built-in support for building both client and server software, includi
 
 Supply like `--params="/option:'value' ..."` ([see docs for --params](https://github.com/chocolatey/choco/wiki/CommandsInstall#options-and-switches))
 
-* `msys2Path` (optional, defaults to c:\tools\msys64) - override this if msys2 is installed elsewhere.
+* `msys2Path` (optional, defaults to c:\msys64) - override this if msys2 is installed elsewhere.
 </description>
     <releaseNotes>$tvReleaseNotesUri</releaseNotes>
     <!-- =============================== -->

--- a/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
@@ -86,7 +86,7 @@ public class ShellConfiguration extends Fragment {
                 + "BAZEL_SH environment variable is set on the first Bazel invocation (that starts "
                 + "up a Bazel server), Bazel uses that. If neither is set, Bazel uses a hard-coded "
                 + "default path depending on the operating system it runs on (Windows: "
-                + "c:/tools/msys64/usr/bin/bash.exe, FreeBSD: /usr/local/bin/bash, all others: "
+                + "c:/msys64/usr/bin/bash.exe, FreeBSD: /usr/local/bin/bash, all others: "
                 + "/bin/bash). Note that using a shell that is not compatible with bash may lead "
                 + "to build failures or runtime failures of the generated binaries."
     )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -153,7 +153,7 @@ public class BazelRuleClassProvider {
 
   public static final ImmutableMap<OS, PathFragment> SHELL_EXECUTABLE =
       ImmutableMap.<OS, PathFragment>builder()
-          .put(OS.WINDOWS, PathFragment.create("c:/tools/msys64/usr/bin/bash.exe"))
+          .put(OS.WINDOWS, PathFragment.create("c:/msys64/usr/bin/bash.exe"))
           .put(OS.FREEBSD, PathFragment.create("/usr/local/bin/bash"))
           .put(OS.OPENBSD, PathFragment.create("/usr/local/bin/bash"))
           .put(OS.UNKNOWN, FALLBACK_SHELL)

--- a/src/main/java/com/google/devtools/build/lib/util/DependencySet.java
+++ b/src/main/java/com/google/devtools/build/lib/util/DependencySet.java
@@ -282,7 +282,7 @@ public final class DependencySet {
               String.format(
                   "\"%1$s\" JVM flag is not set. Use the --host_jvm_args flag. "
                       + "For example: "
-                      + "\"--host_jvm_args=-D%1$s=c:/tools/msys64\".",
+                      + "\"--host_jvm_args=-D%1$s=c:/msys64\".",
                   jvmFlag));
         }
         value = value.replace('\\', '/');

--- a/src/test/cpp/util/file_windows_test.cc
+++ b/src/test/cpp/util/file_windows_test.cc
@@ -108,7 +108,7 @@ TEST_F(FileWindowsTest, TestMsysRootRetrieval) {
   ASSERT_FALSE(AsWindowsPath("/blah", &actual, &error));
   EXPECT_TRUE(error.find("Unix-style") != string::npos);
 
-  SetEnvironmentVariableA("BAZEL_SH", "c:/tools/msys64/usr/bin/bash.exe");
+  SetEnvironmentVariableA("BAZEL_SH", "c:/msys64/usr/bin/bash.exe");
   ASSERT_FALSE(AsWindowsPath("/blah", &actual, &error));
   EXPECT_TRUE(error.find("Unix-style") != string::npos);
 }

--- a/src/test/cpp/util/path_windows_test.cc
+++ b/src/test/cpp/util/path_windows_test.cc
@@ -271,7 +271,7 @@ TEST(PathWindowsTest, TestMsysRootRetrieval) {
   ASSERT_FALSE(AsWindowsPath("/blah", &actual, &error));
   EXPECT_TRUE(error.find("Unix-style") != string::npos);
 
-  SetEnvironmentVariableA("BAZEL_SH", "c:/tools/msys64/usr/bin/bash.exe");
+  SetEnvironmentVariableA("BAZEL_SH", "c:/msys64/usr/bin/bash.exe");
   ASSERT_FALSE(AsWindowsPath("/blah", &actual, &error));
   EXPECT_TRUE(error.find("Unix-style") != string::npos);
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
@@ -223,7 +223,7 @@ public class BazelRuleClassProviderTest extends BuildViewTestCase {
     assertThat(determineShellExecutable(OS.OPENBSD, null))
         .isEqualTo(PathFragment.create("/usr/local/bin/bash"));
     assertThat(determineShellExecutable(OS.WINDOWS, null))
-        .isEqualTo(PathFragment.create("c:/tools/msys64/usr/bin/bash.exe"));
+        .isEqualTo(PathFragment.create("c:/msys64/usr/bin/bash.exe"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleWindowsConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleWindowsConfiguredTargetTest.java
@@ -189,7 +189,7 @@ public class GenRuleWindowsConfiguredTargetTest extends BuildViewTestCase {
     assertThat(shellAction.getOutputs()).containsExactly(messageArtifact);
 
     String expected = "echo \"Hello, Bash cmd.\" >" + messageArtifact.getExecPathString();
-    assertThat(shellAction.getArguments().get(0)).isEqualTo("c:/tools/msys64/usr/bin/bash.exe");
+    assertThat(shellAction.getArguments().get(0)).isEqualTo("c:/msys64/usr/bin/bash.exe");
     assertThat(shellAction.getArguments().get(1)).isEqualTo("-c");
     assertBashCommandEquals(expected, shellAction.getArguments().get(2));
   }


### PR DESCRIPTION
On Windows, msys2 is always installed to `C:\msys64` path by default(1).
Current users would have to override this with this flag

```
common:windows --shell_executable=c:/msys64/usr/bin/bash.exe
```

Let's use the correct default instead for a better Out-of-the-box UX.

(1): https://github.com/search?q=org%3Amsys2+%2Fc%3A.*msys64%2F&type=code&p=1
