### PR TITLE
Add `*_sdk_minimum_os` attributes to `xcode_version` and `XcodeProperties`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionProperties.java
@@ -45,10 +45,15 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
 
   private final Optional<DottedVersion> xcodeVersion;
   private final DottedVersion defaultIosSdkVersion;
+  private final DottedVersion iosSdkMinimumOs;
   private final DottedVersion defaultVisionosSdkVersion;
+  private final DottedVersion visionosSdkMinimumOs;
   private final DottedVersion defaultWatchosSdkVersion;
+  private final DottedVersion watchosSdkMinimumOs;
   private final DottedVersion defaultTvosSdkVersion;
+  private final DottedVersion tvosSdkMinimumOs;
   private final DottedVersion defaultMacosSdkVersion;
+  private final DottedVersion macosSdkMinimumOs;
 
   /**
    * Creates and returns a tuple representing no known Xcode property information (defaults are used
@@ -71,7 +76,7 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
    * specified.
    */
   public XcodeVersionProperties(Object xcodeVersion) {
-    this(xcodeVersion, null, null, null, null, null);
+    this(xcodeVersion, null, null, null, null, null, null, null, null, null, null);
   }
 
   /**
@@ -81,10 +86,15 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
   XcodeVersionProperties(
       @Nullable Object xcodeVersion,
       @Nullable String defaultIosSdkVersion,
+      @Nullable String iosSdkMinimumOs,
       @Nullable String defaultVisionosSdkVersion,
+      @Nullable String visionosSdkMinimumOs,
       @Nullable String defaultWatchosSdkVersion,
+      @Nullable String watchosSdkMinimumOs,
       @Nullable String defaultTvosSdkVersion,
-      @Nullable String defaultMacosSdkVersion) {
+      @Nullable String tvosSdkMinimumOs,
+      @Nullable String defaultMacosSdkVersion,
+      @Nullable String macosSdkMinimumOs) {
     this.xcodeVersion =
         Starlark.isNullOrNone(xcodeVersion)
             ? Optional.absent()
@@ -93,22 +103,42 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
         Strings.isNullOrEmpty(defaultIosSdkVersion)
             ? DottedVersion.fromStringUnchecked(DEFAULT_IOS_SDK_VERSION)
             : DottedVersion.fromStringUnchecked(defaultIosSdkVersion);
+    this.iosSdkMinimumOs =
+        Strings.isNullOrEmpty(iosSdkMinimumOs)
+            ? this.defaultIosSdkVersion
+            : DottedVersion.fromStringUnchecked(iosSdkMinimumOs);
     this.defaultVisionosSdkVersion =
         Strings.isNullOrEmpty(defaultVisionosSdkVersion)
             ? DottedVersion.fromStringUnchecked(DEFAULT_VISIONOS_SDK_VERSION)
             : DottedVersion.fromStringUnchecked(defaultVisionosSdkVersion);
+    this.visionosSdkMinimumOs =
+        Strings.isNullOrEmpty(visionosSdkMinimumOs)
+            ? this.defaultVisionosSdkVersion
+            : DottedVersion.fromStringUnchecked(visionosSdkMinimumOs);
     this.defaultWatchosSdkVersion =
         Strings.isNullOrEmpty(defaultWatchosSdkVersion)
             ? DottedVersion.fromStringUnchecked(DEFAULT_WATCHOS_SDK_VERSION)
             : DottedVersion.fromStringUnchecked(defaultWatchosSdkVersion);
+    this.watchosSdkMinimumOs =
+        Strings.isNullOrEmpty(watchosSdkMinimumOs)
+            ? this.defaultWatchosSdkVersion
+            : DottedVersion.fromStringUnchecked(watchosSdkMinimumOs);
     this.defaultTvosSdkVersion =
         Strings.isNullOrEmpty(defaultTvosSdkVersion)
             ? DottedVersion.fromStringUnchecked(DEFAULT_TVOS_SDK_VERSION)
             : DottedVersion.fromStringUnchecked(defaultTvosSdkVersion);
+    this.tvosSdkMinimumOs =
+        Strings.isNullOrEmpty(tvosSdkMinimumOs)
+            ? this.defaultTvosSdkVersion
+            : DottedVersion.fromStringUnchecked(tvosSdkMinimumOs);
     this.defaultMacosSdkVersion =
         Strings.isNullOrEmpty(defaultMacosSdkVersion)
             ? DottedVersion.fromStringUnchecked(DEFAULT_MACOS_SDK_VERSION)
             : DottedVersion.fromStringUnchecked(defaultMacosSdkVersion);
+    this.macosSdkMinimumOs =
+        Strings.isNullOrEmpty(macosSdkMinimumOs)
+            ? this.defaultMacosSdkVersion
+            : DottedVersion.fromStringUnchecked(macosSdkMinimumOs);
   }
 
   @Override
@@ -133,11 +163,23 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     return defaultIosSdkVersion != null ? defaultIosSdkVersion.toString() : null;
   }
 
+  /** Returns the minimum OS version supported by the iOS SDK for this version of Xcode. */
+  @Override
+  public String getIosSdkMinimumOsString() {
+    return iosSdkMinimumOs.toString();
+  }
+
   /** Returns the default visionOS SDK version to use if this Xcode version is in use. */
   @Nullable
   @Override
   public String getDefaultVisionosSdkVersionString() {
     return defaultVisionosSdkVersion != null ? defaultVisionosSdkVersion.toString() : null;
+  }
+
+  /** Returns the minimum OS version supported by the visionOS SDK for this version of Xcode. */
+  @Override
+  public String getVisionosSdkMinimumOsString() {
+    return visionosSdkMinimumOs.toString();
   }
 
   /** Returns the default watchOS SDK version to use if this Xcode version is in use. */
@@ -147,6 +189,12 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     return defaultWatchosSdkVersion != null ? defaultWatchosSdkVersion.toString() : null;
   }
 
+  /** Returns the minimum OS version supported by the watchOS SDK for this version of Xcode. */
+  @Override
+  public String getWatchosSdkMinimumOsString() {
+    return watchosSdkMinimumOs.toString();
+  }
+
   /** Returns the default tvOS SDK version to use if this Xcode version is in use. */
   @Nullable
   @Override
@@ -154,11 +202,23 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     return defaultTvosSdkVersion != null ? defaultTvosSdkVersion.toString() : null;
   }
 
+  /** Returns the minimum OS version supported by the tvOS SDK for this version of Xcode. */
+  @Override
+  public String getTvosSdkMinimumOsString() {
+    return tvosSdkMinimumOs.toString();
+  }
+
   /** Returns the default macOS SDK version to use if this Xcode version is in use. */
   @Nullable
   @Override
   public String getDefaultMacosSdkVersionString() {
     return defaultMacosSdkVersion != null ? defaultMacosSdkVersion.toString() : null;
+  }
+
+  /** Returns the minimum OS version supported by the macOS SDK for this version of Xcode. */
+  @Override
+  public String getMacosSdkMinimumOsString() {
+    return macosSdkMinimumOs.toString();
   }
 
   /** Returns the Xcode version, or {@link Optional#absent} if the Xcode version is unknown. */
@@ -171,9 +231,17 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     return defaultIosSdkVersion;
   }
 
+  public DottedVersion getIosSdkMinimumOs() {
+    return iosSdkMinimumOs;
+  }
+
   @Nullable
   public DottedVersion getDefaultVisionosSdkVersion() {
     return defaultVisionosSdkVersion;
+  }
+
+  public DottedVersion getVisionosSdkMinimumOs() {
+    return visionosSdkMinimumOs;
   }
 
   @Nullable
@@ -181,14 +249,26 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     return defaultWatchosSdkVersion;
   }
 
+  public DottedVersion getWatchosSdkMinimumOs() {
+    return watchosSdkMinimumOs;
+  }
+
   @Nullable
   public DottedVersion getDefaultTvosSdkVersion() {
     return defaultTvosSdkVersion;
   }
 
+  public DottedVersion getTvosSdkMinimumOs() {
+    return tvosSdkMinimumOs;
+  }
+
   @Nullable
   public DottedVersion getDefaultMacosSdkVersion() {
     return defaultMacosSdkVersion;
+  }
+
+  public DottedVersion getMacosSdkMinimumOs() {
+    return macosSdkMinimumOs;
   }
 
   @Override
@@ -202,10 +282,15 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     XcodeVersionProperties otherData = (XcodeVersionProperties) other;
     return xcodeVersion.equals(otherData.getXcodeVersion())
         && defaultIosSdkVersion.equals(otherData.getDefaultIosSdkVersion())
+        && iosSdkMinimumOs.equals(otherData.getIosSdkMinimumOs())
         && defaultVisionosSdkVersion.equals(otherData.getDefaultVisionosSdkVersion())
+        && visionosSdkMinimumOs.equals(otherData.getVisionosSdkMinimumOs())
         && defaultWatchosSdkVersion.equals(otherData.getDefaultWatchosSdkVersion())
+        && watchosSdkMinimumOs.equals(otherData.getWatchosSdkMinimumOs())
         && defaultTvosSdkVersion.equals(otherData.getDefaultTvosSdkVersion())
-        && defaultMacosSdkVersion.equals(otherData.getDefaultMacosSdkVersion());
+        && tvosSdkMinimumOs.equals(otherData.getTvosSdkMinimumOs())
+        && defaultMacosSdkVersion.equals(otherData.getDefaultMacosSdkVersion())
+        && macosSdkMinimumOs.equals(otherData.getMacosSdkMinimumOs());
   }
 
   @Override
@@ -213,10 +298,15 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     return Objects.hash(
         xcodeVersion,
         defaultIosSdkVersion,
+        iosSdkMinimumOs,
         defaultVisionosSdkVersion,
+        visionosSdkMinimumOs,
         defaultWatchosSdkVersion,
+        watchosSdkMinimumOs,
         defaultTvosSdkVersion,
-        defaultMacosSdkVersion);
+        tvosSdkMinimumOs,
+        defaultMacosSdkVersion,
+        macosSdkMinimumOs);
   }
 
   /** Provider class for {@link XcodeVersionProperties} objects. */
@@ -230,10 +320,15 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     public XcodePropertiesApi createInfo(
         Object starlarkVersion,
         Object starlarkDefaultIosSdkVersion,
+        Object starlarkIosSdkMinimumOs,
         Object starlarkDefaultVisionosSdkVersion,
+        Object starlarkVisionosSdkMinimumOs,
         Object starlarkDefaultWatchosSdkVersion,
+        Object starlarkWatchosSdkMinimumOs,
         Object starlarkDefaultTvosSdkVersion,
+        Object starlarkTvosSdkMinimumOs,
         Object starlarkDefaultMacosSdkVersion,
+        Object starlarkMacosSdkMinimumOs,
         StarlarkThread thread)
         throws EvalException {
       return new XcodeVersionProperties(
@@ -243,18 +338,33 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
           Starlark.isNullOrNone(starlarkDefaultIosSdkVersion)
               ? null
               : (String) starlarkDefaultIosSdkVersion,
+          Starlark.isNullOrNone(starlarkIosSdkMinimumOs)
+              ? null
+              : (String) starlarkIosSdkMinimumOs,
           Starlark.isNullOrNone(starlarkDefaultVisionosSdkVersion)
               ? null
               : (String) starlarkDefaultVisionosSdkVersion,
+          Starlark.isNullOrNone(starlarkVisionosSdkMinimumOs)
+              ? null
+              : (String) starlarkVisionosSdkMinimumOs,
           Starlark.isNullOrNone(starlarkDefaultWatchosSdkVersion)
               ? null
               : (String) starlarkDefaultWatchosSdkVersion,
+          Starlark.isNullOrNone(starlarkWatchosSdkMinimumOs)
+              ? null
+              : (String) starlarkWatchosSdkMinimumOs,
           Starlark.isNullOrNone(starlarkDefaultTvosSdkVersion)
               ? null
               : (String) starlarkDefaultTvosSdkVersion,
+          Starlark.isNullOrNone(starlarkTvosSdkMinimumOs)
+              ? null
+              : (String) starlarkTvosSdkMinimumOs,
           Starlark.isNullOrNone(starlarkDefaultMacosSdkVersion)
               ? null
-              : (String) starlarkDefaultMacosSdkVersion);
+              : (String) starlarkDefaultMacosSdkVersion,
+          Starlark.isNullOrNone(starlarkMacosSdkMinimumOs)
+              ? null
+              : (String) starlarkMacosSdkMinimumOs);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionRule.java
@@ -32,10 +32,15 @@ public class XcodeVersionRule implements RuleDefinition {
   static final String VERSION_ATTR_NAME = "version";
   static final String ALIASES_ATTR_NAME = "aliases";
   static final String DEFAULT_IOS_SDK_VERSION_ATTR_NAME = "default_ios_sdk_version";
+  static final String IOS_SDK_MINIMUM_OS_ATTR_NAME = "ios_sdk_minimum_os";
   static final String DEFAULT_VISIONOS_SDK_VERSION_ATTR_NAME = "default_visionos_sdk_version";
+  static final String VISIONOS_SDK_MINIMUM_OS_ATTR_NAME = "visionos_sdk_minimum_os";
   static final String DEFAULT_WATCHOS_SDK_VERSION_ATTR_NAME = "default_watchos_sdk_version";
+  static final String WATCHOS_SDK_MINIMUM_OS_ATTR_NAME = "watchos_sdk_minimum_os";
   static final String DEFAULT_TVOS_SDK_VERSION_ATTR_NAME = "default_tvos_sdk_version";
+  static final String TVOS_SDK_MINIMUM_OS_ATTR_NAME = "tvos_sdk_minimum_os";
   static final String DEFAULT_MACOS_SDK_VERSION_ATTR_NAME = "default_macos_sdk_version";
+  static final String MACOS_SDK_MINIMUM_OS_ATTR_NAME = "macos_sdk_minimum_os";
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -66,11 +71,23 @@ public class XcodeVersionRule implements RuleDefinition {
         .add(
             attr(DEFAULT_IOS_SDK_VERSION_ATTR_NAME, STRING)
                 .nonconfigurable("this rule determines configuration"))
+        /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(ios_sdk_minimum_os) -->
+        The minimum OS version supported by the iOS SDK for this version of Xcode.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(IOS_SDK_MINIMUM_OS_ATTR_NAME, STRING)
+                .nonconfigurable("this rule determines configuration"))
         /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(default_visionos_sdk_version) -->
         The visionOS SDK version that is used by default when this version of Xcode is being used.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
             attr(DEFAULT_VISIONOS_SDK_VERSION_ATTR_NAME, STRING)
+                .nonconfigurable("this rule determines configuration"))
+        /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(visionos_sdk_minimum_os) -->
+        The minimum OS version supported by the visionOS SDK for this version of Xcode.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(VISIONOS_SDK_MINIMUM_OS_ATTR_NAME, STRING)
                 .nonconfigurable("this rule determines configuration"))
         /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(default_watchos_sdk_version) -->
         The watchOS SDK version that is used by default when this version of Xcode is being used.
@@ -79,6 +96,12 @@ public class XcodeVersionRule implements RuleDefinition {
         .add(
             attr(DEFAULT_WATCHOS_SDK_VERSION_ATTR_NAME, STRING)
                 .nonconfigurable("this rule determines configuration"))
+        /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(watchos_sdk_minimum_os) -->
+        The minimum OS version supported by the watchOS SDK for this version of Xcode.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(WATCHOS_SDK_MINIMUM_OS_ATTR_NAME, STRING)
+                .nonconfigurable("this rule determines configuration"))
         /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(default_tvos_sdk_version) -->
         The tvOS SDK version that is used by default when this version of Xcode is being used.
         The <code>tvos_sdk_version</code> build flag will override the value specified here.
@@ -86,12 +109,24 @@ public class XcodeVersionRule implements RuleDefinition {
         .add(
             attr(DEFAULT_TVOS_SDK_VERSION_ATTR_NAME, STRING)
                 .nonconfigurable("this rule determines configuration"))
+        /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(tvos_sdk_minimum_os) -->
+        The minimum OS version supported by the tvOS SDK for this version of Xcode.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(TVOS_SDK_MINIMUM_OS_ATTR_NAME, STRING)
+                .nonconfigurable("this rule determines configuration"))
         /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(default_macos_sdk_version) -->
         The macOS SDK version that is used by default when this version of Xcode is being used.
         The <code>macos_sdk_version</code> build flag will override the value specified here.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
             attr(DEFAULT_MACOS_SDK_VERSION_ATTR_NAME, STRING)
+                .nonconfigurable("this rule determines configuration"))
+        /* <!-- #BLAZE_RULE(xcode_version).ATTRIBUTE(ios_sdk_minimum_os) -->
+        The minimum OS version supported by the macOS SDK for this version of Xcode.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(MACOS_SDK_MINIMUM_OS_ATTR_NAME, STRING)
                 .nonconfigurable("this rule determines configuration"))
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/XcodePropertiesApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/XcodePropertiesApi.java
@@ -54,6 +54,12 @@ public interface XcodePropertiesApi extends StructApi {
   String getDefaultIosSdkVersionString();
 
   @StarlarkMethod(
+      name = "ios_sdk_minimum_os",
+      doc = "The minimum OS version supported by the iOS SDK for this version of Xcode.",
+      structField = true)
+  String getIosSdkMinimumOsString();
+
+  @StarlarkMethod(
       name = "default_visionos_sdk_version",
       doc =
           "The default visionOS SDK version for this version of Xcode, or <code>None</code> if "
@@ -62,6 +68,12 @@ public interface XcodePropertiesApi extends StructApi {
       allowReturnNones = true)
   @Nullable
   String getDefaultVisionosSdkVersionString();
+
+  @StarlarkMethod(
+      name = "visionos_sdk_minimum_os",
+      doc = "The minimum OS version supported by the visionOS SDK for this version of Xcode.",
+      structField = true)
+  String getVisionosSdkMinimumOsString();
 
   @StarlarkMethod(
       name = "default_watchos_sdk_version",
@@ -74,6 +86,12 @@ public interface XcodePropertiesApi extends StructApi {
   String getDefaultWatchosSdkVersionString();
 
   @StarlarkMethod(
+      name = "watchos_sdk_minimum_os",
+      doc = "The minimum OS version supported by the watchOS SDK for this version of Xcode.",
+      structField = true)
+  String getWatchosSdkMinimumOsString();
+
+  @StarlarkMethod(
       name = "default_tvos_sdk_version",
       doc =
           "The default tvOS SDK version for this version of Xcode, or <code>None</code> if "
@@ -84,6 +102,12 @@ public interface XcodePropertiesApi extends StructApi {
   String getDefaultTvosSdkVersionString();
 
   @StarlarkMethod(
+      name = "tvos_sdk_minimum_os",
+      doc = "The minimum OS version supported by the tvOS SDK for this version of Xcode.",
+      structField = true)
+  String getTvosSdkMinimumOsString();
+
+  @StarlarkMethod(
       name = "default_macos_sdk_version",
       doc =
           "The default macOS SDK version for this version of Xcode, or <code>None</code> if "
@@ -92,6 +116,12 @@ public interface XcodePropertiesApi extends StructApi {
       allowReturnNones = true)
   @Nullable
   String getDefaultMacosSdkVersionString();
+
+  @StarlarkMethod(
+      name = "macos_sdk_minimum_os",
+      doc = "The minimum OS version supported by the macOS SDK for this version of Xcode.",
+      structField = true)
+  String getMacosSdkMinimumOsString();
 
   /** The provider implementing this can construct XcodeProperties objects. */
   @StarlarkBuiltin(name = "Provider", doc = "", documented = false)
@@ -122,7 +152,27 @@ public interface XcodePropertiesApi extends StructApi {
               named = true,
               defaultValue = "None"),
           @Param(
+              name = "ios_sdk_minimum_os",
+              doc = "",
+              positional = false,
+              allowedTypes = {
+                @ParamType(type = NoneType.class),
+                @ParamType(type = String.class),
+              },
+              named = true,
+              defaultValue = "None"),
+          @Param(
               name = "default_visionos_sdk_version",
+              doc = "",
+              positional = false,
+              allowedTypes = {
+                @ParamType(type = NoneType.class),
+                @ParamType(type = String.class),
+              },
+              named = true,
+              defaultValue = "None"),
+          @Param(
+              name = "visionos_sdk_minimum_os",
               doc = "",
               positional = false,
               allowedTypes = {
@@ -142,7 +192,27 @@ public interface XcodePropertiesApi extends StructApi {
               named = true,
               defaultValue = "None"),
           @Param(
+              name = "watchos_sdk_minimum_os",
+              doc = "",
+              positional = false,
+              allowedTypes = {
+                @ParamType(type = NoneType.class),
+                @ParamType(type = String.class),
+              },
+              named = true,
+              defaultValue = "None"),
+          @Param(
               name = "default_tvos_sdk_version",
+              doc = "",
+              positional = false,
+              allowedTypes = {
+                @ParamType(type = NoneType.class),
+                @ParamType(type = String.class),
+              },
+              named = true,
+              defaultValue = "None"),
+          @Param(
+              name = "tvos_sdk_minimum_os",
               doc = "",
               positional = false,
               allowedTypes = {
@@ -161,6 +231,16 @@ public interface XcodePropertiesApi extends StructApi {
               },
               named = true,
               defaultValue = "None"),
+          @Param(
+              name = "macos_sdk_minimum_os",
+              doc = "",
+              positional = false,
+              allowedTypes = {
+                @ParamType(type = NoneType.class),
+                @ParamType(type = String.class),
+              },
+              named = true,
+              defaultValue = "None"),
         },
         selfCall = true,
         documented = false)
@@ -168,10 +248,15 @@ public interface XcodePropertiesApi extends StructApi {
     XcodePropertiesApi createInfo(
         Object version,
         Object defaultIosSdkVersion,
+        Object iosSdkMinimumOs,
         Object defaultVisionosSdkVersion,
+        Object visionosSdkMinimumOs,
         Object defaultWatchosSdkVersion,
+        Object watchosSdkMinimumOs,
         Object defaultTvosSdkVersion,
+        Object tvosSdkMinimumOs,
         Object defaultMacosSdkVersion,
+        Object macosSdkMinimumOs,
         StarlarkThread thread)
         throws EvalException;
   }

--- a/src/main/starlark/builtins_bzl/common/xcode/xcode_version.bzl
+++ b/src/main/starlark/builtins_bzl/common/xcode/xcode_version.bzl
@@ -20,10 +20,15 @@ def _xcode_version_impl(ctx):
     xcode_version_properties = apple_common.XcodeProperties(
         version = ctx.attr.version,
         default_ios_sdk_version = ctx.attr.default_ios_sdk_version,
+        ios_sdk_minimum_os = ctx.attr.ios_sdk_minimum_os,
         default_visionos_sdk_version = ctx.attr.default_visionos_sdk_version,
+        visionos_sdk_minimum_os = ctx.attr.visionos_sdk_minimum_os,
         default_watchos_sdk_version = ctx.attr.default_watchos_sdk_version,
+        watchos_sdk_minimum_os = ctx.attr.watchos_sdk_minimum_os,
         default_tvos_sdk_version = ctx.attr.default_tvos_sdk_version,
+        tvos_sdk_minimum_os = ctx.attr.tvos_sdk_minimum_os,
         default_macos_sdk_version = ctx.attr.default_macos_sdk_version,
+        macos_sdk_minimum_os = ctx.attr.macos_sdk_minimum_os,
     )
     return [
         xcode_version_properties,
@@ -40,10 +45,15 @@ xcode_version = rule(
         "version": attr.string(doc = "The official version number of a version of Xcode.", mandatory = True),
         "aliases": attr.string_list(doc = "Accepted aliases for this version of Xcode. If the value of the xcode_version build flag matches any of the given alias strings, this Xcode version will be used.", allow_empty = True, mandatory = False),
         "default_ios_sdk_version": attr.string(default = "8.4", doc = "The iOS SDK version that is used by default when this version of Xcode is being used. The `--ios_sdk_version` build flag will override the value specified here.", mandatory = False),
+        "ios_sdk_minimum_os": attr.string(doc = "The minimum OS version supported by the iOS SDK for this version of Xcode.", mandatory = False),
         "default_visionos_sdk_version": attr.string(default = "1.0", doc = "The visionOS SDK version that is used by default when this version of Xcode is being used.", mandatory = False),
+        "visionos_sdk_minimum_os": attr.string(doc = "The minimum OS version supported by the visionOS SDK for this version of Xcode.", mandatory = False),
         "default_watchos_sdk_version": attr.string(default = "2.0", doc = "The watchOS SDK version that is used by default when this version of Xcode is being used. The `--watchos_sdk_version` build flag will override the value specified here.", mandatory = False),
+        "watchos_sdk_minimum_os": attr.string(doc = "The minimum OS version supported by the watchOS SDK for this version of Xcode.", mandatory = False),
         "default_tvos_sdk_version": attr.string(default = "10.11", doc = "The tvOS SDK version that is used by default when this version of Xcode is being used. The `--tvos_sdk_version` build flag will override the value specified here.", mandatory = False),
+        "tvos_sdk_minimum_os": attr.string(doc = "The minimum OS version supported by the tvOS SDK for this version of Xcode.", mandatory = False),
         "default_macos_sdk_version": attr.string(default = "9.0", doc = "The macOS SDK version that is used by default when this version of Xcode is being used. The `--macos_sdk_version` build flag will override the value specified here.", mandatory = False),
+        "macos_sdk_minimum_os": attr.string(doc = "The minimum OS version supported by the macOS SDK for this version of Xcode.", mandatory = False),
     },
     implementation = _xcode_version_impl,
 )

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -19,6 +19,72 @@
 
 OSX_EXECUTE_TIMEOUT = 600
 
+def _parse_platforms(xcodebuild_result, developer_dir):
+    if (xcodebuild_result.return_code != 0):
+        error_msg = (
+            "Invoking xcodebuild failed, developer dir: {devdir}, " +
+            "return code {code}, stderr: {err}, stdout: {out}"
+        ).format(
+            devdir = developer_dir,
+            code = xcodebuild_result.return_code,
+            err = xcodebuild_result.stderr,
+            out = xcodebuild_result.stdout,
+        )
+        return None, error_msg
+
+    platforms_array = json.decode(xcodebuild_result.stdout, default = [])
+    if not platforms_array:
+        error_msg =(
+            "Malformed json output from xcodebuild, developer dir: {devdir}, " +
+            "stdout: {out}"
+        ).format(
+            devdir = developer_dir,
+            out = xcodebuild_result.stdout,
+        )
+        return None, error_msg
+
+    platforms = {}
+    for platform in platforms_array:
+        platform_name = platform.get("platform")
+        if not platform_name:
+            error_msg =(
+                "Malformed json output from xcodebuild - " +
+                "missing 'platform' key, developer dir: {devdir}, stdout: {out}"
+            ).format(
+                devdir = developer_dir,
+                out = xcodebuild_result.stdout,
+            )
+            return None, error_msg
+
+        sdk_version = platform.get("sdkVersion")
+        if not sdk_version:
+            error_msg =(
+                "Malformed json output from xcodebuild - " +
+                "missing 'sdkVersion' key, developer dir: {devdir}, stdout: {out}"
+            ).format(
+                devdir = developer_dir,
+                out = xcodebuild_result.stdout,
+            )
+            return None, error_msg
+
+        sdk_path = platform.get("sdkPath")
+        if not sdk_path:
+            error_msg =(
+                "Malformed json output from xcodebuild - " +
+                "missing 'sdkPath' key, developer dir: {devdir}, stdout: {out}"
+            ).format(
+                devdir = developer_dir,
+                out = xcodebuild_result.stdout,
+            )
+            return None, error_msg
+
+        platforms[platform_name] = struct(
+            sdkVersion = sdk_version,
+            sdkPath = sdk_path,
+        )
+
+    return platforms, ""
+
 def _search_string(fullstring, prefix, suffix):
     """Returns the substring between two given substrings of a larger string.
 
@@ -41,56 +107,146 @@ def _search_string(fullstring, prefix, suffix):
         return ""
     return fullstring[result_start_index:suffix_index]
 
-def _search_sdk_output(output, sdkname):
-    """Returns the SDK version given xcodebuild stdout and an sdkname."""
-    return _search_string(output, "(%s" % sdkname, ")")
+def _sdk_info(repository_ctx, platforms, platform_name):
+    """Returns the SDK info for the given platform name."""
+    platform = platforms.get(platform_name)
+    if not platform:
+        return None
+
+    sdk_settings_path = platform.sdkPath + "/SDKSettings.json"
+
+    minimum_os = None
+    sdk_settings = json.decode(repository_ctx.read(sdk_settings_path), default = None)
+    if not sdk_settings:
+        error_msg = (
+            "Malformed SDKSettings.json file for {platform_name} at {path}"
+        ).format(
+            platform_name = platform_name,
+            path = sdk_settings_path,
+        )
+        return struct(
+            error_msg = error_msg,
+            minimum_os = None,
+            version = platform.sdkVersion,
+        )
+
+    supported_targets = sdk_settings.get("SupportedTargets")
+    if not supported_targets:
+        error_msg = (
+            "Malformed SDKSettings.json file for {platform_name} at {path} - " +
+            "Missing 'SupportedTargets' key"
+        ).format(
+            platform_name = platform_name,
+            path = sdk_settings_path,
+        )
+        return struct(
+            error_msg = error_msg,
+            minimum_os = None,
+            version = platform.sdkVersion,
+        )
+
+    platform_settings = supported_targets.get(platform_name)
+    if not platform_settings:
+        error_msg = (
+            "Malformed SDKSettings.json file for {platform_name} at {path} - " +
+            "Missing 'SupportedTargets.{platform_name}' key"
+        ).format(
+            platform_name = platform_name,
+            path = sdk_settings_path,
+        )
+        return struct(
+            error_msg = error_msg,
+            minimum_os = None,
+            version = platform.sdkVersion,
+        )
+
+    minimum_os = platform_settings.get("MinimumDeploymentTarget")
+    if not minimum_os:
+        error_msg = (
+            "Malformed SDKSettings.json file for {platform_name} at {path} - " +
+            "Missing 'SupportedTargets.{platform_name}.MinimumDeploymentTarget' key"
+        ).format(
+            platform_name = platform_name,
+            path = sdk_settings_path,
+        )
+        return struct(
+            error_msg = error_msg,
+            minimum_os = None,
+            version = platform.sdkVersion,
+        )
+
+    return struct(
+        error_msg = None,
+        minimum_os = minimum_os,
+        version = platform.sdkVersion,
+    )
 
 def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir, timeout):
     """Returns a string containing an xcode_version build target."""
     build_contents = ""
     decorated_aliases = []
-    error_msg = ""
+
     for alias in aliases:
         decorated_aliases.append("'%s'" % alias)
+
     repository_ctx.report_progress("Fetching SDK information for Xcode %s" % version)
     xcodebuild_result = repository_ctx.execute(
-        ["xcrun", "xcodebuild", "-version", "-sdk"],
+        ["xcrun", "xcodebuild", "-version", "-sdk", "-json"],
         timeout,
         {"DEVELOPER_DIR": developer_dir},
     )
-    if (xcodebuild_result.return_code != 0):
-        error_msg = (
-            "Invoking xcodebuild failed, developer dir: {devdir} ," +
-            "return code {code}, stderr: {err}, stdout: {out}"
-        ).format(
-            devdir = developer_dir,
-            code = xcodebuild_result.return_code,
-            err = xcodebuild_result.stderr,
-            out = xcodebuild_result.stdout,
-        )
-    ios_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "iphoneos")
-    tvos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "appletvos")
-    macos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "macosx")
-    visionos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "xros")
-    watchos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "watchos")
+    platforms, error_msg = _parse_platforms(xcodebuild_result, developer_dir)
+
+    error_msgs = []
+    if error_msg:
+        error_msgs.append(error_msg)
+
+    ios_sdk = _sdk_info(repository_ctx, platforms, "iphoneos")
+    tvos_sdk = _sdk_info(repository_ctx, platforms, "appletvos")
+    macos_sdk = _sdk_info(repository_ctx, platforms, "macosx")
+    visionos_sdk = _sdk_info(repository_ctx, platforms, "xros")
+    watchos_sdk = _sdk_info(repository_ctx, platforms, "watchos")
+
     build_contents += "xcode_version(\n  name = '%s'," % name
     build_contents += "\n  version = '%s'," % version
     if aliases:
         build_contents += "\n  aliases = [%s]," % ", ".join(decorated_aliases)
-    if ios_sdk_version:
-        build_contents += "\n  default_ios_sdk_version = '%s'," % ios_sdk_version
-    if tvos_sdk_version:
-        build_contents += "\n  default_tvos_sdk_version = '%s'," % tvos_sdk_version
-    if macos_sdk_version:
-        build_contents += "\n  default_macos_sdk_version = '%s'," % macos_sdk_version
-    if visionos_sdk_version:
-        build_contents += "\n  default_visionos_sdk_version = '%s'," % visionos_sdk_version
-    if watchos_sdk_version:
-        build_contents += "\n  default_watchos_sdk_version = '%s'," % watchos_sdk_version
+    if ios_sdk:
+        build_contents += "\n  default_ios_sdk_version = '%s'," % ios_sdk.version
+        if ios_sdk.minimum_os:
+            build_contents += "\n  ios_sdk_minimum_os = '%s'," % ios_sdk.minimum_os
+        if ios_sdk.error_msg:
+            error_msgs.append(ios_sdk.error_msg)
+    if tvos_sdk:
+        build_contents += "\n  default_tvos_sdk_version = '%s'," % tvos_sdk.version
+        if tvos_sdk.minimum_os:
+            build_contents += "\n  tvos_sdk_minimum_os = '%s'," % tvos_sdk.minimum_os
+        if tvos_sdk.error_msg:
+            error_msgs.append(tvos_sdk.error_msg)
+    if macos_sdk:
+        build_contents += "\n  default_macos_sdk_version = '%s'," % macos_sdk.version
+        if macos_sdk.minimum_os:
+            build_contents += "\n  macos_sdk_minimum_os = '%s'," % macos_sdk.minimum_os
+        if macos_sdk.error_msg:
+            error_msgs.append(macos_sdk.error_msg)
+    if visionos_sdk:
+        build_contents += "\n  default_visionos_sdk_version = '%s'," % visionos_sdk.version
+        if visionos_sdk.minimum_os:
+            build_contents += "\n  visionos_sdk_minimum_os = '%s'," % visionos_sdk.minimum_os
+        if visionos_sdk.error_msg:
+            error_msgs.append(visionos_sdk.error_msg)
+    if watchos_sdk:
+        build_contents += "\n  default_watchos_sdk_version = '%s'," % watchos_sdk.version
+        if watchos_sdk.minimum_os:
+            build_contents += "\n  watchos_sdk_minimum_os = '%s'," % watchos_sdk.minimum_os
+        if watchos_sdk.error_msg:
+            error_msgs.append(watchos_sdk.error_msg)
     build_contents += "\n)\n"
-    if error_msg:
-        build_contents += "\n# Error: " + error_msg.replace("\n", " ") + "\n"
+    if error_msgs:
+        error_msg = "\n".join(error_msgs)
+        build_contents += "\n# Error: " + error_msg.replace("\n", "\n# Error: ") + "\n\n"
         print(error_msg)
+
     return build_contents
 
 VERSION_CONFIG_STUB = "xcode_config(name = 'host_xcodes')"


### PR DESCRIPTION
This allows rules to determine the minimum supported OS versions for a given Xcode version. One such use case is emulating Swift Package Manager’s `SupportedPlatform` spec.

This is a backwards compatible change. `xcode_version` accepts not setting these attributes, and will pass on `None` to the `XcodeProperties` constructor. The `XcodeProperties` constructor accepts not setting these attributes as well, defaulting to `None`. The `XcodeProperties` constructor converts `None` to be equal to `default_*_sdk_version`. And since when `default_*_sdk_version` is `None` a “reasonable default” is chosen, these new attributes will always have a value.

In the future we may want to use these values in `xcode_config` to set a better default `*_minimum_os`. That would be a breaking change though.