### PR TITLE
Add digest func to Remote Asset Downloader

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -716,6 +716,7 @@ public final class RemoteModule extends BlazeModule {
               Optional.ofNullable(callCredentials),
               retrier,
               cacheClient,
+              digestUtil.getDigestFunction(),
               remoteOptions,
               verboseFailures,
               fallbackDownloader));

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -20,6 +20,7 @@ import build.bazel.remote.asset.v1.FetchGrpc;
 import build.bazel.remote.asset.v1.FetchGrpc.FetchBlockingStub;
 import build.bazel.remote.asset.v1.Qualifier;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.auth.Credentials;
 import com.google.common.annotations.VisibleForTesting;
@@ -65,6 +66,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
   private final Optional<CallCredentials> credentials;
   private final RemoteRetrier retrier;
   private final RemoteCacheClient cacheClient;
+  private final DigestFunction.Value digestFunction;
   private final RemoteOptions options;
   private final boolean verboseFailures;
   @Nullable private final Downloader fallbackDownloader;
@@ -89,6 +91,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       Optional<CallCredentials> credentials,
       RemoteRetrier retrier,
       RemoteCacheClient cacheClient,
+      DigestFunction.Value digestFunction,
       RemoteOptions options,
       boolean verboseFailures,
       @Nullable Downloader fallbackDownloader) {
@@ -98,6 +101,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     this.credentials = credentials;
     this.retrier = retrier;
     this.cacheClient = cacheClient;
+    this.digestFunction = digestFunction;
     this.options = options;
     this.verboseFailures = verboseFailures;
     this.fallbackDownloader = fallbackDownloader;
@@ -130,7 +134,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
         RemoteActionExecutionContext.create(metadata);
 
     final FetchBlobRequest request =
-        newFetchBlobRequest(options.remoteInstanceName, urls, checksum, canonicalId, headers);
+        newFetchBlobRequest(options.remoteInstanceName, urls, checksum, canonicalId, digestFunction, headers);
     try {
       FetchBlobResponse response =
           retrier.execute(
@@ -178,9 +182,12 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       List<URL> urls,
       Optional<Checksum> checksum,
       String canonicalId,
+      DigestFunction.Value digestFunction,
       Map<String, List<String>> headers) {
     FetchBlobRequest.Builder requestBuilder =
-        FetchBlobRequest.newBuilder().setInstanceName(instanceName);
+        FetchBlobRequest.newBuilder()
+            .setInstanceName(instanceName)
+            .setDigestFunction(digestFunction);
     for (URL url : urls) {
       requestBuilder.addUris(url.toString());
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -27,6 +27,7 @@ import build.bazel.remote.asset.v1.FetchBlobResponse;
 import build.bazel.remote.asset.v1.FetchGrpc.FetchImplBase;
 import build.bazel.remote.asset.v1.Qualifier;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.DigestFunction.Value;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.collect.ImmutableList;
@@ -160,6 +161,7 @@ public class GrpcRemoteDownloaderTest {
         Optional.<CallCredentials>empty(),
         retrier,
         cacheClient,
+        DIGEST_UTIL.getDigestFunction(),
         remoteOptions,
         /* verboseFailures= */ false,
         fallbackDownloader);
@@ -205,6 +207,7 @@ public class GrpcRemoteDownloaderTest {
             assertThat(request)
                 .isEqualTo(
                     FetchBlobRequest.newBuilder()
+                        .setDigestFunction(DIGEST_UTIL.getDigestFunction())
                         .addUris("http://example.com/content.txt")
                         .build());
             responseObserver.onNext(
@@ -270,6 +273,7 @@ public class GrpcRemoteDownloaderTest {
             assertThat(request)
                 .isEqualTo(
                     FetchBlobRequest.newBuilder()
+                        .setDigestFunction(DIGEST_UTIL.getDigestFunction())
                         .addUris("http://example.com/content.txt")
                         .addQualifiers(
                             Qualifier.newBuilder()
@@ -308,6 +312,7 @@ public class GrpcRemoteDownloaderTest {
             assertThat(request)
                 .isEqualTo(
                     FetchBlobRequest.newBuilder()
+                        .setDigestFunction(DIGEST_UTIL.getDigestFunction())
                         .addUris("http://example.com/content.txt")
                         .addQualifiers(
                             Qualifier.newBuilder()
@@ -352,6 +357,7 @@ public class GrpcRemoteDownloaderTest {
                 Checksum.fromSubresourceIntegrity(
                     "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),
             "canonical ID",
+            DIGEST_UTIL.getDigestFunction(),
             ImmutableMap.of(
                 "Authorization", ImmutableList.of("Basic Zm9vOmJhcg=="),
                 "X-Custom-Token", ImmutableList.of("foo", "bar")));
@@ -360,6 +366,7 @@ public class GrpcRemoteDownloaderTest {
         .isEqualTo(
             FetchBlobRequest.newBuilder()
                 .setInstanceName("instance name")
+                .setDigestFunction(DIGEST_UTIL.getDigestFunction())
                 .addUris("http://example.com/a")
                 .addUris("http://example.com/b")
                 .addUris("file:/not/limited/to/http")

--- a/third_party/remoteapis/build/bazel/remote/asset/v1/remote_asset.proto
+++ b/third_party/remoteapis/build/bazel/remote/asset/v1/remote_asset.proto
@@ -201,6 +201,11 @@ message FetchBlobRequest {
   //
   // Specified qualifier names *MUST* be unique.
   repeated Qualifier qualifiers = 5;
+
+  // The digest function the server must use to compute the digest.
+  //
+  // If unset, the server SHOULD default to SHA256.
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // A response message for
@@ -216,6 +221,8 @@ message FetchBlobResponse {
   //   requested an asset from a disallowed origin.
   // * `ABORTED`: The operation could not be completed, typically due to a
   //   failed consistency check.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient quota of some resource to
+  //   perform the requested operation. The client may retry after a delay.
   google.rpc.Status status = 1;
 
   // The uri from the request that resulted in a successful retrieval, or from
@@ -232,6 +239,15 @@ message FetchBlobResponse {
   // The result of the fetch, if the status had code `OK`.
   // The digest of the file's contents, available for download through the CAS.
   build.bazel.remote.execution.v2.Digest blob_digest = 5;
+
+  // This field SHOULD be set to the digest function that was used by the server
+  // to compute [FetchBlobResponse.blob_digest].
+  // Clients could use this to determine whether the server honors
+  // [FetchBlobRequest.digest_function] that was set in the request.
+  //
+  // If unset, clients SHOULD default to use SHA256 regardless of the requested
+  // [FetchBlobRequest.digest_function].
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // A request message for
@@ -280,6 +296,11 @@ message FetchDirectoryRequest {
   //
   // Specified qualifier names *MUST* be unique.
   repeated Qualifier qualifiers = 5;
+
+  // The digest function the server must use to compute the digest.
+  //
+  // If unset, the server SHOULD default to SHA256.
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // A response message for
@@ -295,6 +316,8 @@ message FetchDirectoryResponse {
   //   requested an asset from a disallowed origin.
   // * `ABORTED`: The operation could not be completed, typically due to a
   //   failed consistency check.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient quota of some resource to
+  //   perform the requested operation. The client may retry after a delay.
   google.rpc.Status status = 1;
 
   // The uri from the request that resulted in a successful retrieval, or from
@@ -312,6 +335,15 @@ message FetchDirectoryResponse {
   // the root digest of a directory tree, suitable for fetching via
   // [ContentAddressableStorage.GetTree].
   build.bazel.remote.execution.v2.Digest root_directory_digest = 5;
+
+  // This field SHOULD be set to the digest function that was used by the server
+  // to compute [FetchBlobResponse.root_directory_digest].
+  // Clients could use this to determine whether the server honors
+  // [FetchDirectoryRequest.digest_function] that was set in the request.
+  //
+  // If unset, clients SHOULD default to use SHA256 regardless of the requested
+  // [FetchDirectoryRequest.digest_function].
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 6;
 }
 
 // The Push service is complementary to the Fetch, and allows for
@@ -398,6 +430,15 @@ message PushBlobRequest {
   // indirectly referencing unavailable blobs.
   repeated build.bazel.remote.execution.v2.Digest references_blobs = 6;
   repeated build.bazel.remote.execution.v2.Digest references_directories = 7;
+
+  // The digest function that was used to compute the blob digest.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the action digest hash and the digest functions announced
+  // in the server's capabilities.
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 8;
 }
 
 // A response message for
@@ -438,6 +479,15 @@ message PushDirectoryRequest {
   // indirectly referencing unavailable blobs.
   repeated build.bazel.remote.execution.v2.Digest references_blobs = 6;
   repeated build.bazel.remote.execution.v2.Digest references_directories = 7;
+
+  // The digest function that was used to compute blob digests.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the action digest hash and the digest functions announced
+  // in the server's capabilities.
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 8;
 }
 
 // A response message for


### PR DESCRIPTION
A follow up from https://github.com/bazelbuild/remote-apis/pull/286