### PR TITLE
Clean up test setup for sandboxing tests

### DIFF
--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -27,6 +27,9 @@ source ${CURRENT_DIR}/../sandboxing_test_utils.sh \
 function set_up {
   add_to_bazelrc "build --spawn_strategy=sandboxed"
   add_to_bazelrc "build --genrule_strategy=sandboxed"
+
+  # Enabled in testenv.sh.tmpl, but not in Bazel by default.
+  sed -i.bak '/sandbox_tmpfs_path/d' "$bazelrc"
 }
 
 function test_sandboxed_tooldir() {
@@ -314,8 +317,6 @@ function test_add_mount_pair_tmp_source() {
 
   create_workspace_with_default_repos WORKSPACE
 
-  sed -i.bak '/sandbox_tmpfs_path/d' $TEST_TMPDIR/bazelrc
-
   local mounted=$(mktemp -d "/tmp/bazel_mounted.XXXXXXXX")
   trap "rm -fr $mounted" EXIT
   echo GOOD > "$mounted/data.txt"
@@ -342,8 +343,6 @@ function test_add_mount_pair_tmp_target() {
   fi
 
   create_workspace_with_default_repos WORKSPACE
-
-  sed -i.bak '/sandbox_tmpfs_path/d' $TEST_TMPDIR/bazelrc
 
   local source_dir=$(mktemp -d "/tmp/bazel_mounted.XXXXXXXX")
   trap "rm -fr $source_dir" EXIT
@@ -372,8 +371,6 @@ function test_add_mount_pair_tmp_target_and_source() {
   fi
 
   create_workspace_with_default_repos WORKSPACE
-
-  sed -i.bak '/sandbox_tmpfs_path/d' $TEST_TMPDIR/bazelrc
 
   local mounted=$(mktemp -d "/tmp/bazel_mounted.XXXXXXXX")
   trap "rm -fr $mounted" EXIT
@@ -404,8 +401,6 @@ function test_symlink_with_output_base_under_tmp() {
   fi
 
   create_workspace_with_default_repos WORKSPACE
-
-  sed -i.bak '/sandbox_tmpfs_path/d' $TEST_TMPDIR/bazelrc
 
   mkdir -p pkg
   cat > pkg/BUILD <<'EOF'
@@ -442,9 +437,6 @@ function test_symlink_to_directory_absolute_path() {
   fi
 
   create_workspace_with_default_repos WORKSPACE
-
-  sed -i.bak '/sandbox_tmpfs_path/d' $TEST_TMPDIR/bazelrc
-
 
   mkdir -p /tmp/tree/{a,b}
   touch /tmp/tree/{a,b}/file
@@ -492,8 +484,6 @@ function test_symlink_to_directory_with_output_base_under_tmp() {
   fi
 
   create_workspace_with_default_repos WORKSPACE
-
-  sed -i.bak '/sandbox_tmpfs_path/d' $TEST_TMPDIR/bazelrc
 
   mkdir -p pkg
   cat > pkg/BUILD <<'EOF'
@@ -543,8 +533,6 @@ function test_tmpfs_path_under_tmp() {
   fi
 
   create_workspace_with_default_repos WORKSPACE
-
-  sed -i.bak '/sandbox_tmpfs_path/d' $TEST_TMPDIR/bazelrc
 
   local tmp_file=$(mktemp "/tmp/bazel_tmp.XXXXXXXX")
   trap "rm $tmp_file" EXIT

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -29,6 +29,9 @@ disable_bzlmod
 function set_up() {
   add_to_bazelrc "build --spawn_strategy=sandboxed"
   add_to_bazelrc "build --genrule_strategy=sandboxed"
+
+  # Enabled in testenv.sh.tmpl, but not in Bazel by default.
+  sed -i.bak '/sandbox_tmpfs_path/d' "$bazelrc"
 }
 
 function tear_down() {
@@ -693,7 +696,6 @@ EOF
 }
 
 function test_read_non_hermetic_tmp {
-  sed -i.bak '/sandbox_tmpfs_path/d' "$bazelrc"
   temp_dir=$(mktemp -d /tmp/test.XXXXXX)
   trap 'rm -rf ${temp_dir}' EXIT
 
@@ -748,7 +750,6 @@ function test_read_hermetic_tmp_user_override {
     echo "Skipping test: --incompatible_sandbox_hermetic_tmp is only supported in Linux" 1>&2
     return 0
   fi
-  sed -i.bak '/sandbox_tmpfs_path/d' "$bazelrc"
 
   temp_dir=$(mktemp -d /tmp/test.XXXXXX)
   trap 'rm -rf ${temp_dir}' EXIT
@@ -772,7 +773,6 @@ EOF
 }
 
 function test_write_non_hermetic_tmp {
-  sed -i.bak '/sandbox_tmpfs_path/d' "$bazelrc"
   temp_dir=$(mktemp -d /tmp/test.XXXXXX)
   trap 'rm -rf ${temp_dir}' EXIT
 
@@ -828,7 +828,6 @@ function test_write_hermetic_tmp_user_override {
     echo "Skipping test: --incompatible_sandbox_hermetic_tmp is only supported in Linux" 1>&2
     return 0
   fi
-  sed -i.bak '/sandbox_tmpfs_path/d' "$bazelrc"
 
   temp_dir=$(mktemp -d /tmp/test.XXXXXX)
   trap 'rm -rf ${temp_dir}' EXIT


### PR DESCRIPTION
Sandboxing tests should always run with Bazel defaults, which include no tmpfs path.

Work towards #21215