### PR TITLE
[7.2.0] Fix `resolveToModuleKeys` when checking module extension

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArg.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArg.java
@@ -305,7 +305,7 @@ public interface ModuleArg {
         throws InvalidArgumentException {
       Optional<AugmentedModule> mod =
           depGraph.values().stream()
-              .filter(m -> moduleKeyToCanonicalNames.get(m.getKey()).equals(repoName()))
+              .filter(m -> repoName().equals(moduleKeyToCanonicalNames.get(m.getKey())))
               .findAny();
       if (mod.isPresent() && !includeUnused && warnUnused && !mod.get().isUsed()) {
         // Warn the user when unused modules are allowed and the specified version exists, but the

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -365,6 +365,22 @@ class ModCommandTest(test_base.TestBase):
         'Wrong output in the show with some extensions and some usages query.',
     )
 
+  def testShowExtensionWithUnknownRepo(self):
+    _, _, stderr = self.RunBazel(
+        [
+            'mod',
+            'show_extension',
+            '@@unknown//foo:bar.bzl%x',
+        ],
+        allow_failure=True,
+        rstrip=True,
+    )
+    self.assertIn(
+        'ERROR: In extension argument @@unknown//foo:bar.bzl%x: No module with '
+        'the canonical repo name @@unknown exists in the dependency graph.',
+        '\n'.join(stderr),
+    )
+
   def testShowModuleAndExtensionReposFromBaseModule(self):
     _, stdout, _ = self.RunBazel(
         [


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/21621#issuecomment-2058607125

PiperOrigin-RevId: 625286656
Change-Id: Ibc5d153af96912de39b146e50f081030d1da7257

Commit https://github.com/bazelbuild/bazel/commit/2d54af169478a42d84d9551fab4b31852e0e85c3