### PR TITLE
[7.2.0] http repo rules: Make sure netrc credentials are applied for remote patch files

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2660,7 +2660,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_android_deps": {
       "general": {
-        "bzlTransitiveDigest": "Qn0k2fldjY66WVnZJhLl0HTcRxDUyOqfzTk2SfZ4/kg=",
+        "bzlTransitiveDigest": "1xHBfvy8lWUE+9Ns02wqVWqROfZKJJFwZw62RuYDutw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2801,10 +2801,10 @@
     },
     "//:extensions.bzl%bazel_build_deps": {
       "general": {
-        "bzlTransitiveDigest": "Qn0k2fldjY66WVnZJhLl0HTcRxDUyOqfzTk2SfZ4/kg=",
+        "bzlTransitiveDigest": "1xHBfvy8lWUE+9Ns02wqVWqROfZKJJFwZw62RuYDutw=",
         "recordedFileInputs": {
           "@@//MODULE.bazel": "e32e677a18c4d02bebe4c5df2d8c1d348e16ad8be10c4b0ab6a925f204b3a98c",
-          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "86928e312e9d2f24a87f74fc846eae5a0834c14da5eb066e6deed15caa258590"
+          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "f41b29bff07a6d928ecad2505fab21235f61eca20464e2899a74904cc66c58c9"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3170,7 +3170,7 @@
     },
     "//:extensions.bzl%bazel_test_deps": {
       "general": {
-        "bzlTransitiveDigest": "Qn0k2fldjY66WVnZJhLl0HTcRxDUyOqfzTk2SfZ4/kg=",
+        "bzlTransitiveDigest": "1xHBfvy8lWUE+9Ns02wqVWqROfZKJJFwZw62RuYDutw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3345,7 +3345,7 @@
     },
     "//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "BStbvCDUk7eLNXv/hplB6w2sdjc01aBzsOge0WEdEXw=",
+        "bzlTransitiveDigest": "m0J7XXUL8i0mXixiKvM5Obok4oULDoY2uIlX/+P/bus=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3372,7 +3372,7 @@
     },
     "//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "l5mcjH2gWmbmIycx97bzI2stD0Q0M5gpDc0aLOHKIm8=",
+        "bzlTransitiveDigest": "G6+XhFekebQq8VaobjYeTD9Ge+MVKWqdFRuqyDATPNc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1070,7 +1070,7 @@
     },
     "@@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "BStbvCDUk7eLNXv/hplB6w2sdjc01aBzsOge0WEdEXw=",
+        "bzlTransitiveDigest": "m0J7XXUL8i0mXixiKvM5Obok4oULDoY2uIlX/+P/bus=",
         "usagesDigest": "LPw+9iUcnRY1k89ZEMEZ/AtOYIK2LgSeKnaiYVCDaag=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1163,7 +1163,7 @@
     },
     "@@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "l5mcjH2gWmbmIycx97bzI2stD0Q0M5gpDc0aLOHKIm8=",
+        "bzlTransitiveDigest": "G6+XhFekebQq8VaobjYeTD9Ge+MVKWqdFRuqyDATPNc=",
         "usagesDigest": "O3U7dkKl24l4dKwsK8Y1uf1SAa/eEwLfw4BRsHGugwc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1211,7 +1211,7 @@
     },
     "@@rules_java~//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "KiqmcRAp4qH+XPVV8NRBzuVzmA0tpT0ufDifw+XvVd0=",
+        "bzlTransitiveDigest": "NhI29H1jamjF2K82KYVnBzJWyL5lKvKAX5FsaMeEJxU=",
         "usagesDigest": "1/Dwy6r0Nf/YUE94OFi5Yy0Mo+TrPxA3U8hBaEzYH5s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1777,7 +1777,7 @@
     },
     "@@rules_jvm_external~//:extensions.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "v8HssW6WP6B8s0BwuAMJuQCz6cQ9jlhOfx4dKBtPYB4=",
+        "bzlTransitiveDigest": "rr7+Uisql7Lce6FmGikFtyNcR1UJ5QJwDr5P2pggWK8=",
         "usagesDigest": "L+U25+BzBiliO0i3XrvqC5up0f210dPakCjqg5MBrp4=",
         "recordedFileInputs": {
           "@@rules_jvm_external~//rules_jvm_external_deps_install.json": "10442a5ae27d9ff4c2003e5ab71643bf0d8b48dcf968b4173fa274c3232a8c06"
@@ -2801,7 +2801,7 @@
     },
     "@@rules_jvm_external~//:non-module-deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "DqBh3ObkOvjDFKv8VTy6J2qr7hXsJm9/sES7bha7ftA=",
+        "bzlTransitiveDigest": "KNKaZAVA53/BYR0R8DDwRcJ+fpzxexQD1n5Xj2t4xuo=",
         "usagesDigest": "HWGzpnxaDzDwBkFxYvT/plvwcfNrPZGTg9ZYibwxNGw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -2829,7 +2829,7 @@
     },
     "@@rules_python~//python/extensions:python.bzl%python": {
       "general": {
-        "bzlTransitiveDigest": "31xtOi5rmBJ3jSHeziLzV7KKKgCc6tMnRUZ1BQLBeao=",
+        "bzlTransitiveDigest": "8Cw2liOVPd8duf0hkkvkacm7hxYJswR4qH9ib6K2Q7w=",
         "usagesDigest": "2dLy/xmv7+TD8WRYYIxtxZMeS4nrJZGIDSMkYRE0elw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -2859,7 +2859,7 @@
     },
     "@@rules_python~//python/extensions/private:internal_deps.bzl%internal_deps": {
       "general": {
-        "bzlTransitiveDigest": "fUb5iKCtPgjhclraX+//BnJ+LOcG6I6+O9UUxT+gZ50=",
+        "bzlTransitiveDigest": "4RAcoHmmMtOeH2wANmmp+Kdo85owGdZWOmnqR0fABRM=",
         "usagesDigest": "MZDuELgGnEk5m0vRt+s02bhPv0B21Oi1jm1KuRqZ5FY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -70,7 +70,7 @@ URLs are tried in order until one succeeds, so you should list local mirrors fir
 If all downloads fail, the rule will fail."""
 
 def _get_all_urls(ctx):
-    """Returns all urls provided via the url or urls attributes.
+    """Returns all urls provided via the url, urls and remote_patches attributes.
 
     Also checks that at least one url is provided."""
     if not ctx.attr.url and not ctx.attr.urls:
@@ -81,6 +81,8 @@ def _get_all_urls(ctx):
         all_urls = ctx.attr.urls
     if ctx.attr.url:
         all_urls = [ctx.attr.url] + all_urls
+    if hasattr(ctx.attr, "remote_patches") and ctx.attr.remote_patches:
+        all_urls = all_urls + ctx.attr.remote_patches.keys()
 
     return all_urls
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/21885

PiperOrigin-RevId: 625651940
Change-Id: Id8a29c429e3b283dd0e2eecd1e13c023f0feb357

Commit https://github.com/bazelbuild/bazel/commit/445dfab8fdd7671fe6206ea938ef119c228019f0