### PR TITLE
[7.2.0] Fix trash base not updated when sandbox_base changed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -216,8 +216,13 @@ public final class SandboxModule extends BlazeModule {
         treeDeleter = new SynchronousTreeDeleter();
       }
     } else {
-      if (!(treeDeleter instanceof AsynchronousTreeDeleter)) {
+      if (!(treeDeleter instanceof AsynchronousTreeDeleter treeDeleter)
+          || !treeDeleter.getTrashBase().equals(trashBase)) {
+        if (treeDeleter != null) {
+          treeDeleter.shutdown();
+        }
         treeDeleter = new AsynchronousTreeDeleter(trashBase);
+        firstBuild = true;
       }
     }
     SandboxStash.initialize(env.getWorkspaceName(), sandboxBase, options);

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -1041,6 +1041,27 @@ EOF
     || fail "Test //pkg:b didn't reuse runfiles file"
 }
 
+function test_changed_async_deleter_filesystem() {
+  if [ ! -d /dev/shm ]; then
+    return
+  fi
+
+  mkdir pkg
+  cat >pkg/BUILD <<'EOF'
+cc_library(
+  name = "a",
+  srcs = [ "a.cc" ],
+)
+EOF
+  touch pkg/a.cc
+
+  bazel build //pkg:a \
+    || fail "Expected build to succeed"
+  bazel clean
+  bazel build --sandbox_base=/dev/shm //pkg:a \
+    || fail "Expected build to succeed"
+}
+
 function is_bazel() {
   [ $TEST_WORKSPACE == "_main" ]
 }


### PR DESCRIPTION
Whenever the sandbox base changed via --sandbox_base, the trash base used by the AsynchronousTreeDeleter wasn't being updated accordingly. If the new sandbox base was on a different filesystem (like tmpfs), new async deletions would result in the error (Invalid cross-device link) at the time of moving.

This would then trigger a precondition crash later when we checked whether everything had been deleted correctly.

PiperOrigin-RevId: 625430544
Change-Id: I1547b16bdb803eb5dcee649c9988bad73442a140

Commit https://github.com/bazelbuild/bazel/commit/dfd1763d3ece19bcbf6291fd1493c3cd07c65d46