### PR TITLE
[7.2.0] Fix swallowed I/O exception in LcovPrinter

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
@@ -23,45 +23,30 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.Map.Entry;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Prints coverage data stored in a collection of {@link SourceFileCoverage} in a <a
  * href="http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php">lcov tracefile format</a>
  */
 class LcovPrinter {
-  private static final Logger logger = Logger.getLogger(LcovPrinter.class.getName());
   private final BufferedWriter bufferedWriter;
 
   private LcovPrinter(BufferedWriter bufferedWriter) {
     this.bufferedWriter = bufferedWriter;
   }
 
-  static boolean print(OutputStream outputStream, Coverage coverage) {
-    BufferedWriter bufferedWriter;
-    try (Writer fileWriter = new OutputStreamWriter(outputStream, UTF_8)) {
-      bufferedWriter = new BufferedWriter(fileWriter);
+  static void print(OutputStream outputStream, Coverage coverage) throws IOException {
+    try (Writer fileWriter = new OutputStreamWriter(outputStream, UTF_8);
+        BufferedWriter bufferedWriter = new BufferedWriter(fileWriter); ) {
       LcovPrinter lcovPrinter = new LcovPrinter(bufferedWriter);
       lcovPrinter.print(coverage);
-      bufferedWriter.close();
-    } catch (IOException exception) {
-      logger.log(Level.SEVERE, "Could not write to output file.");
-      return false;
     }
-    return true;
   }
 
-  private boolean print(Coverage coverage) {
-    try {
-      for (SourceFileCoverage sourceFile : coverage.getAllSourceFiles()) {
-        print(sourceFile);
-      }
-    } catch (IOException exception) {
-      logger.log(Level.SEVERE, "Could not write to output file.");
-      return false;
+  private void print(Coverage coverage) throws IOException {
+    for (SourceFileCoverage sourceFile : coverage.getAllSourceFiles()) {
+      print(sourceFile);
     }
-    return true;
   }
 
   /**

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovPrinterTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovPrinterTest.java
@@ -53,7 +53,7 @@ public class LcovPrinterTest {
     coverage.add(sourceFileCoverage1);
     coverage.add(sourceFileCoverage2);
 
-    assertThat(LcovPrinter.print(byteOutputStream, coverage)).isTrue();
+    LcovPrinter.print(byteOutputStream, coverage);
     byteOutputStream.close();
 
     Iterable<String> fileLines = Splitter.on('\n').split(byteOutputStream.toString());
@@ -76,7 +76,7 @@ public class LcovPrinterTest {
   @Test
   public void testPrintOneFile() throws Exception {
     coverage.add(sourceFileCoverage1);
-    assertThat(LcovPrinter.print(byteOutputStream, coverage)).isTrue();
+    LcovPrinter.print(byteOutputStream, coverage);
     byteOutputStream.close();
     Iterable<String> fileLines = Splitter.on('\n').split(byteOutputStream.toString());
     // Last line of the file will always be a newline.
@@ -99,7 +99,7 @@ public class LcovPrinterTest {
     sourceFile.addBranch(7, BranchCoverage.createWithBlockAndBranch(7, "0", "1", false, 0));
     coverage.add(sourceFile);
 
-    assertThat(LcovPrinter.print(byteOutputStream, coverage)).isTrue();
+    LcovPrinter.print(byteOutputStream, coverage);
     Iterable<String> fileLines = Splitter.on('\n').split(byteOutputStream.toString());
     assertThat(fileLines)
         .containsExactly(


### PR DESCRIPTION
The calling code expects the exception, not a return boolean.

Fixes #21982.

Closes #21987.

PiperOrigin-RevId: 626086576
Change-Id: I4abd7a253715c84c323e036dfbdb2fcb94a4825d

Commit https://github.com/bazelbuild/bazel/commit/f8277cf9feebfae390b96218979a66f75693961c