### PR TITLE
[7.2.0] Optimize _virtual_includes when paths are only stripped

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
@@ -96,13 +96,44 @@ def _compute_public_headers(
     if include_prefix and include_prefix.startswith("/"):
         include_prefix = include_prefix[1:]
 
-    if not strip_prefix and not include_prefix:
+    if (not strip_prefix and not include_prefix) or not public_headers_artifacts:
         return struct(
             headers = public_headers_artifacts + non_module_map_headers,
             module_map_headers = public_headers_artifacts,
             virtual_include_path = None,
             virtual_to_original_headers = depset(),
         )
+
+    # When only stripping, we don't need to use _virtual_include path
+    if strip_prefix and not include_prefix:
+        module_map_headers = []
+        virtual_to_original_headers_list = []
+        include_paths = {}
+        for original_header in public_headers_artifacts:
+            repo_relative_path = _repo_relative_path(original_header)
+            if not repo_relative_path.startswith(strip_prefix):
+                fail("header '{}' is not under the specified strip prefix '{}'".format(repo_relative_path, strip_prefix))
+            include_path = original_header.root.path
+            workspace_root = original_header.owner.workspace_root
+            if not include_path:  # this is a source/non-generated file
+                include_path = workspace_root
+            elif workspace_root.startswith("external/"):
+                # in non-sibling repo layout, we need to add workspace root as well
+                include_path = include_path + "/" + workspace_root
+            include_path = paths.get_relative(include_path, strip_prefix)
+            include_paths[include_path] = True
+            module_map_headers.append(original_header)
+
+        virtual_headers = module_map_headers + non_module_map_headers
+
+        # We can only handle 1 include path. In case there are more, fallback to _virtual_imports.
+        if len(include_paths.keys()) == 1:
+            return struct(
+                headers = virtual_headers,
+                module_map_headers = module_map_headers,
+                virtual_include_path = include_paths.keys()[0],
+                virtual_to_original_headers = depset(virtual_to_original_headers_list),
+            )
 
     module_map_headers = []
     virtual_to_original_headers_list = []

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
@@ -927,10 +927,9 @@ public class CcCommonTest extends BuildViewTestCase {
             .getCcCompilationContext();
 
     assertThat(ActionsTestUtil.prettyArtifactNames(relative.getDeclaredIncludeSrcs()))
-        .containsExactly("third_party/a/_virtual_includes/relative/b.h", "third_party/a/v1/b.h");
+        .containsExactly("third_party/a/v1/b.h");
     assertThat(ActionsTestUtil.prettyArtifactNames(absolute.getDeclaredIncludeSrcs()))
-        .containsExactly(
-            "third_party/a/_virtual_includes/absolute/a/v1/b.h", "third_party/a/v1/b.h");
+        .containsExactly("third_party/a/v1/b.h");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -5569,7 +5569,9 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(target).isNotNull();
     CcInfo ccInfo = target.get(CcInfo.PROVIDER);
     assertThat(artifactsToStrings(ccInfo.getCcCompilationContext().getDirectPublicHdrs()))
-        .contains("bin third_party/bar/_virtual_includes/starlark_lib_suffix/starlark_lib.h");
+        .contains("src third_party/bar/v1/starlark_lib.h");
+    assertThat(ccInfo.getCcCompilationContext().getIncludeDirs())
+        .contains(PathFragment.create("third_party/bar/v1"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -1321,8 +1321,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     CommandAction compileAction = compileAction("//package:objc_lib", "b.o");
     // We remove spaces, since the crosstool rules do not use spaces for include paths.
     String compileActionArgs = Joiner.on("").join(compileAction.getArguments()).replace(" ", "");
-    assertThat(compileActionArgs)
-        .matches(".*-iquote.*/third_party/cc_lib/_virtual_includes/cc_lib.*");
+    assertThat(compileActionArgs).matches(".*-iquote.*third_party/cc_lib/.*");
   }
 
   @Test


### PR DESCRIPTION
In this case it's not neccessary to create _virtual_includes, just setting the correct include path is enough.

This should alleviate Windows problems with too long paths.

Related: https://github.com/bazelbuild/bazel/issues/18683
PiperOrigin-RevId: 626360114
Change-Id: I4e7d8ee39e58dd27601f18c4a624c1d206785abe

Commit https://github.com/bazelbuild/bazel/commit/a091d90cded797ce8f6206b56ffd6f89e27e2c76