### PR TITLE
Handle operation stream exception in wrapper

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
@@ -66,11 +66,10 @@ public class ExperimentalGrpcRemoteExecutorTest extends GrpcRemoteExecutorTestBa
   @Test
   public void executeRemotely_executeAndRetryWait_forever() throws Exception {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
-    int errorTimes = MAX_RETRY_ATTEMPTS * 2;
+    int errorTimes = MAX_RETRY_ATTEMPTS;
     for (int i = 0; i < errorTimes; ++i) {
       executionService
           .whenWaitExecution(DUMMY_REQUEST)
-          .thenAck()
           .thenError(Status.DEADLINE_EXCEEDED.asRuntimeException());
     }
     executionService.whenWaitExecution(DUMMY_REQUEST).thenDone(DUMMY_RESPONSE);
@@ -151,7 +150,6 @@ public class ExperimentalGrpcRemoteExecutorTest extends GrpcRemoteExecutorTestBa
     executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
     executionService
         .whenWaitExecution(DUMMY_REQUEST)
-        .thenAck()
         .thenError(Status.UNAUTHENTICATED.asRuntimeException());
     executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTest.java
@@ -88,7 +88,7 @@ public class GrpcRemoteExecutorTest extends GrpcRemoteExecutorTestBase {
   public void executeRemotely_retryWaitExecutionWhenUnauthenticated()
       throws IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
-    executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenError(Code.UNAUTHENTICATED);
+    executionService.whenWaitExecution(DUMMY_REQUEST).thenError(Code.UNAUTHENTICATED);
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 
     ExecuteResponse response =

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTestBase.java
@@ -268,6 +268,21 @@ public abstract class GrpcRemoteExecutorTestBase {
   }
 
   @Test
+  public void executeRemotely_retryExecuteIfNotFoundStream() throws IOException, InterruptedException {
+    executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
+    executionService.whenWaitExecution(DUMMY_REQUEST).thenError(Status.NOT_FOUND.asRuntimeException());
+    executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
+    executionService.whenWaitExecution(DUMMY_REQUEST).thenDone(DUMMY_RESPONSE);
+
+    ExecuteResponse response =
+        executor.executeRemotely(context, DUMMY_REQUEST, OperationObserver.NO_OP);
+
+    assertThat(executionService.getExecTimes()).isEqualTo(2);
+    assertThat(executionService.getWaitTimes()).isEqualTo(2);
+    assertThat(response).isEqualTo(DUMMY_RESPONSE);
+  }
+
+  @Test
   public void executeRemotely_retryExecuteOnFinish() throws IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
     executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().finish();
@@ -285,7 +300,7 @@ public abstract class GrpcRemoteExecutorTestBase {
   public void executeRemotely_notFoundLoop_reportError() {
     for (int i = 0; i <= MAX_RETRY_ATTEMPTS; ++i) {
       executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
-      executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenError(Code.NOT_FOUND);
+      executionService.whenWaitExecution(DUMMY_REQUEST).thenError(Code.NOT_FOUND);
     }
 
     IOException e =
@@ -316,7 +331,7 @@ public abstract class GrpcRemoteExecutorTestBase {
   @Test
   public void executeRemotely_retryExecuteOnNoResultDoneOperation()
       throws IOException, InterruptedException {
-    executionService.whenExecute(DUMMY_REQUEST).thenAck().thenError(Code.UNAVAILABLE);
+    executionService.whenExecute(DUMMY_REQUEST).thenError(Code.UNAVAILABLE);
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 
     ExecuteResponse response =


### PR DESCRIPTION
A literal StatusRuntimeException thrown from a response stream iterator (as an error response to the overall request) should have the same consideration as one thrown from the operation response unwrap.

waitExecution requires an additional check for SRE thrown directly from operation stream pop.
Existing NOT_FOUNDs that do not pass the inner retry check will similarly be passed through.

To detect this NOT_FOUND in test, the actual exception thrown as a result of thenError must be the error response from stream provided by FakeExecutionService. This corrects a number of tests which did not check for explicit exceptions and were relying on UNKNOWN SREs resulting from errors during handling, and removes numerous thenAck()s required to validate tests.