### PR TITLE
Add link stamping to `cc_shared_library`

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
@@ -724,6 +724,7 @@ def _cc_shared_library_impl(ctx):
         actions = ctx.actions,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
+        stamp = cc_helper.is_stamping_enabled(ctx),
         linking_contexts = [linking_context],
         user_link_flags = user_link_flags,
         additional_inputs = additional_inputs,


### PR DESCRIPTION
Adds missing stamp argument to call to `cc_common.link` in `cc_shared_library`. Fixes #21724