### PR TITLE
Doc nit: remove local=True from http_archive example

### DIFF
--- a/site/en/extending/repo.md
+++ b/site/en/extending/repo.md
@@ -40,7 +40,6 @@ the repo rule is defined with a call to `repository_rule`. An example defining
 ```python
 http_archive = repository_rule(
     implementation=_impl,
-    local=True,
     attrs={
         "url": attr.string(mandatory=True)
         "sha256": attr.string(mandatory=True)


### PR DESCRIPTION
`http_archive` is not local - it does not re-download external repos on bazel server restart. Having `local=True` in the example is somewhat confusing.

Looks it was leftover after some older change:
https://github.com/bazelbuild/bazel/commit/13ecdf583301a94484a1ae0eb27c56fcf3248dc5#diff-1f760cde585b814b5608e64ade35cfa8f6fc0b1082316adc2f1bac412169a10eL41