### PR TITLE
Handle file type changes with in-process symlink creation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
@@ -264,7 +264,7 @@ public final class SymlinkTreeHelper {
       // if (!stat.isExecutable() || !stat.isReadable()) {
       //   at.chmod(stat.getMods() | 0700);
       // }
-      for (Dirent dirent : at.readdir(Symlinks.FOLLOW)) {
+      for (Dirent dirent : at.readdir(Symlinks.NOFOLLOW)) {
         String basename = dirent.getName();
         Path next = at.getChild(basename);
         if (symlinks.containsKey(basename)) {
@@ -276,6 +276,11 @@ public final class SymlinkTreeHelper {
             }
             // For consistency with build-runfiles.cc, we don't truncate the file if one exists.
           } else {
+            // ensureSymbolsLink will replace a symlink that doesn't have the correct target, but
+            // everything else needs to be deleted first.
+            if (dirent.getType() != Dirent.Type.SYMLINK) {
+              next.deleteTree();
+            }
             // TODO(ulfjack): On Windows, this call makes a copy rather than creating a symlink.
             FileSystemUtils.ensureSymbolicLink(next, value.getPath().asFragment());
           }

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
@@ -276,7 +276,7 @@ public final class SymlinkTreeHelper {
             }
             // For consistency with build-runfiles.cc, we don't truncate the file if one exists.
           } else {
-            // ensureSymbolsLink will replace a symlink that doesn't have the correct target, but
+            // ensureSymbolicLink will replace a symlink that doesn't have the correct target, but
             // everything else needs to be deleted first.
             if (dirent.getType() != Dirent.Type.SYMLINK) {
               next.deleteTree();


### PR DESCRIPTION
`SymlinkTreeUpdater` now correctly replaces symlinks with directories and vice versa in runfiles trees.

Fixes #20266