### PR TITLE
Always create an empty MODULE.bazel for python tests

### DIFF
--- a/src/test/py/bazel/bazel_workspace_test.py
+++ b/src/test/py/bazel/bazel_workspace_test.py
@@ -25,6 +25,8 @@ class BazelWorkspaceTest(test_base.TestBase):
     self.DisableBzlmod()
 
   def testWorkspaceDotBazelFileInMainRepo(self):
+    # Make sure no existing MODULE.bazel file.
+    os.remove("MODULE.bazel")
     workspace_dot_bazel = self.ScratchFile("WORKSPACE.bazel")
     self.ScratchFile("BUILD", [
         "py_binary(",

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -141,6 +141,8 @@ class TestBase(absltest.TestCase):
         # Prefer ipv6 network on macOS
         f.write('startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true\n')
         f.write('build --jvmopt=-Djava.net.preferIPv6Addresses\n')
+    # An empty MODULE.bazel and a corresponding MODULE.bazel.lock will prevent tests from accessing BCR    
+    self.ScratchFile("MODULE.bazel")
     self.CopyFile(
         self.Rlocation('io_bazel/src/test/tools/bzlmod/MODULE.bazel.lock'),
         'MODULE.bazel.lock',


### PR DESCRIPTION
To prevent python tests from accessing BCR, this was missed in https://github.com/bazelbuild/bazel/commit/055e25b75c74d1e2c4c71694a938b6456323facc