### PR TITLE
[7.2.0] Always create an empty MODULE.bazel for python tests

### DIFF
--- a/src/test/py/bazel/bazel_workspace_test.py
+++ b/src/test/py/bazel/bazel_workspace_test.py
@@ -25,6 +25,8 @@ class BazelWorkspaceTest(test_base.TestBase):
     self.DisableBzlmod()
 
   def testWorkspaceDotBazelFileInMainRepo(self):
+    # Make sure no existing MODULE.bazel file.
+    os.remove("MODULE.bazel")
     workspace_dot_bazel = self.ScratchFile("WORKSPACE.bazel")
     self.ScratchFile("BUILD", [
         "py_binary(",

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -138,6 +138,9 @@ class TestBase(absltest.TestCase):
           # For reducing SSD usage on our physical Mac machines.
           f.write('common --experimental_repository_cache_hardlinks\n')
       f.write('common --enable_bzlmod\n')
+    # An empty MODULE.bazel and a corresponding MODULE.bazel.lock will prevent
+    # tests from accessing BCR
+    self.ScratchFile('MODULE.bazel')
     self.CopyFile(
         self.Rlocation('io_bazel/src/test/tools/bzlmod/MODULE.bazel.lock'),
         'MODULE.bazel.lock',


### PR DESCRIPTION
To prevent python tests from accessing BCR, this was missed in https://github.com/bazelbuild/bazel/commit/055e25b75c74d1e2c4c71694a938b6456323facc

Closes #22089.

PiperOrigin-RevId: 627384354
Change-Id: Ic4545616fad88f479b24553eb7ffe81004d41090

Commit https://github.com/bazelbuild/bazel/commit/c900865bbb3c38b589d6e5fbc422d61d3bba4681