### PR TITLE
Only check for shard status file if a test passed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -677,7 +677,10 @@ public class StandaloneTestStrategy extends TestStrategy {
     }
     long endTimeMillis = actionExecutionContext.getClock().currentTimeMillis();
 
-    if (testAction.isSharded()) {
+    // Do not override a more informative test failure with a generic failure due to the missing
+    // shard file, which may have been caused by the test failing before the runner had a chance to
+    // touch the file
+    if (testResultDataBuilder.getTestPassed() && testAction.isSharded()) {
       if (testAction.checkShardingSupport()
           && !actionExecutionContext
               .getPathResolver()


### PR DESCRIPTION
If a test fails, the failure is going to be informative than a generic exec error and the failure may have interrupted or prevented the test runner from touching the status file.

Speculatively fixes #22028