### PR TITLE
Update the GitHub actions workflow to use "awaiting-PR-merge" label

### DIFF
--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -21,5 +21,5 @@ jobs:
     - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
       with:
         labels: |
-          awaiting-pr-merge
+          awaiting-PR-merge
           awaiting-review


### PR DESCRIPTION
Removes "awaiting-PR-merge" label from the closed or merged PR's.