### PR TITLE
[7.2.0] aquery: interpret "//foo:bar" as "all configured targets with label //foo:bar"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/AqueryProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AqueryProcessor.java
@@ -14,9 +14,11 @@
 package com.google.devtools.build.lib.buildtool;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.analysis.ConfiguredTargetValue;
 import com.google.devtools.build.lib.analysis.actions.TemplateExpansionException;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
@@ -45,11 +47,9 @@ import com.google.devtools.build.lib.skyframe.actiongraph.v2.AqueryConsumingOutp
 import com.google.devtools.build.lib.skyframe.actiongraph.v2.AqueryOutputHandler;
 import com.google.devtools.build.lib.skyframe.actiongraph.v2.AqueryOutputHandler.OutputType;
 import com.google.devtools.build.lib.skyframe.actiongraph.v2.InvalidAqueryOutputFormatException;
-import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.WalkableGraph;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -139,7 +139,7 @@ public final class AqueryProcessor extends PostAnalysisQueryProcessor<Configured
       BuildRequest request,
       CommandEnvironment env,
       TopLevelConfigurations topLevelConfigurations,
-      Collection<SkyKey> transitiveConfigurationKeys,
+      ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations,
       WalkableGraph walkableGraph) {
     ImmutableList<QueryFunction> extraFunctions =
         new ImmutableList.Builder<QueryFunction>()
@@ -157,6 +157,7 @@ public final class AqueryProcessor extends PostAnalysisQueryProcessor<Configured
             env.getReporter(),
             extraFunctions,
             topLevelConfigurations,
+            transitiveConfigurations,
             mainRepoTargetParser,
             env.getPackageManager().getPackagePath(),
             () -> walkableGraph,

--- a/src/main/java/com/google/devtools/build/lib/buildtool/CqueryProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/CqueryProcessor.java
@@ -14,6 +14,8 @@
 package com.google.devtools.build.lib.buildtool;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
@@ -23,9 +25,7 @@ import com.google.devtools.build.lib.query2.cquery.CqueryOptions;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
 import com.google.devtools.build.lib.query2.engine.QueryExpression;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
-import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.WalkableGraph;
-import java.util.Collection;
 import net.starlark.java.eval.StarlarkSemantics;
 
 /** Performs {@code cquery} processing. */
@@ -41,7 +41,7 @@ public final class CqueryProcessor extends PostAnalysisQueryProcessor<CqueryNode
       BuildRequest request,
       CommandEnvironment env,
       TopLevelConfigurations configurations,
-      Collection<SkyKey> transitiveConfigurationKeys,
+      ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations,
       WalkableGraph walkableGraph)
       throws InterruptedException {
     ImmutableList<QueryFunction> extraFunctions =
@@ -58,7 +58,7 @@ public final class CqueryProcessor extends PostAnalysisQueryProcessor<CqueryNode
         env.getReporter(),
         extraFunctions,
         configurations,
-        transitiveConfigurationKeys,
+        transitiveConfigurations,
         mainRepoTargetParser,
         env.getPackageManager().getPackagePath(),
         () -> walkableGraph,

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -13,8 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.query2.cquery;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -62,12 +60,9 @@ import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.WalkableGraph;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -94,23 +89,6 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
 
   private final ConfiguredTargetAccessor accessor;
 
-  /**
-   * F Stores every configuration in the transitive closure of the build graph as a map from its
-   * user-friendly hash to the configuration itself.
-   *
-   * <p>This is used to find configured targets in, e.g. {@code somepath} queries. Given {@code
-   * somepath(//foo, //bar)}, cquery finds the configured targets for {@code //foo} and {@code
-   * //bar} by creating a {@link ConfiguredTargetKey} from their labels and <i>some</i>
-   * configuration, then querying the {@link WalkableGraph} to find the matching configured target.
-   *
-   * <p>Having this map lets cquery choose from all available configurations in the graph,
-   * particularly including configurations that aren't the top-level.
-   *
-   * <p>This can also be used in cquery's {@code config} function to match against explicitly
-   * specified configs. This, in particular, is where having user-friendly hashes is invaluable.
-   */
-  private final ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations;
-
   @Override
   protected KeyExtractor<CqueryNode, ActionLookupKey> getConfiguredTargetKeyExtractor() {
     return configuredTargetKeyExtractor;
@@ -121,7 +99,7 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
       ExtendedEventHandler eventHandler,
       Iterable<QueryFunction> extraFunctions,
       TopLevelConfigurations topLevelConfigurations,
-      Collection<SkyKey> transitiveConfigurationKeys,
+      ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations,
       TargetPattern.Parser mainRepoTargetParser,
       PathPackageLocator pkgPath,
       Supplier<WalkableGraph> walkableGraphSupplier,
@@ -134,6 +112,7 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
         eventHandler,
         extraFunctions,
         topLevelConfigurations,
+        transitiveConfigurations,
         mainRepoTargetParser,
         pkgPath,
         walkableGraphSupplier,
@@ -141,8 +120,6 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
         labelPrinter);
     this.accessor = new ConfiguredTargetAccessor(walkableGraphSupplier.get(), this);
     this.configuredTargetKeyExtractor = CqueryNode::getLookupKey;
-    this.transitiveConfigurations =
-        getTransitiveConfigurations(transitiveConfigurationKeys, walkableGraphSupplier.get());
     this.topLevelArtifactContext = topLevelArtifactContext;
   }
 
@@ -151,7 +128,7 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
       ExtendedEventHandler eventHandler,
       Iterable<QueryFunction> extraFunctions,
       TopLevelConfigurations topLevelConfigurations,
-      Collection<SkyKey> transitiveConfigurationKeys,
+      ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations,
       TargetPattern.Parser mainRepoTargetParser,
       PathPackageLocator pkgPath,
       Supplier<WalkableGraph> walkableGraphSupplier,
@@ -164,7 +141,7 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
         eventHandler,
         extraFunctions,
         topLevelConfigurations,
-        transitiveConfigurationKeys,
+        transitiveConfigurations,
         mainRepoTargetParser,
         pkgPath,
         walkableGraphSupplier,
@@ -183,17 +160,6 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
 
   private static ImmutableList<QueryFunction> getCqueryFunctions() {
     return ImmutableList.of(new ConfigFunction());
-  }
-
-  private static ImmutableMap<String, BuildConfigurationValue> getTransitiveConfigurations(
-      Collection<SkyKey> transitiveConfigurationKeys, WalkableGraph graph)
-      throws InterruptedException {
-    // BuildConfigurationKey and BuildConfigurationValue should be 1:1
-    // so merge function intentionally omitted
-    return graph.getSuccessfulValues(transitiveConfigurationKeys).values().stream()
-        .map(BuildConfigurationValue.class::cast)
-        .sorted(Comparator.comparing(BuildConfigurationValue::checksum))
-        .collect(toImmutableMap(BuildConfigurationValue::checksum, Function.identity()));
   }
 
   @Override
@@ -314,8 +280,7 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
                     partialResult -> {
                       List<CqueryNode> transformedResult = new ArrayList<>();
                       for (Target target : partialResult) {
-                        transformedResult.addAll(
-                            getConfiguredTargetsForConfigFunction(target.getLabel()));
+                        transformedResult.addAll(getConfiguredTargetsForLabel(target.getLabel()));
                       }
                       callback.process(transformedResult);
                     },
@@ -372,7 +337,7 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
    *
    * <p>If there are no matches, returns an empty list.
    */
-  private ImmutableList<CqueryNode> getConfiguredTargetsForConfigFunction(Label label)
+  private ImmutableList<CqueryNode> getConfiguredTargetsForLabel(Label label)
       throws InterruptedException {
     ImmutableList.Builder<CqueryNode> ans = ImmutableList.builder();
     for (BuildConfigurationValue config : transitiveConfigurations.values()) {

--- a/src/test/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryHelper.java
@@ -14,15 +14,15 @@
 package com.google.devtools.build.lib.query2.aquery;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.ConfiguredTargetValue;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.packages.LabelPrinter;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
 import com.google.devtools.build.lib.query2.testutil.PostAnalysisQueryHelper;
-import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.WalkableGraph;
-import java.util.Collection;
 
 /** Helper class for aquery test */
 public class ActionGraphQueryHelper extends PostAnalysisQueryHelper<ConfiguredTargetValue> {
@@ -31,7 +31,7 @@ public class ActionGraphQueryHelper extends PostAnalysisQueryHelper<ConfiguredTa
   protected PostAnalysisQueryEnvironment<ConfiguredTargetValue> getPostAnalysisQueryEnvironment(
       WalkableGraph walkableGraph,
       TopLevelConfigurations topLevelConfigurations,
-      Collection<SkyKey> transitiveConfigurationKeys) {
+      ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations) {
     ImmutableList<QueryFunction> extraFunctions =
         ImmutableList.copyOf(ActionGraphQueryEnvironment.AQUERY_FUNCTIONS);
     return new ActionGraphQueryEnvironment(
@@ -39,6 +39,7 @@ public class ActionGraphQueryHelper extends PostAnalysisQueryHelper<ConfiguredTa
         getReporter(),
         extraFunctions,
         topLevelConfigurations,
+        transitiveConfigurations,
         mainRepoTargetParser,
         analysisHelper.getPackageManager().getPackagePath(),
         () -> walkableGraph,

--- a/src/test/java/com/google/devtools/build/lib/query2/aquery/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/aquery/BUILD
@@ -16,12 +16,12 @@ java_library(
     testonly = 1,
     srcs = ["ActionGraphQueryHelper.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target_value",
         "//src/main/java/com/google/devtools/build/lib/packages:label_printer",
         "//src/main/java/com/google/devtools/build/lib/query2",
         "//src/main/java/com/google/devtools/build/lib/query2/engine",
         "//src/main/java/com/google/devtools/build/skyframe",
-        "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/test/java/com/google/devtools/build/lib/query2/testutil",
         "//third_party:guava",
     ],

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
@@ -89,12 +89,12 @@ java_library(
     testonly = 1,
     srcs = ["ConfiguredTargetQueryHelper.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/build_configuration",
         "//src/main/java/com/google/devtools/build/lib/packages:label_printer",
         "//src/main/java/com/google/devtools/build/lib/query2",
         "//src/main/java/com/google/devtools/build/lib/query2/common:cquery-node",
         "//src/main/java/com/google/devtools/build/lib/query2/engine",
         "//src/main/java/com/google/devtools/build/skyframe",
-        "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/query2/testutil",
         "//third_party:guava",

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
@@ -14,6 +14,8 @@
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.util.AnalysisTestCase;
 import com.google.devtools.build.lib.packages.LabelPrinter;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
@@ -21,9 +23,7 @@ import com.google.devtools.build.lib.query2.common.CqueryNode;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
 import com.google.devtools.build.lib.query2.testutil.AbstractQueryTest.QueryHelper;
 import com.google.devtools.build.lib.query2.testutil.PostAnalysisQueryHelper;
-import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.WalkableGraph;
-import java.util.Collection;
 
 /**
  * {@link QueryHelper} for {@link ConfiguredTargetQueryTest}. Big warts: uses an {@link
@@ -37,7 +37,7 @@ public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<CqueryN
   protected ConfiguredTargetQueryEnvironment getPostAnalysisQueryEnvironment(
       WalkableGraph walkableGraph,
       TopLevelConfigurations topLevelConfigurations,
-      Collection<SkyKey> transitiveConfigurationKeys)
+      ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations)
       throws InterruptedException {
     ImmutableList<QueryFunction> extraFunctions =
         ImmutableList.copyOf(ConfiguredTargetQueryEnvironment.CQUERY_FUNCTIONS);
@@ -46,7 +46,7 @@ public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<CqueryN
         getReporter(),
         extraFunctions,
         topLevelConfigurations,
-        transitiveConfigurationKeys,
+        transitiveConfigurations,
         mainRepoTargetParser,
         analysisHelper.getPackageManager().getPackagePath(),
         () -> walkableGraph,

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryTest.java
@@ -107,10 +107,4 @@ public abstract class ConfiguredTargetQueryTest extends PostAnalysisQueryTest<Cq
       assertThat(getConfiguration(resultIterator.next())).isNull();
     }
   }
-
-  @Override
-  public void testMultipleTopLevelConfigurations_multipleConfigsPrefersTopLevel() {
-    // When the same target exists in multiple configurations, cquery doesn't guarantee which
-    // instance is evaluated first. So disable this test.
-  }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/PostAnalysisQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/PostAnalysisQueryHelper.java
@@ -13,9 +13,11 @@
 // limitations under the License.
 package com.google.devtools.build.lib.query2.testutil;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.devtools.build.lib.testutil.FoundationTestCase.failFastHandler;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.analysis.AnalysisResult;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
@@ -56,8 +58,10 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
 
@@ -204,11 +208,25 @@ public abstract class PostAnalysisQueryHelper<T> extends AbstractQueryHelper<T> 
     analysisResult = analysisHelper.update(universe.toArray(new String[0]));
     WalkableGraph walkableGraph =
         SkyframeExecutorWrappingWalkableGraph.of(analysisHelper.getSkyframeExecutor());
+    ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations =
+        getTransitiveConfigurations(
+            analysisHelper.getSkyframeExecutor().getTransitiveConfigurationKeys(), walkableGraph);
 
     return getPostAnalysisQueryEnvironment(
         walkableGraph,
         new TopLevelConfigurations(analysisResult.getTopLevelTargetsWithConfigs()),
-        analysisHelper.getSkyframeExecutor().getTransitiveConfigurationKeys());
+        transitiveConfigurations);
+  }
+
+  private static ImmutableMap<String, BuildConfigurationValue> getTransitiveConfigurations(
+      Collection<SkyKey> transitiveConfigurationKeys, WalkableGraph graph)
+      throws InterruptedException {
+    // BuildConfigurationKey and BuildConfigurationValue should be 1:1
+    // so merge function intentionally omitted
+    return graph.getSuccessfulValues(transitiveConfigurationKeys).values().stream()
+        .map(BuildConfigurationValue.class::cast)
+        .sorted(Comparator.comparing(BuildConfigurationValue::checksum))
+        .collect(toImmutableMap(BuildConfigurationValue::checksum, Function.identity()));
   }
 
   /**
@@ -218,13 +236,14 @@ public abstract class PostAnalysisQueryHelper<T> extends AbstractQueryHelper<T> 
    *     search over
    * @param topLevelConfigurations the configurations used to build the top-level targets in a
    *     query's universe scope
-   * @param transitiveConfigurationKeys all configurations available in the build graph (including
-   *     those produced by configuration transitions in the top-level targets' transitive deps)
+   * @param transitiveConfigurations all configurations available in the build graph (including
+   *     those produced by configuration transitions in the top-level targets' transitive deps),
+   *     keyed by the configurations' checksums
    */
   protected abstract PostAnalysisQueryEnvironment<T> getPostAnalysisQueryEnvironment(
       WalkableGraph walkableGraph,
       TopLevelConfigurations topLevelConfigurations,
-      Collection<SkyKey> transitiveConfigurationKeys)
+      ImmutableMap<String, BuildConfigurationValue> transitiveConfigurations)
       throws InterruptedException;
 
   @Override


### PR DESCRIPTION
cquery acquired this behavior 4 years ago in unknown commit, but it was never ported to aquery. This fixes some potentially surprising behavior when multiple configured targets corresponding to the same label are present (see added test cases).

RELNOTES: aquery: `//foo:bar` now means "all configured targets with label `//foo:bar`" instead of "choose an arbitrary configured target with label `//foo:bar`". This is in line with cquery behavior.
PiperOrigin-RevId: 620091100
Change-Id: Ib5c5ee33e35fe7ac30bc31f703b119dec40185b7

Commit https://github.com/bazelbuild/bazel/commit/0662df0506507d872e1243c243719aeba72e6a3e