### PR TITLE
[7.2.0] Handle operation stream exception in wrapper

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java
@@ -198,6 +198,17 @@ public class ExperimentalGrpcRemoteExecutor implements RemoteExecutionClient {
         Iterator<Operation> operationStream = waitExecutionFunction.apply(request);
         return handleOperationStream(operationStream, /* waitExecution= */ true);
       } catch (StatusRuntimeException e) {
+        // Handle the error possibility of a NOT_FOUND stream error in addition to the status
+        // embedded in an operation from the stream, since both are possible and should retry
+        // Execute().
+        //
+        // Retry is again contingent upon executeBackoff exhaustion, and if NOT_FOUND was
+        // thrown in handleOperationStream as a result of exhaustion already, this does not
+        // change its counter or retriability state.
+        if (e.getStatus().getCode() == Code.NOT_FOUND && executeBackoff.nextDelayMillis(e) >= 0) {
+          lastOperation = null;
+          return null;
+        }
         throw new IOException(e);
       } catch (Throwable e) {
         lastOperation = null;

--- a/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
@@ -66,11 +66,10 @@ public class ExperimentalGrpcRemoteExecutorTest extends GrpcRemoteExecutorTestBa
   @Test
   public void executeRemotely_executeAndRetryWait_forever() throws Exception {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
-    int errorTimes = MAX_RETRY_ATTEMPTS * 2;
+    int errorTimes = MAX_RETRY_ATTEMPTS;
     for (int i = 0; i < errorTimes; ++i) {
       executionService
           .whenWaitExecution(DUMMY_REQUEST)
-          .thenAck()
           .thenError(Status.DEADLINE_EXCEEDED.asRuntimeException());
     }
     executionService.whenWaitExecution(DUMMY_REQUEST).thenDone(DUMMY_RESPONSE);
@@ -151,7 +150,6 @@ public class ExperimentalGrpcRemoteExecutorTest extends GrpcRemoteExecutorTestBa
     executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
     executionService
         .whenWaitExecution(DUMMY_REQUEST)
-        .thenAck()
         .thenError(Status.UNAUTHENTICATED.asRuntimeException());
     executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutorTest.java
@@ -88,7 +88,7 @@ public class GrpcRemoteExecutorTest extends GrpcRemoteExecutorTestBase {
   public void executeRemotely_retryWaitExecutionWhenUnauthenticated()
       throws IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().finish();
-    executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenError(Code.UNAUTHENTICATED);
+    executionService.whenWaitExecution(DUMMY_REQUEST).thenError(Code.UNAUTHENTICATED);
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 
     ExecuteResponse response =


### PR DESCRIPTION
A literal StatusRuntimeException thrown from a response stream iterator (as an error response to the overall request) should have the same consideration as one thrown from the operation response unwrap.

waitExecution requires an additional check for SRE thrown directly from operation stream pop.
Existing NOT_FOUNDs that do not pass the inner retry check will similarly be passed through.

To detect this NOT_FOUND in test, the actual exception thrown as a result of thenError must be the error response from stream provided by FakeExecutionService. This corrects a number of tests which did not check for explicit exceptions and were relying on UNKNOWN SREs resulting from errors during handling, and removes numerous thenAck()s required to validate tests.

Closes #22067.

PiperOrigin-RevId: 628094669
Change-Id: I011d2c2321074a1a27dc853f6274ba9ef35f6db6

Commit https://github.com/bazelbuild/bazel/commit/6d79e11a15e59b6d2ef6838efe780f7c0b820387