### PR TITLE
[7.2.0] Only check for shard status file if a test passed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -681,7 +681,10 @@ public class StandaloneTestStrategy extends TestStrategy {
     }
     long endTimeMillis = actionExecutionContext.getClock().currentTimeMillis();
 
-    if (testAction.isSharded()) {
+    // Do not override a more informative test failure with a generic failure due to the missing
+    // shard file, which may have been caused by the test failing before the runner had a chance to
+    // touch the file
+    if (testResultDataBuilder.getTestPassed() && testAction.isSharded()) {
       if (testAction.checkShardingSupport()
           && !actionExecutionContext
               .getPathResolver()


### PR DESCRIPTION
If a test fails, the failure is going to be informative than a generic exec error and the failure may have interrupted or prevented the test runner from touching the status file.

Speculatively fixes #22028

Closes #22098.

PiperOrigin-RevId: 628355694
Change-Id: I370c7aba331f2a7a89cb9a9ff99d32b1694fd03a

Commit https://github.com/bazelbuild/bazel/commit/874a050aa7ab3f2034bbd4afb3a5fbf4ed5109d1