### PR TITLE
Fix potential NPE in ModuleFileFunction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -596,11 +596,14 @@ public class ModuleFileFunction implements SkyFunction {
     if (env.valuesMissing()) {
       return null;
     }
-    List<Registry> registryObjects =
-        registryKeys.stream()
-            .map(registryResult::get)
-            .map(Registry.class::cast)
-            .collect(toImmutableList());
+    List<Registry> registryObjects = new ArrayList<>(registryKeys.size());
+    for (RegistryKey registryKey : registryKeys) {
+      Registry registry = (Registry) registryResult.get(registryKey);
+      if (registry == null) {
+        return null;
+      }
+      registryObjects.add(registry);
+    }
 
     // Now go through the list of registries and use the first one that contains the requested
     // module.


### PR DESCRIPTION
`SkyframeLookupResult#get` can return `null` even if `env.valuesMissing()` is `false`.