### PR TITLE
[7.2.0] Share Starlark env across module and repo files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -376,7 +376,7 @@ public class ModuleFileFunction implements SkyFunction {
           .check(starlarkFile);
       net.starlark.java.eval.Module predeclaredEnv =
           net.starlark.java.eval.Module.withPredeclared(
-              starlarkSemantics, starlarkEnv.getStarlarkGlobals().getModuleToplevels());
+              starlarkSemantics, starlarkEnv.getModuleBazelEnv());
       Program program = Program.compileFile(starlarkFile, predeclaredEnv);
       StarlarkThread thread = new StarlarkThread(mu, starlarkSemantics);
       context.storeInThread(thread);

--- a/src/main/java/com/google/devtools/build/lib/packages/BazelStarlarkEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BazelStarlarkEnvironment.java
@@ -94,6 +94,12 @@ public final class BazelStarlarkEnvironment {
   /** The top-level predeclared symbols for a bzl module in the {@code @_builtins} pseudo-repo. */
   private final ImmutableMap<String, Object> builtinsBzlEnv;
 
+  /** The top-level predeclared symbols for a MODULE.bazel file. */
+  private final ImmutableMap<String, Object> moduleBazelEnv;
+
+  /** The top-level predeclared symbols for a REPO.bazel file. */
+  private final ImmutableMap<String, Object> repoBazelEnv;
+
   /**
    * Constructs a new {@code BazelStarlarkEnvironment} that will have complete knowledge of the
    * proper Starlark symbols available in each context, with and without injection.
@@ -141,6 +147,8 @@ public final class BazelStarlarkEnvironment {
             uninjectedBuildBzlEnv);
     this.uninjectedBuildEnv =
         createUninjectedBuildEnv(starlarkGlobals, ruleFunctions, registeredBuildFileToplevels);
+    this.moduleBazelEnv = starlarkGlobals.getModuleToplevels();
+    this.repoBazelEnv = starlarkGlobals.getRepoToplevels();
   }
 
   /**
@@ -204,6 +212,16 @@ public final class BazelStarlarkEnvironment {
    */
   public ImmutableMap<String, Object> getBuiltinsBzlEnv() {
     return builtinsBzlEnv;
+  }
+
+  /** Returns the environment for MODULE.bazel files. */
+  public ImmutableMap<String, Object> getModuleBazelEnv() {
+    return moduleBazelEnv;
+  }
+
+  /** Returns the environment for REPO.bazel files. */
+  public ImmutableMap<String, Object> getRepoBazelEnv() {
+    return repoBazelEnv;
   }
 
   private static ImmutableMap<String, Object> createBzlToplevelsWithoutNative(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepoFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepoFileFunction.java
@@ -150,9 +150,7 @@ public class RepoFileFunction implements SkyFunction {
     try (Mutability mu = Mutability.create("repo file", repoName)) {
       new DotBazelFileSyntaxChecker("REPO.bazel files", /* canLoadBzl= */ false)
           .check(starlarkFile);
-      Module predeclared =
-          Module.withPredeclared(
-              starlarkSemantics, starlarkEnv.getStarlarkGlobals().getRepoToplevels());
+      Module predeclared = Module.withPredeclared(starlarkSemantics, starlarkEnv.getRepoBazelEnv());
       Program program = Program.compileFile(starlarkFile, predeclared);
       StarlarkThread thread = new StarlarkThread(mu, starlarkSemantics);
       thread.setPrintHandler(Event.makeDebugPrintHandler(handler));


### PR DESCRIPTION
This avoids recreating the (immutable) Starlark environment for each file via reflection.

Closes #21951.

PiperOrigin-RevId: 626077632
Change-Id: I55e205680abf37423091842a04324ded948abfad

Commit https://github.com/bazelbuild/bazel/commit/0b698fc520821e4d2f560aae70068c3fbc652854