### PR TITLE
[7.2.0] Set public visibility for R8 desugar binary

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/r8/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/BUILD.tools
@@ -46,7 +46,7 @@ java_binary(
         "-Dcom.android.tools.r8.createSingletonsForStatelessLambdas",
     ],
     main_class = "com.google.devtools.build.android.r8.Desugar",
-    visibility = ["//tools/android:__subpackages__"],
+    visibility = ["//visibility:public"],
     runtime_deps = [
         ":r8",
     ],


### PR DESCRIPTION
We are migrating Android functionality out of Bazel into rules_android. Currently rules_android depends on
@bazel_tools//tools/android:desugar_java8 for a sh_binary that calls the R8 desugar binary. Going forward, we'll maintain the sh_binary directly in rules_android, and therefore will require public visibility on [...]/r8:desugar. Eventually the source code for the Bazel R8 desugar wrapper will also move into rules_android.

Part of https://github.com/bazelbuild/rules_android/issues/122.

Closes #21775.

PiperOrigin-RevId: 618272641
Change-Id: I09d9ca19b742049c2d29a75336d1b0680b0005b1

Commit https://github.com/bazelbuild/bazel/commit/32fd6e9c2e7e4907c263ba8de2e55abd1484389b