### PR TITLE
[7.2.0] Fix potential NPE in ModuleFileFunction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -473,11 +473,14 @@ public class ModuleFileFunction implements SkyFunction {
     if (env.valuesMissing()) {
       return null;
     }
-    List<Registry> registryObjects =
-        registryKeys.stream()
-            .map(registryResult::get)
-            .map(Registry.class::cast)
-            .collect(toImmutableList());
+    List<Registry> registryObjects = new ArrayList<>(registryKeys.size());
+    for (RegistryKey registryKey : registryKeys) {
+      Registry registry = (Registry) registryResult.get(registryKey);
+      if (registry == null) {
+        return null;
+      }
+      registryObjects.add(registry);
+    }
 
     // Now go through the list of registries and use the first one that contains the requested
     // module.

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.errorprone.annotations.FormatMethod;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;


### PR DESCRIPTION
`SkyframeLookupResult#get` can return `null` even if `env.valuesMissing()` is `false`.

Closes #22152.

PiperOrigin-RevId: 629099024
Change-Id: I54e675ce7bdf012d966308fb60d99e9b04e2d75f

Commit https://github.com/bazelbuild/bazel/commit/dacfd9c01b9b0376c8009bed74656755daf16905