### PR TITLE
[7.2.0] Support `select` in deps of a `cc_binary` with `dynamic_deps`

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_shared_library.bzl
@@ -849,15 +849,20 @@ def cc_shared_library_initializer(**kwargs):
     """Initializes dynamic_deps_attrs"""
     if "dynamic_deps" in kwargs and cc_helper.is_non_empty_list_or_select(kwargs["dynamic_deps"], "dynamic_deps"):
         # Propagate an aspect if dynamic_deps attribute is specified.
+        # Use += for lists rather than extend or append to allow for the case where deps
+        # is a select.
         all_deps = []
         if "deps" in kwargs:
-            all_deps.extend(kwargs["deps"])
+            all_deps += kwargs["deps"]
 
         if "linkshared" not in kwargs or not kwargs["linkshared"]:
+            # The += [...] pattern below doesn't work if malloc or link_extra_lib are
+            # themselves selects, but as of March 2024, there is no way to combine mixed
+            # selects and these attributes usually point to label flags anyway.
             if "link_extra_lib" in kwargs:
-                all_deps.append(kwargs["link_extra_lib"])
+                all_deps += [kwargs["link_extra_lib"]]
             if "malloc" in kwargs:
-                all_deps.append(kwargs["malloc"])
+                all_deps += [kwargs["malloc"]]
 
         return kwargs | {"_deps_analyzed_by_graph_structure_aspect": all_deps}
     return kwargs

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/BUILD.builtin_test
@@ -1,0 +1,28 @@
+package(default_visibility = ["//src/main/starlark/tests/builtins_bzl/cc/cc_shared_library:__subpackages__"])
+
+licenses(["notice"])
+
+cc_library(
+    name = "bar",
+    srcs = ["bar.cc"],
+    hdrs = ["bar.h"],
+)
+
+cc_library(name = "extra_link1")
+
+cc_library(name = "extra_link2")
+
+cc_shared_library(
+    name = "bar_so",
+    features = ["windows_export_all_symbols"],
+    deps = select({"//conditions:default": [":bar"]}),
+)
+
+cc_test(
+    name = "cc_test",
+    srcs = ["main.cc"],
+    dynamic_deps = select({"//conditions:default": ["bar_so"]}),
+    link_extra_lib = ":extra_link1",
+    malloc = ":extra_link2",
+    deps = select({"//conditions:default": ["bar"]}),
+)

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/bar.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/bar.cc
@@ -1,0 +1,16 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/bar.h"
+
+int bar() { return 42; }

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/bar.h
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/bar.h
@@ -1,0 +1,19 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef EXAMPLES_TEST_CC_SHARED_LIBRARY4_BAR_H_
+#define EXAMPLES_TEST_CC_SHARED_LIBRARY4_BAR_H_
+
+int bar();
+
+#endif  // EXAMPLES_TEST_CC_SHARED_LIBRARY4_BAR_H_

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/main.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/main.cc
@@ -1,0 +1,21 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <iostream>
+
+#include "src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library4/bar.h"
+
+int main() {
+  std::cout << "hello " << bar() << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Previously, this failed with
```
Error in extend: type 'select' is not iterable
```

Fixes #21875

Closes #21878.

PiperOrigin-RevId: 629183138
Change-Id: I98603ab94261b4f8299e1cc89fc3eaa635661964

Commit https://github.com/bazelbuild/bazel/commit/cd1ef04a064be024280e58275e8b46d22aaf48ab