### PR TITLE
[7.2.0] Do not watch `.netrc` in `read_netrc`

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2691,7 +2691,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_android_deps": {
       "general": {
-        "bzlTransitiveDigest": "7u0Bee/XL6UGuGmaseF4697gGH298WTn84dJcuZiDwk=",
+        "bzlTransitiveDigest": "6vqJ6yadlUU86rSzRzNsiG2x5RGOCIg0gyw3j7iFVK4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2837,10 +2837,10 @@
     },
     "//:extensions.bzl%bazel_build_deps": {
       "general": {
-        "bzlTransitiveDigest": "7u0Bee/XL6UGuGmaseF4697gGH298WTn84dJcuZiDwk=",
+        "bzlTransitiveDigest": "6vqJ6yadlUU86rSzRzNsiG2x5RGOCIg0gyw3j7iFVK4=",
         "recordedFileInputs": {
           "@@//MODULE.bazel": "e556c2e066b73d9d977dd87b497fb917a742c1851c28a1d133060777ef7eea8c",
-          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "6b96a6a50f84f5403a718a27955a8c954943f76ee5c4def7f8b23401b2a417bf"
+          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "669abfca7192ee43cf0d2dd7bc26662f89a6eafdc8e1affa8deddd203abd0276"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3212,7 +3212,7 @@
     },
     "//:extensions.bzl%bazel_test_deps": {
       "general": {
-        "bzlTransitiveDigest": "7u0Bee/XL6UGuGmaseF4697gGH298WTn84dJcuZiDwk=",
+        "bzlTransitiveDigest": "6vqJ6yadlUU86rSzRzNsiG2x5RGOCIg0gyw3j7iFVK4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3392,7 +3392,7 @@
     },
     "//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "m0J7XXUL8i0mXixiKvM5Obok4oULDoY2uIlX/+P/bus=",
+        "bzlTransitiveDigest": "7AujGJs5Ol86xb0COHH2NGNawngyUwI8KmJ0yVuSZ+E=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3419,7 +3419,7 @@
     },
     "//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "G6+XhFekebQq8VaobjYeTD9Ge+MVKWqdFRuqyDATPNc=",
+        "bzlTransitiveDigest": "93Butk3OEer7nGZxtwV/qwe+zpX6eMh1OIi+8Lq+6nY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -1977,6 +1977,7 @@ EOF
   cat > def.bzl <<'EOF'
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
 def _impl(ctx):
+  print("authrepo is being evaluated")
   rc = read_netrc(ctx, ctx.attr.path)
   auth = use_netrc(rc, ctx.attr.urls, {"oauthlife.com": "Bearer <password>",})
   ctx.file("data.bzl", "auth = %s" % (auth,))
@@ -2058,9 +2059,16 @@ genrule(
   cmd = "echo %s > $@" % (check_equal_expected(),)
 )
 EOF
-  bazel build //:check_expected
+  bazel build //:check_expected &> $TEST_log || fail "Expected success"
   grep 'OK' `bazel info bazel-bin`/check_expected.txt \
        || fail "Authentication merged incorrectly"
+  expect_log "authrepo is being evaluated"
+
+  echo "modified" > .netrc
+  bazel build //:check_expected &> $TEST_log || fail "Expected success"
+  grep 'OK' `bazel info bazel-bin`/check_expected.txt \
+       || fail "Authentication information should not have been reevaluated"
+  expect_not_log "authrepo is being evaluated"
 }
 
 function test_disallow_unverified_http() {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1070,7 +1070,7 @@
     },
     "@@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "m0J7XXUL8i0mXixiKvM5Obok4oULDoY2uIlX/+P/bus=",
+        "bzlTransitiveDigest": "7AujGJs5Ol86xb0COHH2NGNawngyUwI8KmJ0yVuSZ+E=",
         "usagesDigest": "LPw+9iUcnRY1k89ZEMEZ/AtOYIK2LgSeKnaiYVCDaag=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1163,7 +1163,7 @@
     },
     "@@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "G6+XhFekebQq8VaobjYeTD9Ge+MVKWqdFRuqyDATPNc=",
+        "bzlTransitiveDigest": "93Butk3OEer7nGZxtwV/qwe+zpX6eMh1OIi+8Lq+6nY=",
         "usagesDigest": "O3U7dkKl24l4dKwsK8Y1uf1SAa/eEwLfw4BRsHGugwc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1211,7 +1211,7 @@
     },
     "@@rules_java~//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "NhI29H1jamjF2K82KYVnBzJWyL5lKvKAX5FsaMeEJxU=",
+        "bzlTransitiveDigest": "g6ePEnDe+cica1jeM4cr5pdiFxzK27/ZwwgBz0qcotU=",
         "usagesDigest": "1/Dwy6r0Nf/YUE94OFi5Yy0Mo+TrPxA3U8hBaEzYH5s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1777,7 +1777,7 @@
     },
     "@@rules_jvm_external~//:extensions.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "rr7+Uisql7Lce6FmGikFtyNcR1UJ5QJwDr5P2pggWK8=",
+        "bzlTransitiveDigest": "s/CmQ+qQgXPq+FR5/0BRBmZ1xJgvIA9uQa2rGcsiSUA=",
         "usagesDigest": "L+U25+BzBiliO0i3XrvqC5up0f210dPakCjqg5MBrp4=",
         "recordedFileInputs": {
           "@@rules_jvm_external~//rules_jvm_external_deps_install.json": "10442a5ae27d9ff4c2003e5ab71643bf0d8b48dcf968b4173fa274c3232a8c06"
@@ -2801,7 +2801,7 @@
     },
     "@@rules_jvm_external~//:non-module-deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "KNKaZAVA53/BYR0R8DDwRcJ+fpzxexQD1n5Xj2t4xuo=",
+        "bzlTransitiveDigest": "lN2hsTr54Jl4C0fITlL6g7MlqCCtezLQgeENrmdNBtg=",
         "usagesDigest": "HWGzpnxaDzDwBkFxYvT/plvwcfNrPZGTg9ZYibwxNGw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -2829,7 +2829,7 @@
     },
     "@@rules_python~//python/extensions:python.bzl%python": {
       "general": {
-        "bzlTransitiveDigest": "8Cw2liOVPd8duf0hkkvkacm7hxYJswR4qH9ib6K2Q7w=",
+        "bzlTransitiveDigest": "V8RFcR2uLgEQnCHK7DYDVnthwCmRsY0zbyChXOGKGGE=",
         "usagesDigest": "2dLy/xmv7+TD8WRYYIxtxZMeS4nrJZGIDSMkYRE0elw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -2859,7 +2859,7 @@
     },
     "@@rules_python~//python/extensions/private:internal_deps.bzl%internal_deps": {
       "general": {
-        "bzlTransitiveDigest": "4RAcoHmmMtOeH2wANmmp+Kdo85owGdZWOmnqR0fABRM=",
+        "bzlTransitiveDigest": "WppdGtl0faMPVX6wx7nN1JlV+cw9XwxYaGfXa5nWObM=",
         "usagesDigest": "MZDuELgGnEk5m0vRt+s02bhPv0B21Oi1jm1KuRqZ5FY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -251,7 +251,10 @@ def read_netrc(ctx, filename):
       dict mapping a machine names to a dict with the information provided
       about them
     """
-    contents = ctx.read(filename)
+
+    # Do not cause the repo rule to rerun due to changes to auth info when it is
+    # successful. Failures are not cached.
+    contents = ctx.read(filename, watch = "no")
     return parse_netrc(contents, filename)
 
 def parse_netrc(contents, filename = None):


### PR DESCRIPTION
Modifying auth information should not result in a repo rule being reevaluated after a successful evaluation. This regressed in a5376aa3e11ea2ecfbd52068794ed3e652d9c179.

Fixes #22118

Closes #22125.

PiperOrigin-RevId: 629182408
Change-Id: I0c553e9ded72230b647a37203d51ba779976d7fc

Commit https://github.com/bazelbuild/bazel/commit/3fc76bea04a1859d4f61f079aca28c052df22550