### PR TITLE
[7.1.2] Do not watch `.netrc` in `read_netrc`

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2286,7 +2286,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_android_deps": {
       "general": {
-        "bzlTransitiveDigest": "KBarN1/r/5veMYz+cUHOlEzjGUdmUkxNYymHZwCJULg=",
+        "bzlTransitiveDigest": "JZ51S3AABXH6rwSbL1o7a3YPujrEGmG7/C0iE3Cq+mA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2422,10 +2422,10 @@
     },
     "//:extensions.bzl%bazel_build_deps": {
       "general": {
-        "bzlTransitiveDigest": "KBarN1/r/5veMYz+cUHOlEzjGUdmUkxNYymHZwCJULg=",
+        "bzlTransitiveDigest": "JZ51S3AABXH6rwSbL1o7a3YPujrEGmG7/C0iE3Cq+mA=",
         "recordedFileInputs": {
           "@@//MODULE.bazel": "c07897f4cf2ea76f689df2779f50aed06ea638d666542078234ebb0efd3ea5a5",
-          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "0cae3b3c6186baa47cd8a48fe55530f613f22016845926e7825dce52dd496540"
+          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "411f9834de64236b4ec52ac0f0c3a31f4896736d03de5d0f2930699f18aec50b"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2784,7 +2784,7 @@
     },
     "//:extensions.bzl%bazel_test_deps": {
       "general": {
-        "bzlTransitiveDigest": "KBarN1/r/5veMYz+cUHOlEzjGUdmUkxNYymHZwCJULg=",
+        "bzlTransitiveDigest": "JZ51S3AABXH6rwSbL1o7a3YPujrEGmG7/C0iE3Cq+mA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2954,7 +2954,7 @@
     },
     "//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "S0n86BFe4SJ3lRaZiRA5D46oH52UO2hP1T50t/zldOw=",
+        "bzlTransitiveDigest": "ZggrqnDIPRFCqT9XaCYOxLiJx1XuMtOZNG1jvKYZ5lA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2981,7 +2981,7 @@
     },
     "//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "l5mcjH2gWmbmIycx97bzI2stD0Q0M5gpDc0aLOHKIm8=",
+        "bzlTransitiveDigest": "7n9r2sWPYvn/OzUdHUoiJN/1hgIqWKOFCEQFVwHZGU0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -1977,6 +1977,7 @@ EOF
   cat > def.bzl <<'EOF'
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
 def _impl(ctx):
+  print("authrepo is being evaluated")
   rc = read_netrc(ctx, ctx.attr.path)
   auth = use_netrc(rc, ctx.attr.urls, {"oauthlife.com": "Bearer <password>",})
   ctx.file("data.bzl", "auth = %s" % (auth,))
@@ -2058,9 +2059,16 @@ genrule(
   cmd = "echo %s > $@" % (check_equal_expected(),)
 )
 EOF
-  bazel build //:check_expected
+  bazel build //:check_expected &> $TEST_log || fail "Expected success"
   grep 'OK' `bazel info bazel-bin`/check_expected.txt \
        || fail "Authentication merged incorrectly"
+  expect_log "authrepo is being evaluated"
+
+  echo "modified" > .netrc
+  bazel build //:check_expected &> $TEST_log || fail "Expected success"
+  grep 'OK' `bazel info bazel-bin`/check_expected.txt \
+       || fail "Authentication information should not have been reevaluated"
+  expect_not_log "authrepo is being evaluated"
 }
 
 function test_disallow_unverified_http() {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1063,7 +1063,7 @@
     },
     "@@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
       "general": {
-        "bzlTransitiveDigest": "S0n86BFe4SJ3lRaZiRA5D46oH52UO2hP1T50t/zldOw=",
+        "bzlTransitiveDigest": "ZggrqnDIPRFCqT9XaCYOxLiJx1XuMtOZNG1jvKYZ5lA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1152,7 +1152,7 @@
     },
     "@@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
       "general": {
-        "bzlTransitiveDigest": "l5mcjH2gWmbmIycx97bzI2stD0Q0M5gpDc0aLOHKIm8=",
+        "bzlTransitiveDigest": "7n9r2sWPYvn/OzUdHUoiJN/1hgIqWKOFCEQFVwHZGU0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1198,7 +1198,7 @@
     },
     "@@rules_java~//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "tJHbmWnq7m+9eUBnUdv7jZziQ26FmcGL9C5/hU3Q9UQ=",
+        "bzlTransitiveDigest": "0N5b5J9fUzo0sgvH4F3kIEaeXunz4Wy2/UtSFV/eXUY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1703,7 +1703,7 @@
     },
     "@@rules_jvm_external~//:extensions.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "v8HssW6WP6B8s0BwuAMJuQCz6cQ9jlhOfx4dKBtPYB4=",
+        "bzlTransitiveDigest": "9ol/f6R1HONuabXvQTFIEvT1pWikli+mTIbvGRmDubk=",
         "recordedFileInputs": {
           "@@rules_jvm_external~//rules_jvm_external_deps_install.json": "10442a5ae27d9ff4c2003e5ab71643bf0d8b48dcf968b4173fa274c3232a8c06"
         },
@@ -2726,7 +2726,7 @@
     },
     "@@rules_jvm_external~//:non-module-deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "DqBh3ObkOvjDFKv8VTy6J2qr7hXsJm9/sES7bha7ftA=",
+        "bzlTransitiveDigest": "Fq6CvJMzD0/LbttG5TUaCtEm/pFvTgO5X9tCUH87Fb0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2753,7 +2753,7 @@
     },
     "@@rules_python~//python/extensions:python.bzl%python": {
       "general": {
-        "bzlTransitiveDigest": "31xtOi5rmBJ3jSHeziLzV7KKKgCc6tMnRUZ1BQLBeao=",
+        "bzlTransitiveDigest": "2Az37kOCPyZmcfbxYv3bex98d5KhE/dEXOXLzid2XhA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2782,7 +2782,7 @@
     },
     "@@rules_python~//python/extensions/private:internal_deps.bzl%internal_deps": {
       "general": {
-        "bzlTransitiveDigest": "fUb5iKCtPgjhclraX+//BnJ+LOcG6I6+O9UUxT+gZ50=",
+        "bzlTransitiveDigest": "6qzMi1W/Ln/TUQ7+HG3HnNFz+oFeaWSDOnjCcoByfhI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -251,7 +251,10 @@ def read_netrc(ctx, filename):
       dict mapping a machine names to a dict with the information provided
       about them
     """
-    contents = ctx.read(filename)
+
+    # Do not cause the repo rule to rerun due to changes to auth info when it is
+    # successful. Failures are not cached.
+    contents = ctx.read(filename, watch = "no")
     return parse_netrc(contents, filename)
 
 def parse_netrc(contents, filename = None):


### PR DESCRIPTION
Modifying auth information should not result in a repo rule being reevaluated after a successful evaluation. This regressed in a5376aa3e11ea2ecfbd52068794ed3e652d9c179.

Fixes #22118

Closes #22125.

PiperOrigin-RevId: 629182408
Change-Id: I0c553e9ded72230b647a37203d51ba779976d7fc

Commit https://github.com/bazelbuild/bazel/commit/3fc76bea04a1859d4f61f079aca28c052df22550