### PR TITLE
Follow unconfigured `alias`es during options parsing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -55,10 +55,6 @@ import javax.annotation.Nullable;
  */
 public class StarlarkOptionsParser {
 
-  // Use the plain strings rather than reaching into the Alias class and adding a dependency edge.
-  private static final String ALIAS_RULE_NAME = "alias";
-  private static final String ALIAS_ACTUAL_ATTRIBUTE_NAME = "actual";
-
   private final OptionsParser nativeOptionsParser;
 
   /**
@@ -332,13 +328,15 @@ public class StarlarkOptionsParser {
         break;
       }
       // Follow the unconfigured values of aliases.
-      if (target.getAssociatedRule().getRuleClass().equals(ALIAS_RULE_NAME)) {
-        targetToLoadNext = switch (target.getAssociatedRule().getAttr(ALIAS_ACTUAL_ATTRIBUTE_NAME)) {
+      if (target.getAssociatedRule().getRuleClass().equals("alias")) {
+        targetToLoadNext = switch (target.getAssociatedRule().getAttr("actual")) {
           case Label label -> label.getUnambiguousCanonicalForm();
           case BuildType.SelectorList<?> ignored -> throw new OptionsParsingException(
                   String.format(
                           "Failed to load build setting '%s' as it resolves to an alias with an actual"
-                                  + " value that uses select(), which is not supported: %s",
+                                  + " value that uses select(): %s. This is not supported as build"
+                                  + " settings are needed to determine the configuration the select"
+                                  + " is evaluated in.",
                           targetToBuild,
                           formatAliasChain(aliasChain.stream())),
                   targetToBuild);

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
@@ -567,4 +567,144 @@ public class StarlarkOptionsParsingTest extends StarlarkOptionsTestCase {
         .hasMessageThat()
         .contains("//test:all: user-defined flags must reference exactly one target");
   }
+
+  @Test
+  public void flagIsAlias() throws Exception {
+    scratch.file(
+        "test/build_setting.bzl",
+        """
+            string_flag = rule(
+                implementation = lambda ctx: [],
+                build_setting = config.string(flag = True),
+            )
+            """);
+    scratch.file(
+        "test/BUILD",
+        """
+            load("//test:build_setting.bzl", "string_flag")
+
+            alias(
+                name = "one",
+                actual = "//test/pkg:two",
+            )
+
+            string_flag(
+                name = "three",
+                build_setting_default = "",
+            )
+            """);
+    scratch.file(
+        "test/pkg/BUILD",
+        """
+            alias(
+                name = "two",
+                actual = "//test:three",
+            )
+            """);
+
+    OptionsParsingResult result = parseStarlarkOptions("--//test:one=one --//test/pkg:two=two");
+
+    assertThat(result.getStarlarkOptions()).containsExactly("//test:three", "two");
+  }
+
+  @Test
+  public void flagIsAlias_cycle() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+                alias(
+                    name = "one",
+                    actual = "//test/pkg:two",
+                )
+
+                alias(
+                    name = "three",
+                    actual = ":one",
+                )
+                """);
+    scratch.file(
+        "test/pkg/BUILD",
+        """
+                alias(
+                    name = "two",
+                    actual = "//test:three",
+                )
+                """);
+
+    OptionsParsingException e =
+        assertThrows(OptionsParsingException.class, () -> parseStarlarkOptions("--//test:one=one"));
+
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Failed to load build setting '//test:one' due to a cycle in alias chain: //test:one"
+                + " -> //test/pkg:two -> //test:three -> //test:one");
+  }
+
+  @Test
+  public void flagIsAlias_usesSelect() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+                    alias(
+                        name = "one",
+                        actual = "//test/pkg:two",
+                    )
+
+                    alias(
+                        name = "three",
+                        actual = ":one",
+                    )
+                    """);
+    scratch.file(
+        "test/pkg/BUILD",
+        """
+                    alias(
+                        name = "two",
+                        actual = select({"//conditions:default": "//test:three"}),
+                    )
+                    """);
+
+    OptionsParsingException e =
+        assertThrows(OptionsParsingException.class, () -> parseStarlarkOptions("--//test:one=one"));
+
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Failed to load build setting '//test:one' as it resolves to an alias with an actual"
+                + " value that uses select(), which is not supported: //test:one -> //test/pkg:two");
+  }
+
+  @Test
+  public void flagIsAlias_resolvesToNonBuildSettingTarget() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+                        alias(
+                            name = "one",
+                            actual = "//test/pkg:two",
+                        )
+
+                        genrule(
+                            name = "three",
+                            outs = ["out"],
+                            cmd = "echo hello > $@",
+                        )
+                        """);
+    scratch.file(
+        "test/pkg/BUILD",
+        """
+                        alias(
+                            name = "two",
+                            actual = "//test:three",
+                        )
+                        """);
+
+    OptionsParsingException e =
+        assertThrows(OptionsParsingException.class, () -> parseStarlarkOptions("--//test:one=one"));
+
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("Unrecognized option: //test:one -> //test/pkg:two -> //test:three");
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
@@ -672,7 +672,9 @@ public class StarlarkOptionsParsingTest extends StarlarkOptionsTestCase {
         .hasMessageThat()
         .isEqualTo(
             "Failed to load build setting '//test:one' as it resolves to an alias with an actual"
-                + " value that uses select(), which is not supported: //test:one -> //test/pkg:two");
+                + " value that uses select(): //test:one -> //test/pkg:two. This is not supported"
+                + " as build settings are needed to determine the configuration the select is"
+                + " evaluated in.");
   }
 
   @Test


### PR DESCRIPTION
Fixes #20582 

RELNOTES: Starlark command-line flags can now be referred to through `alias` targets.