### PR TITLE
Provide "did you mean ...?" suggestions for unknown command-line options

### DIFF
--- a/src/main/java/com/google/devtools/common/options/BUILD
+++ b/src/main/java/com/google/devtools/common/options/BUILD
@@ -51,6 +51,7 @@ java_11_library(
     ),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/util:pair",
+        "//src/main/java/net/starlark/java/spelling",
         "//third_party:auto_value",
         "//third_party:caffeine",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/common/options/IsolatedOptionsData.java
+++ b/src/main/java/com/google/devtools/common/options/IsolatedOptionsData.java
@@ -16,6 +16,7 @@ package com.google.devtools.common.options;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.common.options.OptionsParser.ConstructionException;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -160,7 +161,7 @@ public class IsolatedOptionsData extends OpaqueOptionsData {
    * appear ordered first by their options class (the order in which they were passed to {@link
    * #from(Collection, boolean)}, and then in alphabetic order within each options class.
    */
-  public Collection<Map.Entry<String, OptionDefinition>> getAllOptionDefinitions() {
+  public ImmutableSet<Map.Entry<String, OptionDefinition>> getAllOptionDefinitions() {
     return nameToField.entrySet();
   }
 

--- a/src/main/java/com/google/devtools/common/options/IsolatedOptionsData.java
+++ b/src/main/java/com/google/devtools/common/options/IsolatedOptionsData.java
@@ -160,7 +160,7 @@ public class IsolatedOptionsData extends OpaqueOptionsData {
    * appear ordered first by their options class (the order in which they were passed to {@link
    * #from(Collection, boolean)}, and then in alphabetic order within each options class.
    */
-  public Iterable<Map.Entry<String, OptionDefinition>> getAllOptionDefinitions() {
+  public Collection<Map.Entry<String, OptionDefinition>> getAllOptionDefinitions() {
     return nameToField.entrySet();
   }
 

--- a/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
@@ -798,7 +798,7 @@ class OptionsParserImpl {
       String suggestion;
       // Do not offer suggestions for short-form options.
       if (arg.startsWith("--")) {
-        suggestion = SpellChecker.didYouMean(arg, collectSuggestedOptions(arg));
+        suggestion = SpellChecker.didYouMean(arg, getAllValidArgs());
       } else {
         suggestion = "";
       }
@@ -844,9 +844,7 @@ class OptionsParserImpl {
         Optional.empty());
   }
 
-  // Suggests options that are similar to the given one.
-  private Iterable<String> collectSuggestedOptions(String arg) {
-    boolean includeNoPrefix = arg.startsWith("--no");
+  private Iterable<String> getAllValidArgs() {
     return () ->
         optionsData.getAllOptionDefinitions().stream()
             .filter(entry -> !shouldIgnoreOption(entry.getValue()))
@@ -854,7 +852,7 @@ class OptionsParserImpl {
                 definition -> {
                   Stream.Builder<String> builder = Stream.builder();
                   builder.add("--" + definition.getKey());
-                  if (includeNoPrefix && definition.getValue().usesBooleanValueSyntax()) {
+                  if (definition.getValue().usesBooleanValueSyntax()) {
                     builder.add("--no" + definition.getKey());
                   }
                   return builder.build();

--- a/src/test/java/com/google/devtools/common/options/OptionsTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsTest.java
@@ -435,7 +435,7 @@ public class OptionsTest {
   }
 
   @Test
-  public void unknownBooleanOption() {
+  public void unknownBooleanOptionNegativeForm() {
     OptionsParsingException e =
         assertThrows(
             OptionsParsingException.class,
@@ -443,6 +443,28 @@ public class OptionsTest {
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Unrecognized option: --no-debug (did you mean '--nodebug'?)");
+  }
+
+  @Test
+  public void unknownOption() {
+    OptionsParsingException e =
+        assertThrows(
+            OptionsParsingException.class,
+            () -> Options.parse(HttpOptions.class, new String[] {"--pert"}));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("Unrecognized option: --pert (did you mean '--port'?)");
+  }
+
+  @Test
+  public void unknownBooleanOptionPositiveForm() {
+    OptionsParsingException e =
+        assertThrows(
+            OptionsParsingException.class,
+            () -> Options.parse(HttpOptions.class, new String[] {"--dbg"}));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("Unrecognized option: --dbg (did you mean '--debug'?)");
   }
 
   public static class J extends OptionsBase {

--- a/src/test/java/com/google/devtools/common/options/OptionsTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsTest.java
@@ -440,7 +440,9 @@ public class OptionsTest {
         assertThrows(
             OptionsParsingException.class,
             () -> Options.parse(HttpOptions.class, new String[] {"--no-debug"}));
-    assertThat(e).hasMessageThat().isEqualTo("Unrecognized option: --no-debug");
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("Unrecognized option: --no-debug (did you mean '--nodebug'?)");
   }
 
   public static class J extends OptionsBase {


### PR DESCRIPTION
Examples:

```
$ bazel build //src:bazel-dev --experimental_remote_cache_evection_retries=5
ERROR: --experimental_remote_cache_evection_retries=5 :: Unrecognized option: --experimental_remote_cache_evection_retries=5 (did you mean '--experimental_remote_cache_eviction_retries'?)
$ bazel build //src:bazel-dev --notest_kep_going
ERROR: --notest_kep_going :: Unrecognized option: --notest_kep_going (did you mean '--notest_keep_going'?)