### PR TITLE
[7.2.0] Add a convenience method to Connection to prepare and execute a Statement only once.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/disk/Sqlite.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/Sqlite.java
@@ -100,6 +100,22 @@ public final class Sqlite {
       openStatements.add(stmt);
       return stmt;
     }
+
+    /**
+     * Executes a statement not expected to return a result.
+     *
+     * <p>For statements expected to return a result, or statements that will be executed multiple
+     * times, use {@link #newStatement}.
+     *
+     * @throws IOException if the string contains multiple SQL statements; or the single SQL
+     *     statement could not be parsed and validated; or the statement returned a non-empty
+     *     result; or an execution error occurred
+     */
+    public void executeUpdate(String sql) throws IOException {
+      try (Statement stmt = new Statement(this, sql)) {
+        stmt.executeUpdate();
+      }
+    }
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/SqliteTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/SqliteTest.java
@@ -144,6 +144,18 @@ public final class SqliteTest {
   }
 
   @Test
+  public void executeUpdate_oneShot_works() throws Exception {
+    try (Connection conn = Sqlite.newConnection(dbPath)) {
+      conn.executeUpdate("CREATE TABLE tbl (id INTEGER)");
+
+      try (Statement stmt = conn.newStatement("SELECT COUNT(*) FROM tbl");
+          Result result = stmt.executeQuery()) {
+        assertThat(result.next()).isTrue();
+      }
+    }
+  }
+
+  @Test
   public void executeUpdate_withParameters_works() throws Exception {
     try (Connection conn = Sqlite.newConnection(dbPath)) {
       try (Statement stmt = conn.newStatement("CREATE TABLE tbl AS SELECT ?, ?, ?")) {


### PR DESCRIPTION
This is useful when initially setting up a database, as the statements won't be used again.

PiperOrigin-RevId: 628480119
Change-Id: I87d746bc754663147fbb36e27a2afdb586c57cc0