### PR TITLE
Rewrite Starlark repostory workers using an RPC paradigm...

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -22,7 +22,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
@@ -63,6 +62,7 @@ import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCom
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.RepositoryOverride;
+import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.WorkerForRepoFetching;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
 import com.google.devtools.build.lib.bazel.repository.downloader.DelegatingDownloader;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
@@ -120,9 +120,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -162,9 +159,6 @@ public class BazelRepositoryModule extends BlazeModule {
   private List<String> allowedYankedVersions = ImmutableList.of();
   private boolean disableNativeRepoRules;
   private SingleExtensionEvalFunction singleExtensionEvalFunction;
-  private final ExecutorService repoFetchingWorkerThreadPool =
-      Executors.newFixedThreadPool(
-          100, new ThreadFactoryBuilder().setNameFormat("repo-fetching-worker-%d").build());
 
   @Nullable private CredentialModule credentialModule;
 
@@ -314,37 +308,8 @@ public class BazelRepositoryModule extends BlazeModule {
 
     RepositoryOptions repoOptions = env.getOptions().getOptions(RepositoryOptions.class);
     if (repoOptions != null) {
-      switch (repoOptions.workerForRepoFetching) {
-        case OFF:
-          starlarkRepositoryFunction.setWorkerExecutorService(null);
-          break;
-        case PLATFORM:
-          starlarkRepositoryFunction.setWorkerExecutorService(repoFetchingWorkerThreadPool);
-          break;
-        case VIRTUAL:
-        case AUTO:
-          try {
-            // Since Google hasn't migrated to JDK 21 yet, we can't directly call
-            // Executors.newVirtualThreadPerTaskExecutor here. But a bit of reflection never hurt
-            // anyone... right? (OSS Bazel already ships with a bundled JDK 21)
-            starlarkRepositoryFunction.setWorkerExecutorService(
-                (ExecutorService)
-                    Executors.class
-                        .getDeclaredMethod("newThreadPerTaskExecutor", ThreadFactory.class)
-                        .invoke(
-                            null, Thread.ofVirtual().name("starlark-repository-", 0).factory()));
-          } catch (ReflectiveOperationException e) {
-            if (repoOptions.workerForRepoFetching == RepositoryOptions.WorkerForRepoFetching.AUTO) {
-              starlarkRepositoryFunction.setWorkerExecutorService(null);
-            } else {
-              throw new AbruptExitException(
-                  detailedExitCode(
-                      "couldn't create virtual worker thread executor for repo fetching",
-                      Code.BAD_DOWNLOADER_CONFIG),
-                  e);
-            }
-          }
-      }
+      starlarkRepositoryFunction.setUseWorkers(
+          repoOptions.workerForRepoFetching != WorkerForRepoFetching.OFF);
       downloadManager.setDisableDownload(repoOptions.disableDownload);
       if (repoOptions.repositoryDownloaderRetries >= 0) {
         downloadManager.setRetries(repoOptions.repositoryDownloaderRetries);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -246,10 +246,8 @@ public class RepositoryOptions extends OptionsBase {
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "The threading mode to use for repo fetching. If set to 'off', no worker thread is used,"
-              + " and the repo fetching is subject to restarts. Otherwise, uses a platform thread"
-              + " (i.e. OS thread) if set to 'platform' or a virtual thread if set to 'virtual'. If"
-              + " set to 'auto', virtual threads are used if available (i.e. running on JDK 21+),"
-              + " otherwise no worker thread is used.")
+              + " and the repo fetching is subject to restarts. Otherwise, uses a virtual worker"
+              + " thread.")
   public WorkerForRepoFetching workerForRepoFetching;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoFetchingSkyKeyComputeState.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoFetchingSkyKeyComputeState.java
@@ -14,8 +14,10 @@
 
 package com.google.devtools.build.lib.bazel.repository.starlark;
 
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.google.devtools.build.lib.bazel.repository.starlark.RepoFetchingSkyKeyComputeState.HostState.EnvironmentSent;
+import com.google.devtools.build.lib.bazel.repository.starlark.RepoFetchingSkyKeyComputeState.WorkerState.EnvironmentReceived;
+import com.google.devtools.build.lib.bazel.repository.starlark.RepoFetchingSkyKeyComputeState.HostState.TerminationRequested;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.skyframe.SkyFunction;
@@ -24,7 +26,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.Future;
-import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 /**
  * Captures state that persists across different invocations of {@link
@@ -37,33 +40,88 @@ import javax.annotation.Nullable;
  * restart to get a fresh environment object.
  */
 class RepoFetchingSkyKeyComputeState implements SkyKeyComputeState {
-
-  /** A signal that the worker thread can send to the host Skyframe thread. */
-  sealed interface Signal {
+  /** The state the worker thread is stopped in. */
+  sealed interface WorkerState {
     /**
-     * Indicates that the host thread should return {@code null}, causing a Skyframe restart. After
-     * sending this signal, the client will immediately block on {@code delegateEnvQueue}, waiting
-     * for the host thread to send a fresh {@link SkyFunction.Environment} over.
+     * Indicates that the worker thread added a Skyframe dependency that's not evaluated yet.
+     *
+     * <p>The host thread should return {@code null}, causing a Skyframe restart, then send a new
+     * environment to the worker to unblock it.
      */
-    record Restart() implements Signal {}
+    record EnvironmentRequested() implements WorkerState {}
 
-    /** Indicates that the worker thread has finished running successfully. */
-    record Success(RepositoryDirectoryValue.Builder result) implements Signal {}
+    /** Indicates that the worker received an environment it requested.
+     *
+     * <P>The next state it will be in is {@code EnvironmentRequested}, {@code Success} or
+     * {@code Failure}.
+     */
+    record EnvironmentReceived() implements WorkerState {}
 
-    /** Indicates that the worker thread has finished running with a failure. */
-    record Failure(Throwable e) implements Signal {}
+    /** Indicates that the worker thread has finished running with a failure.
+     *
+     * <p>It will terminate after successfully sending this signal.
+     */
+    record Failure(Throwable e) implements WorkerState {}
+
+    /** Indicates that the worker thread has finished fetching the repository successfully.
+     *
+     * <p>It is now waiting for the host thread to decide whether it should terminate or fetch the
+     * repository again (happens due to a nuance in environment handling, see {@code
+     * StarlarkRepositoryFunction.fetch()}.
+     */
+    record Success(RepositoryDirectoryValue.Builder result) implements WorkerState {}
+
+    /** The worker thread has finished fetching the repository successfully.
+     *
+     * <p>It is now waiting for the host thread to decide whether it should terminate or fetch the
+     * repository again (happens due to a nuance in environment handling, see {@code
+     * StarlarkRepositoryFunction.fetch()}. It should respond with {@code FullRestartRequested}
+     * or {@code TerminationRequested} as appropriate.
+     */
+    record WaitingForRestartDecision() implements WorkerState {}
   }
 
+  /** The state the host thread is stopped in. */
+  sealed interface HostState {
+
+    /** A new environment the worker thread requested.
+     *
+     * <p>The worker thread needs to reply with {@code EnvironmentReceived}.
+     */
+    record EnvironmentSent(SkyFunction.Environment environment) implements HostState {}
+
+    /** The host thread has sent an environment to the worker thread.
+     *
+     * <p>It is now waiting for the worker to decide whether it needs a new environment or it can
+     * do its job without one. The worker should respond with {@code EnvironmentSent},
+     * {@code Success} or {@code Failure} as a appropriate.
+     */
+    record WaitingForWorker() implements HostState {}
+
+    /** Indicates that the worker thread needs to be restarted, despite finishing with success.
+     *
+     * <p>After this, the host thread will send a new environment (with {@code EnvironmentSent}).
+     */
+    record FullRestartRequested() implements HostState {}
+
+    /** Indicates that the worker thread should terminate after finishing with success.
+     *
+     * <p>After this, the host thread will join the worker one.
+     */
+    record TerminationRequested() implements HostState {}
+  }
+
+  /** The name of the repository this state is for. Only there to ease debugging. */
+  private final String repositoryName;
+
   /** Used to ensure that the worker and Skyframe threads both are at a known place. */
-  private final Exchanger rendezvous = new Exchanger();
+  private final Exchanger<Object> rendezvous = new Exchanger();
 
   /** The working thread that actually performs the fetching logic. */
-  // This is volatile since we set it to null to indicate the worker thread isn't running, and this
-  // could happen on multiple threads. Interrupting and joining a thread multiple times is safe,
-  // though, so we only need to worry about nullness. Using a mutex/synchronization is an
-  // alternative but it means we might block in `close()`, which is potentially bad (see its
-  // javadoc).
-  @Nullable volatile Thread workerThread = null;
+  private final Thread workerThread;
+
+  /** Set to indicate that close() has been called at least once. */
+  private final AtomicBoolean closeInProgress = new AtomicBoolean(false);
 
   /**
    * This is where the recorded inputs & values for the whole invocation is collected.
@@ -73,50 +131,106 @@ class RepoFetchingSkyKeyComputeState implements SkyKeyComputeState {
    */
   final Map<RepoRecordedInput, String> recordedInputValues = new TreeMap<>();
 
+  RepoFetchingSkyKeyComputeState(String repositoryName,
+      Function<RepoFetchingSkyKeyComputeState, Runnable> threadFunc) {
+    this.repositoryName = repositoryName;
+    workerThread =
+        Thread.ofVirtual()
+            .name("starlark-repository-" + repositoryName)
+            .start(threadFunc.apply(this));
+  }
+
   SkyFunction.Environment signalForFreshEnv() throws InterruptedException {
-    // First unblock the Skyframe thread, then wait until it has something else to say. The only
-    // thing the Skyframe thread can do to this one is an interrupt so there is no need to do
-    // anything special in between.
-    rendezvousFromWorker(new Signal.Restart());
-    return rendezvousFromWorker(null);
+    // First unblock the host thread, then wait until it has something else to say. The only thing
+    // the host thread can do to this one is an interrupt so there is no need to do anything special
+    // in between.
+    HostState hostState = rendezvousFromWorker(new WorkerState.EnvironmentRequested());
+    if (!(hostState instanceof HostState.WaitingForWorker)) {
+      throw new IllegalStateException("Host thread is in unexpected state %s" + hostState);
+    }
+    return getEnvironmentFromHost();
   }
 
-  SkyFunction.Environment rendezvousFromWorker(Signal signal) throws InterruptedException {
-    return (SkyFunction.Environment) rendezvous.exchange(signal);
+  /** Get a new Environment from the host.
+   *
+   * <p>This should either be called right after the worker thread starts or after sending a
+   * {@code EnvironmentSent} to the host.
+   */
+  SkyFunction.Environment getEnvironmentFromHost() throws InterruptedException {
+    HostState hostState = rendezvousFromWorker(new EnvironmentReceived());
+    return switch (hostState) {
+      case EnvironmentSent(SkyFunction.Environment env) -> env;
+      default -> throw new IllegalStateException(
+          "Host thread is in unexpected state %s" + hostState);
+    };
   }
 
-  Signal rendezvousFromHost(SkyFunction.Environment environment) throws InterruptedException {
-    return (Signal) rendezvous.exchange(environment);
+  private void logMaybe(String msg) {
   }
 
-  Signal rendezvousUninterruptiblyFromHost(SkyFunction.Environment environment) {
+  HostState rendezvousFromWorker(WorkerState workerState) throws InterruptedException {
+    logMaybe(String.format("LOG %s/worker: sending %s", repositoryName, workerState));
+    HostState result = (HostState) rendezvous.exchange(workerState);
+    logMaybe(String.format("LOG %s/worker: received %s", repositoryName, result));
+    return result;
+  }
+
+  WorkerState rendezvousFromHost(HostState hostState) throws InterruptedException {
+    logMaybe(String.format("LOG %s/host: sending %s", repositoryName, hostState));
+    WorkerState result = (WorkerState) rendezvous.exchange(hostState);
+    logMaybe(String.format("LOG %s/host: received %s", repositoryName, result));
+    return result;
+  }
+
+  HostState rendezvousUninterruptiblyFromWorker(WorkerState signal) {
+    logMaybe(String.format("LOG %s/worker: sending %s uninterruptibly", repositoryName, signal));
     while(true) {
       try {
-        return (Signal) rendezvous.exchange(environment);
+        return rendezvousFromWorker(signal);
       } catch (InterruptedException e) {
+        logMaybe(String.format("LOG %s/worker: retrying on interrupt", repositoryName));
       }
     }
   }
 
-  SkyFunction.Environment rendezvousUninterruptiblyFromWorker(Signal signal) {
+  WorkerState rendezvousUninterruptiblyFromHost(HostState signal) {
+    logMaybe(String.format("LOG %s/host: sending %s uninterruptibly", repositoryName, signal));
     while(true) {
       try {
-        return (SkyFunction.Environment) rendezvous.exchange(signal);
+        return rendezvousFromHost(signal);
       } catch (InterruptedException e) {
+        logMaybe(String.format("LOG %s/host: retrying on interrupt", repositoryName));
       }
     }
   }
 
+  /** Join the worker thread.
+   *
+   * This method should only bee called if it either sent a {@code Failure} message or it received
+   * a {@code Finish} one.
+   */
   public void join() {
+    logMaybe(String.format("LOG %s/host: joining", repositoryName));
+    closeInProgress.set(true);
     Uninterruptibles.joinUninterruptibly(workerThread);
-    workerThread = null;
+    logMaybe(String.format("LOG %s/host: joined", repositoryName));
   }
 
+  /** Closes the worker thread forcefully by interrupting it.
+   *
+   * Waits for the worker thread to terminate before returning.
+   */
   @Override
   public void close() {
-    if (workerThread == null) {
+    if (closeInProgress.getAndSet(true)) {
+      logMaybe(String.format("LOG %s/host: not closing", repositoryName));
+      // Someone else already called close(). Just wait until they are done.
+      Uninterruptibles.joinUninterruptibly(workerThread);
+      logMaybe(String.format("LOG %s/host: not closing done", repositoryName));
       return;
     }
+
+    logMaybe(String.format("LOG %s/host: closing with interrupt", repositoryName));
     workerThread.interrupt();
 
     // Wait until the worker thread actually gets interrupted. Be resilient to cases where despite
@@ -125,14 +239,22 @@ class RepoFetchingSkyKeyComputeState implements SkyKeyComputeState {
     // with the exact semantics of thread interruption and it's cheap to be resilient. The important
     // part is that in case an interrupt happens, a Success or Failure is eventually posted by the
     // worker thread.
+SignalLoop:
     while (true) {
-      Signal signal = rendezvousUninterruptiblyFromHost(null);
-      if (signal instanceof Signal.Success || signal instanceof Signal.Failure) {
-        break;
+      WorkerState signal = rendezvousUninterruptiblyFromHost(null);
+      logMaybe(String.format("LOG %s/host: close signal is %s", repositoryName, signal));
+      switch (signal) {
+        case WorkerState.Failure unused: break SignalLoop;
+        case WorkerState.Success unused: {
+          // In this case, the worker thread expects an answer. */
+          rendezvousUninterruptiblyFromHost(new TerminationRequested());
+          break SignalLoop;
+        }
+        default: continue SignalLoop;
       }
     }
 
     Uninterruptibles.joinUninterruptibly(workerThread);
-    workerThread = null;
+    logMaybe(String.format("LOG %s/host: closing with interrupt done", repositoryName));
   }
 }


### PR DESCRIPTION
...where the worker thread can request things from the host thread, but not the other way round.

This makes it much easier to reason about what's happening between the threads and still allow us to share no state between the two.