### PR TITLE
Avoid Windows short paths in Bzlmod

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2917,7 +2917,7 @@
         "bzlTransitiveDigest": "tunTSmgwd2uvTzkCLtdbuCp0AI+WR+ftiPNqZ0rmcZk=",
         "recordedFileInputs": {
           "@@//MODULE.bazel": "eba5503742af5785c2d0d81d88e7407c7f23494b5162c055227435549b8774d1",
-          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "24f151a4b72d795d8290fe7b2f1a0a6d0a20110d644bc9d804ea881baadb8c52"
+          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "7a2be905158d827874491b69503ab454a2850378f48725318647247929f18db5"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -311,6 +311,10 @@ public class BazelDepGraphFunction implements SkyFunction {
     // Starlark identifier, which in the case of an exported symbol cannot start with "_".
     Preconditions.checkArgument(attempt >= 1);
     String extensionNameDisambiguator = attempt == 1 ? "" : String.valueOf(attempt);
+    // Avoid emitting unique names that resemble Windows short paths as those can cause additional
+    // file IO during analysis (see WindowsShortPath). In both cases, the final tilde is followed
+    // by a Starlark identifier (either the exported name of the usage or the extension name),
+    // neither of which can start with a digit.
     return id.getIsolationKey()
         .map(
             namespace ->

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -37,7 +37,7 @@ import java.util.Map;
 @GenerateTypeAdapter
 public abstract class BazelLockFileValue implements SkyValue, Postable {
 
-  public static final int LOCK_FILE_VERSION = 7;
+  public static final int LOCK_FILE_VERSION = 8;
 
   @SerializationConstant public static final SkyKey KEY = () -> SkyFunctions.BAZEL_LOCK_FILE;
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
@@ -104,7 +104,10 @@ public abstract class ModuleKey {
       // getVersion().isEmpty() is true only for modules with non-registry overrides, which enforce
       // that there is a single version of the module in the dep graph.
       Preconditions.checkState(!getVersion().isEmpty());
-      suffix = getVersion().toString();
+      // Prepend "v" to prevent canonical repo names, which form segments of file paths, from
+      // looking like a Windows short path. Such paths segments would incur additional file IO
+      // during analysis (see WindowsShortPath).
+      suffix = "v" + getVersion().toString();
     } else {
       // This results in canonical repository names such as `rules_foo~` for the module `rules_foo`.
       // This particular format is chosen since:

--- a/src/test/java/com/google/devtools/build/lib/analysis/RunfilesRepoMappingManifestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/RunfilesRepoMappingManifestTest.java
@@ -54,9 +54,9 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
   public void setupBareBinaryRule() throws Exception {
     registry.addModule(
         createModuleKey("bare_rule", "1.0"), "module(name='bare_rule',version='1.0')");
-    scratch.overwriteFile(moduleRoot.getRelative("bare_rule~1.0/WORKSPACE").getPathString());
+    scratch.overwriteFile(moduleRoot.getRelative("bare_rule~v1.0/WORKSPACE").getPathString());
     scratch.overwriteFile(
-        moduleRoot.getRelative("bare_rule~1.0/defs.bzl").getPathString(),
+        moduleRoot.getRelative("bare_rule~v1.0/defs.bzl").getPathString(),
         "def _bare_binary_impl(ctx):",
         "  exe = ctx.actions.declare_file(ctx.label.name)",
         "  ctx.actions.write(exe, 'i got nothing', True)",
@@ -70,7 +70,7 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         "  executable=True,",
         ")");
     scratch.overwriteFile(
-        moduleRoot.getRelative("bare_rule~1.0/BUILD").getPathString(),
+        moduleRoot.getRelative("bare_rule~v1.0/BUILD").getPathString(),
         "load('//:defs.bzl', 'bare_binary')",
         "bare_binary(name='bare_binary')");
   }
@@ -131,10 +131,10 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         "bare_binary(name='aaa',data=['@bbb'])");
     ImmutableMap<String, String> buildFiles =
         ImmutableMap.of(
-            "bbb~1.0", "bare_binary(name='bbb',data=['@ddd'])",
-            "ccc~2.0", "bare_binary(name='ccc',data=['@ddd'])",
-            "ddd~1.0", "bare_binary(name='ddd')",
-            "ddd~2.0", "bare_binary(name='ddd')");
+            "bbb~v1.0", "bare_binary(name='bbb',data=['@ddd'])",
+            "ccc~v2.0", "bare_binary(name='ccc',data=['@ddd'])",
+            "ddd~v1.0", "bare_binary(name='ddd')",
+            "ddd~v2.0", "bare_binary(name='ddd')");
     for (Entry<String, String> entry : buildFiles.entrySet()) {
       scratch.overwriteFile(
           moduleRoot.getRelative(entry.getKey()).getRelative("WORKSPACE").getPathString());
@@ -173,9 +173,9 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         "module(name='tooled_rule',version='1.0')",
         "bazel_dep(name='bare_rule',version='1.0')",
         "register_toolchains('//:all')");
-    scratch.overwriteFile(moduleRoot.getRelative("tooled_rule~1.0/WORKSPACE").getPathString());
+    scratch.overwriteFile(moduleRoot.getRelative("tooled_rule~v1.0/WORKSPACE").getPathString());
     scratch.overwriteFile(
-        moduleRoot.getRelative("tooled_rule~1.0/defs.bzl").getPathString(),
+        moduleRoot.getRelative("tooled_rule~v1.0/defs.bzl").getPathString(),
         "def _tooled_binary_impl(ctx):",
         "  exe = ctx.actions.declare_file(ctx.label.name)",
         "  ctx.actions.write(exe, 'i got something', True)",
@@ -204,7 +204,7 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         "    toolchain_type=Label('//:toolchain_type'),",
         "  )");
     scratch.overwriteFile(
-        moduleRoot.getRelative("tooled_rule~1.0/BUILD").getPathString(),
+        moduleRoot.getRelative("tooled_rule~v1.0/BUILD").getPathString(),
         "load('//:defs.bzl', 'tooled_toolchain')",
         "toolchain_type(name='toolchain_type')",
         "tooled_toolchain(name='tooled_toolchain', backing_binary='@bare_rule//:bare_binary')");
@@ -283,10 +283,10 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         "module(name='bbb',version='1.0')",
         "bazel_dep(name='bare_rule',version='1.0')");
     scratch.overwriteFile(
-        moduleRoot.getRelative("bbb~1.0").getRelative("WORKSPACE").getPathString());
-    scratch.overwriteFile(moduleRoot.getRelative("bbb~1.0").getRelative("BUILD").getPathString());
+        moduleRoot.getRelative("bbb~v1.0").getRelative("WORKSPACE").getPathString());
+    scratch.overwriteFile(moduleRoot.getRelative("bbb~v1.0").getRelative("BUILD").getPathString());
     scratch.overwriteFile(
-        moduleRoot.getRelative("bbb~1.0").getRelative("def.bzl").getPathString(), "BBB = '1'");
+        moduleRoot.getRelative("bbb~v1.0").getRelative("def.bzl").getPathString(), "BBB = '1'");
     invalidatePackages();
 
     RepoMappingManifestAction actionBeforeChange = getRepoMappingManifestActionForTarget("//:aaa");
@@ -321,9 +321,9 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         "bazel_dep(name='my_module',version='1.0')",
         "bazel_dep(name='bare_rule',version='1.0')",
         "bazel_dep(name='symlinks',version='1.0')");
-    scratch.overwriteFile(moduleRoot.getRelative("aaa~1.0/WORKSPACE").getPathString());
+    scratch.overwriteFile(moduleRoot.getRelative("aaa~v1.0/WORKSPACE").getPathString());
     scratch.overwriteFile(
-        moduleRoot.getRelative("aaa~1.0/BUILD").getPathString(),
+        moduleRoot.getRelative("aaa~v1.0/BUILD").getPathString(),
         "load('@bare_rule//:defs.bzl', 'bare_binary')",
         "bare_binary(name='aaa',data=['@symlinks'])");
 
@@ -331,9 +331,9 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         createModuleKey("symlinks", "1.0"),
         "module(name='symlinks',version='1.0')",
         "bazel_dep(name='ddd',version='1.0')");
-    scratch.overwriteFile(moduleRoot.getRelative("symlinks~1.0/WORKSPACE").getPathString());
+    scratch.overwriteFile(moduleRoot.getRelative("symlinks~v1.0/WORKSPACE").getPathString());
     scratch.overwriteFile(
-        moduleRoot.getRelative("symlinks~1.0/defs.bzl").getPathString(),
+        moduleRoot.getRelative("symlinks~v1.0/defs.bzl").getPathString(),
         "def _symlinks_impl(ctx):",
         "  runfiles = ctx.runfiles(",
         "    symlinks = {'path/to/pkg/symlink': ctx.file.data},",
@@ -346,7 +346,7 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         "  attrs={'data':attr.label(allow_single_file=True)},",
         ")");
     scratch.overwriteFile(
-        moduleRoot.getRelative("symlinks~1.0/BUILD").getPathString(),
+        moduleRoot.getRelative("symlinks~v1.0/BUILD").getPathString(),
         "load('//:defs.bzl', 'symlinks')",
         "symlinks(name='symlinks',data='@ddd')");
 
@@ -354,9 +354,9 @@ public class RunfilesRepoMappingManifestTest extends BuildViewTestCase {
         createModuleKey("ddd", "1.0"),
         "module(name='ddd',version='1.0')",
         "bazel_dep(name='bare_rule',version='1.0')");
-    scratch.overwriteFile(moduleRoot.getRelative("ddd~1.0/WORKSPACE").getPathString());
+    scratch.overwriteFile(moduleRoot.getRelative("ddd~v1.0/WORKSPACE").getPathString());
     scratch.overwriteFile(
-        moduleRoot.getRelative("ddd~1.0/BUILD").getPathString(),
+        moduleRoot.getRelative("ddd~v1.0/BUILD").getPathString(),
         "load('@bare_rule//:defs.bzl', 'bare_binary')",
         "bare_binary(name='ddd')");
     invalidatePackages();

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
@@ -1464,10 +1464,10 @@ public final class StarlarkRuleTransitionProviderTest extends BuildViewTestCase 
 
     scratch.overwriteFile("MODULE.bazel", "bazel_dep(name='rules_x',version='1.0')");
     registry.addModule(createModuleKey("rules_x", "1.0"), "module(name='rules_x', version='1.0')");
-    scratch.file("modules/rules_x~1.0/WORKSPACE");
-    scratch.file("modules/rules_x~1.0/BUILD");
+    scratch.file("modules/rules_x~v1.0/WORKSPACE");
+    scratch.file("modules/rules_x~v1.0/BUILD");
     scratch.file(
-        "modules/rules_x~1.0/defs.bzl",
+        "modules/rules_x~v1.0/defs.bzl",
         """
         def _tr_impl(settings, attr):
             return {"//command_line_option:platforms": [Label("@@//test:my_platform")]}

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -77,6 +77,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/main/java/com/google/devtools/build/lib/windows:windows_short_path",
         "//src/main/java/com/google/devtools/build/skyframe",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/net/starlark/java/eval",

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -195,9 +195,9 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
         .containsExactly(
             RepositoryName.MAIN,
             ModuleKey.ROOT,
-            RepositoryName.create("dep~1.0"),
+            RepositoryName.create("dep~v1.0"),
             createModuleKey("dep", "1.0"),
-            RepositoryName.create("dep~2.0"),
+            RepositoryName.create("dep~v2.0"),
             createModuleKey("dep", "2.0"),
             RepositoryName.create("rules_cc~"),
             createModuleKey("rules_cc", "1.0"),

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleFunctionTest.java
@@ -184,7 +184,7 @@ public final class BzlmodRepoRuleFunctionTest extends FoundationTestCase {
     assertThat(repoRule.getRuleClassObject().isStarlark()).isFalse();
     assertThat(repoRule.getRuleClass()).isEqualTo("local_repository");
     assertThat(repoRule.getName()).isEqualTo("ccc~");
-    assertThat(repoRule.getAttr("path", Type.STRING)).isEqualTo("/usr/local/modules/ccc~2.0");
+    assertThat(repoRule.getAttr("path", Type.STRING)).isEqualTo("/usr/local/modules/ccc~v2.0");
   }
 
   @Test
@@ -248,7 +248,7 @@ public final class BzlmodRepoRuleFunctionTest extends FoundationTestCase {
     assertThat(repoRule.getRuleClassObject().isStarlark()).isFalse();
     assertThat(repoRule.getRuleClass()).isEqualTo("local_repository");
     assertThat(repoRule.getName()).isEqualTo("ccc~");
-    assertThat(repoRule.getAttr("path", Type.STRING)).isEqualTo("/usr/local/modules/ccc~3.0");
+    assertThat(repoRule.getAttr("path", Type.STRING)).isEqualTo("/usr/local/modules/ccc~v3.0");
   }
 
   @Test
@@ -272,7 +272,7 @@ public final class BzlmodRepoRuleFunctionTest extends FoundationTestCase {
             .addModule(createModuleKey("ddd", "2.0"), "module(name='ddd', version='2.0')");
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableList.of(registry.getUrl()));
 
-    RepositoryName repo = RepositoryName.create("ddd~2.0");
+    RepositoryName repo = RepositoryName.create("ddd~v2.0");
     EvaluationResult<BzlmodRepoRuleValue> result =
         evaluator.evaluate(ImmutableList.of(BzlmodRepoRuleValue.key(repo)), evaluationContext);
     if (result.hasError()) {
@@ -283,8 +283,8 @@ public final class BzlmodRepoRuleFunctionTest extends FoundationTestCase {
 
     assertThat(repoRule.getRuleClassObject().isStarlark()).isFalse();
     assertThat(repoRule.getRuleClass()).isEqualTo("local_repository");
-    assertThat(repoRule.getName()).isEqualTo("ddd~2.0");
-    assertThat(repoRule.getAttr("path", Type.STRING)).isEqualTo("/usr/local/modules/ddd~2.0");
+    assertThat(repoRule.getName()).isEqualTo("ddd~v2.0");
+    assertThat(repoRule.getAttr("path", Type.STRING)).isEqualTo("/usr/local/modules/ddd~v2.0");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -290,10 +290,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     // Set up a simple repo rule.
     registry.addModule(
         createModuleKey("data_repo", "1.0"), "module(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("data_repo~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("data_repo~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("data_repo~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("data_repo~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("data_repo~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("data_repo~v1.0/defs.bzl").getPathString(),
         "def _data_repo_impl(ctx):",
         "  ctx.file('WORKSPACE')",
         "  ctx.file('BUILD')",
@@ -522,10 +522,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         createModuleKey("ext", "1.0"),
         "module(name='ext',version='1.0')",
         "bazel_dep(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_str = ''",
@@ -582,10 +582,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         createModuleKey("ext", "1.0"),
         "module(name='ext',version='1.0')",
         "bazel_dep(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_str = 'modules:'",
@@ -634,10 +634,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         createModuleKey("ext", "1.0"),
         "module(name='ext',version='1.0')",
         "bazel_dep(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_str = 'modules:'",
@@ -704,10 +704,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "ext = use_extension('@ext//:defs.bzl','ext')",
         "ext.tag(data='foo@1.0',expect_isolated=False)",
         "use_repo(ext,'ext_repo')");
-    scratch.file(modulesRoot.getRelative("foo~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("foo~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("foo~1.0/data.bzl").getPathString(),
+        modulesRoot.getRelative("foo~v1.0/data.bzl").getPathString(),
         "load('@ext_repo//:data.bzl', ext_data='data')",
         "load('@isolated_ext_repo//:data.bzl', isolated_ext_data='data')",
         "data=ext_data",
@@ -717,10 +717,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         createModuleKey("ext", "1.0"),
         "module(name='ext',version='1.0')",
         "bazel_dep(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_str = ''",
@@ -783,19 +783,19 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "ext = use_extension('@ext//:defs.bzl','ext')",
         "ext.tag(file='@bar//:requirements.txt')");
     registry.addModule(createModuleKey("bar", "2.0"), "module(name='bar',version='2.0')");
-    scratch.file(modulesRoot.getRelative("bar~2.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("bar~2.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("bar~v2.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("bar~v2.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("bar~2.0/requirements.txt").getPathString(), "go to bed at 11pm.");
+        modulesRoot.getRelative("bar~v2.0/requirements.txt").getPathString(), "go to bed at 11pm.");
 
     registry.addModule(
         createModuleKey("ext", "1.0"),
         "module(name='ext',version='1.0')",
         "bazel_dep(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_str = 'requirements:'",
@@ -840,16 +840,16 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "ext = use_extension('@ext//:defs.bzl','ext')",
         "ext.tag(file='@bar//:requirements.txt')");
     registry.addModule(createModuleKey("bar", "2.0"), "module(name='bar',version='2.0')");
-    scratch.file(modulesRoot.getRelative("bar~2.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("bar~2.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("bar~v2.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("bar~v2.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("bar~2.0/requirements.txt").getPathString(), "go to bed at 11pm.");
+        modulesRoot.getRelative("bar~v2.0/requirements.txt").getPathString(), "go to bed at 11pm.");
 
     registry.addModule(createModuleKey("ext", "1.0"), "module(name='ext',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "def _data_repo_impl(ctx):",
         "  ctx.file('WORKSPACE')",
         "  ctx.file('BUILD')",
@@ -906,10 +906,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     scratch.file(workspaceRoot.getRelative("requirements.txt").getPathString(), "get up at 6am.");
 
     registry.addModule(createModuleKey("ext", "1.0"), "module(name='ext',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "def _data_repo_impl(ctx):",
         "  ctx.file('WORKSPACE')",
         "  ctx.file('BUILD')",
@@ -951,15 +951,15 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "data=ext_data");
 
     registry.addModule(createModuleKey("foo", "1.0"), "module(name='foo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("foo~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("foo~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("foo~1.0/requirements.txt").getPathString(), "get up at 6am.");
+        modulesRoot.getRelative("foo~v1.0/requirements.txt").getPathString(), "get up at 6am.");
     registry.addModule(createModuleKey("bar", "2.0"), "module(name='bar',version='2.0')");
-    scratch.file(modulesRoot.getRelative("bar~2.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("bar~2.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("bar~v2.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("bar~v2.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("bar~2.0/requirements.txt").getPathString(), "go to bed at 11pm.");
+        modulesRoot.getRelative("bar~v2.0/requirements.txt").getPathString(), "go to bed at 11pm.");
 
     registry.addModule(
         createModuleKey("ext", "1.0"),
@@ -967,10 +967,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "bazel_dep(name='foo',version='1.0')",
         "bazel_dep(name='bar',version='2.0')",
         "bazel_dep(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         // The Label() call on the following line should work, using ext.1.0's repo mapping.
@@ -1007,20 +1007,20 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "data=ext_data");
 
     registry.addModule(createModuleKey("foo", "1.0"), "module(name='foo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("foo~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("foo~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("foo~1.0/requirements.txt").getPathString(), "get up at 6am.");
+        modulesRoot.getRelative("foo~v1.0/requirements.txt").getPathString(), "get up at 6am.");
 
     registry.addModule(
         createModuleKey("ext", "1.0"),
         "module(name='ext',version='1.0')",
         "bazel_dep(name='foo',version='1.0')",
         "bazel_dep(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "def _data_repo_impl(ctx):",
         "  ctx.file('WORKSPACE')",
         "  ctx.file('BUILD')",
@@ -1157,9 +1157,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "ext=module_extension(implementation=_ext_impl)");
 
     registry.addModule(createModuleKey("foo", "1.0"), "module(name='foo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("foo~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("foo~1.0/BUILD").getPathString());
-    scratch.file(modulesRoot.getRelative("foo~1.0/data.bzl").getPathString(), "data = 'foo-stuff'");
+    scratch.file(modulesRoot.getRelative("foo~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/BUILD").getPathString());
+    scratch.file(
+        modulesRoot.getRelative("foo~v1.0/data.bzl").getPathString(), "data = 'foo-stuff'");
 
     SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
     EvaluationResult<BzlLoadValue> result =
@@ -1242,9 +1243,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "ext=module_extension(implementation=_ext_impl,tag_classes={'tag':tag})");
 
     registry.addModule(createModuleKey("foo", "1.0"), "module(name='foo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("foo~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("foo~1.0/BUILD").getPathString());
-    scratch.file(modulesRoot.getRelative("foo~1.0/data.bzl").getPathString(), "data = 'outer-foo'");
+    scratch.file(modulesRoot.getRelative("foo~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/BUILD").getPathString());
+    scratch.file(
+        modulesRoot.getRelative("foo~v1.0/data.bzl").getPathString(), "data = 'outer-foo'");
 
     SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
     EvaluationResult<BzlLoadValue> result =
@@ -1426,10 +1428,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         createModuleKey("ext", "1.0"),
         "module(name='ext',version='1.0')",
         "bazel_dep(name='data_repo',version='1.0')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_repo(name='candy', data='cotton candy')",
@@ -1840,10 +1842,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "use_repo(ext, 'indirect_dep')",
         "ext_dev = use_extension('//:defs.bzl', 'ext', dev_dependency = True)",
         "use_repo(ext_dev, 'indirect_dev_dep')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_repo(name='direct_dep')",
@@ -1938,10 +1940,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "use_repo(ext, 'indirect_dep')",
         "ext_dev = use_extension('//:defs.bzl', 'ext', dev_dependency = True)",
         "use_repo(ext_dev, 'indirect_dev_dep')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_repo(name='direct_dep')",
@@ -2030,10 +2032,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "use_repo(ext, 'indirect_dep')",
         "ext_dev = use_extension('//:defs.bzl', 'ext', dev_dependency = True)",
         "use_repo(ext_dev, 'indirect_dev_dep')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_repo(name='direct_dep')",
@@ -2115,10 +2117,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "use_repo(ext, 'indirect_dep')",
         "ext_dev = use_extension('//:defs.bzl', 'ext', dev_dependency = True)",
         "use_repo(ext_dev, 'indirect_dev_dep')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_repo(name='direct_dep')",
@@ -2133,7 +2135,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "  )",
         "ext=module_extension(implementation=_ext_impl)");
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/data.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/data.bzl").getPathString(),
         "load('@indirect_dep//:data.bzl', indirect_dep_data='data')",
         "data = indirect_dep_data");
 
@@ -2182,10 +2184,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "bazel_dep(name='data_repo',version='1.0')",
         "ext = use_extension('//:defs.bzl', 'ext')",
         "use_repo(ext, 'indirect_dep')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_repo(name='direct_dep')",
@@ -2292,10 +2294,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "bazel_dep(name='data_repo',version='1.0')",
         "ext = use_extension('//:defs.bzl', 'ext')",
         "use_repo(ext, 'indirect_dep')");
-    scratch.file(modulesRoot.getRelative("ext~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("ext~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("ext~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("ext~1.0/defs.bzl").getPathString(),
+        modulesRoot.getRelative("ext~v1.0/defs.bzl").getPathString(),
         "load('@data_repo//:defs.bzl','data_repo')",
         "def _ext_impl(ctx):",
         "  data_repo(name='direct_dep')",
@@ -2501,14 +2503,14 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "module(name='foo',version='1.0')",
         "data_repo = use_repo_rule('//:repo.bzl', 'data_repo')",
         "data_repo(name='data', data='go to bed at 11pm.')");
-    scratch.file(modulesRoot.getRelative("foo~1.0/WORKSPACE").getPathString());
-    scratch.file(modulesRoot.getRelative("foo~1.0/BUILD").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("foo~v1.0/BUILD").getPathString());
     scratch.file(
-        modulesRoot.getRelative("foo~1.0/data.bzl").getPathString(),
+        modulesRoot.getRelative("foo~v1.0/data.bzl").getPathString(),
         "load('@data//:data.bzl',repo_data='data')",
         "data=repo_data");
     scratch.file(
-        modulesRoot.getRelative("foo~1.0/repo.bzl").getPathString(),
+        modulesRoot.getRelative("foo~v1.0/repo.bzl").getPathString(),
         "def _data_repo_impl(ctx):",
         "  ctx.file('BUILD.bazel')",
         "  ctx.file('data.bzl', 'data='+json.encode(ctx.attr.data))",

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleTest.java
@@ -16,10 +16,12 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.buildModule;
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createModuleKey;
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createRepositoryMapping;
 
+import com.google.devtools.build.lib.windows.WindowsShortPath;
 import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,8 +82,21 @@ public class ModuleTest {
                 "test_module",
                 "",
                 "my_foo",
-                "foo~1.0",
+                "foo~v1.0",
                 "my_bar",
-                "bar~2.0"));
+                "bar~v2.0"));
+  }
+
+  @Test
+  public void getCanonicalRepoName_isNotAWindowsShortPath() {
+    assertNotAShortPath(createModuleKey("foo", "").getCanonicalRepoNameWithoutVersion().getName());
+    assertNotAShortPath(createModuleKey("foo", "1").getCanonicalRepoNameWithVersion().getName());
+    assertNotAShortPath(createModuleKey("foo", "1.2").getCanonicalRepoNameWithVersion().getName());
+    assertNotAShortPath(
+        createModuleKey("foo", "1.2.3").getCanonicalRepoNameWithVersion().getName());
+  }
+
+  private static void assertNotAShortPath(String name) {
+    assertWithMessage("For %s", name).that(WindowsShortPath.isShortPath(name)).isFalse();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ExtensionArgTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ExtensionArgTest.java
@@ -103,7 +103,7 @@ public class ExtensionArgTest {
                     baseModuleUnusedDeps))
         .isEqualTo(
             ModuleExtensionId.create(
-                Label.parseCanonical("@@foo~1.0//:abc.bzl"), "def", Optional.empty()));
+                Label.parseCanonical("@@foo~v1.0//:abc.bzl"), "def", Optional.empty()));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArgTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArgTest.java
@@ -103,7 +103,7 @@ public class ModuleArgTest {
 
     assertThat(
             arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping))
-        .containsExactly("foo@2.0", RepositoryName.create("foo~2.0"));
+        .containsExactly("foo@2.0", RepositoryName.create("foo~v2.0"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArgTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArgTest.java
@@ -83,7 +83,7 @@ public class ModuleArgTest {
           .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersion));
   ImmutableBiMap<String, ModuleKey> baseModuleDeps = ImmutableBiMap.of("fred", foo2);
   ImmutableBiMap<String, ModuleKey> baseModuleUnusedDeps = ImmutableBiMap.of("fred", foo1);
-  RepositoryMapping rootMapping = createRepositoryMapping(ModuleKey.ROOT, "fred", "foo~2.0");
+  RepositoryMapping rootMapping = createRepositoryMapping(ModuleKey.ROOT, "fred", "foo~v2.0");
 
   public ModuleArgTest() throws Exception {}
 
@@ -192,7 +192,7 @@ public class ModuleArgTest {
     // resolving to repo names doesn't care about unused deps.
     assertThat(
             arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping))
-        .containsExactly("foo@2.0", RepositoryName.create("foo~2.0"));
+        .containsExactly("foo@2.0", RepositoryName.create("foo~v2.0"));
   }
 
   @Test
@@ -244,7 +244,7 @@ public class ModuleArgTest {
 
     assertThat(
             arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping))
-        .containsExactly("@fred", RepositoryName.create("foo~2.0"));
+        .containsExactly("@fred", RepositoryName.create("foo~v2.0"));
   }
 
   @Test
@@ -285,12 +285,12 @@ public class ModuleArgTest {
 
     assertThat(
             arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping))
-        .containsExactly("@@foo~2.0", RepositoryName.create("foo~2.0"));
+        .containsExactly("@@foo~v2.0", RepositoryName.create("foo~v2.0"));
   }
 
   @Test
   public void resolve_canonicalRepoName_notFound() throws Exception {
-    var arg = CanonicalRepoName.create(RepositoryName.create("bar~1.0"));
+    var arg = CanonicalRepoName.create(RepositoryName.create("bar~v1.0"));
 
     assertThrows(
         InvalidArgumentException.class,
@@ -306,7 +306,7 @@ public class ModuleArgTest {
     // The repo need not exist in the "repo -> repo" case.
     assertThat(
             arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping))
-        .containsExactly("@@bar~1.0", RepositoryName.create("bar~1.0"));
+        .containsExactly("@@bar~v1.0", RepositoryName.create("bar~v1.0"));
   }
 
   @Test
@@ -343,6 +343,6 @@ public class ModuleArgTest {
     // resolving to repo names doesn't care about unused deps.
     assertThat(
             arg.resolveToRepoNames(modulesIndex, depGraph, moduleKeyToCanonicalNames, rootMapping))
-        .containsExactly("@@foo~1.0", RepositoryName.create("foo~1.0"));
+        .containsExactly("@@foo~v1.0", RepositoryName.create("foo~v1.0"));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
@@ -2523,13 +2523,13 @@ public abstract class AbstractQueryTest<T> {
         ")");
     helper.addModule(
         ModuleKey.create("repo", Version.parse("1.0")), "module(name = 'repo', version = '1.0')");
-    writeFile(helper.getModuleRoot().getRelative("repo~1.0/WORKSPACE").getPathString(), "");
+    writeFile(helper.getModuleRoot().getRelative("repo~v1.0/WORKSPACE").getPathString(), "");
     writeFile(
-        helper.getModuleRoot().getRelative("repo~1.0/a/BUILD").getPathString(),
+        helper.getModuleRoot().getRelative("repo~v1.0/a/BUILD").getPathString(),
         "exports_files(['x', 'y', 'z'])",
         "sh_library(name = 'a_shar')");
     writeFile(
-        helper.getModuleRoot().getRelative("repo~1.0/a/b/BUILD").getPathString(),
+        helper.getModuleRoot().getRelative("repo~v1.0/a/b/BUILD").getPathString(),
         "exports_files(['p', 'q'])",
         "sh_library(name = 'a_b_shar')");
     RepositoryMapping mapping =

--- a/src/test/java/com/google/devtools/build/lib/rules/LabelBuildSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/LabelBuildSettingTest.java
@@ -425,8 +425,8 @@ public class LabelBuildSettingTest extends BuildViewTestCase {
   public void transitionOutput_otherRepo() throws Exception {
     scratch.overwriteFile("MODULE.bazel", "bazel_dep(name='foo',version='1.0')");
     registry.addModule(createModuleKey("foo", "1.0"), "module(name='foo', version='1.0')");
-    scratch.file("modules/foo~1.0/WORKSPACE");
-    scratch.file("modules/foo~1.0/BUILD", "filegroup(name='other_rule')");
+    scratch.file("modules/foo~v1.0/WORKSPACE");
+    scratch.file("modules/foo~v1.0/BUILD", "filegroup(name='other_rule')");
 
     scratch.overwriteFile(
         "tools/allowlists/function_transition_allowlist/BUILD",

--- a/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
@@ -1189,7 +1189,7 @@ public final class StarlarkDocExtractTest extends BuildViewTestCase {
         "MODULE.bazel", "module(name = 'my_module')", "bazel_dep(name='dep_mod', version='0.1')");
     registry.addModule(
         BzlmodTestUtil.createModuleKey("dep_mod", "0.1"), "module(name='dep_mod', version='0.1')");
-    Path depModRepoPath = moduleRoot.getRelative("dep_mod~0.1");
+    Path depModRepoPath = moduleRoot.getRelative("dep_mod~v0.1");
     scratch.file(depModRepoPath.getRelative("WORKSPACE").getPathString());
     scratch.file(
         depModRepoPath.getRelative("foo.bzl").getPathString(),

--- a/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
@@ -396,7 +396,7 @@ public final class StarlarkDocExtractTest extends BuildViewTestCase {
     registry.addModule(
         BzlmodTestUtil.createModuleKey("origin_repo", "0.1"),
         "module(name='origin_repo', version='0.1')");
-    Path originRepoPath = moduleRoot.getRelative("origin_repo~0.1");
+    Path originRepoPath = moduleRoot.getRelative("origin_repo~v0.1");
     scratch.file(originRepoPath.getRelative("WORKSPACE").getPathString());
     scratch.file(
         originRepoPath.getRelative("BUILD").getPathString(), //

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BzlLoadFunctionTest.java
@@ -1138,7 +1138,7 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
             "module(name='foo',version='1.0')",
             "bazel_dep(name='bar',version='2.0',repo_name='bar_alias')")
         .addModule(createModuleKey("bar", "2.0"), "module(name='bar',version='2.0')");
-    Path fooDir = moduleRoot.getRelative("foo~1.0");
+    Path fooDir = moduleRoot.getRelative("foo~v1.0");
     scratch.file(fooDir.getRelative("WORKSPACE").getPathString());
     scratch.file(fooDir.getRelative("BUILD").getPathString());
     scratch.file(
@@ -1147,7 +1147,7 @@ public class BzlLoadFunctionTest extends BuildViewTestCase {
         "load('@bar_alias//:test.scl', 'haha')",
         "l = Label('@foo//:whatever')",
         "hoho = haha");
-    Path barDir = moduleRoot.getRelative("bar~2.0");
+    Path barDir = moduleRoot.getRelative("bar~v2.0");
     scratch.file(barDir.getRelative("WORKSPACE").getPathString());
     scratch.file(barDir.getRelative("BUILD").getPathString());
     scratch.file(barDir.getRelative("test.scl").getPathString(), "haha = 5");

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternsFunctionTest.java
@@ -364,9 +364,9 @@ public class PrepareDepsOfPatternsFunctionTest extends BuildViewTestCase {
     registry.addModule(
         ModuleKey.create("repo", Version.parse("1.0")),
         "module(name = \"repo\", version = \"1.0\")");
-    scratch.file(moduleRoot.getRelative("repo~1.0/WORKSPACE").getPathString(), "");
+    scratch.file(moduleRoot.getRelative("repo~v1.0/WORKSPACE").getPathString(), "");
     scratch.file(
-        moduleRoot.getRelative("repo~1.0/a/BUILD").getPathString(), "exports_files(['x'])");
+        moduleRoot.getRelative("repo~v1.0/a/BUILD").getPathString(), "exports_files(['x'])");
     invalidatePackages();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RepoFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RepoFileFunctionTest.java
@@ -56,12 +56,12 @@ public class RepoFileFunctionTest extends BuildViewTestCase {
     scratch.overwriteFile("MODULE.bazel", "bazel_dep(name='foo',version='1.0')");
     scratch.overwriteFile("abc/def/BUILD", "filegroup(name='what')");
     registry.addModule(createModuleKey("foo", "1.0"), "module(name='foo',version='1.0')");
-    scratch.overwriteFile(moduleRoot.getRelative("foo~1.0/WORKSPACE.bazel").getPathString());
+    scratch.overwriteFile(moduleRoot.getRelative("foo~v1.0/WORKSPACE.bazel").getPathString());
     scratch.overwriteFile(
-        moduleRoot.getRelative("foo~1.0/REPO.bazel").getPathString(),
+        moduleRoot.getRelative("foo~v1.0/REPO.bazel").getPathString(),
         "repo(default_deprecation='EVERYTHING IS DEPRECATED')");
     scratch.overwriteFile(
-        moduleRoot.getRelative("foo~1.0/abc/def/BUILD").getPathString(), "filegroup(name='what')");
+        moduleRoot.getRelative("foo~v1.0/abc/def/BUILD").getPathString(), "filegroup(name='what')");
 
     invalidatePackages();
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunctionTest.java
@@ -266,9 +266,9 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
                     TestConstants.LEGACY_WORKSPACE_NAME,
                     RepositoryName.MAIN,
                     "bbb1",
-                    RepositoryName.create("bbb~1.0"),
+                    RepositoryName.create("bbb~v1.0"),
                     "bbb2",
-                    RepositoryName.create("bbb~2.0")),
+                    RepositoryName.create("bbb~v2.0")),
                 "aaa",
                 "0.1"));
   }
@@ -304,7 +304,7 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
             valueForBzlmod(
                 ImmutableMap.of(
                     "bbb", RepositoryName.create("bbb~"),
-                    "ddd", RepositoryName.create("ddd~1.0")),
+                    "ddd", RepositoryName.create("ddd~v1.0")),
                 name,
                 "bbb",
                 "1.0"));
@@ -326,7 +326,7 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
         .addModule(createModuleKey("bbb", "2.0"), "module(name='bbb', version='2.0')")
         .addModule(createModuleKey("ccc", "1.0"), "module(name='ccc', version='1.0')");
 
-    RepositoryName name = RepositoryName.create("bbb~1.0");
+    RepositoryName name = RepositoryName.create("bbb~v1.0");
     SkyKey skyKey = RepositoryMappingValue.key(name);
     EvaluationResult<RepositoryMappingValue> result = eval(skyKey);
 
@@ -338,7 +338,7 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
         .isEqualTo(
             valueForBzlmod(
                 ImmutableMap.of(
-                    "bbb", RepositoryName.create("bbb~1.0"),
+                    "bbb", RepositoryName.create("bbb~v1.0"),
                     "com_foo_bar_c", RepositoryName.create("ccc~")),
                 name,
                 "bbb",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/config/PlatformMappingFunctionParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/config/PlatformMappingFunctionParserTest.java
@@ -49,7 +49,7 @@ public class PlatformMappingFunctionParserTest extends AnalysisTestCase {
   private static final Label PLATFORM1 = Label.parseCanonicalUnchecked("//platforms:one");
   private static final Label PLATFORM2 = Label.parseCanonicalUnchecked("//platforms:two");
   private static final Label EXTERNAL_PLATFORM =
-      Label.parseCanonicalUnchecked("@dep~1.0//platforms:two");
+      Label.parseCanonicalUnchecked("@dep~v1.0//platforms:two");
 
   @Test
   public void testParse() throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/config/PlatformMappingFunctionParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/config/PlatformMappingFunctionParserTest.java
@@ -80,7 +80,7 @@ public class PlatformMappingFunctionParserTest extends AnalysisTestCase {
   public void testParseWithRepoMapping() throws Exception {
     RepositoryMapping repoMapping =
         RepositoryMapping.create(
-            ImmutableMap.of("foo", RepositoryName.MAIN, "dep", RepositoryName.create("dep~1.0")),
+            ImmutableMap.of("foo", RepositoryName.MAIN, "dep", RepositoryName.create("dep~v1.0")),
             RepositoryName.MAIN);
     PlatformMappingFunction.Mappings mappings =
         parse(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/config/PlatformMappingValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/config/PlatformMappingValueTest.java
@@ -43,11 +43,11 @@ public final class PlatformMappingValueTest {
 
   private static final Label PLATFORM_ONE = Label.parseCanonicalUnchecked("//platforms:one");
   private static final Label PLATFORM_TWO =
-      Label.parseCanonicalUnchecked("@dep~1.0//platforms:two");
+      Label.parseCanonicalUnchecked("@dep~v1.0//platforms:two");
   private static final RepositoryMapping REPO_MAPPING =
       RepositoryMapping.create(
           ImmutableMap.of(
-              "", RepositoryName.MAIN, "dep", RepositoryName.createUnvalidated("dep~1.0")),
+              "", RepositoryName.MAIN, "dep", RepositoryName.createUnvalidated("dep~v1.0")),
           RepositoryName.MAIN);
   private static final Label DEFAULT_TARGET_PLATFORM =
       Label.parseCanonicalUnchecked("@bazel_tools//tools:host_platform");

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunctionTest.java
@@ -354,7 +354,7 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
             "register_execution_platforms('@eee//:plat', '//:plat')",
             "bazel_dep(name='eee',version='1.0')")
         .addModule(createModuleKey("eee", "1.0"), "module(name='eee', version='1.0')");
-    for (String repo : ImmutableList.of("bbb~1.0", "ccc~1.1", "ddd~1.0", "ddd~1.1", "eee~1.0")) {
+    for (String repo : ImmutableList.of("bbb~v1.0", "ccc~v1.1", "ddd~v1.0", "ddd~v1.1", "eee~v1.0")) {
       scratch.file(moduleRoot.getRelative(repo).getRelative("WORKSPACE").getPathString());
       scratch.file(
           moduleRoot.getRelative(repo).getRelative("BUILD").getPathString(),

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
@@ -419,7 +419,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
             createModuleKey("toolchain_def", "1.0"), "module(name='toolchain_def',version='1.0')");
 
     // Everyone depends on toolchain_def@1.0 for the declare_toolchain macro.
-    Path toolchainDefDir = moduleRoot.getRelative("toolchain_def~1.0");
+    Path toolchainDefDir = moduleRoot.getRelative("toolchain_def~v1.0");
     scratch.file(toolchainDefDir.getRelative("WORKSPACE").getPathString());
     scratch.file(
         toolchainDefDir.getRelative("BUILD").getPathString(),
@@ -440,7 +440,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
         "        data = 'stuff')");
 
     // Now create the toolchains for each module.
-    for (String repo : ImmutableList.of("bbb~1.0", "ccc~1.1", "ddd~1.0", "ddd~1.1", "eee~1.0")) {
+    for (String repo : ImmutableList.of("bbb~v1.0", "ccc~v1.1", "ddd~v1.0", "ddd~v1.1", "eee~v1.0")) {
       scratch.file(moduleRoot.getRelative(repo).getRelative("WORKSPACE").getPathString());
       scratch.file(
           moduleRoot.getRelative(repo).getRelative("BUILD").getPathString(),

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -6158,8 +6158,8 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
 
   @Test
   public void testLabelWithStrictVisibility() throws Exception {
-    RepositoryName currentRepo = RepositoryName.createUnvalidated("module~1.2.3");
-    RepositoryName otherRepo = RepositoryName.createUnvalidated("dep~4.5");
+    RepositoryName currentRepo = RepositoryName.createUnvalidated("module~v1.2.3");
+    RepositoryName otherRepo = RepositoryName.createUnvalidated("dep~v4.5");
     Label bzlLabel =
         Label.create(
             PackageIdentifier.create(currentRepo, PathFragment.create("lib")), "label.bzl");
@@ -6178,14 +6178,14 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
             clientData);
 
     assertThat(eval(module, "Label('//foo:bar').workspace_root"))
-        .isEqualTo("external/module~1.2.3");
+        .isEqualTo("external/module~v1.2.3");
     assertThat(eval(module, "Label('@my_module//foo:bar').workspace_root"))
-        .isEqualTo("external/module~1.2.3");
-    assertThat(eval(module, "Label('@@module~1.2.3//foo:bar').workspace_root"))
-        .isEqualTo("external/module~1.2.3");
-    assertThat(eval(module, "Label('@dep//foo:bar').workspace_root")).isEqualTo("external/dep~4.5");
-    assertThat(eval(module, "Label('@@dep~4.5//foo:bar').workspace_root"))
-        .isEqualTo("external/dep~4.5");
+        .isEqualTo("external/module~v1.2.3");
+    assertThat(eval(module, "Label('@@module~v1.2.3//foo:bar').workspace_root"))
+        .isEqualTo("external/module~v1.2.3");
+    assertThat(eval(module, "Label('@dep//foo:bar').workspace_root")).isEqualTo("external/dep~v4.5");
+    assertThat(eval(module, "Label('@@dep~v4.5//foo:bar').workspace_root"))
+        .isEqualTo("external/dep~v4.5");
     assertThat(eval(module, "Label('@@//foo:bar').workspace_root")).isEqualTo("");
 
     assertThat(eval(module, "str(Label('@@//foo:bar'))")).isEqualTo("@@//foo:bar");
@@ -6195,13 +6195,13 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         .hasMessageThat()
         .isEqualTo(
             "'workspace_name' is not allowed on invalid Label @@[unknown repo '' requested from"
-                + " @@module~1.2.3]//foo:bar");
+                + " @@module~v1.2.3]//foo:bar");
     assertThat(
             assertThrows(
                 EvalException.class, () -> eval(module, "Label('@//foo:bar').workspace_root")))
         .hasMessageThat()
         .isEqualTo(
             "'workspace_root' is not allowed on invalid Label @@[unknown repo '' requested from"
-                + " @@module~1.2.3]//foo:bar");
+                + " @@module~v1.2.3]//foo:bar");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/starlarkbuildapi/core/ContextGuardedValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkbuildapi/core/ContextGuardedValueTest.java
@@ -58,7 +58,7 @@ public final class ContextGuardedValueTest {
   @Test
   public void bzlmodRepo_matchesStart() throws Exception {
     assertAllowed("@rules_foo~override//tools/lang", "@rules_foo//");
-    assertAllowed("@rules_foo~1.2.3//tools/lang", "@rules_foo//");
+    assertAllowed("@rules_foo~v1.2.3//tools/lang", "@rules_foo//");
   }
 
   @Test
@@ -91,7 +91,7 @@ public final class ContextGuardedValueTest {
     assertNotAllowed("@rules_cc_helper//tools/build_defs/cc", "@rules_cc//");
 
     // CC with Bzlmod
-    assertAllowed("@rules_cc~1.2.3~ext_name~local_cc_config//foo", "@local_cc_config//");
+    assertAllowed("@rules_cc~v1.2.3~ext_name~local_cc_config//foo", "@local_cc_config//");
   }
 
   private Object createClientData(String callerLabelStr) {

--- a/src/test/java/com/google/devtools/build/lib/util/ShellEscaperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/ShellEscaperTest.java
@@ -42,8 +42,8 @@ public class ShellEscaperTest {
     assertThat(escapeString("${filename%.c}.o")).isEqualTo("'${filename%.c}.o'");
     assertThat(escapeString("<html!>")).isEqualTo("'<html!>'");
     assertThat(escapeString("~not_home")).isEqualTo("'~not_home'");
-    assertThat(escapeString("external/protobuf~3.19.6/src/google"))
-        .isEqualTo("external/protobuf~3.19.6/src/google");
+    assertThat(escapeString("external/protobuf~v3.19.6/src/google"))
+        .isEqualTo("external/protobuf~v3.19.6/src/google");
     assertThat(escapeString("external/~install_dev_dependencies~foo/pkg"))
         .isEqualTo("external/~install_dev_dependencies~foo/pkg");
   }

--- a/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py
@@ -170,8 +170,8 @@ class BazelRepoMappingTest(test_base.TestBase):
 ,me,_main
 ,me_ws,_main
 foo~,foo,foo~
-foo~,quux,quux~1.0
-quux~1.0,quux,quux~1.0""",
+foo~,quux,quux~v1.0
+quux~v1.0,quux,quux~v1.0""",
         )
     with open(self.Path('bazel-bin/me.runfiles_manifest')) as f:
       self.assertIn('_repo_mapping ', f.read())
@@ -191,8 +191,8 @@ quux~1.0,quux,quux~1.0""",
         self.assertEqual(
             f.read().strip(),
             """bar~,bar,bar~
-bar~,quux,quux~2.0
-quux~2.0,quux,quux~2.0""",
+bar~,quux,quux~v2.0
+quux~v2.0,quux,quux~v2.0""",
         )
     with open(self.Path('bazel-bin/external/bar~/bar.runfiles_manifest')) as f:
       self.assertIn('_repo_mapping ', f.read())

--- a/src/test/py/bazel/bzlmod/external_repo_completion_test.py
+++ b/src/test/py/bazel/bzlmod/external_repo_completion_test.py
@@ -235,7 +235,7 @@ echo ${{COMPREPLY[*]}}
 
     # Canonical repo names are not completed.
     self.assertCountEqual([], self.complete('build @@'))
-    self.assertCountEqual([], self.complete('build @@foo~2.'))
+    self.assertCountEqual([], self.complete('build @@foo~v2.'))
 
     # Packages are completed in external repos with apparent repo names.
     self.assertCountEqual(
@@ -279,7 +279,7 @@ echo ${{COMPREPLY[*]}}
     )
 
     # Targets are completed in external repos with canonical repo names.
-    self.assertCountEqual(['lib_foo'], self.complete('build @@foo~2.0//:'))
+    self.assertCountEqual(['lib_foo'], self.complete('build @@foo~v2.0//:'))
     self.assertCountEqual(
         ['zipper'], self.complete('build @@ext~//tools/zip:zipp')
     )

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -504,7 +504,7 @@ class ModCommandTest(test_base.TestBase):
             'mod',
             'dump_repo_mapping',
             '',
-            'foo~2.0',
+            'foo~v2.0',
         ],
     )
     root_mapping, foo_mapping = [json.loads(l) for l in stdout]
@@ -512,8 +512,8 @@ class ModCommandTest(test_base.TestBase):
     self.assertContainsSubset(
         {
             'my_project': '',
-            'foo1': 'foo~1.0',
-            'foo2': 'foo~2.0',
+            'foo1': 'foo~v1.0',
+            'foo2': 'foo~v2.0',
             'myrepo2': 'ext2~~ext~repo1',
             'bazel_tools': 'bazel_tools',
         }.items(),
@@ -522,7 +522,7 @@ class ModCommandTest(test_base.TestBase):
 
     self.assertContainsSubset(
         {
-            'foo': 'foo~2.0',
+            'foo': 'foo~v2.0',
             'ext_mod': 'ext~',
             'my_repo3': 'ext~~ext~repo3',
             'bazel_tools': 'bazel_tools',

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 7,
+  "lockFileVersion": 8,
   "moduleFileHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "flags": {
     "cmdRegistries": [


### PR DESCRIPTION
When a `PathFragment` is created on Windows and one of its segments looks like a Windows short path, additional file I/O is performed to resolve it to its long form. Certain Bzlmod-managed repository names could look like such paths, which potentially slows down analysis. Instead, prepend a `v` to the version of multi-version modules to avoid this.

Requires bumping the lockfile version as canonical label literals may be embedded in lockfiles.