### PR TITLE
Doc update for root package_name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkNativeModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkNativeModuleApi.java
@@ -231,7 +231,8 @@ public interface StarlarkNativeModuleApi extends StarlarkValue {
               + "For example, in the BUILD file <code>some/package/BUILD</code>, its value "
               + "will be <code>some/package</code>. "
               + "If the BUILD file calls a function defined in a .bzl file, "
-              + "<code>package_name()</code> will match the caller BUILD file package.",
+              + "<code>package_name()</code> will match the caller BUILD file package."
+              + "The value will always be an empty string for the root package.",
       useStarlarkThread = true)
   String packageName(StarlarkThread thread) throws EvalException;
 


### PR DESCRIPTION
Adding a note to the docs for `native.package_name()`. 

From the root package this will always return an empty string.