### PR TITLE
Improve sh_test execution compatibility on MacOS

### DIFF
--- a/src/test/shell/integration_test_setup.sh
+++ b/src/test/shell/integration_test_setup.sh
@@ -46,8 +46,8 @@ else
 
   CURRENT_SCRIPT=${BASH_SOURCE[0]}
   # Go to the directory where the script is running
-  cd "$(dirname ${CURRENT_SCRIPT})" \
-    || print_message_and_exit "Unable to access $(dirname ${CURRENT_SCRIPT})"
+  cd "$(dirname "${CURRENT_SCRIPT}")" \
+    || print_message_and_exit "Unable to access $(dirname "${CURRENT_SCRIPT}")"
 
   DIR=$(pwd)
   # Load the unit test framework

--- a/src/test/shell/testenv.sh.tmpl
+++ b/src/test/shell/testenv.sh.tmpl
@@ -260,7 +260,7 @@ function setup_localjdk_javabase() {
   if [[ $PLATFORM =~ msys ]]; then
     jdk_dir="$(cygpath -m $(cd $(rlocation local_jdk/bin/java.exe)/../..; pwd))"
   else
-    jdk_dir="$(dirname $(dirname $(rlocation local_jdk/bin/java)))"
+    jdk_dir="$(dirname "$(dirname "$(rlocation local_jdk/bin/java)")")"
   fi
   bazel_javabase="${jdk_dir}"
 }


### PR DESCRIPTION
While working on #22213 I ran into errors running any `sh_test`, all invocations terminated without running any of the tests, and ended with these two lines:
```
usage: dirname string [...]
usage: dirname string [...]
```

I'm working on an arm-based Mac with MacOS Sonoma 14.4.1 and with bash reporting a version of GNU bash, version 3.2.57(1)-release.

This PR adds quotes to `dirname` arguments to resolve the `sh_test` execution failures.
