### PR TITLE
feat(java_library): handle output dirs in resources attribute

### DIFF
--- a/src/main/cpp/util/file.cc
+++ b/src/main/cpp/util/file.cc
@@ -93,6 +93,13 @@ bool WriteFile(const std::string &content, const Path &path,
   return WriteFile(content.c_str(), content.size(), path, perm);
 }
 
+CallbackDirEntryConsumer::CallbackDirEntryConsumer(
+  std::function<void(const std::string&)> adder_callback) : _adder_callback(adder_callback) {}
+
+void CallbackDirEntryConsumer::Consume(const std::string &path, bool is_directory) {
+  _adder_callback(path);
+}
+
 class DirectoryTreeWalker : public DirectoryEntryConsumer {
  public:
   DirectoryTreeWalker(vector<string> *files,

--- a/src/main/cpp/util/file.h
+++ b/src/main/cpp/util/file.h
@@ -14,6 +14,7 @@
 #ifndef BAZEL_SRC_MAIN_CPP_UTIL_FILE_H_
 #define BAZEL_SRC_MAIN_CPP_UTIL_FILE_H_
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -77,6 +78,14 @@ void GetAllFilesUnder(const std::string &path,
                       std::vector<std::string> *result);
 
 class DirectoryEntryConsumer;
+
+class CallbackDirEntryConsumer : public DirectoryEntryConsumer {
+ public:
+  CallbackDirEntryConsumer(std::function<void(const std::string&)> adder_callback);
+  void Consume(const std::string &path, bool is_directory) override;
+ private:
+  const std::function<void(const std::string&)> _adder_callback;
+};
 
 // Visible for testing only.
 typedef void (*_ForEachDirectoryEntry)(const std::string &path,

--- a/src/tools/singlejar/output_jar_shell_test.sh
+++ b/src/tools/singlejar/output_jar_shell_test.sh
@@ -74,6 +74,29 @@ function test_empty_resource_file() {
   "$singlejar" --output "$out_jar" --resources $empty
 }
 
+function test_directory_tree() {
+  cd "$TEST_TMPDIR"
+  local -r out_jar="out.jar"
+  local -r dir1="dir1"
+  local -r dir2="dir1/dir2"
+  local -r file1="${dir1}/file1"
+  local -r file2="${dir2}/file2"
+  mkdir "$dir1"
+  mkdir "$dir2"
+  echo -n > "$file1"
+  echo -n > "$file2"
+  "$singlejar" --output "$out_jar" --resources "$dir1"
+  local -r unzipped_dir="unzipped"
+  mkdir "$unzipped_dir"
+  unzip -d "$unzipped_dir" "$out_jar" "$file1" "$file2"
+  [[ -r "${unzipped_dir}/${file1}" ]] || \
+    { echo "${unzipped_dir}/${file1} is not readable" >&2; exit 1; }
+  [[ -r "${unzipped_dir}/${file2}" ]] || \
+    { echo "${unzipped_dir}/${file2} is not readable" >&2; exit 1; }
+}
+
+
+
 run_suite "Misc shell tests"
 #!/bin/bash
 


### PR DESCRIPTION
Passing output directories to the `resources` attribute of `java_library` now adds the contents of that output directory to the resulting jar, not just the directory itself.

Fixes #11996