### PR TITLE
Exit if `--experimental_remote_output_service` is set, but not `--remote_cache` 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BazelOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/BazelOutputService.java
@@ -80,7 +80,9 @@ public class BazelOutputService implements OutputService {
   private final Supplier<Path> execRootSupplier;
   private final Supplier<Path> outputPathSupplier;
   private final DigestFunction.Value digestFunction;
-  private final RemoteOptions remoteOptions;
+  private final String remoteCache;
+  private final String remoteInstanceName;
+  private final String remoteOutputServiceOutputPathPrefix;
   private final boolean verboseFailures;
   private final RemoteRetrier retrier;
   private final ReferenceCountedChannel channel;
@@ -93,7 +95,9 @@ public class BazelOutputService implements OutputService {
       Supplier<Path> execRootSupplier,
       Supplier<Path> outputPathSupplier,
       DigestFunction.Value digestFunction,
-      RemoteOptions remoteOptions,
+      String remoteCache,
+      String remoteInstanceName,
+      String remoteOutputServiceOutputPathPrefix,
       boolean verboseFailures,
       RemoteRetrier retrier,
       ReferenceCountedChannel channel) {
@@ -101,7 +105,9 @@ public class BazelOutputService implements OutputService {
     this.execRootSupplier = execRootSupplier;
     this.outputPathSupplier = outputPathSupplier;
     this.digestFunction = digestFunction;
-    this.remoteOptions = remoteOptions;
+    this.remoteCache = remoteCache;
+    this.remoteInstanceName = remoteInstanceName;
+    this.remoteOutputServiceOutputPathPrefix = remoteOutputServiceOutputPathPrefix;
     this.verboseFailures = verboseFailures;
     this.retrier = retrier;
     this.channel = channel;
@@ -187,7 +193,7 @@ public class BazelOutputService implements OutputService {
       throws AbruptExitException, InterruptedException {
     checkState(this.buildId == null, "this.buildId must be null");
     this.buildId = buildId.toString();
-    var outputPathPrefix = PathFragment.create(remoteOptions.remoteOutputServiceOutputPathPrefix);
+    var outputPathPrefix = PathFragment.create(remoteOutputServiceOutputPathPrefix);
     if (!outputPathPrefix.isEmpty() && !outputPathPrefix.isAbsolute()) {
       throw new AbruptExitException(
           DetailedExitCode.of(
@@ -212,8 +218,8 @@ public class BazelOutputService implements OutputService {
             .setArgs(
                 Any.pack(
                     StartBuildArgs.newBuilder()
-                        .setRemoteCache(remoteOptions.remoteCache)
-                        .setInstanceName(remoteOptions.remoteInstanceName)
+                        .setRemoteCache(remoteCache)
+                        .setInstanceName(remoteInstanceName)
                         .setDigestFunction(digestFunction)
                         .build()))
             .setOutputPathPrefix(outputPathPrefix.toString())

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -75,6 +75,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,6 +86,7 @@ import org.junit.runners.JUnit4;
 public final class RemoteModuleTest {
   private static final String EXECUTION_SERVER_NAME = "execution-server";
   private static final String CACHE_SERVER_NAME = "cache-server";
+  private static final String OUTPUT_SERVICE_SERVER_NAME = "output-service";
   private static final ServerCapabilities CACHE_ONLY_CAPS =
       ServerCapabilities.newBuilder()
           .setLowApiVersion(ApiVersion.low.toSemVer())
@@ -517,6 +519,21 @@ public final class RemoteModuleTest {
     } finally {
       cacheServer.shutdownNow();
       cacheServer.awaitTermination();
+    }
+  }
+
+  @Test
+  public void bazelOutputService_noRemoteCache_exit() throws Exception {
+    Server outputServiceService = createFakeServer(OUTPUT_SERVICE_SERVER_NAME);
+    try {
+    remoteOptions.remoteOutputService = OUTPUT_SERVICE_SERVER_NAME;
+
+    var exception = Assert.assertThrows(AbruptExitException.class, this::beforeCommand);
+
+    assertThat(exception).hasMessageThat().contains("--experimental_remote_output_service");
+    } finally{
+      outputServiceService.shutdownNow();
+      outputServiceService.awaitTermination();
     }
   }
 


### PR DESCRIPTION
... nor `--remote_executor`.

Working towards #21630.