### PR TITLE
Store lastBuildId and compare it with the one in StartBuildResponse

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -138,6 +138,7 @@ public final class RemoteModule extends BlazeModule {
   @Nullable private TempPathGenerator tempPathGenerator;
   @Nullable private BlockWaitingModule blockWaitingModule;
   @Nullable private RemoteOutputChecker remoteOutputChecker;
+  @Nullable private String lastBuildId;
 
   private ChannelFactory channelFactory =
       new ChannelFactory() {
@@ -473,7 +474,8 @@ public final class RemoteModule extends BlazeModule {
               remoteOptions.remoteOutputServiceOutputPathPrefix,
               verboseFailures,
               retrier,
-              bazelOutputServiceChannel);
+              bazelOutputServiceChannel,
+              lastBuildId);
     } else {
       outputService = new RemoteOutputService(env);
     }
@@ -918,6 +920,8 @@ public final class RemoteModule extends BlazeModule {
       blockWaitingModule.submit(
           () -> afterCommandTask(actionContextProviderRef, tempPathGeneratorRef, rpcLogFileRef));
     }
+
+    lastBuildId = Preconditions.checkNotNull(env).getCommandId().toString();
 
     buildEventArtifactUploaderFactoryDelegate.reset();
     repositoryRemoteExecutorFactoryDelegate.reset();


### PR DESCRIPTION
So we don't use stale `StartBuildResponse` from the output service.

Working towards #21630.