### PR TITLE
[7.2.0] Treat an IOException while logging a spawn as an error instead of a warning.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -44,7 +44,6 @@ import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
 import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.UserExecException;
-import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.exec.Protos.Digest;
 import com.google.devtools.build.lib.exec.SpawnCache.CacheHandle;
@@ -198,11 +197,16 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
                 : actionExecutionContext.getExecRoot().getFileSystem(),
             context.getTimeout(),
             spawnResult);
-      } catch (IOException | ForbiddenActionInputException e) {
-        actionExecutionContext
-            .getEventHandler()
-            .handle(
-                Event.warn("Exception " + e + " while logging properties of " + spawn.toString()));
+      } catch (IOException e) {
+        throw new EnvironmentalExecException(
+            e,
+            FailureDetail.newBuilder()
+                .setMessage("IOException while logging spawn")
+                .setSpawn(FailureDetails.Spawn.newBuilder().setCode(Code.SPAWN_LOG_IO_EXCEPTION))
+                .build());
+      } catch (ForbiddenActionInputException e) {
+        // Should have already been thrown during execution.
+        throw new IllegalStateException("ForbiddenActionInputException while logging spawn", e);
       }
     }
     if (ex != null) {

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -227,6 +227,7 @@ message Spawn {
     UNSPECIFIED_EXECUTION_FAILURE = 12 [(metadata) = { exit_code: 1 }];
     FORBIDDEN_INPUT = 13 [(metadata) = { exit_code: 1 }];
     REMOTE_CACHE_EVICTED = 14 [(metadata) = { exit_code: 39 }];
+    SPAWN_LOG_IO_EXCEPTION = 15 [(metadata) = { exit_code: 36 }];
   }
   Code code = 1;
 


### PR DESCRIPTION
Although failing to write a log does not in principle affect the ability to build successfully, treating it as a warning hides problems and makes debugging them difficult (see e.g. https://github.com/bazelbuild/bazel/issues/21820). Spawn log implementations must be able to inspect the spawn inputs even if they're not present on disk (when building without the bytes) by using in-memory data.

PiperOrigin-RevId: 631042310
Change-Id: Iabe48e524dcd77bc434037c3396956f30174f57f