### PR TITLE
Replace `INFO` with `FINE` logging in `CoverageOutputGenerator`

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -217,9 +217,9 @@ public class Main {
   private static List<File> getGcovInfoFiles(List<File> filesInCoverageDir) {
     List<File> gcovFiles = getFilesWithExtension(filesInCoverageDir, GCOV_EXTENSION);
     if (gcovFiles.isEmpty()) {
-      logger.log(Level.INFO, "No gcov info file found.");
+      logger.log(Level.FINE, "No gcov info file found.");
     } else {
-      logger.log(Level.INFO, "Found " + gcovFiles.size() + " gcov info files.");
+      logger.log(Level.FINE, "Found " + gcovFiles.size() + " gcov info files.");
     }
     return gcovFiles;
   }
@@ -227,9 +227,9 @@ public class Main {
   private static List<File> getGcovJsonInfoFiles(List<File> filesInCoverageDir) {
     List<File> gcovJsonFiles = getFilesWithExtension(filesInCoverageDir, GCOV_JSON_EXTENSION);
     if (gcovJsonFiles.isEmpty()) {
-      logger.log(Level.INFO, "No gcov json file found.");
+      logger.log(Level.FINE, "No gcov json file found.");
     } else {
-      logger.log(Level.INFO, "Found " + gcovJsonFiles.size() + " gcov json files.");
+      logger.log(Level.FINE, "Found " + gcovJsonFiles.size() + " gcov json files.");
     }
     return gcovJsonFiles;
   }
@@ -241,7 +241,7 @@ public class Main {
   private static File getProfdataFileOrNull(List<File> files) {
     List<File> profdataFiles = getFilesWithExtension(files, PROFDATA_EXTENSION);
     if (profdataFiles.isEmpty()) {
-      logger.log(Level.INFO, "No .profdata file found.");
+      logger.log(Level.FINE, "No .profdata file found.");
       return null;
     }
     if (profdataFiles.size() > 1) {
@@ -252,7 +252,7 @@ public class Main {
               + " .profadata files were found instead.");
       return null;
     }
-    logger.log(Level.INFO, "Found one .profdata file.");
+    logger.log(Level.FINE, "Found one .profdata file.");
     return profdataFiles.get(0);
   }
 
@@ -264,9 +264,9 @@ public class Main {
       lcovTracefiles = getFilesWithExtension(filesInCoverageDir, TRACEFILE_EXTENSION);
     }
     if (lcovTracefiles.isEmpty()) {
-      logger.log(Level.INFO, "No lcov file found.");
+      logger.log(Level.FINE, "No lcov file found.");
     } else {
-      logger.log(Level.INFO, "Found " + lcovTracefiles.size() + " tracefiles.");
+      logger.log(Level.FINE, "Found " + lcovTracefiles.size() + " tracefiles.");
     }
     return lcovTracefiles;
   }
@@ -310,7 +310,7 @@ public class Main {
     Coverage coverage = new Coverage();
     for (File file : files) {
       try {
-        logger.log(Level.INFO, "Parsing file " + file);
+        logger.log(Level.FINE, "Parsing file " + file);
         List<SourceFileCoverage> sourceFilesCoverage = parser.parse(new FileInputStream(file));
         for (SourceFileCoverage sourceFileCoverage : sourceFilesCoverage) {
           coverage.add(sourceFileCoverage);


### PR DESCRIPTION
This reduces unconditional log spam for coverage report actions. If needed, users can configure the loglevel by wrapping the `CoverageOutputGenerator` jar into a `java_binary` with appropriate `jvmopts`.