### PR TITLE
Reduce coverage log spam

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -310,7 +310,7 @@ public class Main {
     Coverage coverage = new Coverage();
     for (File file : files) {
       try {
-        logger.log(Level.INFO, "Parsing file " + file);
+        logger.log(Level.FINE, "Parsing file" + file);
         List<SourceFileCoverage> sourceFilesCoverage = parser.parse(new FileInputStream(file));
         for (SourceFileCoverage sourceFileCoverage : sourceFilesCoverage) {
           coverage.add(sourceFileCoverage);


### PR DESCRIPTION
Given a large enough scope, the `coverageoutputgenerator` produces lots of log lines that are not really meaningful.
```
Apr 19, 2024 4:14:03 PM com.google.devtools.coverageoutputgenerator.Main parseFilesSequentially
INFO: Parsing file bazel-out/k8-fastbuild/testlogs/X/Y/Z/coverage.dat
Apr 19, 2024 4:14:03 PM com.google.devtools.coverageoutputgenerator.Main parseFilesSequentially
INFO: Parsing file bazel-out/k8-fastbuild/testlogs/A/B/C/coverage.dat
```

This PR changes the log level to make it less verbose by default.