### PR TITLE
[7.2.0] Store lastBuildId and compare it with the one in StartBuildResponse

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -138,6 +138,7 @@ public final class RemoteModule extends BlazeModule {
   @Nullable private TempPathGenerator tempPathGenerator;
   @Nullable private BlockWaitingModule blockWaitingModule;
   @Nullable private RemoteOutputChecker remoteOutputChecker;
+  @Nullable private String lastBuildId;
 
   private ChannelFactory channelFactory =
       new ChannelFactory() {
@@ -471,7 +472,8 @@ public final class RemoteModule extends BlazeModule {
               remoteOptions.remoteOutputServiceOutputPathPrefix,
               verboseFailures,
               retrier,
-              bazelOutputServiceChannel);
+              bazelOutputServiceChannel,
+              lastBuildId);
     } else {
       outputService = new RemoteOutputService(env);
     }
@@ -917,6 +919,8 @@ public final class RemoteModule extends BlazeModule {
       blockWaitingModule.submit(
           () -> afterCommandTask(actionContextProviderRef, tempPathGeneratorRef, rpcLogFileRef));
     }
+
+    lastBuildId = Preconditions.checkNotNull(env).getCommandId().toString();
 
     buildEventArtifactUploaderFactoryDelegate.reset();
     repositoryRemoteExecutorFactoryDelegate.reset();


### PR DESCRIPTION
So we don't use stale `StartBuildResponse` from the output service.

Working towards #21630.

Closes #22252.

PiperOrigin-RevId: 631086641
Change-Id: I8924ceae8a489b156a9ac7d2258193b0f0252d94

Commit https://github.com/bazelbuild/bazel/commit/a5bb1f0510b5aecec1295d31100aec4db6c7e817