### PR TITLE
SpawnLogModule: fix wrong zstd extension

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 
 /** Module providing on-demand spawn logging. */
 public final class SpawnLogModule extends BlazeModule {
-  private static final String EXEC_LOG_FILENAME = "execution_log.binpb.zstd";
+  private static final String EXEC_LOG_FILENAME = "execution_log.binpb.zst";
 
   @Nullable private SpawnLogContext spawnLogContext;
   @Nullable private Path outputPath;


### PR DESCRIPTION
I accidentally added a 'd'.
