### PR TITLE
Add start time to execlog `Spawn`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.XattrProvider;
 import com.google.protobuf.util.Durations;
+import com.google.protobuf.util.Timestamps;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
@@ -234,6 +235,9 @@ public abstract class SpawnLogContext implements ActionContext {
     builder.setMemoryBytesLimit(metrics.memoryLimit());
     if (metrics.timeLimitInMs() != 0L) {
       builder.setTimeLimit(millisToProto(metrics.timeLimitInMs()));
+    }
+    if (result.getStartTime() != null) {
+      builder.setStartTime(Timestamps.fromMillis(result.getStartTime().toEpochMilli()));
     }
     return builder.build();
   }

--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -300,6 +300,7 @@ proto_library(
     srcs = ["spawn.proto"],
     deps = [
         "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package tools.protos;
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 option java_package = "com.google.devtools.build.lib.exec";
 option java_outer_classname = "Protos";
@@ -111,6 +112,8 @@ message SpawnMetrics {
   int64 memory_bytes_limit = 18;
   // Time limit or 0 if unavailable.
   google.protobuf.Duration time_limit = 19;
+  // Instant when the spawn started to execute.
+  google.protobuf.Timestamp start_time = 20;
 }
 
 // Details of an executed spawn.

--- a/src/test/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/exec/BUILD
@@ -87,6 +87,7 @@ java_library(
         "//third_party:junit4",
         "//third_party:mockito",
         "//third_party:truth",
+        "@com_google_protobuf//java/util",
         "@maven//:com_google_testparameterinjector_test_parameter_injector",
         "@zstd-jni",
     ],

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -61,9 +61,12 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.protobuf.util.Timestamps;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
@@ -898,18 +901,22 @@ public abstract class SpawnLogContextTestBase {
 
     SpawnLogContext context = createSpawnLogContext();
 
+    Instant now = Instant.now();
     context.logSpawn(
         defaultSpawn(),
         createInputMetadataProvider(),
         createInputMap(),
         fs,
         defaultTimeout(),
-        defaultSpawnResultBuilder().setSpawnMetrics(metrics).build());
+        defaultSpawnResultBuilder().setSpawnMetrics(metrics).setStartTime(now).build());
 
     closeAndAssertLog(
         context,
         defaultSpawnExecBuilder()
-            .setMetrics(Protos.SpawnMetrics.newBuilder().setTotalTime(millisToProto(1)))
+            .setMetrics(
+                Protos.SpawnMetrics.newBuilder()
+                    .setTotalTime(millisToProto(1))
+                    .setStartTime(Timestamps.fromDate(Date.from(now))))
             .build());
   }
 


### PR DESCRIPTION
RELNOTES: The compact and full execution logs now contain start times for spawns (if available).