### PR TITLE
ExecLogEntry: add start_time to compact exec log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.XattrProvider;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.protobuf.util.Timestamps;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
@@ -238,6 +239,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
         }
       }
 
+      builder.setStartTime(Timestamps.fromMillis(result.getStartTime().toEpochMilli()));
       builder.setExitCode(result.exitCode());
       if (result.status() != SpawnResult.Status.SUCCESS) {
         builder.setStatus(result.status().toString());

--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -300,6 +300,7 @@ proto_library(
     srcs = ["spawn.proto"],
     deps = [
         "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package tools.protos;
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 option java_package = "com.google.devtools.build.lib.exec";
 option java_outer_classname = "Protos";
@@ -335,6 +336,9 @@ message ExecLogEntry {
 
     // See SpawnExec.metrics.
     SpawnMetrics metrics = 18;
+
+    // Time the spawn execution started.
+    google.protobuf.Timestamp start_time = 19;
   }
 
   // The entry ID. Must be nonzero.


### PR DESCRIPTION
It might be desirable for end users to rely on the compact exec log to
know more about the execution of each action. Thanks to the attached
SpawnMetrics, the total execution time is already known.

Add a time stamp indicating when action execution started for a more
complete picture.
