### PR TITLE
[7.2.0] Improve error message when parsing an invalid visibility label, e.g. //visibility:none

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/RuleVisibility.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleVisibility.java
@@ -132,14 +132,22 @@ public interface RuleVisibility {
   }
 
   static void validate(List<Label> labels) throws EvalException {
-    if (labels.size() <= 1) {
-      return;
-    }
     for (Label label : labels) {
       if (label.equals(PUBLIC_LABEL) || label.equals(PRIVATE_LABEL)) {
+        if (labels.size() > 1) {
+          throw Starlark.errorf(
+              "//visibility:public and //visibility:private cannot be used in combination with"
+                  + " other labels");
+        }
+      } else if (label.getPackageIdentifier().equals(PUBLIC_LABEL.getPackageIdentifier())
+          && PackageSpecification.fromLabel(label) == null) {
+        // In other words, if the label is in //visibility and is not //visibility:public,
+        // //visibility:private, or (for the unusual case where //visibility
+        // exists as a package) //visibility:__pkg__ or //visibility:__subpackages__
         throw Starlark.errorf(
-            "Public or private visibility labels (e.g. //visibility:public or"
-                + " //visibility:private) cannot be used in combination with other labels");
+            "Invalid visibility label '%s'; did you mean //visibility:public or"
+                + " //visibility:private?",
+            label);
       }
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleTest.java
@@ -19,6 +19,7 @@ import static com.google.devtools.build.lib.packages.util.TargetDataSubject.asse
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.packages.util.PackageLoadingTestCase;
 import com.google.devtools.build.lib.skyframe.serialization.SerializationException;
@@ -83,6 +84,113 @@ public class RuleTest extends PackageLoadingTestCase {
     Package pkg = getTarget("//x:BUILD").getPackage();
     assertThat(pkg.getRule("pu").getVisibility()).isEqualTo(RuleVisibility.PUBLIC);
     assertThat(pkg.getRule("pr").getVisibility()).isEqualTo(RuleVisibility.PRIVATE);
+  }
+
+  @Test
+  public void testVisibilityTypo_failsCleanly() throws Exception {
+    scratch.file(
+        "x/BUILD",
+        """
+        cc_binary(
+            name = "typo",
+            visibility = ["//visibility:none"],
+        )
+        """);
+    reporter.removeHandler(failFastHandler);
+    Package pkg = getTarget("//x:BUILD").getPackage();
+    assertContainsEvent(
+        "Invalid visibility label '//visibility:none'; did you mean //visibility:public or"
+            + " //visibility:private?");
+    assertThat(pkg.containsErrors()).isTrue();
+  }
+
+  @Test
+  public void testVisibilityTypo_whenVisibilityPackageExists_failsCleanly() throws Exception {
+    scratch.file(
+        "visibility/BUILD",
+        """
+        cc_binary(
+            name = "none",
+        )
+        """);
+    scratch.file(
+        "x/BUILD",
+        """
+        cc_binary(
+            name = "typo",
+            visibility = ["//visibility:none"],
+        )
+        """);
+    assertThat(getTarget("//visibility:BUILD").getPackage().containsErrors()).isFalse();
+    reporter.removeHandler(failFastHandler);
+    Package pkg = getTarget("//x:BUILD").getPackage();
+    assertContainsEvent(
+        "Invalid visibility label '//visibility:none'; did you mean //visibility:public or"
+            + " //visibility:private?");
+    assertThat(pkg.containsErrors()).isTrue();
+  }
+
+  @Test
+  public void testVisibilityPkgSubpackages_whenVisibilityPackageExists_succeeds() throws Exception {
+    scratch.file(
+        "visibility/BUILD",
+        """
+        cc_binary(
+            name = "none",
+        )
+        """);
+    scratch.file(
+        "x/BUILD",
+        """
+        cc_binary(
+            name = "p",
+            visibility = ["//visibility:__pkg__"],
+        )
+
+        cc_binary(
+            name = "s",
+            visibility = ["//visibility:__subpackages__"],
+        )
+        """);
+    assertThat(getTarget("//visibility:BUILD").getPackage().containsErrors()).isFalse();
+    Package pkg = getTarget("//x:BUILD").getPackage();
+    assertThat(pkg.containsErrors()).isFalse();
+    assertThat(pkg.getRule("p").getVisibility().getDeclaredLabels())
+        .containsExactly(Label.parseCanonicalUnchecked("//visibility:__pkg__"));
+    assertThat(pkg.getRule("s").getVisibility().getDeclaredLabels())
+        .containsExactly(Label.parseCanonicalUnchecked("//visibility:__subpackages__"));
+  }
+
+  @Test
+  public void testVisibilityInvalidCombination() throws Exception {
+    scratch.file(
+        "x/BUILD",
+        """
+        cc_binary(
+            name = "is_this_public",
+            visibility = ["//some:__pkg__", "//visibility:public"],
+        )
+        """);
+    scratch.file(
+        "y/BUILD",
+        """
+        cc_binary(
+            name = "is_this_private",
+            visibility = ["//other:__subpackages__", "//visibility:private"],
+        )
+        """);
+    reporter.removeHandler(failFastHandler);
+    Package pkgX = getTarget("//x:BUILD").getPackage();
+    assertContainsEvent(
+        "//visibility:public and //visibility:private cannot be used in combination with other"
+            + " labels");
+    assertThat(pkgX.containsErrors()).isTrue();
+    eventCollector.clear();
+    Package pkgY = getTarget("//y:BUILD").getPackage();
+    assertContainsEvent(
+        "//visibility:public and //visibility:private cannot be used in combination with other"
+            + " labels");
+    assertThat(pkgY.containsErrors()).isTrue();
   }
 
   @Test

--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -523,7 +523,7 @@ cc_library(
 EOF
 
   bazel build //visibility:foo &> $TEST_log && fail "Expected failure" || true
-  expect_log "Public or private visibility labels (e.g. //visibility:public or //visibility:private) cannot be used in combination with other labels"
+  expect_log "//visibility:public and //visibility:private cannot be used in combination with other labels"
 }
 
 function test_executable_without_default_files() {


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/22279

PiperOrigin-RevId: 631778635
Change-Id: I56e6caa3c1e8eb2d00467f5173564d30146bba4a

Commit https://github.com/bazelbuild/bazel/commit/772f10346e9c847402fde973b59f17b632e3ac22