### PR TITLE
[7.2.0] Forward min_sdk_version to dexmerger actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
@@ -1891,7 +1891,8 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
           ruleContext.getTreeArtifact(
               ruleContext.getUniqueDirectory("dexfiles"), ruleContext.getBinOrGenfilesDirectory());
       FilesToRunProvider dexMerger = ruleContext.getExecutablePrerequisite("$dexmerger");
-      createTemplatedMergerActions(ruleContext, multidexShards, shardsToMerge, dexopts, dexMerger);
+      createTemplatedMergerActions(
+          ruleContext, multidexShards, shardsToMerge, dexopts, dexMerger, minSdkVersion);
       // TODO(b/69431301): avoid this action and give the files to apk build action directly
       createZipMergeAction(ruleContext, multidexShards, classesDex);
     }
@@ -2022,7 +2023,8 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
       SpecialArtifact outputTree,
       SpecialArtifact inputTree,
       List<String> dexopts,
-      FilesToRunProvider executable) {
+      FilesToRunProvider executable,
+      int minSdkVersion) {
     SpawnActionTemplate.Builder dexmerger =
         new SpawnActionTemplate.Builder(inputTree, outputTree)
             .setExecutable(executable)
@@ -2039,6 +2041,9 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
                     ruleContext,
                     Iterables.filter(
                         dexopts, Predicates.not(Predicates.equalTo(DX_MINIMAL_MAIN_DEX_OPTION)))));
+    if (minSdkVersion > 0) {
+      commandLine.add("--min_sdk_version", Integer.toString(minSdkVersion));
+    }
     dexmerger.setCommandLineTemplate(commandLine.build());
     ruleContext.registerAction(dexmerger.build(ruleContext.getActionOwner()));
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkCommon.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.starlarkbuildapi.android.AndroidStarlarkCom
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Sequence;
+import net.starlark.java.eval.StarlarkInt;
 
 /** Common utilities for Starlark rules related to Android. */
 public class AndroidStarlarkCommon
@@ -87,14 +88,16 @@ public class AndroidStarlarkCommon
       Artifact output,
       Artifact input,
       Sequence<?> dexopts, // <String> expected.
-      FilesToRunProvider dexmerger)
+      FilesToRunProvider dexmerger,
+      StarlarkInt minSdkVersion)
       throws EvalException, RuleErrorException {
     AndroidBinary.createTemplatedMergerActions(
         starlarkRuleContext.getRuleContext(),
         (SpecialArtifact) output,
         (SpecialArtifact) input,
         Sequence.cast(dexopts, String.class, "dexopts"),
-        dexmerger);
+        dexmerger,
+        minSdkVersion.toInt("min_sdk_version"));
   }
 
   @StarlarkMethod(name = AndroidIdeInfoProviderApi.NAME, structField = true, documented = false)

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidStarlarkCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidStarlarkCommonApi.java
@@ -29,6 +29,7 @@ import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Sequence;
+import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkValue;
 
 /** Common utilities for Starlark rules related to Android. */
@@ -147,13 +148,23 @@ public interface AndroidStarlarkCommonApi<
             doc = "A FilesToRunProvider to be used for dex merging.",
             positional = false,
             named = true,
-            allowedTypes = {@ParamType(type = FilesToRunProviderApi.class)})
+            allowedTypes = {@ParamType(type = FilesToRunProviderApi.class)}),
+        @Param(
+            name = "min_sdk_version",
+            doc = "The minSdkVersion the dexes were built for.",
+            positional = false,
+            named = true,
+            defaultValue = "0",
+            allowedTypes = {
+              @ParamType(type = StarlarkInt.class),
+            })
       })
   void createDexMergerActions(
       StarlarkRuleContextT starlarkRuleContext,
       FileT output,
       FileT input,
       Sequence<?> dexopts, // <String> expected.
-      FilesToRunProviderT dexmerger)
+      FilesToRunProviderT dexmerger,
+      StarlarkInt minSdkVersion)
       throws EvalException, RuleErrorException;
 }


### PR DESCRIPTION
We call DexMerger via SpawnActionTemplate which is only available in native Blaze. So we must expose the parameter to the Starlark API.

PiperOrigin-RevId: 604482423
Change-Id: I2c9c165373d35cb1f7a6f928c11839b201973bed

Commit https://github.com/bazelbuild/bazel/commit/84861027d3f94ce6fc0bcf25ebbb787d6be8567a