### PR TITLE
[7.2.0] Fix wrong zstd extension in SpawnLogModule.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 
 /** Module providing on-demand spawn logging. */
 public final class SpawnLogModule extends BlazeModule {
-  private static final String EXEC_LOG_FILENAME = "execution_log.binpb.zstd";
+  private static final String EXEC_LOG_FILENAME = "execution_log.binpb.zst";
 
   @Nullable private SpawnLogContext spawnLogContext;
   @Nullable private Path outputPath;


### PR DESCRIPTION
I accidentally added a 'd'.

Closes #22280.

PiperOrigin-RevId: 632109445
Change-Id: I1cacbb1f05040d97c2e0418e307bb9883d3d426f

Commit https://github.com/bazelbuild/bazel/commit/b8eb437521374acd1f0047fac1b7ca980cc7e179