### PR TITLE
[7.2.0] Fix inheritance of environment variables in WindowsSubprocessFactory.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/shell/Command.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/Command.java
@@ -176,10 +176,10 @@ public final class Command implements DescribableExecutionUnit {
    * </ul>
    *
    * @param commandLineElements elements of raw command line to execute
-   * @param environmentVariables environment variables to replace JVM's environment variables; may
-   *     be null
-   * @param workingDirectory working directory for execution; if null, the VM's current working
-   *     directory is used
+   * @param environmentVariables environment variables for the child process, or null to inherit
+   *     them from the parent
+   * @param workingDirectory working directory for the child process, or null to inherit it from the
+   *     parent
    * @param timeout timeout; a value less than or equal to 0 is treated as no timeout
    * @throws IllegalArgumentException if commandLine is null or empty
    */

--- a/src/main/java/com/google/devtools/build/lib/shell/SubprocessBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/SubprocessBuilder.java
@@ -125,7 +125,7 @@ public class SubprocessBuilder {
 
   /**
    * Sets the environment passed to the child process. If null, inherit the environment of the
-   * server.
+   * parent. The default is to inherit.
    */
   @CanIgnoreReturnValue
   public SubprocessBuilder setEnv(@Nullable Map<String, String> env) {

--- a/src/test/java/com/google/devtools/build/lib/windows/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/windows/BUILD
@@ -55,6 +55,7 @@ java_binary(
     name = "MockSubprocess",
     testonly = 1,
     srcs = ["MockSubprocess.java"],
+    deps = ["//third_party:guava"],
 )
 
 cc_binary(

--- a/src/test/java/com/google/devtools/build/lib/windows/MockSubprocess.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/MockSubprocess.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.windows;
 
+import com.google.common.base.Strings;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
@@ -62,7 +63,7 @@ public class MockSubprocess {
 
       case '$':
         // Environment variable
-        buf = System.getenv(arg.substring(2)).getBytes(UTF8);
+        buf = Strings.nullToEmpty(System.getenv(arg.substring(2))).getBytes(UTF8);
         break;
 
       case '.':


### PR DESCRIPTION
JavaSubprocessFactory causes the environment to be inherited if SubprocessBuilder#setEnv is never called or called with null. WindowsSubprocessFactory currently interprets it as an empty environment (other than the unconditionally inherited SYSTEMROOT and SYSTEMDRIVE). This CL makes the behavior on Windows the same as elsewhere.

Fixes #22190. The test failures were due to the //src/tools/remote:worker binary spawned by the test being unable to locate the runfiles directory, as the RUNFILES_MANIFEST_FILE environment variable wasn't inherited. It's unclear why the tests used to work, although I suspect it has to do with one of the many runfiles-related changes submitted to the 8.x tree.

These tests are the only uses of SubprocessBuilder without an explicit setEnv call, so other callsites are unaffected.

PiperOrigin-RevId: 632451766
Change-Id: Ifdb5055c60510bf27c72a3cd737ac2300865ce1b

Commit https://github.com/bazelbuild/bazel/commit/70918b83ae854fddd8655cb66cdc3317bf5a4201