### PR TITLE
PyInfo() constructor now uses its has_py3_only_sources parameter

### DIFF
--- a/src/main/starlark/builtins_bzl/common/python/providers.bzl
+++ b/src/main/starlark/builtins_bzl/common/python/providers.bzl
@@ -167,7 +167,7 @@ def _PyInfo_init(
         "imports": imports,
         "uses_shared_libraries": uses_shared_libraries,
         "has_py2_only_sources": has_py2_only_sources,
-        "has_py3_only_sources": has_py2_only_sources,
+        "has_py3_only_sources": has_py3_only_sources,
     }
 
 PyInfo, _unused_raw_py_info_ctor = provider(

--- a/src/test/java/com/google/devtools/build/lib/rules/python/PyInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/PyInfoTest.java
@@ -114,6 +114,32 @@ public class PyInfoTest extends BuildViewTestCase {
   }
 
   @Test
+  public void starlarkConstructorDefaults_has_py2_only_sources() throws Exception {
+    writeCreatePyInfo(
+        "    transitive_sources = depset(direct=[dummy_file])",
+        "    has_py2_only_sources = True");
+
+    PyInfo info = getPyInfo();
+
+    // verify that has_py2_only_sources does not affect has_py3_only_sources
+    assertThat(info.getHasPy2OnlySources()).isTrue();
+    assertThat(info.getHasPy3OnlySources()).isFalse();
+  }
+
+  @Test
+  public void starlarkConstructorDefaults_has_py3_only_sources() throws Exception {
+    writeCreatePyInfo(
+        "    transitive_sources = depset(direct=[dummy_file])",
+        "    has_py3_only_sources = True");
+
+    PyInfo info = getPyInfo();
+
+    // verify that has_py3_only_sources does not affect has_py2_only_sources
+    assertThat(info.getHasPy2OnlySources()).isFalse();
+    assertThat(info.getHasPy3OnlySources()).isTrue();
+  }
+
+  @Test
   public void starlarkConstructorErrors_transitiveSources_missing() throws Exception {
     writeCreatePyInfo();
 


### PR DESCRIPTION
fixes #21971