### PR TITLE
PathFragment: test Windows mixed separator

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/vfs/PathFragmentWindowsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/PathFragmentWindowsTest.java
@@ -177,6 +177,9 @@ public class PathFragmentWindowsTest {
   public void testSegmentsCountWindows() {
     assertThat(create("C:/foo").segmentCount()).isEqualTo(1);
     assertThat(create("C:/").segmentCount()).isEqualTo(0);
+    // Mix usage of Windows and Unix separator is valid
+    assertThat(create("C:/foo\\bar").segmentCount()).isEqualTo(2);
+    assertThat(create("C:\\foo\\bar/baz").segmentCount()).isEqualTo(3);
   }
 
   @Test
@@ -185,6 +188,12 @@ public class PathFragmentWindowsTest {
     assertThat(create("C:/foo/bar").getSegment(1)).isEqualTo("bar");
     assertThat(create("C:/foo/").getSegment(0)).isEqualTo("foo");
     assertThat(create("C:/foo").getSegment(0)).isEqualTo("foo");
+    // Mix usage of Windows and Unix separator is valid
+    assertThat(create("C:/foo\\bar").getSegment(0)).isEqualTo("foo");
+    assertThat(create("C:/foo\\bar").getSegment(1)).isEqualTo("bar");
+    assertThat(create("C:\\foo\\bar/baz").getSegment(0)).isEqualTo("foo");
+    assertThat(create("C:\\foo\\bar/baz").getSegment(1)).isEqualTo("bar");
+    assertThat(create("C:\\foo\\bar/baz").getSegment(2)).isEqualTo("baz");
   }
 
   @Test
@@ -193,6 +202,9 @@ public class PathFragmentWindowsTest {
     assertThat(create("C:/foo").getBaseName()).isEqualTo("foo");
     // Never return the drive name as a basename.
     assertThat(create("C:/").getBaseName()).isEmpty();
+    // Mix usage of Windows and Unix separator is valid
+    assertThat(create("C:/foo\\bar").getBaseName()).isEqualTo("bar");
+    assertThat(create("C:\\foo\\bar/baz").getBaseName()).isEqualTo("baz");
   }
 
   @Test


### PR DESCRIPTION
On Windows, if a user were to specify a PathFragment with mixed
separator such as

```
bazel build --profile='C:/foo\\bar' //...
```

then the profile file will be written as `bar` and recorded in
BuildToolLogs event as so.

Provide a test that demonstrates the current behavior to discuss whether
this is "correct" or not.
