### PR TITLE
Add command profile to the BEP under a fixed name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/buildevent/ProfilerStartedEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/buildevent/ProfilerStartedEvent.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.buildtool.buildevent;
 
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader.UploadContext;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.vfs.Path;
 import javax.annotation.Nullable;
 
@@ -24,11 +25,13 @@ import javax.annotation.Nullable;
 public class ProfilerStartedEvent implements ExtendedEventHandler.Postable {
   @Nullable private final Path profilePath;
   @Nullable private final UploadContext streamingContext;
+  private final Profiler.Format format;
   @Nullable private final String name;
 
-  public ProfilerStartedEvent(String name, Path profilePath, UploadContext streamingContext) {
+  public ProfilerStartedEvent(String name, Path profilePath, Profiler.Format format, UploadContext streamingContext) {
     this.profilePath = profilePath;
     this.streamingContext = streamingContext;
+    this.format = format;
     this.name = name;
   }
 
@@ -38,6 +41,10 @@ public class ProfilerStartedEvent implements ExtendedEventHandler.Postable {
 
   public UploadContext getStreamingContext() {
     return streamingContext;
+  }
+
+  public Profiler.Format getFormat() {
+    return format;
   }
 
   public String getName() {

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -443,7 +443,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
     } catch (IOException e) {
       eventHandler.handle(Event.error("Error while creating profile file: " + e.getMessage()));
     }
-    return new ProfilerStartedEvent(profileName, profilePath, streamingContext);
+    return new ProfilerStartedEvent(profileName, profilePath, format, streamingContext);
   }
 
   public FileSystem getFileSystem() {

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
@@ -65,6 +65,7 @@ public class BuildSummaryStatsModule extends BlazeModule {
   private long executionEndMillis;
   private SpawnStats spawnStats;
   private Path profilePath;
+  private Profiler.Format profileFormat;
   private AtomicBoolean executionStarted;
 
   @Override
@@ -123,6 +124,7 @@ public class BuildSummaryStatsModule extends BlazeModule {
   @Subscribe
   public void profileStarting(ProfilerStartedEvent event) {
     this.profilePath = event.getProfilePath();
+    this.profileFormat = event.getFormat();
   }
 
   @Subscribe
@@ -189,7 +191,12 @@ public class BuildSummaryStatsModule extends BlazeModule {
           event
               .getResult()
               .getBuildToolLogCollection()
-              .addLocalFile(profilePath.getBaseName(), profilePath);
+              .addLocalFile(
+                  switch (profileFormat) {
+                    case JSON_TRACE_FILE_FORMAT -> "command.profile.json";
+                    case JSON_TRACE_FILE_COMPRESSED_FORMAT -> "command.profile.gz";
+                  },
+                  profilePath);
         } catch (IOException e) {
           reporter.handle(Event.error("Error while writing profile file: " + e.getMessage()));
         }

--- a/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
+++ b/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
@@ -540,7 +540,7 @@ EOF
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"
 
-  expect_bes_file_uploaded "mycommand.profile.gz"
+  expect_bes_file_uploaded "command.profile.gz"
 }
 
 function test_upload_all_upload_profile() {
@@ -560,7 +560,27 @@ EOF
       --build_event_json_file=$BEP_JSON \
       //a:foo >& $TEST_log || fail "Failed to build"
 
-  expect_bes_file_uploaded "mycommand.profile.gz"
+  expect_bes_file_uploaded "command.profile.gz"
+}
+
+function test_upload_upload_uncompressed_profile() {
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
+EOF
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_build_event_upload=all \
+      --profile=mycommand.profile \
+      --build_event_json_file=$BEP_JSON \
+      //a:foo >& $TEST_log || fail "Failed to build"
+
+  expect_bes_file_uploaded "command.profile.json"
 }
 
 run_suite "Remote build event uploader tests"


### PR DESCRIPTION
If users specify a custom profile location with `--profile`, the file is added to the BES under its basename. This makes it harder for BES consumers to pick out the profile. Instead, always announce it under its default name `command.profile.gz` or `command.profile` if uncompressed. This additionally allows consumers to detect compression based on just the file name.