### PR TITLE
[7.2.0] Mark bazel_tools extensions as reproducible

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2904,7 +2904,7 @@
         "bzlTransitiveDigest": "ZQlKKnSCJVqDHuXPmDAvyFc/HP1UqQ4Hgsl6trOvHvA=",
         "recordedFileInputs": {
           "@@//MODULE.bazel": "690d0e76bfb200c981d03e6c0f20853ff9533788627a779890330e089aa7c41c",
-          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "ffc0f61d2fb31b4ce6dad9a773279ad434f2aabadfaebcb1df5c94bb7ddb4d7d"
+          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "6c3391f379b29c706137b4a85c27da2b03201ad6227aff51479360e45f824b6d"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3479,54 +3479,6 @@
             "_main~bazel_test_deps~bazelci_rules"
           ]
         ]
-      }
-    },
-    "//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
-      "general": {
-        "bzlTransitiveDigest": "OBuiEhPTsmGJLplgSLRwqDPybt0jns4dOHdzYzOJ1aM=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "android_tools": {
-            "bzlFile": "@@//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2b661a761a735b41c41b3a78089f4fc1982626c76ddb944604ae3ff8c545d3c2",
-              "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.30.0.tar"
-            }
-          },
-          "android_gmaven_r8": {
-            "bzlFile": "@@//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_jar",
-            "attributes": {
-              "sha256": "59753e70a74f918389cc87f1b7d66b5c0862932559167425708ded159e3de439",
-              "url": "https://maven.google.com/com/android/tools/r8/8.3.37/r8-8.3.37.jar"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
-    "//tools/test:extensions.bzl%remote_coverage_tools_extension": {
-      "general": {
-        "bzlTransitiveDigest": "yd81gjOpH9Vd/KF71OifnQucGLfgWXfE+PqqamoczPk=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "remote_coverage_tools": {
-            "bzlFile": "@@//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7006375f6756819b7013ca875eab70a541cf7d89142d9c511ed78ea4fefa38af",
-              "urls": [
-                "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -61,7 +61,7 @@
   "moduleExtensions": {
     "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "pMLFCYaRPkgXPQ8vtuNkMfiHfPmRBy6QJfnid4sWfv0=",
+        "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
         "usagesDigest": "aLmqbvowmHkkBPve05yyDNGN7oh7QE9kBADr3QIZTZs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -85,121 +85,6 @@
             "bazel_tools"
           ]
         ]
-      }
-    },
-    "@@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
-      "general": {
-        "bzlTransitiveDigest": "OBuiEhPTsmGJLplgSLRwqDPybt0jns4dOHdzYzOJ1aM=",
-        "usagesDigest": "pfoI3DAAesYHdp38xIvu9Ry0AM3EIPGwvav/Cyv23Kw=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "android_tools": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "2b661a761a735b41c41b3a78089f4fc1982626c76ddb944604ae3ff8c545d3c2",
-              "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.30.0.tar"
-            }
-          },
-          "android_gmaven_r8": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_jar",
-            "attributes": {
-              "sha256": "59753e70a74f918389cc87f1b7d66b5c0862932559167425708ded159e3de439",
-              "url": "https://maven.google.com/com/android/tools/r8/8.3.37/r8-8.3.37.jar"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
-    "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "PHpT2yqMGms2U4L3E/aZ+WcQalmZWm+ILdP3yiLsDhA=",
-        "usagesDigest": "6zVI5vmN6Evleo1nJgTcfkJmgPFqhlf1Wl94WarCpa0=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "local_config_cc": {
-            "bzlFile": "@@bazel_tools//tools/cpp:cc_configure.bzl",
-            "ruleClassName": "cc_autoconf",
-            "attributes": {}
-          },
-          "local_config_cc_toolchains": {
-            "bzlFile": "@@bazel_tools//tools/cpp:cc_configure.bzl",
-            "ruleClassName": "cc_autoconf_toolchains",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "bazel_tools",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
-    "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "Qh2bWTU6QW6wkrd87qrU4YeY+SG37Nvw3A0PR4Y0L2Y=",
-        "usagesDigest": "hl3K6oDsXyui9k2oT4OTT6CdW6L/lSrBDSOWIZiUT1Q=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "local_config_xcode": {
-            "bzlFile": "@@bazel_tools//tools/osx:xcode_configure.bzl",
-            "ruleClassName": "xcode_autoconf",
-            "attributes": {
-              "xcode_locator": "@bazel_tools//tools/osx:xcode_locator.m",
-              "remote_xcode": ""
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
-    "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "hp4NgmNjEg5+xgvzfh6L83bt9/aiiWETuNpwNuF1MSU=",
-        "usagesDigest": "gYz9qiTxGtMhXZhrQTBErBunPVrPWNhiFJAP9Nf18GM=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "local_config_sh": {
-            "bzlFile": "@@bazel_tools//tools/sh:sh_configure.bzl",
-            "ruleClassName": "sh_config",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
-    "@@bazel_tools//tools/test:extensions.bzl%remote_coverage_tools_extension": {
-      "general": {
-        "bzlTransitiveDigest": "yd81gjOpH9Vd/KF71OifnQucGLfgWXfE+PqqamoczPk=",
-        "usagesDigest": "5AzD10fWCl4vQ0i0Zl96Ial7tU8raC84LTK6DeHefuk=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "remote_coverage_tools": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "7006375f6756819b7013ca875eab70a541cf7d89142d9c511ed78ea4fefa38af",
-              "urls": [
-                "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@buildozer~//:buildozer_binary.bzl%buildozer_binary": {

--- a/tools/android/android_extensions.bzl
+++ b/tools/android/android_extensions.bzl
@@ -16,7 +16,7 @@
 
 load("//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 
-def _remote_android_tools_extensions_impl(_ctx):
+def _remote_android_tools_extensions_impl(module_ctx):
     http_archive(
         name = "android_tools",
         sha256 = "2b661a761a735b41c41b3a78089f4fc1982626c76ddb944604ae3ff8c545d3c2",  # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
@@ -27,6 +27,7 @@ def _remote_android_tools_extensions_impl(_ctx):
         sha256 = "59753e70a74f918389cc87f1b7d66b5c0862932559167425708ded159e3de439",
         url = "https://maven.google.com/com/android/tools/r8/8.3.37/r8-8.3.37.jar",
     )
+    return module_ctx.extension_metadata(reproducible = True)
 
 remote_android_tools_extensions = module_extension(
     implementation = _remote_android_tools_extensions_impl,

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -156,5 +156,6 @@ def cc_configure():
 def _cc_configure_extension_impl(ctx):
     cc_autoconf_toolchains(name = "local_config_cc_toolchains")
     cc_autoconf(name = "local_config_cc")
+    return ctx.extension_metadata(reproducible = True)
 
 cc_configure_extension = module_extension(implementation = _cc_configure_extension_impl)

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -315,6 +315,8 @@ def xcode_configure(xcode_locator_label, remote_xcode_label = None):
         remote_xcode = remote_xcode_label,
     )
 
-xcode_configure_extension = module_extension(
-    implementation = lambda ctx: xcode_configure("@bazel_tools//tools/osx:xcode_locator.m"),
-)
+def _xcode_configure_extension_impl(module_ctx):
+    xcode_configure("@bazel_tools//tools/osx:xcode_locator.m")
+    return module_ctx.extension_metadata(reproducible = True)
+
+xcode_configure_extension = module_extension(implementation = _xcode_configure_extension_impl)

--- a/tools/sh/sh_configure.bzl
+++ b/tools/sh/sh_configure.bzl
@@ -83,6 +83,8 @@ def sh_configure():
     sh_config(name = "local_config_sh")
     native.register_toolchains("@local_config_sh//:local_sh_toolchain")
 
-sh_configure_extension = module_extension(
-    implementation = lambda ctx: sh_config(name = "local_config_sh"),
-)
+def _sh_configure_extension_impl(module_ctx):
+    sh_config(name = "local_config_sh")
+    return module_ctx.extension_metadata(reproducible = True)
+
+sh_configure_extension = module_extension(implementation = _sh_configure_extension_impl)

--- a/tools/test/extensions.bzl
+++ b/tools/test/extensions.bzl
@@ -24,6 +24,7 @@ def _remote_coverage_tools_extension_impl(ctx):
             "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip",
         ],
     )
+    return ctx.extension_metadata(reproducible = True)
 
 remote_coverage_tools_extension = module_extension(
     implementation = _remote_coverage_tools_extension_impl,


### PR DESCRIPTION
Removes unnecessary lockfile entries.

Closes #22335.

PiperOrigin-RevId: 633311588
Change-Id: Ia0ccb2fd14b28123115109db9fa921380319451e