### PR TITLE
[7.2.0] Prevent currentThread().join() on cli thread crash

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -968,11 +968,15 @@ public final class UiEventHandler implements EventHandler {
    * Stop the update thread and wait for it to terminate. As the update thread, which is a separate
    * thread, might have to call a synchronized method between being interrupted and terminating, DO
    * NOT CALL from a SYNCHRONIZED block, as this will give the opportunity for dead locks.
+   *
+   * <p>If this is called from the updateThread itself, ignore the interrupt/join, as it is
+   * hopefully handling a FATAL, and should be terminating anyway.
    */
   private void stopUpdateThread() {
     shutdown = true;
     Thread threadToWaitFor = updateThread.getAndSet(null);
-    if (threadToWaitFor != null) {
+    // we could be second to wait here, or be the current thread, which would hang
+    if (threadToWaitFor != null && threadToWaitFor != Thread.currentThread()) {
       threadToWaitFor.interrupt();
       Uninterruptibles.joinUninterruptibly(threadToWaitFor);
     }


### PR DESCRIPTION
If the cli-update-thread is crashing, it may attempt to interrupt and join on itself. Hopefully no updateThread could be in stopUpdateThread without going through handleCrash() -> Event.FATAL sequence through BlazeRuntime.

Fixes #22051

Closes #22122.

PiperOrigin-RevId: 633653817
Change-Id: Iaef5df56358d74bd7210ad8cb3562b452de9eb6a

Commit https://github.com/bazelbuild/bazel/commit/63062400732c266fe36a5bd54551c356410dfef8