### PR TITLE
[7.2.0] Add `--lockfile_mode=refresh`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -41,6 +41,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/starlark",
         "//src/main/java/com/google/devtools/build/lib/bazel/rules/android",
+        "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -537,7 +537,7 @@ public class BazelRepositoryModule extends BlazeModule {
             (PrecomputedValue)
                 env.getSkyframeExecutor()
                     .getEvaluator()
-                    .getExistingValue(RegistryFunction.LAST_INVALIDATION.getKey());
+                    .getExistingValue(RegistryFunction.LAST_INVALIDATION.getKeyForTesting());
         if (lastRegistryInvalidationValue != null) {
           lastRegistryInvalidation = (Instant) lastRegistryInvalidationValue.get();
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -71,7 +71,7 @@ public class BazelLockFileModule extends BlazeModule {
       // Check the Skyframe value instead of the option since some commands (e.g. shutdown) don't
       // propagate the options to Skyframe, but we can only operate on Skyframe values that were
       // generated in UPDATE mode.
-      if (lockfileMode != LockfileMode.UPDATE) {
+      if (lockfileMode != LockfileMode.UPDATE && lockfileMode != LockfileMode.REFRESH) {
         return;
       }
       moduleResolutionValue =

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Registry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Registry.java
@@ -17,12 +17,12 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
-import com.google.devtools.build.skyframe.SkyValue;
+import com.google.devtools.build.skyframe.NotComparableSkyValue;
 import java.io.IOException;
 import java.util.Optional;
 
 /** A database where module metadata is stored. */
-public interface Registry extends SkyValue {
+public interface Registry extends NotComparableSkyValue {
 
   /** The URL that uniquely identifies the registry. */
   String getUrl();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
@@ -60,9 +60,11 @@ public class RegistryFactoryImpl implements RegistryFactory {
     var knownFileHashesMode =
         switch (uri.getScheme()) {
           case "http", "https" ->
-              lockfileMode == LockfileMode.ERROR
-                  ? KnownFileHashesMode.ENFORCE
-                  : KnownFileHashesMode.USE_AND_UPDATE;
+              switch (lockfileMode) {
+                case ERROR -> KnownFileHashesMode.ENFORCE;
+                case REFRESH -> KnownFileHashesMode.USE_IMMUTABLE_AND_UPDATE;
+                case OFF, UPDATE -> KnownFileHashesMode.USE_AND_UPDATE;
+              };
           case "file" -> KnownFileHashesMode.IGNORE;
           default ->
               throw new URISyntaxException(uri.toString(), "Unrecognized registry URL protocol");

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -215,7 +215,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     // influence the evaluation of the extension and the validation also runs when the extension
     // result is taken from the lockfile, we can already populate the lockfile info. This is
     // necessary to prevent the extension from rerunning when only the imports change.
-    if (lockfileMode.equals(LockfileMode.UPDATE)) {
+    if (lockfileMode == LockfileMode.UPDATE || lockfileMode == LockfileMode.REFRESH) {
       lockFileInfo =
           Optional.of(
               new LockFileModuleExtension.WithFactors(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -320,9 +320,11 @@ public class RepositoryOptions extends OptionsBase {
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       help =
           "Specifies how and whether or not to use the lockfile. Valid values are `update` to"
-              + " use the lockfile and update it if there are changes, `error` to use the lockfile"
-              + " but throw an error if it's not up-to-date, or `off` to neither read from or write"
-              + " to the lockfile.")
+              + " use the lockfile and update it if there are changes, `refresh` to additionally"
+              + " refresh mutable information (yanked versions and previously missing modules)"
+              + " from remote registries from time to time, `error` to use the lockfile but throw"
+              + " an error if it's not up-to-date, or `off` to neither read from or write to the"
+              + " lockfile.")
   public LockfileMode lockfileMode;
 
   @Option(
@@ -369,10 +371,11 @@ public class RepositoryOptions extends OptionsBase {
   /** An enum for specifying how to use the lockfile. */
   public enum LockfileMode {
     OFF, // Don't use the lockfile at all.
-    UPDATE, // Update the lockfile when it mismatches the module.
-    ERROR; // Throw an error when it mismatches the module.
+    UPDATE, // Update the lockfile wh
+    REFRESH,
+    ERROR; // Throw an error when it mismatc
 
-    /** Converts to {@link BazelLockfileMode}. */
+    /** Converts to {@link LockfileMode}. */
     public static class Converter extends EnumConverter<LockfileMode> {
       public Converter() {
         super(LockfileMode.class, "Lockfile mode");


### PR DESCRIPTION
RELNOTES: The new `refresh` value for `--lockfile_mode` behaves like the `update` mode, but additionally forces a refresh of mutable registry content (yanked versions and missing module versions) when switched to or from time to time while enabled.

Closes #22333.

PiperOrigin-RevId: 633737372
Change-Id: I2cae552f6adfcd07a5b3263b5e4997e21653f106

Commit https://github.com/bazelbuild/bazel/commit/88a230f4cf28deec1455cb2caed4dc9f81e108c9