### PR TITLE
BEP: Sets `start_time` on `BuildStarted` events from `NoBuildEvent`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -897,6 +897,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//third_party:guava",
+        "@com_google_protobuf//java/util",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/NoBuildEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/NoBuildEvent.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId;
 import com.google.devtools.build.lib.buildeventstream.GenericBuildEvent;
 import com.google.devtools.build.lib.buildeventstream.ProgressEvent;
+import com.google.protobuf.util.Timestamps;
 
 /** This event raised to indicate that no build will be happening for the given command. */
 public final class NoBuildEvent implements BuildEvent {
@@ -77,6 +78,7 @@ public final class NoBuildEvent implements BuildEvent {
     }
     if (startTimeMillis != null) {
       started.setStartTimeMillis(startTimeMillis);
+      started.setStartTime(Timestamps.fromMillis(startTimeMillis));
     }
     if (id != null) {
       started.setUuid(id);


### PR DESCRIPTION
When handling invocations we noticed some invocations still weren't setting `start_time` on `BuildStarted`. We specifically noticed this on build event streams from `query` invocations. After some spelunking I found `NoBuildEvent`, which didn't get updated with the rest of the codebase in e5c832a16e475f636c845b0247731f65df5e258c.