### PR TITLE
Remove stale extension factors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
@@ -35,7 +36,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nullable;
 
 /**
  * Module collecting Bazel module and module extensions resolution results and updating the
@@ -148,21 +148,32 @@ public class BazelLockFileModule extends BlazeModule {
     Map<ModuleExtensionId, ImmutableMap<ModuleExtensionEvalFactors, LockFileModuleExtension>>
         updatedExtensionMap = new HashMap<>();
 
-    // Keep old extensions if they are still valid.
+    // Keep those per factor extension results that are still used according to the static
+    // information given in the extension declaration (dependence on os and arch, reproducibility).
+    // Other information such as transitive .bzl hash and usages hash are *not* checked here.
     for (var entry : oldExtensionInfos.entrySet()) {
       var moduleExtensionId = entry.getKey();
-      var factorToLockedExtension = entry.getValue();
-      ModuleExtensionEvalFactors firstEntryFactors =
-          factorToLockedExtension.keySet().iterator().next();
-      // All entries for a single extension share the same usages digest, so it suffices to check
-      // the first entry.
-      if (shouldKeepExtension(
-          moduleExtensionId,
-          firstEntryFactors,
-          newExtensionInfos.get(moduleExtensionId),
-          depGraphValue)) {
-        updatedExtensionMap.put(moduleExtensionId, factorToLockedExtension);
+      if (!depGraphValue.getExtensionUsagesTable().containsRow(moduleExtensionId)) {
+        // Extensions without any usages are not needed anymore.
+        continue;
       }
+      var newExtensionInfo = newExtensionInfos.get(moduleExtensionId);
+      if (newExtensionInfo == null) {
+        // No information based on which we could invalidate old entries, keep all of them.
+        updatedExtensionMap.put(moduleExtensionId, entry.getValue());
+        continue;
+      }
+      if (!newExtensionInfo.moduleExtension().shouldLockExtension()) {
+        // Extension has become reproducible and should not be locked anymore.
+        continue;
+      }
+      var newFactors = newExtensionInfo.extensionFactors();
+      var perFactorResultsToKeep =
+          ImmutableMap.copyOf(Maps.filterKeys(entry.getValue(), newFactors::hasSameDependenciesAs));
+      if (perFactorResultsToKeep.isEmpty()) {
+        continue;
+      }
+      updatedExtensionMap.put(moduleExtensionId, perFactorResultsToKeep);
     }
 
     // Add the new resolved extensions
@@ -194,49 +205,6 @@ public class BazelLockFileModule extends BlazeModule {
     // deterministic lockfile by sorting.
     return ImmutableSortedMap.copyOf(
         updatedExtensionMap, ModuleExtensionId.LEXICOGRAPHIC_COMPARATOR);
-  }
-
-  /**
-   * Keep an extension if and only if:
-   *
-   * <ol>
-   *   <li>it still has usages
-   *   <li>its dependency on os & arch didn't change
-   *   <li>it hasn't become reproducible
-   * </ol>
-   *
-   * We do not check for changes in the usage hash of the extension or e.g. hashes of files accessed
-   * during the evaluation. These values are checked in SingleExtensionEvalFunction.
-   *
-   * @param lockedExtensionKey object holding the old extension id and state of os and arch
-   * @param newExtensionInfo the in-memory lockfile entry produced by the most recent up-to-date
-   *     evaluation of this extension (if any)
-   * @param depGraphValue the dep graph value
-   * @return True if this extension should still be in lockfile, false otherwise
-   */
-  private boolean shouldKeepExtension(
-      ModuleExtensionId moduleExtensionId,
-      ModuleExtensionEvalFactors lockedExtensionKey,
-      @Nullable LockFileModuleExtension.WithFactors newExtensionInfo,
-      BazelDepGraphValue depGraphValue) {
-    if (!depGraphValue.getExtensionUsagesTable().containsRow(moduleExtensionId)) {
-      return false;
-    }
-
-    // If there is no new extension info, the properties of the existing extension entry can't have
-    // changed.
-    if (newExtensionInfo == null) {
-      return true;
-    }
-
-    boolean doNotLockExtension = !newExtensionInfo.moduleExtension().shouldLockExtension();
-    boolean dependencyOnOsChanged =
-        lockedExtensionKey.getOs().isEmpty()
-            != newExtensionInfo.extensionFactors().getOs().isEmpty();
-    boolean dependencyOnArchChanged =
-        lockedExtensionKey.getArch().isEmpty()
-            != newExtensionInfo.extensionFactors().getArch().isEmpty();
-    return !doNotLockExtension && !dependencyOnOsChanged && !dependencyOnArchChanged;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -168,9 +168,10 @@ public class BazelLockFileModule extends BlazeModule {
         continue;
       }
       var newFactors = newExtensionInfo.extensionFactors();
-      var perFactorResultsToKeep =
-          ImmutableSortedMap.copyOf(
-              Maps.filterKeys(entry.getValue(), newFactors::hasSameDependenciesAs));
+      ImmutableSortedMap<ModuleExtensionEvalFactors, LockFileModuleExtension>
+          perFactorResultsToKeep =
+              ImmutableSortedMap.copyOf(
+                  Maps.filterKeys(entry.getValue(), newFactors::hasSameDependenciesAs));
       if (perFactorResultsToKeep.isEmpty()) {
         continue;
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -169,7 +169,8 @@ public class BazelLockFileModule extends BlazeModule {
       }
       var newFactors = newExtensionInfo.extensionFactors();
       var perFactorResultsToKeep =
-          ImmutableMap.copyOf(Maps.filterKeys(entry.getValue(), newFactors::hasSameDependenciesAs));
+          ImmutableSortedMap.copyOf(
+              Maps.filterKeys(entry.getValue(), newFactors::hasSameDependenciesAs));
       if (perFactorResultsToKeep.isEmpty()) {
         continue;
       }
@@ -189,10 +190,11 @@ public class BazelLockFileModule extends BlazeModule {
       if (oldExtensionEntries != null) {
         // extension exists, add the new entry to the existing map
         extensionEntries =
-            new ImmutableMap.Builder<ModuleExtensionEvalFactors, LockFileModuleExtension>()
-                .putAll(oldExtensionEntries)
-                .put(factors, extension)
-                .buildKeepingLast();
+            ImmutableSortedMap.copyOf(
+                new ImmutableMap.Builder<ModuleExtensionEvalFactors, LockFileModuleExtension>()
+                    .putAll(oldExtensionEntries)
+                    .put(factors, extension)
+                    .buildKeepingLast());
       } else {
         // new extension
         extensionEntries = ImmutableMap.of(factors, extension);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -168,50 +168,15 @@ public final class GsonTypeAdapterUtil {
       MODULE_EXTENSION_FACTORS_TYPE_ADAPTER =
           new TypeAdapter<>() {
 
-            private static final String OS_KEY = "os:";
-            private static final String ARCH_KEY = "arch:";
-            // This is used when the module extension doesn't depend on os or arch, to indicate that
-            // its value is "general" and can be used with any platform
-            private static final String GENERAL_EXTENSION = "general";
-
             @Override
             public void write(JsonWriter jsonWriter, ModuleExtensionEvalFactors extFactors)
                 throws IOException {
-              if (extFactors.isEmpty()) {
-                jsonWriter.value(GENERAL_EXTENSION);
-              } else {
-                StringBuilder jsonBuilder = new StringBuilder();
-                if (!extFactors.getOs().isEmpty()) {
-                  jsonBuilder.append(OS_KEY).append(extFactors.getOs());
-                }
-                if (!extFactors.getArch().isEmpty()) {
-                  if (jsonBuilder.length() > 0) {
-                    jsonBuilder.append(",");
-                  }
-                  jsonBuilder.append(ARCH_KEY).append(extFactors.getArch());
-                }
-                jsonWriter.value(jsonBuilder.toString());
-              }
+              jsonWriter.value(extFactors.toString());
             }
 
             @Override
             public ModuleExtensionEvalFactors read(JsonReader jsonReader) throws IOException {
-              String jsonString = jsonReader.nextString();
-              if (jsonString.equals(GENERAL_EXTENSION)) {
-                return ModuleExtensionEvalFactors.create("", "");
-              }
-
-              String os = "";
-              String arch = "";
-              var extParts = Splitter.on(',').splitToList(jsonString);
-              for (String part : extParts) {
-                if (part.startsWith(OS_KEY)) {
-                  os = part.substring(OS_KEY.length());
-                } else if (part.startsWith(ARCH_KEY)) {
-                  arch = part.substring(ARCH_KEY.length());
-                }
-              }
-              return ModuleExtensionEvalFactors.create(os, arch);
+              return ModuleExtensionEvalFactors.parse(jsonReader.nextString());
             }
           };
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalFactors.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalFactors.java
@@ -39,6 +39,11 @@ public abstract class ModuleExtensionEvalFactors {
     return getOs().isEmpty() && getArch().isEmpty();
   }
 
+  public boolean hasSameDependenciesAs(ModuleExtensionEvalFactors other) {
+    return getOs().isEmpty() == other.getOs().isEmpty()
+        && getArch().isEmpty() == other.getArch().isEmpty();
+  }
+
   public static ModuleExtensionEvalFactors create(String os, String arch) {
     return new AutoValue_ModuleExtensionEvalFactors(os, arch);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalFactors.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalFactors.java
@@ -15,7 +15,10 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Splitter;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This object holds the evaluation factors for module extensions in the lockfile, such as the
@@ -24,7 +27,14 @@ import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
  */
 @AutoValue
 @GenerateTypeAdapter
-public abstract class ModuleExtensionEvalFactors {
+public abstract class ModuleExtensionEvalFactors implements Comparable<ModuleExtensionEvalFactors> {
+
+  private static final String OS_KEY = "os:";
+  private static final String ARCH_KEY = "arch:";
+
+  // This is used when the module extension doesn't depend on os or arch, to indicate that
+  // its value is "general" and can be used with any platform
+  private static final String GENERAL_EXTENSION = "general";
 
   /** Returns the OS this extension is evaluated on, or empty if it doesn't depend on the os */
   public abstract String getOs();
@@ -44,7 +54,46 @@ public abstract class ModuleExtensionEvalFactors {
         && getArch().isEmpty() == other.getArch().isEmpty();
   }
 
+  @Override
+  public String toString() {
+    if (isEmpty()) {
+      return GENERAL_EXTENSION;
+    }
+
+    List<String> parts = new ArrayList<>();
+    if (!getOs().isEmpty()) {
+      parts.add(OS_KEY + getOs());
+    }
+    if (!getArch().isEmpty()) {
+      parts.add(ARCH_KEY + getArch());
+    }
+    return String.join(",", parts);
+  }
+
+  @Override
+  public int compareTo(ModuleExtensionEvalFactors o) {
+    return toString().compareTo(o.toString());
+  }
+
   public static ModuleExtensionEvalFactors create(String os, String arch) {
     return new AutoValue_ModuleExtensionEvalFactors(os, arch);
+  }
+
+  public static ModuleExtensionEvalFactors parse(String s) {
+    if (s.equals(GENERAL_EXTENSION)) {
+      return ModuleExtensionEvalFactors.create("", "");
+    }
+
+    String os = "";
+    String arch = "";
+    var extParts = Splitter.on(',').splitToList(s);
+    for (String part : extParts) {
+      if (part.startsWith(OS_KEY)) {
+        os = part.substring(OS_KEY.length());
+      } else if (part.startsWith(ARCH_KEY)) {
+        arch = part.substring(ARCH_KEY.length());
+      }
+    }
+    return ModuleExtensionEvalFactors.create(os, arch);
   }
 }


### PR DESCRIPTION
JSON-based merge conflict resolution for `MODULE.bazel.lock` can end up producing entries with, e.g., both a `general` and an `os:Linux` factor result when the OS/arch dependence of the extension changes. `BazelLockFileModule` now invalidates each factor result individually.

Also sort the extension factors.