### PR TITLE
[7.2.0] Include all LocalFiles of type LOG and PERFORMANCE_LOG in --remote_build_event_upload=MINIMAL.

### DIFF
--- a/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
+++ b/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
@@ -543,6 +543,26 @@ EOF
   expect_bes_file_uploaded "mycommand.profile.gz"
 }
 
+function test_upload_minimal_upload_compact_exec_log() {
+  mkdir -p a
+  cat > a/BUILD <<EOF
+genrule(
+  name = 'foo',
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
+EOF
+
+  bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_build_event_upload=minimal \
+      --experimental_execution_log_compact_file=myexeclog \
+      --build_event_json_file=$BEP_JSON \
+      //a:foo >& $TEST_log || fail "Failed to build"
+
+  expect_bes_file_uploaded "execution_log.binpb.zst"
+}
+
 function test_upload_all_upload_profile() {
   mkdir -p a
   cat > a/BUILD <<EOF


### PR DESCRIPTION
In particular, this ensures that the compact execution log is uploaded (for which a test has been added).

ByteStreamBuildEventArtifactUploader would have benefitted from a refactor, but I'm deliberately making a minimal change that can be cherry-picked into 7.2.0 without risking a regression.

PiperOrigin-RevId: 634033159
Change-Id: I4d3df757f612337b5d2b222278d1171cc8e1aed4