### PR TITLE
[7.2.0] Fix version detection logic in release branches

### DIFF
--- a/scripts/docs/get_workspace_status.sh
+++ b/scripts/docs/get_workspace_status.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-RELEASE_NAME=$(source scripts/release/common.sh; get_full_release_name)
+RELEASE_NAME=$(source scripts/release/common.sh; get_release_name)
 
 if [[ -z "$RELEASE_NAME" ]]; then
   echo BUILD_SCM_REVISION UNSAFE_"$(git rev-parse --abbrev-ref HEAD)"

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -64,7 +64,7 @@ function get_release_candidate() {
 function get_release_name() {
   # Match branch name release-X.X.X[-pre.XXXXXXXX.X]rcY and return X.X.X[-pre.XXXXXXXX.X]
   # or match tag name X.X.X[-pre.XXXXXXXX.X] and return X.X.X[-pre.XXXXXXXX.X]
-   git_get_branch 2>/dev/null | grep -Po "(?<=release-)([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?(?=rc)" || git_get_tag | grep -Po "^([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?$" || true
+   git_get_branch 2>/dev/null | grep -Po "(?<=release-)([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?(?=rc)?" || git_get_tag | grep -Po "^([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?$" || true
 }
 
 # Returns whether this is a rolling release (or an RCs of one)


### PR DESCRIPTION
PiperOrigin-RevId: 621452493
Change-Id: I812062db638f171e9e2dcb570f1797cf5118984e

Commit https://github.com/bazelbuild/bazel/commit/31b522fc454f7b5ddf74b830c2c42fedc0d2db65