### PR TITLE
Fix git branch detection in release scripts

### DIFF
--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -41,7 +41,7 @@ function __git_commit_subject() {
 
 # Returns the branch name of the current git repository
 function git_get_branch() {
-  git symbolic-ref --short HEAD
+  git symbolic-ref --short HEAD 2>/dev/null || git branch --remote --contains | cut -d "/" -f2
 }
 
 # Returns the tag name of the current git repository
@@ -57,14 +57,14 @@ function git_commit_msg() {
 # Extract the release candidate number from the git branch name
 function get_release_candidate() {
   # Match rcX and return X
-  git_get_branch 2>/dev/null | grep -Po "(?<=rc)([0-9]|\.)*$" || true
+  git_get_branch | grep -Po "(?<=rc)([0-9]|\.)*$" || true
 }
 
 # Extract the release name from the git branch name
 function get_release_name() {
   # Match branch name release-X.X.X[-pre.XXXXXXXX.X]rcY and return X.X.X[-pre.XXXXXXXX.X]
   # or match tag name X.X.X[-pre.XXXXXXXX.X] and return X.X.X[-pre.XXXXXXXX.X]
-   git_get_branch 2>/dev/null | grep -Po "(?<=release-)([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?(?=rc)?" || git_get_tag | grep -Po "^([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?$" || true
+   git_get_branch | grep -Po "(?<=release-)([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?(?=rc)?" || git_get_tag | grep -Po "^([0-9]|\.)*(-pre\.[0-9]{8}(\.[0-9]+){1,2})?$" || true
 }
 
 # Returns whether this is a rolling release (or an RCs of one)

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -41,6 +41,9 @@ function __git_commit_subject() {
 
 # Returns the branch name of the current git repository
 function git_get_branch() {
+  # Case 1 works when a release branch was checked out,
+  # whereas the second case works if we're in "detached HEAD" state,
+  # which can happen on CI.
   git symbolic-ref --short HEAD 2>/dev/null || git branch --remote --contains | cut -d "/" -f2
 }
 


### PR DESCRIPTION
Previously the code failed when the repository was in detached HEAD state (e.g. on CI).