### PR TITLE
[7.2.0] Preserve paths under hermetic `/tmp` in the sandbox

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
@@ -27,7 +27,6 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -163,9 +162,9 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
       }
       Path key = sandboxExecRoot.getRelative(fragment);
       if (inputs.getFiles().containsKey(fragment)) {
-        RootedPath fileDest = inputs.getFiles().get(fragment);
+        Path fileDest = inputs.getFiles().get(fragment);
         if (fileDest != null) {
-          copyFile(fileDest.asPath(), key);
+          copyFile(fileDest, key);
         } else {
           FileSystemUtils.createEmptyFile(key);
         }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -360,13 +360,11 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
   /**
    * Gets the list of directories that the spawn will assume to be writable.
    *
-   * @param sandboxExecRoot the exec root of the sandbox from the point of view of the Bazel process
-   * @param withinSandboxExecRoot the exec root from the point of view of the sandboxed processes
+   * @param sandboxExecRoot the exec root of the sandbox
    * @param env the environment of the sandboxed processes
    * @throws IOException because we might resolve symlinks, which throws {@link IOException}.
    */
-  protected ImmutableSet<Path> getWritableDirs(
-      Path sandboxExecRoot, Path withinSandboxExecRoot, Map<String, String> env)
+  protected ImmutableSet<Path> getWritableDirs(Path sandboxExecRoot, Map<String, String> env)
       throws IOException {
     // We have to make the TEST_TMPDIR directory writable if it is specified.
     ImmutableSet.Builder<Path> writablePaths = ImmutableSet.builder();
@@ -374,7 +372,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     // On Windows, sandboxExecRoot is actually the main execroot. We will specify
     // exactly which output path is writable.
     if (OS.getCurrent() != OS.WINDOWS) {
-      writablePaths.add(withinSandboxExecRoot);
+      writablePaths.add(execRoot);
     }
 
     String testTmpdir = env.get("TEST_TMPDIR");

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -37,7 +37,6 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -103,7 +102,6 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
   private final SandboxHelpers helpers;
   private final Path execRoot;
-  private final ImmutableList<Root> packageRoots;
   private final boolean allowNetwork;
   private final ProcessWrapper processWrapper;
   private final Path sandboxBase;
@@ -134,7 +132,6 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     super(cmdEnv);
     this.helpers = helpers;
     this.execRoot = cmdEnv.getExecRoot();
-    this.packageRoots = cmdEnv.getPackageLocator().getPathEntries();
     this.allowNetwork = helpers.shouldAllowNetwork(cmdEnv.getOptions());
     this.alwaysWritableDirs = getAlwaysWritableDirs(cmdEnv.getRuntime().getFileSystem());
     this.processWrapper = ProcessWrapper.fromCommandEnvironment(cmdEnv);
@@ -221,18 +218,13 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         localEnvProvider.rewriteLocalEnv(spawn.getEnvironment(), binTools, "/tmp");
 
     final HashSet<Path> writableDirs = new HashSet<>(alwaysWritableDirs);
-    ImmutableSet<Path> extraWritableDirs =
-        getWritableDirs(sandboxExecRoot, sandboxExecRoot, environment);
+    ImmutableSet<Path> extraWritableDirs = getWritableDirs(sandboxExecRoot, environment);
     writableDirs.addAll(extraWritableDirs);
 
     SandboxInputs inputs =
         helpers.processInputFiles(
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            context.getInputMetadataProvider(),
-            execRoot,
-            execRoot,
-            packageRoots,
-            null);
+            execRoot);
     SandboxOutputs outputs = helpers.getOutputs(spawn);
 
     final Path sandboxConfigPath = sandboxPath.getRelative("sandbox.sb");

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -45,7 +45,6 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.ProcessUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -143,7 +142,6 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
   private final SandboxHelpers helpers;
   private final Path execRoot;
-  private final ImmutableList<Root> packageRoots;
   private final boolean allowNetwork;
   private final Path dockerClient;
   private final ProcessWrapper processWrapper;
@@ -181,7 +179,6 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     super(cmdEnv);
     this.helpers = helpers;
     this.execRoot = cmdEnv.getExecRoot();
-    this.packageRoots = cmdEnv.getPackageLocator().getPathEntries();
     this.allowNetwork = helpers.shouldAllowNetwork(cmdEnv.getOptions());
     this.dockerClient = dockerClient;
     this.processWrapper = ProcessWrapper.fromCommandEnvironment(cmdEnv);
@@ -226,11 +223,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     SandboxInputs inputs =
         helpers.processInputFiles(
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            context.getInputMetadataProvider(),
-            execRoot,
-            execRoot,
-            packageRoots,
-            null);
+            execRoot);
     SandboxOutputs outputs = helpers.getOutputs(spawn);
 
     Duration timeout = context.getTimeout();

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxCommandLineBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxCommandLineBuilder.java
@@ -17,9 +17,9 @@ package com.google.devtools.build.lib.sandbox;
 import static com.google.devtools.build.lib.sandbox.LinuxSandboxCommandLineBuilder.NetworkNamespace.NETNS;
 import static com.google.devtools.build.lib.sandbox.LinuxSandboxCommandLineBuilder.NetworkNamespace.NETNS_WITH_LOOPBACK;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.vfs.Path;
@@ -36,20 +36,6 @@ import java.util.Set;
  * linux-sandbox} tool.
  */
 public class LinuxSandboxCommandLineBuilder {
-  /** A bind mount that needs to be present when the sandboxed command runs. */
-  @AutoValue
-  public abstract static class BindMount {
-    public static BindMount of(Path mountPoint, Path source) {
-      return new AutoValue_LinuxSandboxCommandLineBuilder_BindMount(mountPoint, source);
-    }
-
-    /** "target" in mount(2) */
-    public abstract Path getMountPoint();
-
-    /** "source" in mount(2) */
-    public abstract Path getContent();
-  }
-
   private final Path linuxSandboxPath;
   private Path hermeticSandboxPath;
   private Path workingDirectory;
@@ -60,7 +46,7 @@ public class LinuxSandboxCommandLineBuilder {
   private Path stderrPath;
   private Set<Path> writableFilesAndDirectories = ImmutableSet.of();
   private ImmutableSet<PathFragment> tmpfsDirectories = ImmutableSet.of();
-  private List<BindMount> bindMounts = ImmutableList.of();
+  private Map<Path, Path> bindMounts = ImmutableMap.of();
   private Path statisticsPath;
   private boolean useFakeHostname = false;
   private NetworkNamespace createNetworkNamespace = NetworkNamespace.NO_NETNS;
@@ -164,7 +150,7 @@ public class LinuxSandboxCommandLineBuilder {
    * if any.
    */
   @CanIgnoreReturnValue
-  public LinuxSandboxCommandLineBuilder setBindMounts(List<BindMount> bindMounts) {
+  public LinuxSandboxCommandLineBuilder setBindMounts(Map<Path, Path> bindMounts) {
     this.bindMounts = bindMounts;
     return this;
   }
@@ -273,11 +259,12 @@ public class LinuxSandboxCommandLineBuilder {
     for (PathFragment tmpfsPath : tmpfsDirectories) {
       commandLineBuilder.add("-e", tmpfsPath.getPathString());
     }
-    for (BindMount bindMount : bindMounts) {
-      commandLineBuilder.add("-M", bindMount.getContent().getPathString());
+    for (Path bindMountTarget : bindMounts.keySet()) {
+      Path bindMountSource = bindMounts.get(bindMountTarget);
+      commandLineBuilder.add("-M", bindMountSource.getPathString());
       // The file is mounted in a custom location inside the sandbox.
-      if (!bindMount.getContent().equals(bindMount.getMountPoint())) {
-        commandLineBuilder.add("-m", bindMount.getMountPoint().getPathString());
+      if (!bindMountSource.equals(bindMountTarget)) {
+        commandLineBuilder.add("-m", bindMountTarget.getPathString());
       }
     }
     if (statisticsPath != null) {

--- a/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.sandbox;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -27,7 +26,6 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
 import java.io.IOException;
 import java.time.Duration;
 
@@ -41,7 +39,6 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
   private final SandboxHelpers helpers;
   private final ProcessWrapper processWrapper;
   private final Path execRoot;
-  private final ImmutableList<Root> packageRoots;
   private final Path sandboxBase;
   private final LocalEnvProvider localEnvProvider;
   private final TreeDeleter treeDeleter;
@@ -62,7 +59,6 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
     this.helpers = helpers;
     this.processWrapper = ProcessWrapper.fromCommandEnvironment(cmdEnv);
     this.execRoot = cmdEnv.getExecRoot();
-    this.packageRoots = cmdEnv.getPackageLocator().getPathEntries();
     this.localEnvProvider = LocalEnvProvider.forCurrentOs(cmdEnv.getClientEnv());
     this.sandboxBase = sandboxBase;
     this.treeDeleter = treeDeleter;
@@ -100,11 +96,7 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
     SandboxInputs inputs =
         helpers.processInputFiles(
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            context.getInputMetadataProvider(),
-            execRoot,
-            execRoot,
-            packageRoots,
-            null);
+            execRoot);
     SandboxOutputs outputs = helpers.getOutputs(spawn);
 
     return new SymlinkedSandboxedSpawn(
@@ -114,7 +106,7 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
         environment,
         inputs,
         outputs,
-        getWritableDirs(sandboxExecRoot, sandboxExecRoot, environment),
+        getWritableDirs(sandboxExecRoot, environment),
         treeDeleter,
         /* sandboxDebugPath= */ null,
         statisticsPath,

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -20,9 +20,7 @@ import static com.google.devtools.build.lib.vfs.Dirent.Type.DIRECTORY;
 import static com.google.devtools.build.lib.vfs.Dirent.Type.SYMLINK;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -30,8 +28,6 @@ import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.actions.FileArtifactValue;
-import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -48,10 +44,9 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.FileSystemUtils.MoveResult;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.common.options.OptionsParsingResult;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -252,9 +247,9 @@ public final class SandboxHelpers {
    */
   static Optional<PathFragment> getExpectedSymlinkDestination(
       PathFragment fragment, SandboxInputs inputs) {
-    RootedPath file = inputs.getFiles().get(fragment);
+    Path file = inputs.getFiles().get(fragment);
     if (file != null) {
-      return Optional.of(file.asPath().asFragment());
+      return Optional.of(file.asFragment());
     }
     return Optional.ofNullable(inputs.getSymlinks().get(fragment));
   }
@@ -390,40 +385,32 @@ public final class SandboxHelpers {
 
   /** Wrapper class for the inputs of a sandbox. */
   public static final class SandboxInputs {
-    private final Map<PathFragment, RootedPath> files;
+    private final Map<PathFragment, Path> files;
     private final Map<VirtualActionInput, byte[]> virtualInputs;
     private final Map<PathFragment, PathFragment> symlinks;
-    private final Map<Root, Path> sourceRootBindMounts;
 
     private static final SandboxInputs EMPTY_INPUTS =
-        new SandboxInputs(
-            ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+        new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
 
     public SandboxInputs(
-        Map<PathFragment, RootedPath> files,
+        Map<PathFragment, Path> files,
         Map<VirtualActionInput, byte[]> virtualInputs,
-        Map<PathFragment, PathFragment> symlinks,
-        Map<Root, Path> sourceRootBindMounts) {
+        Map<PathFragment, PathFragment> symlinks) {
       this.files = files;
       this.virtualInputs = virtualInputs;
       this.symlinks = symlinks;
-      this.sourceRootBindMounts = sourceRootBindMounts;
     }
 
     public static SandboxInputs getEmptyInputs() {
       return EMPTY_INPUTS;
     }
 
-    public Map<PathFragment, RootedPath> getFiles() {
+    public Map<PathFragment, Path> getFiles() {
       return files;
     }
 
     public Map<PathFragment, PathFragment> getSymlinks() {
       return symlinks;
-    }
-
-    public Map<Root, Path> getSourceRootBindMounts() {
-      return sourceRootBindMounts;
     }
 
     public ImmutableMap<VirtualActionInput, byte[]> getVirtualInputDigests() {
@@ -435,16 +422,10 @@ public final class SandboxHelpers {
      * included.
      */
     public SandboxInputs limitedCopy(Set<PathFragment> allowed) {
-      Map<PathFragment, RootedPath> limitedFiles = Maps.filterKeys(files, allowed::contains);
-      Map<PathFragment, PathFragment> limitedSymlinks =
-          Maps.filterKeys(symlinks, allowed::contains);
-      Set<Root> usedRoots =
-          new HashSet<>(Maps.transformValues(limitedFiles, RootedPath::getRoot).values());
-      Map<Root, Path> limitedSourceRoots =
-          Maps.filterKeys(sourceRootBindMounts, usedRoots::contains);
-
       return new SandboxInputs(
-          limitedFiles, ImmutableMap.of(), limitedSymlinks, limitedSourceRoots);
+          Maps.filterKeys(files, allowed::contains),
+          ImmutableMap.of(),
+          Maps.filterKeys(symlinks, allowed::contains));
     }
 
     @Override
@@ -454,104 +435,19 @@ public final class SandboxHelpers {
   }
 
   /**
-   * Returns the appropriate {@link RootedPath} for a Fileset symlink.
-   *
-   * <p>Filesets are weird because sometimes exec paths of the {@link ActionInput}s in them are not
-   * relative, as exec paths should be, but absolute and point to under one of the package roots or
-   * the execroot. In order to handle this, if we find such an absolute exec path, we iterate over
-   * possible base directories.
-   *
-   * <p>The inputs to this function should be symlinks that are contained within Filesets; in
-   * particular, this is different from "unresolved symlinks" in that Fileset contents are regular
-   * files (but implemented by symlinks in the output tree) whose contents matter and unresolved
-   * symlinks are symlinks for which the important content is the result of {@code readlink()}
-   */
-  private static RootedPath processFilesetSymlink(
-      PathFragment symlink,
-      Root execRootWithinSandbox,
-      PathFragment execRootFragment,
-      ImmutableList<Root> packageRoots) {
-    for (Root packageRoot : packageRoots) {
-      if (packageRoot.contains(symlink)) {
-        return RootedPath.toRootedPath(packageRoot, packageRoot.relativize(symlink));
-      }
-    }
-
-    if (symlink.startsWith(execRootFragment)) {
-      return RootedPath.toRootedPath(execRootWithinSandbox, symlink.relativeTo(execRootFragment));
-    }
-
-    throw new IllegalStateException(
-        String.format(
-            "absolute action input path '%s' not found under package roots",
-            symlink.getPathString()));
-  }
-
-  private static RootedPath processResolvedSymlink(
-      Root absoluteRoot,
-      PathFragment execRootRelativeSymlinkTarget,
-      Root execRootWithinSandbox,
-      PathFragment execRootFragment,
-      ImmutableList<Root> packageRoots,
-      Function<Root, Root> sourceRooWithinSandbox) {
-    PathFragment symlinkTarget = execRootFragment.getRelative(execRootRelativeSymlinkTarget);
-    for (Root packageRoot : packageRoots) {
-      if (packageRoot.contains(symlinkTarget)) {
-        return RootedPath.toRootedPath(
-            sourceRooWithinSandbox.apply(packageRoot), packageRoot.relativize(symlinkTarget));
-      }
-    }
-
-    if (symlinkTarget.startsWith(execRootFragment)) {
-      return RootedPath.toRootedPath(
-          execRootWithinSandbox, symlinkTarget.relativeTo(execRootFragment));
-    }
-
-    return RootedPath.toRootedPath(absoluteRoot, symlinkTarget);
-  }
-
-  /**
    * Returns the inputs of a Spawn as a map of PathFragments relative to an execRoot to paths in the
    * host filesystem where the input files can be found.
    *
    * @param inputMap the map of action inputs and where they should be visible in the action
-   * @param execRootPath the exec root from the point of view of the Bazel server
-   * @param withinSandboxExecRootPath the exec root from within the sandbox (different from {@code
-   *     execRootPath} because the sandbox does magic with fiile system namespaces)
-   * @param packageRoots the package path entries during this build
-   * @param sandboxSourceRoots the directory where source roots are mapped within the sandbox
+   * @param execRoot the exec root
    * @throws IOException if processing symlinks fails
    */
-  public SandboxInputs processInputFiles(
-      Map<PathFragment, ActionInput> inputMap,
-      InputMetadataProvider inputMetadataProvider,
-      Path execRootPath,
-      Path withinSandboxExecRootPath,
-      ImmutableList<Root> packageRoots,
-      Path sandboxSourceRoots)
+  @CanIgnoreReturnValue
+  public SandboxInputs processInputFiles(Map<PathFragment, ActionInput> inputMap, Path execRoot)
       throws IOException, InterruptedException {
-    Root withinSandboxExecRoot = Root.fromPath(withinSandboxExecRootPath);
-    Root execRoot =
-        withinSandboxExecRootPath.equals(execRootPath)
-            ? withinSandboxExecRoot
-            : Root.fromPath(execRootPath);
-    Root absoluteRoot = Root.absoluteRoot(execRootPath.getFileSystem());
-
-    Map<PathFragment, RootedPath> inputFiles = new TreeMap<>();
+    Map<PathFragment, Path> inputFiles = new TreeMap<>();
     Map<PathFragment, PathFragment> inputSymlinks = new TreeMap<>();
     Map<VirtualActionInput, byte[]> virtualInputs = new HashMap<>();
-    Map<Root, Root> sourceRootToSandboxSourceRoot = new TreeMap<>();
-
-    Function<Root, Root> sourceRootWithinSandbox =
-        r -> {
-          if (!sourceRootToSandboxSourceRoot.containsKey(r)) {
-            int next = sourceRootToSandboxSourceRoot.size();
-            sourceRootToSandboxSourceRoot.put(
-                r, Root.fromPath(sandboxSourceRoots.getRelative(Integer.toString(next))));
-          }
-
-          return sourceRootToSandboxSourceRoot.get(r);
-        };
 
     for (Map.Entry<PathFragment, ActionInput> e : inputMap.entrySet()) {
       if (Thread.interrupted()) {
@@ -559,12 +455,11 @@ public final class SandboxHelpers {
       }
       PathFragment pathFragment = e.getKey();
       ActionInput actionInput = e.getValue();
-      if (actionInput instanceof VirtualActionInput) {
+      if (actionInput instanceof VirtualActionInput input) {
         // TODO(larsrc): Figure out which VAIs actually require atomicity, maybe avoid it.
-        VirtualActionInput input = (VirtualActionInput) actionInput;
         byte[] digest =
             input.atomicallyWriteRelativeTo(
-                execRootPath,
+                execRoot,
                 // When 2 actions try to atomically create the same virtual input, they need to have
                 // a different suffix for the temporary file in order to avoid racy write to the
                 // same one.
@@ -578,91 +473,15 @@ public final class SandboxHelpers {
         Path inputPath = execRoot.getRelative(actionInput.getExecPath());
         inputSymlinks.put(pathFragment, inputPath.readSymbolicLink());
       } else {
-        RootedPath inputPath;
-
-        if (actionInput instanceof EmptyActionInput) {
-          inputPath = null;
-        } else if (actionInput instanceof VirtualActionInput) {
-          inputPath = RootedPath.toRootedPath(withinSandboxExecRoot, actionInput.getExecPath());
-        } else if (actionInput instanceof Artifact) {
-          Artifact inputArtifact = (Artifact) actionInput;
-          if (sandboxSourceRoots == null) {
-            inputPath = RootedPath.toRootedPath(withinSandboxExecRoot, inputArtifact.getExecPath());
-          } else {
-            if (inputArtifact.isSourceArtifact()) {
-              Root sourceRoot = inputArtifact.getRoot().getRoot();
-              inputPath =
-                  RootedPath.toRootedPath(
-                      sourceRootWithinSandbox.apply(sourceRoot),
-                      inputArtifact.getRootRelativePath());
-            } else {
-              PathFragment materializationExecPath = null;
-              if (inputArtifact.isChildOfDeclaredDirectory()) {
-                FileArtifactValue parentMetadata =
-                    inputMetadataProvider.getInputMetadata(inputArtifact.getParent());
-                if (parentMetadata.getMaterializationExecPath().isPresent()) {
-                  materializationExecPath =
-                      parentMetadata
-                          .getMaterializationExecPath()
-                          .get()
-                          .getRelative(inputArtifact.getParentRelativePath());
-                }
-              } else if (!inputArtifact.isTreeArtifact()) {
-                // Normally, one would not see tree artifacts here because they have already been
-                // expanded by the time the code gets here. However, there is one very special case:
-                // when an action has an archived tree artifact on its output and is executed on the
-                // local branch of the dynamic execution strategy, the tree artifact is zipped up
-                // in a little extra spawn, which has direct tree artifact on its inputs. Sadly,
-                // it's not easy to fix this because there isn't an easy way to inject this new
-                // tree artifact into the artifact expander being used.
-                //
-                // The best would be to not rely on spawn strategies for executing that little
-                // command: it's entirely under the control of Bazel so we can guarantee that it
-                // does not cause mischief.
-                FileArtifactValue metadata = inputMetadataProvider.getInputMetadata(actionInput);
-                if (metadata.getMaterializationExecPath().isPresent()) {
-                  materializationExecPath = metadata.getMaterializationExecPath().get();
-                }
-              }
-
-              if (materializationExecPath != null) {
-                inputPath =
-                    processResolvedSymlink(
-                        absoluteRoot,
-                        materializationExecPath,
-                        withinSandboxExecRoot,
-                        execRootPath.asFragment(),
-                        packageRoots,
-                        sourceRootWithinSandbox);
-              } else {
-                inputPath =
-                    RootedPath.toRootedPath(withinSandboxExecRoot, inputArtifact.getExecPath());
-              }
-            }
-          }
-        } else {
-          PathFragment execPath = actionInput.getExecPath();
-          if (execPath.isAbsolute()) {
-            // This happens for ActionInputs that are part of Filesets (see the Javadoc on
-            // processFilesetSymlink())
-            inputPath =
-                processFilesetSymlink(
-                    actionInput.getExecPath(), execRoot, execRootPath.asFragment(), packageRoots);
-          } else {
-            inputPath = RootedPath.toRootedPath(execRoot, actionInput.getExecPath());
-          }
-        }
-
+        Path inputPath =
+            actionInput instanceof EmptyActionInput
+                ? null
+                : execRoot.getRelative(actionInput.getExecPath());
         inputFiles.put(pathFragment, inputPath);
       }
     }
-
-    Map<Root, Path> sandboxRootToSourceRoot = new TreeMap<>();
-    sourceRootToSandboxSourceRoot.forEach((k, v) -> sandboxRootToSourceRoot.put(v, k.asPath()));
-
-    return new SandboxInputs(inputFiles, virtualInputs, inputSymlinks, sandboxRootToSourceRoot);
+    return new SandboxInputs(inputFiles, virtualInputs, inputSymlinks);
   }
-
 
   /** The file and directory outputs of a sandboxed spawn. */
   @AutoValue

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxUtil.java
@@ -24,7 +24,6 @@ import com.google.devtools.build.lib.shell.SubprocessBuilder;
 import com.google.devtools.build.lib.shell.SubprocessBuilder.StreamAction;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -107,7 +106,7 @@ public final class WindowsSandboxUtil {
     private Path stdoutPath;
     private Path stderrPath;
     private Set<Path> writableFilesAndDirectories = ImmutableSet.of();
-    private Map<PathFragment, RootedPath> readableFilesAndDirectories = new TreeMap<>();
+    private Map<PathFragment, Path> readableFilesAndDirectories = new TreeMap<>();
     private Set<Path> inaccessiblePaths = ImmutableSet.of();
     private boolean useDebugMode = false;
     private List<String> commandArguments = ImmutableList.of();
@@ -166,7 +165,7 @@ public final class WindowsSandboxUtil {
     /** Sets the files or directories to make readable for the sandboxed process, if any. */
     @CanIgnoreReturnValue
     public CommandLineBuilder setReadableFilesAndDirectories(
-        Map<PathFragment, RootedPath> readableFilesAndDirectories) {
+        Map<PathFragment, Path> readableFilesAndDirectories) {
       this.readableFilesAndDirectories = readableFilesAndDirectories;
       return this;
     }
@@ -213,8 +212,8 @@ public final class WindowsSandboxUtil {
       for (Path writablePath : writableFilesAndDirectories) {
         commandLineBuilder.add("-w", writablePath.getPathString());
       }
-      for (RootedPath readablePath : readableFilesAndDirectories.values()) {
-        commandLineBuilder.add("-r", readablePath.asPath().getPathString());
+      for (Path readablePath : readableFilesAndDirectories.values()) {
+        commandLineBuilder.add("-r", readablePath.getPathString());
       }
       for (Path writablePath : inaccessiblePaths) {
         commandLineBuilder.add("-b", writablePath.getPathString());

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.sandbox;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -27,7 +26,6 @@ import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
 import java.io.IOException;
 import java.time.Duration;
 
@@ -36,7 +34,6 @@ final class WindowsSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
   private final SandboxHelpers helpers;
   private final Path execRoot;
-  private final ImmutableList<Root> packageRoots;
   private final PathFragment windowsSandbox;
   private final LocalEnvProvider localEnvProvider;
   private final Duration timeoutKillDelay;
@@ -57,7 +54,6 @@ final class WindowsSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     super(cmdEnv);
     this.helpers = helpers;
     this.execRoot = cmdEnv.getExecRoot();
-    this.packageRoots = cmdEnv.getPackageLocator().getPathEntries();
     this.windowsSandbox = windowsSandboxPath;
     this.timeoutKillDelay = timeoutKillDelay;
     this.localEnvProvider = new WindowsLocalEnvProvider(cmdEnv.getClientEnv());
@@ -76,14 +72,10 @@ final class WindowsSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     SandboxInputs readablePaths =
         helpers.processInputFiles(
             context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            context.getInputMetadataProvider(),
-            execRoot,
-            execRoot,
-            packageRoots,
-            null);
+            execRoot);
 
     ImmutableSet.Builder<Path> writablePaths = ImmutableSet.builder();
-    writablePaths.addAll(getWritableDirs(execRoot, execRoot, environment));
+    writablePaths.addAll(getWritableDirs(execRoot, environment));
     for (ActionInput output : spawn.getOutputFiles()) {
       writablePaths.add(execRoot.getRelative(output.getExecPath()));
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStore.java
@@ -264,15 +264,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
     Path treeDir = artifactPathResolver.toPath(parent);
     boolean chmod = executionMode.get();
 
-    FileStatus lstat = treeDir.statIfFound(Symlinks.NOFOLLOW);
-    FileStatus stat;
-    if (lstat == null) {
-      stat = null;
-    } else if (!lstat.isSymbolicLink()) {
-      stat = lstat;
-    } else {
-      stat = treeDir.statIfFound(Symlinks.FOLLOW);
-    }
+    FileStatus stat = treeDir.statIfFound(Symlinks.FOLLOW);
 
     // Make sure the tree artifact root exists and is a regular directory. Note that this is how the
     // action is initialized, so this should hold unless the action itself has deleted the root.
@@ -329,18 +321,12 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
     }
 
     // Same rationale as for constructFileArtifactValue.
-    if (lstat.isSymbolicLink()) {
-      PathFragment materializationExecPath = null;
-      if (stat instanceof FileStatusWithMetadata) {
-        materializationExecPath =
-            ((FileStatusWithMetadata) stat).getMetadata().getMaterializationExecPath().orElse(null);
-      }
-
-      if (materializationExecPath == null) {
-        materializationExecPath = treeDir.resolveSymbolicLinks().asFragment().relativeTo(execRoot);
-      }
-
-      tree.setMaterializationExecPath(materializationExecPath);
+    if (anyRemote.get() && treeDir.isSymbolicLink() && stat instanceof FileStatusWithMetadata) {
+      FileArtifactValue metadata = ((FileStatusWithMetadata) stat).getMetadata();
+      tree.setMaterializationExecPath(
+          metadata
+              .getMaterializationExecPath()
+              .orElse(treeDir.resolveSymbolicLinks().asFragment().relativeTo(execRoot)));
     }
 
     return tree.build();
@@ -512,13 +498,7 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
       return value;
     }
 
-    boolean isResolvedSymlink =
-        statAndValue.statNoFollow() != null
-            && statAndValue.statNoFollow().isSymbolicLink()
-            && statAndValue.realPath() != null
-            && !value.isRemote();
-
-    if (type.isFile() && !isResolvedSymlink && fileDigest != null) {
+    if (type.isFile() && fileDigest != null) {
       // The digest is in the file value and that is all that is needed for this file's metadata.
       return value;
     }
@@ -534,30 +514,22 @@ final class ActionOutputMetadataStore implements OutputMetadataStore {
           artifactPathResolver.toPath(artifact).getLastModifiedTime());
     }
 
-    byte[] actualDigest = fileDigest != null ? fileDigest : injectedDigest;
-
-    if (actualDigest == null && type.isFile()) {
+    if (injectedDigest == null && type.isFile()) {
       // We don't have an injected digest and there is no digest in the file value (which attempts a
       // fast digest). Manually compute the digest instead.
+      Path path = statAndValue.pathNoFollow();
+      if (statAndValue.statNoFollow() != null
+          && statAndValue.statNoFollow().isSymbolicLink()
+          && statAndValue.realPath() != null) {
+        // If the file is a symlink, we compute the digest using the target path so that it's
+        // possible to hit the digest cache - we probably already computed the digest for the
+        // target during previous action execution.
+        path = statAndValue.realPath();
+      }
 
-      // If the file is a symlink, we compute the digest using the target path so that it's
-      // possible to hit the digest cache - we probably already computed the digest for the
-      // target during previous action execution.
-      Path pathToDigest = isResolvedSymlink ? statAndValue.realPath() : statAndValue.pathNoFollow();
-      actualDigest = DigestUtils.manuallyComputeDigest(pathToDigest);
+      injectedDigest = DigestUtils.manuallyComputeDigest(path);
     }
-
-    if (!isResolvedSymlink) {
-      return FileArtifactValue.createFromInjectedDigest(value, actualDigest);
-    }
-
-    PathFragment realPathAsFragment = statAndValue.realPath().asFragment();
-    PathFragment execRootRelativeRealPath =
-        realPathAsFragment.startsWith(execRoot)
-            ? realPathAsFragment.relativeTo(execRoot)
-            : realPathAsFragment;
-    return FileArtifactValue.createForResolvedSymlink(
-        execRootRelativeRealPath, value, actualDigest);
+    return FileArtifactValue.createFromInjectedDigest(value, injectedDigest);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorker.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorker.java
@@ -25,7 +25,6 @@ import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.exec.TreeDeleter;
 import com.google.devtools.build.lib.sandbox.CgroupsInfo;
 import com.google.devtools.build.lib.sandbox.LinuxSandboxCommandLineBuilder;
-import com.google.devtools.build.lib.sandbox.LinuxSandboxCommandLineBuilder.BindMount;
 import com.google.devtools.build.lib.sandbox.LinuxSandboxUtil;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
@@ -145,12 +144,11 @@ final class SandboxedWorker extends SingleplexWorker {
     return writableDirs.build();
   }
 
-  private ImmutableList<BindMount> getBindMounts(Path sandboxExecRoot, @Nullable Path sandboxTmp)
+  private SortedMap<Path, Path> getBindMounts(Path sandboxExecRoot, @Nullable Path sandboxTmp)
       throws UserExecException, IOException {
     FileSystem fs = sandboxExecRoot.getFileSystem();
     Path tmpPath = fs.getPath("/tmp");
     final SortedMap<Path, Path> bindMounts = Maps.newTreeMap();
-    ImmutableList.Builder<BindMount> result = ImmutableList.builder();
     // Mount a fresh, empty temporary directory as /tmp for each sandbox rather than reusing the
     // host filesystem's /tmp. Since we're in a worker, we clean this dir between requests.
     bindMounts.put(tmpPath, sandboxTmp);
@@ -167,9 +165,8 @@ final class SandboxedWorker extends SingleplexWorker {
       }
     }
     // TODO(larsrc): Handle hermetic tmp
-    bindMounts.forEach((k, v) -> result.add(BindMount.of(k, v)));
     LinuxSandboxUtil.validateBindMounts(bindMounts);
-    return result.build();
+    return bindMounts;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
@@ -22,7 +22,6 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -87,9 +86,9 @@ final class WorkerExecRoot {
       }
       Path key = dir.getRelative(fragment);
       if (inputs.getFiles().containsKey(fragment)) {
-        RootedPath fileDest = inputs.getFiles().get(fragment);
+        Path fileDest = inputs.getFiles().get(fragment);
         if (fileDest != null) {
-          key.createSymbolicLink(fileDest.asPath());
+          key.createSymbolicLink(fileDest);
         } else {
           FileSystemUtils.createEmptyFile(key);
         }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
@@ -219,7 +219,6 @@ public class WorkerModule extends BlazeModule {
         new WorkerSpawnRunner(
             new SandboxHelpers(),
             env.getExecRoot(),
-            env.getPackageLocator().getPathEntries(),
             workerPool,
             env.getReporter(),
             localEnvProvider,

--- a/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawnTest.java
@@ -35,7 +35,6 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
@@ -374,7 +373,7 @@ public class AbstractContainerizingSandboxedSpawnTest {
 
   private static SandboxInputs createSandboxInputs(
       ImmutableList<String> files, ImmutableMap<String, String> symlinks) {
-    Map<PathFragment, RootedPath> filesMap = Maps.newHashMapWithExpectedSize(files.size());
+    Map<PathFragment, Path> filesMap = Maps.newHashMapWithExpectedSize(files.size());
     for (String file : files) {
       filesMap.put(PathFragment.create(file), null);
     }
@@ -384,8 +383,7 @@ public class AbstractContainerizingSandboxedSpawnTest {
         symlinks.entrySet().stream()
             .collect(
                 toImmutableMap(
-                    e -> PathFragment.create(e.getKey()), e -> PathFragment.create(e.getValue()))),
-        ImmutableMap.of());
+                    e -> PathFragment.create(e.getKey()), e -> PathFragment.create(e.getValue()))));
   }
 
   /** Return a list of all entries under the provided directory recursively. */

--- a/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxCommandLineBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxCommandLineBuilderTest.java
@@ -20,8 +20,9 @@ import static com.google.devtools.build.lib.sandbox.LinuxSandboxCommandLineBuild
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.sandbox.LinuxSandboxCommandLineBuilder.BindMount;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
@@ -125,11 +126,12 @@ public final class LinuxSandboxCommandLineBuilderTest {
 
     ImmutableSet<PathFragment> tmpfsDirectories = ImmutableSet.of(tmpfsDir1, tmpfsDir2);
 
-    ImmutableList<BindMount> bindMounts =
-        ImmutableList.of(
-            BindMount.of(bindMountSameSourceAndTarget, bindMountSameSourceAndTarget),
-            BindMount.of(bindMountTarget1, bindMountSource1),
-            BindMount.of(bindMountTarget2, bindMountSource2));
+    ImmutableMap<Path, Path> bindMounts =
+        ImmutableSortedMap.<Path, Path>naturalOrder()
+            .put(bindMountSameSourceAndTarget, bindMountSameSourceAndTarget)
+            .put(bindMountTarget1, bindMountSource1)
+            .put(bindMountTarget2, bindMountSource2)
+            .buildOrThrow();
 
     String cgroupsDir = "/sys/fs/cgroups/something";
 

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SandboxHelpersTest.java
@@ -24,23 +24,17 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionInput;
-import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
-import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.CommandLines.ParamFileActionInput;
-import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.exec.BinTools;
-import com.google.devtools.build.lib.exec.util.FakeActionInputFileCache;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
-import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -49,8 +43,6 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
@@ -74,17 +66,14 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link SandboxHelpers}. */
 @RunWith(JUnit4.class)
 public class SandboxHelpersTest {
-  private static final byte[] FAKE_DIGEST = new byte[] {1};
 
   private final Scratch scratch = new Scratch();
-  private Path execRootPath;
-  private Root execRoot;
+  private Path execRoot;
   @Nullable private ExecutorService executorToCleanup;
 
   @Before
   public void createExecRoot() throws IOException {
-    execRootPath = scratch.dir("/execRoot");
-    execRoot = Root.fromPath(execRootPath);
+    execRoot = scratch.dir("/execRoot");
   }
 
   @After
@@ -97,83 +86,6 @@ public class SandboxHelpersTest {
     executorToCleanup.awaitTermination(TestUtils.WAIT_TIMEOUT_SECONDS, SECONDS);
   }
 
-  private RootedPath execRootedPath(String execPath) {
-    return RootedPath.toRootedPath(execRoot, PathFragment.create(execPath));
-  }
-
-  @Test
-  public void processInputFiles_resolvesMaterializationPath_fileArtifact() throws Exception {
-    ArtifactRoot outputRoot =
-        ArtifactRoot.asDerivedRoot(execRootPath, ArtifactRoot.RootType.Output, "outputs");
-    Path sandboxSourceRoot = scratch.dir("/faketmp/sandbox-source-roots");
-
-    Artifact input = ActionsTestUtil.createArtifact(outputRoot, "a/a");
-    FileArtifactValue symlinkTargetMetadata =
-        FileArtifactValue.createForNormalFile(FAKE_DIGEST, null, 0L);
-    FileArtifactValue inputMetadata =
-        FileArtifactValue.createForResolvedSymlink(
-            PathFragment.create("b/b"), symlinkTargetMetadata, FAKE_DIGEST);
-
-    FakeActionInputFileCache inputMetadataProvider = new FakeActionInputFileCache();
-    inputMetadataProvider.put(input, inputMetadata);
-
-    SandboxHelpers sandboxHelpers = new SandboxHelpers();
-    SandboxInputs inputs =
-        sandboxHelpers.processInputFiles(
-            inputMap(input),
-            inputMetadataProvider,
-            execRootPath,
-            execRootPath,
-            ImmutableList.of(),
-            sandboxSourceRoot);
-
-    assertThat(inputs.getFiles())
-        .containsEntry(
-            input.getExecPath(), RootedPath.toRootedPath(execRoot, PathFragment.create("b/b")));
-  }
-
-  @Test
-  public void processInputFiles_resolvesMaterializationPath_treeArtifact() throws Exception {
-    ArtifactRoot outputRoot =
-        ArtifactRoot.asDerivedRoot(execRootPath, ArtifactRoot.RootType.Output, "outputs");
-    Path sandboxSourceRoot = scratch.dir("/faketmp/sandbox-source-roots");
-    SpecialArtifact parent =
-        ActionsTestUtil.createTreeArtifactWithGeneratingAction(
-            outputRoot, "bin/config/other_dir/subdir");
-
-    TreeFileArtifact childA = TreeFileArtifact.createTreeOutput(parent, "a/a");
-    TreeFileArtifact childB = TreeFileArtifact.createTreeOutput(parent, "b/b");
-    FileArtifactValue childMetadata = FileArtifactValue.createForNormalFile(FAKE_DIGEST, null, 0L);
-    TreeArtifactValue parentMetadata =
-        TreeArtifactValue.newBuilder(parent)
-            .putChild(childA, childMetadata)
-            .putChild(childB, childMetadata)
-            .setMaterializationExecPath(PathFragment.create("materialized"))
-            .build();
-
-    FakeActionInputFileCache inputMetadataProvider = new FakeActionInputFileCache();
-    inputMetadataProvider.put(parent, parentMetadata.getMetadata());
-
-    SandboxHelpers sandboxHelpers = new SandboxHelpers();
-    SandboxInputs inputs =
-        sandboxHelpers.processInputFiles(
-            inputMap(childA, childB),
-            inputMetadataProvider,
-            execRootPath,
-            execRootPath,
-            ImmutableList.of(),
-            sandboxSourceRoot);
-
-    assertThat(inputs.getFiles())
-        .containsEntry(
-            childA.getExecPath(),
-            RootedPath.toRootedPath(execRoot, PathFragment.create("materialized/a/a")));
-    assertThat(inputs.getFiles())
-        .containsEntry(
-            childB.getExecPath(),
-            RootedPath.toRootedPath(execRoot, PathFragment.create("materialized/b/b")));
-  }
-
   @Test
   public void processInputFiles_materializesParamFile() throws Exception {
     SandboxHelpers sandboxHelpers = new SandboxHelpers();
@@ -184,22 +96,15 @@ public class SandboxHelpersTest {
             ParameterFileType.UNQUOTED,
             UTF_8);
 
-    SandboxInputs inputs =
-        sandboxHelpers.processInputFiles(
-            inputMap(paramFile),
-            new FakeActionInputFileCache(),
-            execRootPath,
-            execRootPath,
-            ImmutableList.of(),
-            null);
+    SandboxInputs inputs = sandboxHelpers.processInputFiles(inputMap(paramFile), execRoot);
 
     assertThat(inputs.getFiles())
-        .containsExactly(PathFragment.create("paramFile"), execRootedPath("paramFile"));
+        .containsExactly(PathFragment.create("paramFile"), execRoot.getChild("paramFile"));
     assertThat(inputs.getSymlinks()).isEmpty();
-    assertThat(FileSystemUtils.readLines(execRootPath.getChild("paramFile"), UTF_8))
+    assertThat(FileSystemUtils.readLines(execRoot.getChild("paramFile"), UTF_8))
         .containsExactly("-a", "-b")
         .inOrder();
-    assertThat(execRootPath.getChild("paramFile").isExecutable()).isTrue();
+    assertThat(execRoot.getChild("paramFile").isExecutable()).isTrue();
   }
 
   @Test
@@ -210,22 +115,16 @@ public class SandboxHelpersTest {
             scratch.file("tool", "#!/bin/bash", "echo hello"),
             PathFragment.create("_bin/say_hello"));
 
-    SandboxInputs inputs =
-        sandboxHelpers.processInputFiles(
-            inputMap(tool),
-            new FakeActionInputFileCache(),
-            execRootPath,
-            execRootPath,
-            ImmutableList.of(),
-            null);
+    SandboxInputs inputs = sandboxHelpers.processInputFiles(inputMap(tool), execRoot);
 
     assertThat(inputs.getFiles())
-        .containsExactly(PathFragment.create("_bin/say_hello"), execRootedPath("_bin/say_hello"));
+        .containsExactly(
+            PathFragment.create("_bin/say_hello"), execRoot.getRelative("_bin/say_hello"));
     assertThat(inputs.getSymlinks()).isEmpty();
-    assertThat(FileSystemUtils.readLines(execRootPath.getRelative("_bin/say_hello"), UTF_8))
+    assertThat(FileSystemUtils.readLines(execRoot.getRelative("_bin/say_hello"), UTF_8))
         .containsExactly("#!/bin/bash", "echo hello")
         .inOrder();
-    assertThat(execRootPath.getRelative("_bin/say_hello").isExecutable()).isTrue();
+    assertThat(execRoot.getRelative("_bin/say_hello").isExecutable()).isTrue();
   }
 
   /**
@@ -261,27 +160,13 @@ public class SandboxHelpersTest {
         executorToCleanup.submit(
             () -> {
               try {
-                var unused =
-                    sandboxHelpers.processInputFiles(
-                        inputMap(input),
-                        new FakeActionInputFileCache(),
-                        customExecRoot,
-                        customExecRoot,
-                        ImmutableList.of(),
-                        null);
+                sandboxHelpers.processInputFiles(inputMap(input), customExecRoot);
                 finishProcessingSemaphore.release();
               } catch (IOException | InterruptedException e) {
                 throw new IllegalArgumentException(e);
               }
             });
-    var unused =
-        sandboxHelpers.processInputFiles(
-            inputMap(input),
-            new FakeActionInputFileCache(),
-            customExecRoot,
-            customExecRoot,
-            ImmutableList.of(),
-            null);
+    sandboxHelpers.processInputFiles(inputMap(input), customExecRoot);
     finishProcessingSemaphore.release();
     future.get();
 
@@ -350,17 +235,14 @@ public class SandboxHelpersTest {
 
   @Test
   public void cleanExisting_updatesDirs() throws IOException, InterruptedException {
-    RootedPath inputTxt =
-        RootedPath.toRootedPath(
-            Root.fromPath(scratch.getFileSystem().getPath("/")), PathFragment.create("hello.txt"));
-    Path rootDir = execRootPath.getParentDirectory();
+    Path inputTxt = scratch.getFileSystem().getPath(PathFragment.create("/hello.txt"));
+    Path rootDir = execRoot.getParentDirectory();
     PathFragment input1 = PathFragment.create("existing/directory/with/input1.txt");
     PathFragment input2 = PathFragment.create("partial/directory/input2.txt");
     PathFragment input3 = PathFragment.create("new/directory/input3.txt");
     SandboxInputs inputs =
         new SandboxInputs(
             ImmutableMap.of(input1, inputTxt, input2, inputTxt, input3, inputTxt),
-            ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of());
     Set<PathFragment> inputsToCreate = new LinkedHashSet<>();
@@ -382,17 +264,17 @@ public class SandboxHelpersTest {
     assertThat(inputsToCreate).containsExactly(input1, input2, input3);
 
     // inputdir1 exists fully
-    execRootPath.getRelative(inputDir1).createDirectoryAndParents();
+    execRoot.getRelative(inputDir1).createDirectoryAndParents();
     // inputdir2 exists partially, should be kept nonetheless.
-    execRootPath
+    execRoot
         .getRelative(inputDir2)
         .getParentDirectory()
         .getRelative("doomedSubdir")
         .createDirectoryAndParents();
     // inputDir3 just doesn't exist
     // outputDir only exists partially
-    execRootPath.getRelative(outputDir).getParentDirectory().createDirectoryAndParents();
-    execRootPath.getRelative("justSomeDir/thatIsDoomed").createDirectoryAndParents();
+    execRoot.getRelative(outputDir).getParentDirectory().createDirectoryAndParents();
+    execRoot.getRelative("justSomeDir/thatIsDoomed").createDirectoryAndParents();
     // `thiswillbeafile/output` simulates a directory that was in the stashed dir but whose same
     // path is used later for a regular file.
     scratch.dir("/execRoot/thiswillbeafile/output");
@@ -403,23 +285,22 @@ public class SandboxHelpersTest {
         new SandboxInputs(
             ImmutableMap.of(input1, inputTxt, input2, inputTxt, input3, inputTxt, input4, inputTxt),
             ImmutableMap.of(),
-            ImmutableMap.of(),
             ImmutableMap.of());
-    SandboxHelpers.cleanExisting(rootDir, inputs2, inputsToCreate, dirsToCreate, execRootPath);
+    SandboxHelpers.cleanExisting(rootDir, inputs2, inputsToCreate, dirsToCreate, execRoot);
     assertThat(dirsToCreate).containsExactly(inputDir2, inputDir3, outputDir);
-    assertThat(execRootPath.getRelative("existing/directory/with").exists()).isTrue();
-    assertThat(execRootPath.getRelative("partial").exists()).isTrue();
-    assertThat(execRootPath.getRelative("partial/doomedSubdir").exists()).isFalse();
-    assertThat(execRootPath.getRelative("partial/directory").exists()).isFalse();
-    assertThat(execRootPath.getRelative("justSomeDir/thatIsDoomed").exists()).isFalse();
-    assertThat(execRootPath.getRelative("out").exists()).isTrue();
-    assertThat(execRootPath.getRelative("out/dir").exists()).isFalse();
+    assertThat(execRoot.getRelative("existing/directory/with").exists()).isTrue();
+    assertThat(execRoot.getRelative("partial").exists()).isTrue();
+    assertThat(execRoot.getRelative("partial/doomedSubdir").exists()).isFalse();
+    assertThat(execRoot.getRelative("partial/directory").exists()).isFalse();
+    assertThat(execRoot.getRelative("justSomeDir/thatIsDoomed").exists()).isFalse();
+    assertThat(execRoot.getRelative("out").exists()).isTrue();
+    assertThat(execRoot.getRelative("out/dir").exists()).isFalse();
   }
 
   @Test
   public void populateInputsAndDirsToCreate_createsMappedDirectories() {
     ArtifactRoot outputRoot =
-        ArtifactRoot.asDerivedRoot(execRootPath, ArtifactRoot.RootType.Output, "outputs");
+        ArtifactRoot.asDerivedRoot(execRoot, ArtifactRoot.RootType.Output, "outputs");
     ActionInput outputFile = ActionsTestUtil.createArtifact(outputRoot, "bin/config/dir/file");
     ActionInput outputDir =
         ActionsTestUtil.createTreeArtifactWithGeneratingAction(
@@ -459,13 +340,13 @@ public class SandboxHelpersTest {
             .setPathMapper(pathMapper)
             .build();
     var sandboxHelpers = new SandboxHelpers();
-    Path sandboxBase = execRootPath.getRelative("sandbox");
+    Path sandboxBase = execRoot.getRelative("sandbox");
     PathFragment mappedOutputPath = PathFragment.create("bin/output");
     sandboxBase.getRelative(mappedOutputPath).getParentDirectory().createDirectoryAndParents();
     FileSystemUtils.writeLinesAs(
         sandboxBase.getRelative(mappedOutputPath), UTF_8, "hello", "pathmapper");
 
-    Path realBase = execRootPath.getRelative("real");
+    Path realBase = execRoot.getRelative("real");
     SandboxHelpers.moveOutputs(sandboxHelpers.getOutputs(spawn), sandboxBase, realBase);
 
     assertThat(

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
@@ -26,8 +26,6 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
@@ -62,9 +60,8 @@ public class SymlinkedSandboxedSpawnTest {
 
   @Test
   public void createFileSystem() throws Exception {
-    RootedPath helloTxt =
-        RootedPath.toRootedPath(Root.fromPath(workspaceDir), PathFragment.create("hello.txt"));
-    FileSystemUtils.createEmptyFile(helloTxt.asPath());
+    Path helloTxt = workspaceDir.getRelative("hello.txt");
+    FileSystemUtils.createEmptyFile(helloTxt);
 
     SymlinkedSandboxedSpawn symlinkedExecRoot =
         new SymlinkedSandboxedSpawn(
@@ -74,7 +71,6 @@ public class SymlinkedSandboxedSpawnTest {
             ImmutableMap.of(),
             new SandboxInputs(
                 ImmutableMap.of(PathFragment.create("such/input.txt"), helloTxt),
-                ImmutableMap.of(),
                 ImmutableMap.of(),
                 ImmutableMap.of()),
             SandboxOutputs.create(
@@ -89,8 +85,7 @@ public class SymlinkedSandboxedSpawnTest {
     symlinkedExecRoot.createFileSystem();
 
     assertThat(execRoot.getRelative("such/input.txt").isSymbolicLink()).isTrue();
-    assertThat(execRoot.getRelative("such/input.txt").resolveSymbolicLinks())
-        .isEqualTo(helloTxt.asPath());
+    assertThat(execRoot.getRelative("such/input.txt").resolveSymbolicLinks()).isEqualTo(helloTxt);
     assertThat(execRoot.getRelative("very").isDirectory()).isTrue();
     assertThat(execRoot.getRelative("wow/writable").isDirectory()).isTrue();
   }
@@ -107,8 +102,7 @@ public class SymlinkedSandboxedSpawnTest {
             execRoot,
             ImmutableList.of("/bin/true"),
             ImmutableMap.of(),
-            new SandboxInputs(
-                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+            new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
             SandboxOutputs.create(
                 ImmutableSet.of(outputFile.relativeTo(execRoot)), ImmutableSet.of()),
             ImmutableSet.of(),

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStoreTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStoreTest.java
@@ -82,6 +82,10 @@ public final class ActionOutputMetadataStoreTest {
     FULLY_LOCAL,
     FULLY_REMOTE,
     MIXED;
+
+    boolean isPartiallyRemote() {
+      return this == FULLY_REMOTE || this == MIXED;
+    }
   }
 
   private final Map<Path, Integer> chmodCalls = Maps.newConcurrentMap();
@@ -432,10 +436,11 @@ public final class ActionOutputMetadataStoreTest {
         .getPath(outputArtifact.getPath().getPathString())
         .createSymbolicLink(targetArtifact.getPath().asFragment());
 
-    PathFragment expectedMaterializationExecPath =
-        location == FileLocation.REMOTE && preexistingPath != null
-            ? preexistingPath
-            : targetArtifact.getExecPath();
+    PathFragment expectedMaterializationExecPath = null;
+    if (location == FileLocation.REMOTE) {
+      expectedMaterializationExecPath =
+          preexistingPath != null ? preexistingPath : targetArtifact.getExecPath();
+    }
 
     assertThat(store.getOutputMetadata(outputArtifact))
         .isEqualTo(createFileMetadataForSymlinkTest(location, expectedMaterializationExecPath));
@@ -445,12 +450,7 @@ public final class ActionOutputMetadataStoreTest {
       FileLocation location, @Nullable PathFragment materializationExecPath) {
     switch (location) {
       case LOCAL:
-        FileArtifactValue target =
-            FileArtifactValue.createForNormalFile(new byte[] {1, 2, 3}, /* proxy= */ null, 10);
-        return materializationExecPath == null
-            ? target
-            : FileArtifactValue.createForResolvedSymlink(
-                materializationExecPath, target, target.getDigest());
+        return FileArtifactValue.createForNormalFile(new byte[] {1, 2, 3}, /* proxy= */ null, 10);
       case REMOTE:
         return RemoteFileArtifactValue.create(
             new byte[] {1, 2, 3}, 10, 1, -1, materializationExecPath);
@@ -495,8 +495,11 @@ public final class ActionOutputMetadataStoreTest {
         .getPath(outputArtifact.getPath().getPathString())
         .createSymbolicLink(targetArtifact.getPath().asFragment());
 
-    PathFragment expectedMaterializationExecPath =
-        preexistingPath != null ? preexistingPath : targetArtifact.getExecPath();
+    PathFragment expectedMaterializationExecPath = null;
+    if (composition.isPartiallyRemote()) {
+      expectedMaterializationExecPath =
+          preexistingPath != null ? preexistingPath : targetArtifact.getExecPath();
+    }
 
     assertThat(store.getTreeArtifactValue(outputArtifact))
         .isEqualTo(
@@ -825,7 +828,7 @@ public final class ActionOutputMetadataStoreTest {
 
     var symlinkMetadata = store.getOutputMetadata(symlink);
 
-    assertThat(symlinkMetadata.getDigest()).isEqualTo(targetMetadata.getDigest());
+    assertThat(symlinkMetadata).isEqualTo(targetMetadata);
     assertThat(DigestUtils.getCacheStats().hitCount()).isEqualTo(1);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
@@ -62,8 +62,6 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.build.lib.worker.WorkerPoolImpl.WorkerPoolConfig;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
@@ -143,8 +141,7 @@ public class WorkerSpawnRunnerTest {
             spawn,
             key,
             context,
-            new SandboxInputs(
-                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+            new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
             SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
             ImmutableList.of(),
             inputFileCache,
@@ -171,7 +168,6 @@ public class WorkerSpawnRunnerTest {
         new WorkerSpawnRunner(
             new SandboxHelpers(),
             execRoot,
-            ImmutableList.of(),
             createWorkerPool(),
             reporter,
             localEnvProvider,
@@ -236,8 +232,7 @@ public class WorkerSpawnRunnerTest {
                 spawn,
                 key,
                 context,
-                new SandboxInputs(
-                    ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+                new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
                 SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
                 ImmutableList.of(),
                 inputFileCache,
@@ -280,8 +275,7 @@ public class WorkerSpawnRunnerTest {
                 spawn,
                 key,
                 context,
-                new SandboxInputs(
-                    ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+                new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
                 SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
                 ImmutableList.of(),
                 inputFileCache,
@@ -322,8 +316,7 @@ public class WorkerSpawnRunnerTest {
                 spawn,
                 key,
                 context,
-                new SandboxInputs(
-                    ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+                new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
                 SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
                 ImmutableList.of(),
                 inputFileCache,
@@ -356,8 +349,7 @@ public class WorkerSpawnRunnerTest {
             spawn,
             key,
             context,
-            new SandboxInputs(
-                ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+            new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
             SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
             ImmutableList.of(),
             inputFileCache,
@@ -394,8 +386,7 @@ public class WorkerSpawnRunnerTest {
                     spawn,
                     key,
                     context,
-                    new SandboxInputs(
-                        ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+                    new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
                     SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of()),
                     ImmutableList.of(),
                     inputFileCache,
@@ -439,12 +430,12 @@ public class WorkerSpawnRunnerTest {
     SandboxInputs inputs =
         new SandboxInputs(
             ImmutableMap.of(
-                    PathFragment.create("file"),
-                    asRootedPath("/file"),
-                    PathFragment.create("file2"),
-                    asRootedPath("/file2")),
-                ImmutableMap.of(),
-            ImmutableMap.of(), ImmutableMap.of());
+                PathFragment.create("file"),
+                fs.getPath("/file"),
+                PathFragment.create("file2"),
+                fs.getPath("/file2")),
+            ImmutableMap.of(),
+            ImmutableMap.of());
     WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder);
     assertThat(requestBuilder.getArgumentsList())
         .containsExactly("arg1", "arg2", "arg3", "multi arg", "");
@@ -457,8 +448,9 @@ public class WorkerSpawnRunnerTest {
     FileSystemUtils.writeIsoLatin1(fs.getPath("/file"), "arg1\n@@nonfile\n@foo//bar\narg2");
     SandboxInputs inputs =
         new SandboxInputs(
-            ImmutableMap.of(PathFragment.create("file"), asRootedPath("/file")), ImmutableMap.of(),
-            ImmutableMap.of(), ImmutableMap.of());
+            ImmutableMap.of(PathFragment.create("file"), fs.getPath("/file")),
+            ImmutableMap.of(),
+            ImmutableMap.of());
     WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder);
     assertThat(requestBuilder.getArgumentsList())
         .containsExactly("arg1", "@@nonfile", "@foo//bar", "arg2");
@@ -469,8 +461,7 @@ public class WorkerSpawnRunnerTest {
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
     SandboxInputs inputs =
         new SandboxInputs(
-            ImmutableMap.of(PathFragment.create("file"), asRootedPath("/dir/file")),
-            ImmutableMap.of(),
+            ImmutableMap.of(PathFragment.create("file"), fs.getPath("/dir/file")),
             ImmutableMap.of(),
             ImmutableMap.of());
     IOException e =
@@ -571,7 +562,6 @@ public class WorkerSpawnRunnerTest {
     return new WorkerSpawnRunner(
         new SandboxHelpers(),
         fs.getPath("/execRoot"),
-        ImmutableList.of(),
         createWorkerPool(),
         reporter,
         localEnvProvider,
@@ -587,18 +577,13 @@ public class WorkerSpawnRunnerTest {
   public void testExpandArgument_failsOnUndeclaredInput() {
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
     SandboxInputs inputs =
-        new SandboxInputs(
-            ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+        new SandboxInputs(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
     IOException e =
         assertThrows(
             IOException.class,
             () -> WorkerSpawnRunner.expandArgument(inputs, "@file", requestBuilder));
     assertThat(e).hasMessageThat().contains("file");
     assertThat(e).hasMessageThat().contains("declared input");
-  }
-
-  private RootedPath asRootedPath(String path) {
-    return RootedPath.toRootedPath(Root.absoluteRoot(fs), fs.getPath(path));
   }
 
   private static String logMarker(String text) {

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnStrategyTest.java
@@ -20,9 +20,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.google.devtools.build.lib.vfs.Root;
-import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import java.io.File;
@@ -51,13 +50,13 @@ public class WorkerSpawnStrategyTest {
       flags.forEach(pw::println);
     }
 
-    RootedPath path =
-        RootedPath.toRootedPath(Root.absoluteRoot(fs), fs.getPath(flagfile.getAbsolutePath()));
+    Path path = fs.getPath(flagfile.getAbsolutePath());
     WorkRequest.Builder requestBuilder = WorkRequest.newBuilder();
     SandboxInputs inputs =
         new SandboxInputs(
-            ImmutableMap.of(PathFragment.create("flagfile.txt"), path), ImmutableMap.of(),
-            ImmutableMap.of(), ImmutableMap.of());
+            ImmutableMap.of(PathFragment.create("flagfile.txt"), path),
+            ImmutableMap.of(),
+            ImmutableMap.of());
     WorkerSpawnRunner.expandArgument(inputs, "@flagfile.txt", requestBuilder);
 
     assertThat(requestBuilder.getArgumentsList()).containsExactlyElementsIn(flags);

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -32,6 +32,14 @@ function set_up {
   sed -i.bak '/sandbox_tmpfs_path/d' "$bazelrc"
 }
 
+function assert_not_exists() {
+  path="$1"
+  [ ! -f "$path" ] && return 0
+
+  fail "Expected file '$path' to not exist, but it did"
+  return 1
+}
+
 function test_sandboxed_tooldir() {
   mkdir -p examples/genrule
 
@@ -309,6 +317,68 @@ EOF
   bazel build //pkg:a &>$TEST_log || fail "expected build to succeed"
 }
 
+# Sets up targets under //test that, when building //test:all, verify that the
+# sandbox setup ensures that /tmp contents written by one action are not visible
+# to another action.
+#
+# Arguments:
+#   - The path to a unique temporary directory under /tmp that a
+#     file named "bazel_was_here" is written to in actions.
+function setup_tmp_hermeticity_check() {
+  local -r tmpdir=$1
+
+  mkdir -p test
+  cat > test/BUILD <<'EOF'
+cc_binary(
+    name = "create_file",
+    srcs = ["create_file.cc"],
+)
+
+[
+    genrule(
+        name = "gen" + str(i),
+        outs = ["gen{}.txt".format(i)],
+        tools = [":create_file"],
+        cmd = """
+        path=$$($(location :create_file))
+        cp "$$path" $@
+        """,
+    )
+    for i in range(1, 3)
+]
+EOF
+  cat > test/create_file.cc <<EOF
+// Create a file in a fixed location only if it doesn't exist.
+// Then write its path to stdout.
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main() {
+  if (mkdir("$tmpdir", 0755) < 0) {
+    perror("mkdir");
+    return 1;
+  }
+  int fd = open("$tmpdir/bazel_was_here", O_CREAT | O_EXCL | O_WRONLY, 0600);
+  if (fd < 0) {
+    perror("open");
+    return 1;
+  }
+  if (write(fd, "HERMETIC\n", 9) != 9) {
+    perror("write");
+    return 1;
+  }
+  close(fd);
+  printf("$tmpdir/bazel_was_here\n");
+  return 0;
+}
+EOF
+}
+
 function test_add_mount_pair_tmp_source() {
   if [[ "$PLATFORM" == "darwin" ]]; then
     # Tests Linux-specific functionality
@@ -321,19 +391,26 @@ function test_add_mount_pair_tmp_source() {
   trap "rm -fr $mounted" EXIT
   echo GOOD > "$mounted/data.txt"
 
+  local tmp_dir=$(mktemp -d "/tmp/bazel_mounted.XXXXXXXX")
+  trap "rm -fr $tmp_dir" EXIT
+  setup_tmp_hermeticity_check "$tmp_dir"
+
   mkdir -p pkg
-  cat > pkg/BUILD <<EOF
+  cat > pkg/BUILD <<'EOF'
 genrule(
     name = "gen",
     outs = ["gen.txt"],
-    # Verify that /tmp is still hermetic.
-    cmd = """[ ! -e "${mounted}/data.txt" ] && cp /etc/data.txt \$@""",
+    cmd = "cp /etc/data.txt $@",
 )
 EOF
 
   # This assumes the existence of /etc on the host system
-  bazel build --sandbox_add_mount_pair="$mounted:/etc" //pkg:gen || fail "build failed"
-  assert_contains GOOD bazel-bin/pkg/gen.txt
+  bazel build --sandbox_add_mount_pair="$mounted:/etc" \
+    //pkg:gen //test:all || fail "build failed"
+  assert_equals GOOD "$(cat bazel-bin/pkg/gen.txt)"
+  assert_equals HERMETIC "$(cat bazel-bin/test/gen1.txt)"
+  assert_equals HERMETIC "$(cat bazel-bin/test/gen2.txt)"
+  assert_not_exists "$tmp_dir/bazel_was_here"
 }
 
 function test_add_mount_pair_tmp_target() {
@@ -348,20 +425,28 @@ function test_add_mount_pair_tmp_target() {
   trap "rm -fr $source_dir" EXIT
   echo BAD > "$source_dir/data.txt"
 
+  local tmp_dir=$(mktemp -d "/tmp/bazel_mounted.XXXXXXXX")
+  trap "rm -fr $tmp_dir" EXIT
+  setup_tmp_hermeticity_check "$tmp_dir"
+
   mkdir -p pkg
   cat > pkg/BUILD <<EOF
 genrule(
     name = "gen",
     outs = ["gen.txt"],
-    # Verify that /tmp is still hermetic.
-    cmd = """[ ! -e "${source_dir}/data.txt" ] && ls "$source_dir" > \$@""",
+    cmd = """ls "$source_dir" > \$@""",
 )
 EOF
 
 
   # This assumes the existence of /etc on the host system
-  bazel build --sandbox_add_mount_pair="/etc:$source_dir" //pkg:gen || fail "build failed"
+  bazel build --sandbox_add_mount_pair="/etc:$source_dir" \
+    //pkg:gen //test:all || fail "build failed"
   assert_contains passwd bazel-bin/pkg/gen.txt
+  assert_not_contains data.txt bazel-bin/pkg/gen.txt
+  assert_equals HERMETIC "$(cat bazel-bin/test/gen1.txt)"
+  assert_equals HERMETIC "$(cat bazel-bin/test/gen2.txt)"
+  assert_not_exists "$tmp_dir/bazel_was_here"
 }
 
 function test_add_mount_pair_tmp_target_and_source() {
@@ -376,22 +461,25 @@ function test_add_mount_pair_tmp_target_and_source() {
   trap "rm -fr $mounted" EXIT
   echo GOOD > "$mounted/data.txt"
 
-  local tmp_file=$(mktemp "/tmp/bazel_tmp.XXXXXXXX")
-  trap "rm $tmp_file" EXIT
-  echo BAD > "$tmp_file"
+  local tmp_dir=$(mktemp -d "/tmp/bazel_mounted.XXXXXXXX")
+  trap "rm -fr $tmp_dir" EXIT
+  setup_tmp_hermeticity_check "$tmp_dir"
 
   mkdir -p pkg
   cat > pkg/BUILD <<EOF
 genrule(
     name = "gen",
     outs = ["gen.txt"],
-    # Verify that /tmp is still hermetic.
-    cmd = """[ ! -e "${tmp_file}" ] && cp "$mounted/data.txt" \$@""",
+    cmd = """cp "$mounted/data.txt" \$@""",
 )
 EOF
 
-  bazel build --sandbox_add_mount_pair="$mounted" //pkg:gen || fail "build failed"
-  assert_contains GOOD bazel-bin/pkg/gen.txt
+  bazel build --sandbox_add_mount_pair="$mounted" \
+    //pkg:gen //test:all || fail "build failed"
+  assert_equals GOOD "$(cat bazel-bin/pkg/gen.txt)"
+  assert_equals HERMETIC "$(cat bazel-bin/test/gen1.txt)"
+  assert_equals HERMETIC "$(cat bazel-bin/test/gen2.txt)"
+  assert_not_exists "$tmp_dir/bazel_was_here"
 }
 
 function test_symlink_with_output_base_under_tmp() {
@@ -400,15 +488,53 @@ function test_symlink_with_output_base_under_tmp() {
     return 0
   fi
 
-  create_workspace_with_default_repos WORKSPACE
+  local repo=$(mktemp -d "/tmp/bazel_mounted.XXXXXXXX")
+  trap "rm -fr $repo" EXIT
+
+  touch WORKSPACE
+
+  mkdir -p $repo/pkg
+  touch $repo/WORKSPACE
+  cat > $repo/pkg/es1 <<'EOF'
+EXTERNAL_SOURCE_CONTENT
+EOF
+  cat > $repo/pkg/BUILD <<'EOF'
+exports_files(["es1"])
+genrule(
+    name="er1",
+    srcs=[],
+    outs=[":er1"],
+    cmd="echo EXTERNAL_GEN_CONTENT > $@",
+    visibility=["//visibility:public"],
+)
+EOF
+
+  mkdir -p $repo/examples
+  cd $repo/examples || fail "cd $repo/examples failed"
+
+  cat > WORKSPACE <<EOF
+local_repository(
+    name = "repo",
+    path = "$repo",
+)
+EOF
 
   mkdir -p pkg
+  cat > pkg/s1 <<'EOF'
+SOURCE_CONTENT
+EOF
   cat > pkg/BUILD <<'EOF'
 load(":r.bzl", "symlink_rule")
 
-genrule(name="r1", srcs=[], outs=[":r1"], cmd="echo CONTENT > $@")
+genrule(name="r1", srcs=[], outs=[":r1"], cmd="echo GEN_CONTENT > $@")
 symlink_rule(name="r2", input=":r1")
 genrule(name="r3", srcs=[":r2"], outs=[":r3"], cmd="cp $< $@")
+symlink_rule(name="s2", input=":s1")
+genrule(name="s3", srcs=[":s2"], outs=[":s3"], cmd="cp $< $@")
+symlink_rule(name="er2", input="@repo//pkg:er1")
+genrule(name="er3", srcs=[":er2"], outs=[":er3"], cmd="cp $< $@")
+symlink_rule(name="es2", input="@repo//pkg:es1")
+genrule(name="es3", srcs=[":es2"], outs=[":es3"], cmd="cp $< $@")
 EOF
 
   cat > pkg/r.bzl <<'EOF'
@@ -425,8 +551,11 @@ EOF
   local tmp_output_base=$(mktemp -d "/tmp/bazel_output_base.XXXXXXXX")
   trap "chmod -R u+w $tmp_output_base && rm -fr $tmp_output_base" EXIT
 
-  bazel --output_base="$tmp_output_base" build //pkg:r3
-  assert_contains CONTENT bazel-bin/pkg/r3
+  bazel --output_base="$tmp_output_base" build //pkg:{er,es,r,s}3 --sandbox_debug
+  assert_contains EXTERNAL_GEN_CONTENT bazel-bin/pkg/er3
+  assert_contains EXTERNAL_SOURCE_CONTENT bazel-bin/pkg/es3
+  assert_contains GEN_CONTENT bazel-bin/pkg/r3
+  assert_contains SOURCE_CONTENT bazel-bin/pkg/s3
   bazel --output_base="$tmp_output_base" shutdown
 }
 
@@ -487,13 +616,13 @@ function test_tmpfs_path_under_tmp() {
 
   create_workspace_with_default_repos WORKSPACE
 
-  local tmp_file=$(mktemp "/tmp/bazel_tmp.XXXXXXXX")
-  trap "rm $tmp_file" EXIT
-  echo BAD > "$tmp_file"
-
   local tmpfs=$(mktemp -d "/tmp/bazel_tmpfs.XXXXXXXX")
   trap "rm -fr $tmpfs" EXIT
   echo BAD > "$tmpfs/data.txt"
+
+  local tmp_dir=$(mktemp -d "/tmp/bazel_mounted.XXXXXXXX")
+  trap "rm -fr $tmp_dir" EXIT
+  setup_tmp_hermeticity_check "$tmp_dir"
 
   mkdir -p pkg
   cat > pkg/BUILD <<EOF
@@ -501,10 +630,9 @@ genrule(
     name = "gen",
     outs = ["gen.txt"],
     cmd = """
-# Verify that /tmp is still hermetic and that the tmpfs under /tmp exists, but is empty.
-[[ ! -e "${tmp_file}" ]]
-[[ -d /tmp/tmpfs ]]
-[[ ! -e /tmp/tmpfs/data.txt ]]
+# Verify that the tmpfs under /tmp exists and is empty.
+[[ -d "$tmpfs" ]]
+[[ ! -e "$tmpfs/data.txt" ]]
 # Verify that the tmpfs on /etc exists and is empty.
 [[ -d /etc ]]
 [[ -z "\$\$(ls -A /etc)" ]]
@@ -514,8 +642,142 @@ touch \$@
 EOF
 
   # This assumes the existence of /etc on the host system
-  bazel build --sandbox_tmpfs_path=/tmp/tmpfs --sandbox_tmpfs_path=/etc \
-    //pkg:gen || fail "build failed"
+  bazel build --sandbox_tmpfs_path="$tmpfs" --sandbox_tmpfs_path=/etc \
+    //pkg:gen //test:all || fail "build failed"
+  assert_equals HERMETIC "$(cat bazel-bin/test/gen1.txt)"
+  assert_equals HERMETIC "$(cat bazel-bin/test/gen2.txt)"
+  assert_not_exists "$tmp_dir/bazel_was_here"
+}
+
+function test_hermetic_tmp_under_tmp {
+  if [[ "$(uname -s)" != Linux ]]; then
+    echo "Skipping test: --incompatible_sandbox_hermetic_tmp is only supported in Linux" 1>&2
+    return 0
+  fi
+
+  temp_dir=$(mktemp -d /tmp/test.XXXXXX)
+  trap 'rm -rf ${temp_dir}' EXIT
+
+  mkdir -p "${temp_dir}/workspace/a"
+  mkdir -p "${temp_dir}/package-path/b"
+  mkdir -p "${temp_dir}/repo/c"
+  mkdir -p "${temp_dir}/output-base"
+
+  cd "${temp_dir}/workspace"
+  cat > WORKSPACE <<EOF
+local_repository(name="repo", path="${temp_dir}/repo")
+EOF
+
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "g",
+  outs = ["go"],
+  srcs = [],
+  cmd = "echo GO > $@",
+)
+sh_binary(
+  name = "bin",
+  srcs = ["bin.sh"],
+  data = [":s", ":go", "//b:s", "//b:go", "@repo//c:s", "@repo//c:go"],
+)
+genrule(
+  name = "t",
+  tools = [":bin"],
+  srcs = [":s", ":go", "//b:s", "//b:go", "@repo//c:s", "@repo//c:go"],
+  outs = ["to"],
+  cmd = "\n".join([
+    "RUNFILES=$(location :bin).runfiles/_main",
+    "S=$(location :s); GO=$(location :go)",
+    "BS=$(location //b:s); BGO=$(location //b:go)",
+    "RS=$(location @repo//c:s); RGO=$(location @repo//c:go)",
+    "for i in $$S $$GO $$BS $$BGO $$RS $$RGO; do",
+    "  echo reading $$i",
+    "  cat $$i >> $@",
+    "done",
+    "for i in a/s a/go b/s b/go ../repo/c/s ../repo/c/go; do",
+    "  echo reading $$RUNFILES/$$i",
+    "  cat $$RUNFILES/$$i >> $@",
+    "done",
+  ]),
+)
+EOF
+
+  touch a/bin.sh
+  chmod +x a/bin.sh
+
+  touch ../repo/WORKSPACE
+  cat > ../repo/c/BUILD <<'EOF'
+exports_files(["s"])
+genrule(
+  name = "g",
+  outs = ["go"],
+  srcs = [],
+  cmd = "echo GO > $@",
+  visibility = ["//visibility:public"],
+)
+EOF
+
+  cat > ../package-path/b/BUILD <<'EOF'
+exports_files(["s"])
+genrule(
+  name = "g",
+  outs = ["go"],
+  srcs = [],
+  cmd = "echo GO > $@",
+  visibility = ["//visibility:public"],
+)
+EOF
+
+  touch "a/s" "../package-path/b/s" "../repo/c/s"
+
+  cat WORKSPACE
+  bazel \
+    --output_base="${temp_dir}/output-base" \
+    build \
+    --incompatible_sandbox_hermetic_tmp \
+    --package_path="%workspace%:${temp_dir}/package-path" \
+    //a:t || fail "build failed"
+}
+
+# Regression test for https://github.com/bazelbuild/bazel/issues/21215
+function test_copy_input_symlinks() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > MODULE.bazel <<'EOF'
+repo = use_repo_rule("//pkg:repo.bzl", "repo")
+repo(name = "some_repo")
+EOF
+
+  mkdir -p pkg
+  cat > pkg/BUILD <<'EOF'
+genrule(
+    name = "copy_files",
+    srcs = [
+        "@some_repo//:files",
+    ],
+    outs = [
+        "some_file1.json",
+        "some_file2.json",
+    ],
+    cmd = "cp -r $(locations @some_repo//:files) $(RULEDIR)",
+)
+EOF
+  cat > pkg/repo.bzl <<'EOF'
+def _impl(rctx):
+  rctx.file("some_file1.json", "hello")
+  rctx.file("some_file2.json", "world")
+  rctx.file("BUILD", """filegroup(
+    name = "files",
+    srcs = ["some_file1.json", "some_file2.json"],
+    visibility = ["//visibility:public"],
+)""")
+
+repo = repository_rule(_impl)
+EOF
+
+  bazel build //pkg:copy_files || fail "build failed"
+  assert_equals hello "$(cat bazel-bin/pkg/some_file1.json)"
+  assert_equals world "$(cat bazel-bin/pkg/some_file2.json)"
 }
 
 # The test shouldn't fail if the environment doesn't support running it.


### PR DESCRIPTION
The bind mounting scheme used with the Linux sandbox' hermetic `/tmp` feature is modified to preserve all paths as they are outside the sandbox, which removes the need to rewrite paths when staging inputs into and, crucially, moving outputs out of the sandbox.

Source roots and output base paths under `/tmp` are now treated just like any user-specified bind mount under `/tmp`: They are mounted under the hermetic tmp directory with their path relativized against `/tmp` before the hermetic tmp directory is mounted as `/tmp` as the final step.

There is one caveat compared to user-specified mounts: Source roots, which may themselves not lie under `/tmp`, can be symlinks to directories under `/tmp` (e.g., when they arise from a `local_repository`). To handle this situation in the common case, all parent directories of package path entries (up to direct children of `/tmp`) are mounted into the sandbox. If users use `local_repository`s with fixed target paths under `/tmp`, they will need to specify `--sandbox_add_mount_pair`.

Overlayfs has been considered as an alternative to this approach, but ultimately doesn't seem to work for this use case since its `lowerpath`, which would be `/tmp`, is not allowed to have child mounts from a different user namespace (see https://unix.stackexchange.com/questions/776030/mounting-overlayfs-in-a-user-namespace-with-child-mounts). However, this is exactly the situation created by a Bazel-in-Bazel test and can also arise if the user has existing mounts under `/tmp` when using Bazel (e.g. the JetBrains toolbox on Linux uses such mounts).

This replaces and mostly reverts the following commits, but keeps their tests:
* https://github.com/bazelbuild/bazel/commit/bf6ebe9f7c428e15b7c4d7e86a762b7470f97d5b
* https://github.com/bazelbuild/bazel/commit/fb6658c86164b81205a056a9a54975a62f2f957a
* https://github.com/bazelbuild/bazel/commit/bc1d9d38bea907beea8fd82c362c9882ddf48cfd
* https://github.com/bazelbuild/bazel/commit/182988347ef02399bc8fbc31a0ad972f0ea72210
* https://github.com/bazelbuild/bazel/commit/70691f2b76be0b9530e49c3df18356925843b465
* https://github.com/bazelbuild/bazel/commit/a556969326107423738fbf8a80bad9aaf9935578
* https://github.com/bazelbuild/bazel/commit/8e32f44a279c5c4e9c24fb84a08276ffe4fe90c0 (had its test lost in an incorrect merge conflict resolution, this PR adds it back)

Fixes #20533
Work towards #20753
Fixes #21215
Fixes #22117
Fixes #22226
Fixes #22290

RELNOTES: Paths in the Linux sandbox are now again identical to those outside the sandbox, even with `--incompatible_sandbox_hermetic_tmp`.

Closes #22001.

PiperOrigin-RevId: 634381503
Change-Id: I9f7f3948c705be120c55c9b0c51204e5bea45f61

Fixes #22291