### PR TITLE
[7.2.0] Expand visibility of DexFileSplitter

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/dexer/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/dexer/BUILD.tools
@@ -51,5 +51,5 @@ java_binary(
     deps = [
         "//src/tools/android/java/com/google/devtools/build/android:all_android_tools",
     ],
-    visibility = ["//tools/android:__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Necessary to remove references to `@bazel_tools//tools/android`, which is necessary to remove bind()s from Starlark android_sdk_repository.

PiperOrigin-RevId: 633693304
Change-Id: Ib49fd219847e63135a4b3e771bf67013e12830b4

Commit https://github.com/bazelbuild/bazel/commit/df9f76aa47afbe9c417a4152b01de97df23e0f64