### PR TITLE
Fix sandboxing hermetic tmp to take into account sandbox_base

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -175,8 +175,10 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     // into the sandbox when using hermetic /tmp. We attempt to collect an over-approximation of
     // these paths, as the main goal of hermetic /tmp is to avoid inheriting any direct
     // or well-known children of /tmp from the host.
+    // TODO(bazel-team): Review all flags whose path may have to be considered here.
     return Stream.concat(
-            Stream.of(cmdEnv.getOutputBase()),
+            Stream.concat(Stream.of(sandboxBase),
+                Stream.of(cmdEnv.getOutputBase())),
             cmdEnv.getPackageLocator().getPathEntries().stream().map(Root::asPath))
         .filter(p -> p.startsWith(slashTmp))
         // For any path /tmp/dir1/dir2 we encounter, we instead mount /tmp/dir1 (first two

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -177,8 +177,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     // or well-known children of /tmp from the host.
     // TODO(bazel-team): Review all flags whose path may have to be considered here.
     return Stream.concat(
-            Stream.concat(Stream.of(sandboxBase),
-                Stream.of(cmdEnv.getOutputBase())),
+            Stream.of(sandboxBase, cmdEnv.getOutputBase()),
             cmdEnv.getPackageLocator().getPathEntries().stream().map(Root::asPath))
         .filter(p -> p.startsWith(slashTmp))
         // For any path /tmp/dir1/dir2 we encounter, we instead mount /tmp/dir1 (first two


### PR DESCRIPTION
The logic for sandboxing hermetic tmp needs to take into account all paths under `/tmp` used during the build. A user may also pass a `sandbox_base` under `/tmp` even when the `output_base` is not. This change adds `sandbox_base` to the list.

Fix suggested by fmeum 