### PR TITLE
Fix writable sandbox path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -372,7 +372,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     // On Windows, sandboxExecRoot is actually the main execroot. We will specify
     // exactly which output path is writable.
     if (OS.getCurrent() != OS.WINDOWS) {
-      writablePaths.add(execRoot);
+      writablePaths.add(sandboxExecRoot);
     }
 
     String testTmpdir = env.get("TEST_TMPDIR");


### PR DESCRIPTION
The reverts in 3fddc7f38ace43981d839ed4558b8a457caf41fb accidentally replaced `sandboxExecRoot` with `execRoot` in the function that computes writable directories for sandbox spawn runners.

This issue was observed in https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3029.