### PR TITLE
Add basic C++ path mapping support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
@@ -41,6 +41,7 @@ public final class SimpleSpawn implements Spawn {
   private final ImmutableList<ActionInput> outputs;
   // If null, all outputs are mandatory.
   @Nullable private final Set<? extends ActionInput> mandatoryOutputs;
+  private final PathMapper pathMapper;
   private final LocalResourcesSupplier localResourcesSupplier;
   private ResourceSet localResourcesCached;
 
@@ -55,7 +56,8 @@ public final class SimpleSpawn implements Spawn {
       Collection<? extends ActionInput> outputs,
       @Nullable final Set<? extends ActionInput> mandatoryOutputs,
       @Nullable ResourceSet localResources,
-      @Nullable LocalResourcesSupplier localResourcesSupplier) {
+      @Nullable LocalResourcesSupplier localResourcesSupplier,
+      PathMapper pathMapper) {
     this.owner = Preconditions.checkNotNull(owner);
     this.arguments = Preconditions.checkNotNull(arguments);
     this.environment = Preconditions.checkNotNull(environment);
@@ -77,6 +79,7 @@ public final class SimpleSpawn implements Spawn {
       this.localResourcesSupplier = localResourcesSupplier;
       this.localResourcesCached = null;
     }
+    this.pathMapper = pathMapper;
   }
 
   public SimpleSpawn(
@@ -101,7 +104,8 @@ public final class SimpleSpawn implements Spawn {
         outputs,
         mandatoryOutputs,
         localResources,
-        /*localResourcesSupplier=*/ null);
+        /* localResourcesSupplier= */ null,
+        PathMapper.NOOP);
   }
 
   @SuppressWarnings("TooManyParameters")
@@ -126,8 +130,63 @@ public final class SimpleSpawn implements Spawn {
         tools,
         outputs,
         mandatoryOutputs,
-        /*localResources=*/ null,
-        localResourcesSupplier);
+        /* localResources= */ null,
+        localResourcesSupplier,
+        PathMapper.NOOP);
+  }
+
+  public SimpleSpawn(
+      ActionExecutionMetadata owner,
+      ImmutableList<String> arguments,
+      ImmutableMap<String, String> environment,
+      ImmutableMap<String, String> executionInfo,
+      ImmutableMap<Artifact, ImmutableList<FilesetOutputSymlink>> filesetMappings,
+      NestedSet<? extends ActionInput> inputs,
+      NestedSet<? extends ActionInput> tools,
+      Collection<? extends ActionInput> outputs,
+      @Nullable Set<? extends ActionInput> mandatoryOutputs,
+      LocalResourcesSupplier localResourcesSupplier,
+      PathMapper pathMapper) {
+    this(
+        owner,
+        arguments,
+        environment,
+        executionInfo,
+        filesetMappings,
+        inputs,
+        tools,
+        outputs,
+        mandatoryOutputs,
+        null,
+        localResourcesSupplier,
+        pathMapper);
+  }
+
+  public SimpleSpawn(
+      ActionExecutionMetadata owner,
+      ImmutableList<String> arguments,
+      ImmutableMap<String, String> environment,
+      ImmutableMap<String, String> executionInfo,
+      ImmutableMap<Artifact, ImmutableList<FilesetOutputSymlink>> filesetMappings,
+      NestedSet<? extends ActionInput> inputs,
+      NestedSet<? extends ActionInput> tools,
+      Collection<? extends ActionInput> outputs,
+      @Nullable Set<? extends ActionInput> mandatoryOutputs,
+      ResourceSet localResources,
+      PathMapper pathMapper) {
+    this(
+        owner,
+        arguments,
+        environment,
+        executionInfo,
+        filesetMappings,
+        inputs,
+        tools,
+        outputs,
+        mandatoryOutputs,
+        localResources,
+        null,
+        pathMapper);
   }
 
   public SimpleSpawn(
@@ -224,6 +283,11 @@ public final class SimpleSpawn implements Spawn {
       localResourcesCached = localResourcesSupplier.get();
     }
     return localResourcesCached;
+  }
+
+  @Override
+  public PathMapper getPathMapper() {
+    return pathMapper;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.AnalysisUtils;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
@@ -287,7 +288,7 @@ public abstract class CcModule
     return Dict.immutableCopyOf(
         featureConfiguration
             .getFeatureConfiguration()
-            .getEnvironmentVariables(actionName, variables));
+            .getEnvironmentVariables(actionName, variables, PathMapper.NOOP));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Interner;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.ArtifactExpander;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.Expandable;
@@ -122,11 +123,12 @@ public class CcToolchainFeatures implements StarlarkValue {
     public void expand(
         CcToolchainVariables variables,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         List<String> commandLine)
         throws ExpansionException {
       StringBuilder flag = new StringBuilder();
       for (StringChunk chunk : chunks) {
-        flag.append(chunk.expand(variables));
+        flag.append(chunk.expand(variables, pathMapper));
       }
       commandLine.add(flag.toString().intern());
     }
@@ -169,9 +171,10 @@ public class CcToolchainFeatures implements StarlarkValue {
       public void expand(
           CcToolchainVariables variables,
           @Nullable ArtifactExpander artifactExpander,
+          PathMapper pathMapper,
           List<String> commandLine)
           throws ExpansionException {
-        commandLine.add(chunk.expand(variables));
+        commandLine.add(chunk.expand(variables, pathMapper));
       }
 
       @Override
@@ -250,14 +253,16 @@ public class CcToolchainFeatures implements StarlarkValue {
      * value of the entry is expanded with the given {@code variables}.
      */
     public void addEnvEntry(
-        CcToolchainVariables variables, ImmutableMap.Builder<String, String> envBuilder)
+        CcToolchainVariables variables,
+        ImmutableMap.Builder<String, String> envBuilder,
+        PathMapper pathMapper)
         throws ExpansionException {
       if (!canBeExpanded(variables)) {
         return;
       }
       StringBuilder value = new StringBuilder();
       for (StringChunk chunk : valueChunks) {
-        value.append(chunk.expand(variables));
+        value.append(chunk.expand(variables, pathMapper));
       }
       envBuilder.put(key, value.toString());
     }
@@ -370,29 +375,30 @@ public class CcToolchainFeatures implements StarlarkValue {
     public void expand(
         CcToolchainVariables variables,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         final List<String> commandLine)
         throws ExpansionException {
-      if (!canBeExpanded(variables, expander)) {
+      if (!canBeExpanded(variables, expander, pathMapper)) {
         return;
       }
       if (iterateOverVariable != null) {
         for (CcToolchainVariables.VariableValue variableValue :
-            variables.getSequenceVariable(iterateOverVariable, expander)) {
+            variables.getSequenceVariable(iterateOverVariable, expander, pathMapper)) {
           CcToolchainVariables nestedVariables =
               new SingleVariables(variables, iterateOverVariable, variableValue);
           for (Expandable expandable : expandables) {
-            expandable.expand(nestedVariables, expander, commandLine);
+            expandable.expand(nestedVariables, expander, pathMapper, commandLine);
           }
         }
       } else {
         for (Expandable expandable : expandables) {
-          expandable.expand(variables, expander, commandLine);
+          expandable.expand(variables, expander, pathMapper, commandLine);
         }
       }
     }
 
     private boolean canBeExpanded(
-        CcToolchainVariables variables, @Nullable ArtifactExpander expander)
+        CcToolchainVariables variables, @Nullable ArtifactExpander expander, PathMapper pathMapper)
         throws ExpansionException {
       for (String variable : expandIfAllAvailable) {
         if (!variables.isAvailable(variable, expander)) {
@@ -418,7 +424,7 @@ public class CcToolchainFeatures implements StarlarkValue {
           && (!variables.isAvailable(expandIfEqual.variable, expander)
               || !variables
                   .getVariable(expandIfEqual.variable)
-                  .getStringValue(expandIfEqual.variable)
+                  .getStringValue(expandIfEqual.variable, pathMapper)
                   .equals(expandIfEqual.value))) {
         return false;
       }
@@ -443,9 +449,10 @@ public class CcToolchainFeatures implements StarlarkValue {
     private void expandCommandLine(
         CcToolchainVariables variables,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         final List<String> commandLine)
         throws ExpansionException {
-      expand(variables, expander, commandLine);
+      expand(variables, expander, pathMapper, commandLine);
     }
 
     @Override
@@ -565,6 +572,7 @@ public class CcToolchainFeatures implements StarlarkValue {
         CcToolchainVariables variables,
         Set<String> enabledFeatureNames,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         List<String> commandLine)
         throws ExpansionException {
       for (String variable : expandIfAllAvailable) {
@@ -579,7 +587,7 @@ public class CcToolchainFeatures implements StarlarkValue {
         return;
       }
       for (FlagGroup flagGroup : flagGroups) {
-        flagGroup.expandCommandLine(variables, expander, commandLine);
+        flagGroup.expandCommandLine(variables, expander, pathMapper, commandLine);
       }
     }
 
@@ -711,6 +719,7 @@ public class CcToolchainFeatures implements StarlarkValue {
     private void expandEnvironment(
         String action,
         CcToolchainVariables variables,
+        PathMapper pathMapper,
         Set<String> enabledFeatureNames,
         ImmutableMap.Builder<String, String> envBuilder)
         throws ExpansionException {
@@ -721,7 +730,7 @@ public class CcToolchainFeatures implements StarlarkValue {
         return;
       }
       for (EnvEntry envEntry : envEntries) {
-        envEntry.addEnvEntry(variables, envBuilder);
+        envEntry.addEnvEntry(variables, envBuilder, pathMapper);
       }
     }
 
@@ -830,11 +839,12 @@ public class CcToolchainFeatures implements StarlarkValue {
     private void expandEnvironment(
         String action,
         CcToolchainVariables variables,
+        PathMapper pathMapper,
         Set<String> enabledFeatureNames,
         ImmutableMap.Builder<String, String> envBuilder)
         throws ExpansionException {
       for (EnvSet envSet : envSets) {
-        envSet.expandEnvironment(action, variables, enabledFeatureNames, envBuilder);
+        envSet.expandEnvironment(action, variables, pathMapper, enabledFeatureNames, envBuilder);
       }
     }
 
@@ -844,10 +854,12 @@ public class CcToolchainFeatures implements StarlarkValue {
         CcToolchainVariables variables,
         Set<String> enabledFeatureNames,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         List<String> commandLine)
         throws ExpansionException {
       for (FlagSet flagSet : flagSets) {
-        flagSet.expandCommandLine(action, variables, enabledFeatureNames, expander, commandLine);
+        flagSet.expandCommandLine(
+            action, variables, enabledFeatureNames, expander, pathMapper, commandLine);
       }
     }
 
@@ -1144,11 +1156,12 @@ public class CcToolchainFeatures implements StarlarkValue {
         CcToolchainVariables variables,
         Set<String> enabledFeatureNames,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         List<String> commandLine)
         throws ExpansionException {
       for (FlagSet flagSet : flagSets) {
         flagSet.expandCommandLine(
-            actionName, variables, enabledFeatureNames, expander, commandLine);
+            actionName, variables, enabledFeatureNames, expander, pathMapper, commandLine);
       }
     }
 
@@ -1348,59 +1361,74 @@ public class CcToolchainFeatures implements StarlarkValue {
     /** @return the command line for the given {@code action}. */
     public List<String> getCommandLine(String action, CcToolchainVariables variables)
         throws ExpansionException {
-      return getCommandLine(action, variables, /* expander= */ null);
+      return getCommandLine(action, variables, /* expander= */ null, PathMapper.NOOP);
     }
 
     public List<String> getCommandLine(
-        String action, CcToolchainVariables variables, @Nullable ArtifactExpander expander)
+        String action,
+        CcToolchainVariables variables,
+        @Nullable ArtifactExpander expander,
+        PathMapper pathMapper)
         throws ExpansionException {
       List<String> commandLine = new ArrayList<>();
       if (actionIsConfigured(action)) {
         actionConfigByActionName
             .get(action)
-            .expandCommandLine(variables, enabledFeatureNames, expander, commandLine);
+            .expandCommandLine(variables, enabledFeatureNames, expander, pathMapper, commandLine);
       }
 
       for (Feature feature : enabledFeatures) {
-        feature.expandCommandLine(action, variables, enabledFeatureNames, expander, commandLine);
+        feature.expandCommandLine(
+            action, variables, enabledFeatureNames, expander, pathMapper, commandLine);
       }
 
       return commandLine;
     }
 
-    /** @return the flags expanded for the given {@code action} in per-feature buckets. */
+    /**
+     * @return the flags expanded for the given {@code action} in per-feature buckets.
+     */
     public ImmutableList<Pair<String, List<String>>> getPerFeatureExpansions(
-        String action, CcToolchainVariables variables) throws ExpansionException {
-      return getPerFeatureExpansions(action, variables, null);
+        String action, CcToolchainVariables variables, PathMapper pathMapper)
+        throws ExpansionException {
+      return getPerFeatureExpansions(action, variables, null, pathMapper);
     }
 
     public ImmutableList<Pair<String, List<String>>> getPerFeatureExpansions(
-        String action, CcToolchainVariables variables, @Nullable ArtifactExpander expander)
+        String action,
+        CcToolchainVariables variables,
+        @Nullable ArtifactExpander expander,
+        PathMapper pathMapper)
         throws ExpansionException {
       ImmutableList.Builder<Pair<String, List<String>>> perFeatureExpansions =
           ImmutableList.builder();
       if (actionIsConfigured(action)) {
         List<String> commandLine = new ArrayList<>();
         ActionConfig actionConfig = actionConfigByActionName.get(action);
-        actionConfig.expandCommandLine(variables, enabledFeatureNames, expander, commandLine);
+        actionConfig.expandCommandLine(
+            variables, enabledFeatureNames, expander, pathMapper, commandLine);
         perFeatureExpansions.add(Pair.of(actionConfig.getName(), commandLine));
       }
 
       for (Feature feature : enabledFeatures) {
         List<String> commandLine = new ArrayList<>();
-        feature.expandCommandLine(action, variables, enabledFeatureNames, expander, commandLine);
+        feature.expandCommandLine(
+            action, variables, enabledFeatureNames, expander, pathMapper, commandLine);
         perFeatureExpansions.add(Pair.of(feature.getName(), commandLine));
       }
 
       return perFeatureExpansions.build();
     }
 
-    /** @return the environment variables (key/value pairs) for the given {@code action}. */
+    /**
+     * @return the environment variables (key/value pairs) for the given {@code action}.
+     */
     public ImmutableMap<String, String> getEnvironmentVariables(
-        String action, CcToolchainVariables variables) throws ExpansionException {
+        String action, CcToolchainVariables variables, PathMapper pathMapper)
+        throws ExpansionException {
       ImmutableMap.Builder<String, String> envBuilder = ImmutableMap.builder();
       for (Feature feature : enabledFeatures) {
-        feature.expandEnvironment(action, variables, enabledFeatureNames, envBuilder);
+        feature.expandEnvironment(action, variables, pathMapper, enabledFeatureNames, envBuilder);
       }
       return envBuilder.buildOrThrow();
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
@@ -450,9 +450,9 @@ public enum CompileBuildVariables {
     }
 
     if (!externalIncludeDirs.isEmpty()) {
-      buildVariables.addStringSequenceVariable(
+      buildVariables.addPathFragmentSequenceVariable(
           EXTERNAL_INCLUDE_PATHS.getVariableName(),
-          Iterables.transform(externalIncludeDirs, PathFragment::getSafePathString));
+          NestedSetBuilder.wrap(Order.STABLE_ORDER, externalIncludeDirs));
     }
 
     buildVariables.addAllStringVariables(additionalBuildVariables);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileCommandLine.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.actions.AbstractCommandLine;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.rules.cpp.CcCommon.CoptsFilter;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.ExpansionException;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.FeatureConfiguration;
@@ -62,9 +63,10 @@ public final class CompileCommandLine {
   }
 
   /** Returns the environment variables that should be set for C++ compile actions. */
-  ImmutableMap<String, String> getEnvironment() throws CommandLineExpansionException {
+  ImmutableMap<String, String> getEnvironment(PathMapper pathMapper)
+      throws CommandLineExpansionException {
     try {
-      return featureConfiguration.getEnvironmentVariables(actionName, variables);
+      return featureConfiguration.getEnvironmentVariables(actionName, variables, pathMapper);
     } catch (ExpansionException e) {
       throw new CommandLineExpansionException(e.getMessage());
     }
@@ -85,7 +87,9 @@ public final class CompileCommandLine {
    *     unmodified original variables are used.
    */
   List<String> getArguments(
-      @Nullable PathFragment parameterFilePath, @Nullable CcToolchainVariables overwrittenVariables)
+      @Nullable PathFragment parameterFilePath,
+      @Nullable CcToolchainVariables overwrittenVariables,
+      PathMapper pathMapper)
       throws CommandLineExpansionException {
     List<String> commandLine = new ArrayList<>();
 
@@ -96,7 +100,7 @@ public final class CompileCommandLine {
     if (parameterFilePath != null) {
       commandLine.add("@" + parameterFilePath.getSafePathString());
     } else {
-      commandLine.addAll(getCompilerOptions(overwrittenVariables));
+      commandLine.addAll(getCompilerOptions(overwrittenVariables, pathMapper));
     }
     return commandLine;
   }
@@ -113,13 +117,14 @@ public final class CompileCommandLine {
       @Override
       public Iterable<String> arguments() throws CommandLineExpansionException {
         CcToolchainVariables overwrittenVariables = cppCompileAction.getOverwrittenVariables();
-        List<String> compilerOptions = getCompilerOptions(overwrittenVariables);
+        List<String> compilerOptions = getCompilerOptions(overwrittenVariables, PathMapper.NOOP);
         return ImmutableList.<String>builder().add(getToolPath()).addAll(compilerOptions).build();
       }
     };
   }
 
-  public List<String> getCompilerOptions(@Nullable CcToolchainVariables overwrittenVariables)
+  public List<String> getCompilerOptions(
+      @Nullable CcToolchainVariables overwrittenVariables, PathMapper pathMapper)
       throws CommandLineExpansionException {
     try {
       List<String> options = new ArrayList<>();
@@ -131,7 +136,8 @@ public final class CompileCommandLine {
         updatedVariables = variablesBuilder.build();
       }
       addFilteredOptions(
-          options, featureConfiguration.getPerFeatureExpansions(actionName, updatedVariables));
+          options,
+          featureConfiguration.getPerFeatureExpansions(actionName, updatedVariables, pathMapper));
 
       return options;
     } catch (ExpansionException e) {
@@ -172,15 +178,15 @@ public final class CompileCommandLine {
   /**
    * Returns all user provided copts flags.
    *
-   * TODO(b/64108724): Get rid of this method when we don't need to parse copts to collect include
-   * directories anymore (meaning there is a way of specifying include directories using an
+   * <p>TODO(b/64108724): Get rid of this method when we don't need to parse copts to collect
+   * include directories anymore (meaning there is a way of specifying include directories using an
    * explicit attribute, not using platform-dependent garbage bag that copts is).
    */
-  public ImmutableList<String> getCopts() {
+  public ImmutableList<String> getCopts(PathMapper pathMapper) {
     if (variables.isAvailable(CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName())) {
       try {
         return CcToolchainVariables.toStringList(
-            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName());
+            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName(), pathMapper);
       } catch (ExpansionException e) {
         throw new IllegalStateException(
             "Should not happen - 'user_compile_flags' should be a string list, but wasn't.", e);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -51,6 +51,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -58,7 +59,9 @@ import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.extra.CppCompileInfo;
 import com.google.devtools.build.lib.actions.extra.EnvironmentVariable;
 import com.google.devtools.build.lib.actions.extra.ExtraActionInfo;
+import com.google.devtools.build.lib.analysis.actions.PathMappers;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputPathsMode;
 import com.google.devtools.build.lib.analysis.starlark.Args;
 import com.google.devtools.build.lib.bugreport.BugReport;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
@@ -672,7 +675,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   public List<PathFragment> getQuoteIncludeDirs() {
     ImmutableList.Builder<PathFragment> result = ImmutableList.builder();
     result.addAll(ccCompilationContext.getQuoteIncludeDirs());
-    ImmutableList<String> copts = compileCommandLine.getCopts();
+    ImmutableList<String> copts = compileCommandLine.getCopts(PathMapper.NOOP);
     for (int i = 0; i < copts.size(); i++) {
       String opt = copts.get(i);
       if (opt.startsWith("-iquote")) {
@@ -693,7 +696,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   public List<PathFragment> getIncludeDirs() {
     ImmutableList.Builder<PathFragment> result = ImmutableList.builder();
     result.addAll(ccCompilationContext.getIncludeDirs());
-    for (String opt : compileCommandLine.getCopts()) {
+    for (String opt : compileCommandLine.getCopts(PathMapper.NOOP)) {
       if (opt.startsWith("-I") || opt.startsWith("/I")) {
         // We insist on the combined form "-Idir".
         String includeDir = opt.substring(2);
@@ -857,9 +860,14 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     }
   }
 
-  @Override()
+  @Override
   public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
       throws CommandLineExpansionException {
+    return getEffectiveEnvironment(clientEnv, PathMapper.NOOP);
+  }
+
+  public ImmutableMap<String, String> getEffectiveEnvironment(
+      Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException {
     ActionEnvironment env = getEnvironment();
     Map<String, String> environment = Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
     env.resolve(environment, clientEnv);
@@ -870,13 +878,17 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       environment.put("PWD", "/proc/self/cwd");
     }
 
-    environment.putAll(compileCommandLine.getEnvironment());
+    environment.putAll(compileCommandLine.getEnvironment(pathMapper));
     return ImmutableMap.copyOf(environment);
   }
 
   @Override
   public List<String> getArguments() throws CommandLineExpansionException {
-    return compileCommandLine.getArguments(paramFilePath, getOverwrittenVariables());
+    return getArguments(PathMapper.NOOP);
+  }
+
+  private List<String> getArguments(PathMapper pathMapper) throws CommandLineExpansionException {
+    return compileCommandLine.getArguments(paramFilePath, getOverwrittenVariables(), pathMapper);
   }
 
   @Override
@@ -884,7 +896,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     try {
       return StarlarkList.immutableCopyOf(
           compileCommandLine.getArguments(
-              /* parameterFilePath= */ null, getOverwrittenVariables()));
+              /* parameterFilePath= */ null, getOverwrittenVariables(), PathMapper.NOOP));
 
     } catch (CommandLineExpansionException ex) {
       throw new EvalException(ex);
@@ -919,7 +931,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     CppCompileInfo.Builder info = CppCompileInfo.newBuilder();
     info.setTool(compileCommandLine.getToolPath());
 
-    List<String> options = compileCommandLine.getCompilerOptions(getOverwrittenVariables());
+    List<String> options =
+        compileCommandLine.getCompilerOptions(getOverwrittenVariables(), PathMapper.NOOP);
 
     for (String option : options) {
       info.addCompilerOption(option);
@@ -954,7 +967,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   /** Returns the compiler options. */
   @VisibleForTesting
   public List<String> getCompilerOptions() throws CommandLineExpansionException {
-    return compileCommandLine.getCompilerOptions(/* overwrittenVariables= */ null);
+    return compileCommandLine.getCompilerOptions(/* overwrittenVariables= */ null, PathMapper.NOOP);
   }
 
   @Override
@@ -1244,7 +1257,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
         actionKeyContext,
         fp,
         getEnvironment(),
-        compileCommandLine.getEnvironment(),
+        compileCommandLine.getEnvironment(PathMapper.NOOP),
         executionInfo,
         getCommandLineKey(),
         ccCompilationContext.getDeclaredIncludeSrcs(),
@@ -1252,7 +1265,9 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
         mandatorySpawnInputs,
         additionalPrunableHeaders,
         builtInIncludeDirectories,
-        ccCompilationContext.getTransitiveCompilationPrerequisites());
+        ccCompilationContext.getTransitiveCompilationPrerequisites(),
+        getMnemonic(),
+        PathMappers.getOutputPathsMode(configuration));
   }
 
   // Separated into a helper method so that it can be called from CppCompileActionTemplate.
@@ -1268,7 +1283,9 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       NestedSet<Artifact> mandatorySpawnInputs,
       NestedSet<Artifact> prunableHeaders,
       List<PathFragment> builtInIncludeDirectories,
-      NestedSet<Artifact> inputsForInvalidation)
+      NestedSet<Artifact> inputsForInvalidation,
+      String mnemonic,
+      OutputPathsMode outputPathsMode)
       throws CommandLineExpansionException, InterruptedException {
     fp.addUUID(GUID);
     env.addTo(fp);
@@ -1294,6 +1311,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     // This is needed for CppLinkstampCompile.
     fp.addInt(0);
     actionKeyContext.addNestedSetToFingerprint(fp, inputsForInvalidation);
+
+    PathMappers.addToFingerprint(mnemonic, executionInfo, outputPathsMode, fp);
   }
 
   private byte[] getCommandLineKey() throws CommandLineExpansionException {
@@ -1319,12 +1338,14 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   @Override
   public ActionResult execute(ActionExecutionContext actionExecutionContext)
       throws ActionExecutionException, InterruptedException {
+    PathMapper pathMapper = PathMappers.create(this, PathMappers.getOutputPathsMode(configuration));
+
     if (featureConfiguration.isEnabled(CppRuleClasses.COMPILER_PARAM_FILE)) {
       try {
         paramFileActionInput =
             new ParamFileActionInput(
                 paramFilePath,
-                compileCommandLine.getCompilerOptions(getOverwrittenVariables()),
+                compileCommandLine.getCompilerOptions(getOverwrittenVariables(), pathMapper),
                 // TODO(b/132888308): Support MSVC, which has its own method of escaping strings.
                 ParameterFileType.GCC_QUOTED,
                 StandardCharsets.ISO_8859_1);
@@ -1360,7 +1381,10 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     Spawn spawn;
     try {
       spawn =
-          createSpawn(actionExecutionContext.getExecRoot(), actionExecutionContext.getClientEnv());
+          createSpawn(
+              actionExecutionContext.getExecRoot(),
+              actionExecutionContext.getClientEnv(),
+              pathMapper);
     } finally {
       clearAdditionalInputs();
     }
@@ -1409,7 +1433,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
               scanningContext.getArtifactResolver(),
               showIncludesFilterForStdout,
               showIncludesFilterForStderr,
-              siblingRepositoryLayout);
+              siblingRepositoryLayout,
+              pathMapper);
       updateActionInputs(discoveredInputs);
       validateInclusions(actionExecutionContext, discoveredInputs);
       return ActionResult.create(spawnResults);
@@ -1427,7 +1452,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
             execRoot,
             scanningContext.getArtifactResolver(),
             dotDContents,
-            siblingRepositoryLayout);
+            siblingRepositoryLayout,
+            pathMapper);
     dotDContents = null; // Garbage collect in-memory .d contents.
 
     updateActionInputs(discoveredInputs);
@@ -1493,7 +1519,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     return featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES);
   }
 
-  Spawn createSpawn(Path execRoot, Map<String, String> clientEnv) throws ActionExecutionException {
+  Spawn createSpawn(Path execRoot, Map<String, String> clientEnv, PathMapper pathMapper)
+      throws ActionExecutionException {
     // Intentionally not adding {@link CppCompileAction#inputsForInvalidation}, those are not needed
     // for execution.
     NestedSetBuilder<ActionInput> inputsBuilder =
@@ -1552,8 +1579,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     try {
       return new SimpleSpawn(
           this,
-          ImmutableList.copyOf(getArguments()),
-          getEffectiveEnvironment(clientEnv),
+          ImmutableList.copyOf(getArguments(pathMapper)),
+          getEffectiveEnvironment(clientEnv, pathMapper),
           executionInfo.buildOrThrow(),
           /* filesetMappings= */ ImmutableMap.of(),
           inputs,
@@ -1565,7 +1592,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
                   enabledCppCompileResourcesEstimation(),
                   getMnemonic(),
                   OS.getCurrent(),
-                  inputs.memoizedFlattenAndGetSize()));
+                  inputs.memoizedFlattenAndGetSize()),
+          pathMapper);
     } catch (CommandLineExpansionException e) {
       String message =
           String.format(
@@ -1581,7 +1609,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       ArtifactResolver artifactResolver,
       ShowIncludesFilter showIncludesFilterForStdout,
       ShowIncludesFilter showIncludesFilterForStderr,
-      boolean siblingRepositoryLayout)
+      boolean siblingRepositoryLayout,
+      PathMapper pathMapper)
       throws ActionExecutionException {
     Collection<Path> stdoutDeps = showIncludesFilterForStdout.getDependencies(execRoot);
     Collection<Path> stderrDeps = showIncludesFilterForStderr.getDependencies(execRoot);
@@ -1613,7 +1642,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
         getAllowedDerivedInputs(),
         execRoot,
         artifactResolver,
-        siblingRepositoryLayout);
+        siblingRepositoryLayout,
+        pathMapper);
   }
 
   @VisibleForTesting
@@ -1622,7 +1652,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
       Path execRoot,
       ArtifactResolver artifactResolver,
       byte[] dotDContents,
-      boolean siblingRepositoryLayout)
+      boolean siblingRepositoryLayout,
+      PathMapper pathMapper)
       throws ActionExecutionException {
     Preconditions.checkNotNull(getDotdFile(), "Trying to scan .d file which is unset");
     return HeaderDiscovery.discoverInputsFromDependencies(
@@ -1634,7 +1665,8 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
         getAllowedDerivedInputs(),
         execRoot,
         artifactResolver,
-        siblingRepositoryLayout);
+        siblingRepositoryLayout,
+        pathMapper);
   }
 
   private DependencySet processDepset(
@@ -1782,7 +1814,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     // The first element in getArguments() is actually the command to execute.
     String legend = "  Command: ";
     try {
-      for (String argument : ShellEscaper.escapeAll(getArguments())) {
+      for (String argument : ShellEscaper.escapeAll(getArguments(PathMapper.NOOP))) {
         message.append(legend);
         message.append(argument);
         message.append('\n');

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionTemplate.java
@@ -31,6 +31,8 @@ import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactExpander;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.MiddlemanType;
+import com.google.devtools.build.lib.actions.PathMapper;
+import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputPathsMode;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -203,16 +205,20 @@ public final class CppCompileActionTemplate extends ActionKeyComputer
           actionKeyContext,
           fp,
           cppCompileActionBuilder.getActionEnvironment(),
-          commandLine.getEnvironment(),
+          commandLine.getEnvironment(PathMapper.NOOP),
           cppCompileActionBuilder.getExecutionInfo(),
           CppCompileAction.computeCommandLineKey(
-              commandLine.getCompilerOptions(/* overwrittenVariables= */ null)),
+              commandLine.getCompilerOptions(/* overwrittenVariables= */ null, PathMapper.NOOP)),
           cppCompileActionBuilder.getCcCompilationContext().getDeclaredIncludeSrcs(),
           mandatoryInputs,
           mandatoryInputs,
           cppCompileActionBuilder.getPrunableHeaders(),
           cppCompileActionBuilder.getBuiltinIncludeDirectories(),
-          cppCompileActionBuilder.getInputsForInvalidation());
+          cppCompileActionBuilder.getInputsForInvalidation(),
+          getMnemonic(),
+          // TODO(fmeum): Replace this with the actual value once CppCompileActionTemplate supports
+          //  path mapping.
+          OutputPathsMode.OFF);
     } catch (EvalException e) {
       throw new CommandLineExpansionException(e.getMessage());
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.FailAction;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.AliasProvider;
 import com.google.devtools.build.lib.analysis.AnalysisUtils;
 import com.google.devtools.build.lib.analysis.Expander;
@@ -290,7 +291,7 @@ public class CppHelper {
       FeatureConfiguration featureConfiguration, CcToolchainVariables variables, String actionName)
       throws EvalException {
     try {
-      return featureConfiguration.getEnvironmentVariables(actionName, variables);
+      return featureConfiguration.getEnvironmentVariables(actionName, variables, PathMapper.NOOP);
     } catch (ExpansionException e) {
       throw new EvalException(e);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.ArtifactResolver;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -71,7 +72,8 @@ final class HeaderDiscovery {
       NestedSet<Artifact> allowedDerivedInputs,
       Path execRoot,
       ArtifactResolver artifactResolver,
-      boolean siblingRepositoryLayout)
+      boolean siblingRepositoryLayout,
+      PathMapper pathMapper)
       throws ActionExecutionException {
     Map<PathFragment, Artifact> regularDerivedArtifacts = new HashMap<>();
     Map<PathFragment, SpecialArtifact> treeArtifacts = new HashMap<>();
@@ -89,9 +91,9 @@ final class HeaderDiscovery {
       // whose path changed, that is not taken into account by the action cache, and it will get an
       // action cache hit using the remaining un-renamed artifact.
       if (a.isTreeArtifact()) {
-        treeArtifacts.putIfAbsent(a.getExecPath(), (SpecialArtifact) a);
+        treeArtifacts.putIfAbsent(pathMapper.map(a.getExecPath()), (SpecialArtifact) a);
       } else {
-        regularDerivedArtifacts.putIfAbsent(a.getExecPath(), a);
+        regularDerivedArtifacts.putIfAbsent(pathMapper.map(a.getExecPath()), a);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java
@@ -103,13 +103,16 @@ public final class LinkCommandLine extends AbstractCommandLine {
         String linkerParamFile =
             variables
                 .getVariable(LINKER_PARAM_FILE.getVariableName())
-                .getStringValue(LINKER_PARAM_FILE.getVariableName());
+                .getStringValue(LINKER_PARAM_FILE.getVariableName(), PathMapper.NOOP);
         argv.addAll(
-            featureConfiguration.getCommandLine(actionName, variables, expander).stream()
+            featureConfiguration
+                .getCommandLine(actionName, variables, expander, PathMapper.NOOP)
+                .stream()
                 .filter(s -> !s.contains(linkerParamFile))
                 .collect(toImmutableList()));
       } else {
-        argv.addAll(featureConfiguration.getCommandLine(actionName, variables, expander));
+        argv.addAll(
+            featureConfiguration.getCommandLine(actionName, variables, expander, PathMapper.NOOP));
       }
     } catch (ExpansionException e) {
       throw new CommandLineExpansionException(e.getMessage());
@@ -125,7 +128,7 @@ public final class LinkCommandLine extends AbstractCommandLine {
     if (splitCommandLine) {
       try {
         Optional<String> formatString =
-            featureConfiguration.getCommandLine(actionName, variables, null).stream()
+            featureConfiguration.getCommandLine(actionName, variables, null, PathMapper.NOOP).stream()
                 .filter(s -> s.contains("LINKER_PARAM_FILE_PLACEHOLDER"))
                 .findAny();
         if (formatString.isPresent()) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LtoBackendArtifacts.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LtoBackendArtifacts.java
@@ -326,7 +326,7 @@ public final class LtoBackendArtifacts implements LtoBackendArtifactsApi<Artifac
             try {
               args.addAll(
                   featureConfiguration.getCommandLine(
-                      CppActionNames.LTO_BACKEND, buildVariables, artifactExpander));
+                      CppActionNames.LTO_BACKEND, buildVariables, artifactExpander, pathMapper));
             } catch (ExpansionException e) {
               throw new CommandLineExpansionException(e.getMessage());
             }

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -23,7 +23,6 @@ import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.actions.DelegateSpawn;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ResourceSet;
@@ -63,27 +62,6 @@ public final class SpawnBuilder {
   private PathMapper pathMapper = PathMapper.NOOP;
   private boolean builtForToolConfiguration;
 
-  /**
-   * A {@link DelegateSpawn} that supports output path mapping as described in {@link
-   * com.google.devtools.build.lib.actions.PathMapper}.
-   *
-   * <p>By overriding {@link #getPathMapper()} - and only in test code - instead of adding an extra
-   * field in {@link SimpleSpawn}, we avoid further pressuring memory on large build graphs.
-   */
-  private static class PathStrippableSpawn extends DelegateSpawn {
-    private final PathMapper pathMapper;
-
-    public PathStrippableSpawn(Spawn spawn, PathMapper pathMapper) {
-      super(spawn);
-      this.pathMapper = pathMapper;
-    }
-
-    @Override
-    public PathMapper getPathMapper() {
-      return pathMapper;
-    }
-  }
-
   public SpawnBuilder(String... args) {
     this.args = ImmutableList.copyOf(args);
   }
@@ -99,18 +77,17 @@ public final class SpawnBuilder {
             platform,
             execProperties,
             builtForToolConfiguration);
-    return new PathStrippableSpawn(
-        new SimpleSpawn(
-            owner,
-            ImmutableList.copyOf(args),
-            ImmutableMap.copyOf(environment),
-            ImmutableMap.copyOf(executionInfo),
-            ImmutableMap.copyOf(filesetMappings),
-            inputs.build(),
-            tools.build(),
-            ImmutableSet.copyOf(outputs),
-            mandatoryOutputs,
-            resourceSet),
+    return new SimpleSpawn(
+        owner,
+        ImmutableList.copyOf(args),
+        ImmutableMap.copyOf(environment),
+        ImmutableMap.copyOf(executionInfo),
+        ImmutableMap.copyOf(filesetMappings),
+        inputs.build(),
+        tools.build(),
+        ImmutableSet.copyOf(outputs),
+        mandatoryOutputs,
+        resourceSet,
         pathMapper);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -390,6 +390,7 @@ java_test(
     name = "CompileBuildVariablesTest",
     srcs = ["CompileBuildVariablesTest.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.ActionConfig;
@@ -289,7 +290,8 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
                 "feature { name: 'g' }")
             .getFeatureConfiguration(ImmutableSet.of("a", "b", "d", "f"));
     ImmutableMap<String, String> env =
-        configuration.getEnvironmentVariables(CppActionNames.CPP_COMPILE, createVariables());
+        configuration.getEnvironmentVariables(
+            CppActionNames.CPP_COMPILE, createVariables(), PathMapper.NOOP);
     assertThat(env)
         .containsExactly(
             "foo", "bar", "cat", "meow", "dog", "woof",
@@ -314,7 +316,8 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
             .getFeatureConfiguration(ImmutableSet.of("a"));
 
     ImmutableMap<String, String> env =
-        configuration.getEnvironmentVariables(CppActionNames.CPP_COMPILE, createVariables());
+        configuration.getEnvironmentVariables(
+            CppActionNames.CPP_COMPILE, createVariables(), PathMapper.NOOP);
 
     assertThat(env).doesNotContainEntry("foo", "bar");
   }
@@ -334,7 +337,7 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
 
     ImmutableMap<String, String> env =
         configuration.getEnvironmentVariables(
-            CppActionNames.CPP_COMPILE, createVariables("v", "1"));
+            CppActionNames.CPP_COMPILE, createVariables("v", "1"), PathMapper.NOOP);
 
     assertThat(env).containsExactly("foo", "bar").inOrder();
   }
@@ -355,7 +358,7 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
 
     ImmutableMap<String, String> env =
         configuration.getEnvironmentVariables(
-            CppActionNames.CPP_COMPILE, createVariables("v", "1"));
+            CppActionNames.CPP_COMPILE, createVariables("v", "1"), PathMapper.NOOP);
 
     assertThat(env).containsExactly("foo", "1").inOrder();
   }
@@ -1728,7 +1731,7 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
     assertThat(
             LibraryToLinkValue.forDynamicLibrary("foo")
                 .getFieldValue("LibraryToLinkValue", LibraryToLinkValue.NAME_FIELD_NAME)
-                .getStringValue(LibraryToLinkValue.NAME_FIELD_NAME))
+                .getStringValue(LibraryToLinkValue.NAME_FIELD_NAME, PathMapper.NOOP))
         .isEqualTo("foo");
     assertThat(
             LibraryToLinkValue.forDynamicLibrary("foo")
@@ -1745,10 +1748,10 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
     Iterable<? extends VariableValue> objects =
         LibraryToLinkValue.forObjectFileGroup(testArtifacts, false)
             .getFieldValue("LibraryToLinkValue", LibraryToLinkValue.OBJECT_FILES_FIELD_NAME)
-            .getSequenceValue(LibraryToLinkValue.OBJECT_FILES_FIELD_NAME);
+            .getSequenceValue(LibraryToLinkValue.OBJECT_FILES_FIELD_NAME, PathMapper.NOOP);
     ImmutableList.Builder<String> objectNames = ImmutableList.builder();
     for (VariableValue object : objects) {
-      objectNames.add(object.getStringValue("name"));
+      objectNames.add(object.getStringValue("name", PathMapper.NOOP));
     }
     assertThat(objectNames.build())
         .containsExactlyElementsIn(Iterables.transform(testArtifacts, Artifact::getExecPathString));

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariablesTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
@@ -60,9 +61,13 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     CcToolchainVariables variables = getCompileBuildVariables("//x:bin", "bin");
 
-    assertThat(variables.getStringVariable(CompileBuildVariables.SOURCE_FILE.getVariableName()))
+    assertThat(
+            variables.getStringVariable(
+                CompileBuildVariables.SOURCE_FILE.getVariableName(), PathMapper.NOOP))
         .contains("x/bin.cc");
-    assertThat(variables.getStringVariable(CompileBuildVariables.OUTPUT_FILE.getVariableName()))
+    assertThat(
+            variables.getStringVariable(
+                CompileBuildVariables.OUTPUT_FILE.getVariableName(), PathMapper.NOOP))
         .contains("_objs/bin/bin");
   }
 
@@ -77,7 +82,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     ImmutableList<String> userCopts =
         CcToolchainVariables.toStringList(
-            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName());
+            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName(), PathMapper.NOOP);
     assertThat(userCopts)
         .containsAtLeastElementsIn(ImmutableList.<String>of("-foo", "-bar"))
         .inOrder();
@@ -94,7 +99,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     ImmutableList<String> copts =
         CcToolchainVariables.toStringList(
-            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName());
+            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName(), PathMapper.NOOP);
     assertThat(copts).contains("-foo");
   }
 
@@ -111,7 +116,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     ImmutableList<String> copts =
         CcToolchainVariables.toStringList(
-            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName());
+            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName(), PathMapper.NOOP);
     assertThat(copts).containsExactly("-foo").inOrder();
   }
 
@@ -130,7 +135,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     ImmutableList<String> copts =
         CcToolchainVariables.toStringList(
-            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName());
+            variables, CompileBuildVariables.USER_COMPILE_FLAGS.getVariableName(), PathMapper.NOOP);
     assertThat(copts).contains("-foo");
     assertThat(copts).doesNotContain("-bar");
     assertThat(copts).doesNotContain("-baz");
@@ -149,7 +154,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     CcToolchainVariables variables = getCompileBuildVariables("//x:bin", "bin");
 
-    assertThat(variables.getStringVariable(CcCommon.SYSROOT_VARIABLE_NAME))
+    assertThat(variables.getStringVariable(CcCommon.SYSROOT_VARIABLE_NAME, PathMapper.NOOP))
         .isEqualTo("/usr/local/custom-sysroot");
   }
 
@@ -167,7 +172,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     CcToolchainVariables variables = getCompileBuildVariables("//x:bin", "bin");
 
-    assertThat(variables.getStringVariable(CcCommon.SYSROOT_VARIABLE_NAME))
+    assertThat(variables.getStringVariable(CcCommon.SYSROOT_VARIABLE_NAME, PathMapper.NOOP))
         .isEqualTo("target_libc");
   }
 
@@ -189,7 +194,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     CcToolchainVariables variables = getCompileBuildVariables("//x:bin", "bin");
 
-    assertThat(variables.getStringVariable(CcCommon.SYSROOT_VARIABLE_NAME))
+    assertThat(variables.getStringVariable(CcCommon.SYSROOT_VARIABLE_NAME, PathMapper.NOOP))
         .isEqualTo("target_libc");
   }
 
@@ -209,7 +214,8 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     assertThat(
             variables.getStringVariable(
-                CompileBuildVariables.PER_OBJECT_DEBUG_INFO_FILE.getVariableName()))
+                CompileBuildVariables.PER_OBJECT_DEBUG_INFO_FILE.getVariableName(),
+                PathMapper.NOOP))
         .isNotNull();
   }
 
@@ -228,7 +234,8 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
     CcToolchainVariables variables = getCompileBuildVariables("//x:bin", "bin");
 
     assertThat(
-            variables.getStringVariable(CompileBuildVariables.IS_USING_FISSION.getVariableName()))
+            variables.getStringVariable(
+                CompileBuildVariables.IS_USING_FISSION.getVariableName(), PathMapper.NOOP))
         .isNotNull();
   }
 
@@ -299,7 +306,8 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     assertThat(
             variables.getStringVariable(
-                CompileBuildVariables.PER_OBJECT_DEBUG_INFO_FILE.getVariableName()))
+                CompileBuildVariables.PER_OBJECT_DEBUG_INFO_FILE.getVariableName(),
+                PathMapper.NOOP))
         .isNotNull();
   }
 
@@ -314,7 +322,8 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
     scratch.file("x/bin.cc");
 
     CcToolchainVariables variables = getCompileBuildVariables("//x:bin", "bin");
-    assertThat(variables.getStringVariable(CcCommon.MINIMUM_OS_VERSION_VARIABLE_NAME))
+    assertThat(
+            variables.getStringVariable(CcCommon.MINIMUM_OS_VERSION_VARIABLE_NAME, PathMapper.NOOP))
         .isEqualTo("6");
   }
 
@@ -387,7 +396,9 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
 
     assertThat(
             CcToolchainVariables.toStringList(
-                    variables, CompileBuildVariables.EXTERNAL_INCLUDE_PATHS.getVariableName())
+                    variables,
+                    CompileBuildVariables.EXTERNAL_INCLUDE_PATHS.getVariableName(),
+                    PathMapper.NOOP)
                 .stream()
                 .map(x -> removeOutDirectory(x))
                 .collect(ImmutableList.toImmutableList()))

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileCommandLineTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.rules.cpp.CcCommon.CoptsFilter;
@@ -100,7 +101,7 @@ public class CompileCommandLineTest extends BuildViewTestCase {
             .build();
     assertThat(
             compileCommandLine.getArguments(
-                /* parameterFilePath= */ null, /* overwrittenVariables= */ null))
+                /* parameterFilePath= */ null, /* overwrittenVariables= */ null, PathMapper.NOOP))
         .contains("-some_foo_flag");
   }
 
@@ -143,7 +144,7 @@ public class CompileCommandLineTest extends BuildViewTestCase {
             .setCoptsFilter(CoptsFilter.fromRegex(Pattern.compile(".*i_am_a_flag.*")))
             .build();
     return compileCommandLine.getArguments(
-        /* parameterFilePath= */ null, /* overwrittenVariables= */ null);
+        /* parameterFilePath= */ null, /* overwrittenVariables= */ null, PathMapper.NOOP);
   }
 
   private CompileCommandLine.Builder makeCompileCommandLineBuilder() throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscoveryTest.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.ArtifactResolver;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -77,7 +78,8 @@ public final class HeaderDiscoveryTest {
         includedHeaders,
         execRoot,
         artifactResolver,
-        /*siblingRepositoryLayout=*/ false);
+        /* siblingRepositoryLayout= */ false,
+        PathMapper.NOOP);
   }
 
   private SpecialArtifact treeArtifact(Path path) {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryToLinkValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryToLinkValueTest.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SourceArtifact;
 import com.google.devtools.build.lib.actions.ArtifactOwner;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.LibraryToLinkValue;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -109,7 +110,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("dynamic_library");
     assertThat(
             libraryToLinkValue
@@ -118,7 +119,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
     assertThat(
             libraryToLinkValue
@@ -127,7 +128,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "name",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -149,7 +150,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("versioned_dynamic_library");
     assertThat(
             libraryToLinkValue
@@ -158,7 +159,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "path",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo/bar.so");
     assertThat(
             libraryToLinkValue
@@ -167,7 +168,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
     assertThat(
             libraryToLinkValue
@@ -176,7 +177,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "name",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -197,7 +198,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("interface_library");
     assertThat(
             libraryToLinkValue
@@ -206,7 +207,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
     assertThat(
             libraryToLinkValue
@@ -215,7 +216,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "name",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -237,7 +238,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("static_library");
     assertThat(
             libraryToLinkValue
@@ -246,7 +247,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
     assertThat(
             libraryToLinkValue
@@ -255,7 +256,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "name",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -277,7 +278,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("static_library");
     assertThat(
             libraryToLinkValue
@@ -286,7 +287,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("1");
     assertThat(
             libraryToLinkValue
@@ -295,7 +296,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "name",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -317,7 +318,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("object_file");
     assertThat(
             libraryToLinkValue
@@ -326,7 +327,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
     assertThat(
             libraryToLinkValue
@@ -335,7 +336,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "name",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -357,7 +358,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("object_file");
     assertThat(
             libraryToLinkValue
@@ -366,7 +367,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("1");
     assertThat(
             libraryToLinkValue
@@ -375,7 +376,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "name",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -405,7 +406,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("object_file_group");
     assertThat(
             libraryToLinkValue
@@ -414,7 +415,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -431,8 +432,8 @@ public class LibraryToLinkValueTest {
                             /* field= */ "object_files",
                             /* expander= */ null,
                             /* throwOnMissingVariable= */ false)
-                        .getSequenceValue("variable name doesn't matter"))
-                .getStringValue("variable name doesn't matter"))
+                        .getSequenceValue("variable name doesn't matter", PathMapper.NOOP))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("artifact");
   }
 
@@ -455,7 +456,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "type",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("object_file_group");
     assertThat(
             libraryToLinkValue
@@ -464,7 +465,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("1");
     assertThat(
             libraryToLinkValue.getFieldValue(
@@ -481,8 +482,8 @@ public class LibraryToLinkValueTest {
                             /* field= */ "object_files",
                             /* expander= */ null,
                             /* throwOnMissingVariable= */ false)
-                        .getSequenceValue("variable name doesn't matter"))
-                .getStringValue("variable name doesn't matter"))
+                        .getSequenceValue("variable name doesn't matter", PathMapper.NOOP))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("artifact");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariablesTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
@@ -95,7 +96,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
     assertThat(librariesToLinkSequence).isNotNull();
     Iterable<? extends VariableValue> librariesToLink =
         librariesToLinkSequence.getSequenceValue(
-            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     assertThat(librariesToLink).hasSize(1);
     VariableValue nameValue =
         librariesToLink
@@ -105,7 +106,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
                 LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(),
                 LibraryToLinkValue.NAME_FIELD_NAME);
     assertThat(nameValue).isNotNull();
-    String name = nameValue.getStringValue(LibraryToLinkValue.NAME_FIELD_NAME);
+    String name = nameValue.getStringValue(LibraryToLinkValue.NAME_FIELD_NAME, PathMapper.NOOP);
     assertThat(name).matches(".*a\\..*o");
   }
 
@@ -140,7 +141,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
         variables.getVariable(LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
     Iterable<? extends VariableValue> librariestoLink =
         librariesToLinkSequence.getSequenceValue(
-            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     VariableValue nameValue =
         librariestoLink
             .iterator()
@@ -149,7 +150,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
                 LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(),
                 LibraryToLinkValue.NAME_FIELD_NAME);
     assertThat(nameValue).isNotNull();
-    String name = nameValue.getStringValue(LibraryToLinkValue.NAME_FIELD_NAME);
+    String name = nameValue.getStringValue(LibraryToLinkValue.NAME_FIELD_NAME, PathMapper.NOOP);
     assertThat(name).isEqualTo("bar");
   }
 
@@ -167,7 +168,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
         variables.getVariable(LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
     Iterable<? extends VariableValue> librariestoLink =
         librariesToLinkSequence.getSequenceValue(
-            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     VariableValue nameValue =
         librariestoLink
             .iterator()
@@ -176,7 +177,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
                 LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(),
                 LibraryToLinkValue.NAME_FIELD_NAME);
     assertThat(nameValue).isNotNull();
-    String name = nameValue.getStringValue(LibraryToLinkValue.NAME_FIELD_NAME);
+    String name = nameValue.getStringValue(LibraryToLinkValue.NAME_FIELD_NAME, PathMapper.NOOP);
     assertThat(name).isEqualTo("libbar.so.1a.2");
   }
 
@@ -194,7 +195,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
         variables.getVariable(LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
     Iterable<? extends VariableValue> librariestoLink =
         librariesToLinkSequence.getSequenceValue(
-            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     VariableValue nameValue =
         librariestoLink
             .iterator()
@@ -203,7 +204,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
                 LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(),
                 LibraryToLinkValue.NAME_FIELD_NAME);
     assertThat(nameValue).isNotNull();
-    String name = nameValue.getStringValue(LibraryToLinkValue.NAME_FIELD_NAME);
+    String name = nameValue.getStringValue(LibraryToLinkValue.NAME_FIELD_NAME, PathMapper.NOOP);
     assertThat(name).isEqualTo("_libbar.so");
   }
 
@@ -631,7 +632,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
 
     ImmutableList<String> userLinkFlags =
         CcToolchainVariables.toStringList(
-            testVariables, LinkBuildVariables.USER_LINK_FLAGS.getVariableName());
+            testVariables, LinkBuildVariables.USER_LINK_FLAGS.getVariableName(), PathMapper.NOOP);
     assertThat(userLinkFlags).containsAtLeast("-foo", "-bar").inOrder();
   }
 
@@ -660,7 +661,7 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
     assertThat(librariesToLinkSequence).isNotNull();
     Iterable<? extends VariableValue> librariesToLink =
         librariesToLinkSequence.getSequenceValue(
-            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     assertThat(Iterables.size(librariesToLink)).isAnyOf(2, 3);
 
     Iterator<? extends VariableValue> librariesToLinkIterator = librariesToLink.iterator();

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.RuleContext;
@@ -587,7 +588,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(environmentVariables)
         .containsExactlyEntriesIn(
             featureConfiguration.getEnvironmentVariables(
-                CppActionNames.CPP_COMPILE, CcToolchainVariables.EMPTY));
+                CppActionNames.CPP_COMPILE, CcToolchainVariables.EMPTY, PathMapper.NOOP));
   }
 
   @Test
@@ -7936,9 +7937,18 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     CppCompileAction action =
         (CppCompileAction) getGeneratingAction(artifactByPath(getFilesToBuild(target), ".o"));
 
-    action.getCompileCommandLine().getVariables().getSequenceVariable("string_sequence_variable");
-    action.getCompileCommandLine().getVariables().getStringVariable("string_variable");
-    action.getCompileCommandLine().getVariables().getSequenceVariable("string_depset_variable");
+    action
+        .getCompileCommandLine()
+        .getVariables()
+        .getSequenceVariable("string_sequence_variable", PathMapper.NOOP);
+    action
+        .getCompileCommandLine()
+        .getVariables()
+        .getStringVariable("string_variable", PathMapper.NOOP);
+    action
+        .getCompileCommandLine()
+        .getVariables()
+        .getSequenceVariable("string_depset_variable", PathMapper.NOOP);
   }
 
   @Test
@@ -7949,9 +7959,15 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     SpawnAction action =
         (SpawnAction) getGeneratingAction(artifactByPath(getFilesToBuild(target), ".a"));
 
-    getLinkCommandLine(action).getBuildVariables().getSequenceVariable("string_sequence_variable");
-    getLinkCommandLine(action).getBuildVariables().getStringVariable("string_variable");
-    getLinkCommandLine(action).getBuildVariables().getSequenceVariable("string_depset_variable");
+    getLinkCommandLine(action)
+        .getBuildVariables()
+        .getSequenceVariable("string_sequence_variable", PathMapper.NOOP);
+    getLinkCommandLine(action)
+        .getBuildVariables()
+        .getStringVariable("string_variable", PathMapper.NOOP);
+    getLinkCommandLine(action)
+        .getBuildVariables()
+        .getSequenceVariable("string_depset_variable", PathMapper.NOOP);
   }
 
   @Test
@@ -7964,9 +7980,15 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
         (SpawnAction)
             getGeneratingAction((Artifact) getMyInfoFromTarget(target).getValue("executable"));
 
-    getLinkCommandLine(action).getBuildVariables().getSequenceVariable("string_sequence_variable");
-    getLinkCommandLine(action).getBuildVariables().getStringVariable("string_variable");
-    getLinkCommandLine(action).getBuildVariables().getSequenceVariable("string_depset_variable");
+    getLinkCommandLine(action)
+        .getBuildVariables()
+        .getSequenceVariable("string_sequence_variable", PathMapper.NOOP);
+    getLinkCommandLine(action)
+        .getBuildVariables()
+        .getStringVariable("string_variable", PathMapper.NOOP);
+    getLinkCommandLine(action)
+        .getBuildVariables()
+        .getSequenceVariable("string_depset_variable", PathMapper.NOOP);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandAction;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
@@ -1483,7 +1484,12 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
             ActionExecutionException.class,
             () ->
                 compileAction.discoverInputsFromDotdFiles(
-                    new ActionExecutionContextBuilder().build(), null, null, null, false));
+                    new ActionExecutionContextBuilder().build(),
+                    null,
+                    null,
+                    null,
+                    false,
+                    PathMapper.NOOP));
     assertThat(expected).hasMessageThat().contains("error while parsing .d file");
   }
 
@@ -2339,7 +2345,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
         "--platforms=" + MockObjcSupport.IOS_X86_64);
 
     CppCompileAction compileA = (CppCompileAction) compileAction("//bin:lib", "lib1.o");
-    assertThat(compileA.compileCommandLine.getCopts())
+    assertThat(compileA.compileCommandLine.getCopts(PathMapper.NOOP))
         .containsAtLeast("bin/lib1.m", "bin/lib2.m", "bin/data.data", "bin/header.h");
   }
 

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -524,6 +524,7 @@ EOF
     --experimental_output_paths=strip \
     --modify_execution_info=CppCompile=+supports-path-mapping \
     --remote_executor=grpc://localhost:${worker_port} \
+    --features=-module_maps \
     "//$pkg:main" &>"$TEST_log" || fail "Expected success"
 
   expect_log 'Hello, lib1!'
@@ -535,6 +536,7 @@ EOF
     --experimental_output_paths=strip \
     --modify_execution_info=CppCompile=+supports-path-mapping \
     --remote_executor=grpc://localhost:${worker_port} \
+    --features=-module_maps \
     "//$pkg:transitioned_main" &>"$TEST_log" || fail "Expected success"
 
   expect_log 'Hi there, lib1!'


### PR DESCRIPTION
Basic support for path mapping for `CppCompile` actions is added by wiring up `PathMapper` with:
* structured path variables for files and include paths (`Artifact` and `NestedSet<PathFragment>`)
* inputs/outputs via `Spawn#getPathMapper()`
* header discovery

Also turns `external_include_paths` into a structured variable, which was missed in #22463.

The following features are known to be unsupported for now:
* `layering_check` (requires rewriting paths to and in module maps)
* source tree artifacts (requires wiring up `PathMapper` in `CppCompileActionTemplate`)
* location expanded paths to generated files such as sanitizer suppression lists (requires heuristically rewriting paths in `user_compile_flags`)

These limitations will be lifted in follow-up PRs.

Work towards #6526 

RELNOTES: Experimental support for path mapping `CppCompile` actions can be enabled via `--modify_execution_info=CppCompile=+supports-path-mapping`.