### PR TITLE
[7.2.0] Fix sandboxing hermetic tmp to take into account sandbox_base

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -175,8 +175,9 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     // into the sandbox when using hermetic /tmp. We attempt to collect an over-approximation of
     // these paths, as the main goal of hermetic /tmp is to avoid inheriting any direct
     // or well-known children of /tmp from the host.
+    // TODO(bazel-team): Review all flags whose path may have to be considered here.
     return Stream.concat(
-            Stream.of(cmdEnv.getOutputBase()),
+            Stream.of(sandboxBase, cmdEnv.getOutputBase()),
             cmdEnv.getPackageLocator().getPathEntries().stream().map(Root::asPath))
         .filter(p -> p.startsWith(slashTmp))
         // For any path /tmp/dir1/dir2 we encounter, we instead mount /tmp/dir1 (first two

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -950,6 +950,17 @@ EOF
   bazel shutdown
 }
 
+function test_hermetic_tmp_with_tmp_sandbox_base() {
+  mkdir pkg
+  cat >pkg/BUILD <<EOF
+genrule(name = "pkg", outs = ["pkg.out"], cmd = "echo >\$@")
+EOF
+  mkdir /tmp/sandbox_base
+  bazel build --incompatible_sandbox_hermetic_tmp \
+     --sandbox_base=/tmp/sandbox_base  //pkg >"${TEST_log}" 2>&1 \
+        || fail "Expected build to succeed"
+}
+
 function test_runfiles_from_tests_get_reused_and_tmp_clean() {
   mkdir pkg
   touch pkg/file.txt


### PR DESCRIPTION
The logic for sandboxing hermetic tmp needs to take into account all paths under `/tmp` used during the build. A user may also pass a `sandbox_base` under `/tmp` even when the `output_base` is not. This change adds `sandbox_base` to the list.

Fix suggested by fmeum

Closes #22435.

PiperOrigin-RevId: 635382607
Change-Id: I32497a514ff16e64a0e0d84c307f280d3d37544b

Commit https://github.com/bazelbuild/bazel/commit/eebf5f97e33fa4abad128c029e5d254783d805ca