### PR TITLE
[7.2.0] Fix writable sandbox path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -372,7 +372,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     // On Windows, sandboxExecRoot is actually the main execroot. We will specify
     // exactly which output path is writable.
     if (OS.getCurrent() != OS.WINDOWS) {
-      writablePaths.add(execRoot);
+      writablePaths.add(sandboxExecRoot);
     }
 
     String testTmpdir = env.get("TEST_TMPDIR");


### PR DESCRIPTION
The reverts in 3fddc7f38ace43981d839ed4558b8a457caf41fb accidentally replaced `sandboxExecRoot` with `execRoot` in the function that computes writable directories for sandbox spawn runners.

This issue was observed in https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3029.

Closes #22443.

PiperOrigin-RevId: 635383877
Change-Id: I3d74bf78cf97ecd267ba90b68cf1b715850aba27

Commit https://github.com/bazelbuild/bazel/commit/b0ed4ca15d3c66fb7a5b19592cefaae709defe63