### PR TITLE
[7.2.0] Disable path mapping with `local` or `no-{sandbox,remote}` tags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
@@ -132,6 +132,12 @@ public final class PathMappers {
 
   private static OutputPathsMode getEffectiveOutputPathsMode(
       OutputPathsMode outputPathsMode, String mnemonic, Map<String, String> executionInfo) {
+    if (executionInfo.containsKey(ExecutionRequirements.LOCAL)
+        || (executionInfo.containsKey(ExecutionRequirements.NO_SANDBOX)
+            && executionInfo.containsKey(ExecutionRequirements.NO_REMOTE))) {
+      // Path mapping requires sandboxed or remote execution.
+      return OutputPathsMode.OFF;
+    }
     if (outputPathsMode == OutputPathsMode.STRIP
         && (SUPPORTED_MNEMONICS.contains(mnemonic)
             || executionInfo.containsKey(ExecutionRequirements.SUPPORTS_PATH_MAPPING))) {


### PR DESCRIPTION
Targets tagged with `local` or `no-sandbox` and `no-remote` can't successfully use path mapping and thus have it disabled implicitly.

Closes #21921.

PiperOrigin-RevId: 635832339
Change-Id: Ib5cac0b202cbcd1704410f06fa3cda645581b849

Commit https://github.com/bazelbuild/bazel/commit/46dce83e62d5142ea588d1f108300dad5da190d7