### PR TITLE
Disable broken layering_check for grpc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -57,6 +57,14 @@ local_path_override(
     path = "./third_party/googleapis",
 )
 
+single_version_override(
+    module_name = "grpc",
+    patch_strip = 1,
+    patches = [
+        "//third_party/grpc:00_disable_layering_check.patch",
+    ],
+)
+
 # The following Bazel modules are not direct dependencies for building Bazel,
 # but are required for visibility from DIST_ARCHIVE_REPOS in repositories.bzl
 bazel_dep(name = "apple_support", version = "1.8.1")

--- a/third_party/grpc/00_disable_layering_check.patch
+++ b/third_party/grpc/00_disable_layering_check.patch
@@ -1,0 +1,13 @@
+diff --git a/BUILD b/BUILD
+index 83e6a3f740..b27df5b71e 100644
+--- a/BUILD
++++ b/BUILD
+@@ -29,7 +29,7 @@ licenses(["reciprocal"])
+ package(
+     default_visibility = ["//visibility:public"],
+     features = [
+-        "layering_check",
++        "-layering_check",
+         "-parse_headers",
+     ],
+ )


### PR DESCRIPTION
This has been done upstream in the BCR for newer versions, but upgrading right now requires more changes.

Should fix https://github.com/bazelbuild/bazel/pull/22259#issuecomment-2122897663