### PR TITLE
Fixing pass by ref option_processor object Google C++ Linter warning

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1089,15 +1089,15 @@ static ATTRIBUTE_NORETURN void RunClientServerMode(
 
 // Parse the options.
 static void ParseOptionsOrDie(const string &cwd, const string &workspace,
-                              OptionProcessor &option_processor, int argc,
+                              OptionProcessor *option_processor, int argc,
                               const char *const *argv) {
   std::string error;
   std::vector<std::string> args(argv, argv + argc);
   const blaze_exit_code::ExitCode parse_exit_code =
-      option_processor.ParseOptions(args, workspace, cwd, &error);
+      option_processor->ParseOptions(args, workspace, cwd, &error);
 
   if (parse_exit_code != blaze_exit_code::SUCCESS) {
-    option_processor.PrintStartupOptionsProvenanceMessage();
+    option_processor->PrintStartupOptionsProvenanceMessage();
     BAZEL_DIE(parse_exit_code) << error;
   }
 }


### PR DESCRIPTION
A linter warning appears with the pass by reference option_processor object.

The official Google C++ guideline say that the pass by ref/pointer options are to either make the reference parameter const if the parameter is not meant to be modified, or use a pointer instead of a non-const reference if the parameter is intended to be modified. Since "option_processor" is modified in the function definition, the change should be opted to pass by pointer.