### PR TITLE
[7.2.0] Remove stale extension factors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GsonTypeAdapterUtil.java
@@ -168,50 +168,15 @@ public final class GsonTypeAdapterUtil {
       MODULE_EXTENSION_FACTORS_TYPE_ADAPTER =
           new TypeAdapter<>() {
 
-            private static final String OS_KEY = "os:";
-            private static final String ARCH_KEY = "arch:";
-            // This is used when the module extension doesn't depend on os or arch, to indicate that
-            // its value is "general" and can be used with any platform
-            private static final String GENERAL_EXTENSION = "general";
-
             @Override
             public void write(JsonWriter jsonWriter, ModuleExtensionEvalFactors extFactors)
                 throws IOException {
-              if (extFactors.isEmpty()) {
-                jsonWriter.value(GENERAL_EXTENSION);
-              } else {
-                StringBuilder jsonBuilder = new StringBuilder();
-                if (!extFactors.getOs().isEmpty()) {
-                  jsonBuilder.append(OS_KEY).append(extFactors.getOs());
-                }
-                if (!extFactors.getArch().isEmpty()) {
-                  if (jsonBuilder.length() > 0) {
-                    jsonBuilder.append(",");
-                  }
-                  jsonBuilder.append(ARCH_KEY).append(extFactors.getArch());
-                }
-                jsonWriter.value(jsonBuilder.toString());
-              }
+              jsonWriter.value(extFactors.toString());
             }
 
             @Override
             public ModuleExtensionEvalFactors read(JsonReader jsonReader) throws IOException {
-              String jsonString = jsonReader.nextString();
-              if (jsonString.equals(GENERAL_EXTENSION)) {
-                return ModuleExtensionEvalFactors.create("", "");
-              }
-
-              String os = "";
-              String arch = "";
-              var extParts = Splitter.on(',').splitToList(jsonString);
-              for (String part : extParts) {
-                if (part.startsWith(OS_KEY)) {
-                  os = part.substring(OS_KEY.length());
-                } else if (part.startsWith(ARCH_KEY)) {
-                  arch = part.substring(ARCH_KEY.length());
-                }
-              }
-              return ModuleExtensionEvalFactors.create(os, arch);
+              return ModuleExtensionEvalFactors.parse(jsonReader.nextString());
             }
           };
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalFactors.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalFactors.java
@@ -15,7 +15,10 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Splitter;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This object holds the evaluation factors for module extensions in the lockfile, such as the
@@ -24,7 +27,14 @@ import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
  */
 @AutoValue
 @GenerateTypeAdapter
-public abstract class ModuleExtensionEvalFactors {
+public abstract class ModuleExtensionEvalFactors implements Comparable<ModuleExtensionEvalFactors> {
+
+  private static final String OS_KEY = "os:";
+  private static final String ARCH_KEY = "arch:";
+
+  // This is used when the module extension doesn't depend on os or arch, to indicate that
+  // its value is "general" and can be used with any platform
+  private static final String GENERAL_EXTENSION = "general";
 
   /** Returns the OS this extension is evaluated on, or empty if it doesn't depend on the os */
   public abstract String getOs();
@@ -39,7 +49,51 @@ public abstract class ModuleExtensionEvalFactors {
     return getOs().isEmpty() && getArch().isEmpty();
   }
 
+  public boolean hasSameDependenciesAs(ModuleExtensionEvalFactors other) {
+    return getOs().isEmpty() == other.getOs().isEmpty()
+        && getArch().isEmpty() == other.getArch().isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    if (isEmpty()) {
+      return GENERAL_EXTENSION;
+    }
+
+    List<String> parts = new ArrayList<>();
+    if (!getOs().isEmpty()) {
+      parts.add(OS_KEY + getOs());
+    }
+    if (!getArch().isEmpty()) {
+      parts.add(ARCH_KEY + getArch());
+    }
+    return String.join(",", parts);
+  }
+
+  @Override
+  public int compareTo(ModuleExtensionEvalFactors o) {
+    return toString().compareTo(o.toString());
+  }
+
   public static ModuleExtensionEvalFactors create(String os, String arch) {
     return new AutoValue_ModuleExtensionEvalFactors(os, arch);
+  }
+
+  public static ModuleExtensionEvalFactors parse(String s) {
+    if (s.equals(GENERAL_EXTENSION)) {
+      return ModuleExtensionEvalFactors.create("", "");
+    }
+
+    String os = "";
+    String arch = "";
+    var extParts = Splitter.on(',').splitToList(s);
+    for (String part : extParts) {
+      if (part.startsWith(OS_KEY)) {
+        os = part.substring(OS_KEY.length());
+      } else if (part.startsWith(ARCH_KEY)) {
+        arch = part.substring(ARCH_KEY.length());
+      }
+    }
+    return ModuleExtensionEvalFactors.create(os, arch);
   }
 }


### PR DESCRIPTION
JSON-based merge conflict resolution for `MODULE.bazel.lock` can end up producing entries with, e.g., both a `general` and an `os:Linux` factor result when the OS/arch dependence of the extension changes. `BazelLockFileModule` now invalidates each factor result individually.

Also sort the extension factors.

Closes #22378.

PiperOrigin-RevId: 635913837
Change-Id: I0064098806c856f16e8f4c0270f609f06cebc945

Commit https://github.com/bazelbuild/bazel/commit/c4092e9c591bf90bd705482e9a889306c28d72f0