### PR TITLE
[7.2.0] Wait for background tasks finished before releasing remoteCache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1597,8 +1597,6 @@ public class RemoteExecutionService {
     }
 
     if (remoteCache != null) {
-      remoteCache.release();
-
       try {
         backgroundTaskPhaser.awaitAdvanceInterruptibly(backgroundTaskPhaser.arrive());
       } catch (InterruptedException e) {
@@ -1606,6 +1604,12 @@ public class RemoteExecutionService {
         remoteCache.shutdownNow();
         Thread.currentThread().interrupt();
       }
+
+      // Only release the remoteCache once all background tasks have been finished. Otherwise, the
+      // last task might try to close the remoteCache inside the callback of network response which
+      // might cause deadlocks.
+      // See https://github.com/bazelbuild/bazel/issues/21568.
+      remoteCache.release();
     }
 
     if (remoteExecutor != null) {


### PR DESCRIPTION
So that the last task won't try to shutdown the remoteCache, otherwise, might cause deadlocks.

Fixes https://github.com/bazelbuild/bazel/issues/21568.

PiperOrigin-RevId: 635746896
Change-Id: Ic321216dd0bda05ef1ad18367c8ebbcd1a1d272c

Commit https://github.com/bazelbuild/bazel/commit/a804fb1748ce767d98f8b7a40e660ed22576e30e