### PR TITLE
[7.2.0] Provide "did you mean ...?" suggestions for unknown command-line options

### DIFF
--- a/src/main/java/com/google/devtools/common/options/BUILD
+++ b/src/main/java/com/google/devtools/common/options/BUILD
@@ -51,6 +51,7 @@ java_11_library(
     ),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/util:pair",
+        "//src/main/java/net/starlark/java/spelling",
         "//third_party:auto_value",
         "//third_party:caffeine",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/common/options/IsolatedOptionsData.java
+++ b/src/main/java/com/google/devtools/common/options/IsolatedOptionsData.java
@@ -17,6 +17,7 @@ package com.google.devtools.common.options;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.common.options.OptionDefinition.NotAnOptionException;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.common.options.OptionsParser.ConstructionException;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -160,7 +161,7 @@ public class IsolatedOptionsData extends OpaqueOptionsData {
    * appear ordered first by their options class (the order in which they were passed to {@link
    * #from(Collection, boolean)}, and then in alphabetic order within each options class.
    */
-  public Iterable<Map.Entry<String, OptionDefinition>> getAllOptionDefinitions() {
+  public ImmutableSet<Map.Entry<String, OptionDefinition>> getAllOptionDefinitions() {
     return nameToField.entrySet();
   }
 

--- a/src/test/java/com/google/devtools/common/options/OptionsTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsTest.java
@@ -435,12 +435,36 @@ public class OptionsTest {
   }
 
   @Test
-  public void unknownBooleanOption() {
+  public void unknownBooleanOptionNegativeForm() {
     OptionsParsingException e =
         assertThrows(
             OptionsParsingException.class,
             () -> Options.parse(HttpOptions.class, new String[] {"--no-debug"}));
-    assertThat(e).hasMessageThat().isEqualTo("Unrecognized option: --no-debug");
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("Unrecognized option: --no-debug (did you mean '--nodebug'?)");
+  }
+
+  @Test
+  public void unknownOption() {
+    OptionsParsingException e =
+        assertThrows(
+            OptionsParsingException.class,
+            () -> Options.parse(HttpOptions.class, new String[] {"--pert"}));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("Unrecognized option: --pert (did you mean '--port'?)");
+  }
+
+  @Test
+  public void unknownBooleanOptionPositiveForm() {
+    OptionsParsingException e =
+        assertThrows(
+            OptionsParsingException.class,
+            () -> Options.parse(HttpOptions.class, new String[] {"--dbg"}));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("Unrecognized option: --dbg (did you mean '--debug'?)");
   }
 
   public static class J extends OptionsBase {


### PR DESCRIPTION
Examples:

```
$ bazel build //src:bazel-dev --experimental_remote_cache_evection_retries=5
ERROR: --experimental_remote_cache_evection_retries=5 :: Unrecognized option: --experimental_remote_cache_evection_retries=5 (did you mean '--experimental_remote_cache_eviction_retries'?)
$ bazel build //src:bazel-dev --notest_kep_going
ERROR: --notest_kep_going :: Unrecognized option: --notest_kep_going (did you mean '--notest_keep_going'?)
```

Closes #22193.

PiperOrigin-RevId: 636258381
Change-Id: Ie81344caa14054e1d328d5a6e9b94da506d6a577

Commit https://github.com/bazelbuild/bazel/commit/0e9287f41ceeea6c980045cbbc126a885a47f42c