### PR TITLE
[7.2.0] Fix a crash on `use_repo_rule` with no repos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -643,18 +643,18 @@ public class ModuleFileGlobals {
       throws EvalException {
     ModuleThreadContext context = ModuleThreadContext.fromOrFail(thread, "use_repo_rule()");
     context.setNonModuleCalled();
-    // The builder for the singular "innate" extension of this module.
+    // Find or create the builder for the singular "innate" extension of this module.
+    for (ModuleExtensionUsageBuilder usageBuilder : context.getExtensionUsageBuilders()) {
+      if (usageBuilder.isForExtension("//:MODULE.bazel", ModuleExtensionId.INNATE_EXTENSION_NAME)) {
+        return new RepoRuleProxy(usageBuilder, bzlFile + '%' + ruleName);
+      }
+    }
     ModuleExtensionUsageBuilder newUsageBuilder =
         new ModuleExtensionUsageBuilder(
             context,
             "//:MODULE.bazel",
             ModuleExtensionId.INNATE_EXTENSION_NAME,
             /* isolate= */ false);
-    for (ModuleExtensionUsageBuilder usageBuilder : context.getExtensionUsageBuilders()) {
-      if (usageBuilder.isForExtension("//:MODULE.bazel", ModuleExtensionId.INNATE_EXTENSION_NAME)) {
-        return new RepoRuleProxy(usageBuilder, bzlFile + '%' + ruleName);
-      }
-    }
     context.getExtensionUsageBuilders().add(newUsageBuilder);
     return new RepoRuleProxy(newUsageBuilder, bzlFile + '%' + ruleName);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -249,6 +249,10 @@ public class ModuleThreadContext {
     // Build module extension usages and the rest of the module.
     var extensionUsages = ImmutableList.<ModuleExtensionUsage>builder();
     for (var extensionUsageBuilder : extensionUsageBuilders) {
+      if (extensionUsageBuilder.proxyBuilders.isEmpty()) {
+        // This can happen for the special extension used for "use_repo_rule" calls.
+        continue;
+      }
       extensionUsages.add(extensionUsageBuilder.buildUsage());
     }
     return module

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -1539,6 +1539,20 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
   }
 
   @Test
+  public void testNoUsages() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa')",
+        "http_archive = use_repo_rule('@bazel_tools//tools/build_defs/repo:http.bzl',"
+            + " 'http_archive')");
+
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.hasError()).isFalse();
+  }
+
+  @Test
   public void testInvalidRepoInPatches() throws Exception {
     scratch.overwriteFile(
         rootDirectory.getRelative("MODULE.bazel").getPathString(),


### PR DESCRIPTION
Fixes #22489

Closes #22493.

PiperOrigin-RevId: 636310898
Change-Id: If2fb41fd8d51f15aa1047cb62d55035e81187e41

Commit https://github.com/bazelbuild/bazel/commit/792d17c223ef5d170814940b28b4a3c69b799a2b