### PR TITLE
Fix non-visible `@platforms` label in builtins repo in analysis tests

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -785,7 +785,10 @@ public final class BazelAnalysisMock extends AnalysisMock {
   @Override
   public void setupMockToolsRepository(MockToolsConfig config) throws IOException {
     config.create("embedded_tools/WORKSPACE", "workspace(name = 'bazel_tools')");
-    config.create("embedded_tools/MODULE.bazel", "module(name='bazel_tools')");
+    config.create(
+        "embedded_tools/MODULE.bazel",
+        "module(name ='bazel_tools')",
+        "bazel_dep(name = 'platforms', version = '0.0.9')");
     config.create("embedded_tools/tools/build_defs/repo/BUILD");
     config.create(
         "embedded_tools/tools/build_defs/build_info/bazel_cc_build_info.bzl",

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -121,7 +121,10 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
   public void setup() throws Exception {
     workspaceRoot = scratch.dir("/ws");
     String bazelToolsPath = "/ws/embedded_tools";
-    scratch.file(bazelToolsPath + "/MODULE.bazel", "module(name = 'bazel_tools')");
+    scratch.file(
+        bazelToolsPath + "/MODULE.bazel",
+        "module(name = 'bazel_tools')",
+        "bazel_dep(name = 'platforms', version = '0.0.9')");
     scratch.file(bazelToolsPath + "/WORKSPACE");
     modulesRoot = scratch.dir("/modules");
     differencer = new SequencedRecordingDifferencer();

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -292,6 +292,8 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     RepositoryDelegatorFunction.IS_VENDOR_COMMAND.set(differencer, false);
     RepositoryDelegatorFunction.VENDOR_DIRECTORY.set(differencer, Optional.empty());
 
+    registry.addModule(
+        createModuleKey("platforms", "0.0.9"), "module(name='platforms', version = '0.0.9')");
     // Set up a simple repo rule.
     registry.addModule(
         createModuleKey("data_repo", "1.0"), "module(name='data_repo',version='1.0')");


### PR DESCRIPTION
The `WINDOWS_CONSTRAINT` label in the `cc_*` semantics file didn't resolve correctly due to a missing repo mapping entry for `@bazel_tools` in the analysis test setup.