### PR TITLE
Fix getting authentication for URLs in http repo rules

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2943,7 +2943,7 @@
         "bzlTransitiveDigest": "iHLxWy9Kdma4o6vQG1U0vO82d7jPg9gng3gCoY4Dn88=",
         "recordedFileInputs": {
           "@@//MODULE.bazel": "26923f93b024aa4aa0410156224bfc1176bfceebc4ae83e866a43839a82e69f9",
-          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "99db65ecc18d13d1bcc88af7af29c05f48a97ee1e3b2516b1df3817eb2843aa5"
+          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "4a9cf4d1d48d36a3d6e24a13094b2c32aa20be5a495d4e5b33e43db973250182"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -78,7 +78,7 @@
     },
     "@@rules_jvm_external~//:extensions.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "226YAg74jgPpN2590v8XjmUVZU1nLLfY26Q0RHpkZYo=",
+        "bzlTransitiveDigest": "ktqZUWl2nBo/3HEhakOj9tfmT3+/Z90z7ldq8XwxYnE=",
         "usagesDigest": "UPebZtX4g40+QepdK3oMHged0o0tq6ojKbW84wE6XRA=",
         "recordedFileInputs": {
           "@@rules_jvm_external~//rules_jvm_external_deps_install.json": "10442a5ae27d9ff4c2003e5ab71643bf0d8b48dcf968b4173fa274c3232a8c06"
@@ -1102,7 +1102,7 @@
     },
     "@@rules_jvm_external~//:non-module-deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "5AogXHZkwASsdwr6DZ7FypQvxHHp3r0l7HGPUx4wbgY=",
+        "bzlTransitiveDigest": "4VF2Z/DNZaLHTP3izo0uTvnjS8it3dSViL5+ack4ogE=",
         "usagesDigest": "bTG4ItERqhG1LeSs62hQ01DiMarFsflWgpZaghM5qik=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1130,7 +1130,7 @@
     },
     "@@rules_python~//python/extensions:python.bzl%python": {
       "general": {
-        "bzlTransitiveDigest": "vmavs6wkry+PckMdBQFrxN22WzruPHKNVE+U7VyukC0=",
+        "bzlTransitiveDigest": "e3ZmjG1ZEg3xSbspFPC5afi43pqfpAU89V2ghTtcNug=",
         "usagesDigest": "7vjNHuEgQORYN9+9/77Q4zw1kawobM2oCQb9p0uhL68=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1160,7 +1160,7 @@
     },
     "@@rules_python~//python/extensions/private:internal_deps.bzl%internal_deps": {
       "general": {
-        "bzlTransitiveDigest": "LtPwHy+IdTsBOPDeTq0hFypO4nTs1oyboirDM9FQ1/4=",
+        "bzlTransitiveDigest": "f4sn8DF0csno6nVTa/bU1ixR43r+jYeZRRCD3xniTxQ=",
         "usagesDigest": "b+nMDqtqPCBxiMBewNNde3aNjzKqZyvJuN5/49xB62s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -101,7 +101,6 @@ def download_remote_files(ctx):
     Args:
       ctx: The repository context of the repository rule calling this utility
         function.
-      auth: An optional dict specifying authentication information for some of the URLs.
     """
     pending = [
         ctx.download(

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -108,7 +108,7 @@ def download_remote_files(ctx):
             remote_file_urls,
             path,
             canonical_id = ctx.attr.canonical_id,
-            auth = get_auth(ctx, [remote_file_urls]),
+            auth = get_auth(ctx, remote_file_urls),
             integrity = ctx.attr.remote_file_integrity.get(path, ""),
             block = False,
         )

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -141,6 +141,7 @@ def patch(ctx, patches = None, patch_cmds = None, patch_cmds_win = None, patch_t
         patches. String.
       patch_args: Arguments to pass to the patch tool. List of strings.
       auth: An optional dict specifying authentication information for some of the URLs.
+
     """
     bash_exe = ctx.os.environ["BAZEL_SH"] if "BAZEL_SH" in ctx.os.environ else "bash"
     powershell_exe = ctx.os.environ["BAZEL_POWERSHELL"] if "BAZEL_POWERSHELL" in ctx.os.environ else "powershell.exe"


### PR DESCRIPTION
- Fixed the leak of `remote_patches` URLs for downloaded the source archive.
- Compute auth for required URLs only

Fixes https://github.com/bazelbuild/bazel/issues/22201