### PR TITLE
Do not print repository errors twice

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -402,7 +402,8 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
       env.getListener()
           .handle(Event.info(RepositoryResolvedEvent.getRuleDefinitionInformation(rule)));
 
-      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+      throw new RepositoryFunctionException(
+          new AlreadyReportedRepositoryAccessException(e), Transience.TRANSIENT);
     }
 
     if (!outputDirectory.isDirectory()) {

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.repository.RepositoryFetchProgress;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue.NoRepositoryDirectoryValue;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.AlreadyReportedRepositoryAccessException;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
+import com.google.devtools.build.lib.skyframe.AlreadyReportedException;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue.Precomputed;
 import com.google.devtools.build.lib.util.Fingerprint;
@@ -424,6 +425,10 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       // Upon an exceptional exit, the fetching of that repository is over as well.
       env.getListener().post(RepositoryFetchProgress.finished(repoName));
       env.getListener().post(new RepositoryFailedEvent(repoName, e.getMessage()));
+
+      if (e.getCause() instanceof AlreadyReportedException) {
+        throw e;
+      }
       env.getListener()
           .handle(
               Event.error(


### PR DESCRIPTION
Instead of

```
ERROR: An error occurred during the fetch of repository 'mydep~':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_fmeum/7d8a4807d1079f03870ba5776e9ca66b/external/bazel_tools/tools/build_defs/repo/http.bzl", line 142, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Bad URL: invalid
ERROR: <builtin>: fetching http_archive rule //:mydep~: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_fmeum/7d8a4807d1079f03870ba5776e9ca66b/external/bazel_tools/tools/build_defs/repo/http.bzl", line 142, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Bad URL: invalid
ERROR: Error computing the main repository mapping: error during computation of main repo mapping: java.io.IOException: Bad URL: invalid
```

print

```
ERROR: An error occurred during the fetch of repository 'mydep~':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_fmeum/7d8a4807d1079f03870ba5776e9ca66b/external/bazel_tools/tools/build_defs/repo/http.bzl", line 142, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Bad URL: invalid
ERROR: Error computing the main repository mapping: error during computation of main repo mapping: java.io.IOException: Bad URL: invalid
```

Fixes #22520