### PR TITLE
chore: Ignore shellcheck error in copy-paste code

### DIFF
--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -70,6 +70,7 @@
 #       # --- begin runfiles.bash initialization v3 ---
 #       # Copy-pasted from the Bazel Bash runfiles library v3.
 #       set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+#       # shellcheck disable=SC1090
 #       source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 #         source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
 #         source "$0.runfiles/$f" 2>/dev/null || \


### PR DESCRIPTION
This piece of code is supposed to be copy-pasted literally, so it is better to already configure shellcheck ignore to help users who apply shellcheck to their scripts.