### PR TITLE
[7.2.0] Validate label attributes of repositories created by module extensions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValues.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValues.java
@@ -15,12 +15,18 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import static java.util.Collections.singletonList;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Starlark;
 
 /** Wraps a dictionary of attribute names and values. Always uses a dict to represent them */
@@ -38,6 +44,49 @@ public abstract class AttributeValues {
   }
 
   public abstract Dict<String, Object> attributes();
+
+  public static void validateAttrs(AttributeValues attributes, String what) throws EvalException {
+    for (var entry : attributes.attributes().entrySet()) {
+      validateSingleAttr(entry.getKey(), entry.getValue(), what);
+    }
+  }
+
+  public static void validateSingleAttr(String attrName, Object attrValue, String what)
+      throws EvalException {
+    var maybeNonVisibleLabel = getFirstNonVisibleLabel(attrValue);
+    if (maybeNonVisibleLabel.isEmpty()) {
+      return;
+    }
+    Label label = maybeNonVisibleLabel.get();
+    String repoName = label.getRepository().getName();
+    throw Starlark.errorf(
+        "no repository visible as '@%s' to the %s, but referenced by label '@%s//%s:%s' in"
+            + " attribute '%s' of %s. Is the %s missing a bazel_dep or use_repo(..., \"%s\")?",
+        repoName,
+        label.getRepository().getOwnerRepoDisplayString(),
+        repoName,
+        label.getPackageName(),
+        label.getName(),
+        attrName,
+        what,
+        label.getRepository().getOwnerModuleDisplayString(),
+        repoName);
+  }
+
+  private static Optional<Label> getFirstNonVisibleLabel(Object nativeAttrValue) {
+    Collection<?> toValidate =
+        switch (nativeAttrValue) {
+          case List<?> list -> list;
+          case Map<?, ?> map -> map.keySet();
+          case null, default -> singletonList(nativeAttrValue);
+        };
+    for (var item : toValidate) {
+      if (item instanceof Label label && !label.getRepository().isVisible()) {
+        return Optional.of(label);
+      }
+    }
+    return Optional.empty();
+  }
 
   // TODO(salmasamy) this is a copy of Attribute::valueToStarlark, Maybe think of a better place?
   private static Object valueToStarlark(Object x) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalStarlarkThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalStarlarkThreadContext.java
@@ -115,11 +115,14 @@ public final class ModuleExtensionEvalStarlarkThreadContext {
           Maps.filterKeys(
               Maps.transformEntries(kwargs, (k, v) -> rule.getAttr(k)), k -> !k.equals("name"));
       String bzlFile = ruleClass.getRuleDefinitionEnvironmentLabel().getUnambiguousCanonicalForm();
+      var attributesValue = AttributeValues.create(attributes);
+      AttributeValues.validateAttrs(
+          attributesValue, String.format("%s '%s'", rule.getRuleClass(), name));
       RepoSpec repoSpec =
           RepoSpec.builder()
               .setBzlFile(bzlFile)
               .setRuleClassName(ruleClass.getName())
-              .setAttributes(AttributeValues.create(attributes))
+              .setAttributes(attributesValue)
               .build();
 
       generatedRepos.put(name, RepoSpecAndLocation.create(repoSpec, thread.getCallerLocation()));

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
@@ -98,6 +98,7 @@ public class TypeCheckedTag implements Structure {
     }
 
     // Check that all mandatory attributes have been specified, and fill in default values.
+    // Along the way, verify that labels in the attribute values refer to visible repos only.
     for (int i = 0; i < attrValues.length; i++) {
       Attribute attr = tagClass.getAttributes().get(i);
       if (attr.isMandatory() && attrValues[i] == null) {
@@ -109,6 +110,13 @@ public class TypeCheckedTag implements Structure {
       }
       if (attrValues[i] == null) {
         attrValues[i] = Attribute.valueToStarlark(attr.getDefaultValueUnchecked());
+      }
+      try {
+        AttributeValues.validateSingleAttr(
+            attr.getPublicName(), attrValues[i], String.format("tag '%s'", tag.getTagName()));
+      } catch (EvalException e) {
+        throw ExternalDepsException.withMessage(
+            Code.BAD_MODULE, "in tag at %s: %s", tag.getLocation(), e.getMessage());
       }
     }
     return new TypeCheckedTag(

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -207,6 +207,20 @@ public final class RepositoryName {
     }
   }
 
+  // Must only be called if isVisible() returns true.
+  public String getOwnerModuleDisplayString() {
+    Preconditions.checkNotNull(ownerRepoIfNotVisible);
+    if (ownerRepoIfNotVisible.isMain()) {
+      return "root module";
+    } else {
+      return String.format(
+          "module '%s'",
+          ownerRepoIfNotVisible
+              .getName()
+              .substring(0, ownerRepoIfNotVisible.getName().indexOf('~')));
+    }
+  }
+
   /** Returns if this is the main repository. */
   public boolean isMain() {
     return equals(MAIN);


### PR DESCRIPTION
Catches a common gotcha of referencing a repo created by an extension elsewhere in an extension without a `use_repo` and provides actionable advice to user. This prevents lockfile corruption caused by non-visible labels.

The same validation is applied to labels in tag attributes.

Fixes #21845

Closes #22495.

PiperOrigin-RevId: 636939357
Change-Id: Ib779207502f7767e4e8d3abc55ba7470f75821b9

Commit https://github.com/bazelbuild/bazel/commit/aa436c3594a6cf329de466cc1faccf4ed585b67f