### PR TITLE
[7.2.0] Track `getenv` calls in module extensions

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2919,7 +2919,7 @@
         "bzlTransitiveDigest": "kGK7vQSUnYTiX5+yCN3M8Mdy5PtT3d9zz8C7MpetGCk=",
         "recordedFileInputs": {
           "@@//MODULE.bazel": "e6dc6d8e38926c6071c69d5c9d37de5491100ec7a1246a774e7a7bb4035b064f",
-          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "a24c42ec0fd1b2b9186ebd26dde26e6242ad52eb547866c743f45084295d5248"
+          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "25e5660da3f92a92d560a450ef453fb64629795bf24613286c52f2da529adfd1"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 @GenerateTypeAdapter
 public abstract class BazelLockFileValue implements SkyValue, Postable {
 
-  public static final int LOCK_FILE_VERSION = 10;
+  public static final int LOCK_FILE_VERSION = 11;
 
   @SerializationConstant public static final SkyKey KEY = () -> SkyFunctions.BAZEL_LOCK_FILE;
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
@@ -48,7 +48,7 @@ public abstract class LockFileModuleExtension implements Postable {
 
   public abstract ImmutableMap<RepoRecordedInput.Dirents, String> getRecordedDirentsInputs();
 
-  public abstract ImmutableMap<String, String> getEnvVariables();
+  public abstract ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> getEnvVariables();
 
   public abstract ImmutableMap<String, RepoSpec> getGeneratedRepoSpecs();
 
@@ -78,7 +78,8 @@ public abstract class LockFileModuleExtension implements Postable {
     public abstract Builder setRecordedDirentsInputs(
         ImmutableMap<RepoRecordedInput.Dirents, String> value);
 
-    public abstract Builder setEnvVariables(ImmutableMap<String, String> value);
+    public abstract Builder setEnvVariables(
+        ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> value);
 
     public abstract Builder setGeneratedRepoSpecs(ImmutableMap<String, RepoSpec> value);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -25,6 +25,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -230,6 +231,15 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     // result is taken from the lockfile, we can already populate the lockfile info. This is
     // necessary to prevent the extension from rerunning when only the imports change.
     if (lockfileMode == LockfileMode.UPDATE || lockfileMode == LockfileMode.REFRESH) {
+      var envVariables =
+          ImmutableMap.<RepoRecordedInput.EnvVar, Optional<String>>builder()
+              // The environment variable dependencies statically declared via the 'environ'
+              // attribute.
+              .putAll(RepoRecordedInput.EnvVar.wrap(extension.getStaticEnvVars()))
+              // The environment variable dependencies dynamically declared via the 'getenv' method.
+              .putAll(moduleExtensionResult.getRecordedEnvVarInputs())
+              .buildKeepingLast();
+
       lockFileInfo =
           Optional.of(
               new LockFileModuleExtension.WithFactors(
@@ -241,7 +251,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                               GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON, usagesValue))
                       .setRecordedFileInputs(moduleExtensionResult.getRecordedFileInputs())
                       .setRecordedDirentsInputs(moduleExtensionResult.getRecordedDirentsInputs())
-                      .setEnvVariables(extension.getEnvVars())
+                      .setEnvVariables(ImmutableSortedMap.copyOf(envVariables))
                       .setGeneratedRepoSpecs(generatedRepoSpecs)
                       .setModuleExtensionMetadata(moduleExtensionMetadata)
                       .setRecordedRepoMappingEntries(
@@ -284,7 +294,11 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                 + extensionId
                 + "' or one of its transitive .bzl files has changed");
       }
-      if (!extension.getEnvVars().equals(lockedExtension.getEnvVariables())) {
+      if (didRecordedInputsChange(
+          env,
+          directories,
+          // didRecordedInputsChange expects possibly null String values.
+          Maps.transformValues(lockedExtension.getEnvVariables(), v -> v.orElse(null)))) {
         diffRecorder.record(
             "The environment variables the extension '"
                 + extensionId
@@ -415,7 +429,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
   private static boolean didRecordedInputsChange(
       Environment env,
       BlazeDirectories directories,
-      ImmutableMap<? extends RepoRecordedInput, String> recordedInputs)
+      Map<? extends RepoRecordedInput, String> recordedInputs)
       throws InterruptedException, NeedsSkyframeRestartException {
     boolean upToDate = RepoRecordedInput.areAllValuesUpToDate(env, directories, recordedInputs);
     if (env.valuesMissing()) {
@@ -522,15 +536,15 @@ public class SingleExtensionEvalFunction implements SkyFunction {
    * <p>The general idiom is to "load" such a {@link RunnableExtension} object by getting as much
    * information about it as needed to determine whether it can be reused from the lockfile (hence
    * methods such as {@link #getEvalFactors()}, {@link #getBzlTransitiveDigest()}, {@link
-   * #getEnvVars()}). Then the {@link #run} method can be called if it's determined that we can't
-   * reuse the cached results in the lockfile and have to re-run this extension.
+   * #getStaticEnvVars()}). Then the {@link #run} method can be called if it's determined that we
+   * can't reuse the cached results in the lockfile and have to re-run this extension.
    */
   private interface RunnableExtension {
     ModuleExtensionEvalFactors getEvalFactors();
 
     byte[] getBzlTransitiveDigest();
 
-    ImmutableMap<String, String> getEnvVars();
+    ImmutableMap<String, Optional<String>> getStaticEnvVars();
 
     @Nullable
     RunModuleExtensionResult run(
@@ -681,7 +695,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     }
 
     @Override
-    public ImmutableMap<String, String> getEnvVars() {
+    public ImmutableMap<String, Optional<String>> getStaticEnvVars() {
       return ImmutableMap.of();
     }
 
@@ -775,6 +789,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       return RunModuleExtensionResult.create(
           ImmutableMap.of(),
           ImmutableMap.of(),
+          ImmutableMap.of(),
           generatedRepoSpecs.buildOrThrow(),
           Optional.of(ModuleExtensionMetadata.REPRODUCIBLE),
           ImmutableTable.of());
@@ -820,7 +835,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     }
 
     ModuleExtension extension = (ModuleExtension) exported;
-    ImmutableMap<String, String> envVars =
+    ImmutableMap<String, Optional<String>> envVars =
         RepositoryFunction.getEnvVarValues(env, ImmutableSet.copyOf(extension.getEnvVariables()));
     if (envVars == null) {
       return null;
@@ -831,15 +846,15 @@ public class SingleExtensionEvalFunction implements SkyFunction {
   private final class RegularRunnableExtension implements RunnableExtension {
     private final BzlLoadValue bzlLoadValue;
     private final ModuleExtension extension;
-    private final ImmutableMap<String, String> envVars;
+    private final ImmutableMap<String, Optional<String>> staticEnvVars;
 
     RegularRunnableExtension(
         BzlLoadValue bzlLoadValue,
         ModuleExtension extension,
-        ImmutableMap<String, String> envVars) {
+        ImmutableMap<String, Optional<String>> staticEnvVars) {
       this.bzlLoadValue = bzlLoadValue;
       this.extension = extension;
-      this.envVars = envVars;
+      this.staticEnvVars = staticEnvVars;
     }
 
     @Override
@@ -850,8 +865,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     }
 
     @Override
-    public ImmutableMap<String, String> getEnvVars() {
-      return envVars;
+    public ImmutableMap<String, Optional<String>> getStaticEnvVars() {
+      return staticEnvVars;
     }
 
     @Override
@@ -951,6 +966,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       return RunModuleExtensionResult.create(
           moduleContext.getRecordedFileInputs(),
           moduleContext.getRecordedDirentsInputs(),
+          moduleContext.getRecordedEnvVarInputs(),
           threadContext.getGeneratedRepoSpecs(),
           moduleExtensionMetadata,
           repoMappingRecorder.recordedEntries());
@@ -1015,6 +1031,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
 
     abstract ImmutableMap<RepoRecordedInput.Dirents, String> getRecordedDirentsInputs();
 
+    abstract ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> getRecordedEnvVarInputs();
+
     abstract ImmutableMap<String, RepoSpec> getGeneratedRepoSpecs();
 
     abstract Optional<ModuleExtensionMetadata> getModuleExtensionMetadata();
@@ -1024,12 +1042,14 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     static RunModuleExtensionResult create(
         ImmutableMap<RepoRecordedInput.File, String> recordedFileInputs,
         ImmutableMap<RepoRecordedInput.Dirents, String> recordedDirentsInputs,
+        ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> recordedEnvVarInputs,
         ImmutableMap<String, RepoSpec> generatedRepoSpecs,
         Optional<ModuleExtensionMetadata> moduleExtensionMetadata,
         ImmutableTable<RepositoryName, String, RepositoryName> recordedRepoMappingEntries) {
       return new AutoValue_SingleExtensionEvalFunction_RunModuleExtensionResult(
           recordedFileInputs,
           recordedDirentsInputs,
+          recordedEnvVarInputs,
           generatedRepoSpecs,
           moduleExtensionMetadata,
           recordedRepoMappingEntries);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
@@ -214,9 +213,12 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
     return ImmutableMap.copyOf(recordedDirentsInputs);
   }
 
-  /** Returns set of environment variable keys encountered so far. */
-  public ImmutableSet<String> getAccumulatedEnvKeys() {
-    return ImmutableSet.copyOf(accumulatedEnvKeys);
+  public ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> getRecordedEnvVarInputs()
+      throws InterruptedException {
+    // getEnvVarValues doesn't return null since the Skyframe dependencies have already been
+    // established by getenv calls.
+    return RepoRecordedInput.EnvVar.wrap(
+        ImmutableSortedMap.copyOf(RepositoryFunction.getEnvVarValues(env, accumulatedEnvKeys)));
   }
 
   protected void checkInOutputDirectory(String operation, StarlarkPath path)

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -20,6 +20,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
@@ -362,16 +363,14 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
         env.getListener().handle(Event.debug(defInfo));
       }
 
-      // Modify marker data to include the files/dirents used by the rule's implementation function.
+      // Modify marker data to include the files/dirents/env vars used by the rule's implementation
+      // function.
       recordedInputValues.putAll(starlarkRepositoryContext.getRecordedFileInputs());
       recordedInputValues.putAll(starlarkRepositoryContext.getRecordedDirentsInputs());
       recordedInputValues.putAll(starlarkRepositoryContext.getRecordedDirTreeInputs());
-
-      // Ditto for environment variables accessed via `getenv`.
-      for (String envKey : starlarkRepositoryContext.getAccumulatedEnvKeys()) {
-        recordedInputValues.put(
-            new RepoRecordedInput.EnvVar(envKey), clientEnvironment.get(envKey));
-      }
+      recordedInputValues.putAll(
+          Maps.transformValues(
+              starlarkRepositoryContext.getRecordedEnvVarInputs(), v -> v.orElse(null)));
 
       for (Table.Cell<RepositoryName, String, RepositoryName> repoMappings :
           repoMappingRecorder.recordedEntries().cellSet()) {

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
@@ -15,11 +15,13 @@
 package com.google.devtools.build.lib.rules.repository;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
@@ -494,7 +496,7 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
 
   /** Represents an environment variable accessed during the repo fetch. */
   public static final class EnvVar extends RepoRecordedInput {
-    static final Parser PARSER =
+    public static final Parser PARSER =
         new Parser() {
           @Override
           public String getPrefix() {
@@ -509,7 +511,13 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
 
     final String name;
 
-    public EnvVar(String name) {
+    public static ImmutableMap<EnvVar, Optional<String>> wrap(
+        Map<String, Optional<String>> envVars) {
+      return envVars.entrySet().stream()
+          .collect(toImmutableMap(e -> new EnvVar(e.getKey()), Map.Entry::getValue));
+    }
+
+    private EnvVar(String name) {
       this.name = name;
     }
 

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -18,6 +18,7 @@ import json
 import os
 import pathlib
 import tempfile
+
 from absl.testing import absltest
 from src.test.py.bazel import test_base
 from src.test.py.bazel.bzlmod.test_utils import BazelRegistry
@@ -2475,6 +2476,126 @@ class BazelLockfileTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(['build', '@hello//:all'])
     stderr = ''.join(stderr)
     self.assertIn('I am running the extension: 4.5.6', stderr)
+
+  def testModuleExtensionRerunsOnGetenvChanges(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'module(name = "old_name", version = "1.2.3")',
+            'lockfile_ext = use_extension("//:extension.bzl", "lockfile_ext")',
+            'use_repo(lockfile_ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def _repo_rule_impl(ctx):',
+            '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
+            '',
+            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            '',
+            'def _module_ext_impl(ctx):',
+            (
+                '    print("UNDECLARED_KEY=%s" %'
+                ' ctx.os.environ.get("UNDECLARED_KEY"))'
+            ),
+            (
+                '    print("PREDECLARED_KEY=%s" %'
+                ' ctx.os.environ.get("PREDECLARED_KEY"))'
+            ),
+            '    print("LAZYEVAL_KEY=%s" % ctx.getenv("LAZYEVAL_KEY"))',
+            '    repo_rule(name="hello")',
+            '',
+            'lockfile_ext = module_extension(',
+            '    implementation=_module_ext_impl,',
+            '    environ = ["PREDECLARED_KEY"],',
+            ')',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], env_add={'UNDECLARED_KEY': 'val1'}
+    )
+    stderr = '\n'.join(stderr)
+    self.assertIn('UNDECLARED_KEY=val1', stderr)
+
+    # No reevaluation if undeclared env var changes
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], env_add={'UNDECLARED_KEY': 'val2'}
+    )
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('UNDECLARED_KEY', stderr)
+
+    # Reevaluation if predeclared env var is first set
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], env_add={'PREDECLARED_KEY': 'val1'}
+    )
+    stderr = '\n'.join(stderr)
+    self.assertIn('PREDECLARED_KEY=val1', stderr)
+
+    # No reevaluation if predeclared env var does not change
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], env_add={'PREDECLARED_KEY': 'val1'}
+    )
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('PREDECLARED_KEY', stderr)
+
+    # Reevaluation if predeclared env var changes
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], env_add={'PREDECLARED_KEY': 'val2'}
+    )
+    stderr = '\n'.join(stderr)
+    self.assertIn('PREDECLARED_KEY=val2', stderr)
+
+    # Reevaluation if predeclared env var becomes unset
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(['build', '@hello//:all'])
+    stderr = '\n'.join(stderr)
+    self.assertIn('PREDECLARED_KEY=None', stderr)
+
+    # Reevaluation if lazily declared env var is first set
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], env_add={'LAZYEVAL_KEY': 'val1'}
+    )
+    stderr = '\n'.join(stderr)
+    self.assertIn('LAZYEVAL_KEY=val1', stderr)
+
+    # No reevaluation if lazily declared env var does not change
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], env_add={'LAZYEVAL_KEY': 'val1'}
+    )
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('LAZYEVAL_KEY', stderr)
+
+    # Reevaluation if lazily declared env var changes
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all'], env_add={'LAZYEVAL_KEY': 'val2'}
+    )
+    stderr = '\n'.join(stderr)
+    self.assertIn('LAZYEVAL_KEY=val2', stderr)
+
+    # Reevaluation if lazily declared env var changes due to --repo_env.
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(
+        ['build', '@hello//:all', '--repo_env=LAZYEVAL_KEY=val3'],
+        env_add={'LAZYEVAL_KEY': 'val2'},
+    )
+    stderr = '\n'.join(stderr)
+    self.assertIn('LAZYEVAL_KEY=val3', stderr)
+
+    # Reevaluation if lazily declared env var becomes unset
+    self.RunBazel(['shutdown'])
+    _, _, stderr = self.RunBazel(['build', '@hello//:all'])
+    stderr = '\n'.join(stderr)
+    self.assertIn('LAZYEVAL_KEY=None', stderr)
 
 
 if __name__ == '__main__':

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 10,
+  "lockFileVersion": 11,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",


### PR DESCRIPTION
Fixes #22404

RELNOTES: Changes to environment variables read via `getenv` now correctly invalidate module extensions.

Closes #22498.

PiperOrigin-RevId: 637058337
Change-Id: Id4aaa4155a728452472eedae4a59c8d29456e512