### PR TITLE
support C++20 Modules, implement compilation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationOutputs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationOutputs.java
@@ -45,6 +45,18 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
   private final ImmutableList<Artifact> picObjectFiles;
 
   /**
+   * All .pcm files built by the target.
+   */
+  private final NestedSet<Artifact.DerivedArtifact> pcmFiles;
+
+  /**
+   * All .pic.pcm files built by the target.
+   */
+  private final NestedSet<Artifact.DerivedArtifact> picPcmFiles;
+
+  private final ImmutableList<Artifact> modulesInfoFiles;
+  private final ImmutableList<Artifact> picModulesInfoFiles;
+  /**
    * Maps all .o bitcode files coming from a ThinLTO C(++) compilation under our control to
    * information needed by the LTO indexing and backend steps.
    */
@@ -82,6 +94,10 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
   private CcCompilationOutputs(
       ImmutableList<Artifact> objectFiles,
       ImmutableList<Artifact> picObjectFiles,
+      NestedSet<Artifact.DerivedArtifact> pcmFiles,
+      NestedSet<Artifact.DerivedArtifact> picPcmFiles,
+      ImmutableList<Artifact> modulesInfoFiles,
+      ImmutableList<Artifact> picModulesInfoFiles,
       LtoCompilationContext ltoCompilationContext,
       ImmutableList<Artifact> dwoFiles,
       ImmutableList<Artifact> picDwoFiles,
@@ -92,6 +108,10 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
       ImmutableList<Artifact> moduleFiles) {
     this.objectFiles = objectFiles;
     this.picObjectFiles = picObjectFiles;
+    this.pcmFiles = pcmFiles;
+    this.picPcmFiles = picPcmFiles;
+    this.modulesInfoFiles = modulesInfoFiles;
+    this.picModulesInfoFiles = picModulesInfoFiles;
     this.ltoCompilationContext = ltoCompilationContext;
     this.dwoFiles = dwoFiles;
     this.picDwoFiles = picDwoFiles;
@@ -109,6 +129,19 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
    */
   public ImmutableList<Artifact> getObjectFiles(boolean usePic) {
     return usePic ? picObjectFiles : objectFiles;
+  }
+
+  /**
+   * Returns an unmodifiable view of the .pcm or .pic.pcm files set.
+   *
+   * @param usePic whether to return .pic.pcm files
+   */
+  public NestedSet<Artifact.DerivedArtifact> getPcmFiles(boolean usePic) {
+    return usePic ? picPcmFiles : pcmFiles;
+  }
+
+  public ImmutableList<Artifact> getModulesInfoFiles(boolean usePic) {
+    return usePic ? picModulesInfoFiles : modulesInfoFiles;
   }
 
   @Override
@@ -244,6 +277,10 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
   public static final class Builder {
     private final Set<Artifact> objectFiles = new LinkedHashSet<>();
     private final Set<Artifact> picObjectFiles = new LinkedHashSet<>();
+    private final NestedSetBuilder<Artifact.DerivedArtifact> pcmFiles = NestedSetBuilder.stableOrder();
+    private final NestedSetBuilder<Artifact.DerivedArtifact> picPcmFiles = NestedSetBuilder.stableOrder();
+    private final Set<Artifact> modulesInfoFiles = new LinkedHashSet<>();
+    private final Set<Artifact> picModulesInfoFiles = new LinkedHashSet<>();
     private final LtoCompilationContext.Builder ltoCompilationContext =
         new LtoCompilationContext.Builder();
     private final Set<Artifact> dwoFiles = new LinkedHashSet<>();
@@ -262,6 +299,10 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
       return new CcCompilationOutputs(
           ImmutableList.copyOf(objectFiles),
           ImmutableList.copyOf(picObjectFiles),
+          pcmFiles.build(),
+          picPcmFiles.build(),
+          ImmutableList.copyOf(modulesInfoFiles),
+          ImmutableList.copyOf(picModulesInfoFiles),
           ltoCompilationContext.build(),
           ImmutableList.copyOf(dwoFiles),
           ImmutableList.copyOf(picDwoFiles),
@@ -276,6 +317,10 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
     public Builder merge(CcCompilationOutputs outputs) {
       this.objectFiles.addAll(outputs.objectFiles);
       this.picObjectFiles.addAll(outputs.picObjectFiles);
+      this.pcmFiles.addTransitive(outputs.pcmFiles);
+      this.picPcmFiles.addTransitive(outputs.picPcmFiles);
+      this.modulesInfoFiles.addAll(outputs.modulesInfoFiles);
+      this.picModulesInfoFiles.addAll(outputs.picModulesInfoFiles);
       this.dwoFiles.addAll(outputs.dwoFiles);
       this.picDwoFiles.addAll(outputs.picDwoFiles);
       this.gcnoFiles.addAll(outputs.gcnoFiles);
@@ -298,6 +343,20 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
       return this;
     }
 
+    /** Adds a pcm file. */
+    @CanIgnoreReturnValue
+    public Builder addPcmFile(Artifact.DerivedArtifact artifact) {
+      pcmFiles.add(artifact);
+      return this;
+    }
+
+    /** Adds a modules info file. */
+    @CanIgnoreReturnValue
+    public Builder addModulesInfoFile(Artifact artifact) {
+      modulesInfoFiles.add(artifact);
+      return this;
+    }
+
     @CanIgnoreReturnValue
     public Builder addObjectFiles(Iterable<Artifact> artifacts) {
       for (Artifact artifact : artifacts) {
@@ -312,6 +371,19 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
     @CanIgnoreReturnValue
     public Builder addPicObjectFile(Artifact artifact) {
       picObjectFiles.add(artifact);
+      return this;
+    }
+
+    /** Adds a pic pcm file. */
+    @CanIgnoreReturnValue
+    public Builder addPicPcmFile(Artifact.DerivedArtifact artifact) {
+      picPcmFiles.add(artifact);
+      return this;
+    }
+    /** Adds a pic modules info file. */
+    @CanIgnoreReturnValue
+    public Builder addPicModulesInfoFile(Artifact artifact) {
+      picModulesInfoFiles.add(artifact);
       return this;
     }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -743,3 +743,19 @@ java_test(
         "//third_party:truth",
     ],
 )
+
+java_test(
+    name = "Cpp20ModuleCompileTest",
+    srcs = ["Cpp20ModuleCompileTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/rules/cpp",
+        "//src/test/java/com/google/devtools/build/lib/actions/util",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/packages:testutil",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/Cpp20ModuleCompileTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/Cpp20ModuleCompileTest.java
@@ -1,0 +1,158 @@
+package com.google.devtools.build.lib.rules.cpp;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.actions.util.ActionsTestUtil.baseArtifactNames;
+
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.OutputGroupInfo;
+import com.google.devtools.build.lib.analysis.actions.SpawnAction;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.packages.util.Crosstool;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class Cpp20ModuleCompileTest extends BuildViewTestCase {
+  private void enableCpp20Module() throws Exception {
+    getAnalysisMock().ccSupport().setupCcToolchainConfig(
+        mockToolsConfig, Crosstool.CcToolchainConfig.builder().withFeatures(
+                             CppRuleClasses.CPP20_MODULES));
+  }
+  // if we use module_interfaces
+  // we need to enable cpp20_module feature
+  @Test
+  public void testCpp20ModuleFeatureNotEnabled1() throws Exception {
+    reporter.removeHandler(failFastHandler);
+    scratch.file("foo/BUILD",
+                 "cc_library(name='foo', module_interfaces=['foo.cppm'])");
+    scratch.file("foo/foo.cppm", "foo");
+    getConfiguredTarget("//foo:foo");
+    assertContainsEvent(
+        "to use C++20 Modules, the feature cpp20_module must be enabled");
+  }
+
+  // when use C++20 Modules, the compile model changed
+  // to keep backward-compatibility
+  // the feature cpp20_module is not enabled by default
+  // we need to enable the feature in rule attr features
+  @Test
+  public void testCpp20ModuleFeatureNotEnabled2() throws Exception {
+    enableCpp20Module();
+    reporter.removeHandler(failFastHandler);
+    scratch.file("foo/BUILD",
+                 "cc_library(name='foo', module_interfaces=['foo.cppm'])");
+    scratch.file("foo/foo.cppm", "foo");
+    getConfiguredTarget("//foo:foo");
+    assertContainsEvent(
+        "to use C++20 Modules, the feature cpp20_module must be enabled");
+  }
+
+  // add the feature cpp20_module to toolchain
+  // add the feature cpp20_module to rule attr features
+  // now we can play with C++20 Modules
+  @Test
+  public void testCpp20ModuleFeatureEnabled() throws Exception {
+    enableCpp20Module();
+    reporter.removeHandler(failFastHandler);
+    scratch.file(
+        "foo/BUILD",
+        "cc_library(name='foo', module_interfaces=['foo.cppm'], features=['cpp20_module'])");
+    scratch.file("foo/foo.cppm", "foo");
+    getConfiguredTarget("//foo:foo");
+    assertDoesNotContainEvent(
+        "to use C++20 Modules, the feature cpp20_module must be enabled");
+  }
+
+  // module_interfaces cannot have two same .cc files
+  @Test
+  public void testSameCcFileTwice1() throws Exception {
+    enableCpp20Module();
+    scratch.file(
+        "a/BUILD",
+        "cc_library(name='a', module_interfaces=['a1', 'a2'], features=['cpp20_module'])",
+        "filegroup(name='a1', srcs=['a.cc'])",
+        "filegroup(name='a2', srcs=['a.cc'])");
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//a:a");
+    assertContainsEvent("Artifact 'a/a.cc' is duplicated");
+  }
+
+  // if one file has already in srcs,
+  // it can not put to module_interfaces
+  // due to module_interfaces is a special srcs that produce bmi files
+  @Test
+  public void testSameCcFileTwice2() throws Exception {
+    enableCpp20Module();
+    scratch.file(
+        "a/BUILD",
+        "cc_library(name='a', srcs=['a1'], module_interfaces=['a2'], features=['cpp20_module'])",
+        "filegroup(name='a1', srcs=['a.cc'])",
+        "filegroup(name='a2', srcs=['a.cc'])");
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//a:a");
+    assertContainsEvent("Artifact 'a/a.cc' is duplicated");
+  }
+  @Test
+  public void testObjectFile() throws Exception {
+    enableCpp20Module();
+    useConfiguration("--cpu=k8");
+    ConfiguredTarget archiveInSrcsTest = scratchConfiguredTarget(
+        "cc_in_module_interfaces", "cc_in_module_interfaces_test",
+        "cc_test(name = 'cc_in_module_interfaces_test',",
+        "           module_interfaces = ['foo.cc'],",
+        "           features = ['cpp20_module'],", ")");
+    List<String> artifactNames =
+        baseArtifactNames(getLinkerInputs(archiveInSrcsTest));
+    assertThat(artifactNames).contains("foo.o");
+  }
+
+  private Iterable<Artifact> getLinkerInputs(ConfiguredTarget target) {
+    Artifact executable = getExecutable(target);
+    SpawnAction linkAction = (SpawnAction)getGeneratingAction(executable);
+    return linkAction.getInputs().toList();
+  }
+
+  // use --precompile to compile .cppm to .pcm
+  @Test
+  public void testModuleCompileOption() throws Exception {
+    enableCpp20Module();
+    useConfiguration("--cpu=k8");
+    scratch.file("a/BUILD", "cc_library(", "name='foo', ",
+                 "features = ['cpp20_module'], ",
+                 "module_interfaces=['foo.cppm']", ")");
+    ConfiguredTarget target = getConfiguredTarget("//a:foo");
+    List<CppCompileAction> compilationSteps =
+        actionsTestUtil().findTransitivePrerequisitesOf(
+            getFilesToBuild(target).toList().get(0), CppCompileAction.class);
+    assertThat(compilationSteps.get(1).getArguments()).contains("--precompile");
+  }
+
+  @Test
+  public void testModuleCompileOnly() throws Exception {
+    enableCpp20Module();
+    useConfiguration("--cpu=k8");
+    scratch.file("a/BUILD", "cc_library(", "name='foo', ",
+                 "features = ['cpp20_module'], ",
+                 "module_interfaces=['foo.cppm']", ")");
+    ConfiguredTarget target = getConfiguredTarget("//a:foo");
+    var outputs =
+        getOutputGroup(target, OutputGroupInfo.FILES_TO_COMPILE).toList();
+    assertThat(outputs).isNotEmpty();
+
+    assertThat(getArtifactByExecPathSuffix(target, "/foo.o")).isNotNull();
+    assertThat(getArtifactByExecPathSuffix(target, "/foo.pcm.o")).isNull();
+  }
+
+  protected static Artifact getArtifactByExecPathSuffix(ConfiguredTarget target,
+                                                        String path) {
+    for (Artifact artifact :
+         getOutputGroup(target, OutputGroupInfo.FILES_TO_COMPILE).toList()) {
+      if (artifact.getExecPathString().endsWith(path)) {
+        return artifact;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
I split the XXL PR https://github.com/bazelbuild/bazel/pull/19940 into several small patches.
This is the fourth patch of Support C++20 Modules, I modify the `CppCompileAction` and add related context, inputs and outputs.
- context: `.pcm` files and `.CXXModules.json` files
- inputs: `.pcm` files, `.modmap` file and `.modmap.input` file
- outputs: `.pcm` files and `.CXXModules.json` files

the main different in `CppCompileAction` is `computeUsedCpp20Modules`.

The restart mechanism is utilized; if the necessary C++20 Modules files are not ready during compilation, the current compilation will exit and wait for an appropriate time to recompile.

Note: To make the code review convenient, I keep only one commit. Due to patch dependencies, it may build and test failed.
I will update the patch after all the prerequisite patches have been merged. At that time, I will then troubleshoot the build and test failures.