### PR TITLE
[5/5] support C++20 Modules, support two phase compilation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
@@ -66,6 +66,8 @@ public enum CompileBuildVariables {
   CPP_MODULE_MODMAP_FILE("cpp_module_modmap_file"),
   /** Variable for the c++20 module output file name. */
   CPP_MODULE_OUTPUT_FILE("cpp_module_output_file"),
+  /** Variable for the c++20 module with 2-phase compilation. */
+  CPP_MODULES_WITH_TWO_PHASE_COMPILATION("cpp_modules_with_two_phase_compilation"),
   /** Variable for the module map file name. */
   MODULE_MAP_FILE("module_map_file"),
   /** Variable for the dependent module map file name. */

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -367,7 +367,11 @@ public final class CppCompileActionBuilder implements StarlarkValue {
     if (ccToolchain.getGrepIncludes() != null) {
       realMandatoryInputsBuilder.add(ccToolchain.getGrepIncludes());
     }
-    if (!getShouldScanIncludes() && dotdFile == null && !shouldParseShowIncludes()) {
+    // Support C++20 Modules with two-phase compilation
+    // For compiling C++20 Modules files to object files (.pcm -> .o) 
+    // headers are not needed as the module interface is already compiled into the pcm file.
+    if (!getShouldScanIncludes() && dotdFile == null && !shouldParseShowIncludes()
+        && !actionName.equals(CppActionNames.CPP20_MODULE_CODEGEN)) {
       realMandatoryInputsBuilder.addTransitive(ccCompilationContext.getDeclaredIncludeSrcs());
       realMandatoryInputsBuilder.addTransitive(additionalPrunableHeaders);
     }

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -2291,6 +2291,15 @@ EOF
   bazel clean || fail "Expected clean success"
   bazel build //:main --experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20 --disk_cache=disk &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
   expect_log "17 disk cache hit"
+
+  # Test with two-phase compilation. enable the following tests after rules_cc updated.
+  bazel build //:main --experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20 --features=cpp_modules_with_two_phase_compilation --disk_cache=disk &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+
+  # Verify that the build can hit the cache without action cycles.
+  bazel clean || fail "Expected clean success"
+  bazel build //:main --experimental_cpp_modules --repo_env=CC=clang --copt=-std=c++20 --features=cpp_modules_with_two_phase_compilation --disk_cache=disk &> $TEST_log || fail "Expected build C++20 Modules success with compiler 'clang'"
+  # 3 module interfaces. 17 + 3 = 20
+  expect_log "20 disk cache hit"
 }
 
 function test_external_repo_lto() {


### PR DESCRIPTION
I split the XXL PR https://github.com/bazelbuild/bazel/pull/19940 into several small patches.
This is the fifth patch of Support C++20 Modules, I construct the build graph of compile with C++20 Modules.

Firstly, all files are scanned to generate `.ddi` files. All the `.ddi` files are then aggregated to create a `.CXXModules.json` file. Subsequently, based on the `.CXXModules.json` file and their respective `.ddi` files, `.modmap` files are generated. Finally, the compilation begins. The two-phase compilation is employed here.


```
              ┌────────┐                  ┌────────┐                  ┌────────┐
              │foo.cppm│                  │bar.cppm│                  │main.cc │
              └────┬───┘                  └────┬───┘                  └────┬───┘
c++20-deps-scanning│                           │                           │
                   │                           │                           │
              ┌────▼───┐                  ┌────▼───┐                  ┌────▼───┐
              │foo.ddi │                  │bar.ddi │                  │main.ddi│
              └────┬───┘                  └────┬───┘                  └────┬───┘
                   │                           │                           │
                   └───────────────────────────┼───────────────────────────┘
                                               │Cpp20ModulesInfoAction
                                      ┌────────▼───────────┐
                                      │demo.CXXModules.json│
                                      └────────────────────┘
```



```
                                              ┌────────────────────┐
                                              │demo.CXXModules.json│
                                              └─────┬──────────────┘
                                                    │
                                                    │
                                  ┌───────┐         │          ┌───────────┐
                               ┌─►│foo.ddi├─────────┤          │ bar.cppm  │
                               │  └───────┘         │          └─────┬─────┘
                               │                    │                │
                               │                    │                │
                               │                    │                │
                               │                    │                │
┌────────┐ c++20-deps-scanning │  ┌───────┐   ┌─────▼────┐      ┌────▼─────┐
│foo.cppm├─────────────────────┴─►│foo.d  │   │foo.modmap│      │ bar.pcm  │
└───┬────┘                        └──┬────┘   └────┬─────┘      └────┬─────┘
    │c++20-module-compile            │             │                 │
┌───▼───┐                            │             │                 │
│foo.pcm├────────────────────────────┴─────────────┼─────────────────┘
└───────┘                                          │c++20-module-codegen
                                              ┌────▼─────┐
                                              │ foo.o    │
                                              └──────────┘
```