### PR TITLE
[7.2.0] Block in repo fetching state's `close()` method

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoFetchingWorkerSkyFunctionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoFetchingWorkerSkyFunctionEnvironment.java
@@ -44,10 +44,10 @@ class RepoFetchingWorkerSkyFunctionEnvironment
   private final RepoFetchingSkyKeyComputeState state;
   private SkyFunction.Environment delegate;
 
-  RepoFetchingWorkerSkyFunctionEnvironment(
-      RepoFetchingSkyKeyComputeState state, SkyFunction.Environment delegate) {
+  RepoFetchingWorkerSkyFunctionEnvironment(RepoFetchingSkyKeyComputeState state)
+      throws InterruptedException {
     this.state = state;
-    this.delegate = delegate;
+    this.delegate = state.delegateEnvQueue.take();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.bazel.bzlmod.NonRegistryOverride;
@@ -143,66 +144,51 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
     if (!useWorkers) {
       return fetchInternal(args);
     }
-    var state = env.getState(() -> new RepoFetchingSkyKeyComputeState(rule.getName()));
-    if (state.workerExecutorService.isShutdown()) {
-      // If we get here and the worker executor is shut down, this can only mean that the worker
-      // future was cancelled while we (the host Skyframe thread) were inactive (as in, having
-      // returned `null` but not yet restarted). So we wait for the previous worker thread to finish
-      // first.
-      // TODO: instead of this complicated dance, consider making it legal for
-      //  `SkyKeyComputeState#close()` to block. This would undo the advice added in commit 8ef0a51,
-      //  but would allow us to merge `close()` and `closeAndWaitForTermination()` and avoid some
-      //  headache.
-      state.closeAndWaitForTermination();
-    }
-    boolean shouldShutDownWorkerExecutorInFinally = true;
-    try {
-      var workerFuture = state.workerFuture;
-      if (workerFuture == null) {
-        // No worker is running yet, which means we're just starting to fetch this repo. Start with
-        // a clean slate, and create the worker.
-        setupRepoRoot(outputDirectory);
-        Environment workerEnv = new RepoFetchingWorkerSkyFunctionEnvironment(state, env);
-        workerFuture =
-            state.startWorker(
-                () -> fetchInternal(args.toWorkerArgs(workerEnv, state.recordedInputValues)));
-      } else {
-        // A worker is already running. This can only mean one thing -- we just had a Skyframe
-        // restart, and need to send over a fresh Environment.
+    // See below (the `catch CancellationException` clause) for why there's a `while` loop here.
+    while (true) {
+      var state = env.getState(() -> new RepoFetchingSkyKeyComputeState(rule.getName()));
+      ListenableFuture<RepositoryDirectoryValue.Builder> workerFuture =
+          state.getOrStartWorker(
+              () -> {
+                Environment workerEnv = new RepoFetchingWorkerSkyFunctionEnvironment(state);
+                setupRepoRoot(outputDirectory);
+                return fetchInternal(args.toWorkerArgs(workerEnv, state.recordedInputValues));
+              });
+      try {
         state.delegateEnvQueue.put(env);
-      }
-      state.signalSemaphore.acquire();
-      if (!workerFuture.isDone()) {
-        // This means that the worker is still running, and expecting a fresh Environment. Return
-        // null to trigger a Skyframe restart, but *don't* shut down the worker executor.
-        shouldShutDownWorkerExecutorInFinally = false;
-        return null;
-      }
-      RepositoryDirectoryValue.Builder result = workerFuture.get();
-      recordedInputValues.putAll(state.recordedInputValues);
-      return result;
-    } catch (ExecutionException e) {
-      Throwables.throwIfInstanceOf(e.getCause(), RepositoryFunctionException.class);
-      Throwables.throwIfUnchecked(e.getCause());
-      throw new IllegalStateException("unexpected exception type: " + e.getClass(), e.getCause());
-    } catch (CancellationException e) {
-      // This can only happen if the state object was invalidated due to memory pressure, in
-      // which case we can simply reattempt the fetch.
-      env.getListener()
-          .post(
-              RepositoryFetchProgress.ongoing(
-                  RepositoryName.createUnvalidated(rule.getName()),
-                  "fetch interrupted due to memory pressure; restarting."));
-      return fetch(rule, outputDirectory, directories, env, recordedInputValues, key);
-    } finally {
-      if (shouldShutDownWorkerExecutorInFinally) {
-        // Unless we know the worker is waiting on a fresh Environment, we should *always* shut down
-        // the worker executor and reset the state by the time we finish executing (successfully or
-        // otherwise). This ensures that 1) no background work happens without our knowledge, and
-        // 2) if the SkyFunction is re-entered for any reason (for example b/330892334 and
-        // https://github.com/bazelbuild/bazel/issues/21238), we don't have lingering state messing
-        // things up.
-        state.closeAndWaitForTermination();
+        state.signalSemaphore.acquire();
+        if (!workerFuture.isDone()) {
+          // This means that the worker is still running, and expecting a fresh Environment. Return
+          // null to trigger a Skyframe restart, but *don't* shut down the worker executor.
+          return null;
+        }
+        RepositoryDirectoryValue.Builder result = workerFuture.get();
+        recordedInputValues.putAll(state.recordedInputValues);
+        return result;
+      } catch (ExecutionException e) {
+        Throwables.throwIfInstanceOf(e.getCause(), RepositoryFunctionException.class);
+        Throwables.throwIfUnchecked(e.getCause());
+        throw new IllegalStateException(
+            "unexpected exception type: " + e.getCause().getClass(), e.getCause());
+      } catch (CancellationException e) {
+        // This can only happen if the state object was invalidated due to memory pressure, in
+        // which case we can simply reattempt the fetch. Show a message and continue into the next
+        // `while` iteration.
+        env.getListener()
+            .post(
+                RepositoryFetchProgress.ongoing(
+                    RepositoryName.createUnvalidated(rule.getName()),
+                    "fetch interrupted due to memory pressure; restarting."));
+      } finally {
+        if (workerFuture.isDone()) {
+          // Unless we know the worker is waiting on a fresh Environment, we should *always* shut
+          // down the worker executor by the time we finish executing (successfully or otherwise).
+          // This ensures that 1) no background work happens without our knowledge, and 2) if the
+          // SkyFunction is re-entered for any reason (for example b/330892334 and
+          // https://github.com/bazelbuild/bazel/issues/21238), we know we'll need to create a new
+          // worker from scratch.
+          state.close();
+        }
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/skyframe/SkyFunction.java
+++ b/src/main/java/com/google/devtools/build/skyframe/SkyFunction.java
@@ -417,8 +417,8 @@ public interface SkyFunction {
        *
        * <p>Implementations <strong>MUST</strong> be idempotent.
        *
-       * <p>Note also that this method should not perform any heavy work (especially blocking
-       * operations).
+       * <p>Note also that this method could be invoked from arbitrary threads, so avoid heavy
+       * operations if possible.
        */
       @Override
       default void close() {}


### PR DESCRIPTION
This greatly simplifies the code flow. Instead of using `volatile` and resorting to some very unsavory workarounds, we can simply make sure only one thread is changing `state.workerFuture` using plain old synchronization, and on memory pressure, make absolutely sure that the state object is cleaned up after we remove it from the central state cache.

This goes against the advice introduced in https://github.com/bazelbuild/bazel/commit/8ef0a519f2e468498fa53f4aede871b658890f92; the wording for `SkyKeyComputeState#close()` has been updated.

Also changed the "retry on cancellation" logic from using recursion to using a `while`-loop for better clarity around nested `finally` blocks.

Fixes https://github.com/bazelbuild/bazel/issues/22393.

PiperOrigin-RevId: 637975501
Change-Id: Ied43f0310ec8953f4ff1c2712fe07b8ccbd6c184

Commit https://github.com/bazelbuild/bazel/commit/de4d519ac52bd6400a016654eb85733ba16ac6f7