### PR TITLE
[7.2.0] Add layering_check support for macOS

### DIFF
--- a/third_party/grpc/00_disable_layering_check.patch
+++ b/third_party/grpc/00_disable_layering_check.patch
@@ -1,0 +1,13 @@
+diff --git a/BUILD b/BUILD
+index 83e6a3f740..b27df5b71e 100644
+--- a/BUILD
++++ b/BUILD
+@@ -29,7 +29,7 @@ licenses(["reciprocal"])
+ package(
+     default_visibility = ["//visibility:public"],
+     features = [
+-        "layering_check",
++        "-layering_check",
+         "-parse_headers",
+     ],
+ )


### PR DESCRIPTION
There were 2 things with the previous implementation that needed to be improved here:

1. Apple Clang has a bug where it doesn't pass module compiler flags to the underlying -cc1 invocation, so we have to manually pass them directly to that invocation with -Xclang
2. The previous search script was too aggressive and slow for macOS. The macOS SDK has tons of files that aren't headers, and tons of symlinks pointing to other files within the SDK. This adds a fork in the script to run a version that works with Apple SDKs. The time difference on my machine is 41s->6s. 6s is still pretty long so if desired we can put this behavior behind an env var for users to opt in with.

I've added a hermetic version of this to the apple_support toolchain, but similar to the Linux setup here the modulemap file includes absolute paths.

Closes #22259.

This reverts commit 1f1b4fd37bacf5fc90bd06403b63dbb54e84db3b.

Partial commit for third_party/*, see #22475.

Change-Id: I801121e36de1504c17adfa4736c49c88d470fec0
Signed-off-by: Hee Cha <heec@google.com>

Commit https://github.com/bazelbuild/bazel/commit/de0a37c33c33bbb419f5003e382c96a25af81012