### PR TITLE
Calculate the bazel directory based on the path of bazel-dev.sh

### DIFF
--- a/scripts/bazel-dev.sh
+++ b/scripts/bazel-dev.sh
@@ -32,7 +32,8 @@ function usage() {
 BAZEL_REPO=${BAZEL_REPO:-https://github.com/bazelbuild/bazel}
 # Where to keep the Bazel repository. If you make changes here, be warned that
 # this script may overwrite or lose them.
-BAZEL_DIR=${BAZEL_DIR:-$HOME/os-bazel}
+PARENT_DIR="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+BAZEL_DIR=${BAZEL_DIR:-${PARENT_DIR}}
 # Bazel to use to build local bazel binaries.
 BAZEL_BINARY=${BAZEL_BINARY:-$(which bazel)}
 


### PR DESCRIPTION
Instead of hardcoding the ~/os-bazel directory, calculate the bazel directory based on the path of the script.

This should make setup simpler, and also allow you to work with multiple bazel checkouts at the same time by simply calling the corresponding bazel-dev.sh script.