### PR TITLE
[7.2.0] Fix getting authentication for URLs in http repo rules

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2767,7 +2767,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%bazel_android_deps": {
       "general": {
-        "bzlTransitiveDigest": "kGK7vQSUnYTiX5+yCN3M8Mdy5PtT3d9zz8C7MpetGCk=",
+        "bzlTransitiveDigest": "fsj2Y0/OdubiefV/mXYFaPLbTvxWyuGu7Pp/xcVMWBE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2923,10 +2923,10 @@
     },
     "//:extensions.bzl%bazel_build_deps": {
       "general": {
-        "bzlTransitiveDigest": "kGK7vQSUnYTiX5+yCN3M8Mdy5PtT3d9zz8C7MpetGCk=",
+        "bzlTransitiveDigest": "fsj2Y0/OdubiefV/mXYFaPLbTvxWyuGu7Pp/xcVMWBE=",
         "recordedFileInputs": {
           "@@//MODULE.bazel": "ebb77f16d8f0a7ce4dfb1163ac6552073681a6fd506bd703e11bd435fa5badf5",
-          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "25e5660da3f92a92d560a450ef453fb64629795bf24613286c52f2da529adfd1"
+          "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "828ca18c55ab0580454760a1a8b00d414057233329bd7a44c31e477cdaa56d81"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3317,7 +3317,7 @@
     },
     "//:extensions.bzl%bazel_test_deps": {
       "general": {
-        "bzlTransitiveDigest": "kGK7vQSUnYTiX5+yCN3M8Mdy5PtT3d9zz8C7MpetGCk=",
+        "bzlTransitiveDigest": "fsj2Y0/OdubiefV/mXYFaPLbTvxWyuGu7Pp/xcVMWBE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -108,7 +108,7 @@
     },
     "@@rules_jvm_external~//:extensions.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "SLfIGbNRszU0h8ge0IMO3/eI3rU4GFZKXkA2TRilJmw=",
+        "bzlTransitiveDigest": "06WDcwoMOciaDDX09JBCxhi9KiKFGUIcXpQjCSle5AE=",
         "usagesDigest": "UPebZtX4g40+QepdK3oMHged0o0tq6ojKbW84wE6XRA=",
         "recordedFileInputs": {
           "@@rules_jvm_external~//rules_jvm_external_deps_install.json": "10442a5ae27d9ff4c2003e5ab71643bf0d8b48dcf968b4173fa274c3232a8c06"
@@ -1132,7 +1132,7 @@
     },
     "@@rules_jvm_external~//:non-module-deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "oHEz4DXnwk2aTh/PnIWUE3E1lOge1JPTJOlZOSOr3wI=",
+        "bzlTransitiveDigest": "l6SlNloqPvd60dcuPdWiJNi3g3jfK76fcZc0i/Yr0dQ=",
         "usagesDigest": "bTG4ItERqhG1LeSs62hQ01DiMarFsflWgpZaghM5qik=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1160,7 +1160,7 @@
     },
     "@@rules_python~//python/extensions:python.bzl%python": {
       "general": {
-        "bzlTransitiveDigest": "8RLGOLaDCviFdE0nDT5TmqaQd1w6Cm2OXWVzHbcIcxQ=",
+        "bzlTransitiveDigest": "GnREFVYskmF5MZu1H3nyqMWFZ2U/bty7gcbHX+l45kY=",
         "usagesDigest": "7vjNHuEgQORYN9+9/77Q4zw1kawobM2oCQb9p0uhL68=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1190,7 +1190,7 @@
     },
     "@@rules_python~//python/extensions/private:internal_deps.bzl%internal_deps": {
       "general": {
-        "bzlTransitiveDigest": "Vndk0q54LA1/G79/d/uCtAGxXLCTRbSCHJiWlL/cQos=",
+        "bzlTransitiveDigest": "PiT9IOA5dSBSmnfZRUrvgo71zttPpvs3cNPbxftlChs=",
         "usagesDigest": "b+nMDqtqPCBxiMBewNNde3aNjzKqZyvJuN5/49xB62s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -70,22 +70,19 @@ Authentication is not supported.
 URLs are tried in order until one succeeds, so you should list local mirrors first.
 If all downloads fail, the rule will fail."""
 
-def _get_all_urls(ctx):
-    """Returns all urls provided via the url, urls and remote_patches attributes.
+def _get_source_urls(ctx):
+    """Returns source urls provided via the url, urls attributes.
 
     Also checks that at least one url is provided."""
     if not ctx.attr.url and not ctx.attr.urls:
         fail("At least one of url and urls must be provided")
 
-    all_urls = []
+    source_urls = []
     if ctx.attr.urls:
-        all_urls = ctx.attr.urls
+        source_urls = ctx.attr.urls
     if ctx.attr.url:
-        all_urls = [ctx.attr.url] + all_urls
-    if hasattr(ctx.attr, "remote_patches") and ctx.attr.remote_patches:
-        all_urls = all_urls + ctx.attr.remote_patches.keys()
-
-    return all_urls
+        source_urls = [ctx.attr.url] + source_urls
+    return source_urls
 
 _AUTH_PATTERN_DOC = """An optional dict mapping host names to custom authorization patterns.
 
@@ -130,25 +127,21 @@ def _http_archive_impl(ctx):
     if ctx.attr.build_file and ctx.attr.build_file_content:
         fail("Only one of build_file and build_file_content can be provided.")
 
-    all_urls = _get_all_urls(ctx)
-    auth = get_auth(ctx, all_urls)
-
+    source_urls = _get_source_urls(ctx)
     download_info = ctx.download_and_extract(
-        # TODO(fzakaria): all_urls here has the remote_patch URL which is incorrect
-        # I believe this to be a file
-        all_urls,
+        source_urls,
         ctx.attr.add_prefix,
         ctx.attr.sha256,
         ctx.attr.type,
         ctx.attr.strip_prefix,
-        canonical_id = ctx.attr.canonical_id or get_default_canonical_id(ctx, all_urls),
-        auth = auth,
+        canonical_id = ctx.attr.canonical_id or get_default_canonical_id(ctx, source_urls),
+        auth = get_auth(ctx, source_urls),
         integrity = ctx.attr.integrity,
     )
     workspace_and_buildfile(ctx)
 
-    download_remote_files(ctx, auth = auth)
-    patch(ctx, auth = auth)
+    download_remote_files(ctx)
+    patch(ctx)
 
     return _update_integrity_attr(ctx, _http_archive_attrs, download_info)
 
@@ -176,15 +169,14 @@ def _http_file_impl(ctx):
     download_path = ctx.path("file/" + downloaded_file_path)
     if download_path in forbidden_files or not str(download_path).startswith(str(repo_root)):
         fail("'%s' cannot be used as downloaded_file_path in http_file" % ctx.attr.downloaded_file_path)
-    all_urls = _get_all_urls(ctx)
-    auth = get_auth(ctx, all_urls)
+    source_urls = _get_source_urls(ctx)
     download_info = ctx.download(
-        all_urls,
+        source_urls,
         "file/" + downloaded_file_path,
         ctx.attr.sha256,
         ctx.attr.executable,
-        canonical_id = ctx.attr.canonical_id or get_default_canonical_id(ctx, all_urls),
-        auth = auth,
+        canonical_id = ctx.attr.canonical_id or get_default_canonical_id(ctx, source_urls),
+        auth = get_auth(ctx, source_urls),
         integrity = ctx.attr.integrity,
     )
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
@@ -211,15 +203,14 @@ filegroup(
 
 def _http_jar_impl(ctx):
     """Implementation of the http_jar rule."""
-    all_urls = _get_all_urls(ctx)
-    auth = get_auth(ctx, all_urls)
+    source_urls = _get_source_urls(ctx)
     downloaded_file_name = ctx.attr.downloaded_file_name
     download_info = ctx.download(
-        all_urls,
+        source_urls,
         "jar/" + downloaded_file_name,
         ctx.attr.sha256,
-        canonical_id = ctx.attr.canonical_id or get_default_canonical_id(ctx, all_urls),
-        auth = auth,
+        canonical_id = ctx.attr.canonical_id or get_default_canonical_id(ctx, source_urls),
+        auth = get_auth(ctx, source_urls),
         integrity = ctx.attr.integrity,
     )
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -79,14 +79,14 @@ def _use_native_patch(patch_args):
             return False
     return True
 
-def _download_patch(ctx, patch_url, integrity, auth):
+def _download_patch(ctx, patch_url, integrity, auth = None):
     name = patch_url.split("/")[-1]
     patch_path = ctx.path(_REMOTE_PATCH_DIR).get_child(name)
     ctx.download(
         patch_url,
         patch_path,
         canonical_id = ctx.attr.canonical_id,
-        auth = auth,
+        auth = get_auth(ctx, [patch_url]) if auth == None else auth,
         integrity = integrity,
     )
     return patch_path
@@ -108,7 +108,7 @@ def download_remote_files(ctx, auth = None):
             remote_file_urls,
             path,
             canonical_id = ctx.attr.canonical_id,
-            auth = auth,
+            auth = get_auth(ctx, remote_file_urls) if auth == None else auth,
             integrity = ctx.attr.remote_file_integrity.get(path, ""),
             block = False,
         )


### PR DESCRIPTION
- Fixed the leak of `remote_patches` URLs for downloaded the source archive.
- Compute auth for required URLs only

Fixes https://github.com/bazelbuild/bazel/issues/22201

Closes #22517.

PiperOrigin-RevId: 638300996
Change-Id: Ib76e3284f209d2314844cfd662ac8eadba785fae

Commit https://github.com/bazelbuild/bazel/commit/5986420a3a5ce3493c50d733618649246a7e8651