### PR TITLE
Keep `/external:I...` on a single param file line

### DIFF
--- a/tools/cpp/windows_cc_toolchain_config.bzl
+++ b/tools/cpp/windows_cc_toolchain_config.bzl
@@ -906,7 +906,7 @@ def _impl(ctx):
                     ],
                     flag_groups = [
                         flag_group(
-                            flags = ["/external:I", "%{external_include_paths}"],
+                            flags = ["/external:I%{external_include_paths}"],
                             iterate_over = "external_include_paths",
                             expand_if_available = "external_include_paths",
                         ),


### PR DESCRIPTION
MSVC fails if `/external:I <some_path>` is broken into two lines in `.param` files. This is avoided by using the alternative `/external:I<some_path>` form.

Fixes #22614 