### PR TITLE
[7.2.0] Keep `/external:I...` on a single param file line

### DIFF
--- a/tools/cpp/windows_cc_toolchain_config.bzl
+++ b/tools/cpp/windows_cc_toolchain_config.bzl
@@ -905,7 +905,7 @@ def _impl(ctx):
                     ],
                     flag_groups = [
                         flag_group(
-                            flags = ["/external:I", "%{external_include_paths}"],
+                            flags = ["/external:I%{external_include_paths}"],
                             iterate_over = "external_include_paths",
                             expand_if_available = "external_include_paths",
                         ),


### PR DESCRIPTION
MSVC fails if `/external:I <some_path>` is broken into two lines in `.param` files. This is avoided by using the alternative `/external:I<some_path>` form.

Fixes #22614

Closes #22616.

PiperOrigin-RevId: 640055579
Change-Id: I5fda2714dc479fd76f22e2f8562dddbdfcdb9a18

Commit https://github.com/bazelbuild/bazel/commit/759fe7d7f3fdf142490e970457f72180f4d1b59a