### PR TITLE
[7.2.0] Add more profiler spans to diff handling

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1210,6 +1210,7 @@ java_library(
         ":incompatible_view_exception",
         ":workspace_info",
         "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auto_value",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/DiffAwarenessManager.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/DiffAwarenessManager.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
+import com.google.devtools.build.lib.profiler.Profiler;
+import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.skyframe.DiffAwareness.View;
 import com.google.devtools.build.lib.vfs.ModifiedFileSet;
 import com.google.devtools.build.lib.vfs.Path;
@@ -111,7 +113,7 @@ public final class DiffAwarenessManager {
     }
     DiffAwareness diffAwareness = diffAwarenessState.diffAwareness;
     View newView;
-    try {
+    try (SilentCloseable c = Profiler.instance().profile("diffAwareness.getCurrentView")) {
       newView = diffAwareness.getCurrentView(options);
     } catch (BrokenDiffAwarenessException e) {
       handleBrokenDiffAwareness(eventHandler, pathEntry, ignoredPaths, e);
@@ -128,7 +130,7 @@ public final class DiffAwarenessManager {
     ModifiedFileSet diff;
     logger.atInfo().log(
         "About to compute diff between %s and %s for %s", baselineView, newView, pathEntry);
-    try {
+    try (SilentCloseable c = Profiler.instance().profile("diffAwareness.getDiff")) {
       diff = diffAwareness.getDiff(baselineView, newView);
     } catch (BrokenDiffAwarenessException e) {
       handleBrokenDiffAwareness(eventHandler, pathEntry, ignoredPaths, e);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3167,15 +3167,20 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     }
     BuildRequestOptions buildRequestOptions = options.getOptions(BuildRequestOptions.class);
     int fsvcThreads = buildRequestOptions == null ? 200 : buildRequestOptions.fsvcThreads;
-    handleDiffsWithCompleteDiffInformation(tsgm, modifiedFilesByPathEntry, fsvcThreads);
+    try (SilentCloseable c =
+        Profiler.instance().profile("handleDiffsWithCompleteDiffInformation")) {
+      handleDiffsWithCompleteDiffInformation(tsgm, modifiedFilesByPathEntry, fsvcThreads);
+    }
     RepositoryOptions repoOptions = options.getOptions(RepositoryOptions.class);
-    handleDiffsWithMissingDiffInformation(
-        eventHandler,
-        tsgm,
-        pathEntriesWithoutDiffInformation,
-        options.getOptions(PackageOptions.class).checkOutputFiles,
-        repoOptions == null || repoOptions.checkExternalRepositoryFiles,
-        fsvcThreads);
+    try (SilentCloseable c = Profiler.instance().profile("handleDiffsWithMissingDiffInformation")) {
+      handleDiffsWithMissingDiffInformation(
+          eventHandler,
+          tsgm,
+          pathEntriesWithoutDiffInformation,
+          options.getOptions(PackageOptions.class).checkOutputFiles,
+          repoOptions == null || repoOptions.checkExternalRepositoryFiles,
+          fsvcThreads);
+    }
     handleClientEnvironmentChanges();
     return workspaceInfo;
   }
@@ -3261,7 +3266,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       ExternalFilesHelper tmpExternalFilesHelper =
           externalFilesHelper.cloneWithFreshExternalFilesKnowledge();
 
-      invalidateValuesMarkedForInvalidation(eventHandler);
+      try (SilentCloseable c =
+          Profiler.instance().profile("invalidateValuesMarkedForInvalidation")) {
+        invalidateValuesMarkedForInvalidation(eventHandler);
+      }
 
       FilesystemValueChecker fsvc =
           new FilesystemValueChecker(


### PR DESCRIPTION
On an incremental build with `--watchfs`, the `handleDiffs` span in the timing profile is now almost fully explained by subspans.

Closes #22622.

PiperOrigin-RevId: 640084976
Change-Id: Iab7c9f22bab5e53cfab1d39dc0b3f2a697453540

Commit https://github.com/bazelbuild/bazel/commit/f4b453722304ffcbe605eb54bc41d2d12a30303a