### PR TITLE
[7.2.0] Make Bazel changes for `oneversion` support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -399,8 +399,8 @@ public class JavaOptions extends FragmentOptions {
       name = "experimental_one_version_enforcement",
       defaultValue = "OFF",
       converter = OneVersionEnforcementLevelConverter.class,
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.UNKNOWN},
+      documentationCategory = OptionDocumentationCategory.INPUT_STRICTNESS,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       help =
           "When enabled, enforce that a java_binary rule can't contain more than one version "
               + "of the same class file on the classpath. This enforcement can break the build, or "
@@ -421,8 +421,8 @@ public class JavaOptions extends FragmentOptions {
   @Option(
       name = "one_version_enforcement_on_java_tests",
       defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.UNKNOWN},
+      documentationCategory = OptionDocumentationCategory.INPUT_STRICTNESS,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       help =
           "When enabled, and with experimental_one_version_enforcement set to a non-NONE value,"
               + " enforce one version on java_test targets. This flag can be disabled to improve"

--- a/src/main/starlark/builtins_bzl/common/java/java_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_binary.bzl
@@ -422,7 +422,7 @@ def _create_one_version_check(ctx, inputs, is_test_rule_class):
     else:
         allowlist = helper.check_and_get_one_version_attribute(ctx, "_one_version_allowlist")
 
-    if not tool or not allowlist:  # On Mac oneversion tool is not available
+    if not tool:  # On Mac oneversion tool is not available
         return None
 
     output = ctx.actions.declare_file("%s-one-version.txt" % ctx.label.name)
@@ -430,8 +430,11 @@ def _create_one_version_check(ctx, inputs, is_test_rule_class):
     args = ctx.actions.args()
     args.set_param_file_format("shell").use_param_file("@%s", use_always = True)
 
+    one_version_inputs = []
     args.add("--output", output)
-    args.add("--whitelist", allowlist)
+    if allowlist:
+        args.add("--whitelist", allowlist)
+        one_version_inputs.append(allowlist)
     if one_version_level == "WARNING":
         args.add("--succeed_on_found_violations")
     args.add_all(
@@ -445,7 +448,7 @@ def _create_one_version_check(ctx, inputs, is_test_rule_class):
         progress_message = "Checking for one-version violations in %{label}",
         executable = tool,
         toolchain = semantics.JAVA_TOOLCHAIN_TYPE,
-        inputs = depset([allowlist], transitive = [inputs]),
+        inputs = depset(one_version_inputs, transitive = [inputs]),
         tools = [tool],
         outputs = [output],
         arguments = [args],

--- a/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
@@ -200,7 +200,11 @@ def _check_and_get_one_version_attribute(ctx, attr):
     return value
 
 def _jar_and_target_arg_mapper(jar):
-    return jar.path + "," + str(jar.owner)
+    # Emit pretty labels for targets in the main repository.
+    label = str(jar.owner)
+    if label.startswith("@@//"):
+        label = label.lstrip("@")
+    return jar.path + "," + label
 
 def _get_feature_config(ctx):
     cc_toolchain = cc_helper.find_cpp_toolchain(ctx, mandatory = False)

--- a/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_helper.bzl
@@ -200,11 +200,7 @@ def _check_and_get_one_version_attribute(ctx, attr):
     return value
 
 def _jar_and_target_arg_mapper(jar):
-    # Emit pretty labels for targets in the main repository.
-    label = str(jar.owner)
-    if label.startswith("@@//"):
-        label = label.lstrip("@")
-    return jar.path + "," + label
+    return jar.path + "," + str(jar.owner)
 
 def _get_feature_config(ctx):
     cc_toolchain = cc_helper.find_cpp_toolchain(ctx, mandatory = False)

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1950,11 +1950,6 @@ EOF
 }
 
 function test_sandboxed_multiplexing() {
-  if [[ "${JAVA_TOOLS_ZIP}" == released ]]; then
-    # TODO: Enable test after the next java_tools release.
-    return 0
-  fi
-
   mkdir -p pkg
   cat << 'EOF' > pkg/BUILD
 load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")


### PR DESCRIPTION
This is a partial cherry-pick of 417c6b803db1078d20077068471427c86c016190 which excludes the changes to `oneversion` itself, which is built and released for Bazel 7 as part of java_tools:

* Avoid passing --whitelist to one_version if no allowlist is configured in the toolchain as it isn't supported by the Bazel version of oneversion yet.
* Document the one_version flags.
* Clean up tests not updated after recent rules_java releases.

Fixes #22576