### PR TITLE
[7.2.0] Add option to track sandbox stashes in memory

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractContainerizingSandboxedSpawn.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.sandbox;
 
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -141,6 +140,7 @@ public abstract class AbstractContainerizingSandboxedSpawn implements SandboxedS
     try (SilentCloseable c = Profiler.instance().profile("sandbox.createInputs")) {
       createInputs(inputsToCreate, inputs);
     }
+    SandboxStash.setLastModified(sandboxPath, System.currentTimeMillis());
   }
 
   protected void filterInputsAndDirsToCreate(

--- a/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -17,9 +17,9 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
-        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/test_configuration",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/collect/compacthashmap",
         "//src/main/java/com/google/devtools/build/lib/exec:tree_deleter",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
@@ -74,6 +74,8 @@ java_library(
     deps = [
         ":sandbox_helpers",
         ":sandbox_options",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/collect/compacthashmap",
         "//src/main/java/com/google/devtools/build/lib/exec:tree_deleter",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/util:command",

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -263,7 +263,8 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         /* sandboxDebugPath= */ null,
         statisticsPath,
         /* interactiveDebugArguments= */ null,
-        spawn.getMnemonic()) {
+        spawn.getMnemonic(),
+        spawn.getTargetLabel()) {
       @Override
       public void createFileSystem() throws IOException, InterruptedException {
         super.createFileSystem();

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -358,7 +358,8 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
           sandboxDebugPath,
           statisticsPath,
           makeInteractiveDebugArguments(commandLineBuilder, sandboxOptions),
-          spawn.getMnemonic());
+          spawn.getMnemonic(),
+          spawn.getTargetLabel());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
@@ -111,7 +111,8 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
         /* sandboxDebugPath= */ null,
         statisticsPath,
         /* interactiveDebugArguments= */ null,
-        spawn.getMnemonic());
+        spawn.getMnemonic(),
+        spawn.getTargetLabel());
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput.EmptyActionInput;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
+import com.google.devtools.build.lib.collect.compacthashmap.CompactHashMap;
 import com.google.devtools.build.lib.exec.TreeDeleter;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.Sandbox;
@@ -148,6 +149,25 @@ public final class SandboxHelpers {
       Path workDir,
       @Nullable TreeDeleter treeDeleter)
       throws IOException, InterruptedException {
+    cleanExisting(
+        root,
+        inputs,
+        inputsToCreate,
+        dirsToCreate,
+        workDir,
+        treeDeleter,
+        /* stashContents= */ null);
+  }
+
+  public static void cleanExisting(
+      Path root,
+      SandboxInputs inputs,
+      Set<PathFragment> inputsToCreate,
+      Set<PathFragment> dirsToCreate,
+      Path workDir,
+      @Nullable TreeDeleter treeDeleter,
+      @Nullable StashContents stashContents)
+      throws IOException, InterruptedException {
     Path inaccessibleHelperDir = workDir.getRelative(INACCESSIBLE_HELPER_DIR);
     // Setting the permissions is necessary when we are using an asynchronous tree deleter in order
     // to move the directory first. This is not necessary for a synchronous tree deleter because the
@@ -171,7 +191,93 @@ public final class SandboxHelpers {
         parent = parent.getParentDirectory();
       }
     }
-    cleanRecursively(root, inputs, inputsToCreate, dirsToCreate, workDir, prefixDirs, treeDeleter);
+    if (stashContents == null) {
+      cleanRecursively(
+          root, inputs, inputsToCreate, dirsToCreate, workDir, prefixDirs, treeDeleter);
+    } else {
+      cleanRecursivelyWithInMemoryStashes(
+          root,
+          inputs,
+          inputsToCreate,
+          dirsToCreate,
+          workDir,
+          prefixDirs,
+          treeDeleter,
+          stashContents);
+    }
+  }
+
+  /**
+   * Deletes unnecessary files/directories and updates the sets if something on disk is already
+   * correct and doesn't need any changes.
+   */
+  private static void cleanRecursivelyWithInMemoryStashes(
+      Path root,
+      SandboxInputs inputs,
+      Set<PathFragment> inputsToCreate,
+      Set<PathFragment> dirsToCreate,
+      Path workDir,
+      Set<PathFragment> prefixDirs,
+      @Nullable TreeDeleter treeDeleter,
+      StashContents stashContents)
+      throws IOException, InterruptedException {
+    Path execroot = workDir.getParentDirectory();
+    Preconditions.checkNotNull(stashContents);
+    for (var fileDirent : stashContents.filesToPath().entrySet()) {
+      if (Thread.interrupted()) {
+        throw new InterruptedException();
+      }
+      Path absPath = root.getChild(fileDirent.getKey());
+      PathFragment pathRelativeToWorkDir = getPathRelativeToWorkDir(absPath, workDir, execroot);
+      Optional<Path> destination =
+          getExpectedSymlinkDestinationForFiles(pathRelativeToWorkDir, inputs);
+      if (destination.isPresent() && fileDirent.getValue().equals(destination.get())) {
+        Preconditions.checkState(inputsToCreate.remove(pathRelativeToWorkDir));
+      } else {
+        absPath.delete();
+      }
+    }
+    for (var symlinkDirent : stashContents.symlinksToPathFragment().entrySet()) {
+      if (Thread.interrupted()) {
+        throw new InterruptedException();
+      }
+      Path absPath = root.getChild(symlinkDirent.getKey());
+      PathFragment pathRelativeToWorkDir = getPathRelativeToWorkDir(absPath, workDir, execroot);
+      Optional<PathFragment> destination =
+          getExpectedSymlinkDestinationForSymlinks(pathRelativeToWorkDir, inputs);
+      if (destination.isPresent() && symlinkDirent.getValue().equals(destination.get())) {
+        Preconditions.checkState(inputsToCreate.remove(pathRelativeToWorkDir));
+      } else {
+        absPath.delete();
+      }
+    }
+    for (var dirent : stashContents.dirEntries().entrySet()) {
+      if (Thread.interrupted()) {
+        throw new InterruptedException();
+      }
+      Path absPath = root.getChild(dirent.getKey());
+      PathFragment pathRelativeToWorkDir = getPathRelativeToWorkDir(absPath, workDir, execroot);
+      if (dirsToCreate.contains(pathRelativeToWorkDir)
+          || prefixDirs.contains(pathRelativeToWorkDir)) {
+        cleanRecursivelyWithInMemoryStashes(
+            absPath,
+            inputs,
+            inputsToCreate,
+            dirsToCreate,
+            workDir,
+            prefixDirs,
+            treeDeleter,
+            dirent.getValue());
+        dirsToCreate.remove(pathRelativeToWorkDir);
+      } else {
+        if (treeDeleter == null) {
+          // TODO(bazel-team): Use async tree deleter for workers too
+          absPath.deleteTree();
+        } else {
+          treeDeleter.deleteTree(absPath);
+        }
+      }
+    }
   }
 
   /**
@@ -238,6 +344,19 @@ public final class SandboxHelpers {
       } else if (!inputsToCreate.contains(pathRelativeToWorkDir)) {
         absPath.delete();
       }
+    }
+  }
+
+  private static PathFragment getPathRelativeToWorkDir(Path absPath, Path workDir, Path execroot) {
+    if (absPath.startsWith(workDir)) {
+      // path is under workDir, i.e. execroot/<workspace name>. Simply get the relative path.
+      return absPath.relativeTo(workDir);
+    } else {
+      // path is not under workDir, which means it belongs to one of external repositories
+      // symlinked directly under execroot. Get the relative path based on there and prepend it
+      // with the designated prefix, '../', so that it's still a valid relative path to workDir.
+      return LabelConstants.EXPERIMENTAL_EXTERNAL_PATH_PREFIX.getRelative(
+          absPath.relativeTo(execroot));
     }
   }
 
@@ -528,6 +647,16 @@ public final class SandboxHelpers {
     return SandboxOutputs.create(files.build(), dirs.build());
   }
 
+  private static Optional<Path> getExpectedSymlinkDestinationForFiles(
+      PathFragment fragment, SandboxInputs inputs) {
+    return Optional.ofNullable(inputs.getFiles().get(fragment));
+  }
+
+  private static Optional<PathFragment> getExpectedSymlinkDestinationForSymlinks(
+      PathFragment fragment, SandboxInputs inputs) {
+    return Optional.ofNullable(inputs.getSymlinks().get(fragment));
+  }
+
   /**
    * Returns true if the build options are set in a way that requires network access for all
    * actions. This is separate from {@link
@@ -543,5 +672,19 @@ public final class SandboxHelpers {
         .getOptions(TestConfiguration.TestOptions.class)
         .testArguments
         .contains("--wrapper_script_flag=--debug");
+  }
+
+  /**
+   * Used to store sandbox stashes in-memory.
+   *
+   * <p>The String keys in the maps are individual path segments.
+   */
+  public record StashContents(
+      Map<String, Path> filesToPath,
+      Map<String, PathFragment> symlinksToPathFragment,
+      Map<String, StashContents> dirEntries) {
+    public StashContents() {
+      this(CompactHashMap.create(), CompactHashMap.create(), CompactHashMap.create());
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -68,7 +68,10 @@ import javax.annotation.Nullable;
 public final class SandboxModule extends BlazeModule {
 
   private static final ImmutableSet<String> SANDBOX_BASE_PERSISTENT_DIRS =
-      ImmutableSet.of(SandboxStash.SANDBOX_STASH_BASE, AsynchronousTreeDeleter.MOVED_TRASH_DIR);
+      ImmutableSet.of(
+          SandboxStash.SANDBOX_STASH_BASE,
+          SandboxStash.TEMPORARY_SANDBOX_STASH_BASE,
+          AsynchronousTreeDeleter.MOVED_TRASH_DIR);
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
@@ -226,7 +229,7 @@ public final class SandboxModule extends BlazeModule {
         firstBuild = true;
       }
     }
-    SandboxStash.initialize(env.getWorkspaceName(), sandboxBase, options);
+    SandboxStash.initialize(env.getWorkspaceName(), sandboxBase, options, treeDeleter);
 
     // SpawnExecutionPolicy#getId returns unique base directories for each sandboxed action during
     // the life of a Bazel server instance so we don't need to worry about stale directories from
@@ -619,6 +622,8 @@ public final class SandboxModule extends BlazeModule {
         treeDeleter = null; // Avoid potential reexecution if we crash.
       }
     }
+
+    SandboxStash.shutdown();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -335,6 +335,18 @@ public class SandboxOptions extends OptionsBase {
   public boolean reuseSandboxDirectories;
 
   @Option(
+      name = "experimental_inmemory_sandbox_stashes",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS, OptionEffectTag.EXECUTION},
+      help =
+          "If set to true, the contents of stashed sandboxes for reuse_sandbox_directories will be"
+              + " tracked in memory. This reduces the amount of I/O needed during reuse. Depending"
+              + " on the build this flag may improve wall time. Depending on the build as well this"
+              + " flag may use a significant amount of additional memory.")
+  public boolean experimentalInMemorySandboxStashes;
+
+  @Option(
       name = "experimental_use_hermetic_linux_sandbox",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxStash.java
@@ -14,18 +14,38 @@
 
 package com.google.devtools.build.lib.sandbox;
 
+import static com.google.devtools.build.lib.vfs.Dirent.Type.DIRECTORY;
+import static com.google.devtools.build.lib.vfs.Dirent.Type.SYMLINK;
+
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.GoogleLogger;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.exec.TreeDeleter;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
+import com.google.devtools.build.lib.sandbox.SandboxHelpers.StashContents;
+import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
@@ -39,6 +59,9 @@ import javax.annotation.Nullable;
 public class SandboxStash {
 
   public static final String SANDBOX_STASH_BASE = "sandbox_stash";
+
+  // Used while we gather all the contents asynchronously.
+  public static final String TEMPORARY_SANDBOX_STASH_BASE = "tmp_sandbox_stash";
   private static final String TEST_RUNNER_MNEMONIC = "TestRunner";
   private static final String TEST_SRCDIR = "TEST_SRCDIR";
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
@@ -61,30 +84,57 @@ public class SandboxStash {
 
   private final Map<Path, String> stashPathToRunfilesDir = new ConcurrentHashMap<>();
 
-  public SandboxStash(String workspaceName, Path sandboxBase) {
+  private static final int POOL_SIZE = Runtime.getRuntime().availableProcessors();
+  private final ExecutorService stashFileListingPool =
+      Executors.newFixedThreadPool(
+          POOL_SIZE,
+          new ThreadFactoryBuilder().setNameFormat("stash-file-listing-thread-%d").build());
+
+  public final Map<Path, StashContents> pathToContents = new ConcurrentHashMap<>();
+  private final Map<Path, Label> sandboxToTarget = new ConcurrentHashMap<>();
+  private final Map<Path, Long> pathToLastModified = new ConcurrentHashMap<>();
+  private boolean inMemoryStashes;
+
+  public SandboxStash(String workspaceName, Path sandboxBase, boolean inMemoryStashes) {
     this.workspaceName = workspaceName;
     this.sandboxBase = sandboxBase;
+    this.inMemoryStashes = inMemoryStashes;
   }
 
-  static boolean takeStashedSandbox(
-      Path sandboxPath, String mnemonic, Map<String, String> environment, SandboxOutputs outputs) {
+  @Nullable
+  @SuppressWarnings("NullableOptional")
+  static Optional<StashContents> takeStashedSandbox(
+      Path sandboxPath,
+      String mnemonic,
+      Map<String, String> environment,
+      SandboxOutputs outputs,
+      Label target) {
     if (instance == null) {
-      return false;
+      return null;
     }
-    return instance.takeStashedSandboxInternal(sandboxPath, mnemonic, environment, outputs);
+    return instance.takeStashedSandboxInternal(sandboxPath, mnemonic, environment, outputs, target);
   }
 
-  private boolean takeStashedSandboxInternal(
-      Path sandboxPath, String mnemonic, Map<String, String> environment, SandboxOutputs outputs) {
+  @Nullable
+  @SuppressWarnings("NullableOptional")
+  private Optional<StashContents> takeStashedSandboxInternal(
+      Path sandboxPath,
+      String mnemonic,
+      Map<String, String> environment,
+      SandboxOutputs outputs,
+      Label target) {
     try {
       Path sandboxes = getSandboxStashDir(mnemonic, sandboxPath.getFileSystem());
       if (sandboxes == null || isTestXmlGenerationOrCoverageSpawn(mnemonic, outputs)) {
-        return false;
+        return null;
       }
-      Collection<Path> stashes = sandboxes.getDirectoryEntries();
-      if (stashes.isEmpty()) {
-        return false;
+
+      Collection<Path> diskStashes = sandboxes.getDirectoryEntries();
+      if (diskStashes.isEmpty()) {
+        return null;
       }
+
+      ImmutableList<Path> stashes = sortStashesByMatchingTargetSegments(target, diskStashes);
       // We have to remove the sandbox execroot dir to move a stash there, but it is currently empty
       // and we reinstate it later if we don't get a sandbox. We can't just move the stash dir
       // fully, as we would then lose siblings of the execroot dir, such as hermetic-tmp dirs.
@@ -97,45 +147,37 @@ public class SandboxStash {
           stash.deleteTree();
           if (isTestAction(mnemonic)) {
             String relativeStashedRunfilesDir = stashPathToRunfilesDir.get(stashExecroot);
-            if (relativeStashedRunfilesDir == null) {
-              StringBuilder errorMessageBuilder = new StringBuilder();
-              errorMessageBuilder.append(
-                  String.format("Current stashExecroot:%s\n", stashExecroot));
-              errorMessageBuilder.append("Stashes:\n");
-              for (Path path : stashes) {
-                errorMessageBuilder.append(path.getPathString()).append("\n");
-              }
-              errorMessageBuilder.append("Environment:\n");
-              for (var entry : environment.entrySet()) {
-                errorMessageBuilder.append(
-                    String.format("%s : %s\n", entry.getKey(), entry.getValue()));
-              }
-              errorMessageBuilder.append("Entries runfiles map:\n");
-              for (var entry : stashPathToRunfilesDir.entrySet()) {
-                errorMessageBuilder.append(
-                    String.format("%s : %s\n", entry.getKey(), entry.getValue()));
-              }
-              Preconditions.checkNotNull(
-                  relativeStashedRunfilesDir, errorMessageBuilder.toString());
-            }
             Path stashedRunfilesDir = sandboxExecroot.getRelative(relativeStashedRunfilesDir);
-            Path currentRunfiles = sandboxExecroot.getRelative(getCurrentRunfilesDir(environment));
+            String relativeCurrentRunfilesDir = getCurrentRunfilesDir(environment);
+            Path currentRunfiles = sandboxExecroot.getRelative(relativeCurrentRunfilesDir);
             currentRunfiles.getParentDirectory().createDirectoryAndParents();
             stashedRunfilesDir.renameTo(currentRunfiles);
             stashPathToRunfilesDir.remove(stashExecroot);
+            if (useInMemoryStashes() && pathToContents.containsKey(stash)) {
+              updateStashContentsAfterRunfilesMove(
+                  relativeStashedRunfilesDir,
+                  relativeCurrentRunfilesDir,
+                  pathToContents.get(stash));
+            }
           }
-          return true;
+          sandboxToTarget.remove(stash);
+          // If we switched the flag experimental_inmemory_sandbox_stashes from false to true
+          // without restarting the Bazel server, we may have a stash but not its contents in
+          // memory.
+          return useInMemoryStashes() && pathToContents.containsKey(stash)
+              ? Optional.of(pathToContents.remove(stash))
+              : Optional.empty();
         } catch (FileNotFoundException e) {
           // Try the next one, somebody else took this one.
         } catch (IOException e) {
           turnOffReuse("Error renaming sandbox stash %s to %s: %s\n", stash, sandboxPath, e);
-          return false;
+          return null;
         }
       }
-      return false;
+      return null;
     } catch (IOException e) {
       turnOffReuse("Failed to prepare for reusing stashed sandbox for %s: %s", sandboxPath, e);
-      return false;
+      return null;
     }
   }
 
@@ -145,28 +187,87 @@ public class SandboxStash {
       String mnemonic,
       Map<String, String> environment,
       SandboxOutputs outputs,
-      TreeDeleter treeDeleter) {
+      TreeDeleter treeDeleter,
+      Label target) {
     if (instance == null) {
       return;
     }
-    instance.stashSandboxInternal(path, mnemonic, environment, outputs, treeDeleter);
-  }
 
-  private void stashSandboxInternal(
-      Path path,
-      String mnemonic,
-      Map<String, String> environment,
-      SandboxOutputs outputs,
-      TreeDeleter treeDeleter) {
-    Path sandboxes = getSandboxStashDir(mnemonic, path.getFileSystem());
-    if (sandboxes == null || isTestXmlGenerationOrCoverageSpawn(mnemonic, outputs)) {
+    Path sandboxes = instance.getSandboxStashDir(mnemonic, path.getFileSystem());
+    if (sandboxes == null
+        || isTestXmlGenerationOrCoverageSpawn(mnemonic, outputs)
+        || !path.exists()) {
       return;
     }
     String stashName = Integer.toString(stash.incrementAndGet());
-    Path stashPath = sandboxes.getChild(stashName);
-    if (!path.exists()) {
-      return;
+
+    if (useInMemoryStashes()) {
+      instance.stashSandboxInternalWithInMemoryStashes(
+          stashName, sandboxes, path, mnemonic, environment, treeDeleter, target);
+    } else {
+      instance.stashSandboxInternal(
+          stashName, sandboxes, path, mnemonic, environment, treeDeleter, target);
     }
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored")
+  private void stashSandboxInternalWithInMemoryStashes(
+      String stashName,
+      Path sandboxes,
+      Path path,
+      String mnemonic,
+      Map<String, String> environment,
+      TreeDeleter treeDeleter,
+      Label target) {
+    Path temporaryStashes = sandboxBase.getChild(TEMPORARY_SANDBOX_STASH_BASE);
+    Path temporaryStash = temporaryStashes.getChild(stashName);
+    try {
+      temporaryStashes.createDirectory();
+      path.getChild("execroot").renameTo(temporaryStash);
+    } catch (IOException e) {
+      turnOffReuse("Error stashing sandbox at %s: %s", temporaryStash, e);
+    }
+    stashFileListingPool.submit(
+        () -> {
+          Path stashPath = sandboxes.getChild(stashName);
+          try {
+            StashContents stashContents = pathToContents.remove(path);
+            Long lastModified = pathToLastModified.remove(path);
+            Preconditions.checkNotNull(lastModified);
+            listContentsRecursively(temporaryStash, lastModified, stashContents);
+            stashPath.createDirectory();
+            Path stashPathExecroot = stashPath.getChild("execroot");
+            if (isTestAction(mnemonic)) {
+              if (environment.get("TEST_TMPDIR").startsWith("_tmp")) {
+                treeDeleter.deleteTree(
+                    temporaryStash.getRelative(environment.get("TEST_WORKSPACE") + "/_tmp"));
+              }
+              // We do this before the rename operation to avoid a race condition.
+              stashPathToRunfilesDir.put(stashPathExecroot, getCurrentRunfilesDir(environment));
+            }
+            setPathContents(stashPath, stashContents);
+            temporaryStash.renameTo(stashPathExecroot);
+            if (target != null) {
+              sandboxToTarget.put(stashPath, target);
+            }
+          } catch (InterruptedException e) {
+            // Finish the job without stashing the sandbox
+          } catch (IOException e) {
+            // TODO(bazel-team): Are we sure we don't want to surface this error?
+            turnOffReuse("Error stashing sandbox at %s: %s", stashPath, e);
+          }
+        });
+  }
+
+  private void stashSandboxInternal(
+      String stashName,
+      Path sandboxes,
+      Path path,
+      String mnemonic,
+      Map<String, String> environment,
+      TreeDeleter treeDeleter,
+      Label target) {
+    Path stashPath = sandboxes.getChild(stashName);
     try {
       stashPath.createDirectory();
       Path stashPathExecroot = stashPath.getChild("execroot");
@@ -181,6 +282,9 @@ public class SandboxStash {
         stashPathToRunfilesDir.put(stashPathExecroot, getCurrentRunfilesDir(environment));
       }
       path.getChild("execroot").renameTo(stashPathExecroot);
+      if (target != null) {
+        sandboxToTarget.put(stashPath, target);
+      }
     } catch (IOException e) {
       // Since stash names are unique, this IOException indicates some other problem with stashing,
       // so we turn it off.
@@ -255,24 +359,63 @@ public class SandboxStash {
     }
   }
 
-  public static void initialize(String workspaceName, Path sandboxBase, SandboxOptions options) {
+  public static void initialize(
+      String workspaceName, Path sandboxBase, SandboxOptions options, TreeDeleter treeDeleter) {
     if (options.reuseSandboxDirectories) {
       if (instance == null) {
-        instance = new SandboxStash(workspaceName, sandboxBase);
-      } else if (!Objects.equals(workspaceName, instance.workspaceName)) {
-        Path stashBase = getStashBase(instance.sandboxBase);
-        try {
-          for (Path directoryEntry : stashBase.getDirectoryEntries()) {
-            directoryEntry.deleteTree();
+        instance =
+            new SandboxStash(
+                workspaceName, sandboxBase, options.experimentalInMemorySandboxStashes);
+      } else {
+        if (!Objects.equals(workspaceName, instance.workspaceName)) {
+          Path stashBase = getStashBase(instance.sandboxBase);
+          try {
+            for (Path directoryEntry : stashBase.getDirectoryEntries()) {
+              treeDeleter.deleteTree(directoryEntry);
+            }
+          } catch (IOException e) {
+            instance.turnOffReuse(
+                "Unable to clear old sandbox stash %s: %s\n", stashBase, e.getMessage());
           }
-        } catch (IOException e) {
-          instance.turnOffReuse(
-              "Unable to clear old sandbox stash %s: %s\n", stashBase, e.getMessage());
+          instance =
+              new SandboxStash(
+                  workspaceName, sandboxBase, options.experimentalInMemorySandboxStashes);
         }
-        instance = new SandboxStash(workspaceName, sandboxBase);
+        instance.inMemoryStashes = options.experimentalInMemorySandboxStashes;
       }
     } else {
       instance = null;
+    }
+  }
+
+  public static boolean useInMemoryStashes() {
+    Preconditions.checkNotNull(instance);
+    return instance.inMemoryStashes;
+  }
+
+  public static void setPathContents(Path path, StashContents stashContents) {
+    Preconditions.checkNotNull(instance);
+    instance.pathToContents.put(path, stashContents);
+  }
+
+  public static void setLastModified(Path path, Long lastModified) {
+    if (instance != null) {
+      instance.pathToLastModified.put(path, lastModified);
+    }
+  }
+
+  public static String getWorkspaceName() {
+    Preconditions.checkNotNull(instance);
+    return instance.workspaceName;
+  }
+
+  public static boolean gotInstance() {
+    return instance != null;
+  }
+
+  public static void shutdown() {
+    if (instance != null) {
+      instance.stashFileListingPool.shutdown();
     }
   }
 
@@ -299,6 +442,13 @@ public class SandboxStash {
       }
     } catch (IOException e) {
       logger.atWarning().withCause(e).log("Failed to clean sandbox stash %s", stashDir);
+    }
+
+    if (instance != null) {
+      instance.stashPathToRunfilesDir.clear();
+      instance.pathToContents.clear();
+      instance.sandboxToTarget.clear();
+      instance.pathToLastModified.clear();
     }
   }
 
@@ -332,4 +482,103 @@ public class SandboxStash {
   private static String getCurrentRunfilesDir(Map<String, String> environment) {
     return environment.get("TEST_WORKSPACE") + "/" + environment.get(TEST_SRCDIR);
   }
+
+  /**
+   * Before this function is called, stashContents will contain the inputs that were set up for the
+   * action before executing it but the action might have written undeclared files into the sandbox
+   * or deleted existing ones, therefore we need to crawl through all directories to see what's in
+   * them and update stashContents.
+   */
+  private static void listContentsRecursively(
+      Path root, Long timestamp, StashContents stashContents)
+      throws IOException, InterruptedException {
+    if (root.statIfFound().getLastChangeTime() > timestamp) {
+      Set<String> dirsToKeep = new HashSet<>();
+      Set<String> filesAndSymlinksToKeep = new HashSet<>();
+      for (Dirent dirent : root.readdir(Symlinks.NOFOLLOW)) {
+        if (Thread.interrupted()) {
+          throw new InterruptedException();
+        }
+        Path absPath = root.getChild(dirent.getName());
+        if (dirent.getType().equals(SYMLINK)) {
+          if ((stashContents.filesToPath().containsKey(dirent.getName())
+                  || stashContents.symlinksToPathFragment().containsKey(dirent.getName()))
+              && absPath.stat().getLastChangeTime() <= timestamp) {
+            filesAndSymlinksToKeep.add(dirent.getName());
+          } else {
+            absPath.delete();
+          }
+        } else if (dirent.getType().equals(DIRECTORY)) {
+          if (stashContents.dirEntries().containsKey(dirent.getName())) {
+            dirsToKeep.add(dirent.getName());
+            listContentsRecursively(
+                absPath, timestamp, stashContents.dirEntries().get(dirent.getName()));
+          } else {
+            absPath.deleteTree();
+            stashContents.dirEntries().remove(dirent.getName());
+          }
+        } else {
+          absPath.delete();
+        }
+      }
+
+      stashContents.dirEntries().keySet().retainAll(dirsToKeep);
+      stashContents.filesToPath().keySet().retainAll(filesAndSymlinksToKeep);
+      stashContents.symlinksToPathFragment().keySet().retainAll(filesAndSymlinksToKeep);
+    } else {
+      for (var entry : stashContents.dirEntries().entrySet()) {
+        Path absPath = root.getChild(entry.getKey());
+        listContentsRecursively(absPath, timestamp, entry.getValue());
+      }
+    }
+  }
+
+  private ImmutableList<Path> sortStashesByMatchingTargetSegments(
+      Label target, Collection<Path> stashes) {
+    List<Path> sortedStashes = new ArrayList<>(stashes);
+    Map<Path, Integer> countMap = new HashMap<>();
+    String[] targetStr = null;
+    if (target != null) {
+      targetStr = target.getPackageName().split("/");
+    }
+    for (Path stash : stashes) {
+      Label stashTarget = sandboxToTarget.getOrDefault(stash, /* defaultValue= */ null);
+      if (target == null) {
+        countMap.put(stash, stashTarget == null ? 1 : 0);
+      } else {
+        countMap.put(
+            stash,
+            stashTarget == null
+                ? 0
+                : Arrays.mismatch(targetStr, stashTarget.getPackageName().split("/")));
+      }
+    }
+    return ImmutableList.sortedCopyOf(
+        Comparator.comparingInt(countMap::get).reversed(), sortedStashes);
+  }
+
+  private void updateStashContentsAfterRunfilesMove(
+      String stashedRunfiles, String currentRunfiles, StashContents stashContents) {
+    ImmutableList<String> stashedRunfilesSegments =
+        ImmutableList.copyOf(PathFragment.create(stashedRunfiles).segments());
+    StashContents runfilesStashContents = stashContents;
+    for (int i = 0; i < stashedRunfilesSegments.size() - 1; i++) {
+      runfilesStashContents =
+          Preconditions.checkNotNull(
+              runfilesStashContents.dirEntries().get(stashedRunfilesSegments.get(i)));
+    }
+    runfilesStashContents =
+        runfilesStashContents.dirEntries().remove(stashedRunfilesSegments.getLast());
+
+    ImmutableList<String> currentRunfilesSegments =
+        ImmutableList.copyOf(PathFragment.create(currentRunfiles).segments());
+    StashContents currentStashContents = stashContents;
+    for (int i = 0; i < currentRunfilesSegments.size() - 1; i++) {
+      String segment = currentRunfilesSegments.get(i);
+      currentStashContents.dirEntries().putIfAbsent(segment, new StashContents());
+      currentStashContents = currentStashContents.dirEntries().get(segment);
+    }
+    currentStashContents.dirEntries().put(currentRunfilesSegments.getLast(), runfilesStashContents);
+  }
 }
+

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -18,17 +18,22 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.compacthashmap.CompactHashMap;
 import com.google.devtools.build.lib.exec.TreeDeleter;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
+import com.google.devtools.build.lib.sandbox.SandboxHelpers.StashContents;
 import com.google.devtools.build.lib.util.CommandDescriptionForm;
 import com.google.devtools.build.lib.util.CommandFailureUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
@@ -39,6 +44,8 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
 
   /** Mnemonic of the action running in this spawn. */
   private final String mnemonic;
+
+  private final Label targetLabel;
 
   @Nullable private final ImmutableList<String> interactiveDebugArguments;
 
@@ -54,7 +61,8 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
       @Nullable Path sandboxDebugPath,
       @Nullable Path statisticsPath,
       @Nullable ImmutableList<String> interactiveDebugArguments,
-      String mnemonic) {
+      String mnemonic,
+      Label targetLabel) {
     super(
         sandboxPath,
         sandboxExecRoot,
@@ -69,29 +77,124 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
         mnemonic);
     this.mnemonic = isNullOrEmpty(mnemonic) ? "_NoMnemonic_" : mnemonic;
     this.interactiveDebugArguments = interactiveDebugArguments;
+    this.targetLabel = targetLabel;
   }
 
   @Override
   public void filterInputsAndDirsToCreate(
       Set<PathFragment> inputsToCreate, LinkedHashSet<PathFragment> dirsToCreate)
       throws IOException, InterruptedException {
-    boolean gotStash =
-        SandboxStash.takeStashedSandbox(sandboxPath, mnemonic, getEnvironment(), outputs);
+    if (!SandboxStash.gotInstance()) {
+      return;
+    }
+    Optional<StashContents> stashContents =
+        SandboxStash.takeStashedSandbox(
+            sandboxPath, mnemonic, getEnvironment(), outputs, targetLabel);
     sandboxExecRoot.createDirectoryAndParents();
-    if (gotStash) {
-      // When reusing an old sandbox, we do a full traversal of the parent directory of
-      // `sandboxExecRoot`. This will use what we computed above, delete anything unnecessary, and
-      // update `inputsToCreate`/`dirsToCreate` if something can be left without changes (e.g., a,
-      // symlink that already points to the right destination). We're traversing from
-      // sandboxExecRoot's parent directory because external repositories can now be symlinked as
-      // siblings of sandboxExecRoot when --experimental_sibling_repository_layout is set.
-      SandboxHelpers.cleanExisting(
-          sandboxExecRoot.getParentDirectory(),
-          inputs,
-          inputsToCreate,
-          dirsToCreate,
-          sandboxExecRoot,
-          treeDeleter);
+
+    if (stashContents != null) {
+      // Delete anything unnecessary, and update `inputsToCreate`/`dirsToCreate` if something can
+      // be left without changes (e.g., a, symlink that already points to the right destination).
+      // We're traversing from sandboxExecRoot's parent directory because external repositories can
+      // now be symlinked as siblings of sandboxExecRoot when
+      // --experimental_sibling_repository_layout is set.
+      if (stashContents.isPresent()) {
+        SandboxHelpers.cleanExisting(
+            sandboxExecRoot.getParentDirectory(),
+            inputs,
+            inputsToCreate,
+            dirsToCreate,
+            sandboxExecRoot,
+            treeDeleter,
+            stashContents.get());
+      } else {
+        // No in-memory stashes enabled but there is a stash.
+        // When reusing an old sandbox, we do a full traversal of the parent directory of
+        // `sandboxExecRoot`.
+        SandboxHelpers.cleanExisting(
+            sandboxExecRoot.getParentDirectory(),
+            inputs,
+            inputsToCreate,
+            dirsToCreate,
+            sandboxExecRoot,
+            treeDeleter);
+        return;
+      }
+    }
+
+    if (SandboxStash.useInMemoryStashes()) {
+      Map<PathFragment, StashContents> stashContentsMap = CompactHashMap.create();
+      for (Map.Entry<PathFragment, Path> entry : inputs.getFiles().entrySet()) {
+        if (entry.getValue() == null) {
+          continue;
+        }
+        PathFragment parent = entry.getKey().getParentDirectory();
+        boolean parentWasPresent = !addParent(stashContentsMap, parent);
+        stashContentsMap
+            .get(parent)
+            .filesToPath()
+            .put(entry.getKey().getBaseName(), entry.getValue());
+        addAllParents(stashContentsMap, parentWasPresent, parent);
+      }
+      for (Map.Entry<PathFragment, PathFragment> entry : inputs.getSymlinks().entrySet()) {
+        if (entry.getValue() == null) {
+          continue;
+        }
+        PathFragment parent = entry.getKey().getParentDirectory();
+        boolean parentWasPresent = !addParent(stashContentsMap, parent);
+        stashContentsMap
+            .get(parent)
+            .symlinksToPathFragment()
+            .put(entry.getKey().getBaseName(), entry.getValue());
+        addAllParents(stashContentsMap, parentWasPresent, parent);
+      }
+
+      for (var outputDir :
+          Stream.concat(
+                  outputs.files().values().stream().map(PathFragment::getParentDirectory),
+                  outputs.dirs().values().stream())
+              .distinct()
+              .collect(ImmutableList.toImmutableList())) {
+        PathFragment parent = outputDir;
+        boolean parentWasPresent = !addParent(stashContentsMap, parent);
+        addAllParents(stashContentsMap, parentWasPresent, parent);
+      }
+      StashContents main = new StashContents();
+      main.dirEntries()
+          .put(SandboxStash.getWorkspaceName(), stashContentsMap.get(PathFragment.EMPTY_FRAGMENT));
+      SandboxStash.setPathContents(sandboxPath, main);
+    }
+  }
+
+  private static boolean addParent(
+      Map<PathFragment, StashContents> stashContentsMap, PathFragment parent) {
+    boolean parentWasPresent = true;
+    if (!stashContentsMap.containsKey(parent)) {
+      stashContentsMap.put(parent, new StashContents());
+      parentWasPresent = false;
+    }
+    return !parentWasPresent;
+  }
+
+  private static void addAllParents(
+      Map<PathFragment, StashContents> stashContentsMap,
+      boolean parentWasPresent,
+      PathFragment parent) {
+    PathFragment parentParent;
+    while (!parentWasPresent && (parentParent = parent.getParentDirectory()) != null) {
+      StashContents parentParentStashContents = stashContentsMap.get(parentParent);
+      if (parentParentStashContents != null) {
+        parentWasPresent = true;
+      } else {
+        parentParentStashContents = new StashContents();
+        stashContentsMap.put(parentParent, parentParentStashContents);
+      }
+      if (!parentParentStashContents.dirEntries().containsKey(parent.getBaseName())) {
+        parentParentStashContents
+            .dirEntries()
+            .put(parent.getBaseName(), stashContentsMap.get(parent));
+      }
+      parent = parentParent;
     }
   }
 
@@ -102,7 +205,8 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
 
   @Override
   public void delete() {
-    SandboxStash.stashSandbox(sandboxPath, mnemonic, getEnvironment(), outputs, treeDeleter);
+    SandboxStash.stashSandbox(
+        sandboxPath, mnemonic, getEnvironment(), outputs, treeDeleter, targetLabel);
     super.delete();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawnTest.java
@@ -80,7 +80,8 @@ public class SymlinkedSandboxedSpawnTest {
             /* sandboxDebugPath= */ null,
             /* statisticsPath= */ null,
             /* interactiveDebugArguments= */ null,
-            "SomeMnemonic");
+            "SomeMnemonic",
+            /* targetLabel= */ null);
 
     symlinkedExecRoot.createFileSystem();
 
@@ -110,7 +111,8 @@ public class SymlinkedSandboxedSpawnTest {
             /* sandboxDebugPath= */ null,
             /* statisticsPath= */ null,
             /* interactiveDebugArguments= */ null,
-            "SomeMnemonic");
+            "SomeMnemonic",
+            /* targetLabel= */ null);
     symlinkedExecRoot.createFileSystem();
 
     FileSystemUtils.createEmptyFile(outputFile);

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -962,21 +962,36 @@ EOF
 }
 
 function test_runfiles_from_tests_get_reused_and_tmp_clean() {
+  do_test_runfiles_from_tests_get_reused_and_tmp_clean \
+    "--noexperimental_inmemory_sandbox_stashes"
+}
+
+function test_runfiles_from_tests_get_reused_and_tmp_clean_in_mem_stashes() {
+  do_test_runfiles_from_tests_get_reused_and_tmp_clean \
+    "--experimental_inmemory_sandbox_stashes"
+}
+
+function do_test_runfiles_from_tests_get_reused_and_tmp_clean() {
+  local -r in_memory_stashes="$1"
   mkdir pkg
-  touch pkg/file.txt
+  mkdir pkg/b
+  touch pkg/file1.txt
+  touch pkg/file2.txt
+  touch pkg/file3.txt
   cat >pkg/reusing_test.bzl <<'EOF'
 def _reused_runfiles_test_impl(ctx):
     output = ctx.actions.declare_file(ctx.label.name + ".sh")
 
-    runfiles = ctx.runfiles(files = ctx.files.file)
+    runfiles = ctx.runfiles(files = ctx.files.files)
     runfiles = runfiles.merge(runfiles)
 
     test_code = """
     #!/bin/bash
     dir_inode_number=$(ls -di $TEST_SRCDIR | cut -f1 -d" ")
     echo "The directory inode is $dir_inode_number"
-    file_inode_number=$(ls -i $TEST_SRCDIR/_main/pkg/file.txt | cut -f1 -d" ")
+    file_inode_number=$(ls -i $TEST_SRCDIR/_main/pkg/file1.txt | cut -f1 -d" ")
     echo "The file inode is $file_inode_number"
+    find -L $TEST_SRCDIR -type f
     """
 
     ctx.actions.run_shell(
@@ -995,18 +1010,34 @@ reused_runfiles_test = rule(
     implementation = _reused_runfiles_test_impl,
     test = True,
     attrs = {
-        "file" : attr.label(allow_files=True,default="//pkg:file.txt"),
+        "files" : attr.label_list(allow_files=True),
     }
 )
 EOF
 
   cat >pkg/BUILD <<'EOF'
 load(":reusing_test.bzl", "reused_runfiles_test")
+exports_files([
+  "file1.txt",
+  "file2.txt",
+  "file3.txt",
+])
 reused_runfiles_test(
     name = "a",
+    files = [
+      "file1.txt",
+      "file2.txt",
+    ],
 )
+EOF
+  cat >pkg/b/BUILD <<'EOF'
+load("//pkg:reusing_test.bzl", "reused_runfiles_test")
 reused_runfiles_test(
     name = "b",
+    files = [
+      "//pkg:file1.txt",
+      "//pkg:file3.txt",
+    ],
 )
 EOF
 
@@ -1014,34 +1045,53 @@ EOF
   local out_directory
   if is_bazel; then
     bazel coverage --test_output=streamed \
-      --experimental_split_coverage_postprocessing=1 \
+      "$in_memory_stashes" --experimental_split_coverage_postprocessing=1 \
       --experimental_fetch_all_coverage_outputs //pkg:a > ${test_output} \
       || fail "Expected build to succeed"
     out_directory="bazel-out"
   else
-    bazel test --test_output=streamed //pkg:a > ${test_output} \
-      || fail "Expected build to succeed"
+    bazel test "$in_memory_stashes" --test_output=streamed \
+     //pkg:a > ${test_output} || fail "Expected build to succeed"
     out_directory="blaze-out"
   fi
+  grep -q "file1.txt" ${test_output} || fail "Missing file1.txt"
+  grep -q "file2.txt" ${test_output} || fail "Missing file2.txt"
+
   dir_inode_a=$(awk '/The directory inode is/ {print $5}' ${test_output})
   file_inode_a=$(awk '/The file inode is/ {print $5}' ${test_output})
 
   local output_base="$(bazel info output_base)"
   local stashed_test_dir="${output_base}/sandbox/sandbox_stash/TestRunner/6/execroot/$WORKSPACE_NAME"
+  touch $(find "$stashed_test_dir/$out_directory/" -name a.sh.runfiles -type d)"/$WORKSPACE_NAME/pkg/file4.txt"
+
   [[ -d "${stashed_test_dir}/$out_directory" ]] \
     || fail "${stashed_test_dir}/$out_directory directory not present"
   [[ -d "${stashed_test_dir}/_tmp" ]] \
       && fail "${stashed_test_dir}/_tmp directory is present"
 
   if is_bazel; then
-    bazel coverage --test_output=streamed //pkg:b \
-      --experimental_split_coverage_postprocessing=1 \
+    bazel coverage --test_output=streamed //pkg/b:b  \
+      "$in_memory_stashes" --experimental_split_coverage_postprocessing=1 \
       --experimental_fetch_all_coverage_outputs > ${test_output} \
       || fail "Expected build to succeed"
   else
-    bazel test --test_output=streamed //pkg:b > ${test_output} \
-      || fail "Expected build to succeed"
+    bazel test "$in_memory_stashes" --test_output=streamed \
+      //pkg/b:b > ${test_output} || fail "Expected build to succeed"
   fi
+  grep -q "file1.txt" ${test_output} || fail "Missing file1.txt"
+  grep -q "file3.txt" ${test_output} || fail "Missing file3.txt"
+  grep -q "file2.txt" ${test_output} && fail "Present file2.txt"
+
+  if [[ "$in_memory_stashes" =~ ^"--no" ]]; then
+    grep -q "file4.txt" ${test_output} \
+      && fail "Present file4.txt which was added artificially and should" \
+          " have been cleaned up with disk clean-up stashes"
+  else
+    grep -q "file4.txt" ${test_output} \
+      || fail "Missing file4.txt which was added artificially and shouldn't" \
+          " have been cleaned up with in-memory stashes"
+  fi
+
   dir_inode_b=$(awk '/The directory inode is/ {print $5}' ${test_output})
   file_inode_b=$(awk '/The file inode is/ {print $5}' ${test_output})
 


### PR DESCRIPTION
This change introduces the flag `--experimental_inmemory_sandbox_stashes` to track in memory the contents of the stashes stored with `--reuse_sandbox_directories=true`

With the old behavior Bazel has to perform a lot of I/O to read the contents of each stash before reusing it in a new action. Essentially, it checks  every directory and subdirectory in the stashed sandbox to find out which files are different to the inputs of the new action about to be executed.

With in-memory stashes we associate each stash to the symlinks that needed to be created for that action. We also store the time at which these symlinks were created. In a background thread after the action has finished executing we stat every directory and for the ones that have changed (this should be rare) we update the contents. Because we only read the contents of the directories that have changed we do much less I/O than before.

If an action purposefully changes a sandbox symlink in-place, this won't be detected by statting the directory. I don't know any use case for this since the symlink itself is an implementation detail to achieve sandboxing. For this reason,  manipulation of sandbox symlinks in-place is not supported.

Depending on the build this change might have a significant effect on memory. It should generally improve wall time further in builds where `--reuse_sandbox_directories` already improved wall time.

This change also introduces a minor optimization which is to associate each stash with the target that it was originally created for. When a new action wants to reuse a stash and there is more than one available, it will take the stash whose target is closest to its own. This is done with the assumption that targets that are closer together in the graph will have more inputs in common.

Fixes #22309 .

Closes #22559.

PiperOrigin-RevId: 640142481
Change-Id: Iece2d718df47f403e2fe91c1bd887604eceee8ee

Commit https://github.com/bazelbuild/bazel/commit/1c0135cf88bf16d9ffddf8f687ded797f07960b1