### PR TITLE
Fix data race in `IndexRegistry#getBazelRegistryJson`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -321,9 +321,10 @@ public class IndexRegistry implements Registry {
 
   private Optional<BazelRegistryJson> getBazelRegistryJson(ExtendedEventHandler eventHandler)
       throws IOException, InterruptedException {
-    if (bazelRegistryJson == null) {
+    if (bazelRegistryJson == null || bazelRegistryJsonEvents == null) {
       synchronized (this) {
-        if (bazelRegistryJson == null) {
+        if (bazelRegistryJson == null || bazelRegistryJsonEvents == null) {
+          Preconditions.checkState(bazelRegistryJson == null && bazelRegistryJsonEvents == null);
           var storedEventHandler = new StoredEventHandler();
           bazelRegistryJson =
               grabJson(


### PR DESCRIPTION
Should fix the following crash observed in the wild:

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'RepoSpecKey{moduleKey=rules_pkg@0.7.0, registryUrl=https://bcr.bazel.build/}' (requested by nodes 'com.google.devtools.build.lib.bazel.bzlmod.BazelModuleResolutionValue$$Lambda/0x00000008005fd220@38aba3ca')
        at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:550)
        at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:414)
        at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.NullPointerException: Cannot invoke "com.google.devtools.build.lib.events.StoredEventHandler.replayOn(com.google.devtools.build.lib.events.ExtendedEventHandler)" because "this.bazelRegistryJsonEvents" is null
        at com.google.devtools.build.lib.bazel.bzlmod.IndexRegistry.getBazelRegistryJson(IndexRegistry.java:336)
        at com.google.devtools.build.lib.bazel.bzlmod.IndexRegistry.getRepoSpec(IndexRegistry.java:295)
        at com.google.devtools.build.lib.bazel.bzlmod.RepoSpecFunction.compute(RepoSpecFunction.java:52)
        at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:461)
        ... 7 more
```