### PR TITLE
Fix building Bazel on old macOS version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -65,6 +65,16 @@ single_version_override(
     ],
 )
 
+# Remove the following patch when the following commit is in a release.
+# https://github.com/abseil/abseil-cpp/commit/65a55c2ba891f6d2492477707f4a2e327a0b40dc
+single_version_override(
+    module_name = "abseil-cpp",
+    patch_strip = 1,
+    patches = [
+        "//third_party:abseil-cpp-macos-fix.patch",
+    ],
+)
+
 # The following Bazel modules are not direct dependencies for building Bazel,
 # but are required for visibility from DIST_ARCHIVE_REPOS in repositories.bzl
 bazel_dep(name = "apple_support", version = "1.8.1")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "510c7c32da0bf633c73a9f30ce2e4cff965074f1a2134ffe8bd17612d5f621b6",
+  "moduleFileHash": "c4124fbd3acadec360c37c532d1405f0c81f3c5388ef4079b525d2c3d9ce18e8",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -39,7 +39,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 87,
+            "line": 97,
             "column": 22
           },
           "imports": {
@@ -170,7 +170,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 88,
+                "line": 98,
                 "column": 14
               }
             },
@@ -185,7 +185,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -200,7 +200,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -215,7 +215,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -230,7 +230,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -245,7 +245,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -260,7 +260,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -275,7 +275,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -290,7 +290,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -305,7 +305,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 214,
+                "line": 224,
                 "column": 19
               }
             },
@@ -333,7 +333,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 354,
+                "line": 364,
                 "column": 22
               }
             }
@@ -347,7 +347,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 235,
+            "line": 245,
             "column": 32
           },
           "imports": {
@@ -387,7 +387,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 269,
+            "line": 279,
             "column": 23
           },
           "imports": {},
@@ -401,7 +401,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 270,
+                "line": 280,
                 "column": 17
               }
             }
@@ -415,7 +415,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 272,
+            "line": 282,
             "column": 20
           },
           "imports": {
@@ -433,7 +433,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 273,
+                "line": 283,
                 "column": 10
               }
             }
@@ -447,7 +447,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 284,
+            "line": 294,
             "column": 33
           },
           "imports": {
@@ -478,7 +478,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 305,
+            "line": 315,
             "column": 29
           },
           "imports": {
@@ -495,7 +495,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 308,
+            "line": 318,
             "column": 20
           },
           "imports": {
@@ -514,7 +514,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 309,
+                "line": 319,
                 "column": 12
               }
             }
@@ -528,7 +528,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 321,
+            "line": 331,
             "column": 32
           },
           "imports": {
@@ -547,7 +547,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 329,
+            "line": 339,
             "column": 31
           },
           "imports": {
@@ -564,7 +564,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 332,
+            "line": 342,
             "column": 48
           },
           "imports": {
@@ -581,7 +581,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 376,
+            "line": 386,
             "column": 35
           },
           "imports": {
@@ -598,7 +598,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 379,
+            "line": 389,
             "column": 42
           },
           "imports": {
@@ -616,7 +616,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 382,
+            "line": 392,
             "column": 45
           },
           "imports": {
@@ -1894,7 +1894,14 @@
           "integrity": "sha256-czcmuMOm05pBINfkXqi0GkNM2s3kAculAPFCNsSbOdw=",
           "strip_prefix": "abseil-cpp-20240116.2",
           "remote_patches": {},
-          "remote_patch_strip": 0
+          "remote_patch_strip": 0,
+          "patches": [
+            "@@//third_party:abseil-cpp-macos-fix.patch"
+          ],
+          "patch_cmds": [],
+          "patch_args": [
+            "-p1"
+          ]
         }
       }
     },
@@ -3012,7 +3019,7 @@
       "general": {
         "bzlTransitiveDigest": "iHLxWy9Kdma4o6vQG1U0vO82d7jPg9gng3gCoY4Dn88=",
         "recordedFileInputs": {
-          "@@//MODULE.bazel": "510c7c32da0bf633c73a9f30ce2e4cff965074f1a2134ffe8bd17612d5f621b6",
+          "@@//MODULE.bazel": "c4124fbd3acadec360c37c532d1405f0c81f3c5388ef4079b525d2c3d9ce18e8",
           "@@//src/test/tools/bzlmod/MODULE.bazel.lock": "4a9cf4d1d48d36a3d6e24a13094b2c32aa20be5a495d4e5b33e43db973250182"
         },
         "recordedDirentsInputs": {},

--- a/third_party/abseil-cpp-macos-fix.patch
+++ b/third_party/abseil-cpp-macos-fix.patch
@@ -1,0 +1,27 @@
+commit 65a55c2ba891f6d2492477707f4a2e327a0b40dc
+Author: Abseil Team <absl-team@google.com>
+Date:   Wed May 29 11:12:50 2024 -0700
+
+    Do not make std::filesystem::path hash available for macOS <10.15
+    
+    C++17 <filesystem> is only available on macOS 10.15 and newer, so
+    do not enable this feature on older versions.
+    
+    PiperOrigin-RevId: 638348906
+    Change-Id: I5e12db47513f7f8aeb9e55a3e253c866ec046d47
+
+diff --git a/absl/hash/internal/hash.h b/absl/hash/internal/hash.h
+index b7d89b01..03bf1839 100644
+--- a/absl/hash/internal/hash.h
++++ b/absl/hash/internal/hash.h
+@@ -599,7 +599,9 @@ H AbslHashValue(H hash_state, std::basic_string_view<Char> str) {
+ #if defined(__cpp_lib_filesystem) && __cpp_lib_filesystem >= 201703L && \
+     !defined(_LIBCPP_HAS_NO_FILESYSTEM_LIBRARY) && \
+     (!defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) ||        \
+-     __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ >= 130000)
++     __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ >= 130000) &&       \
++    (!defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) ||         \
++     __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 101500)
+ 
+ #define ABSL_INTERNAL_STD_FILESYSTEM_PATH_HASH_AVAILABLE 1
+ 


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/commit/417c6b803db1078d20077068471427c86c016190 upgraded abseil-cpp, which doesn't build on old macOS versions. 

There is a fix from abseil-cpp: https://github.com/abseil/abseil-cpp/commit/65a55c2ba891f6d2492477707f4a2e327a0b40dc, but not yet in a release version, so adding it as a patch for now.