### PR TITLE
Force use of Clang over C++ modules with `use_module_maps`

### DIFF
--- a/tools/cpp/BUILD.tpl
+++ b/tools/cpp/BUILD.tpl
@@ -113,6 +113,7 @@ cc_toolchain_config(
     coverage_compile_flags = [%{coverage_compile_flags}],
     coverage_link_flags = [%{coverage_link_flags}],
     supports_start_end_lib = %{supports_start_end_lib},
+    extra_flags_per_feature = %{extra_flags_per_feature},
 )
 
 # Android tooling requires a default toolchain for the armeabi-v7a cpu.

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -54,11 +54,14 @@ def layering_check_features(compiler, is_macos):
                     flag_groups = [
                         flag_group(
                             # macOS requires -Xclang because of a bug in Apple Clang
+                            # -fno-cxx-modules is necessary to avoid clang defaulting
+                            # to C++ modules with -std=c++20. The flag requires the
+                            # -Xclang prefix even on Linux.
                             flags = (["-Xclang"] if is_macos else []) + [
                                 "-fmodule-name=%{module_name}",
                             ] + (["-Xclang"] if is_macos else []) + [
                                 "-fmodule-map-file=%{module_map_file}",
-                            ],
+                            ] + ["-Xclang", "-fno-cxx-modules"],
                         ),
                     ],
                 ),


### PR DESCRIPTION
With `-std=c++20`, Clang defaults to using C++ modules rather than Clang modules, which can result in failures when using `layering_check` and thus `use_module_maps`.

Fixes https://github.com/bazel-contrib/toolchains_llvm/issues/334