### PR TITLE
Format "Repository names and strict deps" bullet list

### DIFF
--- a/site/en/external/module.md
+++ b/site/en/external/module.md
@@ -206,18 +206,18 @@ multiple versions of the module in the entire dependency graph (see
 Note that **the canonical name format** is not an API you should depend on and
 **is subject to change at any time**. Instead of hard-coding the canonical name,
 use a supported way to get it directly from Bazel:
-* In BUILD and `.bzl` files, use
-  [`Label.repo_name`](/rules/lib/builtins/Label#repo_name) on a `Label` instance
-  constructed from a label string given by the apparent name of the repo, e.g.,
-  `Label("@bazel_skylib").repo_name`.
-* When looking up runfiles, use
-  [`$(rlocationpath ...)`](https://bazel.build/reference/be/make-variables#predefined_label_variables)
-  or one of the runfiles libraries in
-  `@bazel_tools//tools/{bash,cpp,java}/runfiles` or, for a ruleset `rules_foo`,
-  in `@rules_foo//foo/runfiles`.
-* When interacting with Bazel from an external tool such as an IDE or language
-  server, use the `bazel mod dump_repo_mapping` command to get the mapping from
-  apparent names to canonical names for a given set of repositories.
+*    In BUILD and `.bzl` files, use
+     [`Label.repo_name`](/rules/lib/builtins/Label#repo_name) on a `Label` instance
+     constructed from a label string given by the apparent name of the repo, e.g.,
+     `Label("@bazel_skylib").repo_name`.
+*    When looking up runfiles, use
+     [`$(rlocationpath ...)`](https://bazel.build/reference/be/make-variables#predefined_label_variables)
+     or one of the runfiles libraries in
+     `@bazel_tools//tools/{bash,cpp,java}/runfiles` or, for a ruleset `rules_foo`,
+     in `@rules_foo//foo/runfiles`.
+*    When interacting with Bazel from an external tool such as an IDE or language
+     server, use the `bazel mod dump_repo_mapping` command to get the mapping from
+     apparent names to canonical names for a given set of repositories.
 
 [Module extensions](/external/extension) can also introduce additional repos
 into the visible scope of a module.


### PR DESCRIPTION
The bullet list in the "Repository names and strict deps" section of https://bazel.build/external/module does not render properly on the website.  However, other bullet lists on this page do render correctly.  The difference is apparently the level of indentation.  This PR attempts to correct the discrepancy.