### PR TITLE
Clarify /rules/lib/builtins/repository_ctx description of default working_directory for execute()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -1561,7 +1561,8 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
             named = true,
             doc =
                 "Working directory for command execution.\n"
-                    + "Can be relative to the repository root or absolute."),
+                    + "Can be relative to the repository root or absolute.\n"
+                    + "The default is the repository root."),
       })
   public StarlarkExecutionResult execute(
       Sequence<?> arguments, // <String> or <StarlarkPath> or <Label> expected


### PR DESCRIPTION
Fixes #21897 per feedback from @meteorcloudy.