### PR TITLE
[7.2.0] Replace //external:android/d8_jar_import with "@android_gmaven_r8//jar"

### DIFF
--- a/src/test/java/com/google/devtools/build/android/r8/BUILD
+++ b/src/test/java/com/google/devtools/build/android/r8/BUILD
@@ -36,13 +36,9 @@ java_library(
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
+        "@android_gmaven_r8//jar",
         "@bazel_tools//tools/java/runfiles",
-    ] + select({
-        "//external:has_androidsdk": [
-            "//external:android/d8_jar_import",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )
 
 java_test(

--- a/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/BUILD
@@ -51,10 +51,8 @@ java_library(
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",
-    ] + select({
-        "//external:has_androidsdk": ["//external:android/d8_jar_import"],
-        "//conditions:default": [],
-    }),
+        "@android_gmaven_r8//jar",
+    ],
 )
 
 java_library(

--- a/src/tools/android/java/com/google/devtools/build/android/r8/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/BUILD.tools
@@ -4,7 +4,7 @@ java_library(
     name = "r8",
     srcs = glob(["*.java", "desugar/*.java"]),
     deps = [
-        "//external:android/d8_jar_import",
+        "@android_gmaven_r8//jar",
         "//src/tools/android/java/com/google/devtools/build/android:all_android_tools",
     ],
     plugins = ["auto_value_plugin"],


### PR DESCRIPTION
When android sdk is defined, android_sdk_repository maps //external:android/d8_jar_import to androidsdk//:d8_jar_import, which refers to android_gmaven_r8//jar:jar.

PiperOrigin-RevId: 611144488
Change-Id: I4ee5945ce5a1fdb30e96775396ec3628cefaa2e8

(cherry-pick from 394dd8e0b468d6fa4d8a70136e534ab429a25ab5)