### PR TITLE
[7.3.0] Cherry-pick fix to make Protobuf work with sibling repository layout into Bazel 7.3

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFactory.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.actions;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SourceArtifact;
@@ -542,14 +541,8 @@ public class ArtifactFactory implements ArtifactResolver {
     }
   }
 
-  /**
-   * Determines if an artifact is derived, that is, its root is a derived root or its exec path
-   * starts with the bazel-out prefix.
-   *
-   * @param execPath The artifact's exec path.
-   */
-  @VisibleForTesting // for our own unit tests only.
-  boolean isDerivedArtifact(PathFragment execPath) {
+  @Override
+  public boolean isDerivedArtifact(PathFragment execPath) {
     return execPath.startsWith(derivedPathPrefix);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactResolver.java
@@ -80,4 +80,12 @@ public interface ArtifactResolver {
       throws PackageRootResolver.PackageRootException, InterruptedException;
 
   Path getPathFromSourceExecPath(Path execRoot, PathFragment execPath);
+
+  /**
+   * Determines if an artifact is derived, that is, its root is a derived root or its exec path
+   * starts with the bazel-out prefix.
+   *
+   * @param execPath The artifact's exec path.
+   */
+  boolean isDerivedArtifact(PathFragment execPath);
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
@@ -1021,6 +1021,11 @@ public final class ActionsTestUtil {
     public Path getPathFromSourceExecPath(Path execRoot, PathFragment execPath) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean isDerivedArtifact(PathFragment execPath) {
+      throw new UnsupportedOperationException();
+    }
   }
 
   /**


### PR DESCRIPTION
This sounds like a weird corner case, but it happens in one very prominent case, which is protobuf: it contains a `local_repository(path=".")` rule in its WORKSPACE file in order to work around the consequences of the uncomfortable fact that `@bazel_tools` depends on it.

If this was *not* done, when sibling repository layout is in effect, paths in the external repo would be resolved as ones in the main repo, thus causing "undeclared inclusion" errors when running C++ actions in the external repo.

This is not perfect (after all, it's ambiguous which Artifact such paths refer to), but seems to be good enough for protobuf and will go away once the `@bazel_tools -> @com_google_protobuf` dependency is cut or if bzlmod is turned on for good.

RELNOTES: None.
PiperOrigin-RevId: 634663132
Change-Id: Id45eaa9bdd7746b33166e838dbb834febbec9335

Commit https://github.com/bazelbuild/bazel/commit/7048ef5eb5395679241f2321a8104b26ecee01c0