### PR TITLE
[7.2.1] Fix crash on `IOException` in SingleExtensionEvalFunction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -946,7 +946,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
           } catch (IOException e1) {
             ExternalDepsException externalDepsException =
                 ExternalDepsException.withCauseAndMessage(
-                    ExternalDeps.Code.UNRECOGNIZED,
+                    ExternalDeps.Code.EXTERNAL_DEPS_UNKNOWN,
                     e1,
                     "Failed to clean up module context directory");
             throw new SingleExtensionEvalFunctionException(


### PR DESCRIPTION
Fixes #22688

Closes #22689.

PiperOrigin-RevId: 642286171
Change-Id: I0c872c06c6dcffb5b90520c492bee247970f42d7

Commit https://github.com/bazelbuild/bazel/commit/705cbb18656d3f314583db099d1e221eb0c9c9d7