### PR TITLE
[7.3.0] Treat missing repo boundary files as transient errors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -549,7 +549,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
     if (!WorkspaceFileHelper.isValidRepoRoot(destination)) {
       throw new RepositoryFunctionException(
           new IOException("No MODULE.bazel, REPO.bazel, or WORKSPACE file found in " + destination),
-          Transience.PERSISTENT);
+          Transience.TRANSIENT);
     }
     return RepositoryDirectoryValue.builder().setExcludeFromVendoring(true).setPath(source);
   }

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -513,6 +513,28 @@ class BazelOverridesTest(test_base.TestBase):
         'Target @@ss~//:choose_me up-to-date (nothing to build)', stderr
     )
 
+  def testLocalPathOverrideErrorResolved(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "module")',
+            'local_path_override(',
+            '  module_name = "module",',
+            '  path = "module",',
+            ')',
+        ],
+    )
+    self.ScratchFile('module/BUILD')
+
+    # MODULE.bazel file is missing
+    stderr, _, exit_code = self.RunBazel(
+        ['build', '@module//:all'], allow_failure=True
+    )
+    self.AssertNotExitCode(exit_code, 0, stderr)
+
+    self.ScratchFile('module/MODULE.bazel', ["module(name = 'module')"])
+    _, _, _ = self.RunBazel(['build', '@module//:all'])
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Fixes #22687

Closes #22700.

PiperOrigin-RevId: 642340825
Change-Id: I96f496b309c4740ae561f69098eca54a12a574f0

Commit https://github.com/bazelbuild/bazel/commit/b868a5919d28554dea614800e8fbb8bd9da3b401