### PR TITLE
[7.2.1] Fix an NPE with the compact execution log and coverage

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -213,7 +213,9 @@ public class CompactSpawnLogContext extends SpawnLogContext {
       builder.setInputSetId(logInputs(spawn, inputMetadataProvider, fileSystem));
       builder.setToolSetId(logTools(spawn, inputMetadataProvider, fileSystem));
 
-      builder.setTargetLabel(spawn.getTargetLabel().getCanonicalForm());
+      if (spawn.getTargetLabel() != null) {
+        builder.setTargetLabel(spawn.getTargetLabel().getCanonicalForm());
+      }
       builder.setMnemonic(spawn.getMnemonic());
 
       for (ActionInput output : spawn.getOutputFiles()) {


### PR DESCRIPTION
Fixes this issue when collecting coverage with the compact execution log:

```
Caused by: java.lang.NullPointerException: Cannot invoke "com.google.devtools.build.lib.cmdline.Label.getCanonicalForm()" because the return value of "com.google.devtools.build.lib.actions.Spawn.getTargetLabel()" is null
	at com.google.devtools.build.lib.exec.CompactSpawnLogContext.logSpawn(CompactSpawnLogContext.java:216)
	at com.google.devtools.build.lib.exec.AbstractSpawnStrategy.exec(AbstractSpawnStrategy.java:191)
	at com.google.devtools.build.lib.exec.AbstractSpawnStrategy.exec(AbstractSpawnStrategy.java:118)
	at com.google.devtools.build.lib.exec.SpawnStrategyResolver.exec(SpawnStrategyResolver.java:45)
	at com.google.devtools.build.lib.bazel.coverage.CoverageReportActionBuilder$CoverageReportAction.execute(CoverageReportActionBuilder.java:136)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.executeAction(SkyframeActionExecutor.java:1159)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.run(SkyframeActionExecutor.java:1076)
	at com.google.devtools.build.lib.skyframe.ActionExecutionState.runStateMachine(ActionExecutionState.java:165)
	at com.google.devtools.build.lib.skyframe.ActionExecutionState.getResultOrDependOnFuture(ActionExecutionState.java:94)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.executeAction(SkyframeActionExecutor.java:573)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.checkCacheAndExecuteIfNeeded(ActionExecutionFunction.java:859)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.computeInternal(ActionExecutionFunction.java:333)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.compute(ActionExecutionFunction.java:171)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:461)
```

Closes #22703.

PiperOrigin-RevId: 642384421
Change-Id: I2c3805f5d5ba250274f8da45bdc53b56a87c5f6c

Commit https://github.com/bazelbuild/bazel/commit/0dbfaccaf5bee5ea7f11c01db1fc0cd1ca7f3810