### PR TITLE
docs: fetch and vendor inherit options from test

### DIFF
--- a/site/en/run/bazelrc.md
+++ b/site/en/run/bazelrc.md
@@ -166,7 +166,7 @@ Option precedence:
     *   The following commands inherit from (and are more specific than)
         `build`: `test`, `run`, `clean`, `mobile-install`, `info`,
         `print_action`, `config`, `cquery`, and `aquery`
-    *   `coverage` inherits from `test`
+    *   `coverage`, `fetch`, and `vendor` inherit from `test`
 
 -   Two lines specifying options for the same command at equal specificity are
     parsed in the order in which they appear within the file.


### PR DESCRIPTION
See
https://github.com/bazelbuild/bazel/blob/0dbfaccaf5bee5ea7f11c01db1fc0cd1ca7f3810/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java#L59-L61 and
https://github.com/bazelbuild/bazel/blob/0dbfaccaf5bee5ea7f11c01db1fc0cd1ca7f3810/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java#L94-L96