### PR TITLE
add dependency_file_feature on macos features

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -1503,6 +1503,7 @@ def _impl(ctx):
         features = [
             macos_minimum_os_feature,
             macos_default_link_flags_feature,
+            dependency_file_feature,
             libtool_feature,
             archiver_flags_feature,
             asan_feature,


### PR DESCRIPTION
This patch add `dependency_file_feature` to features when OS is macos.

the feature `dependency_file_feature` added by default through `CppActionConfigs.java getLegacyFeatures`

https://github.com/bazelbuild/bazel/blob/0dbfaccaf5bee5ea7f11c01db1fc0cd1ca7f3810/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java#L93-L117

## Background

I modified `tools/cpp/unix_cc_toolchain_config.bzl` and found `dependency_file` not work on MacOS when testing https://github.com/bazelbuild/bazel/pull/19940 with new action name `c++20-deps-scanning` and `c++20-module-compile`. After adding `dependency_file_feature` to features, it works.

cc @comius 

