### PR TITLE
[7.3.0] Force use of Clang over C++ modules with `use_module_maps`

### DIFF
--- a/tools/cpp/BUILD.tpl
+++ b/tools/cpp/BUILD.tpl
@@ -113,6 +113,7 @@ cc_toolchain_config(
     coverage_compile_flags = [%{coverage_compile_flags}],
     coverage_link_flags = [%{coverage_link_flags}],
     supports_start_end_lib = %{supports_start_end_lib},
+    extra_flags_per_feature = %{extra_flags_per_feature},
 )
 
 # Android tooling requires a default toolchain for the armeabi-v7a cpu.


### PR DESCRIPTION
With `-std=c++20`, Clang defaults to using C++ modules rather than Clang modules, which can result in failures when using `layering_check` and thus `use_module_maps`.

Fixes https://github.com/bazel-contrib/toolchains_llvm/issues/334

Closes #22660.

PiperOrigin-RevId: 642548168
Change-Id: Ie1dd4c482d716635f7b6c53ffd3c5d84b6aa8cc2

Commit https://github.com/bazelbuild/bazel/commit/9e913fbfa2e3930742fc30dfb60ac5e2694c70cf