### PR TITLE
add compiler_input_flags_feature and compiler_output_flags_feature

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -401,6 +401,70 @@ def _impl(ctx):
         ],
     )
 
+    compiler_input_flags_feature = feature(
+        name = "compiler_input_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.lto_backend,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-c", "%{source_file}"],
+                        expand_if_available = "source_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    compiler_output_flags_feature = feature(
+        name = "compiler_output_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.lto_backend,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-S"],
+                        expand_if_available = "output_assembly_file",
+                    ),
+                    flag_group(
+                        flags = ["-E"],
+                        expand_if_available = "output_preprocess_file",
+                    ),
+                    flag_group(
+                        flags = ["-o", "%{output_file}"],
+                        expand_if_available = "output_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
     fdo_optimize_feature = feature(
         name = "fdo_optimize",
         flag_sets = [
@@ -1486,6 +1550,8 @@ def _impl(ctx):
             opt_feature,
             user_compile_flags_feature,
             sysroot_feature,
+            compiler_input_flags_feature,
+            compiler_output_flags_feature,
             unfiltered_compile_flags_feature,
             treat_warnings_as_errors_feature,
             archive_param_file_feature,
@@ -1526,6 +1592,8 @@ def _impl(ctx):
             opt_feature,
             user_compile_flags_feature,
             sysroot_feature,
+            compiler_input_flags_feature,
+            compiler_output_flags_feature,
             unfiltered_compile_flags_feature,
             treat_warnings_as_errors_feature,
             archive_param_file_feature,


### PR DESCRIPTION
This patch adds `compiler_input_flags_feature` and `compiler_output_flags_feature` to the features.

follow https://github.com/bazelbuild/bazel/pull/22717

By default, the features `compiler_input_flags_feature` and `compiler_output_flags_feature` are included through `CppActionConfigs.java` in the `getFeaturesToAppearLastInFeaturesList` method. 

For reference, see the relevant code here: 

https://github.com/bazelbuild/bazel/blob/0dbfaccaf5bee5ea7f11c01db1fc0cd1ca7f3810/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java#L1513-L1573


## Background



I modified `tools/cpp/unix_cc_toolchain_config.bzl` and found no input and output on macOS when testing https://github.com/bazelbuild/bazel/pull/19940 with the new action names `c++20-deps-scanning` and `c++20-module-compile`. 

As discussed in https://github.com/bazelbuild/bazel/pull/22429#discussion_r1610068395, I added these two features to `unix_cc_toolchain_config.bzl`.

the Windows toolchains already have these features, so no modifications were necessary for `windows_cc_toolchain_config.bzl`.

- Windows input flags:

https://github.com/bazelbuild/bazel/blob/786a893ef6f69a8f77ca008a478bf67abfdcdc57/tools/cpp/windows_cc_toolchain_config.bzl#L1073-L1095

- Windows output flags:

https://github.com/bazelbuild/bazel/blob/786a893ef6f69a8f77ca008a478bf67abfdcdc57/tools/cpp/windows_cc_toolchain_config.bzl#L960-L1020

cc @comius 
