### PR TITLE
[7.3.0] Don't try to bind mount non-existent paths in the sandbox.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -391,6 +391,11 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         getSandboxOptions().sandboxAdditionalMounts, sandboxExecRoot, userBindMounts);
 
     for (Path inaccessiblePath : getInaccessiblePaths()) {
+      if (!inaccessiblePath.exists()) {
+        // No need to make non-existent paths inaccessible (this would make the bind mount fail).
+        continue;
+      }
+
       if (inaccessiblePath.isDirectory(Symlinks.NOFOLLOW)) {
         userBindMounts.put(inaccessiblePath, inaccessibleHelperDir);
       } else {

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -93,7 +93,8 @@ EOF
 
   local output_file="bazel-genfiles/pkg/breaks.txt"
 
-  bazel build --sandbox_block_path="${block_path}" pkg:breaks \
+  bazel build --sandbox_block_path="${block_path}" \
+    --sandbox_block_path=/doesnotexist pkg:breaks \
     &> $TEST_log \
     && fail "Non-hermetic genrule succeeded: examples/genrule:breaks" || true
 


### PR DESCRIPTION
This would make the bind mount fail, which would cause the sandbox to be terminated.

Fixes https://github.com/bazelbuild/bazel/issues/4963

PiperOrigin-RevId: 643257634
Change-Id: I19d83ba2413a1d3c6606e7ea381dff2b71922e86

Commit https://github.com/bazelbuild/bazel/commit/b6bb80078633438be4c8b3537a0ec8d7f8ae3825