### PR TITLE
[7.3.0] Push `makeExecutable` down into `AbstractFileWriteAction` subclasses

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RepoMappingManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RepoMappingManifestAction.java
@@ -105,8 +105,7 @@ public final class RepoMappingManifestAction extends AbstractFileWriteAction
       NestedSet<SymlinkEntry> runfilesSymlinks,
       NestedSet<SymlinkEntry> runfilesRootSymlinks,
       String workspaceName) {
-    super(
-        owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), output, /* makeExecutable= */ false);
+    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), output);
     this.transitivePackages = transitivePackages;
     this.runfilesArtifacts = runfilesArtifacts;
     this.hasRunfilesSymlinks = !runfilesSymlinks.isEmpty();

--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -143,7 +143,7 @@ public final class SourceManifestAction extends AbstractFileWriteAction
       @Nullable Artifact repoMappingManifest,
       boolean remotableSourceManifestActions) {
     // The real set of inputs is computed in #getInputs().
-    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), primaryOutput, false);
+    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), primaryOutput);
     this.manifestWriter = manifestWriter;
     this.runfiles = runfiles;
     this.repoMappingManifest = repoMappingManifest;

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteAction.java
@@ -33,26 +33,20 @@ import javax.annotation.Nullable;
  * Abstract Action to write to a file.
  */
 public abstract class AbstractFileWriteAction extends AbstractAction {
-
-  protected final boolean makeExecutable;
-
   /**
    * Creates a new AbstractFileWriteAction instance.
    *
    * @param owner the action owner.
    * @param inputs the Artifacts that this Action depends on
    * @param output the Artifact that will be created by executing this Action.
-   * @param makeExecutable iff true will change the output file to be executable.
    */
-  public AbstractFileWriteAction(
-      ActionOwner owner, NestedSet<Artifact> inputs, Artifact output, boolean makeExecutable) {
+  public AbstractFileWriteAction(ActionOwner owner, NestedSet<Artifact> inputs, Artifact output) {
     // There is only one output, and it is primary.
     super(owner, inputs, ImmutableSet.of(output));
-    this.makeExecutable = makeExecutable;
   }
 
   public boolean makeExecutable() {
-    return makeExecutable;
+    return false;
   }
 
   @Override
@@ -64,7 +58,7 @@ public abstract class AbstractFileWriteAction extends AbstractAction {
           actionExecutionContext.getContext(FileWriteActionContext.class);
       ImmutableList<SpawnResult> result =
           context.writeOutputToFile(
-              this, actionExecutionContext, deterministicWriter, makeExecutable, isRemotable());
+              this, actionExecutionContext, deterministicWriter, makeExecutable(), isRemotable());
       afterWrite(actionExecutionContext);
       return ActionResult.create(result);
     } catch (ExecException e) {
@@ -95,7 +89,7 @@ public abstract class AbstractFileWriteAction extends AbstractAction {
 
   @Override
   protected String getRawProgressMessage() {
-    return (makeExecutable ? "Writing script " : "Writing file ")
+    return (makeExecutable() ? "Writing script " : "Writing file ")
         + Iterables.getOnlyElement(getOutputs()).prettyPrint();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/BinaryFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/BinaryFileWriteAction.java
@@ -29,7 +29,6 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.util.Fingerprint;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import javax.annotation.Nullable;
 
 /**
@@ -41,6 +40,7 @@ public final class BinaryFileWriteAction extends AbstractFileWriteAction {
   private static final String GUID = "eeee07fe-4b40-11e4-82d6-eba0b4f713e2";
 
   private final ByteSource source;
+  private final boolean makeExecutable;
 
   /**
    * Creates a new BinaryFileWriteAction instance without inputs.
@@ -52,8 +52,14 @@ public final class BinaryFileWriteAction extends AbstractFileWriteAction {
    */
   public BinaryFileWriteAction(
       ActionOwner owner, Artifact output, ByteSource source, boolean makeExecutable) {
-    super(owner, /*inputs=*/ NestedSetBuilder.emptySet(Order.STABLE_ORDER), output, makeExecutable);
+    super(owner, /* inputs= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER), output);
     this.source = Preconditions.checkNotNull(source);
+    this.makeExecutable = makeExecutable;
+  }
+
+  @Override
+  public boolean makeExecutable() {
+    return makeExecutable;
   }
 
   @VisibleForTesting
@@ -63,14 +69,11 @@ public final class BinaryFileWriteAction extends AbstractFileWriteAction {
 
   @Override
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
-    return new DeterministicWriter() {
-      @Override
-      public void writeOutputFile(OutputStream out) throws IOException {
-        try (InputStream in = source.openStream()) {
-          ByteStreams.copy(in, out);
-        }
-        out.flush();
+    return out -> {
+      try (InputStream in = source.openStream()) {
+        ByteStreams.copy(in, out);
       }
+      out.flush();
     };
   }
 
@@ -80,7 +83,7 @@ public final class BinaryFileWriteAction extends AbstractFileWriteAction {
       @Nullable ArtifactExpander artifactExpander,
       Fingerprint fp) {
     fp.addString(GUID);
-    fp.addString(String.valueOf(makeExecutable));
+    fp.addBoolean(makeExecutable());
 
     try (InputStream in = source.openStream()) {
       byte[] buffer = new byte[512];

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/FileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/FileWriteAction.java
@@ -69,6 +69,8 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
   /** Minimum length (in chars) for content to be eligible for compression. */
   private static final int COMPRESS_CHARS_THRESHOLD = 256;
 
+  private final boolean makeExecutable;
+
   /**
    * Creates a FileWriteAction to write contents to the resulting artifact fileName in the genfiles
    * root underneath the package path.
@@ -169,12 +171,18 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
       NestedSet<Artifact> inputs,
       Artifact primaryOutput,
       boolean makeExecutable) {
-    super(owner, inputs, primaryOutput, makeExecutable);
+    super(owner, inputs, primaryOutput);
+    this.makeExecutable = makeExecutable;
   }
 
   @Override
   public final String getFileContents(@Nullable EventHandler eventHandler) {
     return getFileContents();
+  }
+
+  @Override
+  public boolean makeExecutable() {
+    return makeExecutable;
   }
 
   /**
@@ -225,7 +233,7 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
         ActionKeyContext actionKeyContext,
         @Nullable ArtifactExpander artifactExpander,
         Fingerprint fp) {
-      fp.addString(GUID).addBoolean(makeExecutable).addString(getFileContents());
+      fp.addString(GUID).addBoolean(makeExecutable()).addString(getFileContents());
     }
   }
 
@@ -305,7 +313,7 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
         ActionKeyContext actionKeyContext,
         @Nullable ArtifactExpander artifactExpander,
         Fingerprint fp) {
-      fp.addString(GUID).addBoolean(makeExecutable).addBytes(compressedBytes);
+      fp.addString(GUID).addBoolean(makeExecutable()).addBytes(compressedBytes);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/LauncherFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/LauncherFileWriteAction.java
@@ -62,11 +62,15 @@ public final class LauncherFileWriteAction extends AbstractFileWriteAction {
     super(
         ruleContext.getActionOwner(),
         NestedSetBuilder.create(Order.STABLE_ORDER, Preconditions.checkNotNull(launcher)),
-        output,
-        /* makeExecutable= */ true);
+        output);
     this.launcher = launcher; // already null-checked in the superclass c'tor
     this.launchInfo = Preconditions.checkNotNull(launchInfo);
     this.isExecutedOnWindows = ruleContext.isExecutedOnWindows();
+  }
+
+  @Override
+  public boolean makeExecutable() {
+    return true;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWriteNestedSetOfTupleAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWriteNestedSetOfTupleAction.java
@@ -26,8 +26,6 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.util.Fingerprint;
-import java.io.IOException;
-import java.io.OutputStream;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.Tuple;
 
@@ -44,20 +42,14 @@ public final class LazyWriteNestedSetOfTupleAction extends AbstractFileWriteActi
 
   public LazyWriteNestedSetOfTupleAction(
       ActionOwner owner, Artifact output, NestedSet<Tuple> tuplesToWrite, String delimiter) {
-    super(
-        owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), output, /* makeExecutable= */ false);
+    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), output);
     this.tuplesToWrite = tuplesToWrite;
     this.delimiter = delimiter;
   }
 
   @Override
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
-    return new DeterministicWriter() {
-      @Override
-      public void writeOutputFile(OutputStream out) throws IOException {
-        out.write(getContents(delimiter).getBytes(UTF_8));
-      }
-    };
+    return out -> out.write(getContents(delimiter).getBytes(UTF_8));
   }
 
   /** Computes the Action key for this action by computing the fingerprint for the file contents. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWritePathsFileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWritePathsFileAction.java
@@ -27,8 +27,6 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.util.Fingerprint;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -64,7 +62,7 @@ public final class LazyWritePathsFileAction extends AbstractFileWriteAction {
       Function<Artifact, String> converter) {
     // We don't need to pass the given files as explicit inputs to this action; we don't care about
     // them, we only need their names, which we already know.
-    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), output, false);
+    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), output);
     this.files = files;
     this.includeDerivedArtifacts = includeDerivedArtifacts;
     this.filesToIgnore = filesToIgnore;
@@ -73,12 +71,7 @@ public final class LazyWritePathsFileAction extends AbstractFileWriteAction {
 
   @Override
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
-    return new DeterministicWriter() {
-      @Override
-      public void writeOutputFile(OutputStream out) throws IOException {
-        out.write(getContents().toString().getBytes(UTF_8));
-      }
-    };
+    return out -> out.write(getContents().getBytes(UTF_8));
   }
 
   /** Computes the Action key for this action by computing the fingerprint for the file contents. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
@@ -86,7 +86,7 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
       Artifact output,
       CommandLine commandLine,
       ParameterFileType type) {
-    super(owner, inputs, output, false);
+    super(owner, inputs, output);
     this.commandLine = commandLine;
     this.type = type;
     this.hasInputArtifactToExpand = !inputs.isEmpty();
@@ -174,7 +174,6 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
       Fingerprint fp)
       throws CommandLineExpansionException, InterruptedException {
     fp.addString(GUID);
-    fp.addString(String.valueOf(makeExecutable));
     fp.addString(type.toString());
     commandLine.addToFingerprint(actionKeyContext, artifactExpander, fp);
   }
@@ -184,8 +183,6 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
     StringBuilder message = new StringBuilder();
     message.append("GUID: ");
     message.append(GUID);
-    message.append("\nExecutable: ");
-    message.append(makeExecutable);
     message.append("\nParam File Type: ");
     message.append(type);
     message.append("\nContent digest (approximate): ");

--- a/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraActionInfoFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraActionInfoFileWriteAction.java
@@ -53,8 +53,7 @@ public final class ExtraActionInfoFileWriteAction extends AbstractFileWriteActio
         shadowedAction.discoversInputs()
             ? NestedSetBuilder.<Artifact>stableOrder().addAll(shadowedAction.getOutputs()).build()
             : NestedSetBuilder.<Artifact>emptySet(Order.STABLE_ORDER),
-        primaryOutput,
-        /*makeExecutable=*/ false);
+        primaryOutput);
 
     this.shadowedAction = Preconditions.checkNotNull(shadowedAction, primaryOutput);
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/BaselineCoverageAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/BaselineCoverageAction.java
@@ -33,8 +33,6 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintWriter;
 import javax.annotation.Nullable;
 
@@ -47,7 +45,7 @@ public final class BaselineCoverageAction extends AbstractFileWriteAction
 
   private BaselineCoverageAction(
       ActionOwner owner, NestedSet<Artifact> instrumentedFiles, Artifact primaryOutput) {
-    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), primaryOutput, false);
+    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), primaryOutput);
     this.instrumentedFiles = instrumentedFiles;
   }
 
@@ -68,16 +66,13 @@ public final class BaselineCoverageAction extends AbstractFileWriteAction
 
   @Override
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
-    return new DeterministicWriter() {
-      @Override
-      public void writeOutputFile(OutputStream out) throws IOException {
-        PrintWriter writer = new PrintWriter(out);
-        for (Artifact file : instrumentedFiles.toList()) {
-          writer.write("SF:" + file.getExecPathString() + "\n");
-          writer.write("end_of_record\n");
-        }
-        writer.flush();
+    return out -> {
+      PrintWriter writer = new PrintWriter(out);
+      for (Artifact file : instrumentedFiles.toList()) {
+        writer.write("SF:" + file.getExecPathString() + "\n");
+        writer.write("end_of_record\n");
       }
+      writer.flush();
     };
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDeployInfoAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidDeployInfoAction.java
@@ -67,11 +67,7 @@ public final class AndroidDeployInfoAction extends AbstractFileWriteAction {
       Artifact mergedManifest,
       ImmutableList<Artifact> additionalMergedManifests,
       ImmutableList<Artifact> apksToDeploy) {
-    super(
-        owner,
-        makeInputs(mergedManifest, additionalMergedManifests, apksToDeploy),
-        outputFile,
-        false);
+    super(owner, makeInputs(mergedManifest, additionalMergedManifests, apksToDeploy), outputFile);
     this.mergedManifest = mergedManifest;
     this.additionalMergedManifests = additionalMergedManifests;
     this.apksToDeploy = apksToDeploy;

--- a/src/main/java/com/google/devtools/build/lib/rules/android/WriteAdbArgsAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/WriteAdbArgsAction.java
@@ -118,7 +118,7 @@ public final class WriteAdbArgsAction extends AbstractFileWriteAction {
   }
 
   public WriteAdbArgsAction(ActionOwner owner, Artifact outputFile) {
-    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), outputFile, false);
+    super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), outputFile);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppModuleMapAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppModuleMapAction.java
@@ -29,7 +29,6 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -85,12 +84,7 @@ public final class CppModuleMapAction extends AbstractFileWriteAction {
             .addAll(Iterables.filter(privateHeaders, Artifact::isTreeArtifact))
             .addAll(Iterables.filter(publicHeaders, Artifact::isTreeArtifact))
             .build(),
-        cppModuleMap.getArtifact(),
-        // In theory, module maps should not be executable but, in practice, we don't care. As
-        // 'executable' is the default (see
-        // ActionOutputMetadataStore.setPathReadOnlyAndExecutable()),
-        // we want to avoid the extra file operation of making this file non-executable.
-        /* makeExecutable= */ true);
+        cppModuleMap.getArtifact());
     this.cppModuleMap = cppModuleMap;
     this.moduleMapHomeIsCwd = moduleMapHomeIsCwd;
     this.privateHeaders = ImmutableList.copyOf(privateHeaders);
@@ -104,117 +98,124 @@ public final class CppModuleMapAction extends AbstractFileWriteAction {
   }
 
   @Override
-  public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx)  {
+  public boolean makeExecutable() {
+    // In theory, module maps should not be executable but, in practice, we don't care. As
+    // 'executable' is the default (see ActionOutputMetadataStore.setPathReadOnlyAndExecutable()),
+    // we want to avoid the extra file operation of making this file non-executable.
+    // Note that the opposite is true for Bazel: making a file executable results in an extra file
+    // operation in com.google.devtools.build.lib.exec.FileWriteStrategy.
+    return true;
+  }
+
+  @Override
+  public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
     final ArtifactExpander artifactExpander = ctx.getArtifactExpander();
-    return new DeterministicWriter() {
-      @Override
-      public void writeOutputFile(OutputStream out) throws IOException {
-        OutputStreamWriter content = new OutputStreamWriter(out, StandardCharsets.ISO_8859_1);
-        PathFragment fragment = cppModuleMap.getArtifact().getExecPath();
-        int segmentsToExecPath = fragment.segmentCount() - 1;
-        Optional<Artifact> umbrellaHeader = cppModuleMap.getUmbrellaHeader();
-        String leadingPeriods = moduleMapHomeIsCwd ? "" : "../".repeat(segmentsToExecPath);
+    return out -> {
+      OutputStreamWriter content = new OutputStreamWriter(out, StandardCharsets.ISO_8859_1);
+      PathFragment fragment = cppModuleMap.getArtifact().getExecPath();
+      int segmentsToExecPath = fragment.segmentCount() - 1;
+      Optional<Artifact> umbrellaHeader = cppModuleMap.getUmbrellaHeader();
+      String leadingPeriods = moduleMapHomeIsCwd ? "" : "../".repeat(segmentsToExecPath);
 
-        Iterable<Artifact> separateModuleHdrs =
-            expandedHeaders(artifactExpander, separateModuleHeaders);
+      Iterable<Artifact> separateModuleHdrs =
+          expandedHeaders(artifactExpander, separateModuleHeaders);
 
-        // For details about the different header types, see:
-        // http://clang.llvm.org/docs/Modules.html#header-declaration
-        content.append("module \"").append(cppModuleMap.getName()).append("\" {\n");
-        content.append("  export *\n");
+      // For details about the different header types, see:
+      // http://clang.llvm.org/docs/Modules.html#header-declaration
+      content.append("module \"").append(cppModuleMap.getName()).append("\" {\n");
+      content.append("  export *\n");
 
-        HashSet<PathFragment> deduper = new HashSet<>();
-        if (umbrellaHeader.isPresent()) {
+      HashSet<PathFragment> deduper = new HashSet<>();
+      if (umbrellaHeader.isPresent()) {
+        appendHeader(
+            content,
+            "",
+            umbrellaHeader.get().getExecPath(),
+            leadingPeriods,
+            /* canCompile= */ false,
+            deduper,
+            /*isUmbrellaHeader*/ true);
+      } else {
+        for (Artifact artifact : expandedHeaders(artifactExpander, publicHeaders)) {
           appendHeader(
               content,
               "",
-              umbrellaHeader.get().getExecPath(),
+              artifact.getExecPath(),
               leadingPeriods,
-              /*canCompile=*/ false,
+              /* canCompile= */ true,
               deduper,
-              /*isUmbrellaHeader*/ true);
-        } else {
-          for (Artifact artifact : expandedHeaders(artifactExpander, publicHeaders)) {
-            appendHeader(
-                content,
-                "",
-                artifact.getExecPath(),
-                leadingPeriods,
-                /*canCompile=*/ true,
-                deduper,
-                /*isUmbrellaHeader*/ false);
-          }
-          for (Artifact artifact : expandedHeaders(artifactExpander, privateHeaders)) {
-            appendHeader(
-                content,
-                "private",
-                artifact.getExecPath(),
-                leadingPeriods,
-                /*canCompile=*/ true,
-                deduper,
-                /*isUmbrellaHeader*/ false);
-          }
-          for (Artifact artifact : separateModuleHdrs) {
-            appendHeader(
-                content,
-                "",
-                artifact.getExecPath(),
-                leadingPeriods,
-                /*canCompile=*/ false,
-                deduper,
-                /*isUmbrellaHeader*/ false);
-          }
-          for (PathFragment additionalExportedHeader : additionalExportedHeaders) {
-            appendHeader(
-                content,
-                "",
-                additionalExportedHeader,
-                leadingPeriods,
-                /*canCompile*/ false,
-                deduper,
-                /*isUmbrellaHeader*/ false);
-          }
+              /*isUmbrellaHeader*/ false);
+        }
+        for (Artifact artifact : expandedHeaders(artifactExpander, privateHeaders)) {
+          appendHeader(
+              content,
+              "private",
+              artifact.getExecPath(),
+              leadingPeriods,
+              /* canCompile= */ true,
+              deduper,
+              /*isUmbrellaHeader*/ false);
+        }
+        for (Artifact artifact : separateModuleHdrs) {
+          appendHeader(
+              content,
+              "",
+              artifact.getExecPath(),
+              leadingPeriods,
+              /* canCompile= */ false,
+              deduper,
+              /*isUmbrellaHeader*/ false);
+        }
+        for (PathFragment additionalExportedHeader : additionalExportedHeaders) {
+          appendHeader(
+              content,
+              "",
+              additionalExportedHeader,
+              leadingPeriods,
+              /*canCompile*/ false,
+              deduper,
+              /*isUmbrellaHeader*/ false);
+        }
+      }
+      for (CppModuleMap dep : dependencies) {
+        content.append("  use \"").append(dep.getName()).append("\"\n");
+      }
+
+      if (!Iterables.isEmpty(separateModuleHdrs)) {
+        String separateName = cppModuleMap.getName() + CppModuleMap.SEPARATE_MODULE_SUFFIX;
+        content.append("  use \"").append(separateName).append("\"\n");
+        content.append("}\n");
+        content.append("module \"").append(separateName).append("\" {\n");
+        content.append("  export *\n");
+        deduper = new HashSet<>();
+        for (Artifact artifact : separateModuleHdrs) {
+          appendHeader(
+              content,
+              "",
+              artifact.getExecPath(),
+              leadingPeriods,
+              /* canCompile= */ true,
+              deduper,
+              /*isUmbrellaHeader*/ false);
         }
         for (CppModuleMap dep : dependencies) {
           content.append("  use \"").append(dep.getName()).append("\"\n");
         }
-
-        if (!Iterables.isEmpty(separateModuleHdrs)) {
-          String separateName = cppModuleMap.getName() + CppModuleMap.SEPARATE_MODULE_SUFFIX;
-          content.append("  use \"").append(separateName).append("\"\n");
-          content.append("}\n");
-          content.append("module \"").append(separateName).append("\" {\n");
-          content.append("  export *\n");
-          deduper = new HashSet<>();
-          for (Artifact artifact : separateModuleHdrs) {
-            appendHeader(
-                content,
-                "",
-                artifact.getExecPath(),
-                leadingPeriods,
-                /*canCompile=*/ true,
-                deduper,
-                /*isUmbrellaHeader*/ false);
-          }
-          for (CppModuleMap dep : dependencies) {
-            content.append("  use \"").append(dep.getName()).append("\"\n");
-          }
-        }
-        content.append("}");
-
-        if (externDependencies) {
-          for (CppModuleMap dep : dependencies) {
-            content
-                .append("\nextern module \"")
-                .append(dep.getName())
-                .append("\" \"")
-                .append(leadingPeriods)
-                .append(dep.getArtifact().getExecPathString())
-                .append("\"");
-          }
-        }
-        content.flush();
       }
+      content.append("}");
+
+      if (externDependencies) {
+        for (CppModuleMap dep : dependencies) {
+          content
+              .append("\nextern module \"")
+              .append(dep.getName())
+              .append("\" \"")
+              .append(leadingPeriods)
+              .append(dep.getArtifact().getExecPathString())
+              .append("\"");
+        }
+      }
+      content.flush();
     };
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
@@ -379,8 +379,7 @@ public class GenQuery implements RuleConfiguredTargetFactory {
     private final GenQueryResult result;
 
     private QueryResultAction(ActionOwner owner, Artifact output, GenQueryResult result) {
-      super(
-          owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), output, /*makeExecutable=*/ false);
+      super(owner, NestedSetBuilder.emptySet(Order.STABLE_ORDER), output);
       this.result = result;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PyBuiltins.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PyBuiltins.java
@@ -444,11 +444,7 @@ public abstract class PyBuiltins implements StarlarkValue {
     private static final String GUID = "67513fa7-3824-493b-aeab-95a8b778ea07";
 
     CopyWithoutCachingAction(ActionOwner owner, Artifact readFrom, Artifact writeTo) {
-      super(
-          owner,
-          NestedSetBuilder.create(Order.STABLE_ORDER, readFrom),
-          writeTo,
-          /* makeExecutable= */ false);
+      super(owner, NestedSetBuilder.create(Order.STABLE_ORDER, readFrom), writeTo);
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteActionTest.java
@@ -108,16 +108,22 @@ public final class AbstractFileWriteActionTest {
   private static class TestFileWriteAction extends AbstractFileWriteAction {
     private final DeterministicWriter deterministicWriter;
     private final boolean isRemotable;
+    private final boolean makeExecutable;
 
     TestFileWriteAction(
         DeterministicWriter deterministicWriter, boolean executable, boolean isRemotable) {
       super(
           ActionsTestUtil.NULL_ACTION_OWNER,
-          /*inputs=*/ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
-          /*output=*/ ActionsTestUtil.DUMMY_ARTIFACT,
-          executable);
+          /* inputs= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+          /* output= */ ActionsTestUtil.DUMMY_ARTIFACT);
       this.deterministicWriter = deterministicWriter;
+      this.makeExecutable = executable;
       this.isRemotable = isRemotable;
+    }
+
+    @Override
+    public boolean makeExecutable() {
+      return makeExecutable;
     }
 
     @Override


### PR DESCRIPTION
Getting rid of the single boolean field on `AbstractFileWriteAction` reduces padding on each subclass instance and in particular frees up a 4-byte field on `CppModuleMapAction`.

Also use a lambda to define `newDeterministicWriter` if possible for improved readability.

This prepares for future changes that will add fields to `CppModuleMapAction` to support path mapping.

Work towards #6526

Closes #22609.

PiperOrigin-RevId: 643340715
Change-Id: Id3af26049098e6dfa731f0e7a1be6709bea0d9f2

Commit https://github.com/bazelbuild/bazel/commit/f8a7a61f0b7bb2f56c2b26fddae2423dec4f1fc8