### PR TITLE
[7.3.0] Ensure that downloads are cancelled on repo rule restart

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -932,6 +932,18 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
               env.getListener(),
               envVariables,
               getIdentifyingStringForLogging());
+      // Ensure that the download is cancelled if the repo rule is restarted as it runs in its own
+      // executor.
+      PendingDownload pendingTask =
+          new PendingDownload(
+              /* executable= */ false,
+              allowFail,
+              outputPath,
+              checksum,
+              checksumValidation,
+              pendingDownload,
+              thread.getCallerLocation());
+      registerAsyncTask(pendingTask);
       downloadedPath = downloadManager.finalizeDownload(pendingDownload);
     } catch (IOException e) {
       env.getListener().post(w);


### PR DESCRIPTION
When a repository rule is restarted due to memory pressure, all its downloads must be interrupted. While this happened for `repository_ctx.download`, the `download_and_extract` method did not register its `PendingTask`. Since downloads happen on a separate executor, they would continue even through restarts, leading to warnings (see below) or even left over download temp directories.

```
WARNING: Download from https://github.com/uutils/coreutils/releases/download/0.0.26/coreutils-0.0.26-aarch64-apple-darwin.tar.gz failed: class java.io.FileNotFoundException /private/var/tmp/_bazel_fmeum/0465a0857e26a35c072f48ab751a1794/external/aspect_bazel_lib~~toolchains~coreutils_darwin_arm64/temp2576567839043404337/coreutils-0.0.26-aarch64-apple-darwin.tar.gz (No such file or directory)
```

Closes #22748.

PiperOrigin-RevId: 643389876
Change-Id: Ia2cab4b4d73340379c17d4a1e5c327ff43505050

Commit https://github.com/bazelbuild/bazel/commit/2fb187f0af286a4c4e38421481676162452d5d9e