### PR TITLE
Be more precise about where to read the URL rewriter config from

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -385,7 +385,7 @@ public class BazelRepositoryModule extends BlazeModule {
       }
       try {
         UrlRewriter rewriter =
-            UrlRewriter.getDownloaderUrlRewriter(repoOptions.downloaderConfig, env.getReporter());
+            UrlRewriter.getDownloaderUrlRewriter(env.getWorkspace(), repoOptions.downloaderConfig, env.getReporter());
         downloadManager.setUrlRewriter(rewriter);
       } catch (UrlRewriterParseException e) {
         // It's important that the build stops ASAP, because this config file may be required for

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -41,7 +41,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
@@ -94,22 +93,16 @@ public class UrlRewriter {
       return new UrlRewriter(log, "", new StringReader(""));
     }
 
-    // If the `configPath` is absolute, use that. Otherwise, prepend the `workspaceRoot`.
     // There have been reports (eg. https://github.com/bazelbuild/bazel/issues/22104) that
     // there are occasional errors when `configFile` can't be found, and when this happens
     // investigation suggests that the current working directory isn't the workspace root.
-    Path actualConfigPath;
-    if (Paths.get(configPath).isAbsolute()) {
-      actualConfigPath = workspaceRoot.getFileSystem().getPath(configPath);
-    } else {
-      actualConfigPath = workspaceRoot.getRelative(configPath);
-    }
+    Path actualConfigPath = workspaceRoot.getRelative(configPath);
 
     if (!actualConfigPath.exists()) {
       throw new UrlRewriterParseException(String.format("Unable to find downloader config file %s", configPath));
     }
 
-    try (BufferedReader reader = Files.newBufferedReader(Paths.get(configPath))) {
+    try (BufferedReader reader = Files.newBufferedReader(actualConfigPath.getPathFile().toPath())) {
       return new UrlRewriter(log, configPath, reader);
     } catch (IOException e) {
       throw new UrlRewriterParseException(e.getMessage());


### PR DESCRIPTION
There is an [open issue](https://github.com/bazelbuild/bazel/issues/22104) where bazel will occasionally fail at start up time because it is unable to parse the downloader config. While I've yet to create a reliable reproduction for this issue, the one time I've triggered this error with a build with additional logging, it seemed to be because the current working directory wasn't the root of the workspace. While I'm not sure this will actually fully resolve the problem (since I don't know what's causing it) being clearer about where the config file is meant to be can only be a Good Thing.

Addresses #22104 