### PR TITLE
Enforce and await cleanup in `StarlarkBaseExternalContext`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
@@ -83,6 +83,13 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
   }
 
   @Override
+  protected boolean shouldDeleteWorkingDirectory(boolean successful) {
+    // The contents of the working directory are purely ephemeral, only the repos instantiated by
+    // the extension are considered its results.
+    return true;
+  }
+
+  @Override
   protected String getIdentifyingStringForLogging() {
     return ModuleExtensionEvaluationProgress.moduleExtensionEvaluationContextString(extensionId);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
@@ -71,6 +71,7 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
         timeoutScaling,
         processWrapper,
         starlarkSemantics,
+        ModuleExtensionEvaluationProgress.moduleExtensionEvaluationContextString(extensionId),
         remoteExecutor,
         /* allowWatchingPathsOutsideWorkspace= */ false);
     this.extensionId = extensionId;
@@ -83,15 +84,10 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
   }
 
   @Override
-  protected boolean shouldDeleteWorkingDirectory(boolean successful) {
+  protected boolean shouldDeleteWorkingDirectoryOnClose(boolean successful) {
     // The contents of the working directory are purely ephemeral, only the repos instantiated by
     // the extension are considered its results.
     return true;
-  }
-
-  @Override
-  protected String getIdentifyingStringForLogging() {
-    return ModuleExtensionEvaluationProgress.moduleExtensionEvaluationContextString(extensionId);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -938,6 +938,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
           // Restart by returning null.
           return null;
         }
+        moduleContext.markSuccessful();
         return RunModuleExtensionResult.create(
             moduleContext.getRecordedFileInputs(),
             moduleContext.getRecordedDirentsInputs(),

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -132,6 +132,11 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
   }
 
   @Override
+  protected boolean shouldDeleteWorkingDirectory(boolean successful) {
+    return !successful;
+  }
+
+  @Override
   protected String getIdentifyingStringForLogging() {
     return RepositoryFetchProgress.repositoryFetchContextString(repoName);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -77,7 +77,6 @@ import net.starlark.java.eval.StarlarkThread;
             + " repository rule.")
 public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
   private final Rule rule;
-  private final RepositoryName repoName;
   private final PathPackageLocator packageLocator;
   private final StructImpl attrObject;
   private final ImmutableSet<PathFragment> ignoredPatterns;
@@ -112,10 +111,11 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
         timeoutScaling,
         processWrapper,
         starlarkSemantics,
+        RepositoryFetchProgress.repositoryFetchContextString(
+            RepositoryName.createUnvalidated(rule.getName())),
         remoteExecutor,
         /* allowWatchingPathsOutsideWorkspace= */ true);
     this.rule = rule;
-    this.repoName = RepositoryName.createUnvalidated(rule.getName());
     this.packageLocator = packageLocator;
     this.ignoredPatterns = ignoredPatterns;
     this.syscallCache = syscallCache;
@@ -132,13 +132,8 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
   }
 
   @Override
-  protected boolean shouldDeleteWorkingDirectory(boolean successful) {
+  protected boolean shouldDeleteWorkingDirectoryOnClose(boolean successful) {
     return !successful;
-  }
-
-  @Override
-  protected String getIdentifyingStringForLogging() {
-    return RepositoryFetchProgress.repositoryFetchContextString(repoName);
   }
 
   public ImmutableMap<RepoRecordedInput.DirTree, String> getRecordedDirTreeInputs() {
@@ -222,7 +217,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
         WorkspaceRuleEvent.newSymlinkEvent(
             targetPath.toString(),
             linkPath.toString(),
-            getIdentifyingStringForLogging(),
+            identifyingStringForLogging,
             thread.getCallerLocation());
     env.getListener().post(w);
     try {
@@ -314,7 +309,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
             t.toString(),
             substitutionMap,
             executable,
-            getIdentifyingStringForLogging(),
+            identifyingStringForLogging,
             thread.getCallerLocation());
     env.getListener().post(w);
     if (t.isDir()) {
@@ -379,7 +374,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     StarlarkPath starlarkPath = externalPath("delete()", pathObject);
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newDeleteEvent(
-            starlarkPath.toString(), getIdentifyingStringForLogging(), thread.getCallerLocation());
+            starlarkPath.toString(), identifyingStringForLogging, thread.getCallerLocation());
     env.getListener().post(w);
     try {
       Path path = starlarkPath.getPath();
@@ -437,7 +432,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
         WorkspaceRuleEvent.newPatchEvent(
             starlarkPath.toString(),
             strip,
-            getIdentifyingStringForLogging(),
+            identifyingStringForLogging,
             thread.getCallerLocation());
     env.getListener().post(w);
     if (starlarkPath.isDir()) {
@@ -548,7 +543,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
             output.toString(),
             stripPrefix,
             renameFilesMap,
-            getIdentifyingStringForLogging(),
+            identifyingStringForLogging,
             thread.getCallerLocation());
     env.getListener().post(w);
 
@@ -558,7 +553,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
                 outputPath.getPath().toString(), "Extracting " + archivePath.getBasename()));
     DecompressorValue.decompress(
         DecompressorDescriptor.builder()
-            .setContext(getIdentifyingStringForLogging())
+            .setContext(identifyingStringForLogging)
             .setArchivePath(archivePath.getPath())
             .setDestinationPath(outputPath.getPath())
             .setPrefix(stripPrefix)

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -781,7 +781,7 @@ public class HttpDownloaderTest {
       Map<String, String> clientEnv,
       String context)
       throws IOException, InterruptedException {
-    try (ExecutorService executorService = Executors.newSingleThreadExecutor()) {
+    try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
       Future<Path> future =
           downloadManager.startDownload(
               executorService,

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -1035,6 +1035,37 @@ class BazelModuleTest(test_base.TestBase):
         'rule //:foo @other_module//:bar @@canonical_name//:baz', stderr
     )
 
+  def testPendingDownloadDetected(self):
+    self.ScratchFile(
+      'MODULE.bazel',
+      [
+        'ext = use_extension("extensions.bzl", "ext")',
+        'use_repo(ext, "ext")',
+      ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile(
+      'extensions.bzl',
+      [
+        'def _rule_impl(ctx):',
+        '  ctx.file("REPO.bazel")',
+        '  ctx.file("BUILD")',
+        'repo_rule = repository_rule(_rule_impl)',
+        'def ext_impl(module_ctx):',
+        '  repo_rule(name = "ext")',
+        '  module_ctx.download(url = "https://bcr.bazel.build", output = "download", block = False)',
+        'ext = module_extension(implementation = ext_impl)',
+      ],
+    )
+    exit_code, _, stderr = self.RunBazel(
+      ['build', '--nobuild', '@ext//:all'],
+      allow_failure=True,
+    )
+    self.AssertExitCode(exit_code, 48, stderr)
+    self.assertIn(
+      'ERROR: Pending asynchronous work after module extension ext in @@//:extensions.bzl finished execution',
+      stderr,
+    )
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -1047,10 +1047,7 @@ class BazelModuleTest(test_base.TestBase):
     self.ScratchFile(
       'extensions.bzl',
       [
-        'def _rule_impl(ctx):',
-        '  ctx.file("REPO.bazel")',
-        '  ctx.file("BUILD")',
-        'repo_rule = repository_rule(_rule_impl)',
+        'repo_rule = repository_rule(lambda _: None)',
         'def ext_impl(module_ctx):',
         '  repo_rule(name = "ext")',
         '  module_ctx.download(url = "https://bcr.bazel.build", output = "download", block = False)',
@@ -1066,6 +1063,7 @@ class BazelModuleTest(test_base.TestBase):
       'ERROR: Pending asynchronous work after module extension ext in @@//:extensions.bzl finished execution',
       stderr,
     )
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
`StarlarkBaseExternalContext` now implements `AutoCloseable` and, in `close()`:
1. Cancels all pending async tasks.
2. Awaits their termination.
3. Cleans up the working directory (always for module extensions, on failure for repo rules).
4. Fails if there were pending async tasks in an otherwise successful evaluation.

Previously, module extensions didn't do any of those. Repo rules did 1 and 4 and sometimes 3, but not in all cases.

This change required replacing the fixed-size thread pool in `DownloadManager` with virtual threads, thereby resolving a TODO about not using a fixed-size thread pool for the `GrpcRemoteDownloader`.

Work towards #22680
Work towards #22748