### PR TITLE
Do not eval WORKSPACE in LocalRepositoryLookupFunction when `--noenable_workspace`

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -1035,6 +1035,12 @@ class BazelModuleTest(test_base.TestBase):
         'rule //:foo @other_module//:bar @@canonical_name//:baz', stderr
     )
 
+  def testRegression22754(self):
+    """Regression test for issue #22754."""
+    self.ScratchFile('BUILD.bazel', ['print(glob(["testdata/**"]))'])
+    self.ScratchFile('testdata/WORKSPACE')
+    self.RunBazel(['build', ':all'])
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
This still leaves the question of "what do we do instead?". See issues #22208 and #21515.

Fixes https://github.com/bazelbuild/bazel/issues/22754.