### PR TITLE
[7.3.0] Allow discard previous overrides for --override_repository and --override_module

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -460,6 +460,10 @@ public class BazelRepositoryModule extends BlazeModule {
         // We use a LinkedHashMap to preserve the iteration order.
         Map<RepositoryName, PathFragment> overrideMap = new LinkedHashMap<>();
         for (RepositoryOverride override : repoOptions.repositoryOverrides) {
+          if (override.path().isEmpty()) {
+            overrideMap.remove(override.repositoryName());
+            continue;
+          }
           String repoPath = getAbsolutePath(override.path(), env);
           overrideMap.put(override.repositoryName(), PathFragment.create(repoPath));
         }
@@ -474,6 +478,10 @@ public class BazelRepositoryModule extends BlazeModule {
       if (repoOptions.moduleOverrides != null) {
         Map<String, ModuleOverride> moduleOverrideMap = new LinkedHashMap<>();
         for (RepositoryOptions.ModuleOverride override : repoOptions.moduleOverrides) {
+          if (override.path().isEmpty()) {
+            moduleOverrideMap.remove(override.moduleName());
+            continue;
+          }
           String modulePath = getAbsolutePath(override.path(), env);
           moduleOverrideMap.put(override.moduleName(), LocalPathOverride.create(modulePath));
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -171,7 +171,8 @@ public class RepositoryOptions extends OptionsBase {
               + " given path is an absolute path, it will be used as it is. If the given path is a"
               + " relative path, it is relative to the current working directory. If the given path"
               + " starts with '%workspace%, it is relative to the workspace root, which is the"
-              + " output of `bazel info workspace`")
+              + " output of `bazel info workspace`. If the given path is empty, then remove any"
+              + " previous overrides.")
   public List<RepositoryOverride> repositoryOverrides;
 
   @Option(
@@ -186,7 +187,8 @@ public class RepositoryOptions extends OptionsBase {
               + " path is an absolute path, it will be used as it is. If the given path is a"
               + " relative path, it is relative to the current working directory. If the given path"
               + " starts with '%workspace%, it is relative to the workspace root, which is the"
-              + " output of `bazel info workspace`")
+              + " output of `bazel info workspace`. If the given path is empty, then remove any"
+              + " previous overrides.")
   public List<ModuleOverride> moduleOverrides;
 
   @Option(

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -478,6 +478,27 @@ class BazelOverridesTest(test_base.TestBase):
         'Target @@ss~//:choose_me up-to-date (nothing to build)', stderr
     )
 
+    # Test delete previous overrides
+    _, _, stderr = self.RunBazel(
+        [
+            'build',
+            '--announce_rc',
+            '@ss//:all',
+            '--override_module',
+            'ss=../../bb',
+            '--override_module',
+            'ss=',
+            '--enable_bzlmod',
+        ],
+        cwd=self.Path('aa/cc'),
+        allow_failure=True,
+    )
+    self.assertIn(
+        'ERROR: Error computing the main repository mapping: module not found'
+        ' in registries: ss@1.0',
+        stderr,
+    )
+
   def testCmdWorkspaceRelativeModuleOverride(self):
     self.ScratchFile(
         'MODULE.bazel',


### PR DESCRIPTION
`--override_module=foo=` will discard previous overrides specified by this option.

Closes #22751.

PiperOrigin-RevId: 644253498
Change-Id: If723756433545bfc875d7f877d596f2e3f041464

Commit https://github.com/bazelbuild/bazel/commit/82e31358549f7614497bf9d9fe8d16415a49eece