### PR TITLE
Do not fail a sandboxed spawn for missing execution statistics

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -46,7 +46,6 @@ import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.Sandbox.Code;
-import com.google.devtools.build.lib.shell.ExecutionStatistics;
 import com.google.devtools.build.lib.shell.Subprocess;
 import com.google.devtools.build.lib.shell.SubprocessBuilder;
 import com.google.devtools.build.lib.shell.TerminationStatus;
@@ -309,28 +308,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
 
     Path statisticsPath = sandbox.getStatisticsPath();
     if (statisticsPath != null) {
-      ExecutionStatistics.getResourceUsage(statisticsPath)
-          .ifPresent(
-              resourceUsage -> {
-                spawnResultBuilder.setUserTimeInMs(
-                    (int) resourceUsage.getUserExecutionTime().toMillis());
-                spawnResultBuilder.setSystemTimeInMs(
-                    (int) resourceUsage.getSystemExecutionTime().toMillis());
-                spawnResultBuilder.setNumBlockOutputOperations(
-                    resourceUsage.getBlockOutputOperations());
-                spawnResultBuilder.setNumBlockInputOperations(
-                    resourceUsage.getBlockInputOperations());
-                spawnResultBuilder.setNumInvoluntaryContextSwitches(
-                    resourceUsage.getInvoluntaryContextSwitches());
-                // The memory usage of the largest child process. For Darwin maxrss returns size in
-                // bytes.
-                if (OS.getCurrent() == OS.DARWIN) {
-                  spawnResultBuilder.setMemoryInKb(
-                      resourceUsage.getMaximumResidentSetSize() / 1000);
-                } else {
-                  spawnResultBuilder.setMemoryInKb(resourceUsage.getMaximumResidentSetSize());
-                }
-              });
+      spawnResultBuilder.setResourceUsageFromProto(statisticsPath);
     }
 
     return spawnResultBuilder.build();

--- a/src/main/java/com/google/devtools/build/lib/shell/ExecutionStatistics.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/ExecutionStatistics.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.shell;
 
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
@@ -31,11 +32,6 @@ public final class ExecutionStatistics {
    */
   public static Optional<ResourceUsage> getResourceUsage(Path executionStatisticsProtoPath)
       throws IOException {
-    if (!executionStatisticsProtoPath.exists()) {
-      // Collecting resource usage is best-effort and the file may be missing if the wrapper around
-      // the command terminated abnormally.
-      return Optional.empty();
-    }
     try (InputStream protoInputStream =
         new BufferedInputStream(executionStatisticsProtoPath.getInputStream())) {
       Protos.ExecutionStatistics executionStatisticsProto =
@@ -45,6 +41,10 @@ public final class ExecutionStatistics {
       } else {
         return Optional.empty();
       }
+    } catch (FileNotFoundException e) {
+      // Collecting resource usage is best-effort and the file may be missing if the wrapper around
+      // the command terminated abnormally.
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/shell/ExecutionStatistics.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/ExecutionStatistics.java
@@ -31,6 +31,11 @@ public final class ExecutionStatistics {
    */
   public static Optional<ResourceUsage> getResourceUsage(Path executionStatisticsProtoPath)
       throws IOException {
+    if (!executionStatisticsProtoPath.exists()) {
+      // Collecting resource usage is best-effort and the file may be missing if the wrapper around
+      // the command terminated abnormally.
+      return Optional.empty();
+    }
     try (InputStream protoInputStream =
         new BufferedInputStream(executionStatisticsProtoPath.getInputStream())) {
       Protos.ExecutionStatistics executionStatisticsProto =

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -728,6 +728,7 @@ public abstract class FileSystem {
   /**
    * Creates an InputStream accessing the file denoted by the path.
    *
+   * @throws FileNotFoundException if the file does not exist
    * @throws IOException if there was an error opening the file for reading
    */
   protected abstract InputStream getInputStream(PathFragment path) throws IOException;


### PR DESCRIPTION
This was already the case for "local" spawns. Statistics may be missing if the spawn wrapper exits abnormally.

Fixes #22151