### PR TITLE
[7.3.0] Retry on connection reset error for http cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -200,7 +200,7 @@ public final class RemoteModule extends BlazeModule {
                   || status == HttpResponseStatus.GATEWAY_TIMEOUT.code();
         } else if (e instanceof IOException) {
           String msg = Ascii.toLowerCase(e.getMessage());
-          if (msg.contains("connection reset by peer")) {
+          if (msg.contains("connection reset")) {
             retry = true;
           } else if (msg.contains("operation timed out")) {
             retry = true;


### PR DESCRIPTION
Previously, it only retries when we have error whose message contains "connection reset by peer". In some cases, we could also have message like "Connection reset", e.g. https://buildkite.com/bazel/bazel-bazel-macos-ninja/builds/1827#01902690-f35a-4f3d-9166-7b39c1f885fb.

PiperOrigin-RevId: 644325070
Change-Id: I75500646b35681fda25e584ec5d6ec3348cee9a5