### PR TITLE
[7.3.0] Use the generic term "config file" instead of the product-specific ".blazerc" in error messages.

### DIFF
--- a/src/main/cpp/rc_file.cc
+++ b/src/main/cpp/rc_file.cc
@@ -58,8 +58,8 @@ RcFile::ParseError RcFile::ParseFile(const string& filename,
   string error_message;
   if (!blaze_util::ReadFile(filename, &contents, &error_message)) {
     blaze_util::StringPrintf(error_text,
-        "Unexpected error reading .blazerc file '%s': %s",
-        filename.c_str(), error_message.c_str());
+                             "Unexpected error reading config file '%s': %s",
+                             filename.c_str(), error_message.c_str());
     return ParseError::UNREADABLE_FILE;
   }
   const std::string canonical_filename =
@@ -105,7 +105,7 @@ RcFile::ParseError RcFile::ParseFile(const string& filename,
                                                              &words[1]))) {
         blaze_util::StringPrintf(
             error_text,
-            "Invalid import declaration in .blazerc file '%s': '%s'"
+            "Invalid import declaration in config file '%s': '%s'"
             " (are you in your source checkout/WORKSPACE?)",
             canonical_filename.c_str(), line.c_str());
         return ParseError::INVALID_FORMAT;

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -794,7 +794,7 @@ TEST_F(BlazercImportTest, BazelRcImportFailsForMissingFile) {
   const std::vector<std::string> args = {"bazel", "build"};
   ParseOptionsAndCheckOutput(
       args, blaze_exit_code::INTERNAL_ERROR,
-      "Unexpected error reading .blazerc file '.*myimportedbazelrc'", "");
+      "Unexpected error reading config file '.*myimportedbazelrc'", "");
 }
 
 TEST_F(BlazercImportTest, BazelRcTryImportDoesNotFailForMissingFile) {

--- a/src/test/cpp/rc_options_test.cc
+++ b/src/test/cpp/rc_options_test.cc
@@ -406,10 +406,11 @@ TEST_F(RcOptionsTest, FileDoesNotExist) {
   EXPECT_EQ(error, RcFile::ParseError::UNREADABLE_FILE);
   ASSERT_THAT(
       error_text,
-      MatchesRegex(kIsWindows
-        ? "Unexpected error reading \\.blazerc file '.*not_a_file\\.bazelrc':.*"
-        : "Unexpected error reading \\.blazerc file '.*not_a_file\\.bazelrc': "
-          "\\(error: 2\\): No such file or directory"));
+      MatchesRegex(kIsWindows ? "Unexpected error reading config file "
+                                "'.*not_a_file\\.bazelrc':.*"
+                              : "Unexpected error reading config file "
+                                "'.*not_a_file\\.bazelrc': "
+                                "\\(error: 2\\): No such file or directory"));
 }
 
 TEST_F(RcOptionsTest, ImportedFileDoesNotExist) {
@@ -422,12 +423,14 @@ TEST_F(RcOptionsTest, ImportedFileDoesNotExist) {
       Parse("import_fake_file.bazelrc", &error, &error_text);
   EXPECT_EQ(error, RcFile::ParseError::UNREADABLE_FILE);
   if (kIsWindows) {
-    ASSERT_THAT(error_text, MatchesRegex(
-      "Unexpected error reading \\.blazerc file 'somefile':.*"));
+    ASSERT_THAT(
+        error_text,
+        MatchesRegex("Unexpected error reading config file 'somefile':.*"));
   } else {
-    ASSERT_EQ(error_text,
-      "Unexpected error reading .blazerc file 'somefile': (error: 2): No such "
-      "file or directory");
+    ASSERT_EQ(
+        error_text,
+        "Unexpected error reading config file 'somefile': (error: 2): No such "
+        "file or directory");
   }
 }
 
@@ -449,7 +452,7 @@ TEST_F(RcOptionsTest, ImportHasTooManyArgs) {
   EXPECT_EQ(error, RcFile::ParseError::INVALID_FORMAT);
   ASSERT_THAT(
       error_text,
-      MatchesRegex("Invalid import declaration in .blazerc file "
+      MatchesRegex("Invalid import declaration in config file "
                    "'.*bad_import.bazelrc': 'import somefile bar' \\(are you "
                    "in your source checkout/WORKSPACE\\?\\)"));
 }
@@ -463,7 +466,7 @@ TEST_F(RcOptionsTest, TryImportHasTooManyArgs) {
   EXPECT_EQ(error, RcFile::ParseError::INVALID_FORMAT);
   ASSERT_THAT(
       error_text,
-      MatchesRegex("Invalid import declaration in .blazerc file "
+      MatchesRegex("Invalid import declaration in config file "
                    "'.*bad_import.bazelrc': 'try-import somefile bar' \\(are "
                    "you in your source checkout/WORKSPACE\\?\\)"));
 }


### PR DESCRIPTION
Fixes #22685.

PiperOrigin-RevId: 644377301
Change-Id: I05e7e01f1b4f79c219aa974871efcbc41966966c

Commit https://github.com/bazelbuild/bazel/commit/7b02eaa837fabf0e3d0e810690e51d55506529ab