### PR TITLE
Preserve order between stdout and stderr in BES on a best-effort basis

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -434,8 +434,10 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
   private void registerOutAndErrOutputStreams() {
     int bufferSize = besOptions.besOuterrBufferSize;
     int chunkSize = besOptions.besOuterrChunkSize;
-    SynchronizedOutputStream out = new SynchronizedOutputStream(bufferSize, chunkSize);
-    SynchronizedOutputStream err = new SynchronizedOutputStream(bufferSize, chunkSize);
+    SynchronizedOutputStream out =
+        new SynchronizedOutputStream(bufferSize, chunkSize, /* isStderr= */ false);
+    SynchronizedOutputStream err =
+        new SynchronizedOutputStream(bufferSize, chunkSize, /* isStderr= */ true);
 
     this.outErr = OutErr.create(out, err);
     streamer.registerOutErrProvider(

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -291,10 +291,16 @@ message BuildEventId {
 message Progress {
   // The next chunk of stdout that bazel produced since the last progress event
   // or the beginning of the build.
+  // Consumers that need to reason about the relative order of stdout and stderr
+  // can assume that stderr has been emitted before stdout if both are present,
+  // on a best-effort basis.
   string stdout = 1;
 
   // The next chunk of stderr that bazel produced since the last progress event
   // or the beginning of the build.
+  // Consumers that need to reason about the relative order of stdout and stderr
+  // can assume that stderr has been emitted before stdout if both are present,
+  // on a best-effort basis.
   string stderr = 2;
 }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
@@ -266,6 +266,7 @@ public class BuildEventStreamer {
           if (outErrProvider != null) {
             allOut = orEmpty(outErrProvider.getOut());
             allErr = orEmpty(outErrProvider.getErr());
+            progressState.set(ProgressState.ACCEPT_STDERR_AND_STDOUT);
           }
           linkEvents = new ArrayList<>();
           List<BuildEvent> finalLinkEvents = linkEvents;
@@ -661,8 +662,8 @@ public class BuildEventStreamer {
       if (outErrProvider != null) {
         allOut = orEmpty(outErrProvider.getOut());
         allErr = orEmpty(outErrProvider.getErr());
+        progressState.set(ProgressState.ACCEPT_STDERR_AND_STDOUT);
       }
-      progressState.set(ProgressState.ACCEPT_STDERR_AND_STDOUT);
       if (Iterables.isEmpty(allOut) && Iterables.isEmpty(allErr)) {
         // Nothing to flush; avoid generating an unneeded progress event.
         return;
@@ -765,6 +766,7 @@ public class BuildEventStreamer {
     if (outErrProvider != null) {
       allOut = orEmpty(outErrProvider.getOut());
       allErr = orEmpty(outErrProvider.getErr());
+      progressState.set(ProgressState.ACCEPT_STDERR_AND_STDOUT);
     }
     consumeAsPairsofStrings(
         allOut,

--- a/src/main/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStream.java
@@ -99,7 +99,7 @@ public class SynchronizedOutputStream extends OutputStream {
     while (!didWrite) {
       synchronized (this) {
         if ((this.count + (long) count < maxBufferedLength || this.count == 0)
-            && streamer.canWriteWithoutFlush(isStderr)) {
+            && streamer.canBufferProgressWrite(isStderr)) {
           if (this.count + (long) count >= (long) buf.length) {
             // We need to increase the buffer; if within the permissible range range for array
             // sizes, we at least double it, otherwise we only increase as far as needed.

--- a/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
@@ -16,6 +16,8 @@ package com.google.devtools.build.lib.runtime;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.devtools.build.lib.bugreport.BugReport.constructOomExitMessage;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -90,6 +92,9 @@ import com.google.devtools.build.lib.vfs.util.FileSystems;
 import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParsingResult;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -103,14 +108,14 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-/** Tests {@link BuildEventStreamer}. */
-@RunWith(JUnit4.class)
+/** Tests {@link com.google.devtools.build.lib.runtime.BuildEventStreamer}. */
+@RunWith(TestParameterInjector.class)
 public final class BuildEventStreamerTest extends FoundationTestCase {
 
   private static final String OOM_MESSAGE = "Please build fewer targets.";
@@ -1092,6 +1097,77 @@ public final class BuildEventStreamerTest extends FoundationTestCase {
     // The OutErrProvider should be queried only once per flush().
     verify(outErr, times(1)).getOut();
     verify(outErr, times(1)).getErr();
+  }
+
+  @Test
+  public void testtestFlushPreservesStdoutStderrOrder(
+      @TestParameter({"5", "30", "10000"}) int maxBufferedLength,
+      @TestParameter({"5", "30", "10000"}) int maxChunkSize)
+      throws IOException {
+    var stdout =
+        new SynchronizedOutputStream(maxBufferedLength, maxChunkSize, /* isStderr= */ false);
+    var stderr =
+        new SynchronizedOutputStream(maxBufferedLength, maxChunkSize, /* isStderr= */ true);
+    var outErr =
+        new BuildEventStreamer.OutErrProvider() {
+          @Override
+          public Iterable<String> getOut() {
+            return stdout.readAndReset();
+          }
+
+          @Override
+          public Iterable<String> getErr() {
+            return stderr.readAndReset();
+          }
+        };
+    streamer.registerOutErrProvider(outErr);
+    stdout.registerStreamer(streamer);
+    stderr.registerStreamer(streamer);
+
+    var startEvent =
+        new GenericBuildEvent(
+            testId("Initial"), ImmutableSet.of(ProgressEvent.INITIAL_PROGRESS_UPDATE));
+    streamer.buildEvent(startEvent);
+
+    stderr.write("[0 / 3] 3 actions running\n".getBytes(UTF_8));
+    stderr.write("INFO: From Executing genrule //:1:\n".getBytes(UTF_8));
+    stdout.write("Hello from genrule //:1 on stdout\n".getBytes(UTF_8));
+    stderr.write("Hello from genrule //:1 on stderr\n".getBytes(UTF_8));
+    stderr.write("[1 / 3] 2 actions running\n".getBytes(UTF_8));
+    stderr.write("INFO: From Executing genrule //:2:\n".getBytes(UTF_8));
+    stdout.write("Hello from genrule //:2 on stderr\n".getBytes(UTF_8));
+    stderr.write("Hello from genrule //:2 on stdout\n".getBytes(UTF_8));
+    stderr.write("[2 / 3] 1 actions running\n".getBytes(UTF_8));
+    stderr.write("INFO: From Executing genrule //:3:\n".getBytes(UTF_8));
+    stdout.write("Hello from genrule //:3 on stdout\n".getBytes(UTF_8));
+    stderr.write("Hello from genrule //:3 on stderr\n".getBytes(UTF_8));
+    stdout.write("Hello again from genrule //:3 on stdout\n".getBytes(UTF_8));
+    stderr.write("INFO: Build completed successfully, 3 total actions\n".getBytes(UTF_8));
+    streamer.close();
+
+    String reconstructedOutput =
+        transport.getEventProtos().stream()
+            .map(BuildEventStreamProtos.BuildEvent::getProgress)
+            .flatMap(progress -> Stream.of(progress.getStderr(), progress.getStdout()))
+            .collect(joining());
+    assertThat(reconstructedOutput)
+        .isEqualTo(
+            """
+            [0 / 3] 3 actions running
+            INFO: From Executing genrule //:1:
+            Hello from genrule //:1 on stdout
+            Hello from genrule //:1 on stderr
+            [1 / 3] 2 actions running
+            INFO: From Executing genrule //:2:
+            Hello from genrule //:2 on stderr
+            Hello from genrule //:2 on stdout
+            [2 / 3] 1 actions running
+            INFO: From Executing genrule //:3:
+            Hello from genrule //:3 on stdout
+            Hello from genrule //:3 on stderr
+            Hello again from genrule //:3 on stdout
+            INFO: Build completed successfully, 3 total actions
+            """);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
@@ -114,7 +114,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/** Tests {@link com.google.devtools.build.lib.runtime.BuildEventStreamer}. */
+/** Tests {@link BuildEventStreamer}. */
 @RunWith(TestParameterInjector.class)
 public final class BuildEventStreamerTest extends FoundationTestCase {
 

--- a/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
@@ -1100,7 +1100,7 @@ public final class BuildEventStreamerTest extends FoundationTestCase {
   }
 
   @Test
-  public void testtestFlushPreservesStdoutStderrOrder(
+  public void testFlushPreservesStdoutStderrOrder(
       @TestParameter({"5", "30", "10000"}) int maxBufferedLength,
       @TestParameter({"5", "30", "10000"}) int maxChunkSize)
       throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStreamTest.java
@@ -45,7 +45,7 @@ public class SynchronizedOutputStreamTest {
             /* maxBufferedLength= */ 5, /* maxChunkSize= */ 5, /* isStderr= */ false);
 
     BuildEventStreamer mockStreamer = mock(BuildEventStreamer.class);
-    doAnswer(inv -> true).when(mockStreamer).canWriteWithoutFlush(false);
+    doAnswer(inv -> true).when(mockStreamer).canBufferProgressWrite(false);
     underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'});
@@ -72,7 +72,7 @@ public class SynchronizedOutputStreamTest {
             })
         .when(mockStreamer)
         .flush();
-    doAnswer(inv -> true).when(mockStreamer).canWriteWithoutFlush(false);
+    doAnswer(inv -> true).when(mockStreamer).canBufferProgressWrite(false);
     underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'});
@@ -95,7 +95,7 @@ public class SynchronizedOutputStreamTest {
             /* maxBufferedLength= */ 2, /* maxChunkSize= */ 1, /* isStderr= */ false);
 
     BuildEventStreamer mockStreamer = mock(BuildEventStreamer.class);
-    doAnswer(inv -> true).when(mockStreamer).canWriteWithoutFlush(false);
+    doAnswer(inv -> true).when(mockStreamer).canBufferProgressWrite(false);
     underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd'});

--- a/src/test/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStreamTest.java
@@ -41,7 +41,12 @@ public class SynchronizedOutputStreamTest {
   @Test
   public void testReadAndResetReturnsChunkedWritesSinceLastCall() throws IOException {
     SynchronizedOutputStream underTest =
-        new SynchronizedOutputStream(/*maxBufferedLength=*/ 5, /*maxChunkSize=*/ 5);
+        new SynchronizedOutputStream(
+            /* maxBufferedLength= */ 5, /* maxChunkSize= */ 5, /* isStderr= */ false);
+
+    BuildEventStreamer mockStreamer = mock(BuildEventStreamer.class);
+    doAnswer(inv -> true).when(mockStreamer).canWriteWithoutFlush(false);
+    underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'});
     assertThat(underTest.readAndReset()).containsExactly("abcde", "fgh").inOrder();
@@ -55,7 +60,8 @@ public class SynchronizedOutputStreamTest {
   @Test
   public void testWriteFlushesStreamerWhenMaxBufferedLengthReached() throws IOException {
     SynchronizedOutputStream underTest =
-        new SynchronizedOutputStream(/*maxBufferedLength=*/ 3, /*maxChunkSize=*/ 3);
+        new SynchronizedOutputStream(
+            /* maxBufferedLength= */ 3, /* maxChunkSize= */ 3, /* isStderr= */ false);
 
     List<List<String>> writes = new ArrayList<>();
     BuildEventStreamer mockStreamer = mock(BuildEventStreamer.class);
@@ -66,6 +72,7 @@ public class SynchronizedOutputStreamTest {
             })
         .when(mockStreamer)
         .flush();
+    doAnswer(inv -> true).when(mockStreamer).canWriteWithoutFlush(false);
     underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'});
@@ -84,7 +91,12 @@ public class SynchronizedOutputStreamTest {
   @Test
   public void testUsesMaxOfMaxBufferedSizeAndMaxChunkSizeForChunking() throws IOException {
     SynchronizedOutputStream underTest =
-        new SynchronizedOutputStream(/*maxBufferedLength=*/ 2, /*maxChunkSize=*/ 1);
+        new SynchronizedOutputStream(
+            /* maxBufferedLength= */ 2, /* maxChunkSize= */ 1, /* isStderr= */ false);
+
+    BuildEventStreamer mockStreamer = mock(BuildEventStreamer.class);
+    doAnswer(inv -> true).when(mockStreamer).canWriteWithoutFlush(false);
+    underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd'});
     assertThat(underTest.readAndReset()).containsExactly("ab", "cd").inOrder();
@@ -95,7 +107,8 @@ public class SynchronizedOutputStreamTest {
   @Test
   public void testHandlesArbitraryBinaryDataCorrectly() throws IOException {
     SynchronizedOutputStream underTest =
-        new SynchronizedOutputStream(/*maxBufferedLength=*/ 1, /*maxChunkSize=*/ 1);
+        new SynchronizedOutputStream(
+            /* maxBufferedLength= */ 1, /* maxChunkSize= */ 1, /* isStderr= */ false);
 
     byte[] input = new byte[] {(byte) 0xff};
     underTest.write(input);


### PR DESCRIPTION
BES consumers may want to turn the stream of progress events into a view that resembles the terminal output by combining stdout and stderr. In particular in `--curses=on` mode, this resulted in garbled output such as the following due to stdout and stderr being buffered separately:

```
[0 / 3] 3 actions running
INFO: From Executing genrule //:1:
Hello from genrule //:1 on stderr
[1 / 3] 2 actions running
INFO: From Executing genrule //:2:
Hello from genrule //:2 on stdout
[2 / 3] 1 actions running
INFO: From Executing genrule //:3:
Hello from genrule //:3 on stderr
INFO: Build completed successfully, 3 total actions
Hello from genrule //:1 on stdout
Hello from genrule //:2 on stderr
Hello from genrule //:3 on stdout
Hello again from genrule //:3 on stdout
```

when the original output was:

```
[0 / 3] 3 actions running
INFO: From Executing genrule //:1:
Hello from genrule //:1 on stdout
Hello from genrule //:1 on stderr
[1 / 3] 2 actions running
INFO: From Executing genrule //:2:
Hello from genrule //:2 on stderr
Hello from genrule //:2 on stdout
[2 / 3] 1 actions running
INFO: From Executing genrule //:3:
Hello from genrule //:3 on stdout
Hello from genrule //:3 on stderr
Hello again from genrule //:3 on stdout
INFO: Build completed successfully, 3 total actions
```

This changes makes it so that the ordering between stdout and stderr is preserved by declaring that a `ProgressEvent` containing both means that stderr has been emitted first and by flushing an event before any stdout -> stderr transition.

Closes https://github.com/buildbuddy-io/buildbuddy/pull/6861