### PR TITLE
Remove usage of win32api

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,11 +25,6 @@ build:remote --config=ubuntu2004
 
 build:macos --macos_minimum_os=10.13
 
-# On Windows, we need pywin32 pip package, which doesn't work with the Python hermetic toolchain.
-# See https://github.com/bazelbuild/rules_python/issues/1356
-# Therefore, use the local detected Python toolchain on Windows.
-build:windows --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain
-
 build:windows_arm64 --platforms=//:windows_arm64
 build:windows_arm64 --extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windows
 

--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -28,7 +28,7 @@ if os.name == 'nt':
     _GetShortPathNameW.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
     _GetShortPathNameW.restype = wintypes.DWORD
 
-    def get_short_path_name(long_name):
+    def _get_short_path_name(long_name):
         """
         Gets the short path name of a given long path.
         http://stackoverflow.com/a/23598461/200291

--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -21,7 +21,28 @@ from src.test.py.bazel import test_base
 
 # pylint: disable=g-import-not-at-top
 if os.name == 'nt':
-  import win32api
+    import ctypes
+    from ctypes import wintypes
+    kernel32 = ctypes.WinDLL('kernel32')
+    _GetShortPathNameW = kernel32.GetShortPathNameW
+    _GetShortPathNameW.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+    _GetShortPathNameW.restype = wintypes.DWORD
+
+    def get_short_path_name(long_name):
+        """
+        Gets the short path name of a given long path.
+        http://stackoverflow.com/a/23598461/200291
+        """
+        output_buf_size=len(long_name)
+        while True:
+            output_buf = ctypes.create_unicode_buffer(output_buf_size)
+            needed = _GetShortPathNameW(long_name, output_buf, output_buf_size)
+            if needed == 0: 
+              raise ctypes.WinError()
+            elif output_buf_size >= needed:
+                return output_buf.value
+            else:
+                output_buf_size = needed
 
 
 class LauncherTest(test_base.TestBase):
@@ -670,7 +691,7 @@ class LauncherTest(test_base.TestBase):
     _, stdout, _ = self.RunProgram([long_binary_path], shell=True)
     self.assertEqual('helloworld', ''.join(stdout))
     # Make sure we can launch the binary with a shortened Windows 8dot3 path
-    short_binary_path = win32api.GetShortPathName(long_binary_path)
+    short_binary_path = _get_short_path_name(long_binary_path)
     self.assertIn('~', os.path.basename(short_binary_path))
     _, stdout, _ = self.RunProgram([short_binary_path], shell=True)
     self.assertEqual('helloworld', ''.join(stdout))
@@ -680,7 +701,7 @@ class LauncherTest(test_base.TestBase):
     _, stdout, _ = self.RunProgram([long_binary_path], shell=True)
     self.assertEqual('helloworld', ''.join(stdout))
     # Make sure we can launch the binary with a shortened Windows 8dot3 path
-    short_binary_path = win32api.GetShortPathName(long_binary_path)
+    short_binary_path = _get_short_path_name(long_binary_path)
     self.assertIn('~', os.path.basename(short_binary_path))
     _, stdout, _ = self.RunProgram([short_binary_path], shell=True)
     self.assertEqual('helloworld', ''.join(stdout))
@@ -690,7 +711,7 @@ class LauncherTest(test_base.TestBase):
     _, stdout, _ = self.RunProgram([long_binary_path], shell=True)
     self.assertEqual('helloworld', ''.join(stdout))
     # Make sure we can launch the binary with a shortened Windows 8dot3 path
-    short_binary_path = win32api.GetShortPathName(long_binary_path)
+    short_binary_path = _get_short_path_name(long_binary_path)
     self.assertIn('~', os.path.basename(short_binary_path))
     _, stdout, _ = self.RunProgram([short_binary_path], shell=True)
     self.assertEqual('helloworld', ''.join(stdout))


### PR DESCRIPTION
Removes the `win32api` dependency. Only `win32api.GetShortPathName` was used. It has been replaced with a stdlib implementation using `ctypes` instead.

This should fix this issue: https://github.com/bazelbuild/rules_python/issues/1356