### PR TITLE
[7.2.1] Fix permissions on tree artifact subdirectories as needed to move them out of the sandbox.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -602,9 +602,10 @@ public class FileSystemUtils {
       throw new IllegalArgumentException(to + " is a subdirectory of " + from);
     }
 
-    // Actions can make output directories non-writable, which would cause the move to fail.
-    from.setWritable(true);
+    // Actions can make output directories inaccessible, which would cause the move to fail.
+    from.chmod(0755);
 
+    // TODO(tjgq): Don't leave an empty directory behind.
     Collection<Path> entries = from.getDirectoryEntries();
     for (Path entry : entries) {
       if (entry.isDirectory(Symlinks.NOFOLLOW)) {

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -257,8 +257,9 @@ EOF
   bazel build --test_output=streamed :a &>$TEST_log || fail "expected build to succeed"
 }
 
-# Regression test for https://github.com/bazelbuild/bazel/issues/20032.
-function test_read_only_tree_artifact() {
+# Regression test for https://github.com/bazelbuild/bazel/issues/20032 and
+# https://github.com/bazelbuild/bazel/issues/22260.
+function test_permissionless_tree_artifact() {
   create_workspace_with_default_repos WORKSPACE
 
   cat > def.bzl <<'EOF'
@@ -266,7 +267,7 @@ def _r(ctx):
   d = ctx.actions.declare_directory(ctx.label.name)
   ctx.actions.run_shell(
     outputs = [d],
-    command = "touch $1/file.txt && chmod -w $1",
+    command = "touch $1/file.txt && chmod 000 $1",
     arguments = [d.path],
   )
   return DefaultInfo(files = depset([d]))


### PR DESCRIPTION
Similar to https://github.com/bazelbuild/bazel/commit/547f0c6955942e6aafd279adbb2f5368a7a2347e, but also includes the r and x bits.

Fixes #22260.

PiperOrigin-RevId: 644705156
Change-Id: I5354db76dd2c375a6e686fb4808649053b24c500

Commit https://github.com/bazelbuild/bazel/commit/fb05e916ddf18dc06ef1fdde5063de6c49cee5c1