### PR TITLE
Locate BCR module overlay files under the `overlay` subdirectory

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -449,7 +449,7 @@ public class IndexRegistry implements Registry {
         sourceJsonOverlay.entrySet().stream()
             .collect(
                 toImmutableMap(
-                    entry -> entry.getKey(),
+                    Entry::getKey,
                     entry ->
                         new ArchiveRepoSpecBuilder.RemoteFile(
                             entry.getValue(), // integrity
@@ -460,6 +460,7 @@ public class IndexRegistry implements Registry {
                                     "modules",
                                     key.getName(),
                                     key.getVersion().toString(),
+                                    "overlay",
                                     entry.getKey())))));
 
     return new ArchiveRepoSpecBuilder()

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -259,7 +259,8 @@ public class IndexRegistryTest extends FoundationTestCase {
                         new ArchiveRepoSpecBuilder.RemoteFile(
                             "sha256-bleh-overlay",
                             // URLs in the registry itself are not mirrored.
-                            ImmutableList.of(server.getUrl() + "/modules/baz/3.0/BUILD.bazel"))))
+                            ImmutableList.of(
+                                server.getUrl() + "/modules/baz/3.0/overlay/BUILD.bazel"))))
                 .setRemotePatches(ImmutableMap.of())
                 .setRemotePatchStrip(0)
                 .build());


### PR DESCRIPTION
This avoids collisions between overlay files and regular BCR files such as `source.json`.

Overlay support has been released in 7.2.0, but hasn't been used in the BCR yet.