### PR TITLE
Invalidate RepositoryDirecotryValue for vendored repos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
@@ -99,9 +100,6 @@ public class VendorManager {
         replantSymlinks(repoUnderVendor, externalRepoRoot);
         // 5. Rename the temporary marker file after the move is done.
         tMarker.renameTo(markerUnderVendor);
-        // 6. Leave a symlink in external dir to keep things working.
-        repoUnderExternal.deleteTree();
-        FileSystemUtils.ensureSymbolicLink(repoUnderExternal, repoUnderVendor);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
@@ -27,7 +27,6 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
@@ -100,6 +99,9 @@ public class VendorManager {
         replantSymlinks(repoUnderVendor, externalRepoRoot);
         // 5. Rename the temporary marker file after the move is done.
         tMarker.renameTo(markerUnderVendor);
+        // 6. Leave a symlink in external dir to keep things working.
+        repoUnderExternal.deleteTree();
+        FileSystemUtils.ensureSymbolicLink(repoUnderExternal, repoUnderVendor);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
@@ -57,6 +57,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:package_lookup_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:precomputed_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:repository_mapping_value",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:sky_functions",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:command",

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -402,12 +402,10 @@ public final class VendorCommand implements BlazeCommand {
     vendorManager.vendorRepos(externalPath, reposToVendor);
 
     // 3. Invalidate RepositoryDirectoryValue for vendored repos.
-    for (RepositoryName repo : reposToVendor) {
-      env.getSkyframeExecutor().getEvaluator().delete(
-          k -> k.functionName().equals(SkyFunctions.REPOSITORY_DIRECTORY)
-              && k.argument().equals(repo)
-      );
-    }
+    env.getSkyframeExecutor().getEvaluator().delete(
+        k -> k.functionName().equals(SkyFunctions.REPOSITORY_DIRECTORY)
+            && reposToVendor.contains((RepositoryName) k.argument())
+    );
   }
 
   private static BlazeCommandResult createFailedBlazeCommandResult(

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -16,6 +16,7 @@
 
 import os
 import shutil
+import stat
 import tempfile
 from absl.testing import absltest
 from src.test.py.bazel import test_base
@@ -607,7 +608,10 @@ class BazelVendorTest(test_base.TestBase):
     self.assertNotIn('ccc~', os.listdir(self._test_cwd + '/vendor'))
 
     # Delete vendor source and re-vendor should work without server restart
-    shutil.rmtree(self._test_cwd + '/vendor')
+    def on_rm_error(func, path, exc_info):
+       os.chmod(path, stat.S_IWRITE)
+       func(path)
+    shutil.rmtree(self._test_cwd + '/vendor', onerror=on_rm_error)
     self.RunBazel(
         ['vendor', '@aaa//:lib_aaa', '@bbb//:lib_bbb', '--vendor_dir=vendor']
     )

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -15,6 +15,7 @@
 # pylint: disable=g-long-ternary
 
 import os
+import shutil
 import tempfile
 from absl.testing import absltest
 from src.test.py.bazel import test_base
@@ -601,6 +602,15 @@ class BazelVendorTest(test_base.TestBase):
         ['vendor', '@aaa//:lib_aaa', '@bbb//:lib_bbb', '--vendor_dir=vendor']
     )
     # Assert aaa & bbb and are vendored
+    self.assertIn('aaa~', os.listdir(self._test_cwd + '/vendor'))
+    self.assertIn('bbb~', os.listdir(self._test_cwd + '/vendor'))
+    self.assertNotIn('ccc~', os.listdir(self._test_cwd + '/vendor'))
+
+    # Delete vendor source and re-vendor should work without server restart
+    shutil.rmtree(self._test_cwd + '/vendor')
+    self.RunBazel(
+        ['vendor', '@aaa//:lib_aaa', '@bbb//:lib_bbb', '--vendor_dir=vendor']
+    )
     self.assertIn('aaa~', os.listdir(self._test_cwd + '/vendor'))
     self.assertIn('bbb~', os.listdir(self._test_cwd + '/vendor'))
     self.assertNotIn('ccc~', os.listdir(self._test_cwd + '/vendor'))


### PR DESCRIPTION
This makes sure vendored repos work correctly even without a bazel server restart.

For example, when 
```
bazel vendor //:bin --vendor_dir=vendor_src
rm -rf vendor_src
bazel vendor //:bin --vendor_dir=vendor_src
```