### PR TITLE
[7.2.1] Locate BCR module overlay files under the `overlay` subdirectory

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -421,7 +421,7 @@ public class IndexRegistry implements Registry {
         sourceJsonOverlay.entrySet().stream()
             .collect(
                 toImmutableMap(
-                    entry -> entry.getKey(),
+                    Entry::getKey,
                     entry ->
                         new ArchiveRepoSpecBuilder.RemoteFile(
                             entry.getValue(), // integrity
@@ -432,6 +432,7 @@ public class IndexRegistry implements Registry {
                                     "modules",
                                     key.getName(),
                                     key.getVersion().toString(),
+                                    "overlay",
                                     entry.getKey())))));
 
     return new ArchiveRepoSpecBuilder()

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -247,7 +247,8 @@ public class IndexRegistryTest extends FoundationTestCase {
                         new ArchiveRepoSpecBuilder.RemoteFile(
                             "sha256-bleh-overlay",
                             // URLs in the registry itself are not mirrored.
-                            ImmutableList.of(server.getUrl() + "/modules/baz/3.0/BUILD.bazel"))))
+                            ImmutableList.of(
+                                server.getUrl() + "/modules/baz/3.0/overlay/BUILD.bazel"))))
                 .setRemotePatches(ImmutableMap.of())
                 .setRemotePatchStrip(0)
                 .build());


### PR DESCRIPTION
This avoids collisions between overlay files and regular BCR files such as `source.json`.

Overlay support has been released in 7.2.0, but hasn't been used in the BCR yet.

Closes #22811.

PiperOrigin-RevId: 645071272
Change-Id: Ib05855a728ebb09795bf70afb14457e9e6d23bf0

Commit https://github.com/bazelbuild/bazel/commit/36da00463d4b645752d1be7c5b8d41139d3b8811