### PR TITLE
[7.2.1] Be more precise about where to read the URL rewriter config from

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -382,7 +382,8 @@ public class BazelRepositoryModule extends BlazeModule {
       }
       try {
         UrlRewriter rewriter =
-            UrlRewriter.getDownloaderUrlRewriter(repoOptions.downloaderConfig, env.getReporter());
+            UrlRewriter.getDownloaderUrlRewriter(
+                env.getWorkspace(), repoOptions.downloaderConfig, env.getReporter());
         downloadManager.setUrlRewriter(rewriter);
       } catch (UrlRewriterParseException e) {
         // It's important that the build stops ASAP, because this config file may be required for


### PR DESCRIPTION
There is an [open issue](https://github.com/bazelbuild/bazel/issues/22104) where bazel will occasionally fail at start up time because it is unable to parse the downloader config. While I've yet to create a reliable reproduction for this issue, the one time I've triggered this error with a build with additional logging, it seemed to be because the current working directory wasn't the root of the workspace. While I'm not sure this will actually fully resolve the problem (since I don't know what's causing it) being clearer about where the config file is meant to be can only be a Good Thing.

Addresses #22104

Closes #22770.

PiperOrigin-RevId: 645115556
Change-Id: I7e9bea1c55a106cd767ebfd6d557a7c59c47cd66

Commit https://github.com/bazelbuild/bazel/commit/0e220f03f154cbb5e52190e1085b01173f301c02