### PR TITLE
[7.3.0] Optimize Profiler

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
@@ -25,14 +25,18 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Queue;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 
 /** Writes the profile in Json Trace file format. */
 class JsonTraceFileWriter implements Runnable {
-  protected final BlockingQueue<TraceData> queue;
+  protected final Queue<TraceData> queue;
+  private final ReentrantLock lock = new ReentrantLock();
+  private final Condition condition = lock.newCondition();
   protected final Thread thread;
   protected IOException savedException;
 
@@ -57,7 +61,7 @@ class JsonTraceFileWriter implements Runnable {
       boolean slimProfile,
       String outputBase,
       UUID buildID) {
-    this.queue = new LinkedBlockingQueue<>();
+    this.queue = new ConcurrentLinkedQueue<>();
     this.thread = new Thread(this, "profile-writer-thread");
     this.outStream = outStream;
     this.profileStartTimeNanos = profileStartTimeNanos;
@@ -69,6 +73,8 @@ class JsonTraceFileWriter implements Runnable {
   public void shutdown() throws IOException {
     // Add poison pill to queue and then wait for writer thread to shut down.
     queue.add(POISON_PILL);
+    notifyConsumer(/* force= */ true);
+
     try {
       thread.join();
     } catch (InterruptedException e) {
@@ -92,6 +98,10 @@ class JsonTraceFileWriter implements Runnable {
       queue.add(new ThreadMetadata());
     }
     queue.add(data);
+    // Not forcing notification to avoid blocking on the lock. This might cause this signal failed
+    // to be sent if the consumer is holding the lock (to start wait on the condition). But the
+    // assumption is we have events in continuous so that the next event can notify the consumer.
+    notifyConsumer(/* force= */ false);
   }
 
   private static final class MergedEvent {
@@ -161,6 +171,36 @@ class JsonTraceFileWriter implements Runnable {
         && data.type != ProfilerTask.CRITICAL_PATH_COMPONENT;
   }
 
+  private void notifyConsumer(boolean force) {
+    boolean locked;
+    if (force) {
+      lock.lock();
+      locked = true;
+    } else {
+      locked = lock.tryLock();
+    }
+    if (locked) {
+      try {
+        condition.signal();
+      } finally {
+        lock.unlock();
+      }
+    }
+  }
+
+  private TraceData takeData() throws InterruptedException {
+    TraceData data;
+    while ((data = queue.poll()) == null) {
+      lock.lock();
+      try {
+        condition.await();
+      } finally {
+        lock.unlock();
+      }
+    }
+    return data;
+  }
+
   /**
    * Saves all gathered information from taskQueue queue to the file. Method is invoked internally
    * by the Timer-based thread and at the end of profiling session.
@@ -195,7 +235,7 @@ class JsonTraceFileWriter implements Runnable {
         HashMap<Long, MergedEvent> eventsPerThread = new HashMap<>();
         int eventCount = 0;
         TraceData data;
-        while ((data = queue.take()) != POISON_PILL) {
+        while ((data = takeData()) != POISON_PILL) {
           Preconditions.checkNotNull(data);
           eventCount++;
 
@@ -226,7 +266,7 @@ class JsonTraceFileWriter implements Runnable {
       } catch (IOException e) {
         this.savedException = e;
         if (!receivedPoisonPill) {
-          while (queue.take() != POISON_PILL) {
+          while (takeData() != POISON_PILL) {
             // We keep emptying the queue, but we can't write anything.
           }
         }


### PR DESCRIPTION
Currently, we use `LinkedBlockingQueue` to queue up the trace event. But it uses `ReentrantLock` under the hood which means each time we start profiling a block, the `enqueue` method could block the thread - the time for blocking is included in the time span for the block itself which is confusing. The overhead adds ~20ms overhead to each profiled block when we have lots of trace event, e.g. with `--noslim_profile` and `--experimental_profile_additional_tasks=SKYFUNCTION`.

This CL optimizes this by using a lock-free queue, namely `ConcurrentLinkedQueue` and use best effort (explained in the code comment) to signal the consumer. Additionally, it minimizes operations when dealing with virtual lanes. This bring down the overhead to less than 1us.

PiperOrigin-RevId: 645430908
Change-Id: I68fab914dc0eac717260ea6cb43793c58bcddc0a

Commit https://github.com/bazelbuild/bazel/commit/2810c4f874091b344c9f6dd6caeca428cce77ac9