### PR TITLE
Add test sharding to mod_command_test to improve test speed

### DIFF
--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -395,6 +395,7 @@ py_test(
     tags = [
         "requires-network",
     ],
+    shard_count = 8,
     deps = [
         ":bzlmod_test_utils",
         ":test_base",


### PR DESCRIPTION
Before (on my laptop):

```
  INFO: Build completed successfully, 2 total actions
  //src/test/py/bazel:mod_command_test                                     PASSED in 184.3s
```

After:

```
  INFO: Build completed successfully, 9 total actions
  //src/test/py/bazel:mod_command_test                                     PASSED in 40.1s
    Stats over 8 runs: max = 40.1s, min = 30.1s, avg = 37.1s, dev = 3.2s
```