### PR TITLE
Update NDK build doc to refer to the correct platform constraint for armeabi-v7a.

### DIFF
--- a/site/en/docs/android-ndk.md
+++ b/site/en/docs/android-ndk.md
@@ -191,7 +191,7 @@ OS constraint. To migrate the CPU constraint, check this chart:
 
 CPU Value     | Platform
 ------------- | ------------------------------------------
-`armeabi-v7a` | `@platforms//cpu:arm`
+`armeabi-v7a` | `@platforms//cpu:armv7`
 `arm64-v8a`   | `@platforms//cpu:arm64`
 `x86`         | `@platforms//cpu:x86_32`
 `x86_64`      | `@platforms//cpu:x86_64`


### PR DESCRIPTION
The [`rules_android_ndk`](https://github.com/bazelbuild/rules_android_ndk) repository only [defines a toolchain for platform `armv7`](https://github.com/bazelbuild/rules_android_ndk/blob/c2999e4c90d580e850ff1f3831554d5ea4b536a3/target_systems.bzl.tpl#L11).  This updates the [Android NDK bazel build doc](https://bazel.build/docs/android-ndk#configuring-target-abi) with the right platform constraint to work with the toolchain.