### PR TITLE
Preserve `--experimental_skip_ttvs_for_genquery` in the exec config

### DIFF
--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -463,7 +463,7 @@ bazel_fragments["ShellConfiguration$Options"] = fragment(
 
 bazel_fragments["GenQueryConfiguration$GenQueryOptions"] = fragment(
     propagate = [
-        "//command_line_option:experimental_skip_ttvs_for_genquery",
+        "//command_line_option:experimental_skip_ttvs_for_genquerytypoed",
     ],
 )
 

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -461,7 +461,7 @@ bazel_fragments["ShellConfiguration$Options"] = fragment(
     ],
 )
 
-bazel_fragments["GenRuleOptions"] = fragment(
+bazel_fragments["GenQueryConfiguration$GenQueryOptions"] = fragment(
     propagate = [
         "//command_line_option:experimental_skip_ttvs_for_genquery",
     ],

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -463,7 +463,7 @@ bazel_fragments["ShellConfiguration$Options"] = fragment(
 
 bazel_fragments["GenQueryConfiguration$GenQueryOptions"] = fragment(
     propagate = [
-        "//command_line_option:experimental_skip_ttvs_for_genquerytypoed",
+        "//command_line_option:experimental_skip_ttvs_for_genquery",
     ],
 )
 

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -461,6 +461,12 @@ bazel_fragments["ShellConfiguration$Options"] = fragment(
     ],
 )
 
+bazel_fragments["GenRuleOptions"] = fragment(
+    propagate = [
+        "//command_line_option:experimental_skip_ttvs_for_genquery",
+    ],
+)
+
 # TestConfiguration$TestOptions: handled in native code. See b/295936652.
 
 # Bazel's exec transition.


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/14169#issuecomment-2189634085