### PR TITLE
[7.3.0] Switch to a UTF-8 codepage in the client on Windows

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -69,6 +69,7 @@
 #include "src/main/cpp/util/errors.h"
 #include "src/main/cpp/util/exit_code.h"
 #include "src/main/cpp/util/file.h"
+#include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/logging.h"
 #include "src/main/cpp/util/numbers.h"
 #include "src/main/cpp/util/path.h"
@@ -1454,6 +1455,8 @@ static void RunLauncher(const string &self_path,
 
 int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
          OptionProcessor *option_processor, uint64_t start_time) {
+  blaze_util::InitializeStdOutErrForUtf8();
+
   // Logging must be set first to assure no log statements are missed.
   std::unique_ptr<blaze_util::BazelLogHandler> default_handler(
       new blaze_util::BazelLogHandler());

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -132,6 +132,11 @@ struct WriteResult {
   };
 };
 
+// Initializes stdout and stderr for writing UTF-8 (best effort).
+//
+// This should be called once during startup.
+void InitializeStdOutErrForUtf8();
+
 // Writes `size` bytes from `data` into stdout/stderr.
 // Writes to stdout if `to_stdout` is true, writes to stderr otherwise.
 // Returns one of `WriteResult::Errors`.

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -327,6 +327,8 @@ bool WriteFile(const void *data, size_t size, const Path &path,
   return WriteFile(data, size, path.AsNativePath(), perm);
 }
 
+void InitializeStdOutErrForUtf8() {}
+
 int WriteToStdOutErr(const void *data, size_t size, bool to_stdout) {
   size_t r = fwrite(data, 1, size, to_stdout ? stdout : stderr);
   return (r == size) ? WriteResult::SUCCESS

--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -369,6 +369,8 @@ bool WriteFile(const void* data, size_t size, const Path& path,
   return actually_written == size;
 }
 
+void InitializeStdOutErrForUtf8() { SetConsoleOutputCP(CP_UTF8); }
+
 int WriteToStdOutErr(const void* data, size_t size, bool to_stdout) {
   DWORD written = 0;
   HANDLE h = ::GetStdHandle(to_stdout ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE);


### PR DESCRIPTION
This is required for UTF-8 to be rendered properly in a terminal (e.g. for `bazel mod graph`).

Closes #22874.

PiperOrigin-RevId: 646592183
Change-Id: I33692986301ea472462ad0e6da9634bd580c8a5f

Commit https://github.com/bazelbuild/bazel/commit/4a5fe6207eb596effc13fe6b8e862727dc03eda6