### PR TITLE
SF 7.2.0 Release

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandLineEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandLineEvent.java
@@ -30,6 +30,8 @@ import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.Command
 import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.CommandLineSection;
 import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.Option;
 import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.OptionList;
+import com.google.devtools.build.lib.util.OptionsUtils;
+import com.google.devtools.build.lib.util.OptionsUtils.OptionSensitivity;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.common.options.OptionDefinition;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -138,11 +140,13 @@ public abstract class CommandLineEvent implements BuildEventWithOrderConstraint 
 
     private Option createOption(
         OptionDefinition optionDefinition, String combinedForm, @Nullable String value) {
+      OptionSensitivity sensitivity = OptionsUtils.getOptionSensitivity(optionDefinition.getOptionName());
+
       Option.Builder option = Option.newBuilder();
-      option.setCombinedForm(combinedForm);
+      option.setCombinedForm(OptionsUtils.maybeScrubCombinedForm(sensitivity, combinedForm));
       option.setOptionName(optionDefinition.getOptionName());
       if (value != null) {
-        option.setOptionValue(value);
+        option.setOptionValue(OptionsUtils.maybeScrubAssignment(sensitivity, value));
       }
       option.addAllEffectTags(getProtoEffectTags(optionDefinition.getOptionEffectTags()));
       option.addAllMetadataTags(getProtoMetadataTags(optionDefinition.getOptionMetadataTags()));

--- a/src/main/java/com/google/devtools/build/lib/runtime/OriginalUnstructuredCommandLineEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/OriginalUnstructuredCommandLineEvent.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId;
 import com.google.devtools.build.lib.buildeventstream.BuildEventWithOrderConstraint;
 import com.google.devtools.build.lib.buildeventstream.GenericBuildEvent;
+import com.google.devtools.build.lib.util.OptionsUtils;
 import java.util.Collection;
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class OriginalUnstructuredCommandLineEvent implements BuildEventWithOrder
   private final ImmutableList<String> args;
 
   OriginalUnstructuredCommandLineEvent(List<String> args) {
-    this.args = ImmutableList.copyOf(args);
+    this.args = OptionsUtils.scrubArgs(ImmutableList.copyOf(args));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/util/OptionsUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/OptionsUtils.java
@@ -18,16 +18,240 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
 import com.google.devtools.common.options.ParsedOptionDescription;
+import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /** Blaze-specific option utilities. */
 public final class OptionsUtils {
+
+  /**
+   * List of environment variables that are allowed to propagate to the BEP.
+   *
+   * <p>It is tempting (and difficult) to make this list customizable via a command-line flag.
+   * However, if we allowed customization, we would not be able to trust that a given Bazel
+   * version does the right thing because we'd be subject to the contents of the bazelrc or
+   * the flags that a user passes.</p>
+   */
+  private final static ImmutableSet<String> allowedEnvVars = ImmutableSet.of(
+      "BAZEL_SRCDIR",
+      "BAZEL_TEST",
+      "HOME",
+      "LD_LIBRARY_PATH",
+      "PATH",
+      "PWD",
+      "SHLVL",
+      "TEST_BINARY",
+      "TEST_SRCDIR",
+      "TEST_TARGET",
+      "TEST_TIMEOUT",
+      "TEST_TMPDIR",
+      "TEST_WORKSPACE",
+      "TMPDIR",
+      "TZ",
+      "USER",
+      "WORKSPACE_DIR"
+  );
+
+  /**
+   * List of environment variable name prefixes that are allowed to propagate to the BEP.
+   *
+   * <p>This list must only contain prefixes for clients we control as otherwise we could be
+   * allowing unknown variables by mistake.</p>
+   *
+   * <p>See {@link #allowedEnvVars} for more details.</p>
+   */
+  private final static ImmutableSet<String> allowedEnvVarPrefixes = ImmutableSet.of(
+      "BESD_",
+      "CI_SNOWCI_",
+      "IJWB_"
+  );
+
+  /** List of commands that have sensitive residual arguments. */
+  public final static ImmutableSet<String> sensitiveResidualCommands = ImmutableSet.of("run");
+
+  /** Tag for the sensitivity of an option's value. */
+  public enum OptionSensitivity {
+    /** The option has a value that is not sensitive, or it has no value. */
+    NONE,
+
+    /** The option has a value of the form <tt>name=val</tt> and only <tt>val</tt> is sensitive. */
+    PARTIAL,
+
+    /** The option has a value and the whole value is sensitive. */
+    FULL,
+  }
+
+  /** Predicate that returns true if the given string corresponds to an option that carries a
+   * fully sensitive value. */
+  private final static Predicate<String> isFullySensitiveOption =
+      Pattern.compile("_arg([ =].*|)$").asPredicate();
+
+  /** Predicate that returns true if the given string corresponds to an option that carries a
+   * partially sensitive value. */
+  private final static Predicate<String> isPartiallySensitiveOption =
+      Pattern.compile("_(env|header)([ =].*|)$").asPredicate();
+
+  /** Returns true if the given environment variable can be propagated to the BEP. */
+  private static boolean isEnvVarAllowed(String name) {
+    if (allowedEnvVars.contains(name)) {
+      return true;
+    }
+
+    for (String prefix : allowedEnvVarPrefixes) {
+      if (name.startsWith(prefix)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /** Determines the sensitivity of the given option name, where the provided string may include the
+   * option's value as well. */
+  public static OptionSensitivity getOptionSensitivity(String raw) {
+    if (isFullySensitiveOption.test(raw)) {
+      return OptionSensitivity.FULL;
+    } else if (isPartiallySensitiveOption.test(raw)) {
+      return OptionSensitivity.PARTIAL;
+    } else {
+      return OptionSensitivity.NONE;
+    }
+  }
+
+  /** Determines if the given string contains an option name/value pair. */
+  private static boolean containsOptionValue(String raw) {
+    return raw.contains(" ") || raw.contains("=");
+  }
+
+  /**
+   * Given a name/value pair, rewrites the string to redact the value unless the name is in the
+   * {@link #allowedEnvVars} list.
+   *
+   * @param raw a string of the form <tt>name=value</tt>
+   * @return the rewritten string
+   */
+  public static String maybeScrubAssignment(OptionSensitivity sensitivity, String raw) {
+    switch (sensitivity) {
+      case NONE:
+        return raw;
+
+      case PARTIAL:
+        String[] parts = raw.split("=", 2);
+        if (parts.length < 2) {
+          // If we find a lone value, we could redact it with the rationale being that the user
+          // might have made a mistake and typed `--test_env=secret` instead of
+          // `--test_env=VAR=secret`. However, redacting lone values would render the telemetry for
+          // all flags nearly useless and a determined user would pass these checks anyway.
+          return raw;
+        }
+        assert parts.length == 2;
+
+        String name = parts[0];
+        if (isEnvVarAllowed(name)) {
+          return raw;
+        }
+        // We do not add the word REDACTED here because we want the equal sign to be explicitly
+        // followed by a space, which simplifies detecting that there really is no value attached
+        // to the variable.
+        return String.format("%s= ", name);
+
+      default:
+        assert sensitivity.equals(OptionSensitivity.FULL);  // Cope with non-exhaustive switches.
+        return "REDACTED";
+    }
+  }
+
+  /**
+   * Given a literal argument with name/value pairs that may contain a secret, rewrites the string
+   * to redact the value unless the name is in the {@link #allowedEnvVars} or
+   * {@link #allowedEnvVarPrefixes} lists.
+   *
+   * @param raw a string of the form <tt>option=name=value</tt> or <tt>option name=value</tt>. The
+   *     string may or may not be prefixed by <tt>--</tt>.
+   * @return the rewritten string
+   */
+  public static String maybeScrubCombinedForm(OptionSensitivity sensitivity, String raw) {
+    int pos = 0;
+    int[] chars = raw.chars().toArray();
+    for (int ch : chars) {
+      if (ch == ' ' || ch == '=') {
+        break;
+      }
+      pos += 1;
+    }
+    if (pos == chars.length) {
+      if (sensitivity == OptionSensitivity.NONE) {
+        return raw;
+      } else {
+        // This should never happen, but better propagate a placeholder string rather than crash
+        // due to the complexity of option parsing and the fact that we might have missed some
+        // corner case.
+        return "INVALID-OPTION-VALUE";
+      }
+    }
+    pos += 1;
+    return String.format(
+        "%s%s", raw.substring(0, pos), maybeScrubAssignment(sensitivity, raw.substring(pos)));
+  }
+
+  /**
+   * Scrubs secrets from a list of arguments.
+   *
+   * <p>The semantics for scrubbing arguments are the same as those defined by
+   * {@link #maybeScrubCombinedForm}. However, this must take care of options that were split
+   * across two arguments (one with the option's name and one with the value) as well as all
+   * residual arguments.</p>
+   *
+   * @param args the arguments to scrub
+   * @return the scrubbed arguments list
+   */
+  public static ImmutableList<String> scrubArgs(ImmutableList<String> args) {
+    ImmutableList.Builder<String> builder = ImmutableList.builder();
+
+    Iterator<String> iter = args.iterator();
+
+    // Handle Bazel's own arguments first.
+    OptionSensitivity previousSensitivity = OptionSensitivity.NONE;
+    while (iter.hasNext()) {
+      String canonicalForm = iter.next();
+      if (canonicalForm.equals("--")) {
+        builder.add(canonicalForm);
+        break;
+      }
+
+      if (previousSensitivity != OptionSensitivity.NONE) {
+        canonicalForm = maybeScrubAssignment(previousSensitivity, canonicalForm);
+        previousSensitivity = OptionSensitivity.NONE;
+      } else {
+        OptionSensitivity sensitivity = getOptionSensitivity(canonicalForm);
+        if (sensitivity != OptionSensitivity.NONE) {
+          if (containsOptionValue(canonicalForm)) {
+            canonicalForm = maybeScrubCombinedForm(sensitivity, canonicalForm);
+          } else {
+            previousSensitivity = sensitivity;
+          }
+        }
+      }
+      builder.add(canonicalForm);
+    }
+
+    // Handle residual arguments.
+    while (iter.hasNext()) {
+      iter.next();
+      builder.add("REDACTED");
+    }
+
+    return builder.build();
+  }
 
   /**
    * Returns a string representation of the non-hidden specified options; option values are
@@ -42,7 +266,11 @@ public final class OptionsUtils {
       if (result.length() != 0) {
         result.append(' ');
       }
-      result.append(option.getCanonicalFormWithValueEscaper(ShellEscaper::escapeString));
+      OptionSensitivity sensitivity =
+          getOptionSensitivity(option.getOptionDefinition().getOptionName());
+      result.append(option.getCanonicalFormWithValueEscaper(
+          (unescaped) ->
+              ShellEscaper.escapeString(maybeScrubAssignment(sensitivity, unescaped))));
     }
     return result.toString();
   }
@@ -67,7 +295,7 @@ public final class OptionsUtils {
       }
       builder.add(option.getCanonicalForm());
     }
-    return builder.build();
+    return scrubArgs(builder.build());
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/runtime/CommandLineEventTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/CommandLineEventTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.bazel.BazelStartupOptionsModule.Options;
+import com.google.devtools.build.lib.buildeventstream.BuildEventProtocolOptions;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.StructuredCommandLineId;
 import com.google.devtools.build.lib.runtime.CommandLineEvent.CanonicalCommandLineEvent;
 import com.google.devtools.build.lib.runtime.CommandLineEvent.OriginalCommandLineEvent;
@@ -26,6 +27,7 @@ import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.ChunkLi
 import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.CommandLine;
 import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.CommandLineSection;
 import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.CommandLineSection.SectionTypeCase;
+import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.Option;
 import com.google.devtools.build.lib.runtime.proto.CommandLineOuterClass.OptionList;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.common.options.OptionPriority.PriorityCategory;
@@ -510,5 +512,69 @@ public class CommandLineEventTest {
     assertThat(line.getSections(0).getSectionTypeCase()).isEqualTo(SectionTypeCase.CHUNK_LIST);
     assertThat(line.getSections(0).getChunkList().getChunk(0))
         .isEqualTo("The quick brown fox jumps over the lazy dog");
+  }
+
+  @Test
+  public void testScrubEnvOption() throws OptionsParsingException {
+    OptionsParser fakeStartupOptions =
+        OptionsParser.builder().optionsClasses(BlazeServerStartupOptions.class).build();
+    OptionsParser fakeCommandOptions =
+        OptionsParser.builder().optionsClasses(TestOptions.class).build();
+    fakeCommandOptions.parse(
+        PriorityCategory.COMMAND_LINE,
+        "command line",
+        ImmutableList.of(
+            "--stub_env=HOME=/home/jmmv",
+            "--stub_env=NOT_ALLOWED=1234",
+            "--stub_env", "ANOTHER=foo=1234",
+            "--stub_inherit_env=HOME",
+            "--stub_inherit_env=NOT_ALLOWED"
+        ));
+
+    CommandLine line =
+        new OriginalCommandLineEvent(
+            "testblaze",
+            fakeStartupOptions,
+            "someCommandName",
+            fakeCommandOptions,
+            Optional.of(ImmutableList.of()))
+            .asStreamProto(null)
+            .getStructuredCommandLine();
+
+    assertThat(line.getCommandLineLabel()).isEqualTo("original");
+    checkCommandLineSectionLabels(line);
+
+    assertThat(line.getSections(0).getChunkList().getChunk(0)).isEqualTo("testblaze");
+    assertThat(line.getSections(1).getOptionList().getOptionCount()).isEqualTo(0);
+    assertThat(line.getSections(2).getChunkList().getChunk(0)).isEqualTo("someCommandName");
+    // Expect the rc file options and invocation policy options to not be listed with the explicit
+    // command line options.
+    assertThat(line.getSections(3).getOptionList().getOptionCount()).isEqualTo(5);
+    {
+      Option option = line.getSections(3).getOptionList().getOption(0);
+      assertThat(option.getCombinedForm()).isEqualTo("--stub_env=HOME=/home/jmmv");
+      assertThat(option.getOptionValue()).isEqualTo("HOME=/home/jmmv");
+    }
+    {
+      Option option = line.getSections(3).getOptionList().getOption(1);
+      assertThat(option.getCombinedForm()).isEqualTo("--stub_env=NOT_ALLOWED= ");
+      assertThat(option.getOptionValue()).isEqualTo("NOT_ALLOWED= ");
+    }
+    {
+      Option option = line.getSections(3).getOptionList().getOption(2);
+      assertThat(option.getCombinedForm()).isEqualTo("--stub_env ANOTHER= ");
+      assertThat(option.getOptionValue()).isEqualTo("ANOTHER= ");
+    }
+    {
+      Option option = line.getSections(3).getOptionList().getOption(3);
+      assertThat(option.getCombinedForm()).isEqualTo("--stub_inherit_env=HOME");
+      assertThat(option.getOptionValue()).isEqualTo("HOME");
+    }
+    {
+      Option option = line.getSections(3).getOptionList().getOption(4);
+      assertThat(option.getCombinedForm()).isEqualTo("--stub_inherit_env=NOT_ALLOWED");
+      assertThat(option.getOptionValue()).isEqualTo("NOT_ALLOWED");
+    }
+    assertThat(line.getSections(4).getChunkList().getChunkCount()).isEqualTo(0);
   }
 }

--- a/src/test/java/com/google/devtools/common/options/TestOptions.java
+++ b/src/test/java/com/google/devtools/common/options/TestOptions.java
@@ -248,4 +248,26 @@ public class TestOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.NO_OP})
   public String testDeprecated;
+
+  /*
+   * Flags with potential secrets.
+   */
+
+  @Option(
+      name = "stub_env",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "null",
+      allowMultiple = true,
+      help = "a repeatable string-valued flag with its own unhelpful help text")
+  public List<String> testEnvString;
+
+  @Option(
+      name = "stub_inherit_env",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "null",
+      allowMultiple = true,
+      help = "a repeatable string-valued flag with its own unhelpful help text")
+  public List<String> testInheritEnvString;
 }


### PR DESCRIPTION
    This change adds logic to clean up the contents of the BEP before it
    leaves Bazel in an attempt to prevent propagating secrets to a remote
    service.

    In particular, this implements protections for the following:

    *   Secrets stored in the environment which are unconditionally leaked
        via the hidden --client_env flag.

    *   Secrets passed via --bes_header, --test_env, --test_arg, and similar
        options.  This is not completely safe to do because a determined
        user could inject secrets into the BEP in other ways.  So... treat
        this as just a safety net for common innocent mistakes.

    *   Secrets passed to tools run via "bazel run".  Think, for example,
        doing "bazel run //some/docker:command -- --password 1234".

    For the purposes of this change, a "secret" is whatever string we did
    not explicitly allow.  This code does not implement secret detection
    and it does not indend to, because such code would be based on
    heuristics as well.

    Note that services like BuildBuddy implement their own redaction of
    secrets when they receive the BEP... but it's better if we can strip
    them out at the source to minimize exposure.  Defense in depth.

Author: Julio Merino <julio.merino+oss@snowflake.com>
Date:   Thu Oct 5 10:34:10 2023 -0700