### PR TITLE
Fix link to 'Constraints and Platforms'

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ConstraintSettingInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ConstraintSettingInfoApi.java
@@ -27,7 +27,7 @@ import net.starlark.java.annot.StarlarkMethod;
     name = "ConstraintSettingInfo",
     doc =
         "A specific constraint setting that may be used to define a platform. See "
-            + "<a href='${link platforms#defining-constraints-and-platforms}'>Defining "
+            + "<a href='${link platforms#constraints-platforms}'>Defining "
             + "Constraints and Platforms</a> for more information."
             + PlatformInfoApi.EXPERIMENTAL_WARNING,
     category = DocCategory.PROVIDER)

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ConstraintValueInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ConstraintValueInfoApi.java
@@ -28,7 +28,7 @@ import net.starlark.java.annot.StarlarkMethod;
     name = "ConstraintValueInfo",
     doc =
         "A value for a constraint setting that can be used to define a platform. See "
-            + "<a href='${link platforms#defining-constraints-and-platforms}'>Defining "
+            + "<a href='${link platforms#constraints-platforms}'>Defining "
             + "Constraints and Platforms</a> for more information."
             + PlatformInfoApi.EXPERIMENTAL_WARNING,
     category = DocCategory.PROVIDER)

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/PlatformInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/PlatformInfoApi.java
@@ -26,7 +26,7 @@ import net.starlark.java.annot.StarlarkMethod;
     name = "PlatformInfo",
     doc =
         "Provides access to data about a specific platform. See "
-            + "<a href='${link platforms#defining-constraints-and-platforms}'>Defining "
+            + "<a href='${link platforms#constraints-platforms}'>Defining "
             + "Constraints and Platforms</a> for more information."
             + PlatformInfoApi.EXPERIMENTAL_WARNING,
     category = DocCategory.PROVIDER)


### PR DESCRIPTION
Fixed it to match the right anchor ([`#constraints-platforms`](https://bazel.build/extending/platforms#constraints-platforms))