### PR TITLE
Remove nocopts incompatible flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -454,6 +454,14 @@ public final class BazelRulesModule extends BlazeModule {
         help = "No-op",
         deprecationWarning = ANDROID_FLAG_DEPRECATION)
     public boolean incompatibleUseToolchainResolution;
+
+    @Option(
+        name = "incompatible_disable_nocopts",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        help = "No-op")
+    public boolean disableNoCopts;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -861,16 +861,6 @@ public final class CppConfiguration extends Fragment
     return cppOptions.useSpecificToolFiles;
   }
 
-  public boolean disableNoCopts() {
-    return cppOptions.disableNoCopts;
-  }
-
-  @Override
-  public boolean disableNocoptsStarlark(StarlarkThread thread) throws EvalException {
-    CcModule.checkPrivateStarlarkificationAllowlist(thread);
-    return disableNoCopts();
-  }
-
   @Override
   public boolean appleGenerateDsym() {
     return appleGenerateDsym;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -900,17 +900,6 @@ public class CppOptions extends FragmentOptions {
   public boolean useSpecificToolFiles;
 
   @Option(
-      name = "incompatible_disable_nocopts",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "When enabled, it removes nocopts attribute from C++ rules. See"
-              + " https://github.com/bazelbuild/bazel/issues/8706 for details.")
-  public boolean disableNoCopts;
-
-  @Option(
       name = "incompatible_enable_cc_test_feature",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CppConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CppConfigurationApi.java
@@ -192,7 +192,4 @@ public interface CppConfigurationApi<InvalidConfigurationExceptionT extends Exce
 
   @StarlarkMethod(name = "share_native_deps", documented = false, useStarlarkThread = true)
   boolean shareNativeDepsStarlark(StarlarkThread thread) throws EvalException;
-
-  @StarlarkMethod(name = "disable_nocopts", documented = false, useStarlarkThread = true)
-  boolean disableNocoptsStarlark(StarlarkThread thread) throws EvalException;
 }

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -287,7 +287,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:incompatible_require_ctx_in_configure_features",
         "//command_line_option:incompatible_make_thinlto_command_lines_standalone",
         "//command_line_option:incompatible_use_specific_tool_files",
-        "//command_line_option:incompatible_disable_nocopts",
         "//command_line_option:incompatible_validate_top_level_header_inclusions",
         "//command_line_option:strict_system_includes",
         "//command_line_option:experimental_use_cpp_compile_action_args_params_file",

--- a/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
@@ -311,18 +311,6 @@ linking the binary target.
     not declared in <code>deps</code>.
 </p>
 """),
-    "nocopts": attr.string(doc = """
-Remove matching options from the C++ compilation command.
-Subject to <a href="${link make-variables}">"Make" variable</a> substitution.
-The value of this attribute is interpreted as a regular expression.
-Any preexisting <code>COPTS</code> that match this regular expression
-(including values explicitly specified in the rule's <a
-href="#cc_binary.copts">copts</a> attribute)
-will be removed from <code>COPTS</code> for purposes of compiling this rule.
-This attribute should not be needed or used
-outside of <code>third_party</code>.  The values are not preprocessed
-in any way other than the "Make" variable substitution.
-    """),
     "linkstatic": attr.bool(
         default = True,
         doc = linkstatic_doc,
@@ -397,3 +385,4 @@ this option is off.
 
 cc_binary_attrs.update(dynamic_deps_attrs)
 cc_binary_attrs.update(semantics.get_distribs_attr())
+cc_binary_attrs.update(semantics.get_nocopts_attr())

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -1153,10 +1153,6 @@ def _copts_filter(ctx, additional_make_variable_substitutions):
     if nocopts == None or len(nocopts) == 0:
         return nocopts
 
-    # Check if nocopts is disabled.
-    if ctx.fragments.cpp.disable_nocopts():
-        fail("This attribute was removed. See https://github.com/bazelbuild/bazel/issues/8706 for details.", attr = "nocopts")
-
     # Expand nocopts and create CoptsFilter.
     return _expand(ctx, nocopts, additional_make_variable_substitutions)
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoObjDirTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoObjDirTest.java
@@ -959,38 +959,6 @@ public class CcBinaryThinLtoObjDirTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testCoptNoCoptAttributes() throws Exception {
-    createBuildFiles("copts = ['acopt', 'nocopt1'], nocopts = 'nocopt1|nocopt2',");
-
-    setupThinLTOCrosstool(CppRuleClasses.SUPPORTS_PIC);
-    useConfiguration("--copt=nocopt2", "--noincompatible_disable_nocopts");
-
-    /*
-    We follow the chain from the final product backwards.
-
-    binary <=[Link]=
-    .lto-obj/...o <=[LTOBackend]=
-    */
-    ConfiguredTarget pkg = getConfiguredTarget("//pkg:bin");
-
-    Artifact pkgArtifact = getFilesToBuild(pkg).getSingleton();
-    String rootExecPath = pkgArtifact.getRoot().getExecPathString();
-
-    SpawnAction linkAction = (SpawnAction) getGeneratingAction(pkgArtifact);
-    assertThat(linkAction.getOutputs()).containsExactly(pkgArtifact);
-
-    LtoBackendAction backendAction =
-        (LtoBackendAction)
-            getPredecessorByInputName(
-                linkAction, "pkg/bin.lto-obj/" + rootExecPath + "/pkg/_objs/bin/binfile.pic.o");
-    assertThat(backendAction.getMnemonic()).isEqualTo("CcLtoBackendCompile");
-    assertThat(backendAction.getArguments()).contains("acopt");
-    // TODO(b/122303926): Remove when nocopts are removed, or uncomment and fix if not removing.
-    // assertThat(backendAction.getArguments()).doesNotContain("nocopt1");
-    // assertThat(backendAction.getArguments()).doesNotContain("nocopt2");
-  }
-
-  @Test
   public void testLtoBackendOpt() throws Exception {
     createBuildFiles();
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryThinLtoTest.java
@@ -913,38 +913,6 @@ public class CcBinaryThinLtoTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testCoptNoCoptAttributes() throws Exception {
-    createBuildFiles("copts = ['acopt', 'nocopt1'], nocopts = 'nocopt1|nocopt2',");
-
-    setupThinLTOCrosstool(CppRuleClasses.SUPPORTS_PIC);
-    useConfiguration("--copt=nocopt2", "--noincompatible_disable_nocopts");
-
-    /*
-    We follow the chain from the final product backwards.
-
-    binary <=[Link]=
-    .lto/...o <=[LTOBackend]=
-    */
-    ConfiguredTarget pkg = getConfiguredTarget("//pkg:bin");
-
-    Artifact pkgArtifact = getFilesToBuild(pkg).getSingleton();
-    String rootExecPath = pkgArtifact.getRoot().getExecPathString();
-
-    SpawnAction linkAction = (SpawnAction) getGeneratingAction(pkgArtifact);
-    assertThat(linkAction.getOutputs()).containsExactly(pkgArtifact);
-
-    LtoBackendAction backendAction =
-        (LtoBackendAction)
-            getPredecessorByInputName(
-                linkAction, "pkg/bin.lto/" + rootExecPath + "/pkg/_objs/bin/binfile.pic.o");
-    assertThat(backendAction.getMnemonic()).isEqualTo("CcLtoBackendCompile");
-    assertThat(backendAction.getArguments()).contains("acopt");
-    // TODO(b/122303926): Remove when nocopts are removed, or uncomment and fix if not removing.
-    // assertThat(backendAction.getArguments()).doesNotContain("nocopt1");
-    // assertThat(backendAction.getArguments()).doesNotContain("nocopt2");
-  }
-
-  @Test
   public void testLtoBackendOpt() throws Exception {
     createBuildFiles();
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
@@ -1544,20 +1544,6 @@ public class CcCommonTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testNoCoptsDisabled() throws Exception {
-    if (analysisMock.isThisBazel()) {
-      return;
-    }
-    reporter.removeHandler(failFastHandler);
-    scratch.file("x/BUILD", "cc_library(name = 'foo', srcs = ['a.cc'], nocopts = 'abc')");
-    useConfiguration("--incompatible_disable_nocopts");
-    getConfiguredTarget("//x:foo");
-    assertContainsEvent(
-        "This attribute was removed. See https://github.com/bazelbuild/bazel/issues/8706 for"
-            + " details.");
-  }
-
-  @Test
   public void testLinkExtra() throws Exception {
     ConfiguredTarget target =
         scratchConfiguredTarget(


### PR DESCRIPTION
This eventually errors if you use it, but it being here meant it was still in the docs. The flag was flipped 5 years ago. This leaves some parts of this around under the assumption that google is still using this.