### PR TITLE
[7.3.0] Do not eval WORKSPACE in LocalRepositoryLookupFunction when `--noenable_workspace`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunction.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.packages.Package.NameConflictException;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.packages.WorkspaceFileValue;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.repository.ExternalPackageHelper;
 import com.google.devtools.build.lib.rules.repository.LocalRepositoryRule;
 import com.google.devtools.build.lib.rules.repository.WorkspaceFileHelper;
@@ -42,6 +43,7 @@ import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkSemantics;
 
 /** SkyFunction for {@link LocalRepositoryLookupValue}s. */
 public class LocalRepositoryLookupFunction implements SkyFunction {
@@ -58,6 +60,14 @@ public class LocalRepositoryLookupFunction implements SkyFunction {
   @Override
   public SkyValue compute(SkyKey skyKey, Environment env)
       throws SkyFunctionException, InterruptedException {
+    StarlarkSemantics semantics = PrecomputedValue.STARLARK_SEMANTICS.get(env);
+    if (semantics == null) {
+      return null;
+    }
+    if (!semantics.getBool(BuildLanguageOptions.ENABLE_WORKSPACE)) {
+      // TODO: #22208, #21515 - Figure out what to do here.
+      return LocalRepositoryLookupValue.mainRepository();
+    }
     RootedPath directory = (RootedPath) skyKey.argument();
 
     // Is this the root directory? If so, we're in the MAIN repository. This assumes that the main

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -1063,6 +1063,12 @@ class BazelModuleTest(test_base.TestBase):
         stderr,
     )
 
+  def testRegression22754(self):
+    """Regression test for issue #22754."""
+    self.ScratchFile('BUILD.bazel', ['print(glob(["testdata/**"]))'])
+    self.ScratchFile('testdata/WORKSPACE')
+    self.RunBazel(['build', ':all'])
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
This still leaves the question of "what do we do instead?". See issues #22208 and #21515.

Fixes https://github.com/bazelbuild/bazel/issues/22754.

Closes #22774.

PiperOrigin-RevId: 645148811
Change-Id: Ib9d07d2ecbc3a79e3341de6739de1c3349124d6b

Commit https://github.com/bazelbuild/bazel/commit/1246ff498b51acb92776efb9402c40f54d83fdee