### PR TITLE
[toolchains] Allow specifying `platform` in `exec_compatible_with`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.starlarkbuildapi.platform.ConstraintCollect
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -107,6 +108,17 @@ public abstract class ConstraintCollection
 
   /** Returns the constraints supplied by this collection. */
   abstract ImmutableMap<ConstraintSettingInfo, ConstraintValueInfo> constraints();
+
+  /**
+   * Returns the transitive closure of {@link ConstraintSettingInfo}s this {@link ConstraintCollection} has constraints on.
+   */
+  public final ImmutableSet<ConstraintSettingInfo> transitiveConstraintSettings() {
+    var constraints = ImmutableSet.<ConstraintSettingInfo>builder();
+    if (parent() != null) {
+      constraints.addAll(parent().transitiveConstraintSettings());
+    }
+    return constraints.build();
+  }
 
   /**
    * Returns {@code true} if this {@link ConstraintCollection} contains every {@link

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/BUILD
@@ -27,6 +27,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_value_creation_exception",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/protobuf:failure_details_java_proto",
+        "//third_party:guava",
         "//third_party:jsr305",
     ],
 )


### PR DESCRIPTION
This change will allow us (in a follow-up) to add an artificial constraint to the current `--host_platform` for targets marked as `{local,no-remote,no-remote-exec}`, which then avoids build failures when running a build, e.g., from a macOS machine against a remote execution cluster.

Bug: #22848