### PR TITLE
[7.3.0] Retry HTTP download on timeout.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -64,6 +64,7 @@ import com.google.devtools.build.lib.remote.circuitbreaker.CircuitBreakerFactory
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.downloader.GrpcRemoteDownloader;
+import com.google.devtools.build.lib.remote.http.DownloadTimeoutException;
 import com.google.devtools.build.lib.remote.http.HttpException;
 import com.google.devtools.build.lib.remote.logging.LoggingInterceptor;
 import com.google.devtools.build.lib.remote.logging.RemoteExecutionLog.LogEntry;
@@ -190,6 +191,8 @@ public final class RemoteModule extends BlazeModule {
       e -> {
         boolean retry = false;
         if (e instanceof ClosedChannelException) {
+          retry = true;
+        } else if (e instanceof DownloadTimeoutException) {
           retry = true;
         } else if (e instanceof HttpException) {
           int status = ((HttpException) e).response().status().code();

--- a/src/main/java/com/google/devtools/build/lib/remote/http/DownloadTimeoutException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/DownloadTimeoutException.java
@@ -16,7 +16,8 @@ package com.google.devtools.build.lib.remote.http;
 
 import java.io.IOException;
 
-class DownloadTimeoutException extends IOException {
+/** Exception thrown when a HTTP download times out. */
+public class DownloadTimeoutException extends IOException {
 
   public DownloadTimeoutException(String url, long bytesReceived, long contentLength) {
     super(buildMessage(url, bytesReceived, contentLength));


### PR DESCRIPTION
Address https://github.com/bazelbuild/bazel/issues/20559#issuecomment-2203999686.

PiperOrigin-RevId: 649360592
Change-Id: I50ac2ed3b54d6cffb5f96d3f8315279786c4f30f