### PR TITLE
Fix vendoring immediatelly after a normal repo fetch

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDirectoryValue.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDirectoryValue.java
@@ -124,7 +124,8 @@ public abstract class RepositoryDirectoryValue implements SkyValue {
         return Objects.equal(path, otherValue.path)
             && Objects.equal(sourceDir, otherValue.sourceDir)
             && Arrays.equals(digest, otherValue.digest)
-            && Objects.equal(fileValues, otherValue.fileValues);
+            && Objects.equal(fileValues, otherValue.fileValues)
+            && Objects.equal(excludeFromVendoring, otherValue.excludeFromVendoring);
       }
       return false;
     }

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -143,6 +143,25 @@ class BazelVendorTest(test_base.TestBase):
         'ERROR: You cannot run the vendor command with --nofetch', stderr
     )
 
+  def testVendorAfterFetch(self):
+    self.main_registry.createCcModule('aaa', '1.0')
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "aaa", version = "1.0")',
+            'local_path_override(module_name="bazel_tools", path="tools_mock")',
+            'local_path_override(module_name="local_config_platform", ',
+            'path="platforms_mock")',
+        ],
+    )
+    self.ScratchFile('BUILD')
+
+    self.RunBazel(['fetch', '--repo=@@aaa~'])
+    self.RunBazel(['vendor', '--vendor_dir=vendor', '--repo=@@aaa~'])
+
+    repos_vendored = os.listdir(self._test_cwd + '/vendor')
+    self.assertIn('aaa~', repos_vendored)
+
   def testVendoringMultipleTimes(self):
     self.main_registry.createCcModule('aaa', '1.0')
     self.ScratchFile(


### PR DESCRIPTION
Repo wasn't vendored as expected due to wrong SkyValue cache caused by incorrect equals function.

Related: https://github.com/bazelbuild/bazel/issues/19563