### PR TITLE
Support `layering_check` with C++ path mapping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
@@ -575,7 +575,7 @@ public final class CcCompilationContext implements CcCompilationContextApi<Artif
   }
 
   /** @return modules maps from direct dependencies. */
-  public Iterable<Artifact> getDirectModuleMaps() {
+  public ImmutableList<Artifact> getDirectModuleMaps() {
     return directModuleMaps;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
@@ -422,7 +422,9 @@ public class CcStarlarkInternal implements StarlarkValue {
             generateSubmodules,
             withoutExternDependencies,
             PathMappers.getOutputPathsMode(ruleContext.getConfiguration()),
-            ruleContext.getConfiguration()::modifiedExecutionInfo));
+            ruleContext
+                .getConfiguration()
+                .modifiedExecutionInfo(ImmutableMap.of(), CppModuleMapAction.MNEMONIC)));
   }
 
   @SerializationConstant @VisibleForSerialization

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.analysis.LicensesProvider;
 import com.google.devtools.build.lib.analysis.LicensesProvider.TargetLicense;
 import com.google.devtools.build.lib.analysis.LicensesProviderImpl;
 import com.google.devtools.build.lib.analysis.RuleContext;
+import com.google.devtools.build.lib.analysis.actions.PathMappers;
 import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.starlark.Args;
@@ -419,7 +420,9 @@ public class CcStarlarkInternal implements StarlarkValue {
             compiledModule,
             moduleMapHomeIsCwd,
             generateSubmodules,
-            withoutExternDependencies));
+            withoutExternDependencies,
+            PathMappers.getOutputPathsMode(ruleContext.getConfiguration()),
+            ruleContext.getConfiguration()::modifiedExecutionInfo));
   }
 
   @SerializationConstant @VisibleForSerialization

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -1185,6 +1185,54 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     }
   }
 
+  @Immutable
+  private static final class ArtifactSetSequence extends VariableValueAdapter {
+    private final NestedSet<Artifact> values;
+
+    private ArtifactSetSequence(NestedSet<Artifact> values) {
+      Preconditions.checkNotNull(values);
+      this.values = values;
+    }
+
+    @Override
+    public ImmutableList<VariableValue> getSequenceValue(
+        String variableName, PathMapper pathMapper) {
+      ImmutableList<Artifact> valuesList = values.toList();
+      ImmutableList.Builder<VariableValue> sequences =
+          ImmutableList.builderWithExpectedSize(valuesList.size());
+      for (Artifact value : valuesList) {
+        sequences.add(new StringValue(pathMapper.getMappedExecPathString(value)));
+      }
+      return sequences.build();
+    }
+
+    @Override
+    public String getVariableTypeName() {
+      return Sequence.SEQUENCE_VARIABLE_TYPE_NAME;
+    }
+
+    @Override
+    public boolean isTruthy() {
+      return !values.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof ArtifactSetSequence otherArtifacts)) {
+        return false;
+      }
+      return values.shallowEquals(otherArtifacts.values);
+    }
+
+    @Override
+    public int hashCode() {
+      return values.shallowHashCode();
+    }
+  }
+
   /**
    * Single structure value. Be careful not to create sequences of single structures, as the memory
    * overhead is prohibitively big.
@@ -1493,6 +1541,19 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       checkVariableNotPresentAlready(name);
       Preconditions.checkNotNull(values, "Cannot set null as a value for variable '%s'", name);
       variablesMap.put(name, new PathFragmentSetSequence(values));
+      return this;
+    }
+
+    /**
+     * Add a sequence variable that expands {@code name} to {@link Artifact} {@code values}.
+     *
+     * <p>Accepts values as NestedSet. Nested set is stored directly, not cloned, not flattened.
+     */
+    @CanIgnoreReturnValue
+    public Builder addArtifactSequenceVariable(String name, NestedSet<Artifact> values) {
+      checkVariableNotPresentAlready(name);
+      Preconditions.checkNotNull(values, "Cannot set null as a value for variable '%s'", name);
+      variablesMap.put(name, new ArtifactSetSequence(values));
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
@@ -158,7 +158,7 @@ public enum CompileBuildVariables {
       Artifact diagnosticsFile,
       ImmutableList<VariablesExtension> variablesExtensions,
       ImmutableMap<String, String> additionalBuildVariables,
-      Iterable<Artifact> directModuleMaps,
+      ImmutableList<Artifact> directModuleMaps,
       NestedSet<PathFragment> includeDirs,
       NestedSet<PathFragment> quoteIncludeDirs,
       NestedSet<PathFragment> systemIncludeDirs,
@@ -225,7 +225,7 @@ public enum CompileBuildVariables {
       Artifact diagnosticsFile,
       ImmutableList<VariablesExtension> variablesExtensions,
       ImmutableMap<String, String> additionalBuildVariables,
-      Iterable<Artifact> directModuleMaps,
+      ImmutableList<Artifact> directModuleMaps,
       NestedSet<String> includeDirs,
       NestedSet<String> quoteIncludeDirs,
       NestedSet<String> systemIncludeDirs,
@@ -293,7 +293,7 @@ public enum CompileBuildVariables {
       Artifact diagnosticsFile,
       ImmutableList<VariablesExtension> variablesExtensions,
       ImmutableMap<String, String> additionalBuildVariables,
-      Iterable<Artifact> directModuleMaps,
+      ImmutableList<Artifact> directModuleMaps,
       NestedSet<PathFragment> includeDirs,
       NestedSet<PathFragment> quoteIncludeDirs,
       NestedSet<PathFragment> systemIncludeDirs,
@@ -467,7 +467,7 @@ public enum CompileBuildVariables {
       boolean isUsingMemProf,
       List<VariablesExtension> variablesExtensions,
       Map<String, String> additionalBuildVariables,
-      Iterable<Artifact> directModuleMaps,
+      ImmutableList<Artifact> directModuleMaps,
       ImmutableList<PathFragment> includeDirs,
       ImmutableList<PathFragment> quoteIncludeDirs,
       ImmutableList<PathFragment> systemIncludeDirs,
@@ -503,7 +503,7 @@ public enum CompileBuildVariables {
       boolean isUsingMemProf,
       List<VariablesExtension> variablesExtensions,
       Map<String, String> additionalBuildVariables,
-      Iterable<Artifact> directModuleMaps,
+      ImmutableList<Artifact> directModuleMaps,
       NestedSet<PathFragment> includeDirs,
       NestedSet<PathFragment> quoteIncludeDirs,
       NestedSet<PathFragment> systemIncludeDirs,
@@ -522,9 +522,9 @@ public enum CompileBuildVariables {
       buildVariables.addStringVariable(MODULE_NAME.getVariableName(), cppModuleMap.getName());
       buildVariables.addArtifactVariable(
           MODULE_MAP_FILE.getVariableName(), cppModuleMap.getArtifact());
-      buildVariables.addStringSequenceVariable(
+      buildVariables.addArtifactSequenceVariable(
           DEPENDENT_MODULE_MAP_FILES.getVariableName(),
-          Iterables.transform(directModuleMaps, Artifact::getExecPathString));
+          NestedSetBuilder.wrap(Order.STABLE_ORDER, directModuleMaps));
     }
     if (featureConfiguration.isEnabled(CppRuleClasses.USE_HEADER_MODULES)) {
       // Module inputs will be set later when the action is executed.

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -496,6 +496,7 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/core_options",
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/test/java/com/google/devtools/build/lib/actions/util",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppModuleMapActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppModuleMapActionTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.rules.cpp;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
@@ -71,7 +72,7 @@ public final class CppModuleMapActionTest {
         /* generateSubmodules= */ false,
         /* externDependencies= */ false,
         CoreOptions.OutputPathsMode.OFF,
-        (executionInfo, mnemonic) -> executionInfo);
+        /* executionInfo= */ ImmutableMap.of());
   }
 
   private Artifact createOutputArtifact(String rootRelativePath) {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppModuleMapActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppModuleMapActionTest.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
@@ -60,15 +61,17 @@ public final class CppModuleMapActionTest {
     return new CppModuleMapAction(
         ActionsTestUtil.NULL_ACTION_OWNER,
         cppModuleMap,
-        /*privateHeaders=*/ ImmutableList.of(),
-        /*publicHeaders=*/ ImmutableList.of(),
+        /* privateHeaders= */ ImmutableList.of(),
+        /* publicHeaders= */ ImmutableList.of(),
         ImmutableList.copyOf(dependencies),
-        /*additionalExportedHeaders=*/ ImmutableList.of(),
-        /*separateModuleHeaders=*/ ImmutableList.of(),
-        /*compiledModule=*/ false,
-        /*moduleMapHomeIsCwd=*/ false,
-        /*generateSubmodules=*/ false,
-        /*externDependencies=*/ false);
+        /* additionalExportedHeaders= */ ImmutableList.of(),
+        /* separateModuleHeaders= */ ImmutableList.of(),
+        /* compiledModule= */ false,
+        /* moduleMapHomeIsCwd= */ false,
+        /* generateSubmodules= */ false,
+        /* externDependencies= */ false,
+        CoreOptions.OutputPathsMode.OFF,
+        (executionInfo, mnemonic) -> executionInfo);
   }
 
   private Artifact createOutputArtifact(String rootRelativePath) {

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -623,9 +623,9 @@ EOF
   bazel run \
     --verbose_failures \
     --experimental_output_paths=strip \
-    --modify_execution_info=CppCompile=+supports-path-mapping \
+    --modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping \
     --remote_executor=grpc://localhost:${worker_port} \
-    --features=-module_maps \
+    --features=layering_check \
     "//$pkg:main" &>"$TEST_log" || fail "Expected success"
 
   expect_log 'Hello, lib1!'
@@ -636,9 +636,9 @@ EOF
   bazel run \
     --verbose_failures \
     --experimental_output_paths=strip \
-    --modify_execution_info=CppCompile=+supports-path-mapping \
+    --modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping \
     --remote_executor=grpc://localhost:${worker_port} \
-    --features=-module_maps \
+    --features=layering_check \
     "//$pkg:transitioned_main" &>"$TEST_log" || fail "Expected success"
 
   expect_log 'Hi there, lib1!'

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -172,11 +172,7 @@ final class ExecutionServer extends ExecutionImplBase {
       return;
     }
     ((ServerCallStreamObserver<Operation>) responseObserver)
-        .setOnCancelHandler(
-            () -> {
-              future.cancel(true);
-              operationsCache.remove(opName);
-            });
+        .setOnCancelHandler(() -> operationsCache.remove(opName));
     waitExecution(opName, future, responseObserver);
   }
 
@@ -238,11 +234,7 @@ final class ExecutionServer extends ExecutionImplBase {
         executorService.submit(() -> execute(context, request, opName));
     operationsCache.put(opName, future);
     ((ServerCallStreamObserver<Operation>) responseObserver)
-        .setOnCancelHandler(
-            () -> {
-              future.cancel(true);
-              operationsCache.remove(opName);
-            });
+        .setOnCancelHandler(() -> operationsCache.remove(opName));
     // Send the first operation.
     responseObserver.onNext(Operation.newBuilder().setName(opName).build());
     // When the operation completes, send the result.


### PR DESCRIPTION
Users can opt into path mapping for C++ module map actions via `--modify_execution_info=CppModuleMap=+supports-path-mapping`. This is achieved by mapping paths in the module map files as well as converting the sequence variable for module map paths to a new structured `ArtifactSequenceVariable`.

Also makes it so that `ExecutionServer` gracefully handles failing commands instead of crashing.