### PR TITLE
Add `c-header-parsing` action

### DIFF
--- a/site/en/docs/bazel-and-cpp.md
+++ b/site/en/docs/bazel-and-cpp.md
@@ -97,7 +97,8 @@ can improve the hygiene of a C++ project. They can be enabled using the
   [`--process_headers_in_dependencies`](/reference/command-line-reference#flag--process_headers_in_dependencies)
   flag. This can help catch issues in header-only libraries and ensure that
   headers are self-contained and independent of the order in which they are
-  included.
+  included. When the `parse_headers_as_c` feature is also enabled, headers are
+  parsed as C rather than C++.
 * The `layering_check` feature enforces that targets only include headers
   provided by their direct dependencies. The default toolchain supports this
   feature on Linux with `clang` as the compiler.

--- a/site/en/docs/cc-toolchain-config-reference.md
+++ b/site/en/docs/cc-toolchain-config-reference.md
@@ -275,11 +275,19 @@ that implements an action (such as `CppCompileAction`). In particular, the
    </td>
   </tr>
   <tr>
+   <td><code>c-header-parsing</code>
+   </td>
+   <td>Run the compiler's parser on a header file to ensure that the header is
+     self-contained, as it will otherwise produce compilation errors. All header
+     files are assumed to be C.
+   </td>
+  </tr>
+  <tr>
    <td><code>c++-header-parsing</code>
    </td>
    <td>Run the compiler's parser on a header file to ensure that the header is
-     self-contained, as it will otherwise produce compilation errors. Applies
-     only to toolchains that support modules.
+     self-contained, as it will otherwise produce compilation errors. All header
+     files are assumed to be C++.
    </td>
   </tr>
 </table>

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
@@ -73,6 +73,7 @@ public final class CcCommon implements StarlarkValue {
       ImmutableSet.of(
           CppActionNames.C_COMPILE,
           CppActionNames.CPP_COMPILE,
+          CppActionNames.C_HEADER_PARSING,
           CppActionNames.CPP_HEADER_PARSING,
           CppActionNames.CPP_MODULE_COMPILE,
           CppActionNames.CPP_MODULE_CODEGEN,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionNames.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionNames.java
@@ -34,6 +34,8 @@ public class CppActionNames {
   public static final String OBJC_COMPILE = "objc-compile";
   /** A string constant for the objc++ compile action. */
   public static final String OBJCPP_COMPILE = "objc++-compile";
+  /** A string constant for the c header parsing. */
+  public static final String C_HEADER_PARSING = "c-header-parsing";
   /** A string constant for the c++ header parsing. */
   public static final String CPP_HEADER_PARSING = "c++-header-parsing";
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -181,9 +181,12 @@ public final class CppCompileActionBuilder {
     if (CppFileTypes.CPP_MODULE_MAP.matches(sourcePath)) {
       return CppActionNames.CPP_MODULE_COMPILE;
     } else if (CppFileTypes.CPP_HEADER.matches(sourcePath)) {
-      // TODO(bazel-team): Handle C headers that probably don't work in C++ mode.
       if (featureConfiguration.isEnabled(CppRuleClasses.PARSE_HEADERS)) {
-        return CppActionNames.CPP_HEADER_PARSING;
+        if (featureConfiguration.isEnabled(CppRuleClasses.PARSE_HEADERS_AS_C)) {
+          return CppActionNames.C_HEADER_PARSING;
+        } else {
+          return CppActionNames.CPP_HEADER_PARSING;
+        }
       }
       // CcCommon.collectCAndCppSources() ensures we do not add headers to
       // the compilation artifacts unless 'parse_headers' is set.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -182,7 +182,8 @@ public final class CppCompileActionBuilder {
       return CppActionNames.CPP_MODULE_COMPILE;
     } else if (CppFileTypes.CPP_HEADER.matches(sourcePath)) {
       if (featureConfiguration.isEnabled(CppRuleClasses.PARSE_HEADERS)) {
-        if (featureConfiguration.isEnabled(CppRuleClasses.PARSE_HEADERS_AS_C)) {
+        if (featureConfiguration.isEnabled(CppRuleClasses.PARSE_HEADERS_AS_C)
+            && featureConfiguration.actionIsConfigured(CppActionNames.C_HEADER_PARSING)) {
           return CppActionNames.C_HEADER_PARSING;
         } else {
           return CppActionNames.CPP_HEADER_PARSING;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkstampCompileHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkstampCompileHelper.java
@@ -160,7 +160,10 @@ public final class CppLinkstampCompileHelper {
             .map(Artifact::getExecPathString)
             .collect(toImmutableList()),
         CcCompilationHelper.getCoptsFromOptions(
-            ccToolchainProvider.getCppConfiguration(), semantics, sourceFile.getExecPathString()),
+            ccToolchainProvider.getCppConfiguration(),
+            semantics,
+            sourceFile.getExecPathString(),
+            CppActionNames.LINKSTAMP_COMPILE),
         /* cppModuleMap= */ null,
         needsPic,
         fdoBuildStamp,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
@@ -101,6 +101,9 @@ public class CppRuleClasses {
   /** A string constant for the parse_headers feature. */
   public static final String PARSE_HEADERS = "parse_headers";
 
+  /** A string constant for the parse_headers_as_c feature. */
+  public static final String PARSE_HEADERS_AS_C = "parse_headers_as_c";
+  
   /**
    * A string constant for the module_maps feature; this is a precondition to the layering_check and
    * header_modules features.

--- a/tools/build_defs/cc/action_names.bzl
+++ b/tools/build_defs/cc/action_names.bzl
@@ -28,6 +28,9 @@ CC_FLAGS_MAKE_VARIABLE_ACTION_NAME = "cc-flags-make-variable"
 # Name of the C++ module codegen action.
 CPP_MODULE_CODEGEN_ACTION_NAME = "c++-module-codegen"
 
+# Name of the C header parsing action.
+C_HEADER_PARSING_ACTION_NAME = "c-header-parsing"
+
 # Name of the C++ header parsing action.
 CPP_HEADER_PARSING_ACTION_NAME = "c++-header-parsing"
 
@@ -97,6 +100,7 @@ ACTION_NAMES = struct(
     linkstamp_compile = LINKSTAMP_COMPILE_ACTION_NAME,
     cc_flags_make_variable = CC_FLAGS_MAKE_VARIABLE_ACTION_NAME,
     cpp_module_codegen = CPP_MODULE_CODEGEN_ACTION_NAME,
+    c_header_parsing = C_HEADER_PARSING_ACTION_NAME,
     cpp_header_parsing = CPP_HEADER_PARSING_ACTION_NAME,
     cpp_module_compile = CPP_MODULE_COMPILE_ACTION_NAME,
     assemble = ASSEMBLE_ACTION_NAME,

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -103,6 +103,33 @@ def parse_headers_support(parse_headers_tool_path):
         return [], []
     action_configs = [
         action_config(
+            action_name = ACTION_NAMES.c_header_parsing,
+            tools = [
+                tool(path = parse_headers_tool_path),
+            ],
+            flag_sets = [
+                flag_set(
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-xc-header",
+                                "-fsyntax-only",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            implies = [
+                # Copied from the legacy feature definition in CppActionConfigs.java.
+                "legacy_compile_flags",
+                "user_compile_flags",
+                "sysroot",
+                "unfiltered_compile_flags",
+                "compiler_input_flags",
+                "compiler_output_flags",
+            ],
+        ),
+        action_config(
             action_name = ACTION_NAMES.cpp_header_parsing,
             tools = [
                 tool(path = parse_headers_tool_path),
@@ -112,10 +139,6 @@ def parse_headers_support(parse_headers_tool_path):
                     flag_groups = [
                         flag_group(
                             flags = [
-                                # Note: This treats all headers as C++ headers, which may lead to
-                                # parsing failures for C headers that are not valid C++.
-                                # For such headers, use features = ["-parse_headers"] to selectively
-                                # disable parsing.
                                 "-xc++-header",
                                 "-fsyntax-only",
                             ],
@@ -145,6 +168,7 @@ all_compile_actions = [
     ACTION_NAMES.linkstamp_compile,
     ACTION_NAMES.assemble,
     ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.c_header_parsing,
     ACTION_NAMES.cpp_header_parsing,
     ACTION_NAMES.cpp_module_compile,
     ACTION_NAMES.cpp_module_codegen,

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -48,6 +48,7 @@ def layering_check_features(compiler, extra_flags_per_feature, is_macos):
                     actions = [
                         ACTION_NAMES.c_compile,
                         ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.c_header_parsing,
                         ACTION_NAMES.cpp_header_parsing,
                         ACTION_NAMES.cpp_module_compile,
                     ],
@@ -78,6 +79,7 @@ def layering_check_features(compiler, extra_flags_per_feature, is_macos):
                     actions = [
                         ACTION_NAMES.c_compile,
                         ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.c_header_parsing,
                         ACTION_NAMES.cpp_header_parsing,
                         ACTION_NAMES.cpp_module_compile,
                     ],
@@ -159,6 +161,7 @@ def parse_headers_support(parse_headers_tool_path):
     ]
     features = [
         feature(name = "parse_headers"),
+        feature(name = "parse_headers_as_c"),
     ]
     return action_configs, features
 
@@ -409,6 +412,7 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.cpp_module_codegen,
@@ -436,6 +440,7 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.cpp_module_codegen,
@@ -464,6 +469,7 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.cpp_module_codegen,
@@ -630,6 +636,7 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.clif_match,
@@ -809,6 +816,7 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.clif_match,
@@ -880,6 +888,7 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.clif_match,
@@ -913,6 +922,7 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.clif_match,
@@ -1247,6 +1257,7 @@ def _impl(ctx):
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.objc_compile,
                     ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.clif_match,
                 ],
@@ -1272,6 +1283,7 @@ def _impl(ctx):
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.objc_compile,
                     ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.clif_match,
                 ],
@@ -1356,6 +1368,7 @@ def _impl(ctx):
                     ACTION_NAMES.preprocess_assemble,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.c_header_parsing,
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                 ],


### PR DESCRIPTION
The new `c-header-parsing` action is used for header files when the `parse_headers_as_c` feature is enabled (in addition to `parse_headers`). It can be used by toolchains to force the compiler to parse the headers as C rather than C++.