### PR TITLE
Generalise negatable flag detection

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
+import com.google.devtools.common.options.HasNegativeFlag;
 import com.google.devtools.common.options.OptionsProvider;
 import java.io.Closeable;
 import java.io.IOException;
@@ -152,7 +153,7 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
   }
 
   /** Enum for --subcommands flag */
-  public enum ShowSubcommands {
+  public enum ShowSubcommands implements HasNegativeFlag {
     TRUE(true, false), PRETTY_PRINT(true, true), FALSE(false, false);
 
     private final boolean shouldShowSubcommands;

--- a/src/main/java/com/google/devtools/common/options/HasNegativeFlag.java
+++ b/src/main/java/com/google/devtools/common/options/HasNegativeFlag.java
@@ -1,4 +1,4 @@
-// Copyright 2014 The Bazel Authors. All rights reserved.
+// Copyright 2024 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
 package com.google.devtools.common.options;
 
 /**
- * Enum used to represent tri-state options (yes/no/auto).
+ * HasNegativeFlag is a marker interface to show that a flag may be negated.
  */
-public enum TriState implements HasNegativeFlag {
-  YES, NO, AUTO
-}
+public interface HasNegativeFlag {}

--- a/src/main/java/com/google/devtools/common/options/OptionDefinition.java
+++ b/src/main/java/com/google/devtools/common/options/OptionDefinition.java
@@ -126,7 +126,7 @@ public abstract class OptionDefinition implements Comparable<OptionDefinition> {
 
   /** Returns whether an option --foo has a negative equivalent --nofoo. */
   public boolean hasNegativeOption() {
-    return getType().equals(boolean.class) || getType().equals(TriState.class);
+    return getType().equals(boolean.class) || HasNegativeFlag.class.isAssignableFrom(getType());
   }
 
   /** The type of the optionDefinition. */

--- a/src/test/java/com/google/devtools/common/options/BUILD
+++ b/src/test/java/com/google/devtools/common/options/BUILD
@@ -42,6 +42,7 @@ java_test(
     ),
     deps = [
         ":testutils",
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/util:classpath",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/java/com/google/devtools/common/options:invocation_policy",


### PR DESCRIPTION
Previously this code hard-coded that the only negatable flags are booleans or tri-states.

But --subcommands is also negatable.

This allows flag types to declare themselves as negatable by implementing an empty interface, rather than keeping a hard-coded universe of negatable flag types.