### PR TITLE
Fix javadocs for Runfiles

### DIFF
--- a/tools/java/runfiles/Runfiles.java
+++ b/tools/java/runfiles/Runfiles.java
@@ -118,7 +118,7 @@ import java.util.stream.Collectors;
  * Runfiles#preload(Map)} and immutably encapsulate all data required to look up runfiles with the
  * repository mapping of any Bazel repository specified at a later time.
  *
- * <p>Creating {@link Runfiles} instances can be costly, so applications should try to create as few
+ * <p>Creating {@link Preloaded} instances can be costly, so applications should try to create as few
  * instances as possible. {@link Runfiles#preload()}, but not {@link Runfiles#preload(Map)}, returns
  * a single global, softly cached instance of {@link Preloaded} that is constructed based on the
  * JVM's environment variables.


### PR DESCRIPTION
`Runfiles` insurance are cheap, `Preloaded` instances are costly.