### PR TITLE
Mark the implementation_deps feature as stable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -915,13 +915,13 @@ public final class CppConfiguration extends Fragment
   }
 
   @StarlarkMethod(
-      name = "experimental_cc_implementation_deps",
+      name = "cc_implementation_deps",
       documented = false,
       useStarlarkThread = true)
-  public boolean experimentalCcImplementationDepsForStarlark(StarlarkThread thread)
+  public boolean ccImplementationDepsForStarlark(StarlarkThread thread)
       throws EvalException {
     CcModule.checkPrivateStarlarkificationAllowlist(thread);
-    return experimentalCcImplementationDeps();
+    return ccImplementationDeps();
   }
 
   @StarlarkMethod(name = "experimental_cpp_modules", documented = false, useStarlarkThread = true)
@@ -930,8 +930,8 @@ public final class CppConfiguration extends Fragment
     return experimentalCppModules();
   }
 
-  public boolean experimentalCcImplementationDeps() {
-    return cppOptions.experimentalCcImplementationDeps;
+  public boolean ccImplementationDeps() {
+    return cppOptions.ccImplementationDeps;
   }
 
   public boolean experimentalCppModules() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -1028,7 +1028,7 @@ public class CppOptions extends FragmentOptions {
   public boolean objcGenerateDotdFiles;
 
   @Option(
-      name = "experimental_cc_implementation_deps",
+      name = "cc_implementation_deps",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {
@@ -1036,7 +1036,7 @@ public class CppOptions extends FragmentOptions {
       },
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},
       help = "If enabled, cc_library targets can use attribute `implementation_deps`.")
-  public boolean experimentalCcImplementationDeps;
+  public boolean ccImplementationDeps;
 
   @Option(
       name = "experimental_cpp_modules",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -276,7 +276,7 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:host_linkopt",
         "//command_line_option:target libcTop label",
         "//command_line_option:experimental_link_static_libraries_once",
-        "//command_line_option:experimental_cc_implementation_deps",
+        "//command_line_option:cc_implementation_deps",
         "//command_line_option:experimental_cpp_modules",
         "//command_line_option:start_end_lib",
         "//command_line_option:experimental_inmemory_dotd_files",

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -851,7 +851,7 @@ transitive deps) are only used for compilation of this library, and not librarie
 depend on it. Libraries specified with <code>implementation_deps</code> are still linked in
 binary targets that depend on this library.
 <p>For now usage is limited to cc_libraries and guarded by the flag
-<code>--experimental_cc_implementation_deps</code>.</p>
+<code>--cc_implementation_deps</code>.</p>
 """),
         "strip_include_prefix": attr.string(doc = """
 The prefix to strip from the paths of the headers of this rule.

--- a/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
@@ -113,9 +113,9 @@ def _get_implementation_deps_allowed_attr():
     return {}
 
 def _check_can_use_implementation_deps(ctx):
-    experimental_cc_implementation_deps = ctx.fragments.cpp.experimental_cc_implementation_deps()
-    if (not experimental_cc_implementation_deps and ctx.attr.implementation_deps):
-        fail("requires --experimental_cc_implementation_deps", attr = "implementation_deps")
+    cc_implementation_deps = ctx.fragments.cpp.cc_implementation_deps()
+    if (not cc_implementation_deps and ctx.attr.implementation_deps):
+        fail("requires --cc_implementation_deps", attr = "implementation_deps")
 
 _WINDOWS_PLATFORM = Label("@platforms//os:windows")  # Resolve the label within builtins context
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2096,7 +2096,7 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
 
     assertThat(getExecConfiguredTarget("//foo:public_dep")).isNotNull();
     ;
-    assertDoesNotContainEvent("requires --experimental_cc_implementation_deps");
+    assertDoesNotContainEvent("requires --cc_implementation_deps");
   }
 
   @Test
@@ -2120,7 +2120,7 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
         """);
     assertThat(getConfiguredTarget("//foo:lib")).isNotNull();
     ;
-    assertDoesNotContainEvent("requires --experimental_cc_implementation_deps");
+    assertDoesNotContainEvent("requires --cc_implementation_deps");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -7383,7 +7383,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
             "incompatible_enable_cc_test_feature()",
             "build_test_dwp()",
             "grte_top()",
-            "experimental_cc_implementation_deps()",
+            "cc_implementation_deps()",
             "experimental_cpp_modules()",
             "share_native_deps()",
             "experimental_platform_cc_test()");


### PR DESCRIPTION
This cc_library feature is active by default since change 05787f3. Naming the corresponding feature flag experimental is confusing users.

RELNOTES: `--experimental_cc_implementation_deps` has been renamed to `--cc_implementation_deps`

Closes #20098