### PR TITLE
Remove flag `--experimental_cc_implementation_deps`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -914,24 +914,10 @@ public final class CppConfiguration extends Fragment
     return cppOptions.objcEnableBinaryStripping;
   }
 
-  @StarlarkMethod(
-      name = "experimental_cc_implementation_deps",
-      documented = false,
-      useStarlarkThread = true)
-  public boolean experimentalCcImplementationDepsForStarlark(StarlarkThread thread)
-      throws EvalException {
-    CcModule.checkPrivateStarlarkificationAllowlist(thread);
-    return experimentalCcImplementationDeps();
-  }
-
   @StarlarkMethod(name = "experimental_cpp_modules", documented = false, useStarlarkThread = true)
   public boolean experimentalCppModulesForStarlark(StarlarkThread thread) throws EvalException {
     CcModule.checkPrivateStarlarkificationAllowlist(thread);
     return experimentalCppModules();
-  }
-
-  public boolean experimentalCcImplementationDeps() {
-    return cppOptions.experimentalCcImplementationDeps;
   }
 
   public boolean experimentalCppModules() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -1028,17 +1028,6 @@ public class CppOptions extends FragmentOptions {
   public boolean objcGenerateDotdFiles;
 
   @Option(
-      name = "experimental_cc_implementation_deps",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {
-        OptionEffectTag.LOADING_AND_ANALYSIS,
-      },
-      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
-      help = "If enabled, cc_library targets can use attribute `implementation_deps`.")
-  public boolean experimentalCcImplementationDeps;
-
-  @Option(
       name = "experimental_cpp_modules",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -276,7 +276,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:host_linkopt",
         "//command_line_option:target libcTop label",
         "//command_line_option:experimental_link_static_libraries_once",
-        "//command_line_option:experimental_cc_implementation_deps",
         "//command_line_option:experimental_cpp_modules",
         "//command_line_option:start_end_lib",
         "//command_line_option:experimental_inmemory_dotd_files",

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -44,7 +44,6 @@ def _cc_library_impl(ctx):
     semantics.validate_attributes(ctx = ctx)
     _check_no_repeated_srcs(ctx)
 
-    semantics.check_can_use_implementation_deps(ctx)
     interface_deps = ctx.attr.deps + semantics.get_cc_runtimes(ctx, True)
     runtimes_copts = semantics.get_cc_runtimes_copts(ctx)
     compilation_contexts = cc_helper.get_compilation_contexts_from_deps(interface_deps)
@@ -850,8 +849,6 @@ The list of other libraries that the library target depends on. Unlike with
 transitive deps) are only used for compilation of this library, and not libraries that
 depend on it. Libraries specified with <code>implementation_deps</code> are still linked in
 binary targets that depend on this library.
-<p>For now usage is limited to cc_libraries and guarded by the flag
-<code>--experimental_cc_implementation_deps</code>.</p>
 """),
         "strip_include_prefix": attr.string(doc = """
 The prefix to strip from the paths of the headers of this rule.
@@ -952,7 +949,7 @@ See <a href="${link cc_binary.linkshared}"><code>cc_binary.linkshared</code></a>
         # TODO(b/288421584): necessary because IDE aspect can't see toolchains
         "_cc_toolchain": attr.label(default = "@" + semantics.get_repo() + "//tools/cpp:current_cc_toolchain"),
         "_use_auto_exec_groups": attr.bool(default = True),
-    } | semantics.get_distribs_attr() | semantics.get_implementation_deps_allowed_attr() | semantics.get_nocopts_attr(),
+    } | semantics.get_distribs_attr() | semantics.get_nocopts_attr(),
     toolchains = cc_helper.use_cpp_toolchain() +
                  semantics.get_runtimes_toolchain(),
     fragments = ["cpp"] + semantics.additional_fragments(),

--- a/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
@@ -109,14 +109,6 @@ def _get_cc_runtimes(ctx, is_library):
 def _get_cc_runtimes_copts(ctx):
     return []
 
-def _get_implementation_deps_allowed_attr():
-    return {}
-
-def _check_can_use_implementation_deps(ctx):
-    experimental_cc_implementation_deps = ctx.fragments.cpp.experimental_cc_implementation_deps()
-    if (not experimental_cc_implementation_deps and ctx.attr.implementation_deps):
-        fail("requires --experimental_cc_implementation_deps", attr = "implementation_deps")
-
 _WINDOWS_PLATFORM = Label("@platforms//os:windows")  # Resolve the label within builtins context
 
 def _get_linkstatic_default_for_test():
@@ -160,8 +152,6 @@ semantics = struct(
     get_stl = _get_stl,
     should_create_empty_archive = _should_create_empty_archive,
     get_grep_includes = _get_grep_includes,
-    get_implementation_deps_allowed_attr = _get_implementation_deps_allowed_attr,
-    check_can_use_implementation_deps = _check_can_use_implementation_deps,
     get_linkstatic_default_for_test = _get_linkstatic_default_for_test,
     get_runtimes_toolchain = _get_runtimes_toolchain,
     get_test_malloc_attr = _get_test_malloc_attr,

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2096,7 +2096,6 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
 
     assertThat(getExecConfiguredTarget("//foo:public_dep")).isNotNull();
     ;
-    assertDoesNotContainEvent("requires --experimental_cc_implementation_deps");
   }
 
   @Test
@@ -2120,7 +2119,6 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
         """);
     assertThat(getConfiguredTarget("//foo:lib")).isNotNull();
     ;
-    assertDoesNotContainEvent("requires --experimental_cc_implementation_deps");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -7383,7 +7383,6 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
             "incompatible_enable_cc_test_feature()",
             "build_test_dwp()",
             "grte_top()",
-            "experimental_cc_implementation_deps()",
             "experimental_cpp_modules()",
             "share_native_deps()",
             "experimental_platform_cc_test()");


### PR DESCRIPTION
This cc_library feature is active by default since change 05787f3.
Given this is now a stable feature and users have to opt in by using the `implementation_deps` attribute of `cc_library` it makes no sense to keep this flag.

RELNOTES: Remove `--experimental_cc_implementation_deps`, the implementation_deps feature is now usable by default.

Closes #20098