### PR TITLE
Implement incompatible_load_externally

### DIFF
--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -5,14 +5,11 @@
 module(name = "bazel_tools")
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_java", version = "7.6.5")
 bazel_dep(name = "rules_license", version = "0.0.3")
 bazel_dep(name = "rules_proto", version = "4.0.0")
-bazel_dep(name = "rules_python", version = "0.22.1")
 
 bazel_dep(name = "buildozer", version = "7.1.2")
 bazel_dep(name = "platforms", version = "0.0.9")
-bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
 bazel_dep(name = "zlib", version = "1.3")
 
 cc_configure = use_extension("//tools/cpp:cc_configure.bzl", "cc_configure_extension")
@@ -49,3 +46,9 @@ use_repo(android_sdk_proxy_extensions, "android_external")
 # Used by bazel mod tidy (see BazelModTidyFunction).
 buildozer_binary = use_extension("@buildozer//:buildozer_binary.bzl", "buildozer_binary")
 use_repo(buildozer_binary, "buildozer_binary")
+
+# Dependencies used to auto-load removed symbols and rules from Bazel (due to Starlarkification)
+# See also: tools/redirects_do_not_use, --incompatible_load_rules_externally, --incompatible_load_symbols_externally
+bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_java", version = "7.6.5")
+bazel_dep(name = "rules_python", version = "0.22.1")

--- a/src/main/java/com/google/devtools/build/lib/packages/AutoloadsConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AutoloadsConfiguration.java
@@ -1,0 +1,462 @@
+package com.google.devtools.build.lib.packages;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
+import com.google.devtools.build.lib.skyframe.BzlLoadValue;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkSemantics;
+
+/**
+ * Implementation of --incompatible_autoload_externally.
+ *
+ * The
+ */
+public class AutoloadsConfiguration {
+
+  private static final ImmutableSet<String> PREDECLARED_PRISTINE_REPOS = ImmutableSet.of(
+      "rules_python", "bazel_skylib", "rules_android", "com_google_protobuf", "protobuf",
+      "bazel_tools"
+  );
+
+  // Value of --incompatible_autoload_externally, symbols, possibly prefixed with +/-
+  private final ImmutableList<String> symbolConfiguration;
+
+  // Repositories where autoloads shouldn't be used
+  private final ImmutableSet<String> pristineRepos;
+
+  // bzl environment where autoloads are used, uninjected (not loaded yet)
+  private final ImmutableMap<String, Object> uninjectedBuildBzlEnvWithAutoloads;
+
+  // bzl environment where autoloads aren't used, uninjected (not loaded yet)
+  private final ImmutableMap<String, Object> uninjectedBuildBzlEnvPristine;
+
+  // Used for nicer error messages
+  private final boolean bzlmodEnabled;
+
+  public AutoloadsConfiguration(RuleClassProvider ruleClassProvider, StarlarkSemantics semantics) {
+    symbolConfiguration = ImmutableList.copyOf(
+        semantics.get(BuildLanguageOptions.INCOMPATIBLE_AUTOLOAD_EXTERNALLY));
+
+    // Validates the inputs
+    Set<String> uniqueSymbols = new HashSet<>();
+    for (String symbol : semantics.get(BuildLanguageOptions.INCOMPATIBLE_AUTOLOAD_EXTERNALLY)) {
+      String symbolWithoutPrefix =
+          symbol.startsWith("+") || symbol.startsWith("-") ? symbol.substring(1) : symbol;
+      if (!uniqueSymbols.add(symbolWithoutPrefix)) {
+        throw new IllegalStateException(
+            String.format("Duplicated symbol '%s' in --incompatible_autoload_externally",
+                symbolWithoutPrefix));
+      }
+      if (!AUTOLOAD_CONFIG.containsKey(symbolWithoutPrefix)) {
+        throw new IllegalStateException("Undefined symbol in --incompatible_autoload_externally");
+      }
+    }
+
+    this.pristineRepos = ImmutableSet.<String>builder().addAll(PREDECLARED_PRISTINE_REPOS).addAll(
+        semantics.get(BuildLanguageOptions.REPOSITORIES_WITHOUT_AUTOLOAD)).build();
+
+    ImmutableMap<String, Object> originalBuildBzlEnv = ruleClassProvider
+        .getBazelStarlarkEnvironment()
+        .getUninjectedBuildBzlEnv();
+
+    // Sets up environments for BzlCompile function
+    this.uninjectedBuildBzlEnvWithAutoloads = modifyBuildBzlEnv(originalBuildBzlEnv,
+        /* add= */filterSymbols(symbolConfiguration, symbol -> !symbol.startsWith("-")).stream()
+            .collect(toImmutableMap(key -> key, key -> Starlark.NONE)),
+        /* remove= */ filterSymbols(symbolConfiguration, symbol -> symbol.startsWith("-")));
+    this.uninjectedBuildBzlEnvPristine = modifyBuildBzlEnv(originalBuildBzlEnv,
+        /* add= */ ImmutableMap.of(),
+        /* remove= */ filterSymbols(symbolConfiguration, symbol -> !symbol.startsWith("+")));
+
+    // Validate rdeps - this ensures that all the rules using a provider are also removed
+    // Check what's still available in Bazel (some symbols might already be deleted)
+    ImmutableSet<String> allAvailableSymbols = ImmutableSet.<String>builder()
+        .addAll(uninjectedBuildBzlEnvPristine.keySet()).addAll(convertNativeStructToMap(
+            (StarlarkInfo) uninjectedBuildBzlEnvPristine.get("native")).keySet()).build();
+    for (String symbol : filterSymbols(symbolConfiguration, symbol -> !symbol.startsWith("+"))) {
+      ImmutableList<String> unsatisfiedRdeps = AUTOLOAD_CONFIG.get(symbol).getRdeps().stream()
+          .filter(s -> allAvailableSymbols.contains(s)).collect(
+              toImmutableList());
+      if (!unsatisfiedRdeps.isEmpty()) {
+        throw new IllegalStateException(
+            String.format("Symbol in '%s' can't be removed, because it's still used by: %s", symbol,
+                unsatisfiedRdeps.stream().collect(
+                    Collectors.joining(", "))));
+      }
+    }
+
+    this.bzlmodEnabled = semantics.getBool(BuildLanguageOptions.ENABLE_BZLMOD);
+  }
+
+  /**
+   * Returns the environment for BzlCompile function
+   */
+  public ImmutableMap<String, Object> getUninjectedBuildBzlEnv(Label key) {
+    return checkPristine(key) ? uninjectedBuildBzlEnvPristine : uninjectedBuildBzlEnvWithAutoloads;
+  }
+
+  /**
+   * Check if autoloads shouldn't be used.
+   */
+  public boolean checkPristine(Label key) {
+    return key == null || pristineRepos.contains(key.getRepository().getName());
+  }
+
+  /**
+   * Modifies the environment for BzlLoad function (returned from StarlarkBuiltinsFunction)
+   */
+  public ImmutableMap<String, Object> modifyBuildBzlEnv(
+      boolean isWithAutoloads,
+      ImmutableMap<String, Object> originalEnv,
+      ImmutableMap<String, Object> newSymbols) {
+    if (isWithAutoloads) {
+      return modifyBuildBzlEnv(originalEnv,
+          /* add= */ newSymbols,
+          /* remove= */ filterSymbols(symbolConfiguration, symbol -> symbol.startsWith("-")));
+    } else {
+      return modifyBuildBzlEnv(originalEnv,
+          /* add= */ ImmutableMap.of(),
+          /* remove= */ filterSymbols(symbolConfiguration, symbol -> !symbol.startsWith("+")));
+    }
+  }
+
+  /**
+   * Modifies the environment for Package function (returned from StarlarkBuiltinsFunction).
+   */
+  public ImmutableMap<String, Object> modifyBuildEnv(boolean isWithAutoloads,
+      ImmutableMap<String, Object> originalEnv, ImmutableMap<String, Object> newSymbols) {
+    final ImmutableMap<String, Object> add;
+    // Sets up environments for BzlCompile function
+    if (isWithAutoloads) {
+      add = newSymbols;
+    } else {
+      add = ImmutableMap.of();
+    }
+    Map<String, Object> envBuilder = new LinkedHashMap<>(originalEnv);
+    for (var symbol : add.entrySet()) {
+      if (AutoloadsConfiguration.AUTOLOAD_CONFIG.get(symbol.getKey()).isRule()) {
+        envBuilder.put(symbol.getKey(), symbol.getValue());
+      }
+    }
+    ImmutableList<String> remove = filterSymbols(symbolConfiguration,
+        symbol -> symbol.startsWith("-"));
+    for (String symbol : remove) {
+      if (AutoloadsConfiguration.AUTOLOAD_CONFIG.get(symbol).isRule()) {
+        envBuilder.remove(symbol);
+      }
+    }
+    return ImmutableMap.copyOf(envBuilder);
+  }
+
+  /**
+   * Creates modified environment that's used in BzlCompileFunction and StarlarkBuiltinsFunction.
+   *
+   * It starts with the original environment. Adds the symbols to it or removes them.
+   */
+  private ImmutableMap<String, Object> modifyBuildBzlEnv(ImmutableMap<String, Object> originalEnv,
+      ImmutableMap<String, Object> add,
+      ImmutableList<String> remove) {
+    Map<String, Object> envBuilder = new LinkedHashMap<>(originalEnv);
+    Map<String, Object> nativeBindings = convertNativeStructToMap(
+        (StarlarkInfo) envBuilder.remove("native"));
+
+    for (var symbol : add.entrySet()) {
+      if (AutoloadsConfiguration.AUTOLOAD_CONFIG.get(symbol.getKey()).isRule()) {
+        nativeBindings.put(symbol.getKey(), symbol.getValue());
+      } else {
+        envBuilder.put(symbol.getKey(), symbol.getValue());
+      }
+    }
+    for (String symbol : remove) {
+      if (AutoloadsConfiguration.AUTOLOAD_CONFIG.get(symbol).isRule()) {
+        nativeBindings.remove(symbol);
+      } else {
+        envBuilder.remove(symbol);
+      }
+    }
+    envBuilder.put("native",
+        StructProvider.STRUCT.create(nativeBindings, "no native function or rule '%s'"));
+    return ImmutableMap.copyOf(envBuilder);
+  }
+
+  private static ImmutableList<String> filterSymbols(ImmutableList<String> symbols,
+      Predicate<String> when) {
+    return symbols.stream().filter(when).map(
+            symbol -> symbol.startsWith("+") || symbol.startsWith("-") ? symbol.substring(1) : symbol)
+        .collect(
+            toImmutableList());
+  }
+
+  private static LinkedHashMap<String, Object> convertNativeStructToMap(StarlarkInfo struct) {
+    LinkedHashMap<String, Object> destr = new LinkedHashMap<>();
+    for (String field : struct.getFieldNames()) {
+      destr.put(field, struct.getValue(field));
+    }
+    return destr;
+  }
+
+  /**
+   * Returns a list of all the symbols that need to be loaded
+   */
+  public ImmutableList<BzlLoadValue.Key> getAutoloads() {
+    ImmutableList<String> symbolsToLoad =
+        filterSymbols(symbolConfiguration, s -> !s.startsWith("-"));
+
+    // Inject loads for rules and symbols removed from Bazel
+    ImmutableList.Builder<BzlLoadValue.Key> loadKeysBuilder = ImmutableList.builder();
+    for (String symbol : symbolsToLoad) {
+      loadKeysBuilder.add(AutoloadsConfiguration.AUTOLOAD_CONFIG.get(symbol).getKey());
+    }
+    return loadKeysBuilder.build();
+  }
+
+  /**
+   * Processes LoadedValues into a map of symbols
+   */
+  public ImmutableMap<String, Object> processLoads(BzlLoadValue[] autoloadValues)
+      throws AutoloadException {
+    if (autoloadValues.length == 0) {
+      return ImmutableMap.of();
+    }
+    ImmutableMap.Builder<String, Object> newSymbols = ImmutableMap.builder();
+
+    ImmutableList<String> symbolsToLoad =
+        filterSymbols(symbolConfiguration, s -> !s.startsWith("-"));
+    int i = 0;
+    String workspaceWarning =
+        bzlmodEnabled
+            ? ""
+            : " Most likely you need to upgrade the version of rules repository providing it your"
+                + " WORKSPACE file.";
+    for (String symbol : symbolsToLoad) {
+      // Check if the symbol is named differently in the bzl file than natively. Renames are rare:
+      // Example is renaming native.ProguardSpecProvider to ProguardSpecInfo.
+      String newName = AUTOLOAD_CONFIG.get(symbol).getNewName();
+      if (newName == null) {
+        newName = symbol;
+      }
+      BzlLoadValue v = autoloadValues[i];
+      Object symbolValue = v.getModule().getGlobal(newName);
+      if (symbolValue == null) {
+        throw new AutoloadException(
+            String.format(
+                "The toplevel symbol '%s' set by --incompatible_load_symbols_externally couldn't"
+                    + " be loaded. '%s' not found in auto loaded '%s'.%s",
+                symbol, workspaceWarning, newName, AUTOLOAD_CONFIG.get(symbol).getLoadLabel()));
+      }
+      newSymbols.put(symbol, symbolValue); // Exposed as old name
+    }
+    return newSymbols.buildOrThrow();
+  }
+
+  @AutoValue
+  public abstract static class SymbolRedirect {
+
+    @Nullable
+    public abstract Label getLoadLabel();
+
+    public abstract boolean isRule();
+
+    @Nullable
+    public abstract String getNewName();
+
+    public abstract ImmutableSet<String> getRdeps();
+
+    public BzlLoadValue.Key getKey() {
+      return BzlLoadValue.keyForBuild(getLoadLabel());
+    }
+  }
+
+
+  /**
+   * Indicates a problem performing builtins injection.
+   */
+  public static final class AutoloadException extends Exception {
+
+    AutoloadException(String message) {
+      super(message);
+    }
+  }
+
+  private static SymbolRedirect configRule(String label) {
+    return new AutoValue_AutoloadsConfiguration_SymbolRedirect(Label.parseCanonicalUnchecked(label),
+        true, null, ImmutableSet.of());
+  }
+
+  private static SymbolRedirect configSymbol(String label, String... rdeps) {
+    return new AutoValue_AutoloadsConfiguration_SymbolRedirect(
+        label == null ? null : Label.parseCanonicalUnchecked(label),
+        false, null, ImmutableSet.copyOf(rdeps));
+  }
+
+  private static SymbolRedirect configRenamedSymbol(String label, String newName,
+      String... rdeps) {
+    return new AutoValue_AutoloadsConfiguration_SymbolRedirect(Label.parseCanonicalUnchecked(label),
+        false, newName, ImmutableSet.copyOf(rdeps));
+  }
+
+  private static final String[] androidRules = {"aar_import", "android_binary", "android_library",
+      "android_local_test", "android_sdk"};
+
+  public static final ImmutableMap<String, SymbolRedirect> AUTOLOAD_CONFIG = ImmutableMap.<String, SymbolRedirect>builder()
+      .put("CcSharedLibraryInfo",
+          configSymbol("@rules_cc//cc/common:cc_shared_library_info.bzl", "cc_shared_library"))
+      .put("CcSharedLibraryHintInfo",
+          configSymbol("@rules_cc//cc/common:cc_shared_library_hint_info.bzl", "cc_common"))
+      .put("cc_proto_aspect",
+          configSymbol("@com_google_protobuf//bazel/common:cc_proto_library.bzl",
+              "cc_proto_library"))
+      .put("ProtoInfo",
+          configSymbol("@com_google_protobuf//bazel/common:proto_info.bzl", "proto_library",
+              "cc_proto_library", "cc_shared_library", "java_lite_proto_library",
+              "java_proto_library", "proto_lang_toolchain", "java_binary", "py_extension",
+              "proto_common_do_not_use"))
+      .put("proto_common_do_not_use",
+          configSymbol("@com_google_protobuf//bazel/common:proto_common.bzl"))
+      .put("cc_common", configSymbol("@rules_cc//cc/common:cc_common.bzl"))
+      .put("CcInfo",
+          configSymbol("@rules_cc//cc/common:cc_info.bzl", "cc_binary", "cc_library", "cc_test",
+              "cc_shared_library", "cc_common", "java_library", "cc_proto_library", "java_import",
+              "java_runtime", "java_binary", "objc_library", "java_common", "JavaInfo",
+              "py_extension", "cc_import", "objc_import", "objc_library", "cc_toolchain",
+              "PyCcLinkParamsProvider", "py_library"))
+      .put("DebugPackageInfo",
+          configSymbol("@rules_cc//cc/common:debug_package_info.bzl", "cc_binary", "cc_test"))
+      .put("CcToolchainConfigInfo",
+          configSymbol("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "cc_toolchain"))
+      .put("java_common", configSymbol("@rules_java//java/common:java_common.bzl"))
+      .put("JavaInfo",
+          configSymbol("@rules_java//java/common:java_info.bzl", "java_binary", "java_library",
+              "java_test", "java_proto_library", "java_lite_proto_library", "java_plugin",
+              "java_import", "java_common"))
+      .put("JavaPluginInfo",
+          configSymbol("@rules_java//java/common:java_plugin_info.bzl", "java_plugin",
+              "java_library", "java_binary", "java_test"))
+      .put("ProguardSpecProvider",
+          configRenamedSymbol("@rules_java//java/common:proguard_spec_info.bzl",
+              "ProguardSpecInfo", "java_lite_proto_library", "java_import", "android_binary",
+              "android_library"))
+      .put("android_common", configSymbol("@rules_android//rules:common.bzl"))
+      .put("AndroidIdeInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("ApkInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidInstrumentationInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidResourcesInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidNativeLibsInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidApplicationResourceInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidBinaryNativeLibsInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidSdkInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidManifestInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidAssetsInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidLibraryAarInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidProguardInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidIdlInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidPreDexJarInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidCcLinkParamsInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("DataBindingV2Info", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidLibraryResourceClassJarProvider",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidFeatureFlagSet",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("ProguardMappingInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidBinaryData", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("BaselineProfileProvider",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidNeverLinkLibrariesProvider",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidOptimizedJarInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidDexInfo", configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("AndroidOptimizationInfo",
+          configSymbol("@rules_android//rules:providers.bzl", androidRules))
+      .put("PyInfo",
+          configSymbol("@rules_python//python:py_info.bzl", "py_binary", "py_test", "py_library"))
+      .put("PyRuntimeInfo",
+          configSymbol("@rules_python//python:py_runtime_info.bzl", "py_binary", "py_test",
+              "py_library"))
+      .put("PyCcLinkParamsProvider",
+          configRenamedSymbol("@rules_python//python:py_cc_link_params_info.bzl",
+              "PyCcLinkParamsInfo", "py_binary", "py_test", "py_library"))
+      .put("aar_import", configSymbol("@rules_android//rules:rules.bzl"))
+      .put("android_binary", configRule("@rules_android//rules:rules.bzl"))
+      .put("android_device_script_fixture",
+          configRule("@rules_android//rules:rules.bzl"))
+      .put("android_host_service_fixture",
+          configRule("@rules_android//rules:rules.bzl"))
+      .put("android_library", configRule("@rules_android//rules:rules.bzl"))
+      .put("android_local_test", configRule("@rules_android//rules:rules.bzl"))
+      .put("android_sdk", configRule("@rules_android//rules:rules.bzl"))
+      .put("android_tools_defaults_jar", configRule("@rules_android//rules:rules.bzl"))
+      .put("cc_binary", configRule("@rules_cc//cc:cc_binary.bzl"))
+      .put("cc_import", configRule("@rules_cc//cc:cc_import.bzl"))
+      .put("cc_library", configRule("@rules_cc//cc:cc_library.bzl"))
+      .put("cc_proto_library",
+          configRule("@com_google_protobuf//bazel:cc_proto_library.bzl"))
+      .put("cc_shared_library", configRule("@rules_cc//cc:cc_shared_library.bzl"))
+      .put("cc_test", configRule("@rules_cc//cc:cc_test.bzl"))
+      .put("cc_toolchain", configRule("@rules_cc//cc/toolchains:cc_toolchain.bzl"))
+      .put("cc_toolchain_suite",
+          configRule("@rules_cc//cc/toolchains:cc_toolchain_suite.bzl"))
+      .put("fdo_prefetch_hints",
+          configRule("@rules_cc//cc/toolchains:fdo_prefetch_hints.bzl"))
+      .put("fdo_profile", configRule("@rules_cc//cc/toolchains:fdo_profile.bzl"))
+      .put("java_binary", configRule("@rules_java//java:java_binary.bzl"))
+      .put("java_import", configRule("@rules_java//java:java_import.bzl"))
+      .put("java_library", configRule("@rules_java//java:java_library.bzl"))
+      .put("java_lite_proto_library",
+          configRule("@com_google_protobuf//bazel:java_lite_proto_library.bzl"))
+      .put("java_package_configRuleuration",
+          configRule("@rules_java//java/toolchains:java_package_configRuleuration.bzl"))
+      .put("java_plugin", configRule("@rules_java//java:java_plugin.bzl"))
+      .put("java_proto_library",
+          configRule("@com_google_protobuf//bazel:java_proto_library.bzl"))
+      .put("java_runtime", configRule("@rules_java//java/toolchains:java_runtime.bzl"))
+      .put("java_test", configRule("@rules_java//java:java_test.bzl"))
+      .put("java_toolchain",
+          configRule("@rules_java//java/toolchains:java_toolchain.bzl"))
+      .put("memprof_profile",
+          configRule("@rules_cc//cc/toolchains:memprof_profile.bzl"))
+      .put("objc_import", configRule("@rules_cc//cc:objc_import.bzl"))
+      .put("objc_library", configRule("@rules_cc//cc:objc_library.bzl"))
+      .put("propeller_optimize",
+          configRule("@rules_cc//cc/toolchains:propeller_optimize.bzl"))
+      .put("proto_lang_toolchain",
+          configRule("@com_google_protobuf//bazel/toolchain:proto_lang_toolchain.bzl"))
+      .put("proto_library", configRule("@com_google_protobuf//bazel:proto_library.bzl"))
+      .put("py_binary", configRule("@rules_python//python:py_binary.bzl"))
+      .put("py_library", configRule("@rules_python//python:py_library.bzl"))
+      .put("py_runtime", configRule("@rules_python//python:py_runtime.bzl"))
+      .put("py_test", configRule("@rules_python//python:py_test.bzl"))
+      .put("sh_binary", configRule("@rules_sh//sh:sh_binary.bzl"))
+      .put("sh_library", configRule("@rules_sh//sh:sh_library.bzl"))
+      .put("sh_test", configRule("@rules_sh//sh:sh_test.bzl"))
+      .put("available_xcodes", configRule("@apple_support//xcode:available_xcodes.bzl"))
+      .put("xcode_config", configRule("@apple_support//xcode:xcode_configRule.bzl"))
+      .put("xcode_config_alias",
+          configRule("@apple_support//xcode:xcode_configRule_alias.bzl"))
+      .put("xcode_version", configRule("@apple_support//xcode:xcode_version.bzl"))
+      .build();
+
+  // TODO: figure out apple_common
+}

--- a/src/main/java/com/google/devtools/build/lib/packages/AutoloadsConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AutoloadsConfiguration.java
@@ -1,3 +1,18 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package com.google.devtools.build.lib.packages;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -263,6 +278,9 @@ public class AutoloadsConfiguration {
     return newSymbols.buildOrThrow();
   }
 
+  /**
+   * Configuration of a symbol
+   */
   @AutoValue
   public abstract static class SymbolRedirect {
 

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Interner;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.common.options.Converters.CommaSeparatedNonEmptyOptionListConverter;
 import com.google.devtools.common.options.Converters.CommaSeparatedOptionListConverter;
+import com.google.devtools.common.options.Converters.CommaSeparatedOptionSetConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -96,6 +97,37 @@ public final class BuildLanguageOptions extends OptionsBase {
               + "Bazel within its own source tree. Finally, a value of the empty string disables "
               + "the builtins injection mechanism entirely.")
   public String experimentalBuiltinsBzlPath;
+
+  @Option(
+      name = "incompatible_autoload_externally",
+      converter = CommaSeparatedOptionSetConverter.class,
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.LOSES_INCREMENTAL_STATE, OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "A list of rules or symbols (previously part of Bazel) that are automatically loaded"
+              + " from external repositories. For configuration see "
+              + "https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/packages/AttributeValueSource.java "
+              + "Prefixing a symbol with '+', loads the symbol from rules_repository, but keeps "
+              + " the native implementation available in rules_repositories (redirects work). "
+              + "Symbol without a prefix is loaded and the native implementation is not available. "
+              + "Symbol prefixed with a '-' is not loaded and the native implementation is not "
+              + "available (same as if the symbol was deleted from Bazel)")
+  public List<String> incompatibleAutoloadExternally;
+
+  @Option(
+      name = "repositories_without_autoloads",
+      converter = CommaSeparatedOptionSetConverter.class,
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.LOSES_INCREMENTAL_STATE, OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "A list of additional repositories where autoloads aren't be used. Add repositories that "
+              + "are needed by rules_repositories. Adding loads to such repositories would create a"
+              + " cycle back to rules_repositories.")
+  public List<String> repositoriesWithoutAutoloads;
 
   @Option(
       name = "experimental_builtins_dummy",
@@ -735,6 +767,8 @@ public final class BuildLanguageOptions extends OptionsBase {
                 incompatibleStopExportingLanguageModules)
             .setBool(INCOMPATIBLE_ALLOW_TAGS_PROPAGATION, experimentalAllowTagsPropagation)
             .set(EXPERIMENTAL_BUILTINS_BZL_PATH, experimentalBuiltinsBzlPath)
+            .set(INCOMPATIBLE_AUTOLOAD_EXTERNALLY, incompatibleAutoloadExternally)
+            .set(REPOSITORIES_WITHOUT_AUTOLOAD, repositoriesWithoutAutoloads)
             .setBool(EXPERIMENTAL_BUILTINS_DUMMY, experimentalBuiltinsDummy)
             .set(EXPERIMENTAL_BUILTINS_INJECTION_OVERRIDE, experimentalBuiltinsInjectionOverride)
             .setBool(EXPERIMENTAL_BZL_VISIBILITY, experimentalBzlVisibility)
@@ -927,6 +961,10 @@ public final class BuildLanguageOptions extends OptionsBase {
   // non-booleans
   public static final StarlarkSemantics.Key<String> EXPERIMENTAL_BUILTINS_BZL_PATH =
       new StarlarkSemantics.Key<>("experimental_builtins_bzl_path", "%bundled%");
+  public static final StarlarkSemantics.Key<List<String>> INCOMPATIBLE_AUTOLOAD_EXTERNALLY =
+      new StarlarkSemantics.Key<>("incompatible_autoload_externally", ImmutableList.of());
+  public static final StarlarkSemantics.Key<List<String>> REPOSITORIES_WITHOUT_AUTOLOAD =
+      new StarlarkSemantics.Key<>("repositories_without_autoloads", ImmutableList.of());
   public static final StarlarkSemantics.Key<List<String>> EXPERIMENTAL_BUILTINS_INJECTION_OVERRIDE =
       new StarlarkSemantics.Key<>("experimental_builtins_injection_override", ImmutableList.of());
   public static final StarlarkSemantics.Key<Long> MAX_COMPUTATION_STEPS =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlCompileFunction.java
@@ -157,7 +157,11 @@ public class BzlCompileFunction implements SkyFunction {
       // For WORKSPACE-loaded bzl files, the env isn't quite right not because of injection but
       // because the "native" object is different. But A) that will be fixed with #11954, and B) we
       // don't care for the same reason as above.
-      predeclared = bazelStarlarkEnvironment.getUninjectedBuildBzlEnv();
+
+      // Takes into account --incompatible_autoload_externally, similarly to the comment above, this
+      // only defines the correct set of symbols, but does not load them yet.
+      predeclared = PrecomputedValue.AUTOLOADS_CONFIGURATION.get(env)
+          .getUninjectedBuildBzlEnv(key.getLabel());
     }
 
     // We have all deps. Parse, resolve, and return.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
@@ -457,14 +457,17 @@ public abstract class PackageFunction implements SkyFunction {
 
     StarlarkBuiltinsValue starlarkBuiltinsValue;
     try {
+      // Bazel: we do autoloads for all BUILD files if enabled
       if (bzlLoadFunctionForInlining == null) {
         starlarkBuiltinsValue =
             (StarlarkBuiltinsValue)
-                env.getValueOrThrow(StarlarkBuiltinsValue.key(), BuiltinsFailedException.class);
+                env.getValueOrThrow(
+                    StarlarkBuiltinsValue.key(/* withAutoloads= */ true),
+                    BuiltinsFailedException.class);
       } else {
         starlarkBuiltinsValue =
             StarlarkBuiltinsFunction.computeInline(
-                StarlarkBuiltinsValue.key(),
+                StarlarkBuiltinsValue.key(/* withAutoloads= */ true),
                 BzlLoadFunction.InliningState.create(env),
                 packageFactory.getRuleClassProvider().getBazelStarlarkEnvironment(),
                 bzlLoadFunctionForInlining);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.packages.AutoloadsConfiguration;
 import com.google.devtools.build.lib.packages.Package.ConfigSettingVisibilityPolicy;
 import com.google.devtools.build.lib.packages.RuleVisibility;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
@@ -83,6 +84,10 @@ public final class PrecomputedValue implements SkyValue {
 
   public static final Precomputed<StarlarkSemantics> STARLARK_SEMANTICS =
       new Precomputed<>("starlark_semantics");
+
+  // Configuration of  --incompatible_load_externally
+  public static final Precomputed<AutoloadsConfiguration> AUTOLOADS_CONFIGURATION =
+      new Precomputed<>("uninjected_build_bzl_env");
 
   public static final Precomputed<UUID> BUILD_ID =
       new Precomputed<>("build_id", /* shareable= */ false);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -141,6 +141,7 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.io.FileSymlinkCycleUniquenessFunction;
 import com.google.devtools.build.lib.io.FileSymlinkInfiniteExpansionUniquenessFunction;
+import com.google.devtools.build.lib.packages.AutoloadsConfiguration;
 import com.google.devtools.build.lib.packages.BuildFileContainsErrorsException;
 import com.google.devtools.build.lib.packages.BuildFileName;
 import com.google.devtools.build.lib.packages.NoSuchPackageException;
@@ -1313,6 +1314,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     PrecomputedValue.STARLARK_SEMANTICS.set(injectable(), starlarkSemantics);
   }
 
+  private void setAutoloadsConfiguration(AutoloadsConfiguration autoloadsConfiguration) {
+    PrecomputedValue.AUTOLOADS_CONFIGURATION.set(injectable(), autoloadsConfiguration);
+  }
+
   public void setBaselineConfiguration(BuildOptions buildOptions) {
     PrecomputedValue.BASELINE_CONFIGURATION.set(injectable(), buildOptions);
   }
@@ -1455,6 +1460,8 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
     StarlarkSemantics starlarkSemantics = getEffectiveStarlarkSemantics(buildLanguageOptions);
     setStarlarkSemantics(starlarkSemantics);
+    setAutoloadsConfiguration(
+        new AutoloadsConfiguration(ruleClassProvider, starlarkSemantics));
     setSiblingDirectoryLayout(
         starlarkSemantics.getBool(BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT));
     setPackageLocator(pkgLocator);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsValue.java
@@ -131,13 +131,19 @@ public final class StarlarkBuiltinsValue implements SkyValue {
         /* predeclaredForWorkspaceBzl= */ ImmutableMap.of(),
         /* predeclaredForBuild= */ ImmutableMap.of(),
         /* exportedToJava= */ ImmutableMap.of(),
-        /* transitiveDigest= */ new byte[] {},
+        /* transitiveDigest= */ new byte[]{},
         starlarkSemantics);
   }
 
-  /** Returns the singleton SkyKey for this type of value. */
+  /**
+   * Returns the singleton SkyKey for this type of value.
+   */
   public static Key key() {
     return Key.INSTANCE;
+  }
+
+  public static Key key(boolean withAutoloads) {
+    return withAutoloads ? Key.INSTANCE_WITH_AUTOLOADS : Key.INSTANCE;
   }
 
   /**
@@ -147,9 +153,18 @@ public final class StarlarkBuiltinsValue implements SkyValue {
    */
   static final class Key implements SkyKey {
 
-    private static final Key INSTANCE = new Key();
+    private boolean withAutoloads;
 
-    private Key() {}
+    private static final Key INSTANCE = new Key(false);
+    private static final Key INSTANCE_WITH_AUTOLOADS = new Key(true);
+
+    private Key(boolean withAutoloads) {
+      this.withAutoloads = withAutoloads;
+    }
+
+    public boolean isWithAutoloads() {
+      return withAutoloads;
+    }
 
     @Override
     public SkyFunctionName functionName() {
@@ -163,12 +178,12 @@ public final class StarlarkBuiltinsValue implements SkyValue {
 
     @Override
     public boolean equals(Object other) {
-      return other instanceof Key;
+      return other instanceof Key key && this.withAutoloads == key.withAutoloads;
     }
 
     @Override
     public int hashCode() {
-      return 7727; // more or less xkcd/221
+      return withAutoloads ? 7727 : 7277; // more or less xkcd/221
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/AbstractPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/AbstractPackageLoader.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
 import com.google.devtools.build.lib.io.FileSymlinkCycleUniquenessFunction;
 import com.google.devtools.build.lib.io.FileSymlinkInfiniteExpansionUniquenessFunction;
+import com.google.devtools.build.lib.packages.AutoloadsConfiguration;
 import com.google.devtools.build.lib.packages.BuildFileContainsErrorsException;
 import com.google.devtools.build.lib.packages.BuildFileName;
 import com.google.devtools.build.lib.packages.CachingPackageLocator;
@@ -51,6 +52,7 @@ import com.google.devtools.build.lib.packages.PackageFactory;
 import com.google.devtools.build.lib.packages.PackageLoadingListener;
 import com.google.devtools.build.lib.packages.PackageOverheadEstimator;
 import com.google.devtools.build.lib.packages.PackageValidator;
+import com.google.devtools.build.lib.packages.RuleClassProvider;
 import com.google.devtools.build.lib.packages.RuleVisibility;
 import com.google.devtools.build.lib.packages.WorkspaceFileValue;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
@@ -311,6 +313,7 @@ public abstract class AbstractPackageLoader implements PackageLoader {
         makePreinjectedDiff(
             starlarkSemantics,
             builder.pkgLocator,
+            ruleClassProvider,
             ImmutableList.copyOf(builder.extraPrecomputedValues));
     pkgFactory =
         new PackageFactory(
@@ -325,6 +328,7 @@ public abstract class AbstractPackageLoader implements PackageLoader {
   private static ImmutableDiff makePreinjectedDiff(
       StarlarkSemantics starlarkSemantics,
       PathPackageLocator pkgLocator,
+      RuleClassProvider ruleClassProvider,
       ImmutableList<PrecomputedValue.Injected> extraPrecomputedValues) {
     final Map<SkyKey, Delta> valuesToInject = new HashMap<>();
     Injectable injectable =
@@ -347,6 +351,8 @@ public abstract class AbstractPackageLoader implements PackageLoader {
     PrecomputedValue.CONFIG_SETTING_VISIBILITY_POLICY.set(
         injectable, ConfigSettingVisibilityPolicy.LEGACY_OFF);
     PrecomputedValue.STARLARK_SEMANTICS.set(injectable, starlarkSemantics);
+    PrecomputedValue.AUTOLOADS_CONFIGURATION.set(injectable,
+        new AutoloadsConfiguration(ruleClassProvider, starlarkSemantics));
     return new ImmutableDiff(ImmutableList.of(), valuesToInject);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -273,7 +273,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     PrecomputedValue.STARLARK_SEMANTICS.set(differencer, semantics);
     PrecomputedValue.AUTOLOADS_CONFIGURATION.set(
         differencer,
-        new AutoloadsConfiguration(ruleClassProvider, semantics);
+        new AutoloadsConfiguration(ruleClassProvider, semantics));
     RepositoryDelegatorFunction.REPOSITORY_OVERRIDES.set(differencer, ImmutableMap.of());
     RepositoryDelegatorFunction.FORCE_FETCH.set(
         differencer, RepositoryDelegatorFunction.FORCE_FETCH_DISABLED);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.EventKind;
+import com.google.devtools.build.lib.packages.AutoloadsConfiguration;
 import com.google.devtools.build.lib.packages.PackageFactory;
 import com.google.devtools.build.lib.packages.WorkspaceFileValue;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
@@ -264,12 +265,15 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
                 .build(),
             differencer);
 
-    PrecomputedValue.STARLARK_SEMANTICS.set(
-        differencer,
+    StarlarkSemantics semantics =
         StarlarkSemantics.builder()
             .setBool(BuildLanguageOptions.ENABLE_BZLMOD, true)
             .setBool(BuildLanguageOptions.EXPERIMENTAL_ISOLATED_EXTENSION_USAGES, true)
-            .build());
+            .build();
+    PrecomputedValue.STARLARK_SEMANTICS.set(differencer, semantics);
+    PrecomputedValue.AUTOLOADS_CONFIGURATION.set(
+        differencer,
+        new AutoloadsConfiguration(ruleClassProvider, semantics);
     RepositoryDelegatorFunction.REPOSITORY_OVERRIDES.set(differencer, ImmutableMap.of());
     RepositoryDelegatorFunction.FORCE_FETCH.set(
         differencer, RepositoryDelegatorFunction.FORCE_FETCH_DISABLED);

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositor
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.StoredEventHandler;
+import com.google.devtools.build.lib.packages.AutoloadsConfiguration;
 import com.google.devtools.build.lib.packages.PackageFactory;
 import com.google.devtools.build.lib.packages.WorkspaceFileValue;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
@@ -269,9 +270,12 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     RepositoryDelegatorFunction.FORCE_FETCH.set(
         differencer, RepositoryDelegatorFunction.FORCE_FETCH_DISABLED);
     PrecomputedValue.PATH_PACKAGE_LOCATOR.set(differencer, pkgLocator.get());
-    PrecomputedValue.STARLARK_SEMANTICS.set(
+    StarlarkSemantics semantics =
+        StarlarkSemantics.builder().setBool(BuildLanguageOptions.ENABLE_BZLMOD, true).build();
+    PrecomputedValue.STARLARK_SEMANTICS.set(differencer, semantics);
+    PrecomputedValue.AUTOLOADS_CONFIGURATION.set(
         differencer,
-        StarlarkSemantics.builder().setBool(BuildLanguageOptions.ENABLE_BZLMOD, true).build());
+        new AutoloadsConfiguration(ruleClassProvider, semantics));
     RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE.set(
         differencer, Optional.empty());
     PrecomputedValue.REPO_ENV.set(differencer, ImmutableMap.of());

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -762,6 +762,13 @@ sh_test(
 )
 
 sh_test(
+    name = "load_removed_symbols_test",
+    size = "medium",
+    srcs = ["load_removed_symbols_test.sh"],
+    data = [":test-deps"],
+)
+
+sh_test(
     name = "bazel_java_test",
     size = "medium",
     srcs = ["bazel_java_test.sh"],

--- a/src/test/shell/integration/load_removed_symbols_test.sh
+++ b/src/test/shell/integration/load_removed_symbols_test.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+#
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# An end-to-end test of the behavior of tools/build_rules/prelude_bazel.
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+#### SETUP #############################################################
+
+set -e
+
+#### TESTS #############################################################
+
+# TODO: enable this once we have Android rules release
+function disabled_test_removed_rule_loaded() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > BUILD << EOF
+aar_import(
+    name = 'aar',
+    aar = 'aar.file',
+    deps = [],
+)
+EOF
+  bazel build --incompatible_autoload_externally=aar_import :aar >&$TEST_log 2>&1 || fail "build failed"
+}
+
+# TODO: enable this once we have Android rules release
+function disabled_test_removed_rule_loaded_from_bzl() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > macro.bzl << EOF
+def macro():
+    native.aar_import(
+        name = 'aar',
+        aar = 'aar.file',
+        deps = [],
+    )
+EOF
+
+  cat > BUILD << EOF
+load(":macro.bzl", "macro")
+macro()
+EOF
+  bazel build --incompatible_autoload_externally=aar_import :aar >&$TEST_log 2>&1 || fail "build failed"
+}
+
+
+# TODO: enable this once we have a removed symbol
+function disabled_test_removed_symbol_loaded() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > symbol.bzl << EOF
+def symbol():
+  a = ProtoInfo
+EOF
+
+  cat > BUILD << EOF
+load(":symbol.bzl", "symbol")
+symbol()
+EOF
+  bazel build --incompatible_autoload_externally=ProtoInfo :all >&$TEST_log 2>&1 || fail "build failed"
+}
+
+
+function test_existing_rule_is_redirected() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > BUILD << EOF
+py_library(
+    name = 'py_library',
+)
+EOF
+  bazel query --incompatible_autoload_externally=+py_library ':py_library' --output=build >&$TEST_log 2>&1 || fail "build failed"
+  expect_log "rules_python/python/py_library.bzl"
+}
+
+function test_existing_rule_is_redirected_in_bzl() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > macro.bzl << EOF
+def macro():
+    native.py_library(
+        name = 'py_library',
+    )
+EOF
+
+  cat > BUILD << EOF
+load(":macro.bzl", "macro")
+macro()
+EOF
+  bazel query --incompatible_autoload_externally=+py_library ':py_library' --output=build >&$TEST_log 2>&1 || fail "build failed"
+  expect_log "rules_python/python/py_library.bzl"
+}
+
+
+function test_removed_rule_not_loaded() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > BUILD << EOF
+aar_import(
+    name = 'aar',
+    aar = 'aar.file',
+    deps = [],
+    visibility = ['//visibility:public'],
+)
+EOF
+
+  bazel build --incompatible_autoload_externally= :aar >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "name 'aar_import' is not defined"
+}
+
+function test_removed_rule_not_loaded_in_bzl() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > macro.bzl << EOF
+def macro():
+    native.aar_import(
+      name = 'aar',
+      aar = 'aar.file',
+      deps = [],
+      visibility = ['//visibility:public'],
+    )
+EOF
+
+  cat > BUILD << EOF
+load(":macro.bzl", "macro")
+macro()
+EOF
+
+  bazel build --incompatible_autoload_externally= :aar >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "no native function or rule 'aar_import'"
+}
+
+# TODO: enable once we have a removed symbol
+function disabled_test_removed_symbol_not_loaded_in_bzl() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > symbol.bzl << EOF
+def symbol():
+    a = ProtoInfo
+EOF
+
+  cat > BUILD << EOF
+load(":symbol.bzl", "symbol")
+symbol()
+EOF
+
+  bazel build --incompatible_autoload_externally= :all >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "name 'ProtoInfo' is not defined"
+}
+
+
+function test_removing_existing_rule() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > BUILD << EOF
+android_binary(
+    name = "bin",
+    srcs = [
+        "MainActivity.java",
+        "Jni.java",
+    ],
+    manifest = "AndroidManifest.xml",
+    deps = [
+        ":lib",
+        ":jni"
+    ],
+)
+EOF
+
+  bazel build --incompatible_autoload_externally=-android_binary :bin >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "name 'android_binary' is not defined"
+}
+
+function test_removing_existing_rule_in_bzl() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > macro.bzl << EOF
+def macro():
+    native.android_binary(
+        name = "bin",
+        srcs = [
+            "MainActivity.java",
+            "Jni.java",
+        ],
+        manifest = "AndroidManifest.xml",
+        deps = [
+            ":lib",
+            ":jni"
+        ],
+    )
+EOF
+
+  cat > BUILD << EOF
+load(":macro.bzl", "macro")
+macro()
+EOF
+
+  bazel build --incompatible_autoload_externally=-android_binary :bin >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "no native function or rule 'android_binary'"
+}
+
+function test_removing_symbol_incompletely() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > symbol.bzl << EOF
+def symbol():
+   a = ProtoInfo
+EOF
+
+  cat > BUILD << EOF
+load(":symbol.bzl", "symbol")
+symbol()
+EOF
+
+  bazel build --incompatible_autoload_externally=-ProtoInfo :all >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "Symbol in 'ProtoInfo' can't be removed, because it's still used by: proto_library, cc_proto_library, cc_shared_library, java_lite_proto_library, java_proto_library, proto_lang_toolchain, java_binary, proto_common_do_not_use"
+}
+
+function test_removing_existing_symbol() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > symbol.bzl << EOF
+def symbol():
+   a = DebugPackageInfo
+EOF
+
+  cat > BUILD << EOF
+load(":symbol.bzl", "symbol")
+symbol()
+EOF
+
+  bazel build --incompatible_autoload_externally=-DebugPackageInfo,-cc_binary,-cc_test :all >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "name 'DebugPackageInfo' is not defined"
+}
+
+function test_removing_symbol_typo() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > bzl_file.bzl << EOF
+def bzl_file():
+    pass
+EOF
+
+  cat > BUILD << EOF
+load(":bzl_file.bzl", "bzl_file")
+EOF
+
+  bazel build --incompatible_autoload_externally=-ProtozzzInfo :all >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "Undefined symbol in --incompatible_autoload_externally"
+}
+
+function test_removing_rule_typo() {
+  create_workspace_with_default_repos WORKSPACE
+
+  touch BUILD
+
+  bazel build --incompatible_autoload_externally=-androidzzz_binary :all >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "Undefined symbol in --incompatible_autoload_externally"
+}
+
+function test_redirecting_rule_with_bzl_typo() {
+  create_workspace_with_default_repos WORKSPACE
+
+  # Bzl file is evaluated first, so this should cover bzl file support
+  cat > bzl_file.bzl << EOF
+def bzl_file():
+    pass
+EOF
+
+  cat > BUILD << EOF
+load(":bzl_file.bzl", "bzl_file")
+EOF
+
+  bazel build --incompatible_autoload_externally=pyzzz_library :all >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "Undefined symbol in --incompatible_autoload_externally"
+}
+
+function test_redirecting_rule_typo() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > BUILD << EOF
+EOF
+
+
+  bazel build --incompatible_autoload_externally=pyzzz_library :all >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "Undefined symbol in --incompatible_autoload_externally"
+}
+
+function test_redirecting_symbols_typo() {
+  create_workspace_with_default_repos WORKSPACE
+
+  # Bzl file is evaluated first, so this should cover bzl file support
+  cat > bzl_file.bzl << EOF
+def bzl_file():
+    pass
+EOF
+
+  cat > BUILD << EOF
+load(":bzl_file.bzl", "bzl_file")
+EOF
+
+  bazel build --incompatible_autoload_externally=ProotoInfo :all >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+    expect_log "Undefined symbol in --incompatible_autoload_externally"
+}
+
+function test_bad_flag_value() {
+  create_workspace_with_default_repos WORKSPACE
+
+  cat > BUILD << EOF
+py_library(
+    name = 'py_library',
+)
+EOF
+  bazel query --incompatible_autoload_externally=py_library,-py_library ':py_library' --output=build >&$TEST_log 2>&1 && fail "build unexpectedly succeeded"
+  expect_log "Duplicated symbol 'py_library' in --incompatible_autoload_externally"
+}
+
+run_suite "load_removed_symbols"


### PR DESCRIPTION
Issue: https://github.com/bazelbuild/bazel/issues/22928

The flag supports Bazel users in migrating the rules from being embedded in Bazel to external repositories. Listing a symbol or a rule in the flag automatically adds a load to the respective repository. Listing it with a '+' keeps the symbol available in the rules_repository. Listing a symbol with "-" forcefully removes it from Bazel.

Cycles are prevented with a list of repositories where autoloads should not be used.

The new environments are injected into BzlCompile, BzlLoad and Package function.

StarlarkBuiltinsFunction with autoloads true key is used to load the external symbols.