### PR TITLE
virtual-thread: use consistent separator in thread name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -184,7 +184,7 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
     this.executorService =
         Executors.newThreadPerTaskExecutor(
             Thread.ofVirtual()
-                .name("downloads[" + identifyingStringForLogging + "]-", 0)
+                .name("downloads-[" + identifyingStringForLogging + "]-", 0)
                 .factory());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/includescanning/IncludeScanningModule.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/IncludeScanningModule.java
@@ -336,7 +336,7 @@ public class IncludeScanningModule extends BlazeModule {
       if (useAsyncExecution) {
         includePool =
             Executors.newThreadPerTaskExecutor(
-                Thread.ofVirtual().name("Include scanner ", 0).factory());
+                Thread.ofVirtual().name("include-scanner-", 0).factory());
       } else if (threads > 0) {
         logger.atInfo().log("Include scanning configured to use a pool with %d threads", threads);
         if (options.experimentalReuseIncludeScanningThreads) {


### PR DESCRIPTION
As the profile visualization is often made up of mutliple horizontal
lanes stacked on top of each others, each lane representing a unique
thread, using Virtual Thread would create more unique lanes in Bazel
profile visualization and make it harder to see.  Most of the time,
these virtual thread are not reused and thus, would only contain a
single column of parent-child spans. It would be easier to consume if
we can group up the virtual threads of the same category under a
single lane.

Rename some of the existing virtual thread factories to use hyphen as the
separator in the threads' name. This would help downstream toolings to
identify the thread's category easier.
