### PR TITLE
Fix syntax error in example snippet

### DIFF
--- a/site/en/extending/repo.md
+++ b/site/en/extending/repo.md
@@ -41,8 +41,8 @@ the repo rule is defined with a call to `repository_rule`. An example defining
 http_archive = repository_rule(
     implementation=_impl,
     attrs={
-        "url": attr.string(mandatory=True)
-        "sha256": attr.string(mandatory=True)
+        "url": attr.string(mandatory=True),
+        "sha256": attr.string(mandatory=True),
     }
 )
 ```


### PR DESCRIPTION
Fixes:
```
syntax error at '"sha256"': expected }
```