### PR TITLE
Preserve `--experimental_skip_ttvs_for_genquery` in the exec cfg

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryConfiguration.java
@@ -37,6 +37,13 @@ public class GenQueryConfiguration extends Fragment {
             "If true, genquery loads its scope's transitive closure directly instead of by using "
                 + "'TransitiveTargetValue' Skyframe work.")
     public boolean skipTtvs;
+
+    @Override
+    public FragmentOptions getExec() {
+      GenQueryOptions exec = (GenQueryOptions) getDefault();
+      exec.skipTtvs = skipTtvs;
+      return exec;
+    }
   }
 
   private final boolean skipTtvs;


### PR DESCRIPTION
This is not a cherry-pick, but a dedicated fix for Bazel 7.x. Bazel 8 is not affected as the switch to the Starlarkified exec configuration has already resolved this problem.

Fixes #14169