### PR TITLE
Disable WORKSPACE in python integration tests

### DIFF
--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -66,7 +66,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
   def testNewHttpArchive(self):
     ip, port = self._http_server.server_address
     rule_definition = [
-        'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
+        'http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
         'http_archive(',
         '    name = "six_archive",',
         '    urls = ["http://%s:%s/six-1.10.0.tar.gz"],' % (ip, port),
@@ -82,8 +82,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         '  srcs = ["six.py"],',
         ')',
     ]
-    rule_definition.extend(self.GetDefaultRepoRules())
-    self.ScratchFile('WORKSPACE', rule_definition)
+    self.ScratchFile('MODULE.bazel', rule_definition)
     self.ScratchFile('BUILD')
     self.ScratchFile('third_party/BUILD')
     self.ScratchFile('third_party/six.BUILD', build_file)
@@ -113,7 +112,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
   def testNewHttpZipArchiveWithSymlinks(self):
     ip, port = self._http_server.server_address
     rule_definition = [
-        'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
+        'http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
         'http_archive(',
         '    name = "archive_with_symlink",',
         '    urls = ["http://%s:%s/archive_with_symlink.zip"],' % (ip, port),
@@ -122,8 +121,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         '  "c9c32a48ff65f6319885246b1bfc704e60dd72fb0405dfafdffe403421a4c83a",'
         ')',
     ]
-    rule_definition.extend(self.GetDefaultRepoRules())
-    self.ScratchFile('WORKSPACE', rule_definition)
+    self.ScratchFile('MODULE.bazel', rule_definition)
     # In the archive, A is a symlink pointing to B
     self.ScratchFile('archive_with_symlink.BUILD', [
         'filegroup(',
@@ -140,7 +138,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
   def testNewHttpTarArchiveWithSymlinks(self):
     ip, port = self._http_server.server_address
     rule_definition = [
-        'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
+        'http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
         'http_archive(',
         '    name = "archive_with_symlink",',
         '    urls = ["http://%s:%s/archive_with_symlink.tar.gz"],' % (ip, port),
@@ -149,8 +147,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         '  "5ea20285db1b18134e4efe608e41215687f03cd3e3fdd7529860b175fc12fe76",'
         ')',
     ]
-    rule_definition.extend(self.GetDefaultRepoRules())
-    self.ScratchFile('WORKSPACE', rule_definition)
+    self.ScratchFile('MODULE.bazel', rule_definition)
     # In the archive, A is a symlink pointing to B
     self.ScratchFile('archive_with_symlink.BUILD', [
         'filegroup(',
@@ -172,7 +169,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
 
     ip, port = self._http_server.server_address
     rule_definition = [
-        'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
+        'http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
         'http_archive(',
         '    name = "sparse_archive",',
         '    urls = ["http://%s:%s/sparse_archive.tar"],' % (ip, port),
@@ -183,8 +180,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
             ')'
         ),
     ]
-    rule_definition.extend(self.GetDefaultRepoRules())
-    self.ScratchFile('WORKSPACE', rule_definition)
+    self.ScratchFile('MODULE.bazel', rule_definition)
     self.ScratchFile(
         'sparse_archive.BUILD',
         [
@@ -240,19 +236,14 @@ class BazelExternalRepositoryTest(test_base.TestBase):
   def testNewLocalRepositoryNoticesFileChangeInRepoRoot(self):
     """Regression test for https://github.com/bazelbuild/bazel/issues/7063."""
     rule_definition = [
-        'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
-        (
-            'load("@bazel_tools//tools/build_defs/repo:local.bzl",'
-            ' "new_local_repository")'
-        ),
+        'new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")',
         'new_local_repository(',
         '    name = "r",',
         '    path = "./repo",',
         '    build_file_content = "exports_files([\'foo.bzl\'])",',
         ')',
     ]
-    rule_definition.extend(self.GetDefaultRepoRules())
-    self.ScratchFile('WORKSPACE', rule_definition)
+    self.ScratchFile('MODULE.bazel', rule_definition)
     self._CreatePyWritingStarlarkRule('hello!')
     self.ScratchFile('BUILD', [
         'load("@r//:foo.bzl", "gen_py")',
@@ -270,8 +261,18 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.assertNotIn('hello!', os.linesep.join(stdout))
     self.assertIn('world', os.linesep.join(stdout))
 
+  def setUpOtherRepoMyRepo(self):
+    self.ScratchFile('other_repo/REPO.bazel')
+    self.ScratchFile(
+        'my_repo/MODULE.bazel',
+        [
+            'local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
+            'local_repository(name = "other_repo", path="../other_repo")',
+        ],
+    )
+
   def testDeletedPackagesOnExternalRepo(self):
-    self.ScratchFile('other_repo/WORKSPACE')
+    self.setUpOtherRepoMyRepo()
     self.ScratchFile('other_repo/pkg/BUILD', [
         'filegroup(',
         '  name = "file",',
@@ -283,16 +284,6 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     ])
     self.ScratchFile('other_repo/pkg/ignore/file')
     work_dir = self.ScratchDir('my_repo')
-    self.ScratchFile(
-        'my_repo/WORKSPACE',
-        [
-            (
-                'load("@bazel_tools//tools/build_defs/repo:local.bzl",'
-                ' "local_repository")'
-            ),
-            "local_repository(name = 'other_repo', path='../other_repo')",
-        ],
-    )
 
     exit_code, _, stderr = self.RunBazel(
         args=['build', '@other_repo//pkg:file'],
@@ -300,19 +291,20 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         allow_failure=True,
     )
     self.AssertExitCode(exit_code, 1, stderr)
-    self.assertIn("'@@other_repo//pkg/ignore' is a subpackage", ''.join(stderr))
+    self.assertIn("'@@_main~_repo_rules~other_repo//pkg/ignore' is a subpackage", ''.join(stderr))
 
     self.RunBazel(
         args=[
             'build',
             '@other_repo//pkg:file',
-            '--deleted_packages=@other_repo//pkg/ignore',
+            # TODO: support apparent repo name for --deleted_packages
+            '--deleted_packages=@@_main~_repo_rules~other_repo//pkg/ignore',
         ],
         cwd=work_dir,
     )
 
   def testBazelignoreFileOnExternalRepo(self):
-    self.ScratchFile('other_repo/WORKSPACE')
+    self.setUpOtherRepoMyRepo()
     self.ScratchFile('other_repo/pkg/BUILD', [
         'filegroup(',
         '  name = "file",',
@@ -327,16 +319,6 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     ])
     self.ScratchFile('other_repo/pkg/ignore/file.txt')
     work_dir = self.ScratchDir('my_repo')
-    self.ScratchFile(
-        'my_repo/WORKSPACE',
-        [
-            (
-                'load("@bazel_tools//tools/build_defs/repo:local.bzl",'
-                ' "local_repository")'
-            ),
-            'local_repository(name = "other_repo", path="../other_repo")',
-        ],
-    )
 
     exit_code, _, stderr = self.RunBazel(
         args=['build', '@other_repo//pkg:file'],
@@ -344,7 +326,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         allow_failure=True,
     )
     self.AssertExitCode(exit_code, 1, stderr)
-    self.assertIn("'@@other_repo//pkg/ignore' is a subpackage", ''.join(stderr))
+    self.assertIn("'@@_main~_repo_rules~other_repo//pkg/ignore' is a subpackage", ''.join(stderr))
 
     self.ScratchFile('other_repo/.bazelignore', [
         'pkg/ignore',
@@ -362,10 +344,10 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         args=['build', '//:all_files'], cwd=work_dir, allow_failure=True
     )
     self.AssertExitCode(exit_code, 1, stderr)
-    self.assertIn("no such package '@@other_repo//pkg/ignore'", ''.join(stderr))
+    self.assertIn("no such package '@@_main~_repo_rules~other_repo//pkg/ignore'", ''.join(stderr))
 
   def testUniverseScopeWithBazelIgnoreInExternalRepo(self):
-    self.ScratchFile('other_repo/WORKSPACE')
+    self.setUpOtherRepoMyRepo()
     self.ScratchFile('other_repo/pkg/BUILD', [
         'filegroup(',
         '  name = "file",',
@@ -385,16 +367,6 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     ])
 
     work_dir = self.ScratchDir('my_repo')
-    self.ScratchFile(
-        'my_repo/WORKSPACE',
-        [
-            (
-                'load("@bazel_tools//tools/build_defs/repo:local.bzl",'
-                ' "local_repository")'
-            ),
-            'local_repository(name = "other_repo", path="../other_repo")',
-        ],
-    )
 
     _, stdout, _ = self.RunBazel(
         args=[
@@ -409,7 +381,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
 
   def testBazelignoreFileFromMainRepoDoesNotAffectExternalRepos(self):
     # Regression test for https://github.com/bazelbuild/bazel/issues/10234
-    self.ScratchFile('other_repo/WORKSPACE')
+    self.setUpOtherRepoMyRepo()
     self.ScratchFile('other_repo/foo/bar/BUILD', [
         'filegroup(',
         '  name = "file",',
@@ -419,16 +391,6 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.ScratchFile('other_repo/foo/bar/file.txt')
 
     work_dir = self.ScratchDir('my_repo')
-    self.ScratchFile(
-        'my_repo/WORKSPACE',
-        [
-            (
-                'load("@bazel_tools//tools/build_defs/repo:local.bzl",'
-                ' "local_repository")'
-            ),
-            'local_repository(name = "other_repo", path="../other_repo")',
-        ],
-    )
     # This should not exclude @other_repo//foo/bar
     self.ScratchFile('my_repo/.bazelignore', ['foo/bar'])
 
@@ -438,7 +400,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.assertIn('@other_repo//foo/bar:file', ''.join(stdout))
 
   def testBazelignoreFileFromExternalRepoDoesNotAffectMainRepo(self):
-    self.ScratchFile('other_repo/WORKSPACE')
+    self.setUpOtherRepoMyRepo()
     # This should not exclude //foo/bar in main repo
     self.ScratchFile('other_repo/.bazelignore', ['foo/bar'])
     self.ScratchFile('other_repo/BUILD',)
@@ -451,22 +413,12 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         ')',
     ])
     self.ScratchFile('my_repo/foo/bar/file.txt')
-    self.ScratchFile(
-        'my_repo/WORKSPACE',
-        [
-            (
-                'load("@bazel_tools//tools/build_defs/repo:local.bzl",'
-                ' "local_repository")'
-            ),
-            'local_repository(name = "other_repo", path="../other_repo")',
-        ],
-    )
 
     _, stdout, _ = self.RunBazel(args=['query', '//foo/bar/...'], cwd=work_dir)
     self.assertIn('//foo/bar:file', ''.join(stdout))
 
   def testMainBazelignoreContainingRepoName(self):
-    self.ScratchFile('other_repo/WORKSPACE')
+    self.setUpOtherRepoMyRepo()
     self.ScratchFile('other_repo/foo/bar/BUILD', [
         'filegroup(',
         '  name = "file",',
@@ -476,16 +428,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.ScratchFile('other_repo/foo/bar/file.txt')
 
     work_dir = self.ScratchDir('my_repo')
-    self.ScratchFile(
-        'my_repo/WORKSPACE',
-        [
-            (
-                'load("@bazel_tools//tools/build_defs/repo:local.bzl",'
-                ' "local_repository")'
-            ),
-            'local_repository(name = "other_repo", path="../other_repo")',
-        ],
-    )
+
     # This should not exclude @other_repo//foo/bar, because .bazelignore doesn't
     # support having repository name in the path fragment.
     self.ScratchFile('my_repo/.bazelignore', ['@other_repo//foo/bar'])
@@ -493,7 +436,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.RunBazel(args=['build', '@other_repo//foo/bar:file'], cwd=work_dir)
 
   def testExternalBazelignoreContainingRepoName(self):
-    self.ScratchFile('other_repo/WORKSPACE')
+    self.ScratchFile('other_repo/REPO.bazel')
     # This should not exclude @third_repo//foo/bar, because .bazelignore doesn't
     # support having repository name in the path fragment.
     self.ScratchFile('other_repo/.bazelignore', ['@third_repo//foo/bar'])
@@ -504,7 +447,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         ')',
     ])
 
-    self.ScratchFile('third_repo/WORKSPACE')
+    self.ScratchFile('third_repo/REPO.bazel')
     self.ScratchFile('third_repo/foo/bar/BUILD', [
         'filegroup(',
         '  name = "file",',
@@ -516,12 +459,9 @@ class BazelExternalRepositoryTest(test_base.TestBase):
 
     work_dir = self.ScratchDir('my_repo')
     self.ScratchFile(
-        'my_repo/WORKSPACE',
+        'my_repo/MODULE.bazel',
         [
-            (
-                'load("@bazel_tools//tools/build_defs/repo:local.bzl",'
-                ' "local_repository")'
-            ),
+            'local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
             'local_repository(name = "other_repo", path="../other_repo")',
             'local_repository(name = "third_repo", path="../third_repo")',
         ],
@@ -532,8 +472,8 @@ class BazelExternalRepositoryTest(test_base.TestBase):
   def testRepoEnv(self):
     # Testing fix for issue: https://github.com/bazelbuild/bazel/issues/15430
 
-    self.ScratchFile('WORKSPACE', [
-        'load("//:main.bzl", "dump_env")', 'dump_env(', '    name = "debug"',
+    self.ScratchFile('MODULE.bazel', [
+        'dump_env = use_repo_rule("//:main.bzl", "dump_env")', 'dump_env(', '    name = "debug"',
         ')'
     ])
     self.ScratchFile('BUILD')

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -253,7 +253,6 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     ]
     rule_definition.extend(self.GetDefaultRepoRules())
     self.ScratchFile('WORKSPACE', rule_definition)
-    self.CreateWorkspaceWithDefaultRepos('repo/WORKSPACE')
     self._CreatePyWritingStarlarkRule('hello!')
     self.ScratchFile('BUILD', [
         'load("@r//:foo.bzl", "gen_py")',

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -297,7 +297,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         args=[
             'build',
             '@other_repo//pkg:file',
-            # TODO: support apparent repo name for --deleted_packages
+            # TODO(bzlmod): support apparent repo name for --deleted_packages
             '--deleted_packages=@@_main~_repo_rules~other_repo//pkg/ignore',
         ],
         cwd=work_dir,

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -20,7 +20,15 @@ from src.test.py.bazel import test_base
 
 class BazelWindowsCppTest(test_base.TestBase):
 
+  def createModuleDotBazel(self):
+    self.ScratchFile('MODULE.bazel', [
+        'bazel_dep(name = "platforms", version = "0.0.9")',
+        'cc_configure = use_extension("//tools/cpp:cc_configure.bzl", "cc_configure_extension")',
+        'use_repo(cc_configure, "local_config_cc")',
+    ])
+
   def createProjectFiles(self):
+    self.createModuleDotBazel()
     self.ScratchFile('BUILD', [
         'package(',
         '  default_visibility = ["//visibility:public"],',
@@ -312,7 +320,7 @@ class BazelWindowsCppTest(test_base.TestBase):
         len(glob.glob(os.path.join(bazel_bin, 'main', 'A_*.dll'))), 2)
 
   def testDLLIsCopiedFromExternalRepo(self):
-    self.ScratchFile('ext_repo/WORKSPACE')
+    self.ScratchFile('ext_repo/REPO.bazel')
     self.ScratchFile('ext_repo/BUILD', [
         'cc_library(',
         '  name = "A",',
@@ -327,7 +335,8 @@ class BazelWindowsCppTest(test_base.TestBase):
         '  printf("Hello A\\n");',
         '}',
     ])
-    self.ScratchFile('WORKSPACE', [
+    self.ScratchFile('MODULE.bazel', [
+        'local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")'
         'local_repository(',
         '  name = "ext_repo",',
         '  path = "ext_repo",',
@@ -740,6 +749,7 @@ class BazelWindowsCppTest(test_base.TestBase):
 
   def testBuildWithClangClByToolchainResolution(self):
     self.DisableBzlmod()
+    self.ScratchFile('WORKSPACE', [
         'register_execution_platforms(',
         '  ":windows_clang"',
         ')',
@@ -855,6 +865,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testBuild32BitCppBinaryWithMsvcCL(self):
+    self.createModuleDotBazel()
     self.ScratchFile('BUILD', [
         'platform(',
         '  name = "windows_32",',
@@ -880,6 +891,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('x86\\cl.exe', '\n'.join(stderr))
 
   def testBuildArmCppBinaryWithMsvcCL(self):
+    self.createModuleDotBazel()
     self.ScratchFile('BUILD', [
         'platform(',
         '  name = "windows_arm",',
@@ -905,6 +917,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('arm\\cl.exe', '\n'.join(stderr))
 
   def testBuildArm64CppBinaryWithMsvcCLAndCpuX64Arm64Windows(self):
+    self.createModuleDotBazel()
     self.ScratchFile('BUILD', [
         'platform(',
         '  name = "windows_arm64",',
@@ -930,6 +943,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('arm64\\cl.exe', '\n'.join(stderr))
 
   def testBuildCppBinaryWithMingwGCC(self):
+    self.createModuleDotBazel()
     self.ScratchFile('BUILD', [
         'platform(',
         '    name = "x64_windows-mingw-gcc",',
@@ -993,6 +1007,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('-Wl,--gc-sections', ''.join(stderr))
 
   def testBuildCppBinaryWithMsysGCC(self):
+    self.createModuleDotBazel()
     self.ScratchFile('BUILD', [
         'platform(',
         '    name = "x64_windows-msys-gcc",',
@@ -1063,6 +1078,7 @@ class BazelWindowsCppTest(test_base.TestBase):
         os.path.join(bazel_output, paramfile % 'opt'), '-Wl,--gc-sections')
 
   def testBuildArm64CppBinaryWithMsvcCLAndCpuArm64Windows(self):
+    self.createModuleDotBazel()
     self.ScratchFile('BUILD', [
         'platform(',
         '  name = "windows_arm64",',
@@ -1108,6 +1124,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testCompilerSettingMsvc(self):
+    self.createModuleDotBazel()
     self.ScratchFile(
         'BUILD',
         [
@@ -1140,6 +1157,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testCompilerSettingClangCl(self):
+    self.createModuleDotBazel()
     self.ScratchFile(
         'BUILD',
         [

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -23,7 +23,7 @@ class BazelWindowsCppTest(test_base.TestBase):
   def createModuleDotBazel(self):
     self.ScratchFile('MODULE.bazel', [
         'bazel_dep(name = "platforms", version = "0.0.9")',
-        'cc_configure = use_extension("//tools/cpp:cc_configure.bzl", "cc_configure_extension")',
+        'cc_configure = use_extension("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure_extension")',
         'use_repo(cc_configure, "local_config_cc")',
     ])
 

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -25,6 +25,7 @@ class BazelWindowsCppTest(test_base.TestBase):
         'bazel_dep(name = "platforms", version = "0.0.9")',
         'cc_configure = use_extension("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure_extension")',
         'use_repo(cc_configure, "local_config_cc")',
+        'register_toolchains("@local_config_cc//:all")', # Register all cc toolchains for Windows
     ])
 
   def createProjectFiles(self):

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -337,7 +337,7 @@ class BazelWindowsCppTest(test_base.TestBase):
         '}',
     ])
     self.ScratchFile('MODULE.bazel', [
-        'local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")'
+        'local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         'local_repository(',
         '  name = "ext_repo",',
         '  path = "ext_repo",',
@@ -368,7 +368,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     # Test if A.dll is copied to the directory of main.exe
     main_bin = os.path.join(bazel_bin, 'main.exe')
     self.assertTrue(os.path.exists(main_bin))
-    self.assertTrue(os.path.exists(os.path.join(bazel_bin, 'A_9324b6d0.dll')))
+    self.assertTrue(os.path.exists(os.path.join(bazel_bin, 'A_4b00e9cb.dll')))
 
     # Run the binary to see if it runs successfully
     _, stdout, _ = self.RunProgram([main_bin])
@@ -1191,6 +1191,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testCompilerSettingMingwGcc(self):
+    self.createModuleDotBazel()
     self.ScratchFile(
         'BUILD',
         [

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -21,7 +21,6 @@ from src.test.py.bazel import test_base
 class BazelWindowsCppTest(test_base.TestBase):
 
   def createProjectFiles(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'package(',
         '  default_visibility = ["//visibility:public"],',
@@ -570,7 +569,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertFileContentNotContains(empty_def_file, 'hello_A')
 
   def testUsingDefFileGeneratedFromCcLibrary(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('lib_A.cc', ['void hello_A() {}'])
     self.ScratchFile('lib_B.cc', ['void hello_B() {}'])
     self.ScratchFile('BUILD', [
@@ -610,7 +608,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertFileContentContains(def_file, 'hello_B')
 
   def testWinDefFileAttribute(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('lib.cc', ['void hello() {}'])
     self.ScratchFile('my_lib.def', [
         'EXPORTS',
@@ -656,7 +653,6 @@ class BazelWindowsCppTest(test_base.TestBase):
       self.assertIn('/DEF:my_lib.def', param_file.read())
 
   def testCcImportRule(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('A.lib', [])
     self.ScratchFile('A.dll', [])
     self.ScratchFile('A.if.lib', [])
@@ -676,7 +672,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testCopyDLLAsSource(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'cc_import(',
         '  name = "a_import",',
@@ -726,7 +721,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertTrue(os.path.exists(nested_a_dll))
 
   def testCppErrorShouldBeVisible(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'cc_binary(',
         '  name = "bad",',
@@ -746,7 +740,6 @@ class BazelWindowsCppTest(test_base.TestBase):
 
   def testBuildWithClangClByToolchainResolution(self):
     self.DisableBzlmod()
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE', [
         'register_execution_platforms(',
         '  ":windows_clang"',
         ')',
@@ -803,7 +796,6 @@ class BazelWindowsCppTest(test_base.TestBase):
 
   # Regression test for https://github.com/bazelbuild/bazel/issues/9321
   def testCcCompileWithTreeArtifactAsSource(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'load(":genccs.bzl", "genccs")',
         '',
@@ -863,7 +855,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testBuild32BitCppBinaryWithMsvcCL(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'platform(',
         '  name = "windows_32",',
@@ -889,7 +880,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('x86\\cl.exe', '\n'.join(stderr))
 
   def testBuildArmCppBinaryWithMsvcCL(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'platform(',
         '  name = "windows_arm",',
@@ -915,7 +905,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('arm\\cl.exe', '\n'.join(stderr))
 
   def testBuildArm64CppBinaryWithMsvcCLAndCpuX64Arm64Windows(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'platform(',
         '  name = "windows_arm64",',
@@ -941,7 +930,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('arm64\\cl.exe', '\n'.join(stderr))
 
   def testBuildCppBinaryWithMingwGCC(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'platform(',
         '    name = "x64_windows-mingw-gcc",',
@@ -1005,7 +993,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('-Wl,--gc-sections', ''.join(stderr))
 
   def testBuildCppBinaryWithMsysGCC(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'platform(',
         '    name = "x64_windows-msys-gcc",',
@@ -1076,7 +1063,6 @@ class BazelWindowsCppTest(test_base.TestBase):
         os.path.join(bazel_output, paramfile % 'opt'), '-Wl,--gc-sections')
 
   def testBuildArm64CppBinaryWithMsvcCLAndCpuArm64Windows(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'platform(',
         '  name = "windows_arm64",',
@@ -1102,7 +1088,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.assertIn('arm64\\cl.exe', ''.join(stderr))
 
   def testLongCompileCommandLines(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -1123,7 +1108,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testCompilerSettingMsvc(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -1156,7 +1140,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testCompilerSettingClangCl(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -1189,7 +1172,6 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
   def testCompilerSettingMingwGcc(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [

--- a/src/test/py/bazel/bazel_windows_symlinks_test.py
+++ b/src/test/py/bazel/bazel_windows_symlinks_test.py
@@ -19,7 +19,6 @@ from src.test.py.bazel import test_base
 class BazelWindowsSymlinksTest(test_base.TestBase):
 
   def createProjectFiles(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'foo/BUILD',
         [

--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -20,7 +20,6 @@ from src.test.py.bazel import test_base
 class BazelWindowsTest(test_base.TestBase):
 
   def createProjectFiles(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'platform(',
         '    name = "x64_windows-msys-gcc",',
@@ -82,7 +81,6 @@ class BazelWindowsTest(test_base.TestBase):
         os.path.exists(os.path.join(bazel_bin, 'foo\\_objs\\x\\x.obj.params')))
 
   def testWindowsCompilesAssembly(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     _, stdout, _ = self.RunBazel(['info', 'bazel-bin'])
     bazel_bin = stdout[0]
     self.ScratchFile('BUILD', [
@@ -167,7 +165,6 @@ class BazelWindowsTest(test_base.TestBase):
     self.assertIn('foo=bar3', result_in_lower_case)
 
   def testRunPowershellInAction(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'load(":execute.bzl", "run_powershell")',
         'run_powershell(name = "powershell_test", out = "out.txt")',
@@ -206,7 +203,6 @@ class BazelWindowsTest(test_base.TestBase):
     )
 
   def testAnalyzeCcRuleWithoutVCInstalled(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'cc_binary(',
         '  name = "bin",',
@@ -230,7 +226,6 @@ class BazelWindowsTest(test_base.TestBase):
     )
 
   def testBuildNonCcRuleWithoutVCInstalled(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'genrule(',
         '  name="gen",',
@@ -279,7 +274,6 @@ class BazelWindowsTest(test_base.TestBase):
     )
 
   def testDeleteReadOnlyFile(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -295,7 +289,6 @@ class BazelWindowsTest(test_base.TestBase):
     self.RunBazel(['clean'])
 
   def testDeleteReadOnlyDirectory(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'defs.bzl',
         [
@@ -330,7 +323,6 @@ class BazelWindowsTest(test_base.TestBase):
     self.RunBazel(['clean'])
 
   def testBuildJavaTargetWithClasspathJar(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'java_binary(',
         '  name = "java_bin",',
@@ -392,7 +384,6 @@ class BazelWindowsTest(test_base.TestBase):
     self.assertIn('Hello World!', '\n'.join(stdout))
 
   def testRunWithScriptPath(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'sh_binary(',
         '  name = "foo_bin",',
@@ -439,7 +430,6 @@ class BazelWindowsTest(test_base.TestBase):
     self.assertIn('Hello from test!', '\n'.join(stdout))
 
   def testZipUndeclaredTestOutputs(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -488,7 +478,6 @@ class BazelWindowsTest(test_base.TestBase):
     self.assertFalse(os.path.exists(output_zip))
 
   def testBazelForwardsRequiredEnvVariable(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -522,7 +511,6 @@ class BazelWindowsTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr, stdout)
 
   def testTestShardStatusFile(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [
@@ -560,7 +548,6 @@ class BazelWindowsTest(test_base.TestBase):
     if not self.IsWindows():
       return
 
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'BUILD',
         [

--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -20,6 +20,11 @@ from src.test.py.bazel import test_base
 class BazelWindowsTest(test_base.TestBase):
 
   def createProjectFiles(self):
+    self.ScratchFile('MODULE.bazel', [
+        'bazel_dep(name = "platforms", version = "0.0.9")',
+        'cc_configure = use_extension("//tools/cpp:cc_configure.bzl", "cc_configure_extension")',
+        'use_repo(cc_configure, "local_config_cc")',
+    ])
     self.ScratchFile('foo/BUILD', [
         'platform(',
         '    name = "x64_windows-msys-gcc",',
@@ -133,7 +138,7 @@ class BazelWindowsTest(test_base.TestBase):
   def testWindowsEnvironmentVariablesSetting(self):
     self.ScratchFile('BUILD')
     rule_definition = [
-        'my_repo = use_repo_rule(":repo.bzl", "my_repo")',
+        'my_repo = use_repo_rule("//:repo.bzl", "my_repo")',
         'my_repo(name = "env_test")',
     ]
     self.ScratchFile('MODULE.bazel', rule_definition)

--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -22,7 +22,7 @@ class BazelWindowsTest(test_base.TestBase):
   def createProjectFiles(self):
     self.ScratchFile('MODULE.bazel', [
         'bazel_dep(name = "platforms", version = "0.0.9")',
-        'cc_configure = use_extension("//tools/cpp:cc_configure.bzl", "cc_configure_extension")',
+        'cc_configure = use_extension("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure_extension")',
         'use_repo(cc_configure, "local_config_cc")',
     ])
     self.ScratchFile('foo/BUILD', [

--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -133,12 +133,10 @@ class BazelWindowsTest(test_base.TestBase):
   def testWindowsEnvironmentVariablesSetting(self):
     self.ScratchFile('BUILD')
     rule_definition = [
-        'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
-        'load(":repo.bzl", "my_repo")',
+        'my_repo = use_repo_rule(":repo.bzl", "my_repo")',
         'my_repo(name = "env_test")',
     ]
-    rule_definition.extend(self.GetDefaultRepoRules())
-    self.ScratchFile('WORKSPACE', rule_definition)
+    self.ScratchFile('MODULE.bazel', rule_definition)
     self.ScratchFile('repo.bzl', [
         'def my_repo_impl(repository_ctx):',
         '  repository_ctx.file("env.bat", "set FOO\\n")',

--- a/src/test/py/bazel/cc_import_test.py
+++ b/src/test/py/bazel/cc_import_test.py
@@ -26,7 +26,6 @@ class CcImportTest(test_base.TestBase):
                          system_provided=0,
                          linkstatic=1,
                          provide_header=True):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
 
     # We use the outputs of cc_binary and cc_library as precompiled
     # libraries for cc_import

--- a/src/test/py/bazel/first_time_use_test.py
+++ b/src/test/py/bazel/first_time_use_test.py
@@ -23,7 +23,6 @@ class FirstTimeUseTest(test_base.TestBase):
 
   def testNoPythonRequirement(self):
     """Regression test for https://github.com/bazelbuild/bazel/issues/6463."""
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     _, stdout, stderr = self.RunBazel(['info', 'release'])
     for line in stdout + stderr:
       if 'python' in line and 'not found on PATH' in line:
@@ -47,7 +46,6 @@ class FirstTimeUseTest(test_base.TestBase):
 
   def testNoBashRequiredForSimpleBazelRun(self):
     """Regression test for https://github.com/bazelbuild/bazel/issues/8229."""
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'py_binary(',
         '    name = "x",'

--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -237,7 +237,6 @@ class LauncherTest(test_base.TestBase):
     self.assertEqual(stdout, arguments)
 
   def testJavaBinaryLauncher(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'java_binary(',
         '  name = "foo",',
@@ -267,7 +266,6 @@ class LauncherTest(test_base.TestBase):
     self._buildJavaTargets(bazel_bin, '.exe' if self.IsWindows() else '')
 
   def testJavaBinaryArgumentPassing(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'java_binary(',
         '  name = "bin",',
@@ -288,7 +286,6 @@ class LauncherTest(test_base.TestBase):
     self._buildAndCheckArgumentPassing('foo', 'bin')
 
   def testShBinaryLauncher(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'foo/BUILD',
         [
@@ -331,7 +328,6 @@ class LauncherTest(test_base.TestBase):
     self._buildShBinaryTargets(bazel_bin, '.exe' if self.IsWindows() else '')
 
   def testShBinaryArgumentPassing(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'sh_binary(',
         '  name = "bin",',
@@ -354,7 +350,6 @@ class LauncherTest(test_base.TestBase):
     self._buildAndCheckArgumentPassing('foo', 'bin')
 
   def testPyBinaryLauncher(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'foo/foo.bzl',
         [
@@ -411,7 +406,6 @@ class LauncherTest(test_base.TestBase):
     self._buildPyTargets(bazel_bin, '.exe' if self.IsWindows() else '')
 
   def testPyBinaryArgumentPassing(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'py_binary(',
         '  name = "bin",',
@@ -428,7 +422,6 @@ class LauncherTest(test_base.TestBase):
 
   def testPyBinaryLauncherWithDifferentArgv0(self):
     """Test for https://github.com/bazelbuild/bazel/issues/14343."""
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'py_binary(',
         '  name = "bin",',
@@ -454,7 +447,6 @@ class LauncherTest(test_base.TestBase):
     # Skip this test on non-Windows platforms
     if not self.IsWindows():
       return
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'java_binary(',
         '  name = "foo",',
@@ -577,7 +569,6 @@ class LauncherTest(test_base.TestBase):
   def testWindowsNativeLauncherInNonEnglishPath(self):
     if not self.IsWindows():
       return
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('bin/BUILD', [
         'java_binary(',
         '  name = "bin_java",',
@@ -626,7 +617,6 @@ class LauncherTest(test_base.TestBase):
   def testWindowsNativeLauncherInLongPath(self):
     if not self.IsWindows():
       return
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'bin/BUILD',
         [
@@ -723,7 +713,6 @@ class LauncherTest(test_base.TestBase):
   def testWindowsNativeLauncherInvalidArgv0(self):
     if not self.IsWindows():
       return
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'bin/BUILD',
         [

--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -211,9 +211,9 @@ class PyRemoteTest(test_base.TestBase):
 class PyRunfilesLibraryTest(test_base.TestBase):
 
   def testPyRunfilesLibraryCurrentRepository(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE', [
-        'local_repository(', '  name = "other_repo",',
-        '  path = "other_repo_path",', ')'
+    self.ScratchFile('MODULE.bazel', [
+        'local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
+        'local_repository(name = "other_repo", path = "other_repo_path")',
     ])
 
     self.ScratchFile('pkg/BUILD.bazel', [
@@ -260,7 +260,7 @@ class PyRunfilesLibraryTest(test_base.TestBase):
         'print("in pkg/test.py: \'%s\'" % runfiles.Create().CurrentRepository())',
     ])
 
-    self.ScratchFile('other_repo_path/WORKSPACE')
+    self.ScratchFile('other_repo_path/REPO.bazel')
     self.ScratchFile('other_repo_path/pkg/BUILD.bazel', [
         'py_binary(',
         '  name = "binary",',
@@ -304,14 +304,14 @@ class PyRunfilesLibraryTest(test_base.TestBase):
     self.assertIn('in pkg/library.py: \'\'', stdout)
 
     _, stdout, _ = self.RunBazel(['run', '@other_repo//pkg:binary'])
-    self.assertIn('in external/other_repo/pkg/binary.py: \'other_repo\'',
+    self.assertIn('in external/other_repo/pkg/binary.py: \'_main~_repo_rules~other_repo\'',
                   stdout)
     self.assertIn('in pkg/library.py: \'\'', stdout)
 
     _, stdout, _ = self.RunBazel(
         ['test', '@other_repo//pkg:test', '--test_output=streamed']
     )
-    self.assertIn('in external/other_repo/pkg/test.py: \'other_repo\'', stdout)
+    self.assertIn('in external/other_repo/pkg/test.py: \'_main~_repo_rules~other_repo\'', stdout)
     self.assertIn('in pkg/library.py: \'\'', stdout)
 
 

--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -22,7 +22,6 @@ class PyTest(test_base.TestBase):
   """Integration tests for the Python rules of Bazel."""
 
   def createSimpleFiles(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
 
     self.ScratchFile(
         'a/BUILD',
@@ -70,7 +69,6 @@ class PyTest(test_base.TestBase):
 class TestInitPyFiles(test_base.TestBase):
 
   def createSimpleFiles(self, create_init=True):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
 
     self.ScratchFile('src/a/BUILD', [
         'py_binary(name="a", srcs=["a.py"], deps=[":b"], legacy_create_init=%s)'
@@ -118,7 +116,6 @@ class TestInitPyFiles(test_base.TestBase):
 
   # Regression test for https://github.com/bazelbuild/bazel/pull/10119
   def testBuildingZipFileWithTargetNameWithDot(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [
         'py_binary(',
         '  name = "bin.v1",  # .v1 should not be treated as extension and removed accidentally',
@@ -161,7 +158,6 @@ class PyRemoteTest(test_base.TestBase):
     test_base.TestBase.tearDown(self)
 
   def testPyTestRunsRemotely(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'py_test(',
         '  name = "foo_test",',
@@ -180,7 +176,6 @@ class PyRemoteTest(test_base.TestBase):
 
   # Regression test for https://github.com/bazelbuild/bazel/issues/9239
   def testPyTestWithStdlibCollisionRunsRemotely(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'py_library(',
         '  name = "io",',

--- a/src/test/py/bazel/query_test.py
+++ b/src/test/py/bazel/query_test.py
@@ -41,6 +41,7 @@ class QueryTest(test_base.TestBase):
                             '//foo:dep-rule')
 
   def testQueryFilesUsedByRepositoryRules(self):
+    self.DisableBzlmod()
     self.ScratchFile('MODULE.bazel')
     self._AssertQueryOutputContains(
         "kind('source file', deps(//external:*))",
@@ -48,6 +49,7 @@ class QueryTest(test_base.TestBase):
     )
 
   def testBuildFilesForExternalRepos_Simple(self):
+    self.DisableBzlmod()
     self.ScratchFile('MODULE.bazel')
     self.ScratchFile('WORKSPACE', [
         'load("//:deps.bzl", "repos")',
@@ -67,6 +69,7 @@ class QueryTest(test_base.TestBase):
                                     '//:BUILD.bazel')
 
   def testBuildFilesForExternalRepos_IndirectLoads(self):
+    self.DisableBzlmod()
     self.ScratchFile('MODULE.bazel')
     self.ScratchFile('WORKSPACE', [
         'load("//:deps.bzl", "repos")',
@@ -98,6 +101,7 @@ class QueryTest(test_base.TestBase):
         '//:deps.bzl', '//:private_deps.bzl', '//:BUILD.bazel')
 
   def testBuildFilesForExternalRepos_NoDuplicates(self):
+    self.DisableBzlmod()
     self.ScratchFile('MODULE.bazel')
     self.ScratchFile('WORKSPACE', [
         'load("//:deps.bzl", "repos")',

--- a/src/test/py/bazel/runfiles_test.py
+++ b/src/test/py/bazel/runfiles_test.py
@@ -308,8 +308,12 @@ class RunfilesTest(test_base.TestBase):
     self.ScratchFile("A/REPO.bazel")
     self.ScratchFile("A/p/BUILD", ["exports_files(['foo.txt'])"])
     self.ScratchFile("A/p/foo.txt", ["Hello, World!"])
-    self.ScratchFile("MODULE.bazel")
-    self.ScratchFile("WORKSPACE", ["local_repository(name = 'A', path='A')"])
+    self.ScratchFile("MODULE.bazel",
+    """
+local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(name = "A", path = "A")
+""".split("\n")
+    )
     self.ScratchFile("pkg/BUILD", [
         "py_binary(",
         "  name = 'bin',",
@@ -333,7 +337,7 @@ class RunfilesTest(test_base.TestBase):
         "for arg in sys.argv[1:]:",
         "  print(open(r.Rlocation(arg)).read().strip())",
     ])
-    _, stdout, _ = self.RunBazel(["run", "//pkg:bin"], allow_failure=True)
+    _, stdout, _ = self.RunBazel(["run", "//pkg:bin"])
     if len(stdout) != 2:
       self.fail("stdout: %s" % stdout)
     self.assertEqual(stdout[0], "Hello, Bazel!")

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -177,13 +177,6 @@ class TestBase(absltest.TestCase):
     else:
       self.assertTrue(os.path.islink(path), "Path '%s' is not a symlink" % path)
 
-  def GetDefaultRepoRules(self):
-    with open(
-        self.Rlocation('io_bazel/src/test/py/bazel/default_repos_stanza.txt'),
-        'r') as repo_rules:
-      return repo_rules.read().split('\n')
-    return []
-
   @staticmethod
   def GetEnv(name, default=None):
     """Returns environment variable `name`.

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -57,53 +57,6 @@ class TestBase(absltest.TestCase):
   _worker_proc = None
   _cas_path = None
 
-  # Keep in sync with shared repos in src/test/shell/testenv.sh.tmpl
-  _SHARED_REPOS = (
-      'android_tools_for_testing',
-      'android_gmaven_r8',
-      'bazel_skylib',
-      'bazel_toolchains',
-      'com_google_protobuf',
-      'openjdk_linux_aarch64_vanilla',
-      'openjdk_linux_vanilla',
-      'openjdk_macos_x86_64_vanilla',
-      'openjdk_macos_aarch64_vanilla',
-      'openjdk_win_vanilla',
-      'remote_coverage_tools',
-      'remote_java_tools',
-      'remote_java_tools_darwin_x86_64',
-      'remote_java_tools_darwin_arm64',
-      'remote_java_tools_linux',
-      'remote_java_tools_windows',
-      'remotejdk11_linux',
-      'remotejdk11_linux_aarch64',
-      'remotejdk11_linux_ppc64le',
-      'remotejdk11_linux_s390x',
-      'remotejdk11_macos',
-      'remotejdk11_macos_aarch64',
-      'remotejdk11_win',
-      'remotejdk11_win_arm64',
-      'remotejdk17_linux',
-      'remotejdk17_linux_s390x',
-      'remotejdk17_macos',
-      'remotejdk17_macos_aarch64',
-      'remotejdk17_win',
-      'remotejdk17_win_arm64',
-      'remotejdk21_linux',
-      'remotejdk21_macos',
-      'remotejdk21_macos_aarch64',
-      'remotejdk21_win',
-      'remotejdk21_win_arm64',
-      'rules_cc',
-      'rules_java',
-      'rules_java_builtin_for_testing',
-      'rules_license',
-      'rules_proto',
-      'rules_python',
-      'rules_pkg',
-      'rules_testing',
-  )
-
   def setUp(self):
     absltest.TestCase.setUp(self)
     if self._runfiles is None:
@@ -116,12 +69,6 @@ class TestBase(absltest.TestCase):
     self._test_bazelrc = os.path.join(self._temp, 'test_bazelrc')
     with open(self._test_bazelrc, 'wt') as f:
       f.write('common --nolegacy_external_runfiles\n')
-      shared_repo_home = os.environ.get('TEST_REPOSITORY_HOME')
-      if shared_repo_home and os.path.exists(shared_repo_home):
-        for repo in self._SHARED_REPOS:
-          f.write('common --override_repository={}={}\n'.format(
-              repo.replace('_for_testing', ''),
-              os.path.join(shared_repo_home, repo).replace('\\', '/')))
       shared_install_base = os.environ.get('TEST_INSTALL_BASE')
       if shared_install_base:
         f.write('startup --install_base={}\n'.format(shared_install_base))
@@ -141,6 +88,11 @@ class TestBase(absltest.TestCase):
         # Prefer ipv6 network on macOS
         f.write('startup --host_jvm_args=-Djava.net.preferIPv6Addresses=true\n')
         f.write('build --jvmopt=-Djava.net.preferIPv6Addresses\n')
+
+      # Disable WORKSPACE in python tests by default
+      # TODO(pcloudy): Remove when --enable_workspace defaults to false
+      f.write('common --noenable_workspace\n')
+
     # An empty MODULE.bazel and a corresponding MODULE.bazel.lock will prevent
     # tests from accessing BCR
     self.ScratchFile('MODULE.bazel')

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -105,6 +105,7 @@ class TestBase(absltest.TestCase):
   def DisableBzlmod(self):
     with open(self._test_bazelrc, 'at') as f:
       f.write('common --noenable_bzlmod\n')
+      f.write('common --enable_workspace\n')
 
   def tearDown(self):
     self.RunBazel(['shutdown'])

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -176,26 +176,6 @@ class TestBase(absltest.TestCase):
     else:
       self.assertTrue(os.path.islink(path), "Path '%s' is not a symlink" % path)
 
-  def CreateWorkspaceWithDefaultRepos(self, path, lines=None):
-    """Creates a `WORKSPACE` file with default repos and register C++ toolchains."""
-    rule_definition = [
-        'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")'
-    ]
-    rule_definition.extend(self.GetDefaultRepoRules())
-    if lines:
-      rule_definition.extend(lines)
-    rule_definition.extend([
-        'register_toolchains(',
-        '  "@local_config_cc//:all",',
-        ')',
-    ])
-    self.ScratchFile(path, rule_definition)
-    self.ScratchFile(
-        path.replace('WORKSPACE.bazel', 'MODULE.bazel').replace(
-            'WORKSPACE', 'MODULE.bazel'
-        )
-    )
-
   def GetDefaultRepoRules(self):
     with open(
         self.Rlocation('io_bazel/src/test/py/bazel/default_repos_stanza.txt'),

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -33,7 +33,6 @@ class TestWrapperTest(test_base.TestBase):
     self.fail('FAIL:\n | %s\n---' % '\n | '.join(output))
 
   def _CreateMockWorkspace(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile(
         'foo/BUILD',
         [
@@ -681,7 +680,6 @@ class TestWrapperTest(test_base.TestBase):
     ]
     rule_definition.extend(self.GetDefaultRepoRules())
     self.ScratchFile('WORKSPACE', rule_definition)
-    self.CreateWorkspaceWithDefaultRepos('a/WORKSPACE')
     self.ScratchFile('BUILD', ['py_test(name = "x", srcs = ["x.py"])'])
     self.ScratchFile('a/BUILD', ['py_test(name = "x", srcs = ["x.py"])'])
     self.ScratchFile('x.py')

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -675,11 +675,10 @@ class TestWrapperTest(test_base.TestBase):
   # See https://github.com/bazelbuild/bazel/issues/8088
   def testRunningTestFromExternalRepo(self):
     rule_definition = [
-        'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")',
+        'local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")',
         'local_repository(name = "a", path = "a")'
     ]
-    rule_definition.extend(self.GetDefaultRepoRules())
-    self.ScratchFile('WORKSPACE', rule_definition)
+    self.ScratchFile('MODULE.bazel', rule_definition)
     self.ScratchFile('BUILD', ['py_test(name = "x", srcs = ["x.py"])'])
     self.ScratchFile('a/BUILD', ['py_test(name = "x", srcs = ["x.py"])'])
     self.ScratchFile('x.py')

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -680,6 +680,7 @@ class TestWrapperTest(test_base.TestBase):
     ]
     self.ScratchFile('MODULE.bazel', rule_definition)
     self.ScratchFile('BUILD', ['py_test(name = "x", srcs = ["x.py"])'])
+    self.ScratchFile('a/REPO.bazel')
     self.ScratchFile('a/BUILD', ['py_test(name = "x", srcs = ["x.py"])'])
     self.ScratchFile('x.py')
     self.ScratchFile('a/x.py')

--- a/src/test/py/bazel/windows_remote_test.py
+++ b/src/test/py/bazel/windows_remote_test.py
@@ -52,7 +52,6 @@ class WindowsRemoteTest(test_base.TestBase):
   # this means the runfiles manifest, which is not present remotely, must exist
   # locally.
   def testBinaryRunsLocally(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'sh_binary(',
         '  name = "foo",',
@@ -81,7 +80,6 @@ class WindowsRemoteTest(test_base.TestBase):
     self.assertEqual(stdout, ['hello shell'])
 
   def testShTestRunsLocally(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'sh_test(',
         '  name = "foo_test",',
@@ -107,7 +105,6 @@ class WindowsRemoteTest(test_base.TestBase):
 
   # Remotely, the runfiles manifest does not exist.
   def testShTestRunsRemotely(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'sh_test(',
         '  name = "foo_test",',
@@ -134,7 +131,6 @@ class WindowsRemoteTest(test_base.TestBase):
   # The Java launcher uses Rlocation which has differing behavior for local and
   # remote.
   def testJavaTestRunsRemotely(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'java_test(',
         '  name = "foo_test",',
@@ -164,7 +160,6 @@ class WindowsRemoteTest(test_base.TestBase):
   # it elsewhere, add --test_env=JAVA_HOME to your Bazel invocation to fix this
   # test.
   def testJavaTestWithRuntimeRunsRemotely(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'package(default_visibility = ["//visibility:public"])',
         'java_test(',
@@ -194,7 +189,6 @@ class WindowsRemoteTest(test_base.TestBase):
   # for genrule tool launchers, so the runfiles directory is discovered based on
   # the executable path.
   def testGenruleWithToolRunsRemotely(self):
-    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     # TODO(jsharpe): Replace sh_binary with py_binary once
     # https://github.com/bazelbuild/bazel/issues/5087 resolved.
     self.ScratchFile('foo/BUILD', [

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -28,7 +28,6 @@ class BazelApiTest(test_base.TestBase):
     test_base.TestBase.setUp(self)
     self._bazel_api = BazelApi(self.RunBazel)
     self.ScratchFile('WORKSPACE')
-    self.CreateWorkspaceWithDefaultRepos('repo/WORKSPACE')
 
   def tearDown(self):
     test_base.TestBase.tearDown(self)

--- a/tools/ctexplain/lib_test.py
+++ b/tools/ctexplain/lib_test.py
@@ -29,7 +29,6 @@ class LibTest(test_base.TestBase):
     test_base.TestBase.setUp(self)
     self._bazel = bazel_api.BazelApi(self.RunBazel)
     self.ScratchFile('WORKSPACE')
-    self.CreateWorkspaceWithDefaultRepos('repo/WORKSPACE')
 
   def tearDown(self):
     test_base.TestBase.tearDown(self)


### PR DESCRIPTION
Working towards: https://github.com/bazelbuild/bazel/issues/23023