### PR TITLE
Test action interaction with platform

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -152,23 +152,21 @@ public final class TestActionBuilder {
     return this;
   }
 
-  private ActionOwner getTestActionOwner() {
-    if (this.executionRequirements != null) {
-      ActionOwner owner = ruleContext.getActionOwner(this.executionRequirements.getExecGroup());
-      if (owner != null) {
-        return owner;
-      }
+  private ActionOwner getTestActionOwner(boolean useTargetPlatformForTests) {
+    if (useTargetPlatformForTests && this.executionRequirements == null) {
+      return ruleContext.getTestActionOwner();
     }
-    return ruleContext.getTestActionOwner();
-  }
-
-  private ActionOwner getOwner() {
-    ActionOwner owner =
-        ruleContext.getActionOwner(
-            this.executionRequirements != null
-                ? this.executionRequirements.getExecGroup()
-                : DEFAULT_TEST_RUNNER_EXEC_GROUP);
-    return owner == null ? ruleContext.getActionOwner() : owner;
+    var execGroup =
+        this.executionRequirements != null
+            ? this.executionRequirements.getExecGroup()
+            : DEFAULT_TEST_RUNNER_EXEC_GROUP;
+    var owner = ruleContext.getActionOwner(execGroup);
+    if (owner != null) {
+      return owner;
+    }
+    return useTargetPlatformForTests
+        ? ruleContext.getTestActionOwner()
+        : ruleContext.getActionOwner();
   }
 
   public static int getShardCount(RuleContext ruleContext) {
@@ -366,8 +364,7 @@ public final class TestActionBuilder {
     ImmutableList.Builder<Artifact> coverageArtifacts = ImmutableList.builder();
     ImmutableList.Builder<ActionInput> testOutputs = ImmutableList.builder();
 
-    ActionOwner actionOwner =
-        testConfiguration.useTargetPlatformForTests() ? getTestActionOwner() : getOwner();
+    ActionOwner actionOwner = getTestActionOwner(testConfiguration.useTargetPlatformForTests());
 
     // Use 1-based indices for user friendliness.
     for (int shard = 0; shard < shardRuns; shard++) {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3428,6 +3428,15 @@ sh_test(
 )
 EOF
 
+  # A test target includes 2 actions: 1 build action (a) and 1 test action (b)
+  # This test currently demonstrates that:
+  #  - (b) would always be executed on Bazel's target platform, set by "--platforms=" flag.
+  #  - Regardless of 'no-remote-exec' set on (b)'s platform, (b) would still be executed remotely.
+  #    The remote test action will be sent with `"no-remote-exec": "1"` in it's platform.
+  #
+  # TODO: Make this test's result consistent with 'test_platform_no_remote_exec'.
+  # Test action (b) should be executed locally instead of remotely in this setup.
+
   bazel test \
     --extra_execution_platforms=//a:remote,//a:host \
     --platforms=//a:remote \


### PR DESCRIPTION
Add a test to show how no-remote-exec exec prop work w. test action

The most recent test added demonstrated that if `no-remote-exec` is
added to a platform and action were to run on that platform, then that
action will be executed locally instead of remotely. The intended use
case for this was to setup a local "fallback" exec platform that
actions could run on if none of the registered exec platform could be
used. However, this does not hold with test action.

Each test target in Bazel is composed of 2 types of actions:

a. One to build the test executable binary
b. One to run the executable binary to obtain test logs and result

Actions in group (a) are executed on the matched `exec` platform and
produce the artifact intended for the `target` platform. This artifact
is then used in (b), which means that actions in (b) must be executed
in `target` platform, defined by `--platforms` flag.

Provide a test to demonstrate that currently, there is no way to tell
Bazel to execute this test action (b) in the local fallback platform.
