### PR TITLE
Profiler: fix wrong field name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
@@ -225,15 +225,15 @@ class JsonTraceFileWriter implements Runnable {
               // The buffer size of 262144 is chosen at random.
               new OutputStreamWriter(
                   new BufferedOutputStream(outStream, 262144), StandardCharsets.UTF_8))) {
-        var finishDate = Instant.now();
+        var startDate = Instant.now();
         writer.beginObject();
         writer.name("otherData");
         writer.beginObject();
         writer.name("bazel_version").value(BlazeVersionInfo.instance().getReleaseName());
         writer.name("build_id").value(buildID.toString());
         writer.name("output_base").value(outputBase);
-        writer.name("date").value(finishDate.toString());
-        writer.name("profile_finish_ts").value(finishDate.getEpochSecond() * 1000);
+        writer.name("date").value(startDate.toString());
+        writer.name("profile_start_ts").value(startDate.toEpochMilli());
         writer.endObject();
         writer.name("traceEvents");
         writer.beginArray();


### PR DESCRIPTION
As reported in #22505, I misread the initial implemenation and named
this field wrongly. Given there has been no report about this before
this issue, it's safe to assume that the field is not widely used by
other folks and therefore, is safe to change.

Closes #22505.
