### PR TITLE
docs: add missing $ sign before shell commands in the install guide

### DIFF
--- a/site/en/install/os-x.md
+++ b/site/en/install/os-x.md
@@ -107,6 +107,7 @@ Run the Bazel installer as follows:
 
 ```posix-terminal
 chmod +x "bazel-{{ '<var>' }}$BAZEL_VERSION{{ '</var>' }}-installer-darwin-x86_64.sh"
+
 ./bazel-{{ '<var>' }}$BAZEL_VERSION{{ '</var>' }}-installer-darwin-x86_64.sh --user
 ```
 

--- a/site/en/install/ubuntu.md
+++ b/site/en/install/ubuntu.md
@@ -43,8 +43,11 @@ Bazel comes with two completion scripts. After installing Bazel, you can:
 
 ```posix-terminal
 sudo apt install apt-transport-https curl gnupg -y
+
 curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
+
 sudo mv bazel-archive-keyring.gpg /usr/share/keyrings
+
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 ```
 
@@ -81,6 +84,7 @@ Optionally, you can set `bazel` to a specific version by creating a symlink:
 
 ```posix-terminal
 sudo ln -s /usr/bin/bazel-1.0.0 /usr/bin/bazel
+
 bazel --version  # 1.0.0
 ```
 


### PR DESCRIPTION
In the following example screenshot from docs, the missing dollar sign could mislead someone into thinking these are a single command. I have added the missing dollar sign to better individualize each command and for better readability of the install guide.

![image](https://github.com/user-attachments/assets/e2366b34-0a27-4783-9f4c-8aa73b0a5adb)
