### PR TITLE
--experimental_remote_cache_async: Profile upload events.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1423,18 +1423,23 @@ public class RemoteExecutionService {
           .subscribeOn(scheduler)
           .subscribe(
               new SingleObserver<ActionResult>() {
+                long startTime = 0;
+
                 @Override
                 public void onSubscribe(@NonNull Disposable d) {
                   backgroundTaskPhaser.register();
+                  startTime = Profiler.nanoTimeMaybe();
                 }
 
                 @Override
                 public void onSuccess(@NonNull ActionResult actionResult) {
+                  Profiler.instance().completeTask(startTime, ProfilerTask.UPLOAD_TIME, "upload outputs");
                   backgroundTaskPhaser.arriveAndDeregister();
                 }
 
                 @Override
                 public void onError(@NonNull Throwable e) {
+                  Profiler.instance().completeTask(startTime, ProfilerTask.UPLOAD_TIME, "upload outputs");
                   backgroundTaskPhaser.arriveAndDeregister();
                   reportUploadError(e);
                 }


### PR DESCRIPTION
In the experimental_remote_cache_async mode, the
cache upload steps were not profiled, unlike in the non-async case.
This adds the profiling back.
Fixes #20404.

It'd be great if this could be backported into 7.3.0 once merged.