### PR TITLE
[7.3.0] Fix javadocs for Runfiles

### DIFF
--- a/tools/java/runfiles/Runfiles.java
+++ b/tools/java/runfiles/Runfiles.java
@@ -118,10 +118,10 @@ import java.util.stream.Collectors;
  * Runfiles#preload(Map)} and immutably encapsulate all data required to look up runfiles with the
  * repository mapping of any Bazel repository specified at a later time.
  *
- * <p>Creating {@link Runfiles} instances can be costly, so applications should try to create as few
- * instances as possible. {@link Runfiles#preload()}, but not {@link Runfiles#preload(Map)}, returns
- * a single global, softly cached instance of {@link Preloaded} that is constructed based on the
- * JVM's environment variables.
+ * <p>Creating {@link Preloaded} instances can be costly, so applications should try to create as
+ * few instances as possible. {@link Runfiles#preload()}, but not {@link Runfiles#preload(Map)},
+ * returns a single global, softly cached instance of {@link Preloaded} that is constructed based on
+ * the JVM's environment variables.
  *
  * <p>Instance of {@link Runfiles} are only meant to be used by code located in a single Bazel
  * repository and should not be passed around. They are created by calling {@link


### PR DESCRIPTION
`Runfiles` insurance are cheap, `Preloaded` instances are costly.

Closes #23006.

PiperOrigin-RevId: 654661845
Change-Id: I46ee31718a2c5753d983b9c741547fe2a1de5d88

Commit https://github.com/bazelbuild/bazel/commit/7d266153af8516cfcd78f9e986a806566b205b27