### PR TITLE
Add a testcase to ensure that include paths are consistent

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.analysis.util.AnalysisTestUtil;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.packages.Provider;
 import com.google.devtools.build.lib.packages.StarlarkInfo;
@@ -5875,6 +5876,33 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     CcInfo ccInfo = target.get(CcInfo.PROVIDER);
     assertThat(artifactsToStrings(ccInfo.getCcCompilationContext().getDirectPublicHdrs()))
         .contains("bin third_party/bar/_virtual_includes/starlark_lib_suffix/starlark_lib.h");
+  }
+
+  @Test
+  public void testStripIncludePrefixIncludePath() throws Exception {
+    createFilesForTestingCompilation(
+        scratch, "third_party/tools/build_defs/foo", "strip_include_prefix='v1'");
+    scratch.file(
+        "third_party/bar/BUILD",
+        """
+        load("//third_party/tools/build_defs/foo:extension.bzl", "cc_starlark_library")
+
+        cc_starlark_library(
+            name = "starlark_lib",
+            srcs = ["starlark_lib.cc"],
+            private_hdrs = ["v1/private_starlark_lib.h"],
+            public_hdrs = ["v1/starlark_lib.h"],
+        )
+        """);
+    ConfiguredTarget target = getConfiguredTarget("//third_party/bar:starlark_lib");
+    assertThat(target).isNotNull();
+    CcInfo ccInfo = target.get(CcInfo.PROVIDER);
+
+    assertThat(ccInfo.getCcCompilationContext().getIncludeDirs())
+             .containsExactly(
+                 getTargetConfiguration()
+                     .getBinFragment(RepositoryName.MAIN)
+                     .getRelative("third_party/bar/_virtual_includes/starlark_lib_suffix"));
   }
 
   @Test


### PR DESCRIPTION
So far only the generated header in the virtual includes is tested but the Include path pointing to that directory isnt

This is a testcase to reproduce the suspected error reported here:
- https://github.com/bazelbuild/bazel/issues/23061

Assuming that the location of the file is asserted:
```Java
    assertThat(artifactsToStrings(ccInfo.getCcCompilationContext().getDirectPublicHdrs()))
        .contains("bin third_party/bar/_virtual_includes/starlark_lib_suffix/starlark_lib.h");
```

Adding a testcase for the include path seems reasonable.

A local run of the testcase shows the error:
```
1) testStripIncludePrefixIncludePath(com.google.devtools.build.lib.rules.cpp.StarlarkCcCommonTest)
value of: getIncludeDirs().onlyElement()
expected: bazel-out/k8-fastbuild/bin/third_party/bar/_virtual_includes/starlark_lib_suffix
but was : bazel-out/k8-fastbuild/bin/third_party/bar/_virtual_includes/starlark_lib
        at com.google.devtools.build.lib.rules.cpp.StarlarkCcCommonTest.testStripIncludePrefixIncludePath(StarlarkCcCommonTest.java:5902)

FAILURES!!!
Tests run: 73,  Failures: 1
```


The change in behaviour was introduced in https://github.com/bazelbuild/bazel/commit/7e0df68aa4d11307dff8571ebce11d37c79c170c#diff-403c46ec3075b8e9e6d490ce955db88dae2d457b8046608884039b18b10ab6ccR774