### PR TITLE
allow --experimental_remote_cache_ttl=server to request remote cache entries that live as long as the Bazel server

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -74,7 +74,7 @@ public class CompactPersistentActionCache implements ActionCache {
   // cache records.
   private static final int VALIDATION_KEY = -10;
 
-  private static final int VERSION = 21;
+  private static final int VERSION = 22;
 
   /**
    * A timestamp, represented as the number of minutes since the Unix epoch.
@@ -797,7 +797,7 @@ public class CompactPersistentActionCache implements ActionCache {
     }
 
     FileArtifactValue metadata;
-    if (expirationTimeEpochMilli < 0) {
+    if (expirationTimeEpochMilli < 0 && expirationTimeEpochMilli != FileArtifactValue.SERVER_EXPIRATION_SENTINEL) {
       metadata = FileArtifactValue.createForRemoteFile(digest, size, locationIndex);
     } else {
       metadata =

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1311,7 +1311,12 @@ public class RemoteExecutionService {
             combinedCache, digestUtil, context, action.getRemotePathResolver());
 
     // The expiration time for remote cache entries.
-    var expirationTime = Instant.now().plus(remoteOptions.remoteCacheTtl);
+    //
+    // We use SERVER_EXPIRATION_SENTINEL if the user requested it.  Otherwise, we compute
+    // the expiration time based on the current time and remoteOptions.remoteCacheTtl.
+    var expirationTime = remoteOptions.remoteCacheTtl.getSeconds() == FileArtifactValue.SERVER_EXPIRATION_SENTINEL
+      ? Instant.ofEpochMilli(FileArtifactValue.SERVER_EXPIRATION_SENTINEL)
+      : Instant.now().plus(remoteOptions.remoteCacheTtl);
 
     ActionInput inMemoryOutput = null;
     AtomicReference<ByteString> inMemoryOutputData = new AtomicReference<>(null);

--- a/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
@@ -16,6 +16,7 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/remote:scrubber",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -561,6 +561,21 @@ public class CompactPersistentActionCacheTest {
   }
 
   @Test
+  public void putAndGet_savesRemoteFileMetadata_withServerExpirationTime() {
+    Artifact artifact = ActionsTestUtil.DUMMY_ARTIFACT;
+    Instant expirationTime = Instant.ofEpochMilli(FileArtifactValue.SERVER_EXPIRATION_SENTINEL);
+    FileArtifactValue metadata =
+        createRemoteMetadata(artifact, "content", expirationTime, /* resolvedPath= */ null);
+    var entry =
+        builder("key").addOutputFile(artifact, metadata, /* saveFileMetadata= */ true).build();
+    cache.put("key", entry);
+
+    entry = cache.get("key");
+
+    assertThat(entry.getOutputFile(artifact).getExpirationTime()).isEqualTo(expirationTime);
+  }
+
+  @Test
   public void putAndGet_savesRemoteFileMetadata_withResolvedPath() {
     Artifact artifact = ActionsTestUtil.DUMMY_ARTIFACT;
     FileArtifactValue metadata =

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -64,6 +64,7 @@ java_library(
             "BuildWithoutTheBytesIntegrationTest.java",
             "BuildWithoutTheBytesIntegrationTestBase.java",
             "DiskCacheIntegrationTest.java",
+            "ServerLifetimeIntegrationTest.java",
         ],
     ),
     deps = [
@@ -282,5 +283,28 @@ java_test(
         "//third_party:junit4",
         "//third_party:truth",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_test(
+    name = "ServerLifetimeIntegrationTest",
+    size = "large",
+    srcs = ["ServerLifetimeIntegrationTest.java"],
+    tags = ["requires-network"],
+    runtime_deps = [
+        "//third_party/grpc-java:grpc-jar",
+    ],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper:credential_module",
+        "//src/main/java/com/google/devtools/build/lib/dynamic",
+        "//src/main/java/com/google/devtools/build/lib/remote",
+        "//src/main/java/com/google/devtools/build/lib/standalone",
+        "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/test/java/com/google/devtools/build/lib/buildtool/util",
+        "//src/test/java/com/google/devtools/build/lib/remote/util:integration_test_utils",
+        "//third_party:guava",
+        "//third_party:truth",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/remote/ServerLifetimeIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ServerLifetimeIntegrationTest.java
@@ -1,0 +1,161 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.eventbus.Subscribe;
+import com.google.devtools.build.lib.actions.ActionExecutedEvent;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CachedActionEvent;
+import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
+import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
+import com.google.devtools.build.lib.dynamic.DynamicExecutionModule;
+import com.google.devtools.build.lib.remote.util.IntegrationTestUtils.WorkerInstance;
+import com.google.devtools.build.lib.remote.util.IntegrationTestUtils;
+import com.google.devtools.build.lib.runtime.BlazeModule;
+import com.google.devtools.build.lib.runtime.BlazeRuntime;
+import com.google.devtools.build.lib.runtime.BlockWaitingModule;
+import com.google.devtools.build.lib.runtime.BuildSummaryStatsModule;
+import com.google.devtools.build.lib.standalone.StandaloneModule;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Integration tests for --experimental_remote_cache_ttl=server. */
+public class ServerLifetimeIntegrationTest extends BuildIntegrationTestCase {
+  @ClassRule @Rule public static final WorkerInstance worker = IntegrationTestUtils.createWorker();
+
+  @Override
+  protected void setupOptions() throws Exception {
+    super.setupOptions();
+
+    addOptions(
+        "--remote_executor=grpc://localhost:" + worker.getPort(),
+        "--remote_download_minimal",
+        "--dynamic_local_strategy=standalone",
+        "--dynamic_remote_strategy=remote");
+  }
+
+  @Override
+  protected BlazeRuntime.Builder getRuntimeBuilder() throws Exception {
+    return super.getRuntimeBuilder()
+        .addBlazeModule(new RemoteModule())
+        .addBlazeModule(new BuildSummaryStatsModule())
+        .addBlazeModule(new BlockWaitingModule());
+  }
+
+  @Override
+  protected ImmutableList<BlazeModule> getSpawnModules() {
+    return ImmutableList.<BlazeModule>builder()
+        .addAll(super.getSpawnModules())
+        .add(new StandaloneModule())
+        .add(new CredentialModule())
+        .add(new DynamicExecutionModule())
+        .build();
+  }
+
+  protected void assertOutputsDoNotExist(String target) throws Exception {
+    for (Artifact output : getArtifacts(target)) {
+      assertWithMessage(
+              "output %s for target %s should not exist", output.getExecPathString(), target)
+          .that(output.getPath().exists())
+          .isFalse();
+    }
+  }
+
+  protected static class ActionEventCollector {
+    private final List<ActionExecutedEvent> actionExecutedEvents = new ArrayList<>();
+    private final List<CachedActionEvent> cachedActionEvents = new ArrayList<>();
+
+    @Subscribe
+    public void onActionExecuted(ActionExecutedEvent event) {
+      actionExecutedEvents.add(event);
+    }
+
+    @Subscribe
+    public void onCachedAction(CachedActionEvent event) {
+      cachedActionEvents.add(event);
+    }
+
+    public int getNumActionNodesEvaluated() {
+      return getActionExecutedEvents().size() + getCachedActionEvents().size();
+    }
+
+    public void clear() {
+      this.actionExecutedEvents.clear();
+      this.cachedActionEvents.clear();
+    }
+
+    public List<ActionExecutedEvent> getActionExecutedEvents() {
+      return actionExecutedEvents;
+    }
+
+    public List<CachedActionEvent> getCachedActionEvents() {
+      return cachedActionEvents;
+    }
+  }
+
+  protected void restartServer() throws Exception {
+    // Simulates a server restart
+    createRuntimeWrapper();
+  }
+
+  @Test
+  public void incrementalBuild_restartServer_missActionCache() throws Exception {
+    // Prepare workspace
+    addOptions("--experimental_remote_cache_ttl=server");
+    write(
+        "BUILD",
+        "genrule(",
+        "  name = 'foo',",
+        "  srcs = [],",
+        "  outs = ['out/foo.txt'],",
+        "  cmd = 'echo foo > $@',",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo'],",
+        "  outs = ['out/foobar.txt'],",
+        "  cmd = 'cat $(location :foo) > $@ && echo bar >> $@',",
+        ")");
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+
+    // Clean build
+    buildTarget("//:foobar");
+
+    // all action should be executed
+    assertThat(actionEventCollector.getActionExecutedEvents()).hasSize(3);
+    // no outputs are staged
+    assertOutputsDoNotExist("//:foobar");
+
+    restartServer();
+    actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+
+    // Incremental build
+    buildTarget("//:foobar");
+
+    // We expect to see actions here due to expiring the server-lifetime entries
+    // in the action cache.
+    assertThat(actionEventCollector.getActionExecutedEvents()).hasSize(2);
+    // no outputs are staged
+    assertOutputsDoNotExist("//:foobar");
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/options/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/BUILD
@@ -19,6 +19,7 @@ java_test(
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/common/options",
         "//src/test/java/com/google/devtools/build/lib:test_runner",

--- a/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsParsingException;
@@ -93,6 +94,41 @@ public class RemoteOptionsTest {
       Duration convert =
           new CommonRemoteOptions.RemoteDurationConverter().convert(milliseconds + "ms");
       assertThat(Duration.ofMillis(milliseconds)).isEqualTo(convert);
+    } catch (OptionsParsingException e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testRemoteCacheTtlOptionsConverterWithoutUnit() {
+    try {
+      int seconds = 60;
+      Duration convert =
+          new CommonRemoteOptions.RemoteCacheTtlDurationConverter().convert(String.valueOf(seconds));
+      assertThat(Duration.ofSeconds(seconds)).isEqualTo(convert);
+    } catch (OptionsParsingException e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testRemoteCacheTtlOptionsConverterWithUnit() {
+    try {
+      int milliseconds = 60;
+      Duration convert =
+          new CommonRemoteOptions.RemoteCacheTtlDurationConverter().convert(milliseconds + "ms");
+      assertThat(Duration.ofMillis(milliseconds)).isEqualTo(convert);
+    } catch (OptionsParsingException e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testRemoteCacheTtlOptionsConverterServer() {
+    try {
+      Duration convert =
+          new CommonRemoteOptions.RemoteCacheTtlDurationConverter().convert(CommonRemoteOptions.SERVER_KEYWORD);
+      assertThat(Duration.ofSeconds(FileArtifactValue.SERVER_EXPIRATION_SENTINEL)).isEqualTo(convert);
     } catch (OptionsParsingException e) {
       fail(e.getMessage());
     }


### PR DESCRIPTION
Under this flag, Bazel will retain remote execution records in its
persistent action cache for as long as the server runs.  To this end, we
introduce a new FileArtifactValue expirationTime sentinel value of -2.

Note that we bump the VERSION of CompactPersistentActionCache.  This
way, the right thing will happen if an earlier version of Bazel that
does not have the logic to selectively clear the expirationTime ==
-2 entries inherits a persistent action cache from a later version of
Bazel.

In order to see if your CompactPersistentActionCache has server-duration
entries, you can see if:

    bazel dump --action_cache | grep expirationTime=-2

finds anything.