### PR TITLE
Use bootclasspath jar in proguard genrule

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -308,13 +308,14 @@ genrule(
     name = "fastutil_stripped_jar",
     srcs = [
         "@maven//:it_unimi_dsi_fastutil_file",
+        "@rules_java//toolchains:platformclasspath",
     ],
     outs = ["fastutil-stripped.jar"],
     cmd = """
     $(location :proguard) \
-        -injars $< \
+        -injars $(execpath @maven//:it_unimi_dsi_fastutil_file) \
         -outjars $@ \
-        -libraryjars '<java.home>/jmods/java.base.jmod(!**.jar;!module-info.class)' \
+        -libraryjars $(execpath @rules_java//toolchains:platformclasspath) \
         @$(location //tools:fastutil.proguard) \
       | tail -n +2 # Skip the "ProGuard, version X" line
     # Null out the file times stored in the jar to make the output reproducible.


### PR DESCRIPTION
Previously, proguard may attempt to access the Java runtime jmods, which aren't declared as inputs.

Fixes https://github.com/bazelbuild/bazel/pull/22787#issuecomment-2241749240