### PR TITLE
Add link to the official Dockerfile config

### DIFF
--- a/site/en/install/docker-container.md
+++ b/site/en/install/docker-container.md
@@ -130,3 +130,7 @@ Build time: Fri Jun 2 16:59:58 2023 (1685725198)
 Build timestamp: 1685725198
 Build timestamp as int: 1685725198
 ```
+
+## Explore the Bazel Dockerfile {:#explore-bazel-dockerfile}
+
+If you want to check how the Bazel Docker image is built, you can find its Dockerfile at [bazelbuild/continuous-integration/bazel/oci](https://github.com/bazelbuild/continuous-integration/tree/master/bazel/oci).


### PR DESCRIPTION
It's nice to be able to find the Dockerfile for any image easily, so I'm just adding the link to the "Getting Started with Bazel Docker Container" doc.

Maybe it was probably me not knowing how to navigate the Container Registry website but I couldn't find the Dockerfile for the official images. In fact, it was a bit confusing because, while googling, I did find some old versions of the website that pointed to an old registry with very old images!

Luckily, trying to find what was going on, I found [bazelbuild/continuous-integration issue #1060](https://github.com/bazelbuild/continuous-integration/issues/1060) and from there, I found the Dockerfile for the official image.