### PR TITLE
Increase gRPC max recv message size in Bazel client

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1627,6 +1627,9 @@ bool BlazeServer::Connect() {
   // locally over gRPC; so we want to ignore any configured proxies when setting
   // up a gRPC channel to the server.
   channel_args.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY, 0);
+  // The Bazel server may send responses larger than the default (4 MiB), e.g.
+  // when an invocation has a very large failure detail.
+  channel_args.SetMaxReceiveMessageSize(20 * 1024 * 1024);
   std::shared_ptr<grpc::Channel> channel(grpc::CreateCustomChannel(
       port, grpc::InsecureChannelCredentials(), channel_args));
   std::unique_ptr<CommandServer::Stub> client(CommandServer::NewStub(channel));


### PR DESCRIPTION
We have seen invocations where the `FailureDetail` [presumably] is larger than the 4MiB default (we've seen this when we have many `CacheNotFoundException` exceptions; the list of missing digests is very very large, and the associated stack traces are even larger).

This causes the Bazel client to exit with a misleading error:

```
Server terminated abruptly (error code: 8, error message: 'Received message larger than max (9620141 vs. 4194304)', log file: '/mnt/tmpfs/BAZEL_OUTPUT/server/jvm.out')
```

Somewhat confusingly, the server has not actually terminated, but it's a client-side enforced `RESOURCE_EXHAUSTED`.

I picked 20 MiB pretty arbitrarily, it's just what happened to be large enough for us.