### PR TITLE
Mark remote cache errors as retriable by expanding `--incompatible_remote_use_new_exit_code_for_lost_inputs`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -546,17 +546,16 @@ public class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "The maximum number of attempts to retry if the build encountered a remote cache"
+          "The maximum number of attempts to retry if the build encountered a transient remote cache"
               + " error that would otherwise fail the build. Applies for example when artifacts"
-              + " are evicted from the remote cache, or in certain cache failure conditions"
-              + " when using --remote_download_minimal."
+              + " are evicted from the remote cache, or in certain cache failure conditions."
               + " A non-zero value will implicitly set"
               + " --incompatible_remote_use_new_exit_code_for_lost_inputs to true. A new invocation"
               + " id will be generated for each attempt. If you generate invocation id and provide"
               + " it to Bazel with --invocation_id, you should not use this flag. Instead, set flag"
               + " --incompatible_remote_use_new_exit_code_for_lost_inputs and check for the exit"
               + " code 39.")
-  public int remoteRetryOnCacheError;
+  public int remoteRetryOnTransientCacheError;
 
   /** An enum for specifying different formats of test output. */
   public enum TestOutputFormat {

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -534,24 +534,29 @@ public class ExecutionOptions extends OptionsBase {
       effectTags = {OptionEffectTag.UNKNOWN},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
       help =
-          "If set to true, Bazel will use new exit code 39 instead of 34 if remote cache evicts"
-              + " blobs during the build.")
+          "If set to true, Bazel will use new exit code 39 instead of 34 if remote cache"
+          + "errors, like cache evictions cause the build to fail.")
   public boolean useNewExitCodeForLostInputs;
 
   @Option(
+      // TODO: when this flag is moved to non-experimental, rename it to a more general name
+      // to reflect the new logic - it's not only about cache evictions.
       name = "experimental_remote_cache_eviction_retries",
       defaultValue = "0",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "The maximum number of attempts to retry if the build encountered remote cache eviction"
-              + " error. A non-zero value will implicitly set"
+          "The maximum number of attempts to retry if the build encountered a remote cache"
+              + " error that would otherwise fail the build. Applies for example when artifacts"
+              + " are evicted from the remote cache, or in certain cache failure conditions"
+              + " when using --remote_download_minimal."
+              + " A non-zero value will implicitly set"
               + " --incompatible_remote_use_new_exit_code_for_lost_inputs to true. A new invocation"
               + " id will be generated for each attempt. If you generate invocation id and provide"
               + " it to Bazel with --invocation_id, you should not use this flag. Instead, set flag"
               + " --incompatible_remote_use_new_exit_code_for_lost_inputs and check for the exit"
               + " code 39.")
-  public int remoteRetryOnCacheEviction;
+  public int remoteRetryOnCacheError;
 
   /** An enum for specifying different formats of test output. */
   public enum TestOutputFormat {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -631,7 +631,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
     } else if (remoteCacheFailed) {
       status = Status.REMOTE_CACHE_FAILED;
       if (executionOptions.useNewExitCodeForLostInputs
-          || executionOptions.remoteRetryOnCacheEviction > 0) {
+          || executionOptions.remoteRetryOnCacheError > 0) {
         detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_EVICTED;
       } else {
         detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_FAILED;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -631,7 +631,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
     } else if (remoteCacheFailed) {
       status = Status.REMOTE_CACHE_FAILED;
       if (executionOptions.useNewExitCodeForLostInputs
-          || executionOptions.remoteRetryOnCacheError > 0) {
+          || executionOptions.remoteRetryOnTransientCacheError > 0) {
         detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_EVICTED;
       } else {
         detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_FAILED;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -365,7 +365,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
                 env.getCommandId()));
         return Preconditions.checkNotNull(lastResult);
       } else {
-        outErr.printErrLn("Found remote cache eviction error, retrying the build...");
+        outErr.printErrLn("Found fatal remote cache error, retrying the build...");
       }
     }
 
@@ -704,7 +704,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
       if (newResult.getExitCode().equals(ExitCode.REMOTE_CACHE_EVICTED)) {
         var executionOptions =
             Preconditions.checkNotNull(options.getOptions(ExecutionOptions.class));
-        if (attemptedCommandIds.size() < executionOptions.remoteRetryOnCacheEviction) {
+        if (attemptedCommandIds.size() < executionOptions.remoteRetryOnCacheError) {
           throw new RemoteCacheEvictedException(env.getCommandId(), newResult);
         }
       }

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -227,8 +227,10 @@ message Spawn {
     //   refactored to prohibit undetailed failures
     UNSPECIFIED_EXECUTION_FAILURE = 12 [(metadata) = { exit_code: 1 }];
     FORBIDDEN_INPUT = 13 [(metadata) = { exit_code: 1 }];
-    // TODO: This also includes other remote cache errors, not just evictions,
+    // This also includes other remote cache errors, not just evictions,
     // if --incompatible_remote_use_new_exit_code_for_lost_inputs is set.
+    // TODO: Rename it to a more general name when
+    // --experimental_remote_cache_eviction_retries is moved to non-experimental.
     REMOTE_CACHE_EVICTED = 14 [(metadata) = { exit_code: 39 }];
     SPAWN_LOG_IO_EXCEPTION = 15 [(metadata) = { exit_code: 36 }];
   }

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -227,6 +227,8 @@ message Spawn {
     //   refactored to prohibit undetailed failures
     UNSPECIFIED_EXECUTION_FAILURE = 12 [(metadata) = { exit_code: 1 }];
     FORBIDDEN_INPUT = 13 [(metadata) = { exit_code: 1 }];
+    // TODO: This also includes other remote cache errors, not just evictions,
+    // if --incompatible_remote_use_new_exit_code_for_lost_inputs is set.
     REMOTE_CACHE_EVICTED = 14 [(metadata) = { exit_code: 39 }];
     SPAWN_LOG_IO_EXCEPTION = 15 [(metadata) = { exit_code: 36 }];
   }

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -2022,7 +2022,7 @@ EOF
       //a:bar >& $TEST_log || fail "Failed to build"
 
   expect_log 'Failed to fetch blobs because they do not exist remotely.'
-  expect_log "Found fatal remote cache error, retrying the build..."
+  expect_log "Found transient remote cache error, retrying the build..."
 
   local invocation_ids=$(grep "Invocation ID:" $TEST_log)
   local first_id=$(echo "$invocation_ids" | head -n 1)

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -2022,7 +2022,7 @@ EOF
       //a:bar >& $TEST_log || fail "Failed to build"
 
   expect_log 'Failed to fetch blobs because they do not exist remotely.'
-  expect_log "Found remote cache eviction error, retrying the build..."
+  expect_log "Found fatal remote cache error, retrying the build..."
 
   local invocation_ids=$(grep "Invocation ID:" $TEST_log)
   local first_id=$(echo "$invocation_ids" | head -n 1)


### PR DESCRIPTION
If `--incompatible_remote_use_new_exit_code_for_lost_inputs` is set, or if `--experimental_remote_cache_eviction_retries` is set, all remote cache errors during cache lookup will be (eligible for) being retried by restarting the build. This does not apply to remote cache errors during remote execution, though.

Fixes https://github.com/bazelbuild/bazel/issues/23033.

Some words about the design and the backwards compatibility of this change.
I'm not super happy with where I ended up here:
I'm using `REMOTE_CACHE_EVICTED` here for errors that are not cache evictions. The question is, what is more disruptive to bazel users - return exit code 39 more often for remote cache errors (not just evictions), which is the approach taken in this PR, or introduce yet another `incompatible` flag that introduces, say, exit code 40 for remote cache errors that are not eviction errors (or all remote cache errors, if we then merge eviction+general errors).
We can easily change the semantics of `experimental_remote_cache_eviction_retries` as it's experimental, but with `incompatible_remote_use_new_exit_code_for_lost_inputs` this is maybe more sketchy (but done in this PR!).

On the other hand, I don't know the stability guarantees about the protobuf API - `Spawn.Code.REMOTE_CACHE_FAILED` would be the perfect to use for this case, but it's associated with exit code 34, which is all sorts of remote (execution) errors that we, as far as I can see, don't necessarily want to retry when the user specifies `experimental_remote_cache_eviction_retries` (otherwise the flag would change meaning a lot).
Could/should we introduce `REMOTE_CACHE_FAILED_NEW` with exit code 40 that then gets used if the user specifies an incompatible flag? That means that users would need to adjust all their infra scripts to move from exit code 39 (or 34) to 40 at some point, which is a lot of churn.
Could we instead rename `REMOTE_CACHE_EVICTED` to `REMOTE_CACHE_FAILED_NEW`, or does this violate some protobuf longevity guarantees?

Writing all of this down, I'd ideally like to rename `REMOTE_CACHE_EVICTED` to `REMOTE_CACHE_FAILED_NEW`, and then, depending on bazel policy, have `incompatible_remote_use_new_exit_code_for_lost_inputs` emit these errors more often, or introduce another incompatible flag to move more remote errors from `REMOTE_CACHE_FAILED` to `REMOTE_CACHE_FAILED_NEW`.

There's also another problem this PR doesn't address: Remote cache lookups during remote execution - in `RemoteSpawnRunner`, we could track more closely if an exception stems from remote cache lookup, and then follow the semantics outlined above for that - right now, we only distinguish between cache-not-found errors and everything else. The reason I didn't work on this is that if your remote cache is unstable during remote execution, you have a bigger problem anyway.
While you might hit #23033 during a local fallback execution, I believe this PR already takes care of that code path.
For all other remote cache errors during remote execution, I don't see how retrying the entire build will help.

This is a lot of questions I don't feel comfortable answering myself, as I don't know exactly what stability guarantees bazel provides to its users. I'm happy to rework this PR based on feedback, though.

If this PR is accepted eventually, it'd be great to get this in for 7.3.0, if there's enough time, and the PR isn't too breaking.