### PR TITLE
[7.3.0] --experimental_remote_cache_async: Profile upload events.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1424,18 +1424,25 @@ public class RemoteExecutionService {
           .subscribeOn(scheduler)
           .subscribe(
               new SingleObserver<ActionResult>() {
+                long startTime = 0;
+
                 @Override
                 public void onSubscribe(@NonNull Disposable d) {
                   backgroundTaskPhaser.register();
+                  startTime = Profiler.nanoTimeMaybe();
                 }
 
                 @Override
                 public void onSuccess(@NonNull ActionResult actionResult) {
+                  Profiler.instance()
+                      .completeTask(startTime, ProfilerTask.UPLOAD_TIME, "upload outputs");
                   backgroundTaskPhaser.arriveAndDeregister();
                 }
 
                 @Override
                 public void onError(@NonNull Throwable e) {
+                  Profiler.instance()
+                      .completeTask(startTime, ProfilerTask.UPLOAD_TIME, "upload outputs");
                   backgroundTaskPhaser.arriveAndDeregister();
                   reportUploadError(e);
                 }


### PR DESCRIPTION
In the experimental_remote_cache_async mode, the
cache upload steps were not profiled, unlike in the non-async case.
This adds the profiling back.
Fixes #20404.

It'd be great if this could be backported into 7.3.0 once merged.

Closes #23056.

PiperOrigin-RevId: 655466182
Change-Id: Ib450ba4ea88a8ecdad66c6db0728db901e925017

Commit https://github.com/bazelbuild/bazel/commit/54820bde03e5e9330d3ffa063f7a304ce04701fc