### PR TITLE
WIP: disable WORKSPACE in java integration tests

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/bazel/DefaultToolsSetup.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/bazel/DefaultToolsSetup.java
@@ -93,6 +93,8 @@ public class DefaultToolsSetup implements ToolsSetup {
       lines.add("build --jvmopt=-Djava.net.preferIPv6Addresses");
     }
 
+    lines.add("common --noenable_workspace");
+
     context.write(".bazelrc", lines);
   }
 }


### PR DESCRIPTION
Working towards: https://github.com/bazelbuild/bazel/issues/23023