### PR TITLE
Fix deduping for `--extra_toolchains`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
@@ -89,26 +89,6 @@ public abstract class FragmentOptions extends OptionsBase implements Cloneable {
     return result.equals(values) ? ImmutableList.copyOf(values) : result;
   }
 
-  /**
-   * Helper method for subclasses to remove duplicate values. When removing duplicates all but the
-   * first instance will be removed. This way the relative ordering of two values will match the
-   * relative ordering of their first instances.
-   *
-   * <p>Example: [a, b, a, c, b] -> [a, b, c]
-   */
-  protected static ImmutableList<String> dedupeOnly(@Nullable List<String> values) {
-    if (values == null || values.isEmpty()) {
-      return ImmutableList.of();
-    }
-    ImmutableList<String> result = values.stream().distinct().collect(toImmutableList());
-    // If there were no duplicates, return the exact same instance we got.
-    if (result.size() == values.size()) {
-      return ImmutableList.copyOf(values);
-    } else {
-      return result;
-    }
-  }
-
   /** Tracks limitations on referring to an option in a {@code config_setting}. */
   // TODO(bazel-team): There will likely also be a need to customize whether or not an option is
   // visible to users for setting on the command line (or perhaps even in a test of a Starlark

--- a/src/test/java/com/google/devtools/build/lib/analysis/PlatformOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/PlatformOptionsTest.java
@@ -41,7 +41,7 @@ public final class PlatformOptionsTest extends OptionsTestCase<PlatformOptions> 
 
   @Test
   public void testExtraToolchains_ordering() throws Exception {
-    // The ordering matters for tool chains, since we pick the first available toolchain.
+    // The ordering matters for tool chains, but the last one in the list has highest priority.
     PlatformOptions one = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "one", "two");
     PlatformOptions two = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "two", "one");
     assertDifferent(one, two);
@@ -52,6 +52,14 @@ public final class PlatformOptionsTest extends OptionsTestCase<PlatformOptions> 
     // Specifying the same tool chain multiple times is a no-op.
     PlatformOptions one = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "one", "one");
     PlatformOptions two = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "one");
+    assertSame(one, two);
+  }
+
+  @Test
+  public void testExtraToolchains_duplicates_keepLast() throws Exception {
+    // The last toolchain in the list has highest priority, so keep the last of any duplicates.
+    PlatformOptions one = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "one", "two", "one");
+    PlatformOptions two = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "two", "one");
     assertSame(one, two);
   }
 

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -2798,9 +2798,9 @@ EOF
   expect_log "Selected execution platform //${pkg}/platforms:platform2"
 }
 
-# Regression test for https://github.com/bazelbuild/bazel/issues/19945.
-function test_extra_toolchain_precedence {
-  local -r pkg="${FUNCNAME[0]}"
+function setup_toolchain_precedence_tests() {
+  local pkg="$1"
+  shift
 
   write_test_toolchain "${pkg}"
   write_test_rule "${pkg}"
@@ -2841,42 +2841,72 @@ use_toolchain(
     name = 'use',
     message = 'this is the rule')
 EOF
+}
 
-  bazel query "//${pkg}:*"
+# Regression tests for https://github.com/bazelbuild/bazel/issues/19945 and https://github.com/bazelbuild/bazel/issues/22912
+function test_extra_toolchain_precedence_basic {
+  local -r pkg="${FUNCNAME[0]}"
+  setup_toolchain_precedence_tests "${pkg}"
 
+  # Even with other toolchains defined, only one is registered
   bazel \
     build \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
   expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from toolchain_1"'
+}
 
-  # Test that bazelrc options take precedence over registered toolchains
+function test_extra_toolchain_precedence_from_bazelrc {
+  local -r pkg="${FUNCNAME[0]}"
+  setup_toolchain_precedence_tests "${pkg}"
+
   cat > "${pkg}/toolchain_rc" <<EOF
 import ${bazelrc}
 build --extra_toolchains=//${pkg}:toolchain_2
 EOF
 
+  # Test that bazelrc options take precedence over registered toolchains
   bazel \
     --${PRODUCT_NAME}rc="${pkg}/toolchain_rc" \
     build \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
   expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from toolchain_2"'
+}
+
+function test_extra_toolchain_precedence_from_flag {
+  local -r pkg="${FUNCNAME[0]}"
+  setup_toolchain_precedence_tests "${pkg}"
 
   # Test that command-line options take precedence over other toolchains
   bazel \
-    --${PRODUCT_NAME}rc="${pkg}/toolchain_rc" \
     build \
     --extra_toolchains=//${pkg}:toolchain_3 \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
   expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from toolchain_3"'
+}
+
+function test_extra_toolchain_precedence_multiple {
+  local -r pkg="${FUNCNAME[0]}"
+  setup_toolchain_precedence_tests "${pkg}"
 
   # Test that the last --extra_toolchains takes precedence
   bazel \
-    --${PRODUCT_NAME}rc="${pkg}/toolchain_rc" \
     build \
-    --extra_toolchains=//${pkg}:toolchain_3 \
-    --extra_toolchains=//${pkg}:toolchain_4 \
+    --extra_toolchains=//${pkg}:toolchain_3,//${pkg}:toolchain_4 \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
   expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from toolchain_4"'
+}
+
+function test_extra_toolchain_precedence_multiple_repeated {
+  local -r pkg="${FUNCNAME[0]}"
+  setup_toolchain_precedence_tests "${pkg}"
+
+  # Test that the last --extra_toolchains takes precedence even when repeated
+  bazel \
+    build \
+    --extra_toolchains=//${pkg}:toolchain_3,//${pkg}:toolchain_4,//${pkg}:toolchain_3 \
+    "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
+  # Since toolchain_3 is last, it should still have highest precedence
+  expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from toolchain_3"'
 }
 
 # TODO(katre): Test using toolchain-provided make variables from a genrule.


### PR DESCRIPTION
Because the semantics of `--extra_toolchains` are that the last entry has highest priority, when deduping we need to keep the **last** entry, not the first.

Since nothing else used `dedupeOnly`, remove that entirely.

Fixes #22912.