### PR TITLE
Add flag --incompatible_use_plus_in_repo_names

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -26,6 +26,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/net/starlark/java/eval",
         "//third_party:auto_value",
         "//third_party:gson",
@@ -251,6 +252,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repo_recorded_input",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_directory_value",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
@@ -15,7 +15,6 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableBiMap;
@@ -67,15 +66,8 @@ public abstract class BazelDepGraphValue implements SkyValue {
             .build();
 
     ImmutableMap<ModuleKey, Module> emptyDepGraph = ImmutableMap.of(ModuleKey.ROOT, root);
-
     ImmutableMap<RepositoryName, ModuleKey> canonicalRepoNameLookup =
-        emptyDepGraph.keySet().stream()
-            .collect(
-                toImmutableMap(
-                    // All modules in the empty dep graph (just the root module) have an empty
-                    // version, so the choice of including it in the canonical repo name does not
-                    // matter.
-                    ModuleKey::getCanonicalRepoNameWithoutVersion, key -> key));
+        ImmutableMap.of(RepositoryName.MAIN, ModuleKey.ROOT);
 
     return BazelDepGraphValue.create(
         emptyDepGraph,
@@ -83,7 +75,7 @@ public abstract class BazelDepGraphValue implements SkyValue {
         ImmutableList.of(),
         ImmutableTable.of(),
         ImmutableMap.of(),
-        '~');
+        '+');
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphValue.java
@@ -43,13 +43,15 @@ public abstract class BazelDepGraphValue implements SkyValue {
       ImmutableMap<RepositoryName, ModuleKey> canonicalRepoNameLookup,
       ImmutableList<AbridgedModule> abridgedModules,
       ImmutableTable<ModuleExtensionId, ModuleKey, ModuleExtensionUsage> extensionUsagesTable,
-      ImmutableMap<ModuleExtensionId, String> extensionUniqueNames) {
+      ImmutableMap<ModuleExtensionId, String> extensionUniqueNames,
+      char repoNameSeparator) {
     return new AutoValue_BazelDepGraphValue(
         depGraph,
         ImmutableBiMap.copyOf(canonicalRepoNameLookup),
         abridgedModules,
         extensionUsagesTable,
-        extensionUniqueNames);
+        extensionUniqueNames,
+        repoNameSeparator);
   }
 
   public static BazelDepGraphValue createEmptyDepGraph() {
@@ -80,7 +82,8 @@ public abstract class BazelDepGraphValue implements SkyValue {
         canonicalRepoNameLookup,
         ImmutableList.of(),
         ImmutableTable.of(),
-        ImmutableMap.of());
+        ImmutableMap.of(),
+        '~');
   }
 
   /**
@@ -112,6 +115,9 @@ public abstract class BazelDepGraphValue implements SkyValue {
    */
   public abstract ImmutableMap<ModuleExtensionId, String> getExtensionUniqueNames();
 
+  /** The character to use to separate the different segments of a canonical repo name. */
+  public abstract char getRepoNameSeparator();
+
   /**
    * Returns the full {@link RepositoryMapping} for the given module, including repos from Bazel
    * module deps and module extensions.
@@ -122,7 +128,7 @@ public abstract class BazelDepGraphValue implements SkyValue {
         getExtensionUsagesTable().column(key).entrySet()) {
       ModuleExtensionId extensionId = extIdAndUsage.getKey();
       ModuleExtensionUsage usage = extIdAndUsage.getValue();
-      String repoNamePrefix = getExtensionUniqueNames().get(extensionId) + "~";
+      String repoNamePrefix = getExtensionUniqueNames().get(extensionId) + getRepoNameSeparator();
       for (ModuleExtensionUsage.Proxy proxy : usage.getProxies()) {
         for (Map.Entry<String, String> entry : proxy.getImports().entrySet()) {
           String canonicalRepoName = repoNamePrefix + entry.getValue();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -117,6 +117,17 @@ public class BazelLockFileModule extends BlazeModule {
     // lockfile that are still up-to-date and adding the newly resolved extension results.
     BazelLockFileValue newLockfile =
         BazelLockFileValue.builder()
+            // HACK: Flipping the flag `--incompatible_use_plus_in_repo_names` causes the canonical
+            // repo name format to change, which warrants a lockfile invalidation. We could do this
+            // properly by introducing another field in the lockfile, but that's very annoying since
+            // we'll need to 1) keep it around for a while; 2) be careful not to parse the rest of
+            // the lockfile to avoid triggering parsing errors ('~' will be an invalid character in
+            // repo names eventually). So we just increment the lockfile version if '+' is being
+            // used.
+            .setLockFileVersion(
+                depGraphValue.getRepoNameSeparator() == '+'
+                    ? BazelLockFileValue.LOCK_FILE_VERSION + 1
+                    : BazelLockFileValue.LOCK_FILE_VERSION)
             .setRegistryFileHashes(
                 ImmutableSortedMap.copyOf(moduleResolutionValue.getRegistryFileHashes()))
             .setSelectedYankedVersions(moduleResolutionValue.getSelectedYankedVersions())

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -123,7 +123,8 @@ public class BazelLockFileModule extends BlazeModule {
             // we'll need to 1) keep it around for a while; 2) be careful not to parse the rest of
             // the lockfile to avoid triggering parsing errors ('~' will be an invalid character in
             // repo names eventually). So we just increment the lockfile version if '+' is being
-            // used.
+            // used. This does mean that, while this hack exists, normal increments of the lockfile
+            // version need to be done by 2 at a time (i.e. keep LOCK_FILE_VERSION an odd number).
             .setLockFileVersion(
                 depGraphValue.getRepoNameSeparator() == '+'
                     ? BazelLockFileValue.LOCK_FILE_VERSION + 1

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -35,6 +35,8 @@ import java.util.Optional;
 @GenerateTypeAdapter
 public abstract class BazelLockFileValue implements SkyValue, Postable {
 
+  // NOTE: See "HACK" note in BazelLockFileModule. While this hack exists, normal increments of the
+  // lockfile version need to be done by 2 at a time (i.e. keep LOCK_FILE_VERSION an odd number).
   public static final int LOCK_FILE_VERSION = 11;
 
   @SerializationConstant public static final SkyKey KEY = () -> SkyFunctions.BAZEL_LOCK_FILE;

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
@@ -60,6 +60,7 @@ public abstract class ModuleExtensionId {
 
     @Override
     public final String toString() {
+      // NOTE: Can't be bothered to switch this based on the flag.
       return getModule() + "~" + getUsageExportedName();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
@@ -60,7 +60,8 @@ public abstract class ModuleExtensionId {
 
     @Override
     public final String toString() {
-      // NOTE: Can't be bothered to switch this based on the flag.
+      // NOTE: Can't be bothered to switch this based on the flag. But DO change this to "+" by
+      // Bazel 8!
       return getModule() + "~" + getUsageExportedName();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
@@ -20,8 +20,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import java.util.Comparator;
 import java.util.List;
+import net.starlark.java.eval.StarlarkSemantics;
 
 /** A module name, version pair that identifies a module in the external dependency graph. */
 @AutoValue
@@ -79,8 +81,12 @@ public abstract class ModuleKey {
    *
    * <p>This method must not be called if the module has a {@link NonRegistryOverride}.
    */
+  public RepositoryName getCanonicalRepoNameWithVersion(StarlarkSemantics semantics) {
+    return getCanonicalRepoName(/* includeVersion= */ true, semantics);
+  }
+
   public RepositoryName getCanonicalRepoNameWithVersion() {
-    return getCanonicalRepoName(/* includeVersion= */ true);
+    return getCanonicalRepoNameWithVersion(StarlarkSemantics.DEFAULT);
   }
 
   /**
@@ -88,26 +94,31 @@ public abstract class ModuleKey {
    * only guaranteed to be unique when there is a single version of the module in the entire dep
    * graph.
    */
-  public RepositoryName getCanonicalRepoNameWithoutVersion() {
-    return getCanonicalRepoName(/* includeVersion= */ false);
+  public RepositoryName getCanonicalRepoNameWithoutVersion(StarlarkSemantics semantics) {
+    return getCanonicalRepoName(/* includeVersion= */ false, semantics);
   }
 
-  private RepositoryName getCanonicalRepoName(boolean includeVersion) {
+  public RepositoryName getCanonicalRepoNameWithoutVersion() {
+    return getCanonicalRepoNameWithoutVersion(StarlarkSemantics.DEFAULT);
+  }
+
+  private RepositoryName getCanonicalRepoName(boolean includeVersion, StarlarkSemantics semantics) {
     if (WELL_KNOWN_MODULES.containsKey(getName())) {
       return WELL_KNOWN_MODULES.get(getName());
     }
     if (ROOT.equals(this)) {
       return RepositoryName.MAIN;
     }
+    boolean usePlus = semantics.getBool(BuildLanguageOptions.INCOMPATIBLE_USE_PLUS_IN_REPO_NAMES);
     String suffix;
     if (includeVersion) {
       // getVersion().isEmpty() is true only for modules with non-registry overrides, which enforce
       // that there is a single version of the module in the dep graph.
       Preconditions.checkState(!getVersion().isEmpty());
-      // Prepend "v" to prevent canonical repo names, which form segments of file paths, from
-      // looking like a Windows short path. Such paths segments would incur additional file IO
-      // during analysis (see WindowsShortPath).
-      suffix = "v" + getVersion().toString();
+      // When using `~` as the separator, prepend "v" to prevent canonical repo names, which form
+      // segments of file paths, from looking like a Windows short path. Such paths segments would
+      // incur additional file IO during analysis (see WindowsShortPath).
+      suffix = usePlus ? getVersion().toString() : "v" + getVersion().toString();
     } else {
       // This results in canonical repository names such as `rules_foo~` for the module `rules_foo`.
       // This particular format is chosen since:
@@ -125,7 +136,8 @@ public abstract class ModuleKey {
       //   rarely used.
       suffix = "";
     }
-    return RepositoryName.createUnvalidated(String.format("%s~%s", getName(), suffix));
+    return RepositoryName.createUnvalidated(
+        String.format("%s%s%s", getName(), usePlus ? "+" : "~", suffix));
   }
 
   public static ModuleKey fromString(String s) throws Version.ParseException {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
@@ -85,7 +85,7 @@ public abstract class ModuleKey {
     return getCanonicalRepoName(/* includeVersion= */ true, semantics);
   }
 
-  public RepositoryName getCanonicalRepoNameWithVersion() {
+  public RepositoryName getCanonicalRepoNameWithVersionForTesting() {
     return getCanonicalRepoNameWithVersion(StarlarkSemantics.DEFAULT);
   }
 
@@ -98,7 +98,7 @@ public abstract class ModuleKey {
     return getCanonicalRepoName(/* includeVersion= */ false, semantics);
   }
 
-  public RepositoryName getCanonicalRepoNameWithoutVersion() {
+  public RepositoryName getCanonicalRepoNameWithoutVersionForTesting() {
     return getCanonicalRepoNameWithoutVersion(StarlarkSemantics.DEFAULT);
   }
 
@@ -137,7 +137,7 @@ public abstract class ModuleKey {
       suffix = "";
     }
     return RepositoryName.createUnvalidated(
-        String.format("%s%s%s", getName(), usePlus ? "+" : "~", suffix));
+        String.format("%s%c%s", getName(), usePlus ? '+' : '~', suffix));
   }
 
   public static ModuleKey fromString(String s) throws Version.ParseException {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
@@ -85,6 +86,7 @@ public abstract class ModuleKey {
     return getCanonicalRepoName(/* includeVersion= */ true, semantics);
   }
 
+  @VisibleForTesting
   public RepositoryName getCanonicalRepoNameWithVersionForTesting() {
     return getCanonicalRepoNameWithVersion(StarlarkSemantics.DEFAULT);
   }
@@ -98,6 +100,7 @@ public abstract class ModuleKey {
     return getCanonicalRepoName(/* includeVersion= */ false, semantics);
   }
 
+  @VisibleForTesting
   public RepositoryName getCanonicalRepoNameWithoutVersionForTesting() {
     return getCanonicalRepoNameWithoutVersion(StarlarkSemantics.DEFAULT);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
@@ -139,7 +139,7 @@ public class StarlarkBazelModule implements StarlarkValue {
     }
     return new StarlarkBazelModule(
         module.getName(),
-        module.getVersion().getOriginal(),
+        module.getVersion().getNormalized(),
         new Tags(Maps.transformValues(typeCheckedTags, StarlarkList::immutableCopyOf)),
         module.getKey().equals(ModuleKey.ROOT));
   }

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -51,7 +51,7 @@ public final class RepositoryName {
   // Repository names must not start with a tilde as shells treat unescaped paths starting with them
   // specially.
   // https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
-  private static final Pattern VALID_REPO_NAME = Pattern.compile("|[\\w\\-.][\\w\\-.~]*");
+  private static final Pattern VALID_REPO_NAME = Pattern.compile("|[\\w\\-.+][\\w\\-.~+]*");
 
   // Must start with a letter. Can contain ASCII letters and digits, underscore, dash, and dot.
   private static final Pattern VALID_USER_PROVIDED_NAME = Pattern.compile("[a-zA-Z][-.\\w]*$");
@@ -228,11 +228,12 @@ public final class RepositoryName {
     if (ownerRepoIfNotVisible.isMain()) {
       return "root module";
     } else {
+      boolean hasTilde = ownerRepoIfNotVisible.getName().contains("~");
       return String.format(
           "module '%s'",
           ownerRepoIfNotVisible
               .getName()
-              .substring(0, ownerRepoIfNotVisible.getName().indexOf('~')));
+              .substring(0, ownerRepoIfNotVisible.getName().indexOf(hasTilde ? '~' : '+')));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -217,6 +217,17 @@ public final class BuildLanguageOptions extends OptionsBase {
   public boolean enableWorkspace;
 
   @Option(
+      name = "incompatible_use_plus_in_repo_names",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = OptionEffectTag.LOADING_AND_ANALYSIS,
+      help =
+          "If true, uses the plus sign (+) as the separator in canonical repo names, instead of the"
+              + " tilde (~). This is to address severe performance issues on Windows; see"
+              + " https://github.com/bazelbuild/bazel/issues/22865 for more information.")
+  public boolean incompatibleUsePlusInRepoNames;
+
+  @Option(
       name = "experimental_isolated_extension_usages",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -748,6 +759,7 @@ public final class BuildLanguageOptions extends OptionsBase {
             .setBool(EXPERIMENTAL_ENABLE_SCL_DIALECT, experimentalEnableSclDialect)
             .setBool(ENABLE_BZLMOD, enableBzlmod)
             .setBool(ENABLE_WORKSPACE, enableWorkspace)
+            .setBool(INCOMPATIBLE_USE_PLUS_IN_REPO_NAMES, incompatibleUsePlusInRepoNames)
             .setBool(EXPERIMENTAL_ISOLATED_EXTENSION_USAGES, experimentalIsolatedExtensionUsages)
             .setBool(
                 INCOMPATIBLE_EXISTING_RULES_IMMUTABLE_VIEW, incompatibleExistingRulesImmutableView)
@@ -856,6 +868,8 @@ public final class BuildLanguageOptions extends OptionsBase {
   public static final String EXPERIMENTAL_ENABLE_SCL_DIALECT = "-experimental_enable_scl_dialect";
   public static final String ENABLE_BZLMOD = "+enable_bzlmod";
   public static final String ENABLE_WORKSPACE = "+enable_workspace";
+  public static final String INCOMPATIBLE_USE_PLUS_IN_REPO_NAMES =
+      "-incompatible_use_plus_in_repo_names";
   public static final String EXPERIMENTAL_ISOLATED_EXTENSION_USAGES =
       "-experimental_isolated_extension_usages";
   public static final String INCOMPATIBLE_EXISTING_RULES_IMMUTABLE_VIEW =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClassProvider;
 import com.google.devtools.build.lib.packages.RuleFactory.InvalidRuleException;
 import com.google.devtools.build.lib.packages.RuleFunction;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.server.FailureDetails.PackageLoading;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.skyframe.SkyFunction;
@@ -113,9 +114,13 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
     }
 
     // Step 3: look for the repo from module extension evaluation results.
+    char separator =
+        starlarkSemantics.getBool(BuildLanguageOptions.INCOMPATIBLE_USE_PLUS_IN_REPO_NAMES)
+            ? '+'
+            : '~';
     Optional<ModuleExtensionId> extensionId =
         bazelDepGraphValue.getExtensionUniqueNames().entrySet().stream()
-            .filter(e -> repositoryName.getName().startsWith(e.getValue() + "~"))
+            .filter(e -> repositoryName.getName().startsWith(e.getValue() + separator))
             .map(Entry::getKey)
             .findFirst();
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
@@ -233,7 +233,11 @@ public class RepositoryMappingFunction implements SkyFunction {
   private static Optional<ModuleExtensionId> maybeGetModuleExtensionForRepo(
       RepositoryName repositoryName, BazelDepGraphValue bazelDepGraphValue) {
     return bazelDepGraphValue.getExtensionUniqueNames().entrySet().stream()
-        .filter(e -> repositoryName.getName().startsWith(e.getValue() + "~"))
+        .filter(
+            e ->
+                repositoryName
+                    .getName()
+                    .startsWith(e.getValue() + bazelDepGraphValue.getRepoNameSeparator()))
         .map(Entry::getKey)
         .findFirst();
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingValue.java
@@ -73,7 +73,7 @@ public abstract class RepositoryMappingValue implements SkyValue {
     return new AutoValue_RepositoryMappingValue(
         repositoryMapping,
         Optional.of(associatedModuleName),
-        Optional.of(associatedModuleVersion.getOriginal()));
+        Optional.of(associatedModuleVersion.getNormalized()));
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -307,7 +307,7 @@ public final class BzlmodTestUtil {
       mappingBuilder.put(names[i], RepositoryName.createUnvalidated(names[i + 1]));
     }
     return RepositoryMapping.create(
-        mappingBuilder.buildOrThrow(), key.getCanonicalRepoNameWithoutVersion());
+        mappingBuilder.buildOrThrow(), key.getCanonicalRepoNameWithoutVersionForTesting());
   }
 
   public static TagClass createTagClass(Attribute... attrs) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
@@ -81,7 +81,7 @@ public class FakeRegistry implements Registry {
             .setAttributes(
                 AttributeValues.create(
                     ImmutableMap.of(
-                        "path", rootPath + "/" + key.getCanonicalRepoNameWithVersion().getName())))
+                        "path", rootPath + "/" + key.getCanonicalRepoNameWithVersionForTesting().getName())))
             .build();
     eventHandler.post(
         RegistryFileDownloadEvent.create(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModuleTest.java
@@ -39,7 +39,7 @@ public class InterimModuleTest {
                         DepSpec.fromModuleKey(
                             createModuleKey(
                                 depSpec.getName() + "_new",
-                                depSpec.getVersion().getOriginal() + ".1"))))
+                                depSpec.getVersion().getNormalized() + ".1"))))
         .isEqualTo(
             InterimModuleBuilder.create("", "")
                 .addDep("dep_foo", createModuleKey("foo_new", "1.0.1"))

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleTest.java
@@ -46,7 +46,7 @@ public class ModuleTest {
             module.getRepoMappingWithBazelDepsOnly(
                 Stream.of(key, fooKey, barKey, ModuleKey.ROOT)
                     .collect(
-                        toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithoutVersion))))
+                        toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithoutVersionForTesting))))
         .isEqualTo(
             createRepositoryMapping(
                 key,
@@ -73,7 +73,7 @@ public class ModuleTest {
     assertThat(
             module.getRepoMappingWithBazelDepsOnly(
                 Stream.of(ModuleKey.ROOT, fooKey, barKey)
-                    .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersion))))
+                    .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersionForTesting))))
         .isEqualTo(
             createRepositoryMapping(
                 ModuleKey.ROOT,
@@ -89,11 +89,11 @@ public class ModuleTest {
 
   @Test
   public void getCanonicalRepoName_isNotAWindowsShortPath() {
-    assertNotAShortPath(createModuleKey("foo", "").getCanonicalRepoNameWithoutVersion().getName());
-    assertNotAShortPath(createModuleKey("foo", "1").getCanonicalRepoNameWithVersion().getName());
-    assertNotAShortPath(createModuleKey("foo", "1.2").getCanonicalRepoNameWithVersion().getName());
+    assertNotAShortPath(createModuleKey("foo", "").getCanonicalRepoNameWithoutVersionForTesting().getName());
+    assertNotAShortPath(createModuleKey("foo", "1").getCanonicalRepoNameWithVersionForTesting().getName());
+    assertNotAShortPath(createModuleKey("foo", "1.2").getCanonicalRepoNameWithVersionForTesting().getName());
     assertNotAShortPath(
-        createModuleKey("foo", "1.2.3").getCanonicalRepoNameWithVersion().getName());
+        createModuleKey("foo", "1.2.3").getCanonicalRepoNameWithVersionForTesting().getName());
   }
 
   private static void assertNotAShortPath(String name) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -96,8 +96,8 @@ public class StarlarkBazelModuleTest {
             extension,
             module.getRepoMappingWithBazelDepsOnly(
                 ImmutableMap.of(
-                    fooKey, fooKey.getCanonicalRepoNameWithoutVersion(),
-                    barKey, barKey.getCanonicalRepoNameWithoutVersion())),
+                    fooKey, fooKey.getCanonicalRepoNameWithoutVersionForTesting(),
+                    barKey, barKey.getCanonicalRepoNameWithoutVersionForTesting())),
             usage);
 
     assertThat(moduleProxy.getName()).isEqualTo("foo");
@@ -144,7 +144,7 @@ public class StarlarkBazelModuleTest {
                     abridgedModule,
                     extension,
                     module.getRepoMappingWithBazelDepsOnly(
-                        ImmutableMap.of(fooKey, fooKey.getCanonicalRepoNameWithoutVersion())),
+                        ImmutableMap.of(fooKey, fooKey.getCanonicalRepoNameWithoutVersionForTesting())),
                     usage));
     assertThat(e).hasMessageThat().contains("does not have a tag class named blep");
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ExtensionArgTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ExtensionArgTest.java
@@ -89,7 +89,7 @@ public class ExtensionArgTest {
             .buildOrThrow();
     ImmutableMap<ModuleKey, RepositoryName> moduleKeyToCanonicalNames =
         depGraph.keySet().stream()
-            .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersion));
+            .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersionForTesting));
     ImmutableBiMap<String, ModuleKey> baseModuleDeps = ImmutableBiMap.of("fred", key);
     ImmutableBiMap<String, ModuleKey> baseModuleUnusedDeps = ImmutableBiMap.of();
 
@@ -118,7 +118,7 @@ public class ExtensionArgTest {
             .buildOrThrow();
     ImmutableMap<ModuleKey, RepositoryName> moduleKeyToCanonicalNames =
         depGraph.keySet().stream()
-            .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersion));
+            .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersionForTesting));
     ImmutableBiMap<String, ModuleKey> baseModuleDeps = ImmutableBiMap.of("fred", key);
     ImmutableBiMap<String, ModuleKey> baseModuleUnusedDeps = ImmutableBiMap.of();
 
@@ -162,7 +162,7 @@ public class ExtensionArgTest {
             .buildOrThrow();
     ImmutableMap<ModuleKey, RepositoryName> moduleKeyToCanonicalNames =
         depGraph.keySet().stream()
-            .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersion));
+            .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersionForTesting));
     ImmutableBiMap<String, ModuleKey> baseModuleDeps =
         ImmutableBiMap.of("foo1", foo1, "foo2", foo2);
     ImmutableBiMap<String, ModuleKey> baseModuleUnusedDeps = ImmutableBiMap.of();

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArgTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModuleArgTest.java
@@ -80,7 +80,7 @@ public class ModuleArgTest {
 
   ImmutableMap<ModuleKey, RepositoryName> moduleKeyToCanonicalNames =
       depGraph.keySet().stream()
-          .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersion));
+          .collect(toImmutableMap(k -> k, ModuleKey::getCanonicalRepoNameWithVersionForTesting));
   ImmutableBiMap<String, ModuleKey> baseModuleDeps = ImmutableBiMap.of("fred", foo2);
   ImmutableBiMap<String, ModuleKey> baseModuleUnusedDeps = ImmutableBiMap.of("fred", foo1);
   RepositoryMapping rootMapping = createRepositoryMapping(ModuleKey.ROOT, "fred", "foo~v2.0");
@@ -270,7 +270,7 @@ public class ModuleArgTest {
 
   @Test
   public void resolve_canonicalRepoName_good() throws Exception {
-    var arg = CanonicalRepoName.create(foo2.getCanonicalRepoNameWithVersion());
+    var arg = CanonicalRepoName.create(foo2.getCanonicalRepoNameWithVersionForTesting());
 
     assertThat(
             arg.resolveToModuleKeys(
@@ -311,7 +311,7 @@ public class ModuleArgTest {
 
   @Test
   public void resolve_canonicalRepoName_unused() throws Exception {
-    var arg = CanonicalRepoName.create(foo1.getCanonicalRepoNameWithVersion());
+    var arg = CanonicalRepoName.create(foo1.getCanonicalRepoNameWithVersionForTesting());
 
     // Without --include_unused, this doesn't resolve, as foo@1.0 has been replaced by foo@2.0.
     assertThat(

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -126,6 +126,7 @@ public class ConsistencyTest {
         "--experimental_single_package_toolchain_binding=" + rand.nextBoolean(),
         "--enable_bzlmod=" + rand.nextBoolean(),
         "--enable_workspace=" + rand.nextBoolean(),
+        "--incompatible_use_plus_in_repo_names=" + rand.nextBoolean(),
         "--experimental_isolated_extension_usages=" + rand.nextBoolean(),
         "--experimental_google_legacy_api=" + rand.nextBoolean(),
         "--experimental_platforms_api=" + rand.nextBoolean(),
@@ -172,6 +173,7 @@ public class ConsistencyTest {
             BuildLanguageOptions.EXPERIMENTAL_SINGLE_PACKAGE_TOOLCHAIN_BINDING, rand.nextBoolean())
         .setBool(BuildLanguageOptions.ENABLE_BZLMOD, rand.nextBoolean())
         .setBool(BuildLanguageOptions.ENABLE_WORKSPACE, rand.nextBoolean())
+        .setBool(BuildLanguageOptions.INCOMPATIBLE_USE_PLUS_IN_REPO_NAMES, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_ISOLATED_EXTENSION_USAGES, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_GOOGLE_LEGACY_API, rand.nextBoolean())
         .setBool(BuildLanguageOptions.EXPERIMENTAL_PLATFORMS_API, rand.nextBoolean())


### PR DESCRIPTION
Defaults to false. When set to true, we use `+` instead of `~` as the separator in canonical repo names.

Some more subtle changes include:
- We now officially say that the "build" part of version strings (the part that begins with a plus) is ignored and stripped.
- When the flag is set to true, we effectively increase the lockfile version by 1 (see code comment in BazelLockFileModule).
- When true, we no longer insert a `_main` in front of names of repos generated by module extensions hosted in the main repo. (`~abc` as a name was problematic, but `+abc` is not.)
- When true, we no longer insert a `v` in front of numerical versions in canonical repo names. (`my_mod~1.1` could be a Windows short path, but `my_mod+1.1` cannot.)

Work towards https://github.com/bazelbuild/bazel/issues/22865.