### PR TITLE
[7.3.0] Ignore transitive cppmap files from dotd files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -189,6 +189,12 @@ final class HeaderDiscovery {
           inputs.add(artifact);
         }
         continue;
+      } else if (artifact == null && execPathFragment.getFileExtension().equals("cppmap")) {
+        // Transitive cppmap files are added to the dotd files of compiles even
+        // though they are not required for compilation. Since they're not
+        // explicit inputs to the action this only happens when sandboxing is
+        // disabled.
+        continue;
       }
 
       SpecialArtifact treeArtifact = findOwningTreeArtifact(execPathFragment, treeArtifacts);

--- a/src/test/shell/bazel/bazel_layering_check_test.sh
+++ b/src/test/shell/bazel/bazel_layering_check_test.sh
@@ -167,6 +167,11 @@ function test_bazel_layering_check() {
   fi
 
   CC="${clang_tool}" bazel build \
+    //hello:hello --copt=-DFORCE_REBUILD=1 \
+    --spawn_strategy=local --features=layering_check \
+    &> "${TEST_log}" || fail "Build with layering_check failed without sandboxing"
+
+  CC="${clang_tool}" bazel build \
     --copt=-D=private_header \
     //hello:hello --features=layering_check \
     &> "${TEST_log}" && fail "Build of private header violation with "\


### PR DESCRIPTION
When clang generates dotd files when using `-fmodule-map-file` any `extern module` directives in the modulemap are included in the dotd file if they exist. The result of this was that with sandboxing disabled the dotd file included transitive cppmap files that weren't in its input set, resulting in build failures. This change excludes those instead since they're not required as evidence by the fact that with sandboxing enabled they are not part of the input set.

Fixes https://github.com/bazelbuild/bazel/issues/21592

Closes #21832.

PiperOrigin-RevId: 656382428
Change-Id: I4bc9802884ce1bc66ceda65a602db8dffbd1d9ea

Commit https://github.com/bazelbuild/bazel/commit/ad53147cc4f4d47c064845ec9612876161ff139e