### PR TITLE
Blaze -> Bazel in GenQueryRule.java

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQueryRule.java
@@ -91,7 +91,7 @@ public final class GenQueryRule implements RuleDefinition {
 
   <p>
   <code>genquery()</code> runs a query specified in the
-    <a href="${link query}">Blaze query language</a> and dumps the result
+    <a href="${link query}">Bazel query language</a> and dumps the result
     into a file.
   </p>
   <p>


### PR DESCRIPTION
This ought to be the last one in the source code.

There is one more in the public docs for [-batch_cpu_scheduling](https://bazel.build/reference/command-line-reference#startup-options), however, the [source Markdown](https://github.com/bazelbuild/bazel/blob/d08bb13369d840af35a26b5e38b3d0adb896fd29/site/en/docs/user-manual.md?plain=1#L2444) appears to be correct, so I don't know what the issue is there.