### PR TITLE
[7.3.0] Make Window launchers relocatable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShBinary.java
@@ -102,7 +102,7 @@ public class ShBinary implements RuleConfiguredTargetFactory {
   }
 
   private static Artifact createWindowsExeLauncher(
-      RuleContext ruleContext, PathFragment shExecutable) throws RuleErrorException {
+      RuleContext ruleContext, PathFragment shExecutable, Artifact primaryOutput) {
     Artifact bashLauncher =
         ruleContext.getImplicitOutputArtifact(ruleContext.getTarget().getName() + ".exe");
 
@@ -114,6 +114,11 @@ public class ShBinary implements RuleConfiguredTargetFactory {
                 "symlink_runfiles_enabled",
                 ruleContext.getConfiguration().runfilesEnabled() ? "1" : "0")
             .addKeyValuePair("bash_bin_path", shExecutable.getPathString())
+            .addKeyValuePair(
+                "bash_file_rlocationpath",
+                PathFragment.create(ruleContext.getWorkspaceName())
+                    .getRelative(primaryOutput.getRunfilesPathString())
+                    .getPathString())
             .build();
 
     LauncherFileWriteAction.createAndRegister(ruleContext, bashLauncher, launchInfo);
@@ -139,6 +144,6 @@ public class ShBinary implements RuleConfiguredTargetFactory {
     PathFragment shExecutable =
         ShToolchain.getPathForPlatform(
             ruleContext.getConfiguration(), ruleContext.getExecutionPlatform());
-    return createWindowsExeLauncher(ruleContext, shExecutable);
+    return createWindowsExeLauncher(ruleContext, shExecutable, primaryOutput);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessRunner.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessRunner.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.blackbox.framework;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.flogger.LazyArgs;
@@ -77,6 +78,18 @@ final class ProcessRunner {
     ProcessBuilder processBuilder = new ProcessBuilder(commandParts);
     processBuilder.directory(parameters.workingDirectory());
     parameters.environment().ifPresent(map -> processBuilder.environment().putAll(map));
+    // Always clear the variables used for runfiles discovery so that the process doesn't inherit
+    // them from the Bazel test environment.
+    processBuilder
+        .environment()
+        .keySet()
+        .removeAll(
+            ImmutableSet.of(
+                "RUNFILES_DIR",
+                "RUNFILES_MANIFEST_FILE",
+                "RUNFILES_MANIFEST_ONLY",
+                "JAVA_RUNFILES",
+                "PYTHON_RUNFILES"));
 
     parameters.redirectOutput().ifPresent(path -> processBuilder.redirectOutput(path.toFile()));
     parameters.redirectError().ifPresent(path -> processBuilder.redirectError(path.toFile()));

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -265,8 +265,11 @@ function test_java_test() {
 function test_native_python() {
   # On windows, we build a python executable zip as the python binary
   assert_build //examples/py_native:bin
-  # run the python package directly
-  ./bazel-bin/examples/py_native/bin >& $TEST_log \
+  # run the python package directly, clearing out runfiles variables to
+  # ensure that the binary finds its own runfiles correctly
+  env -u RUNFILES_DIR -u RUNFILES_MANIFEST_FILE -u RUNFILES_MANIFEST_ONLY \
+    -u JAVA_RUNFILES -u PYTHON_RUNFILES \
+    ./bazel-bin/examples/py_native/bin >& $TEST_log \
     || fail "//examples/py_native:bin execution failed"
   expect_log "Fib(5) == 8"
   # Using python <zipfile> to run the python package

--- a/src/test/shell/bazel/python_version_test.sh
+++ b/src/test/shell/bazel/python_version_test.sh
@@ -266,7 +266,11 @@ print(__file__)
 EOF
 
   bazel build //test:pybin --build_python_zip &> $TEST_log || fail "bazel build failed"
-  pybin_location=$(bazel-bin/test/pybin)
+  # Clear out runfiles variables to ensure that the binary finds its own
+  # runfiles correctly.
+  pybin_location=$(env -u RUNFILES_DIR -u RUNFILES_MANIFEST_FILE \
+      -u RUNFILES_MANIFEST_ONLY -u JAVA_RUNFILES -u PYTHON_RUNFILES \
+      bazel-bin/test/pybin)
 
   # The pybin location is "<ms root>/runfiles/<workspace>/test/pybin.py",
   # so we have to go up 4 directories to get to the module space root

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -27,6 +27,8 @@ using std::wostringstream;
 using std::wstring;
 
 static constexpr const char* BASH_BIN_PATH = "bash_bin_path";
+static constexpr const char* BASH_FILE_RLOCATIONPATH =
+    "bash_file_rlocationpath";
 
 ExitCode BashBinaryLauncher::Launch() {
   wstring bash_binary = this->GetLaunchInfoByKey(BASH_BIN_PATH);
@@ -52,8 +54,10 @@ ExitCode BashBinaryLauncher::Launch() {
 
   vector<wstring> origin_args = this->GetCommandlineArguments();
   wostringstream bash_command;
-  wstring bash_main_file = GetBinaryPathWithoutExtension(GetLauncherPath());
-  bash_command << BashEscapeArg(bash_main_file);
+  wstring bash_file_rlocationpath =
+      this->GetLaunchInfoByKey(BASH_FILE_RLOCATIONPATH);
+  wstring bash_file = Rlocation(bash_file_rlocationpath, true);
+  bash_command << BashEscapeArg(bash_file);
   for (int i = 1; i < origin_args.size(); i++) {
     bash_command << L' ';
     bash_command << BashEscapeArg(origin_args[i]);

--- a/src/tools/launcher/launcher.cc
+++ b/src/tools/launcher/launcher.cc
@@ -197,6 +197,14 @@ wstring BinaryLauncherBase::GetLaunchInfoByKey(const string& key) {
   return item->second;
 }
 
+wstring BinaryLauncherBase::GetLaunchInfoByKeyOrEmpty(const std::string& key) {
+  auto item = launch_info.find(key);
+  if (item == launch_info.end()) {
+    return L"";
+  }
+  return item->second;
+}
+
 const vector<wstring>& BinaryLauncherBase::GetCommandlineArguments() const {
   return this->commandline_arguments;
 }

--- a/src/tools/launcher/launcher.h
+++ b/src/tools/launcher/launcher.h
@@ -49,6 +49,7 @@ class BinaryLauncherBase {
 
   // Get launch information based on a launch info key.
   std::wstring GetLaunchInfoByKey(const std::string& key);
+  std::wstring GetLaunchInfoByKeyOrEmpty(const std::string& key);
 
   // Get the original command line arguments passed to this binary.
   const std::vector<std::wstring>& GetCommandlineArguments() const;

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -28,6 +28,7 @@ using std::wstring;
 
 static constexpr const char* PYTHON_BIN_PATH = "python_bin_path";
 static constexpr const char* USE_ZIP_FILE = "use_zip_file";
+static constexpr const char* PYTHON_FILE_SHORT_PATH = "python_file_short_path";
 
 ExitCode PythonBinaryLauncher::Launch() {
   wstring python_binary = this->GetLaunchInfoByKey(PYTHON_BIN_PATH);
@@ -54,12 +55,18 @@ ExitCode PythonBinaryLauncher::Launch() {
   }
 
   vector<wstring> args = this->GetCommandlineArguments();
-  wstring use_zip_file = this->GetLaunchInfoByKey(USE_ZIP_FILE);
   wstring python_file;
-  if (use_zip_file == L"1") {
-    python_file = GetBinaryPathWithoutExtension(GetLauncherPath()) + L".zip";
+  wstring python_file_short_path =
+      this->GetLaunchInfoByKeyOrEmpty(PYTHON_FILE_SHORT_PATH);
+  if (!python_file_short_path.empty()) {
+    python_file = Rlocation(python_file_short_path, false);
   } else {
-    python_file = GetBinaryPathWithoutExtension(GetLauncherPath());
+    wstring use_zip_file = this->GetLaunchInfoByKey(USE_ZIP_FILE);
+    if (use_zip_file == L"1") {
+      python_file = GetBinaryPathWithoutExtension(GetLauncherPath()) + L".zip";
+    } else {
+      python_file = GetBinaryPathWithoutExtension(GetLauncherPath());
+    }
   }
 
   // Replace the first argument with python file path


### PR DESCRIPTION
When the Windows launcher binary is copied to become the `executable` of another target, it can't expect to find the main file right next to it. Instead, look it up via `Rlocation`, which doesn't require colocation to find the file. This helps with a common pattern in wrapper rules where `ctx.symlink` is used to work around the limitation that the `executable` of a target has to be produced by that target.

For the Python rules, for which the source of truth is not the Bazel repo anymore, the new launch key is checked for in a backwards compatible way.

Closes #23076.

PiperOrigin-RevId: 657116461
Change-Id: I3f966b48e0812668cfa7bd394f2eaf23d66889b6

Closes #23121