### PR TITLE
[7.3.0] Fail on inapplicable flags on non-common commands expanded from configs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -85,7 +85,7 @@ public final class BlazeOptionHandler {
 
   // All options set on this pseudo command are inherited by all commands, with unrecognized options
   // being ignored as long as they are recognized by at least one (other) command.
-  private static final String COMMON_PSEUDO_COMMAND = "common";
+  static final String COMMON_PSEUDO_COMMAND = "common";
 
   private static final String BUILD_COMMAND = "build";
   private static final ImmutableSet<String> BUILD_COMMAND_ANCESTORS =

--- a/src/main/java/com/google/devtools/common/options/ArgsPreProcessor.java
+++ b/src/main/java/com/google/devtools/common/options/ArgsPreProcessor.java
@@ -13,10 +13,11 @@
 // limitations under the License.
 package com.google.devtools.common.options;
 
+import com.google.devtools.common.options.OptionsParser.ArgAndFallbackData;
 import java.util.List;
 
 /** Defines a preprocessing service for the "args" string list that is executed before parsing. */
 @FunctionalInterface
 interface ArgsPreProcessor {
-  List<String> preProcess(List<String> args) throws OptionsParsingException;
+  List<ArgAndFallbackData> preProcess(List<ArgAndFallbackData> args) throws OptionsParsingException;
 }

--- a/src/main/java/com/google/devtools/common/options/OptionsParser.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParser.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.MoreCollectors;
 import com.google.common.escape.Escaper;
 import com.google.devtools.build.lib.util.Pair;
@@ -709,7 +710,7 @@ public class OptionsParser implements OptionsParsingResult {
    */
   public void parse(OptionPriority.PriorityCategory priority, String source, List<String> args)
       throws OptionsParsingException {
-    parseWithSourceFunction(priority, o -> source, args, null);
+    parseWithSourceFunction(priority, o -> source, args, /* fallbackData= */ null);
   }
 
   /**
@@ -725,9 +726,6 @@ public class OptionsParser implements OptionsParsingResult {
    *     each option will be given an index to track its position. If parse() has already been
    *     called at this priority, the indexing will continue where it left off, to keep ordering.
    * @param sourceFunction a function that maps option names to the source of the option.
-   * @param fallbackData if provided, the full collection of options that should be parsed and
-   *     ignored without raising an error if they are not recognized by the options classes
-   *     registered with this parser.
    * @param args the arg list to parse. Each element might be an option, a value linked to an
    *     option, or residue.
    * @return a list of options and values that were parsed but ignored due to only resolving against
@@ -743,7 +741,8 @@ public class OptionsParser implements OptionsParsingResult {
     Preconditions.checkNotNull(priority);
     Preconditions.checkArgument(priority != OptionPriority.PriorityCategory.DEFAULT);
     OptionsParserImplResult optionsParserImplResult =
-        impl.parse(priority, sourceFunction, args, (OptionsData) fallbackData);
+        impl.parse(
+            priority, sourceFunction, ArgAndFallbackData.wrapWithFallbackData(args, fallbackData));
     addResidueFromResult(optionsParserImplResult);
     aliases.putAll(optionsParserImplResult.aliases);
     return optionsParserImplResult.ignoredArgs;
@@ -757,19 +756,15 @@ public class OptionsParser implements OptionsParsingResult {
    *     will have the same priority as this option.
    * @param source a description of where the expansion arguments came from.
    * @param args the arguments to parse as the expansion. Order matters, as the value of a flag may
-   *     be in the following argument.
-   * @param fallbackData if provided, the full collection of options that should be parsed and
-   *     ignored without raising an error if they are not recognized by the options classes
-   *     registered with this parser.
+   *     be in the following argument. Each arg is optionally annotated with the full collection of
+   *     options that should be parsed and ignored without raising an error if they are not
+   *     recognized by the options classes registered with this parser.
    * @return a list of options and values that were parsed but ignored due to only resolving against
    *     the fallback data
    */
   @CanIgnoreReturnValue
   public ImmutableList<String> parseArgsAsExpansionOfOption(
-      ParsedOptionDescription optionToExpand,
-      String source,
-      List<String> args,
-      @Nullable OpaqueOptionsData fallbackData)
+      ParsedOptionDescription optionToExpand, String source, List<ArgAndFallbackData> args)
       throws OptionsParsingException {
     Preconditions.checkNotNull(
         optionToExpand, "Option for expansion not specified for arglist %s", args);
@@ -779,8 +774,7 @@ public class OptionsParser implements OptionsParsingResult {
         "Priority cannot be default, which was specified for arglist %s",
         args);
     OptionsParserImplResult optionsParserImplResult =
-        impl.parseArgsAsExpansionOfOption(
-            optionToExpand, o -> source, args, (OptionsData) fallbackData);
+        impl.parseArgsAsExpansionOfOption(optionToExpand, o -> source, args);
     addResidueFromResult(optionsParserImplResult);
     return optionsParserImplResult.ignoredArgs;
   }
@@ -934,5 +928,24 @@ public class OptionsParser implements OptionsParsingResult {
   public static boolean getUsesOnlyCoreTypes(Class<? extends OptionsBase> optionsClass) {
     OptionsData data = OptionsParser.getOptionsDataInternal(optionsClass);
     return data.getUsesOnlyCoreTypes(optionsClass);
+  }
+
+  /**
+   * A container for an arg and associated options that should be silently ignored when parsed but
+   * not recognized by the current command.
+   */
+  public static final class ArgAndFallbackData {
+    public final String arg;
+    @Nullable final OptionsData fallbackData;
+
+    public ArgAndFallbackData(String arg, @Nullable OpaqueOptionsData fallbackData) {
+      this.arg = Preconditions.checkNotNull(arg);
+      this.fallbackData = (OptionsData) fallbackData;
+    }
+
+    public static List<ArgAndFallbackData> wrapWithFallbackData(
+        List<String> args, @Nullable OpaqueOptionsData fallbackData) {
+      return Lists.transform(args, arg -> new ArgAndFallbackData(arg, fallbackData));
+    }
   }
 }

--- a/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.common.options.Converters.CommaSeparatedOptionListConverter;
 import com.google.devtools.common.options.OptionPriority.PriorityCategory;
+import com.google.devtools.common.options.OptionsParser.ArgAndFallbackData;
 import com.google.devtools.common.options.OptionsParser.ConstructionException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -370,8 +371,9 @@ public final class OptionsParserTest {
                 parser.parseArgsAsExpansionOfOption(
                     optionToExpand,
                     "source",
-                    ImmutableList.of("--underlying=direct_value", "residue", "in", "expansion"),
-                    /* fallbackData= */ null));
+                    ArgAndFallbackData.wrapWithFallbackData(
+                        ImmutableList.of("--underlying=direct_value", "residue", "in", "expansion"),
+                        /* fallbackData= */ null)));
     assertThat(parser.getResidue()).isNotEmpty();
     assertThat(e).hasMessageThat().isEqualTo("Unrecognized arguments: residue in expansion");
   }

--- a/src/test/java/com/google/devtools/common/options/ShellQuotedParamsFilePreProcessorTest.java
+++ b/src/test/java/com/google/devtools/common/options/ShellQuotedParamsFilePreProcessorTest.java
@@ -17,7 +17,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.jimfs.Jimfs;
+import com.google.devtools.common.options.OptionsParser.ArgAndFallbackData;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
@@ -54,7 +56,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("arg1 arg2  arg3\targ4\\ arg5"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("arg1", "arg2", "", "arg3", "arg4\\", "arg5").inOrder();
   }
 
@@ -65,7 +67,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("arg1\narg2\rarg3\r\narg4\n\rarg5"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("arg1", "arg2", "arg3", "arg4", "", "arg5").inOrder();
   }
 
@@ -76,7 +78,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("'arg1' 'arg2' '' 'arg3'\t'arg4'\\ 'arg5'"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("arg1", "arg2", "", "arg3", "arg4\\", "arg5").inOrder();
   }
 
@@ -87,7 +89,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("'arg1'\n'arg2'\r'arg3'\r\n'arg4'\n''\r'arg5'"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("arg1", "arg2", "arg3", "arg4", "", "arg5").inOrder();
   }
 
@@ -98,7 +100,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("'arg1 arg2  arg3\targ4'"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("arg1 arg2  arg3\targ4").inOrder();
   }
 
@@ -109,7 +111,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("'arg1\narg2\rarg3\r\narg4\n\rarg5'"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("arg1\narg2\rarg3\r\narg4\n\rarg5").inOrder();
   }
 
@@ -120,7 +122,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("'ar'\\''g1'", "'a'\\''rg'\\''2'"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("ar'g1", "a'rg'2").inOrder();
   }
 
@@ -131,7 +133,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("ar'g1 ar'g2 arg3"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("arg1 arg2", "arg3").inOrder();
   }
 
@@ -145,7 +147,7 @@ public class ShellQuotedParamsFilePreProcessorTest {
     OptionsParsingException expected =
         assertThrows(
             OptionsParsingException.class,
-            () -> paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile)));
+            () -> preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile)));
     assertThat(expected)
         .hasMessageThat()
         .isEqualTo(
@@ -162,7 +164,14 @@ public class ShellQuotedParamsFilePreProcessorTest {
         ImmutableList.of("ar\\'g1'"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args).containsExactly("ar\\g1").inOrder();
+  }
+
+  private static List<String> preProcess(ParamsFilePreProcessor preProcessor, List<String> args)
+      throws OptionsParsingException {
+    return Lists.transform(
+        preProcessor.preProcess(ArgAndFallbackData.wrapWithFallbackData(args, null)),
+        argAndFallbackData -> argAndFallbackData.arg);
   }
 }

--- a/src/test/java/com/google/devtools/common/options/UnquotedParamsFilePreProcessorTest.java
+++ b/src/test/java/com/google/devtools/common/options/UnquotedParamsFilePreProcessorTest.java
@@ -16,7 +16,9 @@ package com.google.devtools.common.options;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.jimfs.Jimfs;
+import com.google.devtools.common.options.OptionsParser.ArgAndFallbackData;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
@@ -51,9 +53,16 @@ public class UnquotedParamsFilePreProcessorTest {
         ImmutableList.of("arg1\narg2\rarg3\r\narg4 arg5\targ6\n\rarg7\\ arg8"),
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE);
-    List<String> args = paramsFilePreProcessor.preProcess(ImmutableList.of("@" + paramsFile));
+    List<String> args = preProcess(paramsFilePreProcessor, ImmutableList.of("@" + paramsFile));
     assertThat(args)
         .containsExactly("arg1", "arg2", "arg3", "arg4 arg5\targ6", "", "arg7\\ arg8")
         .inOrder();
+  }
+
+  private static List<String> preProcess(ParamsFilePreProcessor preProcessor, List<String> args)
+      throws OptionsParsingException {
+    return Lists.transform(
+        preProcessor.preProcess(ArgAndFallbackData.wrapWithFallbackData(args, null)),
+        argAndFallbackData -> argAndFallbackData.arg);
   }
 }


### PR DESCRIPTION
This regressed in https://github.com/bazelbuild/bazel/commit/44d395338ab9a27596b0796c14076641f4cb2093.

Fixes #22980

Closes #23105.

PiperOrigin-RevId: 657276908
Change-Id: If2e88455a344082bfbec405c30c148c0d044adb6

Commit https://github.com/bazelbuild/bazel/commit/9fbf427d3c9943f0efa659f9934e77358c64e9a7