### PR TITLE
[7.4.0] Preserve order between stdout and stderr in BES on a best-eff…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -424,8 +424,10 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
   private void registerOutAndErrOutputStreams() {
     int bufferSize = besOptions.besOuterrBufferSize;
     int chunkSize = besOptions.besOuterrChunkSize;
-    SynchronizedOutputStream out = new SynchronizedOutputStream(bufferSize, chunkSize);
-    SynchronizedOutputStream err = new SynchronizedOutputStream(bufferSize, chunkSize);
+    SynchronizedOutputStream out =
+        new SynchronizedOutputStream(bufferSize, chunkSize, /* isStderr= */ false);
+    SynchronizedOutputStream err =
+        new SynchronizedOutputStream(bufferSize, chunkSize, /* isStderr= */ true);
 
     this.outErr = OutErr.create(out, err);
     streamer.registerOutErrProvider(

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -291,10 +291,16 @@ message BuildEventId {
 message Progress {
   // The next chunk of stdout that bazel produced since the last progress event
   // or the beginning of the build.
+  // Consumers that need to reason about the relative order of stdout and stderr
+  // can assume that stderr has been emitted before stdout if both are present,
+  // on a best-effort basis.
   string stdout = 1;
 
   // The next chunk of stderr that bazel produced since the last progress event
   // or the beginning of the build.
+  // Consumers that need to reason about the relative order of stdout and stderr
+  // can assume that stderr has been emitted before stdout if both are present,
+  // on a best-effort basis.
   string stderr = 2;
 }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildEventStreamer.java
@@ -74,6 +74,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
@@ -136,6 +137,66 @@ public class BuildEventStreamer {
   // True, if we already closed the stream.
   @GuardedBy("this")
   private boolean closed;
+
+  /**
+   * The current state of buffered progress events.
+   *
+   * <p>The typical case in which stdout and stderr alternate is output of the form:
+   *
+   * <pre>
+   * INFO: From Executing genrule //:genrule:
+   * &lt;genrule stdout output>
+   * [123 / 1234] 16 actions running
+   * </pre>
+   *
+   * We want the relative order of the stdout and stderr output to be preserved on a best-effort
+   * basis and thus flush the two streams into a progress event before we are seeing a second type
+   * transition. We are free to declare either stdout or stderr to come first. We choose stderr here
+   * as that provides the more natural split in the example above: The INFO line and the stdout of
+   * the action it precedes both end up in the same progress event.
+   */
+  enum ProgressBufferState {
+    ACCEPT_STDERR_AND_STDOUT {
+      @Override
+      ProgressBufferState nextStateOnStderr() {
+        return ACCEPT_STDERR_AND_STDOUT;
+      }
+
+      @Override
+      ProgressBufferState nextStateOnStdout() {
+        return ACCEPT_STDOUT;
+      }
+    },
+    ACCEPT_STDOUT {
+      @Override
+      ProgressBufferState nextStateOnStderr() {
+        return REQUIRE_FLUSH;
+      }
+
+      @Override
+      ProgressBufferState nextStateOnStdout() {
+        return ACCEPT_STDOUT;
+      }
+    },
+    REQUIRE_FLUSH {
+      @Override
+      ProgressBufferState nextStateOnStderr() {
+        return REQUIRE_FLUSH;
+      }
+
+      @Override
+      ProgressBufferState nextStateOnStdout() {
+        return REQUIRE_FLUSH;
+      }
+    };
+
+    abstract ProgressBufferState nextStateOnStderr();
+
+    abstract ProgressBufferState nextStateOnStdout();
+  }
+
+  private final AtomicReference<ProgressBufferState> progressBufferState =
+      new AtomicReference<>(ProgressBufferState.ACCEPT_STDERR_AND_STDOUT);
 
   /** Holds the futures for the closing of each transport */
   private ImmutableMap<BuildEventTransport, ListenableFuture<Void>> closeFuturesMap =
@@ -236,6 +297,7 @@ public class BuildEventStreamer {
           if (outErrProvider != null) {
             allOut = orEmpty(outErrProvider.getOut());
             allErr = orEmpty(outErrProvider.getErr());
+            progressBufferState.set(ProgressBufferState.ACCEPT_STDERR_AND_STDOUT);
           }
           linkEvents = new ArrayList<>();
           List<BuildEvent> finalLinkEvents = linkEvents;
@@ -582,6 +644,16 @@ public class BuildEventStreamer {
     return updateEvent;
   }
 
+  /** Whether the given output type can be written without first flushing the streamer. */
+  boolean canBufferProgressWrite(boolean isStderr) {
+    var newState =
+        progressBufferState.updateAndGet(
+            isStderr
+                ? ProgressBufferState::nextStateOnStderr
+                : ProgressBufferState::nextStateOnStdout);
+    return newState != ProgressBufferState.REQUIRE_FLUSH;
+  }
+
   // @GuardedBy annotation is doing lexical analysis that doesn't understand the closures below
   // will be running under the synchronized block.
   @SuppressWarnings("GuardedBy")
@@ -593,6 +665,7 @@ public class BuildEventStreamer {
       if (outErrProvider != null) {
         allOut = orEmpty(outErrProvider.getOut());
         allErr = orEmpty(outErrProvider.getErr());
+        progressBufferState.set(ProgressBufferState.ACCEPT_STDERR_AND_STDOUT);
       }
       if (Iterables.isEmpty(allOut) && Iterables.isEmpty(allErr)) {
         // Nothing to flush; avoid generating an unneeded progress event.
@@ -692,6 +765,7 @@ public class BuildEventStreamer {
     if (outErrProvider != null) {
       allOut = orEmpty(outErrProvider.getOut());
       allErr = orEmpty(outErrProvider.getErr());
+      progressBufferState.set(ProgressBufferState.ACCEPT_STDERR_AND_STDOUT);
     }
     consumeAsPairsofStrings(
         allOut,

--- a/src/main/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStream.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * {@link OutputStream} suitably synchronized for producer-consumer use cases. The method {@link
@@ -43,20 +44,25 @@ public class SynchronizedOutputStream extends OutputStream {
   // {@link write(byte[] buffer, int offset, int count)} method.
   private final int maxBufferedLength;
 
-  private final int maxChunkSize;
+  private final Splitter maxChunkSizeSplitter;
 
+  private final boolean isStderr;
+
+  @GuardedBy("this")
   private byte[] buf;
+
   private long count;
 
   // The event streamer that is supposed to flush stdout/stderr.
   private BuildEventStreamer streamer;
 
-  public SynchronizedOutputStream(int maxBufferedLength, int maxChunkSize) {
+  public SynchronizedOutputStream(int maxBufferedLength, int maxChunkSize, boolean isStderr) {
     Preconditions.checkArgument(maxChunkSize > 0);
     buf = new byte[64];
     count = 0;
     this.maxBufferedLength = maxBufferedLength;
-    this.maxChunkSize = Math.max(maxChunkSize, maxBufferedLength);
+    this.maxChunkSizeSplitter = Splitter.fixedLength(Math.max(maxChunkSize, maxBufferedLength));
+    this.isStderr = isStderr;
   }
 
   public void registerStreamer(BuildEventStreamer streamer) {
@@ -71,9 +77,7 @@ public class SynchronizedOutputStream extends OutputStream {
     String content = new String(buf, 0, (int) count, UTF_8);
     buf = new byte[64];
     count = 0;
-    return content.isEmpty()
-        ? ImmutableList.of()
-        : Splitter.fixedLength(maxChunkSize).split(content);
+    return content.isEmpty() ? ImmutableList.of() : maxChunkSizeSplitter.split(content);
   }
 
   @Override
@@ -94,7 +98,8 @@ public class SynchronizedOutputStream extends OutputStream {
     boolean didWrite = false;
     while (!didWrite) {
       synchronized (this) {
-        if (this.count + (long) count < maxBufferedLength || this.count == 0) {
+        if ((this.count + (long) count < maxBufferedLength || this.count == 0)
+            && streamer.canBufferProgressWrite(isStderr)) {
           if (this.count + (long) count >= (long) buf.length) {
             // We need to increase the buffer; if within the permissible range range for array
             // sizes, we at least double it, otherwise we only increase as far as needed.

--- a/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BuildEventStreamerTest.java
@@ -15,6 +15,8 @@ package com.google.devtools.build.lib.runtime;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -84,6 +86,9 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
 import com.google.devtools.common.options.Options;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -96,14 +101,14 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Tests {@link BuildEventStreamer}. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public final class BuildEventStreamerTest extends FoundationTestCase {
 
   private static final String OOM_MESSAGE = "Please build fewer targets.";
@@ -1083,6 +1088,77 @@ public final class BuildEventStreamerTest extends FoundationTestCase {
     // The OutErrProvider should be queried only once per flush().
     verify(outErr, times(1)).getOut();
     verify(outErr, times(1)).getErr();
+  }
+
+  @Test
+  public void testFlushPreservesStdoutStderrOrder(
+      @TestParameter({"5", "30", "10000"}) int maxBufferedLength,
+      @TestParameter({"5", "30", "10000"}) int maxChunkSize)
+      throws IOException {
+    var stdout =
+        new SynchronizedOutputStream(maxBufferedLength, maxChunkSize, /* isStderr= */ false);
+    var stderr =
+        new SynchronizedOutputStream(maxBufferedLength, maxChunkSize, /* isStderr= */ true);
+    var outErr =
+        new BuildEventStreamer.OutErrProvider() {
+          @Override
+          public Iterable<String> getOut() {
+            return stdout.readAndReset();
+          }
+
+          @Override
+          public Iterable<String> getErr() {
+            return stderr.readAndReset();
+          }
+        };
+    streamer.registerOutErrProvider(outErr);
+    stdout.registerStreamer(streamer);
+    stderr.registerStreamer(streamer);
+
+    var startEvent =
+        new GenericBuildEvent(
+            testId("Initial"), ImmutableSet.of(ProgressEvent.INITIAL_PROGRESS_UPDATE));
+    streamer.buildEvent(startEvent);
+
+    stderr.write("[0 / 3] 3 actions running\n".getBytes(UTF_8));
+    stderr.write("INFO: From Executing genrule //:1:\n".getBytes(UTF_8));
+    stdout.write("Hello from genrule //:1 on stdout\n".getBytes(UTF_8));
+    stderr.write("Hello from genrule //:1 on stderr\n".getBytes(UTF_8));
+    stderr.write("[1 / 3] 2 actions running\n".getBytes(UTF_8));
+    stderr.write("INFO: From Executing genrule //:2:\n".getBytes(UTF_8));
+    stdout.write("Hello from genrule //:2 on stderr\n".getBytes(UTF_8));
+    stderr.write("Hello from genrule //:2 on stdout\n".getBytes(UTF_8));
+    stderr.write("[2 / 3] 1 actions running\n".getBytes(UTF_8));
+    stderr.write("INFO: From Executing genrule //:3:\n".getBytes(UTF_8));
+    stdout.write("Hello from genrule //:3 on stdout\n".getBytes(UTF_8));
+    stderr.write("Hello from genrule //:3 on stderr\n".getBytes(UTF_8));
+    stdout.write("Hello again from genrule //:3 on stdout\n".getBytes(UTF_8));
+    stderr.write("INFO: Build completed successfully, 3 total actions\n".getBytes(UTF_8));
+    streamer.close();
+
+    String reconstructedOutput =
+        transport.getEventProtos().stream()
+            .map(BuildEventStreamProtos.BuildEvent::getProgress)
+            .flatMap(progress -> Stream.of(progress.getStderr(), progress.getStdout()))
+            .collect(joining());
+    assertThat(reconstructedOutput)
+        .isEqualTo(
+            """
+            [0 / 3] 3 actions running
+            INFO: From Executing genrule //:1:
+            Hello from genrule //:1 on stdout
+            Hello from genrule //:1 on stderr
+            [1 / 3] 2 actions running
+            INFO: From Executing genrule //:2:
+            Hello from genrule //:2 on stderr
+            Hello from genrule //:2 on stdout
+            [2 / 3] 1 actions running
+            INFO: From Executing genrule //:3:
+            Hello from genrule //:3 on stdout
+            Hello from genrule //:3 on stderr
+            Hello again from genrule //:3 on stdout
+            INFO: Build completed successfully, 3 total actions
+            """);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SynchronizedOutputStreamTest.java
@@ -41,7 +41,12 @@ public class SynchronizedOutputStreamTest {
   @Test
   public void testReadAndResetReturnsChunkedWritesSinceLastCall() throws IOException {
     SynchronizedOutputStream underTest =
-        new SynchronizedOutputStream(/*maxBufferedLength=*/ 5, /*maxChunkSize=*/ 5);
+        new SynchronizedOutputStream(
+            /* maxBufferedLength= */ 5, /* maxChunkSize= */ 5, /* isStderr= */ false);
+
+    BuildEventStreamer mockStreamer = mock(BuildEventStreamer.class);
+    doAnswer(inv -> true).when(mockStreamer).canBufferProgressWrite(false);
+    underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'});
     assertThat(underTest.readAndReset()).containsExactly("abcde", "fgh").inOrder();
@@ -55,7 +60,8 @@ public class SynchronizedOutputStreamTest {
   @Test
   public void testWriteFlushesStreamerWhenMaxBufferedLengthReached() throws IOException {
     SynchronizedOutputStream underTest =
-        new SynchronizedOutputStream(/*maxBufferedLength=*/ 3, /*maxChunkSize=*/ 3);
+        new SynchronizedOutputStream(
+            /* maxBufferedLength= */ 3, /* maxChunkSize= */ 3, /* isStderr= */ false);
 
     List<List<String>> writes = new ArrayList<>();
     BuildEventStreamer mockStreamer = mock(BuildEventStreamer.class);
@@ -66,6 +72,7 @@ public class SynchronizedOutputStreamTest {
             })
         .when(mockStreamer)
         .flush();
+    doAnswer(inv -> true).when(mockStreamer).canBufferProgressWrite(false);
     underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'});
@@ -84,7 +91,12 @@ public class SynchronizedOutputStreamTest {
   @Test
   public void testUsesMaxOfMaxBufferedSizeAndMaxChunkSizeForChunking() throws IOException {
     SynchronizedOutputStream underTest =
-        new SynchronizedOutputStream(/*maxBufferedLength=*/ 2, /*maxChunkSize=*/ 1);
+        new SynchronizedOutputStream(
+            /* maxBufferedLength= */ 2, /* maxChunkSize= */ 1, /* isStderr= */ false);
+
+    BuildEventStreamer mockStreamer = mock(BuildEventStreamer.class);
+    doAnswer(inv -> true).when(mockStreamer).canBufferProgressWrite(false);
+    underTest.registerStreamer(mockStreamer);
 
     underTest.write(new byte[] {'a', 'b', 'c', 'd'});
     assertThat(underTest.readAndReset()).containsExactly("ab", "cd").inOrder();
@@ -95,7 +107,8 @@ public class SynchronizedOutputStreamTest {
   @Test
   public void testHandlesArbitraryBinaryDataCorrectly() throws IOException {
     SynchronizedOutputStream underTest =
-        new SynchronizedOutputStream(/*maxBufferedLength=*/ 1, /*maxChunkSize=*/ 1);
+        new SynchronizedOutputStream(
+            /* maxBufferedLength= */ 1, /* maxChunkSize= */ 1, /* isStderr= */ false);
 
     byte[] input = new byte[] {(byte) 0xff};
     underTest.write(input);


### PR DESCRIPTION
…ort basis

BES consumers may want to turn the stream of progress events into a view that resembles the terminal output by combining stdout and stderr. In particular in `--curses=on` mode, this resulted in garbled output such as the following due to stdout and stderr being buffered separately:

```
[0 / 3] 3 actions running
INFO: From Executing genrule //:1:
Hello from genrule //:1 on stderr
[1 / 3] 2 actions running
INFO: From Executing genrule //:2:
Hello from genrule //:2 on stdout
[2 / 3] 1 actions running
INFO: From Executing genrule //:3:
Hello from genrule //:3 on stderr
INFO: Build completed successfully, 3 total actions
Hello from genrule //:1 on stdout
Hello from genrule //:2 on stderr
Hello from genrule //:3 on stdout
Hello again from genrule //:3 on stdout
```

when the original output was:

```
[0 / 3] 3 actions running
INFO: From Executing genrule //:1:
Hello from genrule //:1 on stdout
Hello from genrule //:1 on stderr
[1 / 3] 2 actions running
INFO: From Executing genrule //:2:
Hello from genrule //:2 on stderr
Hello from genrule //:2 on stdout
[2 / 3] 1 actions running
INFO: From Executing genrule //:3:
Hello from genrule //:3 on stdout
Hello from genrule //:3 on stderr
Hello again from genrule //:3 on stdout
INFO: Build completed successfully, 3 total actions
```

This changes makes it so that the ordering between stdout and stderr is preserved by declaring that a `ProgressEvent` containing both means that stderr has been emitted first and by flushing an event before any stdout -> stderr transition.

Closes https://github.com/buildbuddy-io/buildbuddy/pull/6861

Closes #22795.

PiperOrigin-RevId: 657521787
Change-Id: I95bbe1cfdc1e8230771ca5769af41c5ddfc507a1

Closes #23130 