### PR TITLE
Add no-supports-cgroups exec requiremnt

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -306,4 +306,7 @@ public class ExecutionRequirements {
    * segment from the paths of all inputs and outputs.
    */
   public static final String SUPPORTS_PATH_MAPPING = "supports-path-mapping";
+
+  /** Disables cgroups for a sandbox spawn */
+  public static final String NO_SUPPORTS_CGROUPS = "no-supports-cgroups";
 }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -322,22 +322,24 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
       commandLineBuilder.setSandboxDebugPath(sandboxDebugPath.getPathString());
     }
 
-    if (cgroupFactory != null) {
-      ImmutableMap<String, Double> spawnResourceLimits = ImmutableMap.of();
-      if (sandboxOptions.enforceResources.regexPattern().matcher(spawn.getMnemonic()).matches()) {
-        spawnResourceLimits = spawn.getLocalResources().getResources();
-      }
-      VirtualCgroup cgroup = cgroupFactory.create(context.getId(), spawnResourceLimits);
-      commandLineBuilder.setCgroupsDirs(cgroup.paths());
-    } else if (sandboxOptions.memoryLimitMb > 0) {
-      // We put the sandbox inside a unique subdirectory using the context's ID. This ID is
-      // unique per spawn run by this spawn runner.
-      CgroupsInfo sandboxCgroup =
-          CgroupsInfo.getBlazeSpawnsCgroup()
-              .createIndividualSpawnCgroup(
-                  "sandbox_" + context.getId(), sandboxOptions.memoryLimitMb);
-      if (sandboxCgroup.exists()) {
-        commandLineBuilder.setCgroupsDirs(ImmutableSet.of(sandboxCgroup.getCgroupDir().toPath()));
+    if (!spawn.getExecutionInfo().containsKey(ExecutionRequirements.NO_SUPPORTS_CGROUPS)) {
+      if (cgroupFactory != null) {
+        ImmutableMap<String, Double> spawnResourceLimits = ImmutableMap.of();
+        if (sandboxOptions.enforceResources.regexPattern().matcher(spawn.getMnemonic()).matches()) {
+          spawnResourceLimits = spawn.getLocalResources().getResources();
+        }
+        VirtualCgroup cgroup = cgroupFactory.create(context.getId(), spawnResourceLimits);
+        commandLineBuilder.setCgroupsDirs(cgroup.paths());
+      } else if (sandboxOptions.memoryLimitMb > 0) {
+        // We put the sandbox inside a unique subdirectory using the context's ID. This ID is
+        // unique per spawn run by this spawn runner.
+        CgroupsInfo sandboxCgroup =
+            CgroupsInfo.getBlazeSpawnsCgroup()
+                .createIndividualSpawnCgroup(
+                    "sandbox_" + context.getId(), sandboxOptions.memoryLimitMb);
+        if (sandboxCgroup.exists()) {
+          commandLineBuilder.setCgroupsDirs(ImmutableSet.of(sandboxCgroup.getCgroupDir().toPath()));
+        }
       }
     }
 

--- a/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -105,6 +105,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
         "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
         "//src/main/java/com/google/devtools/build/lib/exec:bin_tools",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",

--- a/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunnerTest.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.CommandLines.ParamFileActionInput;
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.LocalHostCapacity;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -64,6 +65,7 @@ public final class LinuxSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTes
     Spawn spawn = new SpawnBuilder("echo", "echolalia").build();
     Path stdout = testRoot.getChild("stdout");
     SpawnExecutionContext policy = createSpawnExecutionContext(spawn, stdout);
+
 
     SpawnResult spawnResult = runner.exec(spawn, policy);
 
@@ -203,6 +205,22 @@ public final class LinuxSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTes
     assertThat(args).doesNotContain("-m /tmp");
   }
 
+  @Test
+  public void cgroup_canDisableWithExecReq() throws Exception {
+    LinuxSandboxedSpawnRunner runner = setupSandboxAndCreateRunner(createCommandEnvironment());
+    Spawn spawn = new SpawnBuilder("cat", "/proc/self/cgroup")
+        .withExecutionInfo(ExecutionRequirements.NO_SUPPORTS_CGROUPS, "1")
+        .build();
+    Path stdout = testRoot.getChild("stdout");
+    SpawnExecutionContext policy = createSpawnExecutionContext(spawn, stdout);
+
+    SpawnResult spawnResult = runner.exec(spawn, policy);
+
+    assertThat(spawnResult.status()).isEqualTo(SpawnResult.Status.SUCCESS);
+    assertThat(spawnResult.exitCode()).isEqualTo(0);
+    assertThat(FileSystemUtils.readLines(stdout, UTF_8)).doesNotContain("bazel_");
+  }
+
   private static LinuxSandboxedSpawnRunner setupSandboxAndCreateRunner(
       CommandEnvironment commandEnvironment) throws IOException {
     Path execRoot = commandEnvironment.getExecRoot();
@@ -238,4 +256,5 @@ public final class LinuxSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTes
         .setAvailableResources(LocalHostCapacity.getLocalHostCapacity());
     return commandEnvironment;
   }
+
 }


### PR DESCRIPTION
Follow up for https://github.com/bazelbuild/bazel/pull/21322#discussion_r1521227701, just add the excution requirement and ensure it can be used to disable cgroups on a spawn