### PR TITLE
Show "did you mean" suggestion for unknown repo names

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/BUILD
@@ -55,6 +55,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/net/starlark/java/annot",
         "//src/main/java/net/starlark/java/eval",
+        "//src/main/java/net/starlark/java/spelling",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:auto_value",
         "//third_party:caffeine",

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import net.starlark.java.spelling.SpellChecker;
 
 /**
  * Stores the mapping from apparent repo name to canonical repo name, from the viewpoint of an
@@ -128,7 +129,8 @@ public class RepositoryMapping {
     if (ownerRepo() == null) {
       return RepositoryName.createUnvalidated(preMappingName);
     } else {
-      return RepositoryName.createUnvalidated(preMappingName).toNonVisible(ownerRepo());
+      return RepositoryName.createUnvalidated(preMappingName)
+          .toNonVisible(ownerRepo(), SpellChecker.didYouMean(preMappingName, entries().keySet()));
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryMappingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryMappingTest.java
@@ -89,4 +89,13 @@ public final class RepositoryMappingTest {
     assertThat(mapping.get("C")).isEqualTo(RepositoryName.create("C_mapped"));
     assertThat(mapping.get("D")).isEqualTo(RepositoryName.create("D"));
   }
+
+  @Test
+  public void unknownRepoDidYouMean() throws LabelSyntaxException {
+    RepositoryMapping mapping =
+        RepositoryMapping.create(
+            ImmutableMap.of("foo", RepositoryName.create("foo_internal")), RepositoryName.MAIN);
+    assertThat(mapping.get("boo").getNameWithAt())
+        .isEqualTo("@@[unknown repo 'boo' requested from @@ (did you mean 'foo'?)]");
+  }
 }


### PR DESCRIPTION
If `@boo` is parsed in a context in which only `@foo` is visible, the resulting `RepositoryName` object will show as follows in error messages:

```
@@[unknown repo 'boo' requested from @@ (did you mean 'foo'?)]
```