### PR TITLE
Rewrite entries in authHeaders

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -147,34 +147,35 @@ public class UrlRewriter {
       }
 
       String userInfo = url.url().getUserInfo();
-      if (userInfo != null) {
-        try {
-          String token =
-              "Basic " + Base64.getEncoder().encodeToString(userInfo.getBytes(ISO_8859_1));
-          updatedAuthHeaders.put(
-              url.url().toURI(), ImmutableMap.of("Authorization", ImmutableList.of(token)));
-        } catch (URISyntaxException e) {
-          // If the credentials extraction failed, we're letting bazel try without credentials.
-        }
-      } else if (netrcCreds != null) {
-        try {
-          Map<String, List<String>> urlAuthHeaders =
-              netrcCreds.getRequestMetadata(url.url().toURI());
-          if (urlAuthHeaders == null || urlAuthHeaders.isEmpty()) {
-            continue;
-          }
-          // there could be multiple Auth headers, take the first one
-          Map.Entry<String, List<String>> firstAuthHeader =
-              urlAuthHeaders.entrySet().stream().findFirst().get();
-          if (firstAuthHeader.getValue() != null && !firstAuthHeader.getValue().isEmpty()) {
+      try {
+        // This is the core change - if auth was set in download, but the url got rewritten. Pass auth from original url
+        // to rewritten one 
+        if (authHeaders.containsKey(url.original().toURI())) {
+          updatedAuthHeaders.put(url.url().toURI(), authHeaders.get(url.original().toURI()));
+        } else if (userInfo != null) {
+            String token =
+                "Basic " + Base64.getEncoder().encodeToString(userInfo.getBytes(ISO_8859_1));
             updatedAuthHeaders.put(
-                url.url().toURI(),
-                ImmutableMap.of(
-                    firstAuthHeader.getKey(), ImmutableList.of(firstAuthHeader.getValue().get(0))));
-          }
-        } catch (URISyntaxException | IOException e) {
-          // If the credentials extraction failed, we're letting bazel try without credentials.
+                url.url().toURI(), ImmutableMap.of("Authorization", ImmutableList.of(token)));
+            // If the credentials extraction failed, we're letting bazel try without credentials.
+        } else if (netrcCreds != null) {
+            Map<String, List<String>> urlAuthHeaders =
+                netrcCreds.getRequestMetadata(url.url().toURI());
+            if (urlAuthHeaders == null || urlAuthHeaders.isEmpty()) {
+              continue;
+            }
+            // there could be multiple Auth headers, take the first one
+            Map.Entry<String, List<String>> firstAuthHeader =
+                urlAuthHeaders.entrySet().stream().findFirst().get();
+            if (firstAuthHeader.getValue() != null && !firstAuthHeader.getValue().isEmpty()) {
+              updatedAuthHeaders.put(
+                  url.url().toURI(),
+                  ImmutableMap.of(
+                      firstAuthHeader.getKey(), ImmutableList.of(firstAuthHeader.getValue().get(0))));
+            }
         }
+      } catch (URISyntaxException | IOException e) {
+          // If the credentials extraction failed, we're letting bazel try without credentials.
       }
     }
 
@@ -187,7 +188,7 @@ public class UrlRewriter {
     // Cowardly refuse to rewrite non-HTTP(S) urls
     if (REWRITABLE_SCHEMES.stream()
         .noneMatch(scheme -> Ascii.equalsIgnoreCase(scheme, url.getProtocol()))) {
-      return ImmutableList.of(RewrittenURL.create(url, false));
+      return ImmutableList.of(RewrittenURL.create(url, url, false));
     }
 
     ImmutableList<RewrittenURL> rewrittenUrls = applyRewriteRules(url);
@@ -255,12 +256,12 @@ public class UrlRewriter {
     }
 
     if (!matchMade) {
-      return ImmutableList.of(RewrittenURL.create(url, false));
+      return ImmutableList.of(RewrittenURL.create(url, url, false));
     }
 
     return rewrittenUrls.build().stream()
         .map(urlString -> prefixWithProtocol(urlString, url.getProtocol()))
-        .map(plainUrl -> RewrittenURL.create(plainUrl, true))
+        .map(plainUrl -> RewrittenURL.create(url, plainUrl, true))
         .collect(toImmutableList());
   }
 
@@ -337,9 +338,11 @@ public class UrlRewriter {
   /** Holds the URL along with meta-info, such as whether URL was re-written or not. */
   @AutoValue
   public abstract static class RewrittenURL {
-    static RewrittenURL create(URL url, boolean rewritten) {
-      return new AutoValue_UrlRewriter_RewrittenURL(url, rewritten);
+    static RewrittenURL create(URL original, URL url, boolean rewritten) {
+      return new AutoValue_UrlRewriter_RewrittenURL(original, url, rewritten);
     }
+
+    abstract URL original();
 
     abstract URL url();
 


### PR DESCRIPTION
Should address https://github.com/bazelbuild/bazel/issues/21425

This came up when trying to use [rules_oci](https://github.com/bazel-contrib/rules_oci) with `--experimental_downloader_config`.

If one uses both [auth in download](https://bazel.build/rules/lib/builtins/repository_ctx#download) and `--experimental_downloader_config` the rewritten urls don't use auth headers from auth, as there is no corresponding rewritten entry in the dict.

This PR updates the auth dict to contain rewritten entries.