### PR TITLE
Remove extra whitespace in OptionFilterDescriptions.java

### DIFF
--- a/src/main/java/com/google/devtools/common/options/OptionFilterDescriptions.java
+++ b/src/main/java/com/google/devtools/common/options/OptionFilterDescriptions.java
@@ -72,7 +72,7 @@ public class OptionFilterDescriptions {
         .put(
             OptionDocumentationCategory.INPUT_STRICTNESS,
             "Options that affect how strictly Bazel enforces valid build inputs (rule definitions, "
-                + " flag combinations, etc.)")
+                + "flag combinations, etc.)")
         .put(
             OptionDocumentationCategory.SIGNING,
             "Options that affect the signing outputs of a build")


### PR DESCRIPTION
There is an extra whitespace in `bazel test --help` output. It can be reproduced using:
```bash
> bazel test --help | grep 'enforces valid build inputs'
Options that affect how strictly Bazel enforces valid build inputs (rule definitions,  flag combinations, etc.):
```