### PR TITLE
Don't mask error in `cquery` transitions output formatter

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryTransitionResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryTransitionResolver.java
@@ -131,8 +131,8 @@ public class CqueryTransitionResolver {
    * @see ResolvedTransition for more details.
    * @param configuredTarget the configured target whose dependencies are being looked up.
    */
-  public ImmutableSet<ResolvedTransition> dependencies(CqueryNode configuredTarget)
-      throws EvaluateException, InterruptedException {
+  ImmutableSet<ResolvedTransition> dependencies(CqueryNode configuredTarget)
+      throws EvaluateException, InterruptedException, IncompatibleTargetException {
     if (!(configuredTarget instanceof RuleConfiguredTarget)) {
       return ImmutableSet.of();
     }
@@ -161,7 +161,7 @@ public class CqueryTransitionResolver {
           eventHandler)) {
         throw new EvaluateException("DependencyResolver.evaluate did not complete");
       }
-    } catch (ReportedException | UnreportedException | IncompatibleTargetException e) {
+    } catch (ReportedException | UnreportedException e) {
       throw new EvaluateException(e.getMessage());
     }
 

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
@@ -529,6 +529,29 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
         .doesNotContain("//test:my_child");
   }
 
+
+  @Test
+  public void incompatibleTarget() throws Exception {
+    writeFile(
+        "test/BUILD",
+        """
+            constraint_setting(name = "incompatible_setting")
+            constraint_value(
+                name = "incompatible",
+                constraint_setting = ":incompatible_setting",
+            )
+            genrule(
+                name = "my_target",
+                cmd = "touch $@",
+                outs = ["out"],
+                target_compatible_with = [":incompatible"],
+            )""");
+
+    options.transitions = Transitions.LITE;
+    AnalysisProtosV2.CqueryResult cqueryResult =
+        getProtoOutput("deps(//test:my_target)", AnalysisProtosV2.CqueryResult.parser());
+  }
+
   private CqueryNode getKeyedTargetByLabel(Set<CqueryNode> keyedTargets, String label) {
     return Iterables.getOnlyElement(
         keyedTargets.stream()

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
@@ -529,29 +529,6 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
         .doesNotContain("//test:my_child");
   }
 
-
-  @Test
-  public void incompatibleTarget() throws Exception {
-    writeFile(
-        "test/BUILD",
-        """
-            constraint_setting(name = "incompatible_setting")
-            constraint_value(
-                name = "incompatible",
-                constraint_setting = ":incompatible_setting",
-            )
-            genrule(
-                name = "my_target",
-                cmd = "touch $@",
-                outs = ["out"],
-                target_compatible_with = [":incompatible"],
-            )""");
-
-    options.transitions = Transitions.LITE;
-    AnalysisProtosV2.CqueryResult cqueryResult =
-        getProtoOutput("deps(//test:my_target)", AnalysisProtosV2.CqueryResult.parser());
-  }
-
   private CqueryNode getKeyedTargetByLabel(Set<CqueryNode> keyedTargets, String label) {
     return Iterables.getOnlyElement(
         keyedTargets.stream()


### PR DESCRIPTION
All errors used to be wrapped in an `InterruptedException` instead of being reported with a message. Also show a warning when an incompatible target is skipped instead of failing the build.

Work towards #21010