### PR TITLE
Add s390x support for Bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -258,6 +258,7 @@ use_repo(
     "remotejdk17_win",
     "remotejdk17_win_arm64",
     "remotejdk21_linux",
+    "remotejdk21_linux_s390x",
     "remotejdk21_macos",
     "remotejdk21_macos_aarch64",
     "remotejdk21_win",
@@ -268,12 +269,12 @@ use_repo(
 # =========================================
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.8")
+python.toolchain(python_version = "3.10")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "bazel_pip_dev_deps",
-    python_version = "3.8",
+    python_version = "3.10",
     requirements_lock = "//:requirements.txt",
 )
 use_repo(pip, "bazel_pip_dev_deps")
@@ -330,6 +331,13 @@ http_file(
     executable = True,
     integrity = "sha256-TdLYoGYd8LIvG7mh+YMPBrbzuPfZEhGh7118TwaotKU=",
     urls = ["https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64"],
+)
+
+http_file(
+    name = "jq_linux_s390x",
+    executable = True,
+    integrity = "sha256-hot8PKdCJKAt22EyYd38LkOxLart1etYNz29x/LF+SQ=",
+    urls = ["https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-s390x"],
 )
 
 http_file(

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -45,6 +45,7 @@ filegroup(
     srcs = select({
         "@platforms//cpu:arm64": ["@jq_linux_arm64//file"],
         "@platforms//cpu:x86_64": ["@jq_linux_amd64//file"],
+	"@platforms//cpu:s390x": ["@jq_linux_s390x//file"],
     }),
 )
 


### PR DESCRIPTION
Hello,

Please help in adding following changes to support s390x for Bazel.

1. jdk21 support.
2. jq support.
3. Python version upgrade as test run fails on s390x with 3.8 

Thanks and Regards,
Sangita

