### PR TITLE
RemoteExecutionService: conditionally download std{err,out}

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -101,6 +101,7 @@ import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.remote.salt.CacheSalt;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TempPathGenerator;
@@ -1228,13 +1229,15 @@ public class RemoteExecutionService {
     }
 
     FileOutErr outErr = action.getSpawnExecutionContext().getFileOutErr();
-
-    // Always download the action stdout/stderr.
     FileOutErr tmpOutErr = outErr.childOutErr();
-    List<ListenableFuture<Void>> outErrDownloads =
-        remoteCache.downloadOutErr(context, result.actionResult, tmpOutErr);
-    for (ListenableFuture<Void> future : outErrDownloads) {
-      downloadsBuilder.add(transform(future, (v) -> null, directExecutor()));
+
+    // Skip downloading the action stdout/stderr when remote_download_outputs=minimal and the action is successful.
+    if (remoteOptions.remoteOutputsMode != RemoteOutputsMode.MINIMAL || result.getExitCode() != 0) {
+      List<ListenableFuture<Void>> outErrDownloads =
+          remoteCache.downloadOutErr(context, result.actionResult, tmpOutErr);
+      for (ListenableFuture<Void> future : outErrDownloads) {
+        downloadsBuilder.add(transform(future, (v) -> null, directExecutor()));
+      }
     }
 
     ImmutableList<ListenableFuture<FileMetadata>> downloads = downloadsBuilder.build();

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -236,6 +236,41 @@ EOF
   expect_not_log "START.*: \[.*\] Executing genrule //a:foobar"
 }
 
+function test_downloads_minimal_skip_download_stderrout() {
+  # Test that action stderr and stdout are not downloaded when using
+  # --remote_download_minimal
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "foo",
+  srcs = [],
+  outs = ["foo.txt"],
+  cmd = """
+echo some_stdout
+echo some_stderr 1>&2
+touch $@
+""",
+)
+EOF
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:foo >& $TEST_log || fail "Failed to build //a:foo"
+
+  expect_log "some_stdout"
+  expect_log "some_stderr"
+
+  bazel clean
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_download_minimal \
+    //a:foo >& $TEST_log || fail "Failed to build //a:foo"
+
+  expect_not_log "some_stdout"
+  expect_not_log "some_stderr"
+}
+
 function setup_genrule_with_dep() {
   mkdir -p a
   cat > a/BUILD <<'EOF'


### PR DESCRIPTION
When Build without the Bytes is used, only download stderr and stdout
for failed actions.
