### PR TITLE
Use `+` instead of `^` to combine digests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
@@ -200,12 +200,6 @@ public interface ActionCache {
     /**
      * Computes an order-independent digest of action properties. This includes a map of client
      * environment variables and the non-default permissions for output artifacts of the action.
-     *
-     * <p>Note that as discussed in https://github.com/bazelbuild/bazel/issues/15660, using {@link
-     * DigestUtils#xor} to achieve order-independence is questionable in case it is possible that
-     * multiple string keys map to the same bytes when passed through {@link Fingerprint#addString}
-     * (due to lossy conversion from UTF-16 to UTF-8). We could instead use a sorted map, however
-     * changing the digest function would cause action cache misses across bazel versions.
      */
     private static byte[] digestActionProperties(
         Map<String, String> clientEnv, OutputPermissions outputPermissions) {
@@ -214,14 +208,14 @@ public interface ActionCache {
       for (Map.Entry<String, String> entry : clientEnv.entrySet()) {
         fp.addString(entry.getKey());
         fp.addString(entry.getValue());
-        result = DigestUtils.xor(result, fp.digestAndReset());
+        result = DigestUtils.combineUnordered(result, fp.digestAndReset());
       }
       // Add the permissions mode to the digest if it differs from the default.
       // This is a bit of a hack to save memory on entries which have the default permissions mode
       // and no client env.
       if (outputPermissions != OutputPermissions.READONLY) {
         fp.addInt(outputPermissions.getPermissionsMode());
-        result = DigestUtils.xor(result, fp.digestAndReset());
+        result = DigestUtils.combineUnordered(result, fp.digestAndReset());
       }
       return result;
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -78,7 +78,7 @@ public class CompactPersistentActionCache implements ActionCache {
 
   private static final int NO_INPUT_DISCOVERY_COUNT = -1;
 
-  private static final int VERSION = 16;
+  private static final int VERSION = 17;
 
   private static final class ActionMap extends PersistentMap<Integer, byte[]> {
     private final Clock clock;

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataDigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataDigestUtils.java
@@ -48,12 +48,6 @@ public final class MetadataDigestUtils {
   /**
    * Computes an order-independent digest from the given (path, metadata) pairs.
    *
-   * <p>Note that as discussed in https://github.com/bazelbuild/bazel/issues/15660, using {@link
-   * DigestUtils#xor} to achieve order-independence is questionable in case it is possible that
-   * multiple string keys map to the same bytes when passed through {@link Fingerprint#addString}
-   * (due to lossy conversion from UTF-16 to UTF-8). We expect however that paths are represented as
-   * latin1 bytes encoded as a string, so the concern does not apply.
-   *
    * @param mdMap A collection of (execPath, FileArtifactValue) pairs. Values may be null.
    */
   public static byte[] fromMetadata(Map<String, FileArtifactValue> mdMap) {
@@ -62,7 +56,7 @@ public final class MetadataDigestUtils {
     // instance for this computation to amortize its cost.
     Fingerprint fp = new Fingerprint();
     for (Map.Entry<String, FileArtifactValue> entry : mdMap.entrySet()) {
-      result = DigestUtils.xor(result, getDigest(fp, entry.getKey(), entry.getValue()));
+      result = DigestUtils.combineUnordered(result, getDigest(fp, entry.getKey(), entry.getValue()));
     }
     return result;
   }

--- a/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
@@ -225,15 +225,24 @@ public class DigestUtils {
     return digest;
   }
 
-  /** Compute lhs ^= rhs bitwise operation of the arrays. May clobber either argument. */
-  public static byte[] xor(byte[] lhs, byte[] rhs) {
+  /**
+   * Combines two digests into one such that swapping the arguments results in the same result. May
+   * clobber either argument.
+   */
+  public static byte[] combineUnordered(byte[] lhs, byte[] rhs) {
     int n = rhs.length;
     if (lhs.length >= n) {
       for (int i = 0; i < n; i++) {
-        lhs[i] ^= rhs[i];
+        // Use + as in Guava's Hashing.combineUnordered.
+        // This has a number of advantages over XOR, which was used in the past:
+        // * Identical inputs will not cancel each other out.
+        // * Due to the carry, addition isn't a linear operation on the level of bit vectors.
+        //   This prevents adversaries from producing linear combinations (i.e., subsets of input
+        //   sets) that collide with other inputs.
+        lhs[i] += rhs[i];
       }
       return lhs;
     }
-    return xor(rhs, lhs);
+    return combineUnordered(rhs, lhs);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
@@ -15,12 +15,8 @@ package com.google.devtools.build.lib.vfs;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.devtools.build.lib.testutil.TestThread;
-import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Test;
@@ -34,67 +30,6 @@ public final class DigestUtilsTest {
   @After
   public void tearDown() {
     DigestUtils.configureCache(/*maximumSize=*/ 0);
-  }
-
-  private static void assertDigestCalculationConcurrency(
-      boolean expectConcurrent,
-      boolean fastDigest,
-      int fileSize1,
-      int fileSize2,
-      DigestHashFunction hf)
-      throws Exception {
-    CountDownLatch barrierLatch = new CountDownLatch(2); // Used to block test threads.
-    CountDownLatch readyLatch = new CountDownLatch(1); // Used to block main thread.
-
-    FileSystem myfs =
-        new InMemoryFileSystem(hf) {
-          @Override
-          protected byte[] getDigest(PathFragment path) throws IOException {
-            try {
-              barrierLatch.countDown();
-              readyLatch.countDown();
-              // Either both threads will be inside getDigest at the same time or they
-              // both will be blocked.
-              barrierLatch.await();
-            } catch (Exception e) {
-              throw new IOException(e);
-            }
-            return super.getDigest(path);
-          }
-
-          @Override
-          protected byte[] getFastDigest(PathFragment path) throws IOException {
-            return fastDigest ? super.getDigest(path) : null;
-          }
-        };
-
-    Path myFile1 = myfs.getPath("/f1.dat");
-    Path myFile2 = myfs.getPath("/f2.dat");
-    FileSystemUtils.writeContentAsLatin1(myFile1, "a".repeat(fileSize1));
-    FileSystemUtils.writeContentAsLatin1(myFile2, "b".repeat(fileSize2));
-
-    TestThread thread1 =
-        new TestThread(
-            () -> {
-              var unused = DigestUtils.getDigestWithManualFallback(myFile1, SyscallCache.NO_CACHE);
-            });
-    TestThread thread2 =
-        new TestThread(
-            () -> {
-              var unused = DigestUtils.getDigestWithManualFallback(myFile2, SyscallCache.NO_CACHE);
-            });
-     thread1.start();
-     thread2.start();
-     if (!expectConcurrent) { // Synchronized case.
-      // Wait until at least one thread reached getDigest().
-      assertThat(readyLatch.await(TestUtils.WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
-      // Only 1 thread should be inside getDigest().
-      assertThat(barrierLatch.getCount()).isEqualTo(1);
-       barrierLatch.countDown(); // Release barrier latch, allowing both threads to proceed.
-     }
-     // Test successful execution within 5 seconds.
-     thread1.joinAndAssertState(TestUtils.WAIT_TIMEOUT_MILLISECONDS);
-     thread2.joinAndAssertState(TestUtils.WAIT_TIMEOUT_MILLISECONDS);
   }
 
   @Test
@@ -158,5 +93,20 @@ public final class DigestUtilsTest {
     FileSystemUtils.writeContentAsLatin1(file, "contents");
 
     assertThat(DigestUtils.manuallyComputeDigest(file)).isEqualTo(digest);
+  }
+
+  @Test
+  public void combineUnordered_commutative() {
+    byte[] a = {1, 2, 3};
+    byte[] b = {4, 5, 6};
+    assertThat(DigestUtils.combineUnordered(a.clone(), b.clone()))
+        .isEqualTo(DigestUtils.combineUnordered(b.clone(), a.clone()));
+  }
+
+  @Test
+  public void combineUnordered_noCancellation() {
+    byte[] a = {1, 2, 3};
+    assertThat(DigestUtils.combineUnordered(a.clone(), a.clone()))
+        .isNotEqualTo(new byte[] {0, 0, 0});
   }
 }


### PR DESCRIPTION
Use + as in Guava's Hashing.combineUnordered. This has a number of advantages over XOR, which was used in the past:
* Identical inputs will not cancel each other out.
* Due to the carry, addition isn't a linear operation on the level of bit vectors. This prevents adversaries from producing linear combinations (i.e., subsets of input sets) that collide with other inputs.

Also removes an unused test helper.

Fixes #15660