### PR TITLE
Be resilient to outdated exec paths in action cache entries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/PackageIdentifier.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/PackageIdentifier.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.skyframe.SkyKey.SkyKeyInterner;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import java.io.IOException;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -88,8 +89,11 @@ public final class PackageIdentifier implements SkyKey, Comparable<PackageIdenti
    *
    * In this case, this method returns a package identifier for foo/bar, even though that is not a
    * package. Callers need to look up the actual package if needed.
+   *
+   * <p>Returns {@link Optional#empty()} if the path corresponds to an invalid label (e.g. with a
+   * malformed repo name).
    */
-  public static PackageIdentifier discoverFromExecPath(
+  public static Optional<PackageIdentifier> discoverFromExecPath(
       PathFragment execPath, boolean forFiles, boolean siblingRepositoryLayout) {
     Preconditions.checkArgument(!execPath.isAbsolute(), execPath);
     PathFragment tofind =
@@ -104,10 +108,15 @@ public final class PackageIdentifier implements SkyKey, Comparable<PackageIdenti
     if (tofind.startsWith(prefix)) {
       // Using the path prefix can be either "external" or "..", depending on whether the sibling
       // repository layout is used.
-      RepositoryName repository = RepositoryName.createUnvalidated(tofind.getSegment(1));
-      return PackageIdentifier.create(repository, tofind.subFragment(2));
+      try {
+        RepositoryName repository = RepositoryName.create(tofind.getSegment(1));
+        return Optional.of(PackageIdentifier.create(repository, tofind.subFragment(2)));
+      } catch (LabelSyntaxException e) {
+        // The path corresponds to an invalid label.
+        return Optional.empty();
+      }
     } else {
-      return PackageIdentifier.createInMainRepo(tofind);
+      return Optional.of(PackageIdentifier.createInMainRepo(tofind));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -22,7 +22,6 @@ import com.google.devtools.build.lib.actions.ArtifactResolver;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
-import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
@@ -32,6 +31,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -178,10 +178,13 @@ final class HeaderDiscovery {
       }
       Artifact artifact = regularDerivedArtifacts.get(execPathFragment);
       if (artifact == null) {
-        RepositoryName repository =
-            PackageIdentifier.discoverFromExecPath(execPathFragment, false, siblingRepositoryLayout)
-                .getRepository();
-        artifact = artifactResolver.resolveSourceArtifact(execPathFragment, repository);
+        Optional<PackageIdentifier> pkgId =
+            PackageIdentifier.discoverFromExecPath(
+                execPathFragment, false, siblingRepositoryLayout);
+        if (pkgId.isPresent()) {
+          artifact =
+              artifactResolver.resolveSourceArtifact(execPathFragment, pkgId.get().getRepository());
+        }
       }
       if (artifact != null) {
         // We don't need to add the sourceFile itself as it is a mandatory input.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -113,6 +113,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntFunction;
@@ -728,11 +729,13 @@ public final class ActionExecutionFunction implements SkyFunction {
         PathFragment parent =
             checkNotNull(path.getParentDirectory(), "Must pass in files, not root directory");
         checkArgument(!parent.isAbsolute(), path);
-        ContainingPackageLookupValue.Key depKey =
-            ContainingPackageLookupValue.key(
-                PackageIdentifier.discoverFromExecPath(path, true, siblingRepositoryLayout));
-        depKeys.put(path, depKey);
-        packageLookupsRequested.add(depKey);
+        Optional<PackageIdentifier> pkgId =
+            PackageIdentifier.discoverFromExecPath(path, true, siblingRepositoryLayout);
+        if (pkgId.isPresent()) {
+          ContainingPackageLookupValue.Key depKey = ContainingPackageLookupValue.key(pkgId.get());
+          depKeys.put(path, depKey);
+          packageLookupsRequested.add(depKey);
+        }
       }
 
       SkyframeLookupResult values = env.getValuesAndExceptions(depKeys.values());


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/commit/60924fdc2972184494f6382d39e8c786aa14b9a9 changed the canonical repo name separator from `~` to `+`. Older repo names containing `~` now trigger a syntax error. If an action cache entry refers to an exec path from a previous version of Bazel that used `~`, we need to be resilient and treat the cache entry as corrupted, rather than just crash.

Fixes https://github.com/bazelbuild/bazel/issues/23180.