### PR TITLE
Remove 4 no-op CLI flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -252,19 +252,6 @@ public class RepositoryOptions extends OptionsBase {
   public CheckDirectDepsMode checkDirectDependencies;
 
   @Option(
-      name = "experimental_repository_cache_urls_as_default_canonical_id",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      metadataTags = OptionMetadataTag.DEPRECATED,
-      effectTags = {OptionEffectTag.NO_OP},
-      deprecationWarning =
-          "This behavior is enabled by default for http_* and jvm_* rules and no "
-              + "longer controlled by this flag. Use "
-              + "--repo_env=BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID=0 to disable it instead.",
-      help = "No-op.")
-  public boolean urlsAsDefaultCanonicalId;
-
-  @Option(
       name = "experimental_check_external_repository_files",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -354,16 +354,6 @@ public final class BazelRulesModule extends BlazeModule {
 
     @Deprecated
     @Option(
-        name = "direct_run",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED},
-        help = "Deprecated no-op.")
-    public boolean directRun;
-
-    @Deprecated
-    @Option(
         name = "glibc",
         defaultValue = "null",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfiguration.java
@@ -44,24 +44,6 @@ public class BazelPythonConfiguration extends Fragment {
   /** Bazel-specific Python configuration options. */
   public static final class Options extends FragmentOptions {
     @Option(
-        name = "python2_path",
-        defaultValue = "null",
-        documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED},
-        help = "Deprecated, no-op. Disabled by `--incompatible_use_python_toolchains`.")
-    public String python2Path;
-
-    @Option(
-        name = "python3_path",
-        defaultValue = "null",
-        documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED},
-        help = "Deprecated, no-op. Disabled by `--incompatible_use_python_toolchains`.")
-    public String python3Path;
-
-    @Option(
         name = "python_top",
         converter = LabelConverter.class,
         defaultValue = "null",
@@ -115,18 +97,6 @@ public class BazelPythonConfiguration extends Fragment {
     Options opts = buildOptions.get(Options.class);
     if (pythonOpts.incompatibleUsePythonToolchains) {
       // Forbid deprecated flags.
-      if (opts.python2Path != null) {
-        reporter.handle(
-            Event.error(
-                "`--python2_path` is disabled by `--incompatible_use_python_toolchains`. Since "
-                    + "`--python2_path` is a deprecated no-op, there is no need to pass it."));
-      }
-      if (opts.python3Path != null) {
-        reporter.handle(
-            Event.error(
-                "`--python3_path` is disabled by `--incompatible_use_python_toolchains`. Since "
-                    + "`--python3_path` is a deprecated no-op, there is no need to pass it."));
-      }
       if (opts.pythonTop != null) {
         reporter.handle(
             Event.error(

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -179,8 +179,6 @@ bazel_fragments["BazelConfigurarion$Options"] = fragment(
 
 bazel_fragments["BazelPythonConfiguration$Options"] = fragment(
     propagate = [
-        "//command_line_option:python2_path",
-        "//command_line_option:python3_path",
         "//command_line_option:python_top",
         "//command_line_option:python_path",
         "//command_line_option:experimental_python_import_all_repositories",

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfigurationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonConfigurationTest.java
@@ -66,14 +66,6 @@ public class BazelPythonConfigurationTest extends ConfigurationTestCase {
   @Test
   public void legacyFlagsDeprecatedByPythonToolchains() throws Exception {
     checkError(
-        "`--python2_path` is disabled by `--incompatible_use_python_toolchains`",
-        "--incompatible_use_python_toolchains=true",
-        "--python2_path=/system/python2");
-    checkError(
-        "`--python3_path` is disabled by `--incompatible_use_python_toolchains`",
-        "--incompatible_use_python_toolchains=true",
-        "--python3_path=/system/python3");
-    checkError(
         "`--python_top` is disabled by `--incompatible_use_python_toolchains`",
         "--incompatible_use_python_toolchains=true",
         "--python_top=//mypkg:my_py_runtime");


### PR DESCRIPTION
- `--experimental_repository_cache_urls_as_default_canonical_id`
  Documented as no-op from v7.
- `--python2_path` and `--python3_path`
  Documented as no-op from v0.25.0.
- `--direct_run`
  Documented as no-op from v0.15.0

All show no signs of usage in the Bazel codebase in current `master` (v8).