### PR TITLE
Add configuration hash to trace profile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.profiler.PredicateBasedStatRecorder.Recorde
 import com.google.devtools.build.lib.profiler.StatRecorder.VfsHeuristics;
 import com.google.gson.stream.JsonWriter;
 import com.sun.management.OperatingSystemMXBean;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
@@ -197,7 +198,7 @@ public final class Profiler {
           // Primary outputs are non-mergeable, thus incompatible with slim profiles.
           jsonWriter.name("out").value(actionTaskData.primaryOutputPath);
         }
-        if (actionTaskData.targetLabel != null || actionTaskData.mnemonic != null) {
+        if (actionTaskData.targetLabel != null || actionTaskData.mnemonic != null || actionTaskData.configuration != null) {
           jsonWriter.name("args");
           jsonWriter.beginObject();
           if (actionTaskData.targetLabel != null) {
@@ -205,6 +206,9 @@ public final class Profiler {
           }
           if (actionTaskData.mnemonic != null) {
             jsonWriter.name("mnemonic").value(actionTaskData.mnemonic);
+          }
+          if (actionTaskData.configuration != null) {
+            jsonWriter.name("configuration").value(actionTaskData.configuration);
           }
           jsonWriter.endObject();
         }
@@ -234,6 +238,7 @@ public final class Profiler {
     @Nullable final String primaryOutputPath;
     @Nullable final String targetLabel;
     @Nullable final String mnemonic;
+    @Nullable final String configuration;
 
     ActionTaskData(
         long threadId,
@@ -243,11 +248,13 @@ public final class Profiler {
         @Nullable String mnemonic,
         String description,
         @Nullable String primaryOutputPath,
-        @Nullable String targetLabel) {
+        @Nullable String targetLabel,
+        @Nullable String configuration) {
       super(threadId, startTimeNanos, durationNanos, eventType, description);
       this.primaryOutputPath = primaryOutputPath;
       this.targetLabel = targetLabel;
       this.mnemonic = mnemonic;
+      this.configuration = configuration;
     }
   }
 
@@ -337,6 +344,7 @@ public final class Profiler {
   private boolean collectTaskHistograms;
   private boolean includePrimaryOutput;
   private boolean includeTargetLabel;
+  private boolean includeConfiguration;
 
   private Profiler() {
     actionCountTimeSeriesRef = new AtomicReference<>();
@@ -444,6 +452,7 @@ public final class Profiler {
       boolean slimProfile,
       boolean includePrimaryOutput,
       boolean includeTargetLabel,
+      boolean includeConfiguration,
       boolean collectTaskHistograms,
       LocalResourceCollector localResourceCollector)
       throws IOException {
@@ -463,6 +472,7 @@ public final class Profiler {
     this.collectTaskHistograms = collectTaskHistograms;
     this.includePrimaryOutput = includePrimaryOutput;
     this.includeTargetLabel = includeTargetLabel;
+    this.includeConfiguration = includeConfiguration;
     this.recordAllDurations = recordAllDurations;
 
     JsonTraceFileWriter writer = null;
@@ -811,7 +821,8 @@ public final class Profiler {
       String mnemonic,
       String description,
       String primaryOutput,
-      String targetLabel) {
+      String targetLabel,
+      String configuration) {
     checkNotNull(description);
     if (isActive() && isProfiling(type)) {
       final long startTimeNanos = clock.nanoTime();
@@ -825,7 +836,8 @@ public final class Profiler {
               description,
               mnemonic,
               includePrimaryOutput ? primaryOutput : null,
-              includeTargetLabel ? targetLabel : null);
+              includeTargetLabel ? targetLabel : null,
+              includeConfiguration ? configuration : null);
         } finally {
           releaseLane(lane);
         }
@@ -833,11 +845,6 @@ public final class Profiler {
     } else {
       return NOP;
     }
-  }
-
-  public SilentCloseable profileAction(
-      ProfilerTask type, String description, String primaryOutput, String targetLabel) {
-    return profileAction(type, /* mnemonic= */ null, description, primaryOutput, targetLabel);
   }
 
   private static final SilentCloseable NOP = () -> {};
@@ -874,7 +881,8 @@ public final class Profiler {
       String description,
       String mnemonic,
       @Nullable String primaryOutput,
-      @Nullable String targetLabel) {
+      @Nullable String targetLabel,
+      @Nullable String configuration) {
     if (isActive()) {
       long endTimeNanos = clock.nanoTime();
       long duration = endTimeNanos - startTimeNanos;
@@ -889,7 +897,8 @@ public final class Profiler {
                 mnemonic,
                 description,
                 primaryOutput,
-                targetLabel));
+                targetLabel,
+                configuration));
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/profiler/TraceEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/TraceEvent.java
@@ -44,7 +44,8 @@ public abstract class TraceEvent {
       @Nullable ImmutableMap<String, Object> args,
       @Nullable String primaryOutputPath,
       @Nullable String targetLabel,
-      @Nullable String mnemonic) {
+      @Nullable String mnemonic,
+      @Nullable String configuration) {
     return new AutoValue_TraceEvent(
         category,
         name,
@@ -56,7 +57,8 @@ public abstract class TraceEvent {
         args,
         primaryOutputPath,
         targetLabel,
-        mnemonic);
+        mnemonic,
+        configuration);
   }
 
   @Nullable
@@ -90,6 +92,9 @@ public abstract class TraceEvent {
   @Nullable
   public abstract String mnemonic();
 
+  @Nullable
+  public abstract String configuration();
+
   private static TraceEvent createFromJsonReader(JsonReader reader) throws IOException {
     String category = null;
     String name = null;
@@ -101,6 +106,7 @@ public abstract class TraceEvent {
     String targetLabel = null;
     String mnemonic = null;
     String type = null;
+    String configuration = null;
     ImmutableMap<String, Object> args = null;
 
     reader.beginObject();
@@ -122,6 +128,8 @@ public abstract class TraceEvent {
           targetLabel = target instanceof String ? (String) target : null;
           Object mnemonicValue = args.get("mnemonic");
           mnemonic = mnemonicValue instanceof String ? (String) mnemonicValue : null;
+          Object configurationValue = args.get("configuration");
+          configuration = configurationValue instanceof String ? (String) configurationValue : null;
         }
         default -> reader.skipValue();
       }
@@ -138,7 +146,8 @@ public abstract class TraceEvent {
         args,
         primaryOutputPath,
         targetLabel,
-        mnemonic);
+        mnemonic,
+        configuration);
   }
 
   private static ImmutableMap<String, Object> parseMap(JsonReader reader) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -419,6 +419,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
             commandOptions.slimProfile,
             commandOptions.includePrimaryOutput,
             commandOptions.profileIncludeTargetLabel,
+            commandOptions.profileIncludeTargetConfiguration,
             commandOptions.alwaysProfileSlowOperations,
             new CollectLocalResourceUsage(
                 bugReporter,

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -258,6 +258,14 @@ public class CommonCommandOptions extends OptionsBase {
   public boolean profileIncludeTargetLabel;
 
   @Option(
+      name = "experimental_profile_include_target_configuration",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.BAZEL_MONITORING},
+      help = "Includes target configuration hash in action events' JSON profile data.")
+  public boolean profileIncludeTargetConfiguration;
+
+  @Option(
       name = "profile",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.LOGGING,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -1020,7 +1020,8 @@ public final class SkyframeActionExecutor {
               action.getMnemonic(),
               action.describe(),
               action.getPrimaryOutput().getExecPathString(),
-              getOwnerLabelAsString(action))) {
+              getOwnerLabelAsString(action),
+              getOwnerConfigurationAsString(action))) {
         String message = action.getProgressMessage();
         if (message != null) {
           reporter.startTask(null, prependExecPhaseStats(message));
@@ -1087,6 +1088,14 @@ public final class SkyframeActionExecutor {
         return "";
       }
       return ownerLabel.getCanonicalForm();
+    }
+
+    private String getOwnerConfigurationAsString(Action action) {
+        ActionOwner owner = action.getOwner();
+        if (owner == null) {
+            return "";
+        }
+        return owner.getConfigurationChecksum();
     }
 
     private void notifyActionCompletion(

--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
@@ -413,6 +413,7 @@ public class BlazeRuntimeWrapper {
             /* slimProfile= */ false,
             /* includePrimaryOutput= */ false,
             /* includeTargetLabel= */ false,
+            /* includeConfiguration= */ false,
             /* collectTaskHistograms= */ true,
             new CollectLocalResourceUsage(
                 runtime.getBugReporter(),


### PR DESCRIPTION
Similar to the target label and mnemonic, allow storing the configuration hash in the action trace data