### PR TITLE
Fixing issue 21741: Modifying reference documentation

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
@@ -119,10 +119,36 @@ most build rules</a>.
    and that rule's <code>outs</code> are automatically added to
    this <code>cc_library</code>'s data files.
 </p>
-<p>Your C++ code can access these data files like so:</p>
+<p>Using the functionality defined by the <code>runfiles_src.h</code> located under 
+   <code>tools/cpp/runfiles/runfiles_src.h</code> Your C++ code can access these data files,
+   like so:
+</p>
 <pre><code class="lang-starlark">
-  const std::string path = devtools_build::GetDataDependencyFilepath(
-      "my/test/data/file");
+  
+  #include "runfiles_src.h"
+
+  int main(int argc, char** argv) {
+    
+    try {
+
+    using bazel::tools::cpp::runfiles::Runfiles;
+    
+    std::string error;
+    std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY, &error));
+    
+    // "cpp_example" is the WORKSPACE name attribute
+    // "data/example.json" is the path relative from the project root
+
+    std::string path = runfiles->Rlocation("cpp_example/data/example.json");
+    
+    //...
+    
+    } catch (const std::exception& e) {
+    	// ...
+    }
+
+    return 0;
+  }
 </code></pre>
 """,
     ),

--- a/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
@@ -120,7 +120,8 @@ most build rules</a>.
    this <code>cc_library</code>'s data files.
 </p>
 <p>Using the functionality defined by the <code>runfiles.h</code> located under 
-   <code>tools/cpp/runfiles/runfiles_src.h</code> Your C++ code can access these data files,
+   <code>tools/cpp/runfiles/runfiles.h</code>. This header is provided by the following target
+   <code>@bazel_tools//cpp/runfiles:runfiles</code> Your C++ code can access these data files,
    like so:
 </p>
 <pre><code class="lang-starlark">

--- a/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
@@ -119,13 +119,13 @@ most build rules</a>.
    and that rule's <code>outs</code> are automatically added to
    this <code>cc_library</code>'s data files.
 </p>
-<p>Using the functionality defined by the <code>runfiles_src.h</code> located under 
+<p>Using the functionality defined by the <code>runfiles.h</code> located under 
    <code>tools/cpp/runfiles/runfiles_src.h</code> Your C++ code can access these data files,
    like so:
 </p>
 <pre><code class="lang-starlark">
   
-  #include "runfiles_src.h"
+  #include "tools/cpp/runfiles/runfiles.h"
 
   int main(int argc, char** argv) {
     
@@ -136,7 +136,7 @@ most build rules</a>.
     std::string error;
     std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY, &error));
     
-    // "cpp_example" is the WORKSPACE name attribute
+    // "cpp_example" is the module name attribute
     // "data/example.json" is the path relative from the project root
 
     std::string path = runfiles->Rlocation("cpp_example/data/example.json");

--- a/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
@@ -120,7 +120,8 @@ most build rules</a>.
    this <code>cc_library</code>'s data files.
 </p>
 <p>The functionality of locating data files (runfiles) at runtime in Bazel-built 
-C++ binaries is provided by runfiles.h.
+C++ binaries is provided by <a href="https://github.com/bazelbuild/rules_cc/blob/main/cc/runfiles/runfiles.h">runfiles.h.</a>.
+The functionality are documented inside the header file.
 </p>
 """,
     ),

--- a/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
@@ -119,38 +119,9 @@ most build rules</a>.
    and that rule's <code>outs</code> are automatically added to
    this <code>cc_library</code>'s data files.
 </p>
-<p>Using the functionality defined by the <code>runfiles.h</code> located under 
-   <code>tools/cpp/runfiles/runfiles.h</code>. This header is provided by the following target
-   <code>@bazel_tools//cpp/runfiles:runfiles</code> Your C++ code can access these data files,
-   like so:
+<p>The functionality of locating data files (runfiles) at runtime in Bazel-built 
+C++ binaries is provided by runfiles.h.
 </p>
-<pre><code class="lang-starlark">
-  
-  #include "tools/cpp/runfiles/runfiles.h"
-
-  int main(int argc, char** argv) {
-    
-    try {
-
-    using bazel::tools::cpp::runfiles::Runfiles;
-    
-    std::string error;
-    std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY, &error));
-    
-    // "cpp_example" is the module name attribute
-    // "data/example.json" is the path relative from the project root
-
-    std::string path = runfiles->Rlocation("cpp_example/data/example.json");
-    
-    //...
-    
-    } catch (const std::exception& e) {
-    	// ...
-    }
-
-    return 0;
-  }
-</code></pre>
 """,
     ),
     "includes": attr.string_list(doc = """

--- a/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
@@ -121,7 +121,7 @@ most build rules</a>.
 </p>
 <p>The functionality of locating data files (runfiles) at runtime in Bazel-built 
 C++ binaries is provided by <a href="https://github.com/bazelbuild/rules_cc/blob/main/cc/runfiles/runfiles.h">runfiles.h.</a>.
-The functionality are documented inside the header file.
+The functionality is documented inside the header file.
 </p>
 """,
     ),


### PR DESCRIPTION
Fixes #21741 

Changing the [reference documentation](https://bazel.build/contribute/docs). Fix was first tested in private project, based on  the comments contained in [runfiles_src.h](https://github.com/bazelbuild/bazel/blob/master/tools/cpp/runfiles/runfiles_src.h). Related to comments of issue #11212.
