### PR TITLE
Warn if a module extension produces an invalid lockfile entry

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -19,6 +19,7 @@ import static com.google.common.base.StandardSystemProperty.OS_ARCH;
 import static com.google.common.collect.ImmutableBiMap.toImmutableBiMap;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.stream.Collectors.joining;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Splitter;
@@ -205,6 +206,22 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     Optional<ModuleExtensionMetadata> moduleExtensionMetadata =
         moduleExtensionResult.getModuleExtensionMetadata();
 
+    if (!lockfileMode.equals(LockfileMode.OFF)) {
+      var nonVisibleRepoNames =
+          moduleExtensionResult.getRecordedRepoMappingEntries().values().stream()
+              .filter(repoName -> !repoName.isVisible())
+              .map(RepositoryName::toString)
+              .collect(joining(", "));
+      if (!nonVisibleRepoNames.isEmpty()) {
+        env.getListener()
+            .handle(
+                Event.warn(
+                    String.format(
+                        "The module extension %s produced an invalid lockfile entry because it"
+                            + " referenced %s. Please report this issue to its maintainers.",
+                        extensionId.asTargetString(), nonVisibleRepoNames)));
+      }
+    }
     if (lockfileMode.equals(LockfileMode.ERROR)) {
       boolean extensionShouldHaveBeenLocked =
           moduleExtensionMetadata.map(metadata -> !metadata.getReproducible()).orElse(true);


### PR DESCRIPTION
Lockfile entries that record repo mapping usages for invalid repo names are always invalid. They can lead to confusing situations where updating the lockfile doesn't result in changes, yet running in `error` mode fails with an error saying that the lockfile is not up to date.

Instead, show a warning such as the following that users can forward to the extensions maintainers:
```
WARNING: The module extension @@rules_rust+//rust/private:extensions.bzl%i produced an invalid lockfile entry because it referenced @@[unknown repo 'cui__url-2.5.2' requested from @@rules_rust+]. Please report this issue to its maintainers.
```

Context: https://bazelbuild.slack.com/archives/C014RARENH0/p1723132195268549