### PR TITLE
Filter files early in bytestream uploader to avoid redundant work and double handling

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -389,14 +389,14 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
                 entry -> {
                   Path path = entry.getKey();
 
-                  // If this a test log? (regex needed as `test_log` not tagged as logs)
+                  // Is this a test log? (regex needed as `test_log` not tagged as logs)
                   if (TEST_LOG_PATTERN.matcher(path.getPathString()).matches()) {
                     return true;
                   }
 
                   LocalFile file = entry.getValue();
 
-                  // If this a log?
+                  // Is this a log?
                   if (file.type == LocalFileType.LOG || file.type == LocalFileType.PERFORMANCE_LOG) {
                     return true;
                   }

--- a/src/main/java/com/google/devtools/build/lib/runtime/NamedArtifactGroup.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/NamedArtifactGroup.java
@@ -108,6 +108,9 @@ class NamedArtifactGroup implements BuildEvent {
       if (expandedArtifact.relPath == null) {
         String uri =
             pathConverter.apply(completionContext.pathResolver().toPath(expandedArtifact.artifact));
+        if (uri == null) {
+          continue;
+        }
         BuildEventStreamProtos.File file =
             newFileFromArtifact(
                 /* name= */ null, expandedArtifact.artifact, completionContext, uri);
@@ -119,6 +122,9 @@ class NamedArtifactGroup implements BuildEvent {
         String uri =
             pathConverter.apply(
                 completionContext.pathResolver().convertPath(expandedArtifact.target));
+        if (uri == null) {
+          continue;
+        }
         BuildEventStreamProtos.File file =
             newFileFromArtifact(
                 /* name= */ null,

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assert_;
 import static org.junit.Assume.assumeNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -188,7 +189,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     for (Path file : filesToUpload.keySet()) {
@@ -197,6 +198,60 @@ public class ByteStreamBuildEventArtifactUploaderTest {
       String conversion = pathConverter.apply(file);
       assertThat(conversion)
           .isEqualTo("bytestream://localhost/instance/blobs/" + hash + "/" + size);
+    }
+
+    artifactUploader.release();
+
+    assertThat(remoteCache.refCnt()).isEqualTo(0);
+    assertThat(refCntChannel.isShutdown()).isTrue();
+  }
+
+  
+  @Test
+  public void uploadsShouldWorkWithMinimalMode() throws Exception {
+    int numUploads = 2;
+    Map<HashCode, byte[]> blobsByHash = new HashMap<>();
+    Map<Path, LocalFile> filesToUpload = new HashMap<>();
+    Random rand = new Random();
+    for (LocalFileType localFileType : new LocalFileType[]{ LocalFileType.OUTPUT, LocalFileType.LOG }) {
+      Path file = fs.getPath("/file" + localFileType.name());
+      OutputStream out = file.getOutputStream();
+      int blobSize = rand.nextInt(100) + 1;
+      byte[] blob = new byte[blobSize];
+      rand.nextBytes(blob);
+      out.write(blob);
+      out.close();
+      blobsByHash.put(HashCode.fromString(DIGEST_UTIL.compute(file).getHash()), blob);
+      filesToUpload.put(
+          file,
+          new LocalFile(
+              file, localFileType, /* artifact= */ null, /* artifactMetadata= */ null));
+    }
+    serviceRegistry.addService(new MaybeFailOnceUploadService(blobsByHash));
+
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
+    ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
+    RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.MINIMAL);
+
+    PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
+    for (LocalFile file : filesToUpload.values()) {
+      if (file.type == LocalFileType.OUTPUT) {
+        try {
+          pathConverter.apply(file.path);
+          assert_().withMessage("Expected exception to be thrown.").fail();
+        } catch (IllegalStateException e) {
+          assertThat(e.getMessage())
+            .isEqualTo(String.format("Illegal file reference: '%s'", file.path.getPathString()));
+        }
+      } else {
+        String hash = BaseEncoding.base16().lowerCase().encode(file.path.getDigest());
+        long size = file.path.getFileSize();
+        String conversion = pathConverter.apply(file.path);
+        assertThat(conversion)
+            .isEqualTo("bytestream://localhost/instance/blobs/" + hash + "/" + size);
+      }
     }
 
     artifactUploader.release();
@@ -232,7 +287,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     // number of permits is less than number of uploads to affirm permit is released
     RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     for (Path file : filesToUpload.keySet()) {
@@ -264,7 +319,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     assertThat(pathConverter.apply(dir)).isNull();
@@ -283,7 +338,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     assertThat(pathConverter.apply(sym)).isNull();
@@ -303,7 +358,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     String hash = BaseEncoding.base16().lowerCase().encode(file.getDigest());
@@ -329,7 +384,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     String hash = BaseEncoding.base16().lowerCase().encode(file.getDigest());
@@ -369,7 +424,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     assertThat(pathConverter.apply(dir)).isNull();
@@ -442,7 +497,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     artifactUploader.upload(filesToUpload).get();
 
@@ -468,7 +523,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     RemoteCache remoteCache = spy(newRemoteCache(refCntChannel, retrier));
     RemoteActionInputFetcher actionInputFetcher = mock(RemoteActionInputFetcher.class);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     ActionInputMap outputs = new ActionInputMap(2);
     Artifact artifact = createRemoteArtifact("file1.txt", "foo", outputs);
@@ -530,7 +585,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     doAnswer(invocationOnMock -> Futures.immediateFuture(null))
         .when(remoteCache)
         .uploadFile(any(), any(), any());
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache, RemoteBuildEventUploadMode.ALL);
 
     // act
     Map<Path, LocalFile> files =
@@ -598,7 +653,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     return new RemoteCache(cacheClient, remoteOptions, DIGEST_UTIL);
   }
 
-  private ByteStreamBuildEventArtifactUploader newArtifactUploader(RemoteCache remoteCache) {
+  private ByteStreamBuildEventArtifactUploader newArtifactUploader(
+      RemoteCache remoteCache, RemoteBuildEventUploadMode remoteBuildEventUploadMode) {
 
     return new ByteStreamBuildEventArtifactUploader(
         MoreExecutors.directExecutor(),
@@ -610,7 +666,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         /* buildRequestId= */ "none",
         /* commandId= */ "none",
         SyscallCache.NO_CACHE,
-        RemoteBuildEventUploadMode.ALL);
+        remoteBuildEventUploadMode);
   }
 
   private static class StaticMissingDigestsFinder implements MissingDigestsFinder {


### PR DESCRIPTION
Re-implementation of #20575 and a test case for minimal mode.

In this PR;
* Paths affected by `--remote_build_event_upload=minimal` (default) are treated similar to those affected by the tag `no-remote-cache` (they are omitted).
  The actual paths are still resolvable by the returned resolver (`bytestream://` URIs that do not reflect an uploaded asset are intended, as per discussion in #16999)
* Latter paths skip file kind checks, since the information is only needed to upload and has overhead.
* Made calling `isDirectory` and `isSymlink` on an omitted file an error (they would otherwise return `false`, which is technically incorrect).

This should improve performance. Benchmarking (in Bazel v6) has shown 54% of a Bazel profile for a fully cached build is spent in `readPathMetadata`.

The test case in this PR appears to be the _only_ such test for minimal mode (at least in Java code).

Fixes #20576

## TODO

- [ ] Run new test case against current implementation to ensure no behaviour differences (and if there are, that the new behaviour is intended).
- [x] Give `PathConverterImpl` the full list of files, while only a subset is uploaded under minimal they paths are still needed for protos.
- [ ] Apply optimisations to all omitted files (e.g. `no-remote-cache` tagged)