### PR TITLE
ij/sync: fix by excluding :bazel_android_tools_test

### DIFF
--- a/scripts/ij.bazelproject
+++ b/scripts/ij.bazelproject
@@ -22,6 +22,7 @@ targets:
   # These tests require the Android SDK and enabling it in our WORKSPACE file.
   -//src/test/java/com/google/devtools/build/android/...
   -//src/test/shell/bazel/android/...
+  -//src/test/shell/bazel:bazel_android_tools_test
   # These tests cause the build to fail on macOS:
   # https://github.com/bazelbuild/bazel/issues/13636
   -//src/test/shell/bazel:all_tests


### PR DESCRIPTION
Out of the box, bazel sync on intellij fails with the following error:

```
ERROR: /private/var/tmp/_bazel_christian.s/fdbf284d3c76f6c92ce5c78320642a21/external/bazel_tools/tools/android/BUILD:14:27: While resolving toolchains for target @@bazel_tools//tools/android:android_jar (a5aa1aa): No matching toolchains found for types @@bazel_tools//tools/android:sdk_toolchain_type.
To debug, rerun with --toolchain_resolution_debug='@@bazel_tools//tools/android:sdk_toolchain_type'
If platforms or toolchains are a new concept for you, we'd encourage reading https://bazel.build/concepts/platforms-intro.
```

Excluding this target from the sync makes it work for me.