### PR TITLE
remount sys to make /sys/class/net consist with network namespace

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -406,12 +406,21 @@ static void MakeFilesystemMostlyReadOnly() {
   endmntent(mounts);
 }
 
-static void MountProc() {
+static void MountProcAndSys() {
   // Mount a new proc on top of the old one, because the old one still refers to
   // our parent PID namespace.
   if (mount("/proc", "/proc", "proc", MS_NODEV | MS_NOEXEC | MS_NOSUID,
             nullptr) < 0) {
-    DIE("mount");
+    DIE("mount /proc");
+  }
+
+  if(opt.create_netns == NO_NETNS) {
+        return;
+  }
+  //similar for sys, 
+  if (mount("none", "/sys", "sysfs", MS_NOEXEC|MS_NOSUID|MS_NODEV|MS_RDONLY,
+            nullptr) < 0) {
+    DIE("mount /sys");
   }
 }
 
@@ -688,13 +697,13 @@ int Pid1Main(void *args) {
     MountSandboxAndGoThere();
     CreateEmptyFile();
     MountDev();
-    MountProc();
+    MountProcAndSys();
     MountAllMounts();
     ChangeRoot();
   } else {
     MountFilesystems();
     MakeFilesystemMostlyReadOnly();
-    MountProc();
+    MountProcAndSys();
   }
   SetupNetworking();
   EnterWorkingDirectory();


### PR DESCRIPTION
similar to proc, without remount, sys still refer to parent namespace, device created inside namespace (tun for example) won't shown under /sys/class/net