### PR TITLE
[7.3.1] Fix expected lockfile version to change based on `--incompatible_use_plus_in_repo_names`

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -2597,6 +2597,12 @@ class BazelLockfileTest(test_base.TestBase):
     stderr = '\n'.join(stderr)
     self.assertIn('LAZYEVAL_KEY=None', stderr)
 
+  def testLockFileVersionIsCorrectWithUsePlusFlag(self):
+    self.RunBazel(['mod', 'graph', '--incompatible_use_plus_in_repo_names'])
+    self.RunBazel(['clean', '--expunge'])
+    self.RunBazel(['mod', 'graph', '--incompatible_use_plus_in_repo_names',
+                   '--lockfile_mode=error'])
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
We write a different lockfile version based on `--incompatible_use_plus_in_repo_names` (see HACK in `BazelLockFileModule.java`). But we don't _expect_ a different lockfile version based on that flag; this causes us to consider the lockfile _always_ out-of-date when that flag is set.

Fixes https://github.com/bazelbuild/bazel/issues/23279.