### PR TITLE
Implement `TEST_PREMATURE_EXIT_FILE`

### DIFF
--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -554,6 +554,34 @@ class BazelWindowsTest(test_base.TestBase):
         ['test', '--incompatible_check_sharding_support', '//:foo_test']
     )
 
+  def testTestPrematureExitFile(self):
+    self.ScratchFile(
+        'BUILD',
+        [
+            'sh_test(',
+            '  name = "foo_test",',
+            '  srcs = ["foo.sh"],',
+            ')',
+        ],
+    )
+    self.ScratchFile(
+         'foo.sh',
+         [
+            '#!/bin/sh',
+            'touch "$TEST_PREMATURE_EXIT_FILE"',
+            'echo "fake pass"',
+            'exit 0',
+         ],
+    )
+
+    exit_code, stdout, stderr = self.RunBazel(
+        ['test', '--test_output=errors', '//:foo_test'],
+        allow_failure=True,
+    )
+    # Check for "tests failed" exit code
+    self.AssertExitCode(exit_code, 3, stderr, stdout)
+    self.assertIn('-- Test exited prematurely (TEST_PREMATURE_EXIT_FILE exists) --', stderr)
+
   def testMakeVariableForDumpbinExecutable(self):
     if not self.IsWindows():
       return

--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -580,7 +580,7 @@ class BazelWindowsTest(test_base.TestBase):
     )
     # Check for "tests failed" exit code
     self.AssertExitCode(exit_code, 3, stderr, stdout)
-    self.assertIn('-- Test exited prematurely (TEST_PREMATURE_EXIT_FILE exists) --', stderr)
+    self.assertIn('-- Test exited prematurely (TEST_PREMATURE_EXIT_FILE exists) --', stdout)
 
   def testMakeVariableForDumpbinExecutable(self):
     if not self.IsWindows():

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -1097,4 +1097,23 @@ EOF
       //:x  &> $TEST_log || fail "expected success"
 }
 
+function test_premature_exit_file_checked() {
+  cat <<'EOF' > BUILD
+sh_test(
+    name = 'x',
+    srcs = ['x.sh'],
+)
+EOF
+  cat <<'EOF' > x.sh
+#!/bin/sh
+touch "$TEST_PREMATURE_EXIT_FILE"
+echo "fake pass"
+exit 0
+EOF
+  chmod +x x.sh
+
+  bazel test //:x --test_output=errors &> $TEST_log && fail "expected failure"
+  expect_log "-- Test exited prematurely (TEST_PREMATURE_EXIT_FILE exists) --"
+}
+
 run_suite "bazel test tests"

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3259,6 +3259,29 @@ EOF
       //:x  &> $TEST_log || fail "expected success"
 }
 
+function test_premature_exit_file_checked_remote_download_minimal() {
+  cat <<'EOF' > BUILD
+sh_test(
+    name = 'x',
+    srcs = ['x.sh'],
+)
+EOF
+  cat <<'EOF' > x.sh
+#!/bin/sh
+touch "$TEST_PREMATURE_EXIT_FILE"
+echo "fake pass"
+exit 0
+EOF
+  chmod +x x.sh
+
+  bazel test \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      --test_output=errors \
+      //:x  &> $TEST_log && fail "expected failure"
+  expect_log "-- Test exited prematurely (TEST_PREMATURE_EXIT_FILE exists) --"
+}
+
 function test_cache_key_scrubbing() {
   echo foo > foo
   echo bar > bar


### PR DESCRIPTION
The Bazel test docs claim that a test will fail if a file exists at the path indicated by `TEST_PREMATURE_EXIT_FILE`, but this has not yet been the case in Bazel.

This feature is used by `googletest` (https://google.github.io/googletest/advanced.html#detecting-test-premature-exit).