### PR TITLE
Make Javac diagnostic paths hermetic with multiplex sandboxing

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/JavaLibraryBuildRequest.java
@@ -385,7 +385,8 @@ public final class JavaLibraryBuildRequest {
             .sourceOutput(getSourceGenDir())
             .processorPath(getProcessorPath())
             .plugins(getPlugins())
-            .requestId(getRequestId());
+            .requestId(getRequestId())
+            .workDir(workDir);
     addJavacArguments(builder);
     // Performance optimization: when reduced classpaths are enabled, stop the compilation after
     // the first diagnostic that would result in fallback to the transitive classpath. The user

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacArguments.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacArguments.java
@@ -78,6 +78,12 @@ public abstract class BlazeJavacArguments {
 
   public abstract OptionalInt requestId();
 
+  /**
+   * The working directory for the compilation relative to which paths should be emitted in
+   * diagnostics.
+   */
+  public abstract Path workDir();
+
   public static Builder builder() {
     return new AutoValue_BlazeJavacArguments.Builder()
         .classPath(ImmutableList.of())
@@ -126,6 +132,8 @@ public abstract class BlazeJavacArguments {
     Builder inputsAndDigest(ImmutableMap<String, ByteString> inputsAndDigest);
 
     Builder requestId(OptionalInt requestId);
+
+    Builder workDir(Path workDir);
 
     BlazeJavacArguments build();
   }

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/BlazeJavacMain.java
@@ -118,7 +118,8 @@ public class BlazeJavacMain {
     // TODO(cushon): where is this used when a diagnostic listener is registered? Consider removing
     // it and handling exceptions directly in callers.
     PrintWriter errWriter = new PrintWriter(errOutput);
-    Listener diagnosticsBuilder = new Listener(arguments.failFast(), maybeWerrorCustom, context);
+    Listener diagnosticsBuilder =
+        new Listener(arguments.failFast(), maybeWerrorCustom, context, arguments.workDir());
 
     // Initialize parts of context that the filemanager depends on
     context.put(DiagnosticListener.class, diagnosticsBuilder);

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/FormattedDiagnostic.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/FormattedDiagnostic.java
@@ -24,6 +24,7 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.JavacMessages;
 import com.sun.tools.javac.util.Log;
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Optional;
@@ -140,7 +141,7 @@ public class FormattedDiagnostic implements Diagnostic<JavaFileObject> {
       if (workDir.toString().isEmpty()) {
         this.workDirPattern = null;
       } else {
-        this.workDirPattern = Pattern.compile("^" + Pattern.quote(workDir.toString()) + "/");
+        this.workDirPattern = Pattern.compile("^" + Pattern.quote(workDir + File.separator));
       }
     }
 

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1955,6 +1955,41 @@ EOF
     >& $TEST_log || fail "build failed"
 }
 
+function test_sandboxed_multiplexing_hermetic_paths_in_diagnostics() {
+  if [[ "${JAVA_TOOLS_ZIP}" == released ]]; then
+    # TODO: Enable test after the next java_tools release.
+    return 0
+  fi
+
+  mkdir -p pkg
+  cat << 'EOF' > pkg/BUILD
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+default_java_toolchain(
+    name = "java_toolchain",
+    source_version = "17",
+    target_version = "17",
+    javac_supports_worker_multiplex_sandboxing = True,
+)
+java_library(name = "lib", srcs = ["Lib.java"])
+EOF
+  cat << 'EOF' > pkg/Lib.java
+public class Lib {
+  public static void foo() {
+    String a = 5; // __sandbox/1/_main/pkg/Lib.java:3: error: incompatible types: int cannot be converted to String
+  }
+}
+EOF
+
+  bazel build //pkg:lib \
+    --experimental_worker_multiplex_sandboxing \
+    --java_language_version=17 \
+    --extra_toolchains=//pkg:java_toolchain_definition \
+    >& $TEST_log && fail "build succeeded"
+  # Verify that the working directory is only stripped from source file paths.
+  expect_log "^pkg/Lib.java:3: error:"
+  expect_log "^    String a = 5; // __sandbox/1/_main/pkg/Lib.java:3: error: incompatible types: int cannot be converted to String"
+}
+
 function test_strict_deps_error_external_repo_starlark_action() {
   cat << 'EOF' > MODULE.bazel
 bazel_dep(
@@ -2082,11 +2117,6 @@ EOF
 }
 
 function test_one_version() {
-  if [[ "${JAVA_TOOLS_ZIP}" == released ]]; then
-    # TODO: Enable test after the next java_tools release.
-    return 0
-  fi
-
   # TODO: Remove patch on rules_java and add test for prebuilt tool after the next release.
   cat << 'EOF' > MODULE.bazel
 bazel_dep(

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1986,7 +1986,7 @@ EOF
     --extra_toolchains=//pkg:java_toolchain_definition \
     >& $TEST_log && fail "build succeeded"
   # Verify that the working directory is only stripped from source file paths.
-  expect_log "^pkg/Lib.java:3: error:"
+  expect_log "^pkg[\\/]Lib.java:3: error:"
   expect_log "^    String a = 5; // __sandbox/1/_main/pkg/Lib.java:3: error: incompatible types: int cannot be converted to String"
 }
 
@@ -2117,6 +2117,11 @@ EOF
 }
 
 function test_one_version() {
+  if [[ "${JAVA_TOOLS_ZIP}" == released ]]; then
+    # TODO: Enable test after the next java_tools release.
+    return 0
+  fi
+
   # TODO: Remove patch on rules_java and add test for prebuilt tool after the next release.
   cat << 'EOF' > MODULE.bazel
 bazel_dep(


### PR DESCRIPTION
Strip the non-hermetic `__sandbox/<N>/_main/` prefix from all Javac diagnostics to make the output identical to what other execution strategies emit.