### PR TITLE
Build Bazel with `--experimental_output_paths=strip` in RBE pipeline

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -318,6 +318,7 @@ tasks:
       - "--experimental_remote_cache_async"
       - "--experimental_remote_merkle_tree_cache"
       - "--remote_download_minimal"
+      - "--experimental_output_paths=strip"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
@@ -329,6 +330,7 @@ tasks:
       - "--experimental_remote_cache_async"
       - "--experimental_remote_merkle_tree_cache"
       - "--remote_download_minimal"
+      - "--experimental_output_paths=strip"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -335,6 +335,7 @@ tasks:
       - "--experimental_remote_cache_async"
       - "--experimental_remote_merkle_tree_cache"
       - "--remote_download_minimal"
+      - "--experimental_output_paths=strip"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
@@ -346,6 +347,7 @@ tasks:
       - "--experimental_remote_cache_async"
       - "--experimental_remote_merkle_tree_cache"
       - "--remote_download_minimal"
+      - "--experimental_output_paths=strip"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."

--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -800,8 +800,4 @@ public final class Label implements Comparable<Label>, StarlarkValue, SkyKey, Co
       return Label.createUnvalidated(pkgId, name);
     }
   }
-
-  public void foo() {
-
-  }
 }

--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -800,4 +800,8 @@ public final class Label implements Comparable<Label>, StarlarkValue, SkyKey, Co
       return Label.createUnvalidated(pkgId, name);
     }
   }
+
+  public void foo() {
+
+  }
 }


### PR DESCRIPTION
Since `//src/main/java/...` builds `BazelServer` twice (in the target and exec configuration), path mapping can reduce load on the remote executor by making these actions cache hits for each other.