### PR TITLE
Allow all characters in runfile source and target paths

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -138,6 +138,7 @@
     "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
     "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.11.1/MODULE.bazel": "b4782e019dd0b0151bd49fd8929136fd4441f527eb208fbd991b77e480b7236e",
     "https://bcr.bazel.build/modules/rules_java/7.12.1/MODULE.bazel": "0a2ebb53b48a6eb092aef24b36db23294d4d3ebf96bff02b0ccc962bdc70717d",
     "https://bcr.bazel.build/modules/rules_java/7.12.1/source.json": "2ab5ceabe9d87a773fa44e4cce42c950e34ff6d2f5164e7413088542fa4f1f3e",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",

--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -302,6 +302,9 @@ public final class SourceManifestAction extends AbstractFileWriteAction
           @Nullable PathFragment symlinkTarget)
           throws IOException {
         String rootRelativePathString = rootRelativePath.getPathString();
+        // Source paths with spaces require escaping. Target paths with spaces don't as consumers
+        // are expected to split on the first space (without escaping) or after the part indicated
+        // by the length prefix (with escaping).
         if (rootRelativePathString.indexOf(' ') != -1) {
           manifestWriter.append(' ');
           manifestWriter.append(String.valueOf(rootRelativePathString.length()));

--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -301,7 +301,13 @@ public final class SourceManifestAction extends AbstractFileWriteAction
           PathFragment rootRelativePath,
           @Nullable PathFragment symlinkTarget)
           throws IOException {
-        manifestWriter.append(rootRelativePath.getPathString());
+        String rootRelativePathString = rootRelativePath.getPathString();
+        if (rootRelativePathString.indexOf(' ') != -1) {
+          manifestWriter.append(' ');
+          manifestWriter.append(String.valueOf(rootRelativePathString.length()));
+          manifestWriter.append(' ');
+        }
+        manifestWriter.append(rootRelativePathString);
         // This trailing whitespace is REQUIRED to process the single entry line correctly.
         manifestWriter.append(' ');
         if (symlinkTarget != null) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -166,18 +166,6 @@ public final class BlazeOptionHandler {
     }
 
     Path workspacePath = workspace.getWorkspace();
-    // TODO(kchodorow): Remove this once spaces are supported.
-    if (workspacePath.getPathString().contains(" ")) {
-      String message =
-          runtime.getProductName()
-              + " does not currently work properly from paths "
-              + "containing spaces ("
-              + workspacePath
-              + ").";
-      eventHandler.handle(Event.error(message));
-      return createDetailedExitCode(message, Code.SPACES_IN_WORKSPACE_PATH);
-    }
-
     if (workspacePath.getParentDirectory() != null) {
       Path doNotBuild =
           workspacePath.getParentDirectory().getRelative(BlazeWorkspace.DO_NOT_BUILD_FILE_NAME);

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -596,7 +596,7 @@ message Command {
     STARLARK_OPTIONS_PARSE_FAILURE = 10 [(metadata) = { exit_code: 2 }];
     ARGUMENTS_NOT_RECOGNIZED = 11 [(metadata) = { exit_code: 2 }];
     NOT_IN_WORKSPACE = 12 [(metadata) = { exit_code: 2 }];
-    SPACES_IN_WORKSPACE_PATH = 13 [(metadata) = { exit_code: 36 }];
+    reserved 13;
     IN_OUTPUT_DIRECTORY = 14 [(metadata) = { exit_code: 2 }];
   }
 

--- a/src/main/tools/build-runfiles-windows.cc
+++ b/src/main/tools/build-runfiles-windows.cc
@@ -43,6 +43,7 @@ using std::wstring;
 namespace {
 
 const std::regex kEscapedBackslash(R"(\\b)");
+const std::regex kEscapedNewline(R"(\\n)");
 const std::regex kEscapedSpace(R"(\\s)");
 
 const wchar_t* manifest_filename;
@@ -173,9 +174,13 @@ class RunfilesCreator {
         }
         std::string link_path = line.substr(1, idx - 1);
         link_path = std::regex_replace(link_path, kEscapedSpace, " ");
+        link_path = std::regex_replace(link_path, kEscapedNewline, "\n");
         link_path = std::regex_replace(link_path, kEscapedBackslash, "\\");
         link = blaze_util::CstringToWstring(link_path);
-        target = blaze_util::CstringToWstring(line.substr(idx + 1));
+        std::string target_path = line.substr(idx + 1);
+        target_path = std::regex_replace(target_path, kEscapedNewline, "\n");
+        target_path = std::regex_replace(target_path, kEscapedBackslash, " ");
+        target = blaze_util::CstringToWstring(target_path);
       } else {
         string::size_type idx = line.find(' ');
         if (idx == string::npos) {

--- a/src/main/tools/build-runfiles-windows.cc
+++ b/src/main/tools/build-runfiles-windows.cc
@@ -100,11 +100,6 @@ wstring GetParentDirFromPath(const wstring& path) {
   return path.substr(0, path.find_last_of(L"\\/"));
 }
 
-inline void Trim(wstring& str) {
-  str.erase(0, str.find_first_not_of(' '));
-  str.erase(str.find_last_not_of(' ') + 1);
-}
-
 bool ReadSymlink(const wstring& abs_path, wstring* target, wstring* error) {
   switch (bazel::windows::ReadSymlinkOrJunction(abs_path, target, error)) {
     case bazel::windows::ReadSymlinkOrJunctionResult::kSuccess:

--- a/src/main/tools/build-runfiles.cc
+++ b/src/main/tools/build-runfiles.cc
@@ -61,6 +61,7 @@
 static const char *argv0;
 
 static const std::regex kEscapedBackslash(R"(\\b)");
+static const std::regex kEscapedNewline(R"(\\n)");
 static const std::regex kEscapedSpace(R"(\\s)");
 
 const char *input_filename;
@@ -162,7 +163,7 @@ class RunfilesCreator {
         DIE("paths must not be absolute: line %d: '%s'\n", lineno, buf);
       }
       std::string link;
-      const char *target;
+      std::string target;
       if (buf[0] == ' ') {
         // The link path contains escape sequences for spaces and backslashes.
         char *s = strchr(buf + 1, ' ');
@@ -171,8 +172,11 @@ class RunfilesCreator {
         }
         link = std::string(buf + 1, s);
         link = std::regex_replace(link, kEscapedSpace, " ");
+        link = std::regex_replace(link, kEscapedNewline, "\n");
         link = std::regex_replace(link, kEscapedBackslash, "\\");
         target = s + 1;
+        target = std::regex_replace(target, kEscapedNewline, "\n");
+        target = std::regex_replace(target, kEscapedBackslash, "\\");
       } else {
         // The line is of the form "foo /target/path", with only a single space
         // in the link path.

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -309,6 +309,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/test/java/com/google/devtools/build/lib/actions/util",

--- a/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
@@ -394,8 +394,12 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
 
     ArtifactRoot trivialRoot =
         ArtifactRoot.asSourceRoot(Root.fromPath(rootDirectory.getRelative("trivial")));
-    Path fileWithSpacePath = scratch.file("trivial/file with sp\\ace", "foo");
-    Artifact fileWithSpaceAndBackslash = ActionsTestUtil.createArtifact(trivialRoot, fileWithSpacePath);
+    Path fileWithSpaceAndBackslashPath = scratch.file("trivial/file with sp\\ace", "foo");
+    Artifact fileWithSpaceAndBackslash =
+        ActionsTestUtil.createArtifact(trivialRoot, fileWithSpaceAndBackslashPath);
+    Path fileWithNewlineAndBackslashPath = scratch.file("trivial/file\nwith\\newline", "foo");
+    Artifact fileWithNewlineAndBackslash =
+        ActionsTestUtil.createArtifact(trivialRoot, fileWithNewlineAndBackslashPath);
 
     SourceManifestAction action =
         new SourceManifestAction(
@@ -405,16 +409,35 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
             new Runfiles.Builder("TESTING", false)
                 .addSymlink(PathFragment.create("no/sp\\ace"), buildFile)
                 .addSymlink(PathFragment.create("also/no/sp\\ace"), fileWithSpaceAndBackslash)
+                .addSymlink(PathFragment.create("still/no/sp\\ace"), fileWithNewlineAndBackslash)
                 .addSymlink(PathFragment.create("with sp\\ace"), buildFile)
                 .addSymlink(PathFragment.create("also/with sp\\ace"), fileWithSpaceAndBackslash)
+                .addSymlink(PathFragment.create("more/with sp\\ace"), fileWithNewlineAndBackslash)
+                .addSymlink(PathFragment.create("with\nnew\\line"), buildFile)
+                .addSymlink(PathFragment.create("also/with\nnewline"), fileWithSpaceAndBackslash)
+                .addSymlink(PathFragment.create("more/with\nnewline"), fileWithNewlineAndBackslash)
+                .addSymlink(PathFragment.create("with\nnew\\line and space"), buildFile)
+                .addSymlink(
+                    PathFragment.create("also/with\nnewline and space"), fileWithSpaceAndBackslash)
+                .addSymlink(
+                    PathFragment.create("more/with\nnewline and space"),
+                    fileWithNewlineAndBackslash)
                 .build());
     if (OS.getCurrent().equals(OS.WINDOWS)) {
       assertThat(action.getFileContents(reporter))
           .isEqualTo(
               """
             TESTING/also/no/sp/ace /workspace/trivial/file with sp/ace
+             TESTING/also/with\\nnewline /workspace/trivial/file with sp/ace
+             TESTING/also/with\\nnewline\\sand\\sspace /workspace/trivial/file with sp/ace
              TESTING/also/with\\ssp/ace /workspace/trivial/file with sp/ace
+             TESTING/more/with\\nnewline /workspace/trivial/file\\nwith/newline
+             TESTING/more/with\\nnewline\\sand\\sspace /workspace/trivial/file\\nwith/newline
+             TESTING/more/with\\ssp/ace /workspace/trivial/file\\nwith/newline
             TESTING/no/sp/ace /workspace/trivial/BUILD
+             TESTING/still/no/sp/ace /workspace/trivial/file\\nwith/newline
+             TESTING/with\\nnew/line /workspace/trivial/BUILD
+             TESTING/with\\nnew/line\\sand\\sspace /workspace/trivial/BUILD
              TESTING/with\\ssp/ace /workspace/trivial/BUILD
             """);
     } else {
@@ -422,8 +445,16 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
           .isEqualTo(
               """
             TESTING/also/no/sp\\ace /workspace/trivial/file with sp\\ace
-             TESTING/also/with\\ssp\\bace /workspace/trivial/file with sp\\ace
+             TESTING/also/with\\nnewline /workspace/trivial/file with sp\\bace
+             TESTING/also/with\\nnewline\\sand\\sspace /workspace/trivial/file with sp\\bace
+             TESTING/also/with\\ssp\\bace /workspace/trivial/file with sp\\bace
+             TESTING/more/with\\nnewline /workspace/trivial/file\\nwith\\bnewline
+             TESTING/more/with\\nnewline\\sand\\sspace /workspace/trivial/file\\nwith\\bnewline
+             TESTING/more/with\\ssp\\bace /workspace/trivial/file\\nwith\\bnewline
             TESTING/no/sp\\ace /workspace/trivial/BUILD
+             TESTING/still/no/sp\\bace /workspace/trivial/file\\nwith\\bnewline
+             TESTING/with\\nnew\\bline /workspace/trivial/BUILD
+             TESTING/with\\nnew\\bline\\sand\\sspace /workspace/trivial/BUILD
              TESTING/with\\ssp\\bace /workspace/trivial/BUILD
             """);
     }

--- a/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.analysis.SourceManifestAction.ManifestType;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -407,15 +408,25 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
                 .addSymlink(PathFragment.create("with sp\\ace"), buildFile)
                 .addSymlink(PathFragment.create("also/with sp\\ace"), fileWithSpaceAndBackslash)
                 .build());
-
-    assertThat(action.getFileContents(reporter))
-        .isEqualTo(
-            """
+    if (OS.getCurrent().equals(OS.WINDOWS)) {
+      assertThat(action.getFileContents(reporter))
+          .isEqualTo(
+              """
+            TESTING/also/no/sp/ace /workspace/trivial/file with sp/ace
+             TESTING/also/with\\ssp/ace /workspace/trivial/file with sp/ace
+            TESTING/no/sp/ace /workspace/trivial/BUILD
+             TESTING/with\\ssp/ace /workspace/trivial/BUILD
+            """);
+    } else {
+      assertThat(action.getFileContents(reporter))
+          .isEqualTo(
+              """
             TESTING/also/no/sp\\ace /workspace/trivial/file with sp\\ace
              TESTING/also/with\\ssp\\bace /workspace/trivial/file with sp\\ace
             TESTING/no/sp\\ace /workspace/trivial/BUILD
              TESTING/with\\ssp\\bace /workspace/trivial/BUILD
             """);
+    }
   }
 
   private String computeKey(SourceManifestAction action) {

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -61,6 +61,7 @@ function hash_outputs() {
 }
 
 function test_determinism()  {
+    # Verify that Bazel can build itself under a path with spaces.
     local workdir="${TEST_TMPDIR}/work dir"
     mkdir "${workdir}" || fail "Could not create work directory"
     cd "${workdir}" || fail "Could not change to work directory"

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -61,7 +61,7 @@ function hash_outputs() {
 }
 
 function test_determinism()  {
-    local workdir="${TEST_TMPDIR}/workdir"
+    local workdir="${TEST_TMPDIR}/work dir"
     mkdir "${workdir}" || fail "Could not create work directory"
     cd "${workdir}" || fail "Could not change to work directory"
     unzip -q "${DISTFILE}"

--- a/src/test/shell/bazel/workspace_test.sh
+++ b/src/test/shell/bazel/workspace_test.sh
@@ -73,7 +73,7 @@ function test_path_with_spaces() {
   cd "$ws"
   touch WORKSPACE
 
-  bazel info &> $TEST_log && fail "Info succeeeded"
+  bazel info &> $TEST_log || fail "Info failed"
   bazel help &> $TEST_log || fail "Help failed"
 }
 

--- a/src/test/shell/integration/runfiles_test.sh
+++ b/src/test/shell/integration/runfiles_test.sh
@@ -603,7 +603,7 @@ EOF
 }
 
 function test_spaces_in_runfiles_source_and_target_paths() {
-  dir=$(mktemp -d -t 'runfiles test.XXXXXX')
+  dir=$(mktemp -d 'runfiles test.XXXXXX')
   cd "$dir" || fail "failed to cd to $dir"
   touch MODULE.bazel
 

--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -357,7 +357,19 @@ function runfiles_rlocation_checked() {
     if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
       echo >&2 "INFO[runfiles.bash]: rlocation($1): looking in RUNFILES_MANIFEST_FILE ($RUNFILES_MANIFEST_FILE)"
     fi
-    local -r result=$(__runfiles_maybe_grep -m1 "^$1 " "${RUNFILES_MANIFEST_FILE}" | cut -d ' ' -f 2-)
+    # If the rlocation path contains a space, it needs to be prefixed with
+    # " <length> ", where <length> is the length of the path in bytes.
+    if [[ "$1" == *" "* ]]; then
+      local search_prefix=" $(echo -n "$1" | wc -c | tr -d ' ') $1"
+      if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
+        echo >&2 "INFO[runfiles.bash]: rlocation($1): using escaped search prefix ($search_prefix)"
+      fi
+    else
+      local search_prefix="$1"
+    fi
+    # The extra space below is added because cut counts from 1.
+    local trim_length=$(echo -n "$search_prefix  " | wc -c)
+    local -r result=$(__runfiles_maybe_grep -m1 "^$search_prefix " "${RUNFILES_MANIFEST_FILE}" | cut -b ${trim_length}-)
     if [[ -z "$result" ]]; then
       # If path references a runfile that lies under a directory that itself
       # is a runfile, then only the directory is listed in the manifest. Look
@@ -370,7 +382,14 @@ function runfiles_rlocation_checked() {
         new_prefix="${prefix%/*}"
         [[ "$new_prefix" == "$prefix" ]] && break
         prefix="$new_prefix"
-        prefix_result=$(__runfiles_maybe_grep -m1 "^$prefix " "${RUNFILES_MANIFEST_FILE}" | cut -d ' ' -f 2-)
+        if [[ "$prefix" == *" "* ]]; then
+          search_prefix=" $(echo -n "$prefix" | wc -c | tr -d ' ') $prefix"
+        else
+          search_prefix="$prefix"
+        fi
+        # The extra space below is added because cut counts from 1.
+        trim_length=$(echo -n "$search_prefix  " | wc -c)
+        prefix_result=$(__runfiles_maybe_grep -m1 "^$search_prefix " "${RUNFILES_MANIFEST_FILE}" | cut -b ${trim_length}-)
         [[ -z "$prefix_result" ]] && continue
         local -r candidate="${prefix_result}${1#"${prefix}"}"
         if [[ -e "$candidate" ]]; then

--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -357,21 +357,25 @@ function runfiles_rlocation_checked() {
     if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
       echo >&2 "INFO[runfiles.bash]: rlocation($1): looking in RUNFILES_MANIFEST_FILE ($RUNFILES_MANIFEST_FILE)"
     fi
-    # If the rlocation path contains a space, it needs to be prefixed with a
-    # space and spaces and backslashes have to be escaped as \s and \b.
-    if [[ "$1" == *" "* ]]; then
+    # If the rlocation path contains a space or newline, it needs to be prefixed
+    # with a space and spaces, newlines, and backslashes have to be escaped as
+    # \s, \n, and \b.
+    if [[ "$1" == *" "* || "$1" == *$'\n'* ]]; then
       local search_prefix=" $(echo -n "$1" | sed 's/\\/\\b/g; s/ /\\s/g')"
+      search_prefix="${search_prefix//$'\n'/\\n}"
+      local escaped=true
       if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
         echo >&2 "INFO[runfiles.bash]: rlocation($1): using escaped search prefix ($search_prefix)"
       fi
     else
       local search_prefix="$1"
+      local escaped=false
     fi
     # The extra space below is added because cut counts from 1.
     local trim_length=$(echo -n "$search_prefix  " | wc -c)
     # Escape the search prefix for use in the grep regex below *after*
     # determining the trim length.
-    local -r result=$(__runfiles_maybe_grep -m1 "^$(echo -n "$search_prefix" | sed 's/[.[\*^$]/\\&/g') " "${RUNFILES_MANIFEST_FILE}" | cut -b ${trim_length}-)
+    local result=$(__runfiles_maybe_grep -m1 "^$(echo -n "$search_prefix" | sed 's/[.[\*^$]/\\&/g') " "${RUNFILES_MANIFEST_FILE}" | cut -b ${trim_length}-)
     if [[ -z "$result" ]]; then
       # If path references a runfile that lies under a directory that itself
       # is a runfile, then only the directory is listed in the manifest. Look
@@ -387,17 +391,24 @@ function runfiles_rlocation_checked() {
         if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
           echo >&2 "INFO[runfiles.bash]: rlocation($1): looking for prefix ($prefix)"
         fi
-        if [[ "$prefix" == *" "* ]]; then
+        if [[ "$prefix" == *" "* || "$prefix" == *$'\n'* ]]; then
           search_prefix=" $(echo -n "$prefix" | sed 's/\\/\\b/g; s/ /\\s/g')"
+          search_prefix="${search_prefix//$'\n'/\\n}"
+          escaped=true
           if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
             echo >&2 "INFO[runfiles.bash]: rlocation($1): using escaped search prefix ($search_prefix)"
           fi
         else
           search_prefix="$prefix"
+          escaped=false
         fi
         # The extra space below is added because cut counts from 1.
         trim_length=$(echo -n "$search_prefix  " | wc -c)
         prefix_result=$(__runfiles_maybe_grep -m1 "$(echo -n "$search_prefix" | sed 's/[.[\*^$]/\\&/g') " "${RUNFILES_MANIFEST_FILE}" | cut -b ${trim_length}-)
+        if [[ "$escaped" = true ]]; then
+          prefix_result="${prefix_result//\\n/$'\n'}"
+          prefix_result="${prefix_result//\\b/\\}"
+        fi
         [[ -z "$prefix_result" ]] && continue
         local -r candidate="${prefix_result}${1#"${prefix}"}"
         if [[ -e "$candidate" ]]; then
@@ -427,6 +438,10 @@ function runfiles_rlocation_checked() {
       fi
       echo ""
     else
+      if [[ "$escaped" = true ]]; then
+        result="${result//\\n/$'\n'}"
+        result="${result//\\b/\\}"
+      fi
       if [[ -e "$result" ]]; then
         if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
           echo >&2 "INFO[runfiles.bash]: rlocation($1): found in manifest as ($result)"

--- a/tools/bash/runfiles/runfiles_test.bash
+++ b/tools/bash/runfiles/runfiles_test.bash
@@ -141,6 +141,8 @@ e/f $tmpdir/g h
 y $tmpdir/y
 c/dir $tmpdir/dir
 unresolved $tmpdir/unresolved
+ 4 h/ i $tmpdir/ j k
+ 15 dir with spaces $tmpdir/dir with spaces
 EOF
   mkdir "${tmpdir}/c"
   mkdir "${tmpdir}/y"
@@ -149,7 +151,11 @@ EOF
   touch "${tmpdir}/dir/file"
   ln -s /does/not/exist "${tmpdir}/dir/unresolved"
   touch "${tmpdir}/dir/deeply/nested/file"
+  touch "${tmpdir}/dir/deeply/nested/file with spaces"
   ln -s /does/not/exist "${tmpdir}/unresolved"
+  touch "${tmpdir}/ j k"
+  mkdir -p "${tmpdir}/dir with spaces/nested"
+  touch "${tmpdir}/dir with spaces/nested/file"
 
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE=$tmpdir/foo.runfiles_manifest
@@ -166,14 +172,21 @@ EOF
   [[ "$(rlocation c/dir/file || echo failed)" == "$tmpdir/dir/file" ]] || fail
   [[ -z "$(rlocation c/dir/unresolved || echo failed)" ]] || fail
   [[ "$(rlocation c/dir/deeply/nested/file || echo failed)" == "$tmpdir/dir/deeply/nested/file" ]] || fail
+  [[ "$(rlocation "c/dir/deeply/nested/file with spaces" || echo failed)" == "$tmpdir/dir/deeply/nested/file with spaces" ]] || fail
   [[ -z "$(rlocation unresolved || echo failed)" ]] || fail
-  rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y" "$tmpdir/dir" "$tmpdir/unresolved"
+  [[ "$(rlocation "h/ i" || echo failed)" == "$tmpdir/ j k" ]] || fail
+  [[ "$(rlocation "dir with spaces" || echo failed)" == "$tmpdir/dir with spaces" ]] || fail
+  [[ "$(rlocation "dir with spaces/nested/file" || echo failed)" == "$tmpdir/dir with spaces/nested/file" ]] || fail
+  rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y" "$tmpdir/dir" "$tmpdir/unresolved" "$tmpdir/ j k" "$tmpdir/dir with spaces"
   [[ -z "$(rlocation a/b || echo failed)" ]] || fail
   [[ -z "$(rlocation e/f || echo failed)" ]] || fail
   [[ -z "$(rlocation y || echo failed)" ]] || fail
   [[ -z "$(rlocation c/dir || echo failed)" ]] || fail
   [[ -z "$(rlocation c/dir/file || echo failed)" ]] || fail
   [[ -z "$(rlocation c/dir/deeply/nested/file || echo failed)" ]] || fail
+  [[ -z "$(rlocation "h/ i" || echo failed)" ]] || fail
+  [[ -z "$(rlocation "dir with spaces" || echo failed)" ]] || fail
+  [[ -z "$(rlocation "dir with spaces/nested/file" || echo failed)" ]] || fail
 }
 
 function test_manifest_based_envvars() {

--- a/tools/bash/runfiles/runfiles_test.bash
+++ b/tools/bash/runfiles/runfiles_test.bash
@@ -143,7 +143,9 @@ c/dir $tmpdir/dir
 unresolved $tmpdir/unresolved
  h/\si $tmpdir/ j k
  h/\s\bi $tmpdir/ j k b
+ h/\n\bi $tmpdir/ \bnj k \na
  dir\swith\sspaces $tmpdir/dir with spaces
+ space\snewline\nbackslash\b_dir $tmpdir/space newline\nbackslash\ba
 EOF
   mkdir "${tmpdir}/c"
   mkdir "${tmpdir}/y"
@@ -158,6 +160,11 @@ EOF
   touch "${tmpdir}/ j k b"
   mkdir -p "${tmpdir}/dir with spaces/nested"
   touch "${tmpdir}/dir with spaces/nested/file"
+  if ! is_windows; then
+    touch "${tmpdir}/ \nj k "$'\n'a
+    mkdir -p "${tmpdir}/space newline"$'\n'"backslash\a"
+    touch "${tmpdir}/space newline"$'\n'"backslash\a/f i\le"
+  fi
 
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE=$tmpdir/foo.runfiles_manifest
@@ -180,7 +187,17 @@ EOF
   [[ "$(rlocation "h/ \i" || echo failed)" == "$tmpdir/ j k b" ]] || fail
   [[ "$(rlocation "dir with spaces" || echo failed)" == "$tmpdir/dir with spaces" ]] || fail
   [[ "$(rlocation "dir with spaces/nested/file" || echo failed)" == "$tmpdir/dir with spaces/nested/file" ]] || fail
+  if ! is_windows; then
+    [[ "$(rlocation $'h/\n\\i' || echo failed)" == "$tmpdir/ \nj k "$'\n'a ]] || fail
+    [[ "$(rlocation "space newline"$'\n'"backslash\_dir/f i\le" || echo failed)" == "${tmpdir}/space newline"$'\n'"backslash\a/f i\le" ]] || fail
+  fi
+
   rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y" "$tmpdir/dir" "$tmpdir/unresolved" "$tmpdir/ j k" "$tmpdir/dir with spaces"
+  if ! is_windows; then
+    rm -r "$tmpdir/ \nj k "$'\n'a "${tmpdir}/space newline"$'\n'"backslash\a"
+    [[ -z "$(rlocation $'h/\n\\i' || echo failed)" ]] || fail
+    [[ -z "$(rlocation "space newline"$'\n'"backslash\_dir/f i\le" || echo failed)" ]] || fail
+  fi
   [[ -z "$(rlocation a/b || echo failed)" ]] || fail
   [[ -z "$(rlocation e/f || echo failed)" ]] || fail
   [[ -z "$(rlocation y || echo failed)" ]] || fail

--- a/tools/bash/runfiles/runfiles_test.bash
+++ b/tools/bash/runfiles/runfiles_test.bash
@@ -141,8 +141,9 @@ e/f $tmpdir/g h
 y $tmpdir/y
 c/dir $tmpdir/dir
 unresolved $tmpdir/unresolved
- 4 h/ i $tmpdir/ j k
- 15 dir with spaces $tmpdir/dir with spaces
+ h/\si $tmpdir/ j k
+ h/\s\bi $tmpdir/ j k b
+ dir\swith\sspaces $tmpdir/dir with spaces
 EOF
   mkdir "${tmpdir}/c"
   mkdir "${tmpdir}/y"
@@ -154,6 +155,7 @@ EOF
   touch "${tmpdir}/dir/deeply/nested/file with spaces"
   ln -s /does/not/exist "${tmpdir}/unresolved"
   touch "${tmpdir}/ j k"
+  touch "${tmpdir}/ j k b"
   mkdir -p "${tmpdir}/dir with spaces/nested"
   touch "${tmpdir}/dir with spaces/nested/file"
 
@@ -175,6 +177,7 @@ EOF
   [[ "$(rlocation "c/dir/deeply/nested/file with spaces" || echo failed)" == "$tmpdir/dir/deeply/nested/file with spaces" ]] || fail
   [[ -z "$(rlocation unresolved || echo failed)" ]] || fail
   [[ "$(rlocation "h/ i" || echo failed)" == "$tmpdir/ j k" ]] || fail
+  [[ "$(rlocation "h/ \i" || echo failed)" == "$tmpdir/ j k b" ]] || fail
   [[ "$(rlocation "dir with spaces" || echo failed)" == "$tmpdir/dir with spaces" ]] || fail
   [[ "$(rlocation "dir with spaces/nested/file" || echo failed)" == "$tmpdir/dir with spaces/nested/file" ]] || fail
   rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y" "$tmpdir/dir" "$tmpdir/unresolved" "$tmpdir/ j k" "$tmpdir/dir with spaces"

--- a/tools/cpp/runfiles/runfiles_src.cc
+++ b/tools/cpp/runfiles/runfiles_src.cc
@@ -51,6 +51,7 @@ using std::vector;
 namespace {
 
 const std::regex kEscapedBackslash("\\\\b");
+const std::regex kEscapedNewline("\\\\n");
 const std::regex kEscapedSpace("\\\\s");
 
 bool starts_with(const string& s, const char* prefix) {
@@ -275,8 +276,11 @@ bool ParseManifest(const string& path, map<string, string>* result,
       }
       source = line.substr(1, idx - 1);
       source = std::regex_replace(source, kEscapedSpace, " ");
+      source = std::regex_replace(source, kEscapedNewline, "\n");
       source = std::regex_replace(source, kEscapedBackslash, "\\");
       target = line.substr(idx + 1);
+      target = std::regex_replace(target, kEscapedNewline, "\n");
+      target = std::regex_replace(target, kEscapedBackslash, "\\");
     } else {
       string::size_type idx = line.find(' ');
       if (idx == string::npos) {

--- a/tools/cpp/runfiles/runfiles_test.cc
+++ b/tools/cpp/runfiles/runfiles_test.cc
@@ -230,8 +230,9 @@ TEST_F(RunfilesTest, ManifestBasedRunfilesRlocationAndEnvVars) {
       "foo" LINE_AS_STRING() ".runfiles_manifest", {
           "a/b c/d",
           "e/f target path with spaces",
-          " 4 h/ i j k",
-          " 15 dir with spaces l/m",
+          " h/\\si j k",
+          " dir\\\swith\\\sspaces l/m",
+          " h/\\s\\bi j k b",
       }));
   ASSERT_TRUE(mf != nullptr);
 
@@ -265,6 +266,7 @@ TEST_F(RunfilesTest, ManifestBasedRunfilesRlocationAndEnvVars) {
   EXPECT_EQ(r->Rlocation("e/f"), "target path with spaces");
   EXPECT_EQ(r->Rlocation("e/f/file"), "target path with spaces/file");
   EXPECT_EQ(r->Rlocation("h/ i"), "j k");
+  EXPECT_EQ(r->Rlocation("h/ \\i"), "j k b");
   EXPECT_EQ(r->Rlocation("dir with spaces"), "l/m");
   EXPECT_EQ(r->Rlocation("dir with spaces/file"), "l/m/file");
 }

--- a/tools/cpp/runfiles/runfiles_test.cc
+++ b/tools/cpp/runfiles/runfiles_test.cc
@@ -231,8 +231,9 @@ TEST_F(RunfilesTest, ManifestBasedRunfilesRlocationAndEnvVars) {
           "a/b c/d",
           "e/f target path with spaces",
           " h/\\si j k",
-          " dir\\\swith\\\sspaces l/m",
-          " h/\\s\\bi j k b",
+          " dir\\swith\\sspaces l/m",
+          " h/\\n\\s\\bi j k \\n\\b",
+          "not_escaped with\\backslash and spaces",
       }));
   ASSERT_TRUE(mf != nullptr);
 
@@ -266,9 +267,10 @@ TEST_F(RunfilesTest, ManifestBasedRunfilesRlocationAndEnvVars) {
   EXPECT_EQ(r->Rlocation("e/f"), "target path with spaces");
   EXPECT_EQ(r->Rlocation("e/f/file"), "target path with spaces/file");
   EXPECT_EQ(r->Rlocation("h/ i"), "j k");
-  EXPECT_EQ(r->Rlocation("h/ \\i"), "j k b");
+  EXPECT_EQ(r->Rlocation("h/\n \\i"), "j k \n\\");
   EXPECT_EQ(r->Rlocation("dir with spaces"), "l/m");
   EXPECT_EQ(r->Rlocation("dir with spaces/file"), "l/m/file");
+  EXPECT_EQ(r->Rlocation("not_escaped"), "with\\backslash and spaces");
 }
 
 TEST_F(RunfilesTest, DirectoryBasedRunfilesRlocationAndEnvVars) {

--- a/tools/cpp/runfiles/runfiles_test.cc
+++ b/tools/cpp/runfiles/runfiles_test.cc
@@ -227,7 +227,12 @@ TEST_F(RunfilesTest, CannotCreateManifestBasedRunfilesDueToBadManifest) {
 
 TEST_F(RunfilesTest, ManifestBasedRunfilesRlocationAndEnvVars) {
   unique_ptr<MockFile> mf(MockFile::Create(
-      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b c/d"}));
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {
+          "a/b c/d",
+          "e/f target path with spaces",
+          " 4 h/ i j k",
+          " 15 dir with spaces l/m",
+      }));
   ASSERT_TRUE(mf != nullptr);
 
   string error;
@@ -256,6 +261,12 @@ TEST_F(RunfilesTest, ManifestBasedRunfilesRlocationAndEnvVars) {
   EXPECT_EQ(r->Rlocation("c:\\Foo"), "c:\\Foo");
   EXPECT_EQ(r->Rlocation("a/b/file"), "c/d/file");
   EXPECT_EQ(r->Rlocation("a/b/deeply/nested/file"), "c/d/deeply/nested/file");
+  EXPECT_EQ(r->Rlocation("a/b/deeply/nested/file with spaces"), "c/d/deeply/nested/file with spaces");
+  EXPECT_EQ(r->Rlocation("e/f"), "target path with spaces");
+  EXPECT_EQ(r->Rlocation("e/f/file"), "target path with spaces/file");
+  EXPECT_EQ(r->Rlocation("h/ i"), "j k");
+  EXPECT_EQ(r->Rlocation("dir with spaces"), "l/m");
+  EXPECT_EQ(r->Rlocation("dir with spaces/file"), "l/m/file");
 }
 
 TEST_F(RunfilesTest, DirectoryBasedRunfilesRlocationAndEnvVars) {

--- a/tools/java/runfiles/Runfiles.java
+++ b/tools/java/runfiles/Runfiles.java
@@ -495,24 +495,17 @@ public final class Runfiles {
           String runfile;
           String realPath;
           if (line.startsWith(" ")) {
-            // Lines starting with a space are of the form " 7 foo bar /tar get/path", with
-            // the first field indicating the length of the runfiles path.
-            int endOfLengthField = line.indexOf(' ', 1);
-            if (endOfLengthField == -1) {
+            // In lines starting with a space, the runfile path contains spaces and backslashes
+            // escaped with a backslash. The real path is the rest of the line after the first
+            // unescaped space.
+            int firstSpace = line.indexOf(' ', 1);
+            if (firstSpace == -1) {
               throw new IOException(
-                  "Invalid runfiles manifest line, expected second space with leading space: "
+                  "Invalid runfiles manifest line, expected at least one space after the leading space: "
                       + line);
             }
-            int runfileLength;
-            try {
-              runfileLength = Integer.parseUnsignedInt(line.substring(1, endOfLengthField));
-            } catch (NumberFormatException e) {
-              throw new IOException(
-                  "Invalid runfiles manifest line, expected unsigned integer length field: "
-                      + line);
-            }
-            runfile = line.substring(endOfLengthField + 1, endOfLengthField + 1 + runfileLength);
-            realPath = line.substring(endOfLengthField + 1 + runfileLength + 1);
+            runfile = line.substring(1, firstSpace).replace("\\s", " ").replace("\\b", "\\");
+            realPath = line.substring(firstSpace + 1);
           } else {
             int firstSpace = line.indexOf(' ');
             if (firstSpace == -1) {

--- a/tools/java/runfiles/Runfiles.java
+++ b/tools/java/runfiles/Runfiles.java
@@ -157,9 +157,10 @@ public final class Runfiles {
         if (this == o) {
           return true;
         }
-        if (!(o instanceof RepoMappingKey that)) {
+        if (o == null || !(o instanceof RepoMappingKey)) {
           return false;
         }
+        RepoMappingKey that = (RepoMappingKey) o;
         return sourceRepo.equals(that.sourceRepo)
             && targetRepoApparentName.equals(that.targetRepoApparentName);
       }

--- a/tools/java/runfiles/Runfiles.java
+++ b/tools/java/runfiles/Runfiles.java
@@ -504,8 +504,12 @@ public final class Runfiles {
                   "Invalid runfiles manifest line, expected at least one space after the leading space: "
                       + line);
             }
-            runfile = line.substring(1, firstSpace).replace("\\s", " ").replace("\\b", "\\");
-            realPath = line.substring(firstSpace + 1);
+            runfile =
+                line.substring(1, firstSpace)
+                    .replace("\\s", " ")
+                    .replace("\\n", "\n")
+                    .replace("\\b", "\\");
+            realPath = line.substring(firstSpace + 1).replace("\\n", "\n").replace("\\b", "\\");
           } else {
             int firstSpace = line.indexOf(' ');
             if (firstSpace == -1) {

--- a/tools/java/runfiles/testing/RunfilesTest.java
+++ b/tools/java/runfiles/testing/RunfilesTest.java
@@ -247,21 +247,21 @@ public final class RunfilesTest {
             ImmutableList.of(
                 "Foo/runfile1 C:/Actual Path\\runfile1",
                 "Foo/Bar/runfile2 D:\\the path\\run file 2.txt",
-                "Foo/Bar/Dir E:\\Actual Path\\Directory",
-                " h/\\si F:\\jk",
-                " dir\\swith\\sspaces F:\\j k\\dir with spaces",
-                " h/\\s\\bi F:\\jkb"));
+                "Foo/Bar/Dir E:\\Actual Path\\bDirectory",
+                " h/\\si F:\\bjk",
+                " dir\\swith\\sspaces F:\\bj k\\bdir with spaces",
+                " h/\\s\\n\\bi F:\\bjk\\nb"));
     Runfiles r = Runfiles.createManifestBasedForTesting(mf.toString()).withSourceRepository("");
     assertThat(r.rlocation("Foo/runfile1")).isEqualTo("C:/Actual Path\\runfile1");
     assertThat(r.rlocation("Foo/Bar/runfile2")).isEqualTo("D:\\the path\\run file 2.txt");
-    assertThat(r.rlocation("Foo/Bar/Dir")).isEqualTo("E:\\Actual Path\\Directory");
-    assertThat(r.rlocation("Foo/Bar/Dir/File")).isEqualTo("E:\\Actual Path\\Directory/File");
+    assertThat(r.rlocation("Foo/Bar/Dir")).isEqualTo("E:\\Actual Path\\bDirectory");
+    assertThat(r.rlocation("Foo/Bar/Dir/File")).isEqualTo("E:\\Actual Path\\bDirectory/File");
     assertThat(r.rlocation("Foo/Bar/Dir/Deeply/Nested/File"))
-        .isEqualTo("E:\\Actual Path\\Directory/Deeply/Nested/File");
+        .isEqualTo("E:\\Actual Path\\bDirectory/Deeply/Nested/File");
     assertThat(r.rlocation("Foo/Bar/Dir/Deeply/Nested/File With Spaces"))
-        .isEqualTo("E:\\Actual Path\\Directory/Deeply/Nested/File With Spaces");
+        .isEqualTo("E:\\Actual Path\\bDirectory/Deeply/Nested/File With Spaces");
     assertThat(r.rlocation("h/ i")).isEqualTo("F:\\jk");
-    assertThat(r.rlocation("h/ \\i")).isEqualTo("F:\\jkb");
+    assertThat(r.rlocation("h/ \n\\i")).isEqualTo("F:\\jk\nb");
     assertThat(r.rlocation("dir with spaces")).isEqualTo("F:\\j k\\dir with spaces");
     assertThat(r.rlocation("dir with spaces/file")).isEqualTo("F:\\j k\\dir with spaces/file");
     assertThat(r.rlocation("unknown")).isNull();

--- a/tools/java/runfiles/testing/RunfilesTest.java
+++ b/tools/java/runfiles/testing/RunfilesTest.java
@@ -248,8 +248,9 @@ public final class RunfilesTest {
                 "Foo/runfile1 C:/Actual Path\\runfile1",
                 "Foo/Bar/runfile2 D:\\the path\\run file 2.txt",
                 "Foo/Bar/Dir E:\\Actual Path\\Directory",
-                " 4 h/ i F:\\jk",
-                " 15 dir with spaces F:\\j k\\dir with spaces"));
+                " h/\\si F:\\jk",
+                " dir\\swith\\sspaces F:\\j k\\dir with spaces",
+                " h/\\s\\bi F:\\jkb"));
     Runfiles r = Runfiles.createManifestBasedForTesting(mf.toString()).withSourceRepository("");
     assertThat(r.rlocation("Foo/runfile1")).isEqualTo("C:/Actual Path\\runfile1");
     assertThat(r.rlocation("Foo/Bar/runfile2")).isEqualTo("D:\\the path\\run file 2.txt");
@@ -260,6 +261,7 @@ public final class RunfilesTest {
     assertThat(r.rlocation("Foo/Bar/Dir/Deeply/Nested/File With Spaces"))
         .isEqualTo("E:\\Actual Path\\Directory/Deeply/Nested/File With Spaces");
     assertThat(r.rlocation("h/ i")).isEqualTo("F:\\jk");
+    assertThat(r.rlocation("h/ \\i")).isEqualTo("F:\\jkb");
     assertThat(r.rlocation("dir with spaces")).isEqualTo("F:\\j k\\dir with spaces");
     assertThat(r.rlocation("dir with spaces/file")).isEqualTo("F:\\j k\\dir with spaces/file");
     assertThat(r.rlocation("unknown")).isNull();

--- a/tools/java/runfiles/testing/RunfilesTest.java
+++ b/tools/java/runfiles/testing/RunfilesTest.java
@@ -247,7 +247,9 @@ public final class RunfilesTest {
             ImmutableList.of(
                 "Foo/runfile1 C:/Actual Path\\runfile1",
                 "Foo/Bar/runfile2 D:\\the path\\run file 2.txt",
-                "Foo/Bar/Dir E:\\Actual Path\\Directory"));
+                "Foo/Bar/Dir E:\\Actual Path\\Directory",
+                " 4 h/ i F:\\jk",
+                " 15 dir with spaces F:\\j k\\dir with spaces"));
     Runfiles r = Runfiles.createManifestBasedForTesting(mf.toString()).withSourceRepository("");
     assertThat(r.rlocation("Foo/runfile1")).isEqualTo("C:/Actual Path\\runfile1");
     assertThat(r.rlocation("Foo/Bar/runfile2")).isEqualTo("D:\\the path\\run file 2.txt");
@@ -255,6 +257,11 @@ public final class RunfilesTest {
     assertThat(r.rlocation("Foo/Bar/Dir/File")).isEqualTo("E:\\Actual Path\\Directory/File");
     assertThat(r.rlocation("Foo/Bar/Dir/Deeply/Nested/File"))
         .isEqualTo("E:\\Actual Path\\Directory/Deeply/Nested/File");
+    assertThat(r.rlocation("Foo/Bar/Dir/Deeply/Nested/File With Spaces"))
+        .isEqualTo("E:\\Actual Path\\Directory/Deeply/Nested/File With Spaces");
+    assertThat(r.rlocation("h/ i")).isEqualTo("F:\\jk");
+    assertThat(r.rlocation("dir with spaces")).isEqualTo("F:\\j k\\dir with spaces");
+    assertThat(r.rlocation("dir with spaces/file")).isEqualTo("F:\\j k\\dir with spaces/file");
     assertThat(r.rlocation("unknown")).isNull();
   }
 


### PR DESCRIPTION
Adds support for spaces and newlines in source and target paths of runfiles symlinks to `build-runfiles` as well as to the Bash, C++, and Java runfiles libraries (the Python runfiles library has moved out of the repo).

If a symlink has spaces or newlines in its source path, it is prefixed with a space in the manifest and spaces, newlines, and backslashes in the source path are escaped with `\s`, `\n`, and `\b` respectively. This scheme has been chosen as it has the following properties:
1. There is no change to the format of manifest lines for entries whose source and target paths don't contain a space. This ensures compatibility with existing runfiles libraries.
2. There is even no change to the format of manifest lines for entries whose target path contains spaces but whose source path does not. These manifests previously failed in `build-runfiles`, but were usable on Windows and supported by the official runfiles libraries. This also ensures that the initialization snippet for the Bash runfiles library doesn't need to change, even when used on Unix with a space in the output base path.
3. The scheme is fully reversible and only depends on the source path, which gives runfiles libraries a choice between reversing the escaping when parsing the manifest (C++, Java) or applying the escaping when searching the manifest (Bash).

Fixes #4327 

RELNOTES: Bazel now supports all characters in the rlocation and target paths of runfiles and can be run from workspaces with a space in their full path.