### PR TITLE
Consider invalid entries in the marker file reason for refetch

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -710,12 +710,15 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
           int sChar = line.indexOf(' ');
           if (sChar > 0) {
             RepoRecordedInput input = RepoRecordedInput.parse(unescape(line.substring(0, sChar)));
-            if (input == null) {
-              // ignore invalid entries.
+            if (!input.equals(RepoRecordedInput.NEVER_UP_TO_DATE)) {
+              recordedInputValues.put(input, unescape(line.substring(sChar + 1)));
               continue;
             }
-            recordedInputValues.put(input, unescape(line.substring(sChar + 1)));
           }
+          // On parse failure, just forget everything else and mark the whole input out of date.
+          recordedInputValues.clear();
+          recordedInputValues.put(RepoRecordedInput.NEVER_UP_TO_DATE, "");
+          break;
         }
       }
       return markerRuleKey;

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -703,6 +703,9 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
 
       boolean firstLine = true;
       for (String line : lines) {
+        if (line.isEmpty()) {
+          continue;
+        }
         if (firstLine) {
           markerRuleKey = line;
           firstLine = false;

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2897,15 +2897,11 @@ EOF
   local marker_file=$(bazel info output_base)/external/@+_repo_rules+foo.marker
   # the marker file for this repo should contain a reference to "@@+_repo_rules+bar". Mangle that.
   sed -i'' -e 's/@@+_repo_rules+bar/@@LOL@@LOL/g' ${marker_file}
-  # add some more nonsensical lines for good measure...
-  echo 'BLAH:BLEH:BLOO BLEE' > ${marker_file}
-  echo 'no colons at all' > ${marker_file}
-  echo 'REPO_MAPPING:bad**bad,worse**worse gaaa'
-  echo 'REPO_MAPPING:bad,worse worst**worst'
 
-  # Running Bazel again shouldn't crash.
+  # Running Bazel again shouldn't crash, and should result in a refetch.
   bazel shutdown
   bazel build @foo >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: nothing"
 }
 
 function test_file_watching_in_undefined_repo() {

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2864,6 +2864,50 @@ EOF
   expect_log "I see: something"
 }
 
+function test_bad_marker_file_ignored() {
+  # when reading a file in another repo, we should watch it.
+  local outside_dir="${TEST_TMPDIR}/outside_dir"
+  mkdir -p "${outside_dir}"
+  echo nothing > ${outside_dir}/data.txt
+
+  create_new_workspace
+  cat > $(setup_module_dot_bazel) <<EOF
+foo = use_repo_rule("//:r.bzl", "foo")
+foo(name = "foo")
+bar = use_repo_rule("//:r.bzl", "bar")
+bar(name = "bar", data = "nothing")
+EOF
+  touch BUILD
+  cat > r.bzl <<EOF
+def _foo(rctx):
+  rctx.file("BUILD", "filegroup(name='foo')")
+  # intentionally grab a file that's not directly addressable by a label
+  otherfile = rctx.path(Label("@bar//subpkg:BUILD")).dirname.dirname.get_child("data.txt")
+  print("I see: " + rctx.read(otherfile))
+foo=repository_rule(_foo)
+def _bar(rctx):
+  rctx.file("subpkg/BUILD")
+  rctx.file("data.txt", rctx.attr.data)
+bar=repository_rule(_bar, attrs={"data":attr.string()})
+EOF
+
+  bazel build @foo >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: nothing"
+
+  local marker_file=$(bazel info output_base)/external/@+_repo_rules+foo.marker
+  # the marker file for this repo should contain a reference to "@@+_repo_rules+bar". Mangle that.
+  sed -i'' -e 's/@@+_repo_rules+bar/@@LOL@@LOL/g' ${marker_file}
+  # add some more nonsensical lines for good measure...
+  echo 'BLAH:BLEH:BLOO BLEE' > ${marker_file}
+  echo 'no colons at all' > ${marker_file}
+  echo 'REPO_MAPPING:bad**bad,worse**worse gaaa'
+  echo 'REPO_MAPPING:bad,worse worst**worst'
+
+  # Running Bazel again shouldn't crash.
+  bazel shutdown
+  bazel build @foo >& $TEST_log || fail "expected bazel to succeed"
+}
+
 function test_file_watching_in_undefined_repo() {
   create_new_workspace
   cat > $(setup_module_dot_bazel) <<EOF


### PR DESCRIPTION
Especially due to https://github.com/bazelbuild/bazel/issues/23127, older marker files may contain entries that don't even parse correctly. Instead of crashing Bazel, we should signal a refetch.

Fixes https://github.com/bazelbuild/bazel/issues/23322.