### PR TITLE
Fix ml path for Windows clang-cl cc toolchain

### DIFF
--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -789,13 +789,37 @@ class BazelWindowsCppTest(test_base.TestBase):
         '',
         'cc_binary(',
         '  name = "main",',
-        '  srcs = ["main.cc"],',
+        '  srcs = ['
+        '    "main.cc",',
+        '    "inc.asm",',  # Test assemble action_config
+        '    "dec.S",',    # Test preprocess-assemble action_config
+        '  ],',
         ')',
     ])
     self.ScratchFile('main.cc', [
         'int main() {',
         '  return 0;',
         '}',
+    ])
+    self.ScratchFile('inc.asm', [
+        '.code',
+        'PUBLIC increment',
+        'increment PROC x:WORD',
+        '  xchg rcx,rax',
+        '  inc rax',
+        '  ret',
+        'increment EndP',
+        'END',
+    ])
+    self.ScratchFile('dec.S', [
+        '.code',
+        'PUBLIC decrement',
+        'decrement PROC x:WORD',
+        '  xchg rcx,rax',
+        '  dec rax',
+        '  ret',
+        'decrement EndP',
+        'END',
     ])
     exit_code, _, stderr = self.RunBazel(['build', '-s', '//:main'])
     self.AssertExitCode(exit_code, 0, stderr)

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -794,7 +794,8 @@ def _get_clang_cl_vars(repository_ctx, paths, msvc_vars, target_arch):
         "%{clang_cl_cl_path_" + target_arch + "}": clang_cl_path,
         "%{clang_cl_link_path_" + target_arch + "}": lld_link_path,
         "%{clang_cl_lib_path_" + target_arch + "}": llvm_lib_path,
-        "%{clang_cl_ml_path_" + target_arch + "}": clang_cl_path,
+        # clang-cl does not support assembly files as input.
+        "%{clang_cl_ml_path_" + target_arch + "}": msvc_vars["%{msvc_ml_path_" + target_arch + "}"],
         # LLVM's lld-link.exe doesn't support /DEBUG:FASTLINK.
         "%{clang_cl_dbg_mode_debug_flag_" + target_arch + "}": "/DEBUG",
         "%{clang_cl_fastbuild_mode_debug_flag_" + target_arch + "}": "/DEBUG",


### PR DESCRIPTION
Assembly files are not valid inputs for `clang-cl.exe`; the MSVC `ml64.exe` must be used instead.

Fixes #23128.