### PR TITLE
[7.4.0] Fix versioned shared libraries for macOS toolchain

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -673,6 +673,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
 
     public static final String OBJECT_FILES_FIELD_NAME = "object_files";
     public static final String NAME_FIELD_NAME = "name";
+    public static final String PATH_FIELD_NAME = "path";
     public static final String TYPE_FIELD_NAME = "type";
     public static final String IS_WHOLE_ARCHIVE_FIELD_NAME = "is_whole_archive";
 
@@ -682,8 +683,8 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       return interner.intern(new ForDynamicLibrary(name));
     }
 
-    public static LibraryToLinkValue forVersionedDynamicLibrary(String name) {
-      return interner.intern(new ForVersionedDynamicLibrary(name));
+    public static LibraryToLinkValue forVersionedDynamicLibrary(String name, String path) {
+      return interner.intern(new ForVersionedDynamicLibrary(name, path));
     }
 
     public static LibraryToLinkValue forInterfaceLibrary(String name) {
@@ -809,8 +810,40 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     }
 
     private static final class ForVersionedDynamicLibrary extends LibraryToLinkValueWithName {
-      private ForVersionedDynamicLibrary(String name) {
+      private final String path;
+
+      private ForVersionedDynamicLibrary(String name, String path) {
         super(name);
+        this.path = path;
+      }
+
+      @Override
+      public VariableValue getFieldValue(
+          String variableName,
+          String field,
+          @Nullable ArtifactExpander expander,
+          boolean throwOnMissingVariable) {
+        if (PATH_FIELD_NAME.equals(field)) {
+          return new StringValue(path);
+        }
+        return super.getFieldValue(variableName, field, expander, throwOnMissingVariable);
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (!(obj instanceof ForVersionedDynamicLibrary)) {
+          return false;
+        }
+        if (this == obj) {
+          return true;
+        }
+        ForVersionedDynamicLibrary other = (ForVersionedDynamicLibrary) obj;
+        return this.path.equals(other.path) && super.equals(other);
+      }
+
+      @Override
+      public int hashCode() {
+        return 31 * super.hashCode() + path.hashCode();
       }
 
       @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -818,7 +818,7 @@ public class CppActionConfigs {
                             "      variable: 'libraries_to_link.type'",
                             "      value: 'versioned_dynamic_library'",
                             "    }",
-                            "    flag: '-l:%{libraries_to_link.name}'",
+                            "    flag: '%{libraries_to_link.path}'",
                             "  }"),
                         "      flag_group {",
                         "        expand_if_equal: {",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
@@ -614,7 +614,8 @@ public class LibrariesToLinkCollector {
       librariesToLink.addValue(LibraryToLinkValue.forDynamicLibrary(libName));
     } else if (CppFileTypes.SHARED_LIBRARY.matches(name)
         || CppFileTypes.VERSIONED_SHARED_LIBRARY.matches(name)) {
-      librariesToLink.addValue(LibraryToLinkValue.forVersionedDynamicLibrary(name));
+      librariesToLink.addValue(
+          LibraryToLinkValue.forVersionedDynamicLibrary(name, inputArtifact.getExecPathString()));
     } else {
       // Interface shared objects have a non-standard extension
       // that the linker won't be able to find.  So use the

--- a/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
@@ -6473,11 +6473,11 @@ def _impl(ctx):
                             flag_group(
                                 flag_groups = [
                                     flag_group(
-                                        flags = ["-l:%{libraries_to_link.name}"],
+                                        flags = ["%{libraries_to_link.path}"],
                                         expand_if_false = "libraries_to_link.is_whole_archive",
                                     ),
                                     flag_group(
-                                        flags = ["-Wl,-force_load,-l:%{libraries_to_link.name}"],
+                                        flags = ["-Wl,-force_load,%{libraries_to_link.path}"],
                                         expand_if_true = "libraries_to_link.is_whole_archive",
                                     ),
                                 ],

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryToLinkValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryToLinkValueTest.java
@@ -159,7 +159,7 @@ public class LibraryToLinkValueTest {
                     /* field= */ "path",
                     /* expander= */ null,
                     /* throwOnMissingVariable= */ false)
-                .getStringValue("variable name doesn't matter"))
+                .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo/bar.so");
     assertThat(
             libraryToLinkValue

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryToLinkValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryToLinkValueTest.java
@@ -46,9 +46,10 @@ public class LibraryToLinkValueTest {
 
     // #forVersionedDynamicLibrary
     equalsTester.addEqualityGroup(
-        LibraryToLinkValue.forVersionedDynamicLibrary("foo"),
-        LibraryToLinkValue.forVersionedDynamicLibrary("foo"));
-    equalsTester.addEqualityGroup(LibraryToLinkValue.forVersionedDynamicLibrary("bar"));
+        LibraryToLinkValue.forVersionedDynamicLibrary("foo", /* path= */ ""),
+        LibraryToLinkValue.forVersionedDynamicLibrary("foo", /* path= */ ""));
+    equalsTester.addEqualityGroup(
+        LibraryToLinkValue.forVersionedDynamicLibrary("bar", /* path= */ ""));
 
     // #forInterfaceLibrary
     equalsTester.addEqualityGroup(
@@ -140,7 +141,8 @@ public class LibraryToLinkValueTest {
 
   @Test
   public void getFieldValue_forVersionedDynamicLibrary() throws Exception {
-    LibraryToLinkValue libraryToLinkValue = LibraryToLinkValue.forVersionedDynamicLibrary("foo");
+    LibraryToLinkValue libraryToLinkValue =
+        LibraryToLinkValue.forVersionedDynamicLibrary("foo", "foo/bar.so");
     assertThat(
             libraryToLinkValue
                 .getFieldValue(
@@ -150,6 +152,15 @@ public class LibraryToLinkValueTest {
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("versioned_dynamic_library");
+    assertThat(
+            libraryToLinkValue
+                .getFieldValue(
+                    /* variableName= */ "variable name doesn't matter",
+                    /* field= */ "path",
+                    /* expander= */ null,
+                    /* throwOnMissingVariable= */ false)
+                .getStringValue("variable name doesn't matter"))
+        .isEqualTo("foo/bar.so");
     assertThat(
             libraryToLinkValue
                 .getFieldValue(


### PR DESCRIPTION
The toolchain was passing -l:name. This mechanism doesn' t exist on macOS,
instead the full path to the shared library should be passed.

This is a cherry pick of f0ade80ce920be0719b1a43a40258397f68a944d and eb50e5b83bc0f54e7409f553b67a33b8793b7508