### PR TITLE
[7.4.0] Warn if a module extension produces an invalid lockfile entry

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -19,6 +19,7 @@ import static com.google.common.base.StandardSystemProperty.OS_ARCH;
 import static com.google.common.collect.ImmutableBiMap.toImmutableBiMap;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.stream.Collectors.joining;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Splitter;
@@ -208,6 +209,22 @@ public class SingleExtensionEvalFunction implements SkyFunction {
     Optional<ModuleExtensionMetadata> moduleExtensionMetadata =
         moduleExtensionResult.getModuleExtensionMetadata();
 
+    if (!lockfileMode.equals(LockfileMode.OFF)) {
+      var nonVisibleRepoNames =
+          moduleExtensionResult.getRecordedRepoMappingEntries().values().stream()
+              .filter(repoName -> !repoName.isVisible())
+              .map(RepositoryName::toString)
+              .collect(joining(", "));
+      if (!nonVisibleRepoNames.isEmpty()) {
+        env.getListener()
+            .handle(
+                Event.warn(
+                    String.format(
+                        "The module extension %s produced an invalid lockfile entry because it"
+                            + " referenced %s. Please report this issue to its maintainers.",
+                        extensionId.asTargetString(), nonVisibleRepoNames)));
+      }
+    }
     if (lockfileMode.equals(LockfileMode.ERROR)) {
       boolean extensionShouldHaveBeenLocked =
           moduleExtensionMetadata.map(metadata -> !metadata.getReproducible()).orElse(true);


### PR DESCRIPTION
Lockfile entries that record repo mapping usages for invalid repo names are always invalid. They can lead to confusing situations where updating the lockfile doesn't result in changes, yet running in `error` mode fails with an error saying that the lockfile is not up to date.

Instead, show a warning such as the following that users can forward to the extensions maintainers:
```
WARNING: The module extension @@rules_rust+//rust/private:extensions.bzl%i produced an invalid lockfile entry because it referenced @@[unknown repo 'cui__url-2.5.2' requested from @@rules_rust+]. Please report this issue to its maintainers.
```

Context: https://bazelbuild.slack.com/archives/C014RARENH0/p1723132195268549

Closes #23244.

PiperOrigin-RevId: 661334265
Change-Id: Ib6415cc9911b30d1f9ce493033cd25a347734b7e

Commit https://github.com/bazelbuild/bazel/commit/8cee5f5e6aca1e553a4434c9e7ef4bafd3e723c3