### PR TITLE
[7.4.0] document --invocation_id

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -167,7 +167,7 @@ public class CommonCommandOptions extends OptionsBase {
       name = "invocation_id",
       defaultValue = "",
       converter = UUIDConverter.class,
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.BAZEL_MONITORING, OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
       help =
           "Unique identifier, in UUID format, for the command being run. If explicitly specified"


### PR DESCRIPTION
This flag is widely used to integrate Bazel with existing CI and a BES
service. Let's make sure that it's documented.

Closes #19703.

PiperOrigin-RevId: 661331479
Change-Id: Ifae2cfacb734170ebdd898f0c4ef30a80dcae94a

Commit https://github.com/bazelbuild/bazel/commit/bfe268399a08e8873ef66f6512794fcbb2569910