### PR TITLE
[7.4.0] Do not reuse gRPC connections that fail with native Netty errors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/grpc/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/grpc/BUILD
@@ -18,6 +18,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//third_party:guava",
         "//third_party:jsr305",
+        "//third_party:netty",
         "//third_party:rxjava3",
         "//third_party/grpc-java:grpc-jar",
     ],

--- a/src/test/java/com/google/devtools/build/lib/remote/grpc/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/grpc/BUILD
@@ -29,5 +29,6 @@ java_test(
         "//third_party:mockito",
         "//third_party:rxjava3",
         "//third_party:truth",
+        "//third_party/grpc-java:grpc-jar",
     ],
 )


### PR DESCRIPTION
Such connections are usually not in a recoverable state and should not be used for retries, which would otherwise likely fail in the same way.

Fixes #20868

Closes #23150.

PiperOrigin-RevId: 662091153
Change-Id: Iaf160b11a13af013b9969c7fdaa966bca8ab6be2

Commit https://github.com/bazelbuild/bazel/commit/06691b3073590f68118132017ff30874c533ca6d