### PR TITLE
[7.4.0] Verify in tests that coverage supports `--nobuild_runfile_links`

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -138,7 +138,10 @@ function test_cc_test_llvm_coverage_produces_lcov_report() {
   setup_llvm_coverage_tools_for_lcov || return 0
   setup_a_cc_lib_and_t_cc_test
 
-  bazel coverage --test_output=all //:t &>$TEST_log || fail "Coverage for //:t failed"
+  # Ensure that coverage succeeds even with lazily built runfiles trees for the
+  # merger tool.
+  bazel coverage --nobuild_runfile_links \
+      --test_output=all //:t &>$TEST_log || fail "Coverage for //:t failed"
 
   local expected_result="SF:a.cc
 FN:3,_Z1ab
@@ -163,7 +166,10 @@ function test_cc_test_llvm_coverage_produces_lcov_report_with_split_postprocessi
   setup_llvm_coverage_tools_for_lcov || return 0
   setup_a_cc_lib_and_t_cc_test
 
+  # Ensure that coverage succeeds even with lazily built runfiles trees for the
+  # merger tool.
   bazel coverage \
+    --nobuild_runfile_links \
     --experimental_split_coverage_postprocessing --experimental_fetch_all_coverage_outputs \
       --test_env=VERBOSE_COVERAGE=1 --test_output=all //:t &>$TEST_log || fail "Coverage for //:t failed"
 

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -210,7 +210,11 @@ public class TestCollatz {
 }
 EOF
 
-  bazel coverage --test_output=all //:test --coverage_report_generator=@bazel_tools//tools/test:coverage_report_generator --combined_report=lcov &>$TEST_log \
+  # Ensure that coverage succeeds even with lazily built runfiles trees for the
+  # merger tool.
+  bazel coverage \
+      --nobuild_runfile_links \
+      --test_output=all //:test --coverage_report_generator=@bazel_tools//tools/test:coverage_report_generator --combined_report=lcov &>$TEST_log \
    || echo "Coverage for //:test failed"
 
   local expected_result="SF:src/main/com/example/Collatz.java


### PR DESCRIPTION
Fixes #20577

Closes #22676.

PiperOrigin-RevId: 649065192
Change-Id: I0a57f580c1cb3a03184950e3e5ea24e9ef4962b4

Commit https://github.com/bazelbuild/bazel/commit/c8006084e70f7faa942572808b6329b044f0f7ab