### PR TITLE
[7.4.0] Apply a workaround for absolute paths in .d files which can lead to cache issues with the Android NDK on Windows.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/DependencySet.java
+++ b/src/main/java/com/google/devtools/build/lib/util/DependencySet.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -104,7 +106,7 @@ public final class DependencySet {
     if (OS.getCurrent() != OS.WINDOWS) {
       return path;
     }
-    return WindowsPath.translateWindowsPath(path);
+    return WindowsPath.removeWorkspace(WindowsPath.translateWindowsPath(path));
   }
 
   /** Reads a dotd file into this DependencySet instance. */
@@ -250,6 +252,17 @@ public final class DependencySet {
 
   private static final class WindowsPath {
     private static final AtomicReference<String> UNIX_ROOT = new AtomicReference<>(null);
+
+    private static final Pattern EXECROOT_BASE_HEADER_PATTERN =
+        Pattern.compile(".*execroot[\\\\/](?<headerPath>.*)");
+
+    private static String removeWorkspace(String path) {
+      Matcher m = EXECROOT_BASE_HEADER_PATTERN.matcher(path);
+      if (m.matches()) {
+        path = "../" + m.group("headerPath");
+      }
+      return path;
+    }
 
     private static String translateWindowsPath(String path) {
       int n = path.length();


### PR DESCRIPTION
PiperOrigin-RevId: 658725449
Change-Id: I09edfa9af8a4956d661174bef76a7f8776891a8b

Commit https://github.com/bazelbuild/bazel/commit/638f293a0f608db0ea6de4e0b58cd61870086db6