### PR TITLE
[7.4.0] Add path mapping support for C++ compile action templates

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -1378,6 +1378,13 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public Builder overrideArtifactVariable(String name, Artifact value) {
+      Preconditions.checkNotNull(value, "Cannot set null as a value for variable '%s'", name);
+      variablesMap.put(name, value);
+      return this;
+    }
+
     /**
      * Add an artifact or string variable that expands {@code name} to {@code value}.
      *

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionTemplate.java
@@ -237,27 +237,23 @@ public final class CppCompileActionTemplate extends ActionKeyCacher
 
     CcToolchainVariables.Builder buildVariables =
         CcToolchainVariables.builder(cppCompileActionBuilder.getVariables());
-    buildVariables.overrideStringVariable(
-        CompileBuildVariables.SOURCE_FILE.getVariableName(),
-        sourceTreeFileArtifact.getExecPathString());
-    buildVariables.overrideStringVariable(
-        CompileBuildVariables.OUTPUT_FILE.getVariableName(),
-        outputTreeFileArtifact.getExecPathString());
+    buildVariables.overrideArtifactVariable(
+        CompileBuildVariables.SOURCE_FILE.getVariableName(), sourceTreeFileArtifact);
+    buildVariables.overrideArtifactVariable(
+        CompileBuildVariables.OUTPUT_FILE.getVariableName(), outputTreeFileArtifact);
     if (dotdFileArtifact != null) {
-      buildVariables.overrideStringVariable(
-          CompileBuildVariables.DEPENDENCY_FILE.getVariableName(),
-          dotdFileArtifact.getExecPathString());
+      buildVariables.overrideArtifactVariable(
+          CompileBuildVariables.DEPENDENCY_FILE.getVariableName(), dotdFileArtifact);
     }
     if (diagnosticsFileArtifact != null) {
-      buildVariables.overrideStringVariable(
+      buildVariables.overrideArtifactVariable(
           CompileBuildVariables.SERIALIZED_DIAGNOSTICS_FILE.getVariableName(),
-          diagnosticsFileArtifact.getExecPathString());
+          diagnosticsFileArtifact);
     }
 
     if (ltoIndexFileArtifact != null) {
-      buildVariables.overrideStringVariable(
-          CompileBuildVariables.LTO_INDEXING_BITCODE_FILE.getVariableName(),
-          ltoIndexFileArtifact.getExecPathString());
+      buildVariables.overrideArtifactVariable(
+          CompileBuildVariables.LTO_INDEXING_BITCODE_FILE.getVariableName(), ltoIndexFileArtifact);
     }
 
     builder.setVariables(buildVariables.build());

--- a/src/test/java/com/google/devtools/build/lib/remote/util/IntegrationTestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/IntegrationTestUtils.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.shell.Subprocess;
 import com.google.devtools.build.lib.shell.SubprocessBuilder;
 import com.google.devtools.build.lib.util.OS;
@@ -193,9 +194,14 @@ public final class IntegrationTestUtils {
       ensureMkdir(stdPath);
       ensureTouchFile(stdoutPath);
       ensureTouchFile(stderrPath);
-      String workerPath = Runfiles.create().rlocation(WORKER_PATH.getSafePathString());
+      Runfiles runfiles = Runfiles.preload().withSourceRepository("");
+      String workerPath = runfiles.rlocation(WORKER_PATH.getSafePathString());
+      ImmutableMap.Builder<String, String> env = ImmutableMap.builder();
+      env.putAll(System.getenv());
+      env.putAll(runfiles.getEnvVars());
       process =
           new SubprocessBuilder()
+              .setEnv(env.buildKeepingLast())
               .setStdout(new File(stdoutPath.getSafePathString()))
               .setStderr(new File(stderrPath.getSafePathString()))
               .setArgv(

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -469,13 +469,6 @@ class TestBase(absltest.TestCase):
     port = s.getsockname()[1]
     s.close()
 
-    env_add = {}
-    try:
-      env_add['RUNFILES_MANIFEST_FILE'] = TestBase.GetEnv(
-          'RUNFILES_MANIFEST_FILE')
-    except EnvVarUndefinedError:
-      pass
-
     # Tip: To help debug remote build problems, add the --debug flag below.
     self._worker_proc = subprocess.Popen(
         [
@@ -490,7 +483,8 @@ class TestBase(absltest.TestCase):
         stdout=self._worker_stdout,
         stderr=self._worker_stderr,
         cwd=self._test_cwd,
-        env=self._EnvMap(env_add=env_add))
+        env=self._EnvMap(env_add=self._runfiles.EnvVars()),
+    )
 
     return port
 

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1367,7 +1367,10 @@ sh_test(
         ":test-deps",
         "//src/tools/remote:worker",
     ],
-    tags = ["no_windows"],
+    tags = [
+        "no_windows",
+        "requires-network",  # for Bzlmod
+    ],
     deps = [
         "//src/test/shell/bazel/remote:remote_utils",
         "@bazel_tools//tools/bash/runfiles",

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -378,17 +378,29 @@ EOF
 function test_path_stripping_cc_remote() {
   local -r pkg="${FUNCNAME[0]}"
 
+  cat > MODULE.bazel <<EOF
+bazel_dep(name = "apple_support", version = "1.15.1")
+EOF
+
   mkdir -p "$pkg"
   cat > "$pkg/BUILD" <<EOF
-load("//$pkg/common/utils:defs.bzl", "transition_wrapper")
+load("//$pkg/common/utils:defs.bzl", "gen_cc", "transition_wrapper")
 
 cc_binary(
     name = "main",
-    srcs = ["main.cc"],
+    srcs = [
+        "main.cc",
+        ":gen",
+    ],
     deps = [
         "//$pkg/lib1",
         "//$pkg/lib2",
     ],
+)
+
+gen_cc(
+    name = "gen",
+    subject = "TreeArtifact",
 )
 
 transition_wrapper(
@@ -399,12 +411,16 @@ transition_wrapper(
 EOF
   cat > "$pkg/main.cc" <<EOF
 #include <iostream>
+#include <string>
 #include "$pkg/lib1/lib1.h"
 #include "lib2.h"
+
+std::string TreeArtifactGreeting();
 
 int main() {
   std::cout << GetLib1Greeting() << std::endl;
   std::cout << GetLib2Greeting() << std::endl;
+  std::cout << TreeArtifactGreeting() << std::endl;
   return 0;
 }
 EOF
@@ -558,6 +574,34 @@ transition_wrapper = rule(
     },
     executable = True,
 )
+
+def _gen_cc_impl(ctx):
+    out = ctx.actions.declare_directory(ctx.label.name)
+    ctx.actions.run_shell(
+        outputs = [out],
+        command = """\
+cat >{out_path}/gen.cc <<EOF2
+#include <string>
+
+std::string TreeArtifactGreeting() {{
+  return "Hello, {subject}!";
+}}
+EOF2
+        """.format(
+            out_path = out.path,
+            subject = ctx.attr.subject,
+        ),
+    )
+    return [
+        DefaultInfo(files = depset([out])),
+    ]
+
+gen_cc = rule(
+    implementation = _gen_cc_impl,
+    attrs = {
+        "subject": attr.string(),
+    },
+)
 EOF
   cat > "$pkg/common/utils/utils.cc.tpl" <<'EOF'
 #include "utils.h"
@@ -577,6 +621,7 @@ EOF
 
   expect_log 'Hello, lib1!'
   expect_log 'Hello, lib2!'
+  expect_log 'Hello, TreeArtifact!'
   expect_not_log 'remote cache hit'
 
   bazel run \
@@ -589,9 +634,10 @@ EOF
 
   expect_log 'Hi there, lib1!'
   expect_log 'Hi there, lib2!'
+  expect_log 'Hello, TreeArtifact!'
   # Compilation actions for lib1, lib2 and main should result in cache hits due
   # to path stripping, utils is legitimately different and should not.
-  expect_log ' 3 remote cache hit'
+  expect_log ' 4 remote cache hit'
 }
 
 run_suite "path mapping tests"

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_java//java:defs.bzl", "java_library")
 
 package(
@@ -13,15 +14,25 @@ filegroup(
     visibility = ["//src:__subpackages__"],
 )
 
+copy_file(
+    name = "xcode_locator",
+    src = "//tools/osx:xcode-locator",
+    out = "xcode-locator",
+)
+
 java_library(
     name = "worker",
     srcs = glob(["*.java"]),
+    data = [
+        ":xcode_locator",
+    ],
     resources = ["//src/main/tools:linux-sandbox"],
     visibility = ["//src/tools/remote:__subpackages__"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
-        "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
         "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/exec:bin_tools",
+        "//src/main/java/com/google/devtools/build/lib/exec/local",
         "//src/main/java/com/google/devtools/build/lib/remote",
         "//src/main/java/com/google/devtools/build/lib/remote:store",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
@@ -46,6 +57,7 @@ java_library(
         "//third_party/grpc-java:grpc-jar",
         "//third_party/protobuf:protobuf_java",
         "//third_party/protobuf:protobuf_java_util",
+        "//tools/java/runfiles",
         "@googleapis//:google_bytestream_bytestream_java_grpc",
         "@googleapis//:google_bytestream_bytestream_java_proto",
         "@googleapis//:google_longrunning_operations_java_proto",

--- a/tools/java/runfiles/BUILD
+++ b/tools/java/runfiles/BUILD
@@ -42,6 +42,7 @@ java_library(
     visibility = [
         "//src/main/java/com/google/devtools/build/skydoc:__pkg__",
         "//src/test/java/com/google/devtools/build/skydoc:__pkg__",
+        "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker:__pkg__",
         "//tools/java/runfiles/testing:__pkg__",
     ],
 )


### PR DESCRIPTION
C++ action templates are now properly path mapped.

Since the default Unix toolchain doesn't support object file groups on macOS, `apple_support` is needed in the test. This requires wiring up `LocalEnvProvider` in the remote worker to get `DEVELOPER_DIR` to be set, which in turn requires improving the runfiles handling for the the worker.

Work towards #6526

Closes #22890.

PiperOrigin-RevId: 657733074
Change-Id: I132e338d7a44964a8a1aad3062a5c9a4c8e79e57

Commit https://github.com/bazelbuild/bazel/commit/23f3be03262c89e7c2d18a110c187ee5c760af31