### PR TITLE
[7.4.0] Don't mask error in `cquery` transitions output formatter

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryTransitionResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryTransitionResolver.java
@@ -125,8 +125,8 @@ public class CqueryTransitionResolver {
    * @see ResolvedTransition for more details.
    * @param configuredTarget the configured target whose dependencies are being looked up.
    */
-  public ImmutableSet<ResolvedTransition> dependencies(CqueryNode configuredTarget)
-      throws EvaluateException, InterruptedException {
+  ImmutableSet<ResolvedTransition> dependencies(CqueryNode configuredTarget)
+      throws EvaluateException, InterruptedException, IncompatibleTargetException {
     if (!(configuredTarget instanceof RuleConfiguredTarget)) {
       return ImmutableSet.of();
     }
@@ -154,7 +154,7 @@ public class CqueryTransitionResolver {
           eventHandler)) {
         throw new EvaluateException("DependencyResolver.evaluate did not complete");
       }
-    } catch (ReportedException | UnreportedException | IncompatibleTargetException e) {
+    } catch (ReportedException | UnreportedException e) {
       throw new EvaluateException(e.getMessage());
     }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.analysis.config.StarlarkTransitionCache;
 import com.google.devtools.build.lib.analysis.config.transitions.ConfigurationTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
+import com.google.devtools.build.lib.analysis.constraints.IncompatibleTargetChecker;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -105,8 +106,18 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
                     eventHandler, accessor, this, ruleClassProvider, transitionCache)
                 .dependencies(keyedConfiguredTarget);
       } catch (EvaluateException e) {
-        // This is an abuse of InterruptedException.
-        throw new InterruptedException(e.getMessage());
+        eventHandler.handle(
+            Event.error(
+                String.format(
+                    "Failed to evaluate %s: %s", keyedConfiguredTarget.getOriginalLabel(), e)));
+        return;
+      } catch (IncompatibleTargetChecker.IncompatibleTargetException e) {
+        eventHandler.handle(
+            Event.warn(
+                String.format(
+                    "Skipping dependencies of incompatible target %s",
+                    keyedConfiguredTarget.getOriginalLabel())));
+        return;
       }
       for (ResolvedTransition dep : dependencies) {
         addResult(


### PR DESCRIPTION
All errors used to be wrapped in an `InterruptedException` instead of being reported with a message. Also show a warning when an incompatible target is skipped instead of failing the build.

Work towards #21010

Closes #23210.

PiperOrigin-RevId: 660116656
Change-Id: I22651110984e471a6b31dcc59a387f3f85ad49bc

https://github.com/bazelbuild/bazel/commit/300c5867b7d2da1ba32abc20e95662096c2a7a08