### PR TITLE
[7.4.0] Introduce `--http_max_parallel_downloads`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
@@ -26,16 +26,19 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /** Prod implementation of {@link RegistryFactory}. */
 public class RegistryFactoryImpl implements RegistryFactory {
-  private final DownloadManager downloadManager;
+  @Nullable private DownloadManager downloadManager;
   private final Supplier<Map<String, String>> clientEnvironmentSupplier;
 
-  public RegistryFactoryImpl(
-      DownloadManager downloadManager, Supplier<Map<String, String>> clientEnvironmentSupplier) {
-    this.downloadManager = downloadManager;
+  public RegistryFactoryImpl(Supplier<Map<String, String>> clientEnvironmentSupplier) {
     this.clientEnvironmentSupplier = clientEnvironmentSupplier;
+  }
+
+  public void setDownloadManager(DownloadManager downloadManager) {
+    this.downloadManager = downloadManager;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -101,18 +101,19 @@ import net.starlark.java.syntax.Location;
 public class SingleExtensionEvalFunction implements SkyFunction {
   private final BlazeDirectories directories;
   private final Supplier<Map<String, String>> clientEnvironmentSupplier;
-  private final DownloadManager downloadManager;
 
   private double timeoutScaling = 1.0;
   @Nullable private ProcessWrapper processWrapper = null;
   @Nullable private RepositoryRemoteExecutor repositoryRemoteExecutor = null;
+  @Nullable private DownloadManager downloadManager = null;
 
   public SingleExtensionEvalFunction(
-      BlazeDirectories directories,
-      Supplier<Map<String, String>> clientEnvironmentSupplier,
-      DownloadManager downloadManager) {
+      BlazeDirectories directories, Supplier<Map<String, String>> clientEnvironmentSupplier) {
     this.directories = directories;
     this.clientEnvironmentSupplier = clientEnvironmentSupplier;
+  }
+
+  public void setDownloadManager(DownloadManager downloadManager) {
     this.downloadManager = downloadManager;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -109,14 +109,16 @@ import javax.annotation.Nullable;
 public final class VendorCommand implements BlazeCommand {
   public static final String NAME = "vendor";
 
-  private final DownloadManager downloadManager;
   private final Supplier<Map<String, String>> clientEnvironmentSupplier;
   @Nullable private VendorManager vendorManager = null;
+  @Nullable private DownloadManager downloadManager;
 
-  public VendorCommand(
-      DownloadManager downloadManager, Supplier<Map<String, String>> clientEnvironmentSupplier) {
-    this.downloadManager = downloadManager;
+  public VendorCommand(Supplier<Map<String, String>> clientEnvironmentSupplier) {
     this.clientEnvironmentSupplier = clientEnvironmentSupplier;
+  }
+
+  public void setDownloadManager(DownloadManager downloadManager) {
+    this.downloadManager = downloadManager;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -27,7 +27,6 @@ import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParsingException;
-import java.time.Duration;
 import java.util.List;
 
 /** Command-line options for repositories. */
@@ -133,31 +132,7 @@ public class RepositoryOptions extends OptionsBase {
               + "to download them.")
   public List<PathFragment> experimentalDistdir;
 
-  @Option(
-      name = "http_timeout_scaling",
-      defaultValue = "1.0",
-      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
-      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
-      help = "Scale all timeouts related to http downloads by the given factor")
-  public double httpTimeoutScaling;
 
-  @Option(
-      name = "http_connector_attempts",
-      defaultValue = "8",
-      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
-      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
-      help = "The maximum number of attempts for http downloads.")
-  public int httpConnectorAttempts;
-
-  @Option(
-      name = "http_connector_retry_max_timeout",
-      defaultValue = "0s",
-      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
-      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
-      help =
-          "The maximum timeout for http download retries. With a value of 0, no timeout maximum is"
-              + " defined.")
-  public Duration httpConnectorRetryMaxTimeout;
 
   @Option(
       name = "override_repository",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -73,19 +73,21 @@ import net.starlark.java.eval.StarlarkThread;
 
 /** A repository function to delegate work done by Starlark remote repositories. */
 public final class StarlarkRepositoryFunction extends RepositoryFunction {
-  private final DownloadManager downloadManager;
   private double timeoutScaling = 1.0;
   private boolean useWorkers;
+  @Nullable private DownloadManager downloadManager;
   @Nullable private ProcessWrapper processWrapper = null;
   @Nullable private RepositoryRemoteExecutor repositoryRemoteExecutor;
   @Nullable private SyscallCache syscallCache;
 
-  public StarlarkRepositoryFunction(DownloadManager downloadManager) {
-    this.downloadManager = downloadManager;
-  }
+  public StarlarkRepositoryFunction() {}
 
   public void setTimeoutScaling(double timeoutScaling) {
     this.timeoutScaling = timeoutScaling;
+  }
+
+  public void setDownloadManager(DownloadManager downloadManager) {
+    this.downloadManager = downloadManager;
   }
 
   public void setProcessWrapper(@Nullable ProcessWrapper processWrapper) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -45,7 +45,6 @@ import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelpe
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialModule;
 import com.google.devtools.build.lib.authandtls.credentialhelper.GetCredentialsResponse;
 import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
-import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.buildeventstream.LocalFilesArtifactUploader;
 import com.google.devtools.build.lib.buildtool.BuildRequest;
@@ -89,7 +88,6 @@ import com.google.devtools.build.lib.server.FailureDetails.Execution;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution;
 import com.google.devtools.build.lib.server.FailureDetails.RemoteExecution.Code;
-import com.google.devtools.build.lib.skyframe.MutableSupplier;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
@@ -165,7 +163,7 @@ public final class RemoteModule extends BlazeModule {
   private final RepositoryRemoteExecutorFactoryDelegate repositoryRemoteExecutorFactoryDelegate =
       new RepositoryRemoteExecutorFactoryDelegate();
 
-  private final MutableSupplier<Downloader> remoteDownloaderSupplier = new MutableSupplier<>();
+  private Downloader remoteDownloader;
 
   private CredentialModule credentialModule;
 
@@ -174,7 +172,6 @@ public final class RemoteModule extends BlazeModule {
     builder.addBuildEventArtifactUploaderFactory(
         buildEventArtifactUploaderFactoryDelegate, "remote");
     builder.setRepositoryRemoteExecutorFactory(repositoryRemoteExecutorFactoryDelegate);
-    builder.setDownloaderSupplier(remoteDownloaderSupplier);
   }
 
   /** Returns whether remote execution should be available. */
@@ -723,9 +720,9 @@ public final class RemoteModule extends BlazeModule {
 
       Downloader fallbackDownloader = null;
       if (remoteOptions.remoteDownloaderLocalFallback) {
-        fallbackDownloader = new HttpDownloader();
+        fallbackDownloader = env.getHttpDownloader();
       }
-      remoteDownloaderSupplier.set(
+      remoteDownloader =
           new GrpcRemoteDownloader(
               buildRequestId,
               invocationId,
@@ -736,8 +733,9 @@ public final class RemoteModule extends BlazeModule {
               digestUtil.getDigestFunction(),
               remoteOptions,
               verboseFailures,
-              fallbackDownloader));
+              fallbackDownloader);
       downloaderChannel.release();
+      env.getDownloaderDelegate().setDelegate(remoteDownloader);
     }
   }
 
@@ -927,7 +925,7 @@ public final class RemoteModule extends BlazeModule {
 
     buildEventArtifactUploaderFactoryDelegate.reset();
     repositoryRemoteExecutorFactoryDelegate.reset();
-    remoteDownloaderSupplier.set(null);
+    remoteDownloader = null;
     actionContextProvider = null;
     actionInputFetcher = null;
     remoteOptions = null;
@@ -1226,7 +1224,7 @@ public final class RemoteModule extends BlazeModule {
   }
 
   @VisibleForTesting
-  MutableSupplier<Downloader> getRemoteDownloaderSupplier() {
-    return remoteDownloaderSupplier;
+  Downloader getRemoteDownloader() {
+    return remoteDownloader;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -39,7 +39,6 @@ import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.test.CoverageReportActionFactory;
-import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
 import com.google.devtools.build.lib.bugreport.BugReport;
 import com.google.devtools.build.lib.bugreport.BugReporter;
 import com.google.devtools.build.lib.bugreport.Crash;
@@ -135,7 +134,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -188,7 +186,6 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
   private final ActionKeyContext actionKeyContext;
   private final ImmutableMap<String, AuthHeadersProvider> authHeadersProviderMap;
   @Nullable private final RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory;
-  private final Supplier<Downloader> downloaderSupplier;
 
   // Workspace state (currently exactly one workspace per server)
   private BlazeWorkspace workspace;
@@ -215,8 +212,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
       String productName,
       BuildEventArtifactUploaderFactoryMap buildEventArtifactUploaderFactoryMap,
       ImmutableMap<String, AuthHeadersProvider> authHeadersProviderMap,
-      RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory,
-      Supplier<Downloader> downloaderSupplier) {
+      RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory) {
     // Server state
     this.fileSystem = fileSystem;
     this.blazeModules = blazeModules;
@@ -246,7 +242,6 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
     this.authHeadersProviderMap =
         Preconditions.checkNotNull(authHeadersProviderMap, "authHeadersProviderMap");
     this.repositoryRemoteExecutorFactory = repositoryRemoteExecutorFactory;
-    this.downloaderSupplier = downloaderSupplier;
   }
 
   public BlazeWorkspace initWorkspace(BlazeDirectories directories, BinTools binTools)
@@ -1430,10 +1425,6 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
     return repositoryRemoteExecutorFactory;
   }
 
-  public Supplier<Downloader> getDownloaderSupplier() {
-    return downloaderSupplier;
-  }
-
   /**
    * A builder for {@link BlazeRuntime} objects. The only required fields are the {@link
    * BlazeDirectories}, and the {@link com.google.devtools.build.lib.packages.RuleClassProvider}
@@ -1560,8 +1551,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
               productName,
               serverBuilder.getBuildEventArtifactUploaderMap(),
               serverBuilder.getAuthHeadersProvidersMap(),
-              serverBuilder.getRepositoryRemoteExecutorFactory(),
-              serverBuilder.getDownloaderSupplier());
+              serverBuilder.getRepositoryRemoteExecutorFactory());
       AutoProfiler.setClock(runtime.getClock());
       BugReport.setRuntime(runtime);
       return runtime;

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -31,6 +31,7 @@ import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.TriState;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -531,6 +532,40 @@ public class CommonCommandOptions extends OptionsBase {
               + " likely that these nodes will be needed again. If so, the program will re-evaluate"
               + " them.")
   public boolean heuristicallyDropNodes;
+
+  @Option(
+      name = "http_timeout_scaling",
+      defaultValue = "1.0",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      help = "Scale all timeouts related to http downloads by the given factor")
+  public double httpTimeoutScaling;
+
+  @Option(
+      name = "http_connector_attempts",
+      defaultValue = "8",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      help = "The maximum number of attempts for http downloads.")
+  public int httpConnectorAttempts;
+
+  @Option(
+      name = "http_connector_retry_max_timeout",
+      defaultValue = "0s",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      help =
+          "The maximum timeout for http download retries. With a value of 0, no timeout maximum is"
+              + " defined.")
+  public Duration httpConnectorRetryMaxTimeout;
+
+  @Option(
+      name = "http_max_parallel_downloads",
+      defaultValue = "8",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      help = "The maximum number parallel http downloads.")
+  public int httpMaxParallelDownloads;
 
   /** The option converter to check that the user can only specify legal profiler tasks. */
   public static class ProfilerTaskConverter extends EnumConverter<ProfilerTask> {

--- a/src/main/java/com/google/devtools/build/lib/runtime/ServerBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/ServerBuilder.java
@@ -17,13 +17,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
 import com.google.devtools.build.lib.query2.QueryEnvironmentFactory;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
 import com.google.devtools.build.lib.query2.query.output.OutputFormatter;
 import com.google.devtools.build.lib.runtime.proto.InvocationPolicyOuterClass.InvocationPolicy;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.function.Supplier;
 
 /**
  * Builder class to create a {@link BlazeRuntime} instance. This class is part of the module API,
@@ -42,7 +40,6 @@ public final class ServerBuilder {
   private final ImmutableMap.Builder<String, AuthHeadersProvider> authHeadersProvidersMap =
       ImmutableMap.builder();
   private RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory;
-  private Supplier<Downloader> downloaderSupplier = () -> null;
 
   @VisibleForTesting
   public ServerBuilder() {}
@@ -80,10 +77,6 @@ public final class ServerBuilder {
 
   public RepositoryRemoteExecutorFactory getRepositoryRemoteExecutorFactory() {
     return repositoryRemoteExecutorFactory;
-  }
-
-  public Supplier<Downloader> getDownloaderSupplier() {
-    return downloaderSupplier;
   }
 
   /**
@@ -174,12 +167,6 @@ public final class ServerBuilder {
   public ServerBuilder setRepositoryRemoteExecutorFactory(
       RepositoryRemoteExecutorFactory repositoryRemoteExecutorFactory) {
     this.repositoryRemoteExecutorFactory = repositoryRemoteExecutorFactory;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public ServerBuilder setDownloaderSupplier(Supplier<Downloader> downloaderSupplier) {
-    this.downloaderSupplier = downloaderSupplier;
     return this;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
@@ -36,7 +36,6 @@ import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.rules.android.AndroidNdkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.rules.android.AndroidNdkRepositoryRule;
@@ -65,7 +64,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import org.mockito.Mockito;
 
 /** Create a mock client for the analysis phase, as well as a configuration factory. */
 public abstract class AnalysisMock extends LoadingMock {
@@ -157,14 +155,12 @@ public abstract class AnalysisMock extends LoadingMock {
 
     addExtraRepositoryFunctions(repositoryHandlers);
 
-    DownloadManager downloadManager = Mockito.mock(DownloadManager.class);
-
     return ImmutableMap.<SkyFunctionName, SkyFunction>builder()
         .put(
             SkyFunctions.REPOSITORY_DIRECTORY,
             new RepositoryDelegatorFunction(
                 repositoryHandlers.buildKeepingLast(),
-                new StarlarkRepositoryFunction(downloadManager),
+                new StarlarkRepositoryFunction(),
                 new AtomicBoolean(true),
                 ImmutableMap::of,
                 directories,
@@ -181,7 +177,7 @@ public abstract class AnalysisMock extends LoadingMock {
         .put(SkyFunctions.SINGLE_EXTENSION, new SingleExtensionFunction())
         .put(
             SkyFunctions.SINGLE_EXTENSION_EVAL,
-            new SingleExtensionEvalFunction(directories, ImmutableMap::of, downloadManager))
+            new SingleExtensionEvalFunction(directories, ImmutableMap::of))
         .put(SkyFunctions.SINGLE_EXTENSION_USAGES, new SingleExtensionUsagesFunction())
         .put(
             SkyFunctions.REGISTRY,

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
@@ -31,7 +31,6 @@ import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
@@ -76,7 +75,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 
 /** Tests for {@link BazelModuleResolutionFunction}. */
 @RunWith(JUnit4.class)
@@ -121,9 +119,7 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
     ConfiguredRuleClassProvider ruleClassProvider = builder.build();
     ImmutableMap<String, RepositoryFunction> repositoryHandlers =
         ImmutableMap.of(LocalRepositoryRule.NAME, new LocalRepositoryFunction());
-    DownloadManager downloadManager = Mockito.mock(DownloadManager.class);
-    StarlarkRepositoryFunction starlarkRepositoryFunction =
-        new StarlarkRepositoryFunction(downloadManager);
+    StarlarkRepositoryFunction starlarkRepositoryFunction = new StarlarkRepositoryFunction();
 
     evaluator =
         new InMemoryMemoizingEvaluator(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -78,7 +78,7 @@ public class IndexRegistryTest extends FoundationTestCase {
   @Rule public final TestHttpServer server = new TestHttpServer(authToken);
   @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
-  private RegistryFactory registryFactory;
+  private RegistryFactoryImpl registryFactory;
   private RepositoryCache repositoryCache;
 
   @Before
@@ -86,9 +86,10 @@ public class IndexRegistryTest extends FoundationTestCase {
     eventRecorder = new EventRecorder();
     eventBus.register(eventRecorder);
     repositoryCache = new RepositoryCache();
-    downloadManager = new DownloadManager(repositoryCache, new HttpDownloader());
-    registryFactory =
-        new RegistryFactoryImpl(downloadManager, Suppliers.ofInstance(ImmutableMap.of()));
+    HttpDownloader httpDownloader = new HttpDownloader();
+    downloadManager = new DownloadManager(repositoryCache, httpDownloader, httpDownloader);
+    registryFactory = new RegistryFactoryImpl(Suppliers.ofInstance(ImmutableMap.of()));
+    registryFactory.setDownloadManager(downloadManager);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -34,7 +34,6 @@ import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
@@ -106,7 +105,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 
 /** Tests for module extension resolution. */
 @RunWith(JUnit4.class)
@@ -163,10 +161,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             .getPackageFactoryBuilderForTesting(directories)
             .build(ruleClassProvider, fileSystem);
     HashFunction hashFunction = fileSystem.getDigestFunction().getHashFunction();
-
-    DownloadManager downloadManager = Mockito.mock(DownloadManager.class);
-    StarlarkRepositoryFunction starlarkRepositoryFunction =
-        new StarlarkRepositoryFunction(downloadManager);
+    StarlarkRepositoryFunction starlarkRepositoryFunction = new StarlarkRepositoryFunction();
 
     ImmutableMap<String, RepositoryFunction> repositoryHandlers =
         ImmutableMap.of(LocalRepositoryRule.NAME, new LocalRepositoryFunction());
@@ -267,7 +262,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
                 .put(SkyFunctions.SINGLE_EXTENSION, new SingleExtensionFunction())
                 .put(
                     SkyFunctions.SINGLE_EXTENSION_EVAL,
-                    new SingleExtensionEvalFunction(directories, ImmutableMap::of, downloadManager))
+                    new SingleExtensionEvalFunction(directories, ImmutableMap::of))
                 .put(
                     SkyFunctions.REGISTRY,
                     new RegistryFunction(registryFactory, directories.getWorkspace()))

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryTest.java
@@ -21,9 +21,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
-import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
-import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import org.junit.Test;
@@ -37,9 +34,7 @@ public class RegistryFactoryTest {
   @Test
   public void badSchemes() {
     RegistryFactory registryFactory =
-        new RegistryFactoryImpl(
-            new DownloadManager(new RepositoryCache(), new HttpDownloader()),
-            Suppliers.ofInstance(ImmutableMap.of()));
+        new RegistryFactoryImpl(Suppliers.ofInstance(ImmutableMap.of()));
     Throwable exception =
         assertThrows(
             URISyntaxException.class,
@@ -67,9 +62,7 @@ public class RegistryFactoryTest {
   @Test
   public void badPath() {
     RegistryFactory registryFactory =
-        new RegistryFactoryImpl(
-            new DownloadManager(new RepositoryCache(), new HttpDownloader()),
-            Suppliers.ofInstance(ImmutableMap.of()));
+        new RegistryFactoryImpl(Suppliers.ofInstance(ImmutableMap.of()));
     Throwable exception =
         assertThrows(
             URISyntaxException.class,

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -45,6 +45,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -73,9 +74,10 @@ public class HttpDownloaderTest {
   @Rule public final Timeout timeout = new Timeout(30, SECONDS);
 
   private final RepositoryCache repositoryCache = mock(RepositoryCache.class);
-  private final HttpDownloader httpDownloader = new HttpDownloader();
+  // Scale timeouts down to make test fast.
+  private final HttpDownloader httpDownloader = new HttpDownloader(0, Duration.ZERO, 8, .1f);
   private final DownloadManager downloadManager =
-      new DownloadManager(repositoryCache, httpDownloader);
+      new DownloadManager(repositoryCache, httpDownloader, httpDownloader);
 
   private final ExecutorService executor = Executors.newFixedThreadPool(2);
   private final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
@@ -83,9 +85,6 @@ public class HttpDownloaderTest {
 
   public HttpDownloaderTest() {
     fs = new JavaIoFileSystem(DigestHashFunction.SHA256);
-
-    // Scale timeouts down to make tests fast.
-    httpDownloader.setTimeoutScaling(0.1f);
   }
 
   @After
@@ -646,7 +645,9 @@ public class HttpDownloaderTest {
   @Test
   public void download_contentLengthMismatch_propagateErrorIfNotRetry() throws Exception {
     Downloader downloader = mock(Downloader.class);
-    DownloadManager downloadManager = new DownloadManager(repositoryCache, downloader);
+    HttpDownloader httpDownloader = mock(HttpDownloader.class);
+    DownloadManager downloadManager =
+        new DownloadManager(repositoryCache, downloader, httpDownloader);
     // do not retry
     downloadManager.setRetries(0);
     AtomicInteger times = new AtomicInteger(0);
@@ -682,9 +683,11 @@ public class HttpDownloaderTest {
   @Test
   public void download_contentLengthMismatch_retries() throws Exception {
     Downloader downloader = mock(Downloader.class);
-    int retires = 5;
-    DownloadManager downloadManager = new DownloadManager(repositoryCache, downloader);
-    downloadManager.setRetries(retires);
+    HttpDownloader httpDownloader = mock(HttpDownloader.class);
+    int retries = 5;
+    DownloadManager downloadManager =
+        new DownloadManager(repositoryCache, downloader, httpDownloader);
+    downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
     doAnswer(
@@ -725,9 +728,11 @@ public class HttpDownloaderTest {
   @Test
   public void download_contentLengthMismatchWithOtherErrors_retries() throws Exception {
     Downloader downloader = mock(Downloader.class);
-    int retires = 5;
-    DownloadManager downloadManager = new DownloadManager(repositoryCache, downloader);
-    downloadManager.setRetries(retires);
+    HttpDownloader httpDownloader = mock(HttpDownloader.class);
+    int retries = 5;
+    DownloadManager downloadManager =
+        new DownloadManager(repositoryCache, downloader, httpDownloader);
+    downloadManager.setRetries(retries);
     AtomicInteger times = new AtomicInteger(0);
     byte[] data = "content".getBytes(UTF_8);
     doAnswer(

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -148,6 +148,7 @@ public final class RemoteModuleTest {
     ServerDirectories serverDirectories =
         new ServerDirectories(
             scratch.dir("install"), scratch.dir("output"), scratch.dir("user_root"));
+
     BlazeRuntime runtime =
         new BlazeRuntime.Builder()
             .setProductName(productName)
@@ -237,7 +238,7 @@ public final class RemoteModuleTest {
       beforeCommand();
 
       // Wait for the channel to be connected.
-      var downloader = (GrpcRemoteDownloader) remoteModule.getRemoteDownloaderSupplier().get();
+      var downloader = (GrpcRemoteDownloader) remoteModule.getRemoteDownloader();
       var unused = downloader.getChannel().withChannelBlocking(ch -> new Object());
 
       // Remote downloader uses Remote Asset API, and Bazel doesn't have any capability requirement

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -44,7 +44,6 @@ import com.google.devtools.build.lib.bazel.bzlmod.YankedVersionsUtil;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.BazelCompatibilityMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
-import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
@@ -108,7 +107,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 
 /** Tests for {@link RepositoryDelegatorFunction} */
 @RunWith(JUnit4.class)
@@ -132,14 +130,13 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
             rootPath,
             /* defaultSystemJavabase= */ null,
             TestConstants.PRODUCT_NAME);
-    DownloadManager downloader = Mockito.mock(DownloadManager.class);
     RepositoryFunction localRepositoryFunction = new LocalRepositoryFunction();
     ImmutableMap<String, RepositoryFunction> repositoryHandlers =
         ImmutableMap.of(LocalRepositoryRule.NAME, localRepositoryFunction);
     RepositoryDelegatorFunction delegatorFunction =
         new RepositoryDelegatorFunction(
             repositoryHandlers,
-            new StarlarkRepositoryFunction(downloader),
+            new StarlarkRepositoryFunction(),
             /* isFetch= */ new AtomicBoolean(true),
             /* clientEnvironmentSupplier= */ ImmutableMap::of,
             directories,


### PR DESCRIPTION
This option sets the global limit for how many parallel HTTP connections bazel will initiate to download files.

Working towards https://github.com/bazelbuild/bazel/issues/19315.

Note: The first four commits of the PR are a refactoring from  #23080. The last commit is a bigger refactoring, moving `HttpDownloader` around further. Commit-by-commit review is encouraged. The hope is to get this PR in before 7.3.0rc1 is cut on Monday.

Closes #23106.

PiperOrigin-RevId: 657111369
Change-Id: I9a848758517cd78cd5a0e1b380bf39625045b77a

Commit https://github.com/bazelbuild/bazel/commit/01d477dc424cf4c61ca828252f3e747c2c5c185e