### PR TITLE
[7.4.0] Delay execution phase reporting in Skymeld.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTracker.java
@@ -100,10 +100,11 @@ final class SkymeldUiStateTracker extends UiStateTracker {
         writeLoadingAnalysisPhaseProgress(
             "Analyzing", additionalMessage, terminalWriter, shortVersion);
         terminalWriter.newline();
-        writeExecutionProgress(terminalWriter, shortVersion);
-        break;
+      // fall through
       case EXECUTION:
-        writeExecutionProgress(terminalWriter, shortVersion);
+        if (executionPhaseStarted) {
+          writeExecutionProgress(terminalWriter, shortVersion);
+        }
         break;
       case BUILD_COMPLETED:
         writeBaseProgress(ok ? "INFO" : "FAILED", additionalMessage, terminalWriter);

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -52,6 +52,7 @@ import com.google.devtools.build.lib.pkgcache.LoadingPhaseCompleteEvent;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.skyframe.ConfigurationPhaseStartedEvent;
 import com.google.devtools.build.lib.skyframe.LoadingPhaseStartedEvent;
+import com.google.devtools.build.lib.skyframe.TopLevelStatusEvents.SomeExecutionStartedEvent;
 import com.google.devtools.build.lib.skyframe.TopLevelStatusEvents.TestAnalyzedEvent;
 import com.google.devtools.build.lib.util.io.AnsiTerminal;
 import com.google.devtools.build.lib.util.io.AnsiTerminal.Color;
@@ -573,6 +574,14 @@ public final class UiEventHandler implements EventHandler {
   public synchronized void analysisComplete(AnalysisPhaseCompleteEvent event) {
     String analysisSummary = stateTracker.analysisComplete();
     handle(Event.info(null, analysisSummary));
+  }
+
+  @Subscribe
+  public void executionPhaseStarted(SomeExecutionStartedEvent event) {
+    if (event.countedInExecutionTime()) {
+      stateTracker.executionPhaseStarted();
+      refresh();
+    }
   }
 
   @Subscribe

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -369,6 +369,7 @@ class UiStateTracker {
   protected int failedTests;
   protected boolean ok;
   private boolean buildComplete;
+  protected volatile boolean executionPhaseStarted;
 
   @Nullable protected ExecutionProgressReceiver executionProgressReceiver;
   @Nullable protected PackageProgressReceiver packageProgressReceiver;
@@ -390,6 +391,7 @@ class UiStateTracker {
     this.ok = true;
     this.clock = clock;
     this.targetWidth = targetWidth;
+    this.executionPhaseStarted = false;
   }
 
   UiStateTracker(Clock clock) {
@@ -429,6 +431,10 @@ class UiStateTracker {
       additionalMessage = count + " targets";
     }
     mainRepositoryMapping = event.getMainRepositoryMapping();
+  }
+
+  void executionPhaseStarted() {
+    executionPhaseStarted = true;
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTrackerTest.java
@@ -127,7 +127,7 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
     assertThat(output).contains(loadingState);
     assertThat(output).contains(loadingActivity);
     assertThat(output).contains(configuredTargetProgressString);
-    assertThat(output).contains("[0 / 0]");
+    assertThat(output).doesNotContain("[0 / 0]");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
@@ -226,6 +226,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     if (this.isSkymeld) {
       // SkymeldUiStateTracker needs to be in the configuration phase before the execution phase.
       ((SkymeldUiStateTracker) uiStateTracker).buildStatus = BuildStatus.ANALYSIS_COMPLETE;
+      uiStateTracker.executionPhaseStarted();
     } else {
       String unused = uiStateTracker.analysisComplete();
     }

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -268,7 +268,11 @@ function test_noshow_progress() {
 }
 
 function test_basic_progress_no_curses() {
-  bazel test --curses=no --color=yes pkg:true 2>$TEST_log \
+  # --experimental_ui_debug_all_events is necessary so that we don't miss the
+  # progress indicator event which is only shown once a second when curses is
+  # disabled
+  bazel test --curses=no --color=yes --experimental_ui_debug_all_events \
+    pkg:true 2>$TEST_log \
     || fail "${PRODUCT_NAME} test failed"
   # some progress indicator is shown
   expect_log '\[[0-9,]* / [0-9,]*\]'
@@ -281,7 +285,10 @@ function test_basic_progress_no_curses() {
 }
 
 function test_no_curses_no_linebreak() {
-  bazel test --curses=no --color=yes --terminal_columns=9 \
+  # --experimental_ui_debug_all_events is necessary so that we don't miss the
+  # progress indicator event which is only shown once a second when curses is
+  # disabled
+  bazel test --curses=no --color=yes --experimental_ui_debug_all_events \
     pkg:true 2>$TEST_log || fail "${PRODUCT_NAME} test failed"
   # expect a long-ish status line
   expect_log '\[[0-9,]* / [0-9,]*\]......'


### PR DESCRIPTION
Previously:
Since Skymeld executes actions as soon as it can, it will execute the workspace status command action right at the start of the invocation. From that moment on, until the end of the analysis phase, even for single top-level targets, we would see the misleading message `[1/1] checking cached actions`.

Now:
We wait with displaying execution phase progress until the first "real" action has been enqueued, i.e. we explicitly ignore the workspace status command action. PiperOrigin-RevId: 661185053
Change-Id: I0755fc33dbb6e9cea5f98aefa5516f8565b827f3

Commit https://github.com/bazelbuild/bazel/commit/5744abd7831fec791067ec8e182cd47f82aaaf3e