### PR TITLE
[7.4.0] Replace "checking cached actions" message when no action is running.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionProgressReceiver.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionProgressReceiver.java
@@ -243,4 +243,8 @@ public final class ExecutionProgressReceiver
       }
     };
   }
+
+  public boolean hasActionsInFlight() {
+    return completedActions.size() < exclusiveTestsCount + enqueuedActions.size();
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -1246,7 +1246,11 @@ class UiStateTracker {
     ActionState oldestAction = getOldestAction();
     if (actionsCount == 0 || oldestAction == null) {
       // TODO(b/239693084): Improve the message here.
-      terminalWriter.normal().append(" checking cached actions");
+      if (executionProgressReceiver != null && executionProgressReceiver.hasActionsInFlight()) {
+        terminalWriter.normal().append(" checking cached actions");
+      } else {
+        terminalWriter.normal().append(" no actions running");
+      }
       maybeShowRecentTest(terminalWriter, shortVersion, targetWidth - terminalWriter.getPosition());
     } else if (actionsCount == 1) {
       if (maybeShowRecentTest(null, shortVersion, targetWidth - terminalWriter.getPosition())) {


### PR DESCRIPTION
While we delay the execution phase progress until we execution real actions (see unknown commit), with Skymeld we could still see the following scenario:
- Bazel completes the analysis for the first top-level target
- Bazel starts execution for the first top-level target, still analyzing other top-level targets
- Bazel completes execution for the first top-level target, still running analysis for other top-level targets

Prior to this CL, we would have reported something like `[42 / 42] checking cached actions` until we continue with execution (after the next top-level target finishes analysis). Now, we do report `[42 / 42] no actions running`.

RELNOTES: Improve progress message in case there are no actions in flight, and display explicitly "no actions running" in that case.
PiperOrigin-RevId: 661205481
Change-Id: Ieaf77090ecf3d4979330fcd8229a92afc98c7557

Commit https://github.com/bazelbuild/bazel/commit/b215cb804510bdc0ff357fd90c3c6fdf9aa77b4c