### PR TITLE
[7.4.0] Remove unused code from Bzlmod package

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -18,7 +18,6 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
-import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
 import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
 import com.google.devtools.build.skyframe.SkyKey;
@@ -33,7 +32,7 @@ import java.util.Optional;
  */
 @AutoValue
 @GenerateTypeAdapter
-public abstract class BazelLockFileValue implements SkyValue, Postable {
+public abstract class BazelLockFileValue implements SkyValue {
 
   // NOTE: See "HACK" note in BazelLockFileModule. While this hack exists, normal increments of the
   // lockfile version need to be done by 2 at a time (i.e. keep LOCK_FILE_VERSION an odd number).

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleValue.java
@@ -47,7 +47,7 @@ public class BzlmodRepoRuleValue implements SkyValue {
   }
 
   /** Represents an unsuccessful repository lookup. */
-  public static final class RepoRuleNotFoundValue extends BzlmodRepoRuleValue {
+  private static final class RepoRuleNotFoundValue extends BzlmodRepoRuleValue {
     private RepoRuleNotFoundValue() {
       super(/*pkg=*/ null, /*ruleName=*/ null);
     }
@@ -58,7 +58,7 @@ public class BzlmodRepoRuleValue implements SkyValue {
     }
   }
 
-  public static final RepoRuleNotFoundValue REPO_RULE_NOT_FOUND_VALUE = new RepoRuleNotFoundValue();
+  public static final BzlmodRepoRuleValue REPO_RULE_NOT_FOUND_VALUE = new RepoRuleNotFoundValue();
 
   /** Argument for the SkyKey to request a BzlmodRepoRuleValue. */
   @AutoCodec

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitRepoSpecBuilder.java
@@ -86,11 +86,6 @@ public class GitRepoSpecBuilder {
     return setAttr("patch_cmds", patchCmds);
   }
 
-  @CanIgnoreReturnValue
-  public GitRepoSpecBuilder setPatchCmdsWin(List<String> patchCmdsWin) {
-    return setAttr("patch_cmds_win", patchCmdsWin);
-  }
-
   public RepoSpec build() {
     return RepoSpec.builder()
         .setBzlFile(GIT_REPO_PATH)

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 import javax.annotation.Nullable;
@@ -38,7 +37,6 @@ import javax.annotation.Nullable;
  * each dep, the {@code compatibility_level}, the {@code registry} the module comes from, etc.
  */
 @AutoValue
-@GenerateTypeAdapter
 public abstract class InterimModule extends ModuleBase {
 
   /**
@@ -133,8 +131,6 @@ public abstract class InterimModule extends ModuleBase {
     /** Optional; defaults to {@link #setName}. */
     public abstract Builder setRepoName(String value);
 
-    public abstract Builder setBazelCompatibility(ImmutableList<String> value);
-
     abstract ImmutableList.Builder<String> bazelCompatibilityBuilder();
 
     @CanIgnoreReturnValue
@@ -143,8 +139,6 @@ public abstract class InterimModule extends ModuleBase {
       return this;
     }
 
-    public abstract Builder setExecutionPlatformsToRegister(ImmutableList<String> value);
-
     abstract ImmutableList.Builder<String> executionPlatformsToRegisterBuilder();
 
     @CanIgnoreReturnValue
@@ -152,8 +146,6 @@ public abstract class InterimModule extends ModuleBase {
       executionPlatformsToRegisterBuilder().addAll(values);
       return this;
     }
-
-    public abstract Builder setToolchainsToRegister(ImmutableList<String> value);
 
     abstract ImmutableList.Builder<String> toolchainsToRegisterBuilder();
 
@@ -166,22 +158,6 @@ public abstract class InterimModule extends ModuleBase {
     public abstract Builder setOriginalDeps(ImmutableMap<String, DepSpec> value);
 
     public abstract Builder setDeps(ImmutableMap<String, DepSpec> value);
-
-    abstract ImmutableMap.Builder<String, DepSpec> depsBuilder();
-
-    @CanIgnoreReturnValue
-    public Builder addDep(String depRepoName, DepSpec depSpec) {
-      depsBuilder().put(depRepoName, depSpec);
-      return this;
-    }
-
-    abstract ImmutableMap.Builder<String, DepSpec> originalDepsBuilder();
-
-    @CanIgnoreReturnValue
-    public Builder addOriginalDep(String depRepoName, DepSpec depSpec) {
-      originalDepsBuilder().put(depRepoName, depSpec);
-      return this;
-    }
 
     public abstract Builder setRegistry(Registry value);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
@@ -57,8 +57,6 @@ public abstract class LockFileModuleExtension implements Postable {
   public abstract ImmutableTable<RepositoryName, String, RepositoryName>
       getRecordedRepoMappingEntries();
 
-  public abstract Builder toBuilder();
-
   public boolean shouldLockExtension() {
     return getModuleExtensionMetadata().isEmpty()
         || !getModuleExtensionMetadata().get().getReproducible();

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Module.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Module.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -35,7 +34,6 @@ import javax.annotation.Nullable;
  * <p>For the intermediate type used during module resolution, see {@link InterimModule}.
  */
 @AutoValue
-@GenerateTypeAdapter
 public abstract class Module extends ModuleBase {
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionUsage.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionUsage.java
@@ -47,9 +47,6 @@ public abstract class ModuleExtensionUsage {
    */
   public abstract Optional<ModuleExtensionId.IsolationKey> getIsolationKey();
 
-  /** The module that contains this particular extension usage. */
-  public abstract ModuleKey getUsingModule();
-
   /** Represents one "proxy object" returned from one {@code use_extension} call. */
   @AutoValue
   @GenerateTypeAdapter
@@ -167,8 +164,6 @@ public abstract class ModuleExtensionUsage {
     public abstract Builder setExtensionName(String value);
 
     public abstract Builder setIsolationKey(Optional<ModuleExtensionId.IsolationKey> value);
-
-    public abstract Builder setUsingModule(ModuleKey value);
 
     public abstract Builder setProxies(ImmutableList<Proxy> value);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -50,7 +50,6 @@ import com.google.devtools.build.lib.skyframe.PackageLookupFunction;
 import com.google.devtools.build.lib.skyframe.PackageLookupValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue.Precomputed;
-import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -163,8 +162,6 @@ public class ModuleFileFunction implements SkyFunction {
       return null;
     }
     getModuleFileResult.downloadEventHandler.replayOn(env.getListener());
-    String moduleFileHash =
-        new Fingerprint().addBytes(getModuleFileResult.moduleFile.getContent()).hexDigestAndReset();
 
     CompiledModuleFile compiledModuleFile;
     try {
@@ -224,7 +221,6 @@ public class ModuleFileFunction implements SkyFunction {
 
     return NonRootModuleFileValue.create(
         module,
-        moduleFileHash,
         RegistryFileDownloadEvent.collectToMap(
             getModuleFileResult.downloadEventHandler.getPosts()));
   }
@@ -420,10 +416,6 @@ public class ModuleFileFunction implements SkyFunction {
       StarlarkSemantics starlarkSemantics,
       ExtendedEventHandler eventHandler)
       throws ModuleFileFunctionException, InterruptedException {
-    String moduleFileHash =
-        new Fingerprint()
-            .addBytes(compiledRootModuleFile.moduleFile().getContent())
-            .hexDigestAndReset();
     ModuleThreadContext moduleThreadContext =
         execModuleFile(
             compiledRootModuleFile,
@@ -487,7 +479,6 @@ public class ModuleFileFunction implements SkyFunction {
             .collect(toImmutableSet());
     return RootModuleFileValue.create(
         module,
-        moduleFileHash,
         overrides,
         nonRegistryOverrideCanonicalRepoNameLookup,
         moduleFilePaths);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileValue.java
@@ -42,9 +42,6 @@ public abstract class ModuleFileValue implements SkyValue {
    */
   public abstract InterimModule getModule();
 
-  /** The hash string of Module.bazel (using SHA256) */
-  public abstract String getModuleFileHash();
-
   /**
    * Hashes of files obtained (or known to be missing) from registries while obtaining this module
    * file.
@@ -57,10 +54,8 @@ public abstract class ModuleFileValue implements SkyValue {
 
     public static NonRootModuleFileValue create(
         InterimModule module,
-        String moduleFileHash,
         ImmutableMap<String, Optional<Checksum>> registryFileHashes) {
-      return new AutoValue_ModuleFileValue_NonRootModuleFileValue(
-          module, moduleFileHash, registryFileHashes);
+      return new AutoValue_ModuleFileValue_NonRootModuleFileValue(module, registryFileHashes);
     }
   }
 
@@ -97,13 +92,11 @@ public abstract class ModuleFileValue implements SkyValue {
 
     public static RootModuleFileValue create(
         InterimModule module,
-        String moduleFileHash,
         ImmutableMap<String, ModuleOverride> overrides,
         ImmutableMap<RepositoryName, String> nonRegistryOverrideCanonicalRepoNameLookup,
         ImmutableSet<PathFragment> moduleFilePaths) {
       return new AutoValue_ModuleFileValue_RootModuleFileValue(
           module,
-          moduleFileHash,
           overrides,
           nonRegistryOverrideCanonicalRepoNameLookup,
           moduleFilePaths);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -187,7 +187,6 @@ public class ModuleThreadContext {
           ModuleExtensionUsage.builder()
               .setExtensionBzlFile(extensionBzlFile)
               .setExtensionName(extensionName)
-              .setUsingModule(context.getModuleBuilder().getKey())
               .setProxies(proxies)
               .setTags(tags.build());
       if (isolate) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
@@ -130,8 +130,12 @@ final class Selection {
           moduleName, compatibilityLevel);
     }
 
+    @SuppressWarnings("unused")
+    // Used in equals.
     abstract String getModuleName();
 
+    @SuppressWarnings("unused")
+    // Used in equals.
     abstract int getCompatibilityLevel();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TagClass.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TagClass.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.starlarkbuildapi.repository.RepositoryModuleApi.TagClassApi;
 import java.util.Optional;
-import net.starlark.java.syntax.Location;
 
 /**
  * Represents a tag class, which is a "class" of {@link Tag}s that share the same attribute schema.
@@ -33,23 +32,18 @@ public abstract class TagClass implements TagClassApi {
   /** Documentation about this tag class. */
   public abstract Optional<String> getDoc();
 
-  /** The Starlark code location where this tag class was defined. */
-  public abstract Location getLocation();
-
   /**
    * A mapping from the <em>public</em> name of an attribute to the position of said attribute in
    * {@link #getAttributes}.
    */
   public abstract ImmutableMap<String, Integer> getAttributeIndices();
 
-  public static TagClass create(
-      ImmutableList<Attribute> attributes, Optional<String> doc, Location location) {
+  public static TagClass create(ImmutableList<Attribute> attributes, Optional<String> doc) {
     ImmutableMap.Builder<String, Integer> attributeIndicesBuilder =
         ImmutableMap.builderWithExpectedSize(attributes.size());
     for (int i = 0; i < attributes.size(); i++) {
       attributeIndicesBuilder.put(attributes.get(i).getPublicName(), i);
     }
-    return new AutoValue_TagClass(
-        attributes, doc, location, attributeIndicesBuilder.buildOrThrow());
+    return new AutoValue_TagClass(attributes, doc, attributeIndicesBuilder.buildOrThrow());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -328,9 +328,8 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
   @Override
   public TagClass tagClass(
       Dict<?, ?> attrs, // Dict<String, StarlarkAttrModule.Descriptor>
-      Object doc, // <String> or Starlark.NONE
-      StarlarkThread thread)
-      throws EvalException {
+      Object doc // <String> or Starlark.NONE
+      ) throws EvalException {
     ImmutableList.Builder<Attribute> attrBuilder = ImmutableList.builder();
     for (Map.Entry<String, Descriptor> attr :
         Dict.cast(attrs, String.class, Descriptor.class, "attrs").entrySet()) {
@@ -343,7 +342,6 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
     }
     return TagClass.create(
         attrBuilder.build(),
-        Starlark.toJavaOptional(doc, String.class).map(Starlark::trimDocString),
-        thread.getCallerLocation());
+        Starlark.toJavaOptional(doc, String.class).map(Starlark::trimDocString));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/RepositoryModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/RepositoryModuleApi.java
@@ -225,12 +225,10 @@ public interface RepositoryModuleApi {
                     + " generating tools.",
             named = true,
             positional = false)
-      },
-      useStarlarkThread = true)
+      })
   TagClassApi tagClass(
       Dict<?, ?> attrs, // Dict<String, StarlarkAttrModuleApi.Descriptor>
-      Object doc,
-      StarlarkThread thread)
+      Object doc)
       throws EvalException;
 
   /** Represents a tag class, which is a "class" of tags that share the same attribute schema. */

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/FakeRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/FakeRepositoryModule.java
@@ -137,7 +137,7 @@ public class FakeRepositoryModule implements RepositoryModuleApi {
   }
 
   @Override
-  public TagClassApi tagClass(Dict<?, ?> attrs, Object doc, StarlarkThread thread)
+  public TagClassApi tagClass(Dict<?, ?> attrs, Object doc)
       throws EvalException {
     return new TagClassApi() {};
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunctionTest.java
@@ -227,7 +227,6 @@ public class BazelDepGraphFunctionTest extends FoundationTestCase {
                 .setImports(importsBuilder.buildOrThrow())
                 .setContainingModuleFilePath(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME)
                 .build())
-        .setUsingModule(ModuleKey.ROOT)
         .build();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -311,7 +311,7 @@ public final class BzlmodTestUtil {
   }
 
   public static TagClass createTagClass(Attribute... attrs) {
-    return TagClass.create(ImmutableList.copyOf(attrs), Optional.of("doc"), Location.BUILTIN);
+    return TagClass.create(ImmutableList.copyOf(attrs), Optional.of("doc"));
   }
 
   /** A builder for {@link Tag} for testing purposes. */

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -757,7 +757,6 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         .setExtensionBzlFile("@mymod//:defs.bzl")
                         .setExtensionName("myext1")
                         .setIsolationKey(Optional.empty())
-                        .setUsingModule(myMod)
                         .addProxy(
                             ModuleExtensionUsage.Proxy.builder()
                                 .setLocation(
@@ -788,7 +787,6 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         .setExtensionBzlFile("@mymod//:defs.bzl")
                         .setExtensionName("myext2")
                         .setIsolationKey(Optional.empty())
-                        .setUsingModule(myMod)
                         .addProxy(
                             ModuleExtensionUsage.Proxy.builder()
                                 .setLocation(
@@ -833,7 +831,6 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         .setExtensionBzlFile("@rules_jvm_external//:defs.bzl")
                         .setExtensionName("maven")
                         .setIsolationKey(Optional.empty())
-                        .setUsingModule(myMod)
                         .addProxy(
                             ModuleExtensionUsage.Proxy.builder()
                                 .setLocation(
@@ -911,7 +908,6 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         .setExtensionBzlFile("@//:defs.bzl")
                         .setExtensionName("myext")
                         .setIsolationKey(Optional.empty())
-                        .setUsingModule(ModuleKey.ROOT)
                         .addProxy(
                             ModuleExtensionUsage.Proxy.builder()
                                 .setLocation(
@@ -1043,7 +1039,6 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         .setExtensionBzlFile("@mymod//:defs.bzl")
                         .setExtensionName("myext")
                         .setIsolationKey(Optional.empty())
-                        .setUsingModule(myMod)
                         .addProxy(
                             ModuleExtensionUsage.Proxy.builder()
                                 .setLocation(
@@ -1163,7 +1158,6 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         .setExtensionBzlFile("//:MODULE.bazel")
                         .setExtensionName("_repo_rules")
                         .setIsolationKey(Optional.empty())
-                        .setUsingModule(ModuleKey.ROOT)
                         .addProxy(
                             ModuleExtensionUsage.Proxy.builder()
                                 .setLocation(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -45,8 +45,7 @@ public class StarlarkBazelModuleTest {
     return ModuleExtensionUsage.builder()
         .setExtensionBzlFile("//:rje.bzl")
         .setExtensionName("maven")
-        .setIsolationKey(Optional.empty())
-        .setUsingModule(ModuleKey.ROOT);
+        .setIsolationKey(Optional.empty());
   }
 
   /** A builder for ModuleExtension that sets all the mandatory but irrelevant fields. */

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/ModExecutorTest.java
@@ -614,7 +614,6 @@ public class ModExecutorTest {
                             .setDevDependency(false)
                             .setContainingModuleFilePath(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME)
                             .build())
-                    .setUsingModule(createModuleKey("C", "1.0"))
                     .build())
             .put(
                 mavenId,
@@ -629,7 +628,6 @@ public class ModExecutorTest {
                             .setDevDependency(false)
                             .setContainingModuleFilePath(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME)
                             .build())
-                    .setUsingModule(createModuleKey("D", "1.0"))
                     .build())
             .put(
                 gradleId,
@@ -644,7 +642,6 @@ public class ModExecutorTest {
                             .setDevDependency(false)
                             .setContainingModuleFilePath(LabelConstants.MODULE_DOT_BAZEL_FILE_NAME)
                             .build())
-                    .setUsingModule(createModuleKey("Y", "2.0"))
                     .build())
             .put(
                 mavenId,
@@ -667,7 +664,6 @@ public class ModExecutorTest {
                                 "pom_xmls",
                                 StarlarkList.immutableOf("//:pom.xml", "@bar//:pom.xml"))
                             .build())
-                    .setUsingModule(createModuleKey("Y", "2.0"))
                     .build())
             .buildOrThrow();
 

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -64,7 +64,7 @@
     "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
-        "usagesDigest": "aLmqbvowmHkkBPve05yyDNGN7oh7QE9kBADr3QIZTZs=",
+        "usagesDigest": "bqyfVLJn+3M/ql9kdKGz7q083cAayVTcmlm5kEJfGAI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -92,7 +92,7 @@
     "@@platforms//host:extension.bzl%host_platform": {
       "general": {
         "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "meSzxn3DUCcYEhq4HQwExWkWtU4EjriRBQLsZN+Q0SU=",
+        "usagesDigest": "whARuERE2fGO0oER/yUJ9UnuDcSkR227eYWZUVNy/3Y=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -109,7 +109,7 @@
     "@@rules_jvm_external~//:extensions.bzl%maven": {
       "general": {
         "bzlTransitiveDigest": "06WDcwoMOciaDDX09JBCxhi9KiKFGUIcXpQjCSle5AE=",
-        "usagesDigest": "UPebZtX4g40+QepdK3oMHged0o0tq6ojKbW84wE6XRA=",
+        "usagesDigest": "G7bV9l+zJ2RkplFf3E987nj8RPcxAqfzTHS5Zdc3rZw=",
         "recordedFileInputs": {
           "@@rules_jvm_external~//rules_jvm_external_deps_install.json": "10442a5ae27d9ff4c2003e5ab71643bf0d8b48dcf968b4173fa274c3232a8c06"
         },
@@ -1133,7 +1133,7 @@
     "@@rules_jvm_external~//:non-module-deps.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "l6SlNloqPvd60dcuPdWiJNi3g3jfK76fcZc0i/Yr0dQ=",
-        "usagesDigest": "bTG4ItERqhG1LeSs62hQ01DiMarFsflWgpZaghM5qik=",
+        "usagesDigest": "Ogn82YkpKa5kvheD/dv6YN0tP3nfvTIqAuPJrebCbWM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1161,7 +1161,7 @@
     "@@rules_python~//python/extensions:python.bzl%python": {
       "general": {
         "bzlTransitiveDigest": "GnREFVYskmF5MZu1H3nyqMWFZ2U/bty7gcbHX+l45kY=",
-        "usagesDigest": "7vjNHuEgQORYN9+9/77Q4zw1kawobM2oCQb9p0uhL68=",
+        "usagesDigest": "dMk5TOHswAZLEIKE5VenuXubFWbTzMdJplFIkYHPSSU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1191,7 +1191,7 @@
     "@@rules_python~//python/extensions/private:internal_deps.bzl%internal_deps": {
       "general": {
         "bzlTransitiveDigest": "PiT9IOA5dSBSmnfZRUrvgo71zttPpvs3cNPbxftlChs=",
-        "usagesDigest": "b+nMDqtqPCBxiMBewNNde3aNjzKqZyvJuN5/49xB62s=",
+        "usagesDigest": "B/G2N6d9Y4VpHFgkQT4wRYFBJ9RP+vFT/Ngiwz7Ejt8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
Also avoids a pattern that could result in a class initialization deadlock.

Closes #23229.

PiperOrigin-RevId: 660673482
Change-Id: Ie89ffc2e956b6e14b81cfe4462cd97241bf78be3

Closes #23346