### PR TITLE
[7.4.0] Show "did you mean" suggestion for unknown repo names

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/BUILD
@@ -57,6 +57,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/net/starlark/java/annot",
         "//src/main/java/net/starlark/java/eval",
+        "//src/main/java/net/starlark/java/spelling",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:auto_value",
         "//third_party:caffeine",

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import net.starlark.java.spelling.SpellChecker;
 
 /**
  * Stores the mapping from apparent repo name to canonical repo name, from the viewpoint of an
@@ -128,7 +129,8 @@ public class RepositoryMapping {
     if (ownerRepo() == null) {
       return RepositoryName.createUnvalidated(preMappingName);
     } else {
-      return RepositoryName.createUnvalidated(preMappingName).toNonVisible(ownerRepo());
+      return RepositoryName.createUnvalidated(preMappingName)
+          .toNonVisible(ownerRepo(), SpellChecker.didYouMean(preMappingName, entries().keySet()));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.cmdline;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
@@ -132,13 +133,22 @@ public final class RepositoryName {
    */
   private final RepositoryName ownerRepoIfNotVisible;
 
-  private RepositoryName(String name, RepositoryName ownerRepoIfNotVisible) {
+  /**
+   * If ownerRepoIfNotVisible is not null, this field stores the suffix to be appended to the error
+   */
+  @Nullable private final String didYouMeanSuffix;
+
+  private RepositoryName(
+      String name,
+      @Nullable RepositoryName ownerRepoIfNotVisible,
+      @Nullable String didYouMeanSuffix) {
     this.name = name;
     this.ownerRepoIfNotVisible = ownerRepoIfNotVisible;
+    this.didYouMeanSuffix = didYouMeanSuffix;
   }
 
   private RepositoryName(String name) {
-    this(name, null);
+    this(name, /* ownerRepoIfNotVisible= */ null, /* didYouMeanSuffix= */ null);
   }
 
   /**
@@ -192,10 +202,16 @@ public final class RepositoryName {
    * actually not visible from the owner repository and should fail in {@code
    * RepositoryDelegatorFunction} when fetching with this {@link RepositoryName} instance.
    */
-  public RepositoryName toNonVisible(RepositoryName ownerRepo) {
+  public RepositoryName toNonVisible(RepositoryName ownerRepo, String didYouMeanSuffix) {
     Preconditions.checkNotNull(ownerRepo);
     Preconditions.checkArgument(ownerRepo.isVisible());
-    return new RepositoryName(name, ownerRepo);
+    Preconditions.checkNotNull(didYouMeanSuffix);
+    return new RepositoryName(name, ownerRepo, didYouMeanSuffix);
+  }
+
+  @VisibleForTesting
+  public RepositoryName toNonVisible(RepositoryName ownerRepo) {
+    return toNonVisible(ownerRepo, "");
   }
 
   public boolean isVisible() {
@@ -239,7 +255,9 @@ public final class RepositoryName {
   // TODO(bazel-team): Rename to "getCanonicalForm".
   public String getNameWithAt() {
     if (!isVisible()) {
-      return String.format("@@[unknown repo '%s' requested from %s]", name, ownerRepoIfNotVisible);
+      return String.format(
+          "@@[unknown repo '%s' requested from %s%s]",
+          name, ownerRepoIfNotVisible, didYouMeanSuffix);
     }
     return "@@" + name;
   }
@@ -339,16 +357,17 @@ public final class RepositoryName {
     if (this == object) {
       return true;
     }
-    if (!(object instanceof RepositoryName)) {
+    if (!(object instanceof RepositoryName other)) {
       return false;
     }
-    RepositoryName other = (RepositoryName) object;
     return OsPathPolicy.getFilePathOs().equals(name, other.name)
-        && Objects.equals(ownerRepoIfNotVisible, other.ownerRepoIfNotVisible);
+        && Objects.equals(ownerRepoIfNotVisible, other.ownerRepoIfNotVisible)
+        && Objects.equals(didYouMeanSuffix, other.didYouMeanSuffix);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(OsPathPolicy.getFilePathOs().hash(name), ownerRepoIfNotVisible);
+    return Objects.hash(
+        OsPathPolicy.getFilePathOs().hash(name), ownerRepoIfNotVisible, didYouMeanSuffix);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryMappingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/cmdline/RepositoryMappingTest.java
@@ -89,4 +89,13 @@ public final class RepositoryMappingTest {
     assertThat(mapping.get("C")).isEqualTo(RepositoryName.create("C_mapped"));
     assertThat(mapping.get("D")).isEqualTo(RepositoryName.create("D"));
   }
+
+  @Test
+  public void unknownRepoDidYouMean() throws LabelSyntaxException {
+    RepositoryMapping mapping =
+        RepositoryMapping.create(
+            ImmutableMap.of("foo", RepositoryName.create("foo_internal")), RepositoryName.MAIN);
+    assertThat(mapping.get("boo").getNameWithAt())
+        .isEqualTo("@@[unknown repo 'boo' requested from @@ (did you mean 'foo'?)]");
+  }
 }


### PR DESCRIPTION
If `@boo` is parsed in a context in which only `@foo` is visible, the resulting `RepositoryName` object will show as follows in error messages:

```
@@[unknown repo 'boo' requested from @@ (did you mean 'foo'?)]
```

Closes #23184.

PiperOrigin-RevId: 660678414
Change-Id: Iecb5b1d211ff9e1f04ff0f2189376a98b7b261a9

Closes #23189
Closes #23239