### PR TITLE
[7.4.0] Delay execution phase reporting in Skymeld

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -1029,7 +1029,8 @@ message BuildMetrics {
     int64 analysis_phase_time_in_ms = 3;
     // The elapsed wall time in milliseconds during the execution phase.
     // When analysis and execution phases are interleaved, this measures the
-    // elapsed time from the first action execution to the last.
+    // elapsed time from the first action execution (excluding workspace status
+    // actions) to the last.
     int64 execution_phase_time_in_ms = 4;
   }
   TimingMetrics timing_metrics = 5;

--- a/src/main/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTracker.java
@@ -100,10 +100,11 @@ final class SkymeldUiStateTracker extends UiStateTracker {
         writeLoadingAnalysisPhaseProgress(
             "Analyzing", additionalMessage, terminalWriter, shortVersion);
         terminalWriter.newline();
-        writeExecutionProgress(terminalWriter, shortVersion);
-        break;
+      // fall through
       case EXECUTION:
-        writeExecutionProgress(terminalWriter, shortVersion);
+        if (executionPhaseStarted) {
+          writeExecutionProgress(terminalWriter, shortVersion);
+        }
         break;
       case BUILD_COMPLETED:
         writeBaseProgress(ok ? "INFO" : "FAILED", additionalMessage, terminalWriter);

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -52,6 +52,7 @@ import com.google.devtools.build.lib.pkgcache.LoadingPhaseCompleteEvent;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.skyframe.ConfigurationPhaseStartedEvent;
 import com.google.devtools.build.lib.skyframe.LoadingPhaseStartedEvent;
+import com.google.devtools.build.lib.skyframe.TopLevelStatusEvents.SomeExecutionStartedEvent;
 import com.google.devtools.build.lib.skyframe.TopLevelStatusEvents.TestAnalyzedEvent;
 import com.google.devtools.build.lib.util.io.AnsiTerminal;
 import com.google.devtools.build.lib.util.io.AnsiTerminal.Color;
@@ -573,6 +574,14 @@ public final class UiEventHandler implements EventHandler {
   public synchronized void analysisComplete(AnalysisPhaseCompleteEvent event) {
     String analysisSummary = stateTracker.analysisComplete();
     handle(Event.info(null, analysisSummary));
+  }
+
+  @Subscribe
+  public void executionPhaseStarted(SomeExecutionStartedEvent event) {
+    if (event.countedInExecutionTime()) {
+      stateTracker.executionPhaseStarted();
+      refresh();
+    }
   }
 
   @Subscribe

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -369,6 +369,7 @@ class UiStateTracker {
   protected int failedTests;
   protected boolean ok;
   private boolean buildComplete;
+  protected volatile boolean executionPhaseStarted;
 
   @Nullable protected ExecutionProgressReceiver executionProgressReceiver;
   @Nullable protected PackageProgressReceiver packageProgressReceiver;
@@ -390,6 +391,7 @@ class UiStateTracker {
     this.ok = true;
     this.clock = clock;
     this.targetWidth = targetWidth;
+    this.executionPhaseStarted = false;
   }
 
   UiStateTracker(Clock clock) {
@@ -429,6 +431,10 @@ class UiStateTracker {
       additionalMessage = count + " targets";
     }
     mainRepositoryMapping = event.getMainRepositoryMapping();
+  }
+
+  void executionPhaseStarted() {
+    executionPhaseStarted = true;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -2040,7 +2040,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       }
       eventHandler.post(new ConfigurationPhaseStartedEvent(configuredTargetProgress));
       // For the workspace status actions.
-      eventHandler.post(SomeExecutionStartedEvent.create());
+      eventHandler.post(SomeExecutionStartedEvent.notCountedInExecutionTime());
       EvaluationContext evaluationContext =
           newEvaluationContextBuilder()
               .setKeepGoing(keepGoing)

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TopLevelStatusEvents.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TopLevelStatusEvents.java
@@ -144,18 +144,31 @@ public final class TopLevelStatusEvents {
     }
   }
 
-  /** An event that denotes that some execution has started in this build. */
+  /**
+   * An event that denotes that some execution has started in this build.
+   *
+   * <p>Some special actions e.g. the WorkspaceStatusAction should be excluded from the execution
+   * time.
+   */
   @AutoValue
   public abstract static class SomeExecutionStartedEvent implements TopLevelStatusEventWithType {
 
     public static SomeExecutionStartedEvent create() {
-      return new AutoValue_TopLevelStatusEvents_SomeExecutionStartedEvent();
+      return new AutoValue_TopLevelStatusEvents_SomeExecutionStartedEvent(
+          /* countedInExecutionTime= */ true);
+    }
+
+    public static SomeExecutionStartedEvent notCountedInExecutionTime() {
+      return new AutoValue_TopLevelStatusEvents_SomeExecutionStartedEvent(
+          /* countedInExecutionTime= */ false);
     }
 
     @Override
     public Type getType() {
       return Type.SOME_EXECUTION_STARTED;
     }
+
+    public abstract boolean countedInExecutionTime();
   }
   /** An event that marks the successful build of a top-level target, including tests. */
   @AutoValue

--- a/src/test/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTrackerTest.java
@@ -127,7 +127,7 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
     assertThat(output).contains(loadingState);
     assertThat(output).contains(loadingActivity);
     assertThat(output).contains(configuredTargetProgressString);
-    assertThat(output).contains("[0 / 0]");
+    assertThat(output).doesNotContain("[0 / 0]");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
@@ -226,6 +226,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     if (this.isSkymeld) {
       // SkymeldUiStateTracker needs to be in the configuration phase before the execution phase.
       ((SkymeldUiStateTracker) uiStateTracker).buildStatus = BuildStatus.ANALYSIS_COMPLETE;
+      uiStateTracker.executionPhaseStarted();
     } else {
       String unused = uiStateTracker.analysisComplete();
     }

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -268,7 +268,12 @@ function test_noshow_progress() {
 }
 
 function test_basic_progress_no_curses() {
-  bazel test --curses=no --color=yes pkg:true 2>$TEST_log \
+  bazel clean || fail "${PRODUCT_NAME} clean failed"
+  # --experimental_ui_debug_all_events is necessary so that we don't miss the
+  # progress indicator event which is only shown once a second when curses is
+  # disabled
+  bazel test --curses=no --color=yes --experimental_ui_debug_all_events \
+    pkg:true 2>$TEST_log \
     || fail "${PRODUCT_NAME} test failed"
   # some progress indicator is shown
   expect_log '\[[0-9,]* / [0-9,]*\]'
@@ -281,7 +286,11 @@ function test_basic_progress_no_curses() {
 }
 
 function test_no_curses_no_linebreak() {
-  bazel test --curses=no --color=yes --terminal_columns=9 \
+  bazel clean || fail "${PRODUCT_NAME} clean failed"
+  # --experimental_ui_debug_all_events is necessary so that we don't miss the
+  # progress indicator event which is only shown once a second when curses is
+  # disabled
+  bazel test --curses=no --color=yes --experimental_ui_debug_all_events \
     pkg:true 2>$TEST_log || fail "${PRODUCT_NAME} test failed"
   # expect a long-ish status line
   expect_log '\[[0-9,]* / [0-9,]*\]......'


### PR DESCRIPTION
Cherry-pick of the following commits:

* Exclude WorkspaceStatusActions `from execution_phase_time_in_ms` (8a413983fc1c053d1f24b09cb72697d24397ba59)
* Delay execution phase reporting in Skymeld (5744abd7831fec791067ec8e182cd47f82aaaf3e)

Closes #23354