### PR TITLE
Fix locations reported in repo rule instantiation errors for extensions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleCreator.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleCreator.java
@@ -35,9 +35,7 @@ import java.util.Map;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkSemantics;
-import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkThread.CallStackEntry;
-import net.starlark.java.syntax.Location;
 
 /**
  * Creates a repo rule instance for Bzlmod. This class contrasts with the WORKSPACE repo rule
@@ -53,7 +51,7 @@ public final class BzlmodRepoRuleCreator {
       BlazeDirectories directories,
       StarlarkSemantics semantics,
       ExtendedEventHandler eventHandler,
-      String callStackEntry,
+      ImmutableList<CallStackEntry> callStack,
       RuleClass ruleClass,
       Map<String, Object> attributes)
       throws InterruptedException, InvalidRuleException, NoSuchPackageException, EvalException {
@@ -72,8 +70,6 @@ public final class BzlmodRepoRuleCreator {
             repoMapping);
     BuildLangTypedAttributeValuesMap attributeValues =
         new BuildLangTypedAttributeValuesMap(attributes);
-    ImmutableList<CallStackEntry> callStack =
-        ImmutableList.of(StarlarkThread.callStackEntry(callStackEntry, Location.BUILTIN));
     Rule rule;
     try {
       rule =

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalStarlarkThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionEvalStarlarkThreadContext.java
@@ -113,7 +113,7 @@ public final class ModuleExtensionEvalStarlarkThreadContext extends StarlarkThre
               directories,
               thread.getSemantics(),
               eventHandler,
-              "RepositoryRuleFunction.createRule",
+              thread.getCallStack(),
               ruleClass,
               Maps.transformEntries(kwargs, (k, v) -> k.equals("name") ? prefixedName : v));
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -763,6 +763,12 @@ public class SingleExtensionEvalFunction implements SkyFunction {
         String prefixedName = usagesValue.getExtensionUniqueName() + "+" + name;
         Rule ruleInstance;
         AttributeValues attributesValue;
+        var fakeCallStackEntry =
+            StarlarkThread.callStackEntry("InnateRunnableExtension.run", repo.tag().getLocation());
+        // Rule creation strips the top-most entry from the call stack, so we need to add the fake
+        // one twice.
+        ImmutableList<StarlarkThread.CallStackEntry> fakeCallStack =
+            ImmutableList.of(fakeCallStackEntry, fakeCallStackEntry);
         try {
           ruleInstance =
               BzlmodRepoRuleCreator.createRule(
@@ -771,7 +777,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                   directories,
                   starlarkSemantics,
                   env.getListener(),
-                  "SingleExtensionEval.createInnateExtensionRepoRule",
+                  fakeCallStack,
                   repoRule.getRuleClass(),
                   Maps.transformEntries(kwargs, (k, v) -> k.equals("name") ? prefixedName : v));
           attributesValue =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.skyframe;
 
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -52,6 +51,7 @@ import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Module;
 import net.starlark.java.eval.StarlarkSemantics;
+import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.syntax.Location;
 
 /**
@@ -194,7 +194,9 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
               directories,
               starlarkSemantics,
               env.getListener(),
-              "BzlmodRepoRuleFunction.createRule",
+              ImmutableList.of(
+                  StarlarkThread.callStackEntry(
+                      "BzlmodRepoRuleFunction.createRuleFromSpec", Location.BUILTIN)),
               ruleClass,
               attributes);
       return new BzlmodRepoRuleValue(rule.getPackage(), rule.getName());

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -270,16 +270,16 @@ class BazelModuleTest(test_base.TestBase):
     exit_code, _, stderr = self.RunBazel(['run', '@foo//...'],
                                          allow_failure=True)
     self.AssertExitCode(exit_code, 48, stderr)
+    stderr = '\n'.join(stderr)
     self.assertIn(
-        'ERROR: <builtin>: //pkg:+module_ext+foo: no such attribute'
+        '/pkg/extension.bzl:3:14: //pkg:+module_ext+foo: no such attribute'
         " 'invalid_attr' in 'repo_rule' rule",
         stderr,
     )
-    self.assertTrue(
-        any([
-            '/pkg/extension.bzl", line 3, column 14, in _module_ext_impl'
-            in line for line in stderr
-        ]))
+    self.assertIn(
+        '/pkg/extension.bzl", line 3, column 14, in _module_ext_impl',
+        stderr,
+    )
 
   def testDownload(self):
     data_path = self.ScratchFile('data.txt', ['some data'])


### PR DESCRIPTION
Since `Rule` logic drops a call stack entry, errors during repo rule instantiation in a module extension weren't reported with a useful `Location`.

Work towards #19055