### PR TITLE
Add //src/tools/execlog:converter to docs

### DIFF
--- a/site/en/remote/cache-remote.md
+++ b/site/en/remote/cache-remote.md
@@ -147,6 +147,10 @@ each action there is a
 element containing all of the information from the action key, Thus, if the
 logs are identical then so are the action cache keys.
 
+If you're using the `--experimental_execution_log_compact_file` flag you
+must first convert to the binary or json format using the
+`//src/tools/execlog:converter` tool.
+
 To compare logs for two builds that are not sharing cache hits as expected,
 do the following:
 


### PR DESCRIPTION
This was mentioned in
https://blog.bazel.build/2024/04/01/bazel-q1-2024-community-update.html but not in the docs