### PR TITLE
Remove 6 no-op CLI flags

### DIFF
--- a/site/en/remote/bep-glossary.md
+++ b/site/en/remote/bep-glossary.md
@@ -244,7 +244,6 @@ separating startup options from command options. It also includes the
       "--output_user_root=/tmp/.cache/bazel/_bazel_foo",
       "--output_base=/tmp/.cache/bazel/_bazel_foo/a61fd0fbee3f9d6c1e30d54b68655d35",
       "--deep_execroot",
-      "--expand_configs_in_place",
       "--idle_server_tasks",
       "--write_command_log",
       "--nowatchfs",

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -424,11 +424,6 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
         startup_options.failure_detail_out.AsCommandLineArgument());
   }
 
-  if (startup_options.expand_configs_in_place) {
-    result.push_back("--expand_configs_in_place");
-  } else {
-    result.push_back("--noexpand_configs_in_place");
-  }
   if (!startup_options.digest_function.empty()) {
     // Only include this if a value is requested - we rely on the empty case
     // being "null" to set the programmatic default in the server.

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -89,7 +89,6 @@ StartupOptions::StartupOptions(const string &product_name,
       preemptible(false),
       java_logging_formatter(
           "com.google.devtools.build.lib.util.SingleLineFormatter"),
-      expand_configs_in_place(true),
       digest_function(),
       idle_server_tasks(true),
       original_startup_options_(std::vector<RcStartupFlag>()),
@@ -136,8 +135,6 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterNullaryStartupFlag("block_for_lock", &block_for_lock);
   RegisterNullaryStartupFlag("client_debug", &client_debug);
   RegisterNullaryStartupFlag("preemptible", &preemptible);
-  RegisterNullaryStartupFlag("expand_configs_in_place",
-                             &expand_configs_in_place);
   RegisterNullaryStartupFlag("fatal_event_bus_exceptions",
                              &fatal_event_bus_exceptions);
   RegisterNullaryStartupFlag("host_jvm_debug", &host_jvm_debug);

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -252,8 +252,6 @@ class StartupOptions {
   // Value of the java.util.logging.FileHandler.formatter Java property.
   std::string java_logging_formatter;
 
-  bool expand_configs_in_place;
-
   // The hash function to use when computing file digests.
   std::string digest_function;
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -496,15 +496,6 @@ public final class BazelRulesModule extends BlazeModule {
     public boolean useEventBasedBuildCompletionStatus;
 
     @Option(
-        name = "experimental_use_priority_in_analysis",
-        defaultValue = "false",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        metadataTags = OptionMetadataTag.DEPRECATED,
-        effectTags = {OptionEffectTag.NO_OP},
-        help = "No-op.")
-    public boolean usePrioritization;
-
-    @Option(
         name = "incompatible_generated_protos_in_virtual_imports",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -496,15 +496,6 @@ public final class BazelRulesModule extends BlazeModule {
     public boolean useEventBasedBuildCompletionStatus;
 
     @Option(
-        name = "incompatible_generated_protos_in_virtual_imports",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED},
-        help = "No-op.")
-    public boolean generatedProtosInVirtualImports;
-
-    @Option(
         name = "experimental_java_proto_add_allowed_public_imports",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -342,16 +342,6 @@ public final class BazelRulesModule extends BlazeModule {
         effectTags = {OptionEffectTag.NO_OP})
     public String makeVariableSource;
 
-    @Option(
-        name = "incompatible_cc_coverage",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        oldName = "experimental_cc_coverage",
-        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE, OptionMetadataTag.DEPRECATED},
-        help = "Obsolete, no effect.")
-    public boolean useGcovCoverage;
-
     @Deprecated
     @Option(
         name = "glibc",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -496,15 +496,6 @@ public final class BazelRulesModule extends BlazeModule {
     public boolean useEventBasedBuildCompletionStatus;
 
     @Option(
-        name = "experimental_use_fork_join_pool",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        metadataTags = OptionMetadataTag.DEPRECATED,
-        effectTags = {OptionEffectTag.NO_OP},
-        help = "No-op.")
-    public boolean useForkJoinPool;
-
-    @Option(
         name = "experimental_use_priority_in_analysis",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -342,16 +342,6 @@ public final class BazelRulesModule extends BlazeModule {
         effectTags = {OptionEffectTag.NO_OP})
     public String makeVariableSource;
 
-    @Deprecated
-    @Option(
-        name = "glibc",
-        defaultValue = "null",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.NO_OP},
-        metadataTags = {OptionMetadataTag.DEPRECATED},
-        help = "Deprecated no-op.")
-    public String glibc;
-
     @Option(
         name = "force_ignore_dash_static",
         defaultValue = "false",

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -414,19 +414,6 @@ public class BlazeServerStartupOptions extends OptionsBase {
       help = "The hash function to use when computing file digests.")
   public DigestHashFunction digestHashFunction;
 
-  @Deprecated
-  @Option(
-      name = "expand_configs_in_place",
-      defaultValue = "true", // NOTE: only for documentation, value is always passed by the client.
-      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
-      effectTags = {OptionEffectTag.NO_OP},
-      metadataTags = {OptionMetadataTag.DEPRECATED},
-      deprecationWarning = "This option is now a no-op and will soon be deleted.",
-      help =
-          "Changed the expansion of --config flags to be done in-place, as opposed to in a fixed "
-              + "point expansion between normal rc options and command-line specified options.")
-  public boolean expandConfigsInPlace;
-
   @Option(
       name = "idle_server_tasks",
       defaultValue = "true", // NOTE: only for documentation, value is set and used by the client.


### PR DESCRIPTION
* `--incompatible_cc_coverage`
  Documented as no-op from v0.26.0.
* `--glibc`
  Documented as no-op from v0.16.0
* `--experimental_use_fork_join_pool`
  Documented as no-op from v7.
* `--experimental_use_priority_in_analysis`
  Introduced in v7 preview, no-op by time of v7 release.
* `--incompatible_generated_protos_in_virtual_imports`
  Documented as no-op from v7.
* `--expand_configs_in_place`
  Documented as no-op from v0.16.0