### PR TITLE
[7.4.0] CommandLinePathFactory: skip empty or relative path elements

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandLinePathFactory.java
@@ -127,7 +127,14 @@ public final class CommandLinePathFactory {
     String pathVariable = env.getOrDefault("PATH", "");
     if (!Strings.isNullOrEmpty(pathVariable)) {
       for (String lookupPath : PATH_SPLITTER.split(pathVariable)) {
-        Path maybePath = fileSystem.getPath(lookupPath).getRelative(path);
+        PathFragment lookupPathFragment = PathFragment.create(lookupPath);
+        if (lookupPathFragment.isEmpty() || !lookupPathFragment.isAbsolute()) {
+          // Ignore empty or relative path components. These are uncommon and may be confusing if
+          // bazel is running in a different directory than the user's current directory.
+          continue;
+        }
+
+        Path maybePath = fileSystem.getPath(lookupPathFragment).getRelative(path);
         if (maybePath.exists(Symlinks.FOLLOW)
             && maybePath.isFile(Symlinks.FOLLOW)
             && maybePath.isExecutable()) {

--- a/src/test/java/com/google/devtools/build/lib/runtime/CommandLinePathFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/CommandLinePathFactoryTest.java
@@ -198,4 +198,13 @@ public class CommandLinePathFactoryTest {
                 ImmutableMap.of("PATH", PATH_JOINER.join("/bin", "/does/not/exist", "/usr/bin")),
                 "a"));
   }
+
+  @Test
+  public void pathLookupWithInvalidPath() throws Exception {
+    CommandLinePathFactory factory = new CommandLinePathFactory(filesystem, ImmutableMap.of());
+
+    createExecutable("/bin/true");
+    var path = ImmutableMap.of("PATH", PATH_JOINER.join("", ".", "/bin"));
+    assertThat(factory.create(path, "true")).isEqualTo(filesystem.getPath("/bin/true"));
+  }
 }


### PR DESCRIPTION
Fixes #23305

Closes #23310.

PiperOrigin-RevId: 665745084
Change-Id: Ib22290e08f62c52c5a596eeabd31b1b910fcf421

Commit https://github.com/bazelbuild/bazel/commit/8b2057e774854fa0a917d3bfdec3a35278e6ee11