### PR TITLE
[7.4.0] Improve user-visible error message when an IOException occurs while copying sandbox inputs/outputs.

### DIFF
--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -765,6 +765,8 @@ message Sandbox {
     MOUNT_TARGET_DOES_NOT_EXIST = 9 [(metadata) = { exit_code: 1 }];
     SUBPROCESS_START_FAILED = 10 [(metadata) = { exit_code: 36 }];
     FORBIDDEN_INPUT = 11 [(metadata) = { exit_code: 1 }];
+    COPY_INPUTS_IO_EXCEPTION = 12 [(metadata) = { exit_code: 36 }];
+    COPY_OUTPUTS_IO_EXCEPTION = 13 [(metadata) = { exit_code: 36 }];
   }
 
   Code code = 1;

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -664,7 +664,7 @@ EOF
   expect_not_log "Executing genrule //:test failed: linux-sandbox failed: error executing command"
 
   # This is the error message telling us that some output artifacts couldn't be copied.
-  expect_log "Could not move output artifacts from sandboxed execution"
+  expect_log "Could not copy outputs from sandbox:.*readonlydir/output.txt (Permission denied)"
 
   # The build fails, because the action didn't generate its output artifact.
   expect_log "ERROR:.*Executing genrule //:test failed"
@@ -689,10 +689,10 @@ EOF
 
   # This is the error message printed by the EventHandler telling us that some
   # output artifacts couldn't be copied.
-  expect_log "Could not move output artifacts from sandboxed execution"
+  expect_log "Could not copy outputs from sandbox:.*readonlydir/output.txt (Permission denied)"
 
   # This is the UserExecException telling us that the build failed.
-  expect_log "Executing genrule //:test failed:"
+  expect_log "ERROR:.*Executing genrule //:test failed:"
 }
 
 function test_read_non_hermetic_tmp {


### PR DESCRIPTION
Also wrap it in an EnvironmentalExecException, as it seems more appropriate than a UserExecException; introduce separate failure codes while at it.

(We should probably rethink whether SpawnRunner#exec should even be allowed to return a naked IOException, but that's a much larger change.)

Fixes #23283.

PiperOrigin-RevId: 665790329
Change-Id: Ibf12481c19d155dc3d4f95e21df3e8ee305f3512

Commit https://github.com/bazelbuild/bazel/commit/f5df0e759f3d3b69092eae8266e919f29a67529b