### PR TITLE
Force synchronous upload and reuse of possibly modified spawn outputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
@@ -116,7 +116,7 @@ public interface ActionExecutionMetadata extends ActionAnalysisMetadata {
   }
 
   /**
-   * Returns true if the action may modify its outputs after executing spawns.
+   * Returns true if the action may modify spawn outputs after the spawn has executed.
    *
    * <p>If this returns true, any kind of spawn output caching or reuse needs to happen
    * synchronously directly after the spawn execution.

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
@@ -114,4 +114,14 @@ public interface ActionExecutionMetadata extends ActionAnalysisMetadata {
   default boolean mayInsensitivelyPropagateInputs() {
     return false;
   }
+
+  /**
+   * Returns true if the action may modify its outputs after executing spawns.
+   *
+   * <p>If this returns true, any kind of spawn output caching or reuse needs to happen
+   * synchronously directly after the spawn execution.
+   */
+  default boolean mayModifySpawnOutputsAfterExecution() {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -309,6 +309,16 @@ public class TestRunnerAction extends AbstractAction
     this.isExecutedOnWindows = isExecutedOnWindows;
   }
 
+  @Override
+  public boolean mayModifySpawnOutputsAfterExecution() {
+    // Test actions modify test spawn outputs after execution:
+    // - if there are multiple attempts (unavoidable);
+    // - in all cases due to appending any stray stderr output to the test log in
+    //   StandaloneTestStrategy.
+    // TODO: Get rid of the second case and only return true if there are multiple attempts.
+    return true;
+  }
+
   public boolean isExecutedOnWindows() {
     return isExecutedOnWindows;
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -129,8 +129,6 @@ final class RemoteSpawnCache implements SpawnCache {
           previousExecution =
               previousOrThisExecution == thisExecution ? null : previousOrThisExecution;
         }
-        // Metadata will be available in context.current() until we detach.
-        // This is done via a thread-local variable.
         try {
           RemoteActionResult result;
           try (SilentCloseable c =
@@ -269,7 +267,9 @@ final class RemoteSpawnCache implements SpawnCache {
             // existing executions finish the reuse.
             // Note that while this call itself isn't interruptible, all operations it awaits are
             // interruptible.
-            thisExecutionFinal.awaitAllOutputReuse();
+            try (SilentCloseable c = prof.profile(REMOTE_DOWNLOAD, "await output reuse")) {
+              thisExecutionFinal.awaitAllOutputReuse();
+            }
           }
         }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -109,89 +109,112 @@ final class RemoteSpawnCache implements SpawnCache {
       // results haven't been uploaded to the cache yet and deduplicate all of them against the
       // first one.
       LocalExecution previousExecution = null;
-      thisExecution = LocalExecution.createIfDeduplicatable(action);
-      if (shouldUploadLocalResults && thisExecution != null) {
-        previousExecution = inFlightExecutions.putIfAbsent(action.getActionKey(), thisExecution);
-      }
-      // Metadata will be available in context.current() until we detach.
-      // This is done via a thread-local variable.
       try {
-        RemoteActionResult result;
-        try (SilentCloseable c = prof.profile(ProfilerTask.REMOTE_CACHE_CHECK, "check cache hit")) {
-          result = remoteExecutionService.lookupCache(action);
-        }
-        // In case the remote cache returned a failed action (exit code != 0) we treat it as a
-        // cache miss
-        if (result != null && result.getExitCode() == 0) {
-          Stopwatch fetchTime = Stopwatch.createStarted();
-          InMemoryOutput inMemoryOutput;
-          try (SilentCloseable c = prof.profile(REMOTE_DOWNLOAD, "download outputs")) {
-            inMemoryOutput = remoteExecutionService.downloadOutputs(action, result);
-          }
-          fetchTime.stop();
-          totalTime.stop();
-          spawnMetrics
-              .setFetchTimeInMs((int) fetchTime.elapsed().toMillis())
-              .setTotalTimeInMs((int) totalTime.elapsed().toMillis())
-              .setNetworkTimeInMs((int) action.getNetworkTime().getDuration().toMillis());
-          SpawnResult spawnResult =
-              createSpawnResult(
-                  digestUtil,
+        thisExecution = LocalExecution.createIfDeduplicatable(action);
+        if (shouldUploadLocalResults && thisExecution != null) {
+          LocalExecution previousOrThisExecution =
+              inFlightExecutions.merge(
                   action.getActionKey(),
-                  result.getExitCode(),
-                  /* cacheHit= */ true,
-                  result.cacheName(),
-                  inMemoryOutput,
-                  result.getExecutionMetadata().getExecutionStartTimestamp(),
-                  result.getExecutionMetadata().getExecutionCompletedTimestamp(),
-                  spawnMetrics.build(),
-                  spawn.getMnemonic());
-          return SpawnCache.success(spawnResult);
+                  thisExecution,
+                  (existingExecution, thisExecutionArg) -> {
+                    if (existingExecution.registerForOutputReuse()) {
+                      return existingExecution;
+                    } else {
+                      // The existing execution has completed and its results may have already
+                      // been modified by its action, so we can't deduplicate against it. Instead,
+                      // start a new in-flight execution.
+                      return thisExecutionArg;
+                    }
+                  });
+          previousExecution =
+              previousOrThisExecution == thisExecution ? null : previousOrThisExecution;
         }
-      } catch (CacheNotFoundException e) {
-        // Intentionally left blank
-      } catch (IOException e) {
-        if (BulkTransferException.allCausedByCacheNotFoundException(e)) {
-          // Intentionally left blank
-        } else {
-          String errorMessage = Utils.grpcAwareErrorMessage(e, verboseFailures);
-          if (isNullOrEmpty(errorMessage)) {
-            errorMessage = e.getClass().getSimpleName();
+        // Metadata will be available in context.current() until we detach.
+        // This is done via a thread-local variable.
+        try {
+          RemoteActionResult result;
+          try (SilentCloseable c =
+              prof.profile(ProfilerTask.REMOTE_CACHE_CHECK, "check cache hit")) {
+            result = remoteExecutionService.lookupCache(action);
           }
-          errorMessage = "Remote Cache: " + errorMessage;
-          remoteExecutionService.report(Event.warn(errorMessage));
+          // In case the remote cache returned a failed action (exit code != 0) we treat it as a
+          // cache miss
+          if (result != null && result.getExitCode() == 0) {
+            Stopwatch fetchTime = Stopwatch.createStarted();
+            InMemoryOutput inMemoryOutput;
+            try (SilentCloseable c = prof.profile(REMOTE_DOWNLOAD, "download outputs")) {
+              inMemoryOutput = remoteExecutionService.downloadOutputs(action, result);
+            }
+            fetchTime.stop();
+            totalTime.stop();
+            spawnMetrics
+                .setFetchTimeInMs((int) fetchTime.elapsed().toMillis())
+                .setTotalTimeInMs((int) totalTime.elapsed().toMillis())
+                .setNetworkTimeInMs((int) action.getNetworkTime().getDuration().toMillis());
+            SpawnResult spawnResult =
+                createSpawnResult(
+                    digestUtil,
+                    action.getActionKey(),
+                    result.getExitCode(),
+                    /* cacheHit= */ true,
+                    result.cacheName(),
+                    inMemoryOutput,
+                    result.getExecutionMetadata().getExecutionStartTimestamp(),
+                    result.getExecutionMetadata().getExecutionCompletedTimestamp(),
+                    spawnMetrics.build(),
+                    spawn.getMnemonic());
+            return SpawnCache.success(spawnResult);
+          }
+        } catch (CacheNotFoundException e) {
+          // Intentionally left blank
+        } catch (IOException e) {
+          if (BulkTransferException.allCausedByCacheNotFoundException(e)) {
+            // Intentionally left blank
+          } else {
+            String errorMessage = Utils.grpcAwareErrorMessage(e, verboseFailures);
+            if (isNullOrEmpty(errorMessage)) {
+              errorMessage = e.getClass().getSimpleName();
+            }
+            errorMessage = "Remote Cache: " + errorMessage;
+            remoteExecutionService.report(Event.warn(errorMessage));
+          }
         }
-      }
-      if (previousExecution != null) {
-        Stopwatch fetchTime = Stopwatch.createStarted();
-        SpawnResult previousResult;
-        try (SilentCloseable c = prof.profile(REMOTE_DOWNLOAD, "reuse outputs")) {
-          previousResult = remoteExecutionService.waitForAndReuseOutputs(action, previousExecution);
-        }
-        if (previousResult != null) {
-          spawnMetrics
-              .setFetchTimeInMs((int) fetchTime.elapsed().toMillis())
-              .setTotalTimeInMs((int) totalTime.elapsed().toMillis())
-              .setNetworkTimeInMs((int) action.getNetworkTime().getDuration().toMillis());
-          SpawnMetrics buildMetrics = spawnMetrics.build();
-          return SpawnCache.success(
-              new SpawnResult.DelegateSpawnResult(previousResult) {
-                @Override
-                public String getRunnerName() {
-                  return "deduplicated";
-                }
+        if (previousExecution != null) {
+          Stopwatch fetchTime = Stopwatch.createStarted();
+          SpawnResult previousResult;
+          try (SilentCloseable c = prof.profile(REMOTE_DOWNLOAD, "reuse outputs")) {
+            previousResult =
+                remoteExecutionService.waitForAndReuseOutputs(action, previousExecution);
+          }
+          if (previousResult != null) {
+            spawnMetrics
+                .setFetchTimeInMs((int) fetchTime.elapsed().toMillis())
+                .setTotalTimeInMs((int) totalTime.elapsed().toMillis())
+                .setNetworkTimeInMs((int) action.getNetworkTime().getDuration().toMillis());
+            SpawnMetrics buildMetrics = spawnMetrics.build();
+            return SpawnCache.success(
+                new SpawnResult.DelegateSpawnResult(previousResult) {
+                  @Override
+                  public String getRunnerName() {
+                    return "deduplicated";
+                  }
 
-                @Override
-                public SpawnMetrics getMetrics() {
-                  return buildMetrics;
-                }
-              });
+                  @Override
+                  public SpawnMetrics getMetrics() {
+                    return buildMetrics;
+                  }
+                });
+          }
+          // If we reach here, the previous execution was not successful (it encountered an
+          // exception or the spawn had an exit code != 0). Since it isn't possible to accurately
+          // recreate the failure without rerunning the action, we fall back to running the action
+          // locally. This means that we have introduced an unnecessary wait, but that can only
+          // happen in the case of a failing build with --keep_going.
         }
-        // If we reach here, the previous execution was not successful (it encountered an exception
-        // or the spawn had an exit code != 0). Since it isn't possible to accurately recreate the
-        // failure without rerunning the action, we fall back to running the action locally. This
-        // means that we have introduced an unnecessary wait, but that can only happen in the case
-        // of a failing build with --keep_going.
+      } finally {
+        if (previousExecution != null) {
+          previousExecution.unregister();
+        }
       }
     }
 
@@ -239,6 +262,15 @@ final class RemoteSpawnCache implements SpawnCache {
           // large.
           remoteExecutionService.uploadOutputs(
               action, result, () -> inFlightExecutions.remove(action.getActionKey()));
+          if (thisExecutionFinal != null
+              && action.getSpawn().getResourceOwner().mayModifySpawnOutputsAfterExecution()) {
+            // In this case outputs have been uploaded synchronously and the callback above has run,
+            // so no new executions will be deduplicated against this one. We can safely await all
+            // existing executions finish the reuse.
+            // Note that while this call itself isn't interruptible, all operations it awaits are
+            // interruptible.
+            thisExecutionFinal.awaitAllOutputReuse();
+          }
         }
 
         private void checkForConcurrentModifications()

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -713,7 +713,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
   public boolean mayModifySpawnOutputsAfterExecution() {
     // Causes of spawn output modification after execution:
     // - Fallback to the full classpath with --experimental_java_classpath=bazel.
-    // - In-place rewriting of .jdeps files when with --experimental_output_paths=strip.
+    // - In-place rewriting of .jdeps files with --experimental_output_paths=strip.
     return true;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -709,6 +709,14 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     return null;
   }
 
+  @Override
+  public boolean mayModifySpawnOutputsAfterExecution() {
+    // Causes of spawn output modification after execution:
+    // - Fallback to the full classpath with --experimental_java_classpath=bazel.
+    // - In-place rewriting of .jdeps files when with --experimental_output_paths=strip.
+    return true;
+  }
+
   /**
    * Locally rewrites a .jdeps file to replace missing config prefixes.
    *

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -157,6 +157,14 @@ public final class JavaHeaderCompileAction extends SpawnAction {
     }
   }
 
+  @Override
+  public boolean mayModifySpawnOutputsAfterExecution() {
+    // Causes of spawn output modification after execution:
+    // - In-place rewriting of .jdeps files when with --experimental_output_paths=strip.
+    // TODO: Use separate files as action and spawn output to avoid in-place modification.
+    return true;
+  }
+
   public static Builder newBuilder(RuleContext ruleContext) {
     return new Builder(ruleContext);
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -160,7 +160,7 @@ public final class JavaHeaderCompileAction extends SpawnAction {
   @Override
   public boolean mayModifySpawnOutputsAfterExecution() {
     // Causes of spawn output modification after execution:
-    // - In-place rewriting of .jdeps files when with --experimental_output_paths=strip.
+    // - In-place rewriting of .jdeps files with --experimental_output_paths=strip.
     // TODO: Use separate files as action and spawn output to avoid in-place modification.
     return true;
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -44,10 +44,12 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionContext;
+import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ArtifactExpander;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
@@ -94,6 +96,8 @@ import com.google.devtools.common.options.Options;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.SortedMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
@@ -243,10 +247,16 @@ public class RemoteSpawnCacheTest {
   }
 
   private static SimpleSpawn simplePathMappedSpawn(String configSegment) {
+    return simplePathMappedSpawn(
+        configSegment, new FakeOwner("Mnemonic", "Progress Message", "//dummy:label"));
+  }
+
+  private static SimpleSpawn simplePathMappedSpawn(
+      String configSegment, ActionExecutionMetadata owner) {
     String inputPath = "bazel-bin/%s/bin/input";
     String outputPath = "bazel-bin/%s/bin/output";
     return new SimpleSpawn(
-        new FakeOwner("Mnemonic", "Progress Message", "//dummy:label"),
+        owner,
         ImmutableList.of("cp", inputPath.formatted("cfg"), outputPath.formatted("cfg")),
         ImmutableMap.of("VARIABLE", "value"),
         ImmutableMap.of(ExecutionRequirements.SUPPORTS_PATH_MAPPING, ""),
@@ -744,6 +754,111 @@ public class RemoteSpawnCacheTest {
               .build());
     }
     CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
+
+    // assert
+    assertThat(secondCacheHandle.hasResult()).isTrue();
+    assertThat(secondCacheHandle.getResult().getRunnerName()).isEqualTo("deduplicated");
+    assertThat(
+            FileSystemUtils.readContent(
+                fs.getPath("/exec/root/bazel-bin/k8-opt/bin/output"), UTF_8))
+        .isEqualTo("hello");
+    assertThat(secondCacheHandle.willStore()).isFalse();
+  }
+
+  @Test
+  public void pathMappedActionIsDeduplicatedWithSpawnOutputModification() throws Exception {
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+
+    ActionExecutionMetadata firstExecutionOwner =
+        new FakeOwner("Mnemonic", "Progress Message", "//dummy:label") {
+          @Override
+          public boolean mayModifySpawnOutputsAfterExecution() {
+            return true;
+          }
+        };
+    SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild", firstExecutionOwner);
+    FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
+    firstFakeFileCache.createScratchInput(firstSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext firstPolicy =
+        createSpawnExecutionContext(firstSpawn, execRoot, firstFakeFileCache, outErr);
+
+    SimpleSpawn secondSpawn = simplePathMappedSpawn("k8-opt");
+    FakeActionInputFileCache secondFakeFileCache = new FakeActionInputFileCache(execRoot);
+    secondFakeFileCache.createScratchInput(secondSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext secondPolicy =
+        createSpawnExecutionContext(secondSpawn, execRoot, secondFakeFileCache, outErr);
+
+    RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
+    CountDownLatch enteredWaitForAndReuseOutputs = new CountDownLatch(1);
+    CountDownLatch completeWaitForAndReuseOutputs = new CountDownLatch(1);
+    Mockito.doAnswer(
+            (Answer<SpawnResult>)
+                invocation -> {
+                  enteredWaitForAndReuseOutputs.countDown();
+                  completeWaitForAndReuseOutputs.await();
+                  return (SpawnResult) invocation.callRealMethod();
+                })
+        .when(remoteExecutionService)
+        .waitForAndReuseOutputs(any(), any());
+    // Simulate a very slow upload to the remote cache to ensure that the second spawn is
+    // deduplicated rather than a cache hit. This is a slight hack, but also avoids introducing
+    // more concurrency to this test.
+    Mockito.doNothing().when(remoteExecutionService).uploadOutputs(any(), any(), any());
+
+    // act
+    // Simulate the first spawn writing to the output, but delay its completion.
+    CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy);
+    FileSystemUtils.writeContent(
+        fs.getPath("/exec/root/bazel-bin/k8-fastbuild/bin/output"), UTF_8, "hello");
+
+    // Start the second spawn and wait for it to deduplicate against the first one.
+    AtomicReference<CacheHandle> secondCacheHandleRef = new AtomicReference<>();
+    Thread lookupSecondSpawn =
+        new Thread(
+            () -> {
+              try {
+                secondCacheHandleRef.set(cache.lookup(secondSpawn, secondPolicy));
+              } catch (InterruptedException
+                  | IOException
+                  | ExecException
+                  | ForbiddenActionInputException e) {
+                throw new IllegalStateException(e);
+              }
+            });
+    lookupSecondSpawn.start();
+    enteredWaitForAndReuseOutputs.await();
+
+    // Complete the first spawn and immediately corrupt its outputs.
+    Thread completeFirstSpawn =
+        new Thread(
+            () -> {
+              try {
+                firstCacheHandle.store(
+                    new SpawnResult.Builder()
+                        .setExitCode(0)
+                        .setStatus(Status.SUCCESS)
+                        .setRunnerName("test")
+                        .build());
+                FileSystemUtils.writeContent(
+                    fs.getPath("/exec/root/bazel-bin/k8-fastbuild/bin/output"), UTF_8, "corrupted");
+              } catch (IOException | ExecException | InterruptedException e) {
+                throw new IllegalStateException(e);
+              }
+            });
+    completeFirstSpawn.start();
+    // Make it more likely to detect races by waiting for this thread to make as much progress as
+    // possible before letting the second spawn continue.
+    while (completeFirstSpawn.getState().compareTo(Thread.State.WAITING) < 0) {
+      Thread.sleep(10);
+    }
+
+    // Let the second spawn complete its output reuse.
+    completeWaitForAndReuseOutputs.countDown();
+    lookupSecondSpawn.join();
+    CacheHandle secondCacheHandle = secondCacheHandleRef.get();
+
+    completeFirstSpawn.join();
 
     // assert
     assertThat(secondCacheHandle.hasResult()).isTrue();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -852,6 +852,7 @@ public class RemoteSpawnCacheTest {
     while (completeFirstSpawn.getState().compareTo(Thread.State.WAITING) < 0) {
       Thread.sleep(10);
     }
+    assertThat(completeFirstSpawn.getState()).isEqualTo(Thread.State.WAITING);
 
     // Let the second spawn complete its output reuse.
     completeWaitForAndReuseOutputs.countDown();


### PR DESCRIPTION
When an action may modify a spawn's outputs after execution, the upload of outputs to the cache and reuse for deduplicated actions need to happen synchronously directly after spawn execution to avoid a race.

This commit implements this for cache uploads by marking all actions with this property and simply disabling async upload for all spawns executed by such actions.

For output reuse, all executions deduplicated against the first one register atomically upon deduplication and cause the cache upload to wait for all of them to complete reuse. 

Fixes #22501
Fixes #23288 
Work towards #21578 
Closes #23307 (no longer needed)