### PR TITLE
Use `--experimental_java_classpath=bazel` by default

### DIFF
--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -36,6 +36,7 @@ fi
 _BAZEL_ARGS="--spawn_strategy=standalone \
       --nojava_header_compilation \
       --strategy=Javac=worker --worker_quit_after_build --ignore_unsupported_sandboxing \
+      --experimental_java_classpath=off \
       --compilation_mode=opt \
       --repository_cache=derived/repository_cache \
       --repo_contents_cache= \

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -174,7 +174,7 @@ public class JavaOptions extends FragmentOptions {
   @Option(
       name = "experimental_java_classpath",
       allowMultiple = false,
-      defaultValue = "javabuilder",
+      defaultValue = "bazel",
       converter = JavaClasspathModeConverter.class,
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -2234,7 +2234,7 @@ EOF
     --experimental_worker_multiplex_sandboxing \
     --java_language_version=17 \
     --extra_toolchains=//pkg/java/hello:java_toolchain_definition \
-    >& $TEST_log || fail "build succeeded"
+    >& $TEST_log || fail "build failed"
 }
 
 function test_strict_deps_error_external_repo_starlark_action() {

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -2150,7 +2150,7 @@ function test_sandboxed_multiplexing_hermetic_paths_in_diagnostics() {
   if [[ "$is_windows" ]]; then
     # https://bugs.openjdk.org/browse/JDK-8357249 makes sandboxed multiplex
     # workers incompatible with the reduced classpath heuristic on Windows.
-    add_to_bazelrc "--experimental_java_classpath=off"
+    add_to_bazelrc "common --experimental_java_classpath=off"
   fi
 
   mkdir -p pkg
@@ -2188,7 +2188,7 @@ function test_sandboxed_multiplexing_full_classpath_fallback() {
   if [[ "$is_windows" ]]; then
     # https://bugs.openjdk.org/browse/JDK-8357249 makes sandboxed multiplex
     # workers incompatible with the reduced classpath heuristic on Windows.
-    add_to_bazelrc "--experimental_java_classpath=off"
+    add_to_bazelrc "common --experimental_java_classpath=off"
   fi
 
   mkdir -p pkg/java/hello || fail "Expected success"

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -2238,7 +2238,6 @@ EOF
   bazel build \
       --remote_executor=grpc://localhost:${worker_port} \
       --remote_download_minimal \
-      --experimental_java_classpath=bazel \
       //a:bin >& $TEST_log || fail "Failed to build"
 
   bazel clean
@@ -2247,7 +2246,6 @@ EOF
   bazel build \
       --remote_executor=grpc://localhost:${worker_port} \
       --remote_download_minimal \
-      --experimental_java_classpath=bazel \
       //a:bin >& $TEST_log || fail "Failed to build"
 
   if [[ -f bazel-bin/a/liblib-hjar.jdeps ]]; then
@@ -2273,7 +2271,6 @@ EOF
       --remote_executor=grpc://localhost:${worker_port} \
       --remote_download_minimal \
       --experimental_remote_cache_eviction_retries=1 \
-      --experimental_java_classpath=bazel \
       //a:bin >& $TEST_log || fail "Failed to build"
 
   expect_log "Lost inputs no longer available remotely: a/liblib-hjar.jdeps (.*)"

--- a/src/test/shell/integration/config_stripped_outputs_test.sh
+++ b/src/test/shell/integration/config_stripped_outputs_test.sh
@@ -180,9 +180,7 @@ function test_inmemory_jdeps_support() {
   write_java_classpath_reduction_files "$pkg"
 
   bazel clean
-  bazel build --experimental_java_classpath=bazel  \
-    --experimental_output_paths=strip \
-    --experimental_inmemory_jdeps_files \
+  bazel build --experimental_output_paths=strip \
     //"$pkg"/java/hello:a -s 2>"$TEST_log" \
     || fail "Expected success"
 
@@ -312,9 +310,7 @@ public class BaseLib {
 EOF
 
   bazel clean
-  bazel build --experimental_java_classpath=bazel  \
-    --experimental_output_paths=strip \
-    --experimental_inmemory_jdeps_files \
+  bazel build --experimental_output_paths=strip \
     //$pkg/java:Main -s 2>"$TEST_log" \
     || fail "Expected success"
 
@@ -369,8 +365,7 @@ java_library(name='c', srcs=['C.java'], deps = [':d'])
 java_library(name='d', srcs=['D.java'])
 EOF
 
-  bazel build --experimental_java_classpath=bazel  \
-    --experimental_output_paths=strip \
+  bazel build --experimental_output_paths=strip \
     //"$pkg"/java/hello:a -s 2>"$TEST_log" \
     || fail "Expected success"
 


### PR DESCRIPTION
Disable `--experimental_java_class=bazel` in tests for sandboxed multiplex workers on Windows due to https://bugs.openjdk.org/browse/JDK-8357249, which would require a highly intrusive workaround (https://github.com/bazelbuild/bazel/pull/26095).

RELNOTES[inc]: `--experimental_java_classpath` now defaults to `bazel` (was: `javabuilder`). This is expected to reduce the number of Java compilations running on incremental builds if a remote or disk cache is used. Other types of builds are not expected to be negatively affected by this change.