### PR TITLE
[7.4.0] Downloader: Treat 502 as recoverable HTTP error.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -203,7 +203,6 @@ class HttpConnector {
           throw new IOException(describeHttpResponse(connection));
         } else if (code < 500          // 4xx means client seems to have erred quoth RFC7231 § 6.5
                     || code == 501     // Server doesn't support function quoth RFC7231 § 6.6.2
-                    || code == 502     // Host not configured on server cf. RFC7231 § 6.6.3
                     || code == 505) {  // Server refuses to support version quoth RFC7231 § 6.6.6
           // This is a permanent error so we're not going to retry.
           readAllBytesAndClose(connection.getErrorStream());
@@ -214,7 +213,7 @@ class HttpConnector {
           }
           throw new UnrecoverableHttpException(describeHttpResponse(connection));
         } else {
-          // However we will retry on some 5xx errors, particularly 500 and 503.
+          // However we will retry on some 5xx errors, particularly 500, 502 and 503.
           throw new IOException(describeHttpResponse(connection));
         }
       } catch (UnrecoverableHttpException | FileNotFoundException e) {


### PR DESCRIPTION
GitHub releases sometimes fails with a 502 Bad Gateway error, as an internal request times out.
We want to retry these requests, so treat the 502 errors as the other 500s.

Fixes https://github.com/bazelbuild/bazel/issues/23334

Closes #23378.

PiperOrigin-RevId: 666244539
Change-Id: I2ed02ed9ecb3a7378c4d29b5ec5b96358e289779

Commit https://github.com/bazelbuild/bazel/commit/5081ddb2ba8f2688afd825f24f1865b4a402d7bc