### PR TITLE
[7.4.0] Fix in-process materialization of unresolved symlinks in runfiles

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -986,6 +986,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     exec.strictConflictChecks = strictConflictChecks;
     exec.disallowUnsoundDirectoryOutputs = disallowUnsoundDirectoryOutputs;
     exec.additiveModifyExecutionInfo = additiveModifyExecutionInfo;
+    exec.inProcessSymlinkCreation = inProcessSymlinkCreation;
 
     // === Output path calculation
     exec.outputDirectoryNamingScheme = outputDirectoryNamingScheme;

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
@@ -268,6 +268,8 @@ public final class SymlinkTreeHelper {
         Path next = at.getChild(entry.getKey());
         if (entry.getValue() == null) {
           FileSystemUtils.createEmptyFile(next);
+        } else if (entry.getValue().isSymlink()) {
+          FileSystemUtils.ensureSymbolicLink(next, entry.getValue().getPath().readSymbolicLink());
         } else {
           FileSystemUtils.ensureSymbolicLink(next, entry.getValue().getPath().asFragment());
         }

--- a/src/test/shell/bazel/bazel_symlink_test.sh
+++ b/src/test/shell/bazel/bazel_symlink_test.sh
@@ -784,6 +784,28 @@ function test_unresolved_symlink_as_input_local() {
   bazel build //pkg:c || fail "symlink should resolve"
 }
 
+function test_unresolved_symlink_as_input_local_inprocess() {
+  if "$is_windows"; then
+    # TODO(#10298): Support unresolved symlinks on Windows.
+    return 0
+  fi
+
+  setup_unresolved_symlink_as_input
+  add_to_bazelrc build --spawn_strategy=local
+  add_to_bazelrc build --experimental_inprocess_symlink_creation
+
+  bazel build //pkg:b && fail "symlink should not resolve"
+
+  bazel clean
+  bazel build  //pkg:file
+  # Since the build isn't sandboxed, the symlink to //:a resolves even though
+  # the action does not declare it as an input.
+  bazel build  //pkg:b || fail "symlink expected to resolve non-hermetically"
+
+  bazel clean
+  bazel build  //pkg:c || fail "symlink should resolve"
+}
+
 function test_unresolved_symlink_as_input_sandbox() {
   if "$is_windows"; then
     # TODO(#10298): Support unresolved symlinks on Windows.
@@ -797,7 +819,7 @@ function test_unresolved_symlink_as_input_sandbox() {
 
   bazel clean
   bazel build //pkg:a
-  # Since the build isn't sandboxed, the symlink to //:a does not resolves even
+  # Since the build is sandboxed, the symlink to //:a does not resolves even
   # though it would in the unsandboxed exec root due to //:a having been built
   # before.
   bazel build //pkg:b && fail "sandboxed build is not hermetic"
@@ -878,6 +900,23 @@ function test_unresolved_symlink_as_runfile_local() {
 
   setup_unresolved_symlink_as_runfile
   add_to_bazelrc build --spawn_strategy=local
+
+  bazel build //pkg:use_tool || fail "local build failed"
+  # Keep the implicitly built //pkg:a around to make the symlink resolve
+  # outside the runfiles tree. The build should still fail as the relative
+  # symlink is staged as is and doesn't resolve outside the runfiles tree.
+  bazel build //pkg:use_tool_non_hermetically && fail "symlink in runfiles resolved outside the runfiles tree" || true
+}
+
+function test_unresolved_symlink_as_runfile_local_inprocess() {
+  if "$is_windows"; then
+    # TODO(#10298): Support unresolved symlinks on Windows.
+    return 0
+  fi
+
+  setup_unresolved_symlink_as_runfile
+  add_to_bazelrc build --spawn_strategy=local
+  add_to_bazelrc build --experimental_inprocess_symlink_creation
 
   bazel build //pkg:use_tool || fail "local build failed"
   # Keep the implicitly built //pkg:a around to make the symlink resolve


### PR DESCRIPTION
Unresolved symlinks, when consumed as runfiles with `--experimental_inprocess_symlink_creation`, are now created as symlinks directly pointing to their target path instead of to the absolute path of the unresolved symlink artifact under the execroot, just like with out-of-process symlink creation.

Along the way, fix the propagation of `--experimental_inprocess_symlink_creation` to the exec configuration, which previously would have caused the new test cases to fail open.

Fixes #23327

Closes #23328.

PiperOrigin-RevId: 665754549
Change-Id: I6b240ca27dac513738056b015c97baec91677c4e

Closes #23329