### PR TITLE
Add back path mapping test deleted in conflict resolution

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -232,7 +232,7 @@ public class PathMappersTest extends BuildViewTestCase {
         .inOrder();
   }
 
-    @Test
+  @Test
   public void starlarkRule_stringExecutablePath() throws Exception {
     scratch.file("defs/BUILD");
     scratch.file(

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -232,6 +232,67 @@ public class PathMappersTest extends BuildViewTestCase {
         .inOrder();
   }
 
+    @Test
+  public void starlarkRule_stringExecutablePath() throws Exception {
+    scratch.file("defs/BUILD");
+    scratch.file(
+        "defs/defs.bzl",
+        """
+        def my_rule_impl(ctx):
+            out = ctx.actions.declare_file(ctx.label.name)
+            ctx.actions.run(
+                executable = ctx.executable.tool.path,
+                arguments = [ctx.actions.args().add(out)],
+                outputs = [out],
+                tools = [ctx.executable.tool],
+                execution_requirements = {"supports-path-mapping": "1"},
+            )
+            return DefaultInfo(files = depset([out]))
+        my_rule = rule(
+            implementation = my_rule_impl,
+            attrs = {
+                "tool": attr.label(
+                    default = "//foo:script",
+                    cfg = "exec",
+                    executable = True,
+                ),
+            },
+        )
+        """);
+    scratch.file(
+        "foo/BUILD",
+        """
+        sh_binary(
+            name = 'script',
+            srcs = ['script.sh'],
+            visibility = ['//visibility:public'],
+        )
+        """);
+    scratch.file(
+        "BUILD",
+        """
+        load("//defs:defs.bzl", "my_rule")
+        my_rule(name = "my_rule")
+        """);
+
+    ConfiguredTarget configuredTarget = getConfiguredTarget("//:my_rule");
+    Artifact outputArtifact =
+        configuredTarget.getProvider(FileProvider.class).getFilesToBuild().toList().get(0);
+    SpawnAction action = (SpawnAction) getGeneratingAction(outputArtifact);
+    Spawn spawn =
+        action.getSpawn(
+            new ActionExecutionContextBuilder()
+                .setMetadataProvider(new FakeActionInputFileCache())
+                .build());
+
+    assertThat(spawn.getPathMapper().isNoop()).isFalse();
+    String outDir = analysisMock.getProductName() + "-out";
+    assertThat(spawn.getArguments())
+        .containsExactly(
+            "%s/cfg/bin/foo/script".formatted(outDir), "%s/cfg/bin/my_rule".formatted(outDir))
+        .inOrder();
+  }
+
   @Test
   public void forActionKey() {
     var pathMapper = PathMappers.forActionKey(CoreOptions.OutputPathsMode.STRIP);


### PR DESCRIPTION
This was accidentally removed in https://github.com/bazelbuild/bazel/commit/ca6e80ec48efda914d91050caf485b3a2c72f415#diff-7bc3ba395805947dd483290efc60e0157b69b5d9b074cb431b7e7d289fbfd4e1.