### PR TITLE
[7.4.0] Remount sys to make /sys/class/net consistent with network namespace.

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -438,12 +438,22 @@ static void MakeFilesystemMostlyReadOnly() {
   endmntent(mounts);
 }
 
-static void MountProc() {
+static void MountProcAndSys() {
   // Mount a new proc on top of the old one, because the old one still refers to
   // our parent PID namespace.
   if (mount("/proc", "/proc", "proc", MS_NODEV | MS_NOEXEC | MS_NOSUID,
             nullptr) < 0) {
-    DIE("mount");
+    DIE("mount /proc");
+  }
+
+  if (opt.create_netns == NO_NETNS) {
+    return;
+  }
+
+  // Same for sys, but only if a separate network namespace was requested.
+  if (mount("none", "/sys", "sysfs",
+            MS_NOEXEC | MS_NOSUID | MS_NODEV | MS_RDONLY, nullptr) < 0) {
+    DIE("mount /sys");
   }
 }
 
@@ -719,13 +729,13 @@ int Pid1Main(void *sync_pipe_param) {
     MountSandboxAndGoThere();
     CreateEmptyFile();
     MountDev();
-    MountProc();
+    MountProcAndSys();
     MountAllMounts();
     ChangeRoot();
   } else {
     MountFilesystems();
     MakeFilesystemMostlyReadOnly();
-    MountProc();
+    MountProcAndSys();
   }
   SetupNetworking();
   EnterWorkingDirectory();


### PR DESCRIPTION
Without a remount, sys still refers to the parent namespace, so a device created inside the namespace (e.g. tun) won't be shown under /sys/class/net.

Closes #23274.

PiperOrigin-RevId: 666303783
Change-Id: I3e0ddd9a150eb10b581abbf0d165babde7fe28ee

Commit https://github.com/bazelbuild/bazel/commit/448fd0bb11982139a158ea77b845589efbf1236e