### PR TITLE
[7.4.0] Fix ml path for Windows clang-cl cc toolchain

### DIFF
--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -793,7 +793,8 @@ def _get_clang_cl_vars(repository_ctx, paths, msvc_vars, target_arch):
         "%{clang_cl_cl_path_" + target_arch + "}": clang_cl_path,
         "%{clang_cl_link_path_" + target_arch + "}": lld_link_path,
         "%{clang_cl_lib_path_" + target_arch + "}": llvm_lib_path,
-        "%{clang_cl_ml_path_" + target_arch + "}": clang_cl_path,
+        # clang-cl does not support assembly files as input.
+        "%{clang_cl_ml_path_" + target_arch + "}": msvc_vars["%{msvc_ml_path_" + target_arch + "}"],
         # LLVM's lld-link.exe doesn't support /DEBUG:FASTLINK.
         "%{clang_cl_dbg_mode_debug_flag_" + target_arch + "}": "/DEBUG",
         "%{clang_cl_fastbuild_mode_debug_flag_" + target_arch + "}": "/DEBUG",


### PR DESCRIPTION
Assembly files are not valid inputs for `clang-cl.exe`; the MSVC `ml64.exe` must be used instead.

Fixes #23128.

Closes #23337.

PiperOrigin-RevId: 666406544
Change-Id: Ia7a5fc4702f08a5754145ca286c079d1a4f0e204

Commit https://github.com/bazelbuild/bazel/commit/e5a083d47e7174357997c851c20521e03a9c80ce