### PR TITLE
makes ICMP works under fakeroot

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -443,6 +443,15 @@ static void SetupNetworking() {
       DIE("close");
     }
   }
+
+  if(opt.create_netns == NO_NETNS || !opt.fake_root){
+      return;
+  }
+  //within network namespace, must write /proc/sys/net/ipv4/ping_group_range
+  //to valid group id, otherwise default value 1 0 can't map back to valid gid
+  //prevent IPPROTO_ICMP from working.
+  //due to current kernel limitation, this only possible when mapped user is root
+  WriteFile("/proc/sys/net/ipv4/ping_group_range", "0 0");
 }
 
 static void EnterWorkingDirectory() {


### PR DESCRIPTION
network namespace reset /proc/sys/net/ipv4/ping_group_range to default value 1 0, which can't map to valid gid, prevent IPPPROTO_ICMP to work. fix this by written valid gid 0 0, only possible for fakeroot. podman has similar process https://github.com/containers/common/blob/ae4a61e1b2e0af84a668f87f7622d86ebc418cba/pkg/config/containers.conf#L80

detail information here https://github.com/bazelbuild/bazel/issues/23275