### PR TITLE
Fix various UTF-8 encoding bugs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ParameterFile.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ParameterFile.java
@@ -171,7 +171,7 @@ public class ParameterFile {
       byte[] bytes = stringUnsafe.getByteArray(line);
       if (stringUnsafe.getCoder(line) == StringUnsafe.LATIN1 && isAscii(bytes)) {
         outputStream.write(bytes);
-      } else if (!StringUtil.decodeBytestringUtf8(line).equals(line)) {
+      } else if (!StringUtil.reencodeInternalToExternal(line).equals(line)) {
         // We successfully decoded line from utf8 - meaning it was already encoded as utf8.
         // We do not want to double-encode.
         outputStream.write(bytes);

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -14,7 +14,7 @@
 package com.google.devtools.build.lib.query2.aquery;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
+import static com.google.devtools.build.lib.util.StringUtil.reencodeInternalToExternal;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
@@ -373,7 +373,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
       return maybeUtf8;
     }
 
-    final String decoded = decodeBytestringUtf8(maybeUtf8);
+    final String decoded = reencodeInternalToExternal(maybeUtf8);
     final StringBuilder sb = new StringBuilder(decoded.length() * 8);
     decoded
         .codePoints()

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -249,7 +249,8 @@ public class RemoteExecutionService {
     ArrayList<String> outputDirectories = new ArrayList<>();
     ArrayList<String> outputPaths = new ArrayList<>();
     for (ActionInput output : outputs) {
-      String pathString = remotePathResolver.localPathToOutputPath(output);
+      String pathString =
+          reencodeInternalToExternal(remotePathResolver.localPathToOutputPath(output));
       if (output.isDirectory()) {
         outputDirectories.add(pathString);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -338,7 +338,7 @@ public class UploadManifest {
   private void addFileSymbolicLink(Path file, PathFragment target) {
     OutputSymlink outputSymlink =
         OutputSymlink.newBuilder()
-            .setPath(remotePathResolver.localPathToOutputPath(file))
+            .setPath(reencodeInternalToExternal(remotePathResolver.localPathToOutputPath(file)))
             .setTarget(reencodeInternalToExternal(target.toString()))
             .build();
     result.addOutputFileSymlinks(outputSymlink);
@@ -348,17 +348,17 @@ public class UploadManifest {
   private void addDirectorySymbolicLink(Path file, PathFragment target) {
     OutputSymlink outputSymlink =
         OutputSymlink.newBuilder()
-            .setPath(remotePathResolver.localPathToOutputPath(file))
+            .setPath(reencodeInternalToExternal(remotePathResolver.localPathToOutputPath(file)))
             .setTarget(reencodeInternalToExternal(target.toString()))
             .build();
     result.addOutputDirectorySymlinks(outputSymlink);
     result.addOutputSymlinks(outputSymlink);
   }
 
-  private void addFile(Digest digest, Path file) throws IOException {
+  private void addFile(Digest digest, Path file) {
     result
         .addOutputFilesBuilder()
-        .setPath(remotePathResolver.localPathToOutputPath(file))
+        .setPath(reencodeInternalToExternal(remotePathResolver.localPathToOutputPath(file)))
         .setDigest(digest)
         .setIsExecutable(true);
 
@@ -564,7 +564,7 @@ public class UploadManifest {
 
     result
         .addOutputDirectoriesBuilder()
-        .setPath(remotePathResolver.localPathToOutputPath(dir))
+        .setPath(reencodeInternalToExternal(remotePathResolver.localPathToOutputPath(dir)))
         .setTreeDigest(treeDigest)
         .setIsTopologicallySorted(true);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -21,6 +21,7 @@ import static com.google.devtools.build.lib.remote.util.RxFutures.toCompletable;
 import static com.google.devtools.build.lib.remote.util.RxFutures.toSingle;
 import static com.google.devtools.build.lib.remote.util.RxUtils.mergeBulkTransfer;
 import static com.google.devtools.build.lib.remote.util.RxUtils.toTransferResult;
+import static com.google.devtools.build.lib.util.StringUtil.reencodeInternalToExternal;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.reverseOrder;
@@ -338,7 +339,7 @@ public class UploadManifest {
     OutputSymlink outputSymlink =
         OutputSymlink.newBuilder()
             .setPath(remotePathResolver.localPathToOutputPath(file))
-            .setTarget(target.toString())
+            .setTarget(reencodeInternalToExternal(target.toString()))
             .build();
     result.addOutputFileSymlinks(outputSymlink);
     result.addOutputSymlinks(outputSymlink);
@@ -348,7 +349,7 @@ public class UploadManifest {
     OutputSymlink outputSymlink =
         OutputSymlink.newBuilder()
             .setPath(remotePathResolver.localPathToOutputPath(file))
-            .setTarget(target.toString())
+            .setTarget(reencodeInternalToExternal(target.toString()))
             .build();
     result.addOutputDirectorySymlinks(outputSymlink);
     result.addOutputSymlinks(outputSymlink);

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
@@ -55,6 +55,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_input_expander",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_runner",
+        "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:auto_value",

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
@@ -14,6 +14,8 @@
 package com.google.devtools.build.lib.remote.common;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.devtools.build.lib.util.StringUtil.reencodeExternalToInternal;
+import static com.google.devtools.build.lib.util.StringUtil.reencodeInternalToExternal;
 
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -32,6 +34,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * A {@link RemotePathResolver} is used to resolve input/output paths for remote execution from
  * Bazel's internal path, or vice versa.
+ *
+ * <p>Instances are expected to convert between Bazel's internal string representation, which stores
+ * strings as raw bytes (Latin-1), and the Protobuf representation, which is UTF-8.
  */
 public interface RemotePathResolver {
 
@@ -120,17 +125,17 @@ public interface RemotePathResolver {
 
     @Override
     public String localPathToOutputPath(Path path) {
-      return path.relativeTo(execRoot).getPathString();
+      return reencodeInternalToExternal(path.relativeTo(execRoot).getPathString());
     }
 
     @Override
     public String localPathToOutputPath(PathFragment execPath) {
-      return execPath.getPathString();
+      return reencodeInternalToExternal(execPath.getPathString());
     }
 
     @Override
     public Path outputPathToLocalPath(String outputPath) {
-      return execRoot.getRelative(outputPath);
+      return execRoot.getRelative(reencodeExternalToInternal(outputPath));
     }
   }
 
@@ -161,7 +166,7 @@ public interface RemotePathResolver {
 
     @Override
     public String getWorkingDirectory() {
-      return execRoot.getBaseName();
+      return reencodeInternalToExternal(execRoot.getBaseName());
     }
 
     @Override
@@ -199,17 +204,17 @@ public interface RemotePathResolver {
 
     @Override
     public String localPathToOutputPath(Path path) {
-      return path.relativeTo(getBase()).getPathString();
+      return reencodeInternalToExternal(path.relativeTo(getBase()).getPathString());
     }
 
     @Override
     public String localPathToOutputPath(PathFragment execPath) {
-      return localPathToOutputPath(execRoot.getRelative(execPath));
+      return reencodeInternalToExternal(localPathToOutputPath(execRoot.getRelative(execPath)));
     }
 
     @Override
     public Path outputPathToLocalPath(String outputPath) {
-      return getBase().getRelative(outputPath);
+      return getBase().getRelative(reencodeExternalToInternal(outputPath));
     }
 
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
@@ -14,8 +14,6 @@
 package com.google.devtools.build.lib.remote.common;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.devtools.build.lib.util.StringUtil.reencodeExternalToInternal;
-import static com.google.devtools.build.lib.util.StringUtil.reencodeInternalToExternal;
 
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -34,9 +32,6 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * A {@link RemotePathResolver} is used to resolve input/output paths for remote execution from
  * Bazel's internal path, or vice versa.
- *
- * <p>Instances are expected to convert between Bazel's internal string representation, which stores
- * strings as raw bytes (Latin-1), and the Protobuf representation, which is UTF-8.
  */
 public interface RemotePathResolver {
 
@@ -125,17 +120,17 @@ public interface RemotePathResolver {
 
     @Override
     public String localPathToOutputPath(Path path) {
-      return reencodeInternalToExternal(path.relativeTo(execRoot).getPathString());
+      return path.relativeTo(execRoot).getPathString();
     }
 
     @Override
     public String localPathToOutputPath(PathFragment execPath) {
-      return reencodeInternalToExternal(execPath.getPathString());
+      return execPath.getPathString();
     }
 
     @Override
     public Path outputPathToLocalPath(String outputPath) {
-      return execRoot.getRelative(reencodeExternalToInternal(outputPath));
+      return execRoot.getRelative(outputPath);
     }
   }
 
@@ -166,7 +161,7 @@ public interface RemotePathResolver {
 
     @Override
     public String getWorkingDirectory() {
-      return reencodeInternalToExternal(execRoot.getBaseName());
+      return execRoot.getBaseName();
     }
 
     @Override
@@ -204,17 +199,17 @@ public interface RemotePathResolver {
 
     @Override
     public String localPathToOutputPath(Path path) {
-      return reencodeInternalToExternal(path.relativeTo(getBase()).getPathString());
+      return path.relativeTo(getBase()).getPathString();
     }
 
     @Override
     public String localPathToOutputPath(PathFragment execPath) {
-      return reencodeInternalToExternal(localPathToOutputPath(execRoot.getRelative(execPath)));
+      return localPathToOutputPath(execRoot.getRelative(execPath));
     }
 
     @Override
     public Path outputPathToLocalPath(String outputPath) {
-      return getBase().getRelative(reencodeExternalToInternal(outputPath));
+      return getBase().getRelative(outputPath);
     }
 
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.merkletree;
 
-import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
+import static com.google.devtools.build.lib.util.StringUtil.reencodeInternalToExternal;
 
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
@@ -398,7 +398,7 @@ public class MerkleTree {
   private static FileNode buildProto(DirectoryTree.FileNode file) {
     var node =
         FileNode.newBuilder()
-            .setName(decodeBytestringUtf8(file.getPathSegment()))
+            .setName(reencodeInternalToExternal(file.getPathSegment()))
             .setDigest(file.getDigest())
             .setIsExecutable(file.isExecutable());
     if (file.isToolInput()) {
@@ -409,15 +409,15 @@ public class MerkleTree {
 
   private static DirectoryNode buildProto(String baseName, MerkleTree dir) {
     return DirectoryNode.newBuilder()
-        .setName(decodeBytestringUtf8(baseName))
+        .setName(reencodeInternalToExternal(baseName))
         .setDigest(dir.getRootDigest())
         .build();
   }
 
   private static SymlinkNode buildProto(DirectoryTree.SymlinkNode symlink) {
     return SymlinkNode.newBuilder()
-        .setName(decodeBytestringUtf8(symlink.getPathSegment()))
-        .setTarget(decodeBytestringUtf8(symlink.getTarget()))
+        .setName(reencodeInternalToExternal(symlink.getPathSegment()))
+        .setTarget(reencodeInternalToExternal(symlink.getTarget()))
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
@@ -14,9 +14,7 @@
 
 package com.google.devtools.build.lib.shell;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.shell.SubprocessBuilder.StreamAction;
 import com.google.devtools.build.lib.util.StringUtil;
 import java.io.File;
@@ -24,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ProcessBuilder.Redirect;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -147,18 +146,33 @@ public class JavaSubprocessFactory implements SubprocessFactory {
   @Override
   public Subprocess create(SubprocessBuilder params) throws IOException {
     ProcessBuilder builder = new ProcessBuilder();
-    ImmutableList<String> argv = params.getArgv();
-    if (Runtime.version().feature() >= 19
-        && Objects.equals(System.getProperty("sun.jnu.encoding"), "UTF-8")) {
-      // On JDK 19 and newer, java.lang.ProcessImpl#start encodes argv using sun.jnu.encoding, so if
-      // sun.jnu.encoding is set to UTF-8, our argv needs to be UTF-8. (Note that on some platforms,
-      // for example on macOS, sun.jnu.encoding is hard-coded in the JVM as UTF-8.)
-      argv = argv.stream().map(StringUtil::decodeBytestringUtf8).collect(toImmutableList());
+    // On JDK 19 and newer, java.lang.ProcessImpl#start encodes argv and the environment using
+    // sun.jnu.encoding, so if sun.jnu.encoding is set to UTF-8, our argv needs to be UTF-8. (Note
+    // that on some platforms, for example on macOS, sun.jnu.encoding is hard-coded in the JVM as
+    // UTF-8.)
+    boolean reencodeToUtf8 =
+        Runtime.version().feature() >= 19
+            && Objects.equals(System.getProperty("sun.jnu.encoding"), "UTF-8");
+    List<String> argv = params.getArgv();
+    if (reencodeToUtf8) {
+      argv = Lists.transform(argv, StringUtil::reencodeInternalToExternal);
     }
     builder.command(argv);
     if (params.getEnv() != null) {
       builder.environment().clear();
-      builder.environment().putAll(params.getEnv());
+      if (reencodeToUtf8) {
+        params
+            .getEnv()
+            .forEach(
+                (key, value) ->
+                    builder
+                        .environment()
+                        .put(
+                            StringUtil.reencodeInternalToExternal(key),
+                            StringUtil.reencodeInternalToExternal(value)));
+      } else {
+        builder.environment().putAll(params.getEnv());
+      }
     }
 
     builder.redirectOutput(getRedirect(params.getStdout(), params.getStdoutFile()));

--- a/src/main/java/com/google/devtools/build/lib/util/StringUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/util/StringUtil.java
@@ -138,7 +138,7 @@ public class StringUtil {
    * <p>The return value is suitable for passing to Protobuf string fields or printing to the
    * terminal.
    */
-  public static String decodeBytestringUtf8(String maybeUtf8) {
+  public static String reencodeInternalToExternal(String maybeUtf8) {
     if (maybeUtf8.chars().allMatch(c -> c < 128)) {
       return maybeUtf8;
     }
@@ -173,9 +173,9 @@ public class StringUtil {
    *
    * <p>encodeBytestringUtf8("\u2049") == "\u00E2\u0081\u0089"
    *
-   * <p>See {@link #decodeBytestringUtf8} for motivation.
+   * <p>See {@link #reencodeInternalToExternal} for motivation.
    */
-  public static String encodeBytestringUtf8(String unicode) {
+  public static String reencodeExternalToInternal(String unicode) {
     if (unicode.chars().allMatch(c -> c < 128)) {
       return unicode;
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -121,6 +121,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/util:temp_path_generator",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/util/io:io-proto",

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -21,6 +21,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.devtools.build.lib.actions.ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS;
 import static com.google.devtools.build.lib.remote.util.DigestUtil.toBinaryDigest;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.util.StringUtil.reencodeExternalToInternal;
 import static com.google.devtools.build.lib.vfs.FileSystemUtils.readContent;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
@@ -1546,7 +1547,7 @@ public class RemoteExecutionServiceTest {
     ImmutableSet.Builder<Artifact> outputs = ImmutableSet.builder();
     ImmutableList<String> expectedOutputFiles = ImmutableList.of("outputs/foo", "outputs/bar");
     for (String outputFile : expectedOutputFiles) {
-      Path path = remotePathResolver.outputPathToLocalPath(outputFile);
+      Path path = remotePathResolver.outputPathToLocalPath(reencodeExternalToInternal(outputFile));
       Artifact output = ActionsTestUtil.createArtifact(artifactRoot, path);
       outputs.add(output);
     }
@@ -2406,13 +2407,15 @@ public class RemoteExecutionServiceTest {
       ImmutableMap<String, String> executionInfo, RemoteActionResult result) {
     ImmutableSet.Builder<Artifact> outputs = ImmutableSet.builder();
     for (OutputFile file : result.getOutputFiles()) {
-      Path path = remotePathResolver.outputPathToLocalPath(file.getPath());
+      Path path =
+          remotePathResolver.outputPathToLocalPath(reencodeExternalToInternal(file.getPath()));
       Artifact output = ActionsTestUtil.createArtifact(artifactRoot, path);
       outputs.add(output);
     }
 
     for (OutputDirectory directory : result.getOutputDirectories()) {
-      Path path = remotePathResolver.outputPathToLocalPath(directory.getPath());
+      Path path =
+          remotePathResolver.outputPathToLocalPath(reencodeExternalToInternal(directory.getPath()));
       Artifact output =
           ActionsTestUtil.createTreeArtifactWithGeneratingAction(
               artifactRoot, path.relativeTo(execRoot));
@@ -2420,13 +2423,17 @@ public class RemoteExecutionServiceTest {
     }
 
     for (OutputSymlink fileSymlink : result.getOutputFileSymlinks()) {
-      Path path = remotePathResolver.outputPathToLocalPath(fileSymlink.getPath());
+      Path path =
+          remotePathResolver.outputPathToLocalPath(
+              reencodeExternalToInternal(fileSymlink.getPath()));
       Artifact output = ActionsTestUtil.createArtifact(artifactRoot, path);
       outputs.add(output);
     }
 
     for (OutputSymlink directorySymlink : result.getOutputDirectorySymlinks()) {
-      Path path = remotePathResolver.outputPathToLocalPath(directorySymlink.getPath());
+      Path path =
+          remotePathResolver.outputPathToLocalPath(
+              reencodeExternalToInternal(directorySymlink.getPath()));
       Artifact output =
           ActionsTestUtil.createTreeArtifactWithGeneratingAction(
               artifactRoot, path.relativeTo(execRoot));
@@ -2434,7 +2441,8 @@ public class RemoteExecutionServiceTest {
     }
 
     for (OutputSymlink symlink : result.getOutputSymlinks()) {
-      Path path = remotePathResolver.outputPathToLocalPath(symlink.getPath());
+      Path path =
+          remotePathResolver.outputPathToLocalPath(reencodeExternalToInternal(symlink.getPath()));
       Artifact output = ActionsTestUtil.createArtifact(artifactRoot, path);
       outputs.add(output);
     }

--- a/src/test/java/com/google/devtools/build/lib/util/StringUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/StringUtilTest.java
@@ -14,8 +14,8 @@
 package com.google.devtools.build.lib.util;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
-import static com.google.devtools.build.lib.util.StringUtil.encodeBytestringUtf8;
+import static com.google.devtools.build.lib.util.StringUtil.reencodeInternalToExternal;
+import static com.google.devtools.build.lib.util.StringUtil.reencodeExternalToInternal;
 import static com.google.devtools.build.lib.util.StringUtil.joinEnglishList;
 import static com.google.devtools.build.lib.util.StringUtil.joinEnglishListSingleQuoted;
 
@@ -74,39 +74,39 @@ public class StringUtilTest {
 
   @Test
   @SuppressWarnings("UnicodeEscape")
-  public void testDecodeBytestringUtf8() throws Exception {
+  public void testReencodeInternalToExternal() throws Exception {
     // Regular ASCII passes through OK.
-    assertThat(decodeBytestringUtf8("ascii")).isEqualTo("ascii");
+    assertThat(reencodeInternalToExternal("ascii")).isEqualTo("ascii");
 
     // Valid UTF-8 is decoded.
-    assertThat(decodeBytestringUtf8("\u00E2\u0081\u0089"))
+    assertThat(reencodeInternalToExternal("\u00E2\u0081\u0089"))
         .isEqualTo("\u2049"); // U+2049 EXCLAMATION QUESTION MARK
-    assertThat(decodeBytestringUtf8("\u00f0\u009f\u008c\u00b1"))
+    assertThat(reencodeInternalToExternal("\u00f0\u009f\u008c\u00b1"))
         .isEqualTo("\uD83C\uDF31"); // U+1F331 SEEDLING
 
     // Strings that contain characters that can't be UTF-8 are returned as-is,
     // to support Windows file paths.
-    assertThat(decodeBytestringUtf8("\u2049"))
+    assertThat(reencodeInternalToExternal("\u2049"))
         .isEqualTo("\u2049"); // U+2049 EXCLAMATION QUESTION MARK
-    assertThat(decodeBytestringUtf8("\uD83C\uDF31")).isEqualTo("\uD83C\uDF31"); // U+1F331 SEEDLING
+    assertThat(reencodeInternalToExternal("\uD83C\uDF31")).isEqualTo("\uD83C\uDF31"); // U+1F331 SEEDLING
 
     // Strings that might be either UTF-8 or Unicode are optimistically decoded,
     // and returned as-is if decoding succeeded with no replacement characters.
-    assertThat(decodeBytestringUtf8("\u00FC\u006E\u00EF\u0063\u00F6\u0064\u00EB"))
+    assertThat(reencodeInternalToExternal("\u00FC\u006E\u00EF\u0063\u00F6\u0064\u00EB"))
         .isEqualTo("\u00FC\u006E\u00EF\u0063\u00F6\u0064\u00EB"); // "ünïcödë"
 
     // A string that is both valid ISO-8859-1 and valid UTF-8 will be decoded
     // as UTF-8.
-    assertThat(decodeBytestringUtf8("\u00C2\u00A3")) // "Â£"
+    assertThat(reencodeInternalToExternal("\u00C2\u00A3")) // "Â£"
         .isEqualTo("\u00A3"); // U+00A3 POUND SIGN
   }
 
   @Test
   public void testEncodeBytestringUtf8() throws Exception {
-    assertThat(encodeBytestringUtf8("ascii")).isEqualTo("ascii");
-    assertThat(encodeBytestringUtf8("\u2049")) // U+2049 EXCLAMATION QUESTION MARK
+    assertThat(reencodeExternalToInternal("ascii")).isEqualTo("ascii");
+    assertThat(reencodeExternalToInternal("\u2049")) // U+2049 EXCLAMATION QUESTION MARK
         .isEqualTo("\u00E2\u0081\u0089");
-    assertThat(encodeBytestringUtf8("\uD83C\uDF31")) // U+1F331 SEEDLING
+    assertThat(reencodeExternalToInternal("\uD83C\uDF31")) // U+1F331 SEEDLING
         .isEqualTo("\u00f0\u009f\u008c\u00b1");
   }
 }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -2992,8 +2992,7 @@ function test_unicode_cache() {
       --remote_cache=grpc://localhost:${worker_port} \
       //:test_unicode >& $TEST_log \
       || fail "Failed to build //:test_unicode to populate the cache"
-  # Catch any remote cache warnings.
-  expect_not_log WARNING
+  expect_not_log "WARNING: Remote cache:"
 
   # Don't leak LC_ALL into other tests.
   bazel shutdown
@@ -3006,8 +3005,7 @@ function test_unicode_cache() {
       --remote_cache=grpc://localhost:${worker_port} \
       //:test_unicode >& $TEST_log \
       || fail "Failed to build //:test_unicode with remote cache"
-  # Catch any remote cache warnings.
-  expect_not_log WARNING
+  expect_not_log "WARNING: Remote cache:"
   expect_log "3 processes: 1 remote cache hit, 2 internal."
 
   # Don't leak LC_ALL into other tests.


### PR DESCRIPTION
Fixes missing reencodings from Bazel's internal representation to UTF-8 or vice versa:
* environment variables for locally executed spawns when the JVM uses a UTF-8 locale
* output file paths for remote cache uploads
* symlink targets

Also renames the encoding/decoding methods to make it more clear which one is correct for which situation.