### PR TITLE
Convert values to Starlark values when concating string_list_dict type

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Type.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Type.java
@@ -620,11 +620,11 @@ public abstract class Type<T> {
 
     @Override
     public Map<KeyT, ValueT> concat(Iterable<Map<KeyT, ValueT>> iterable) {
-      Dict.Builder<KeyT, ValueT> output = new Dict.Builder<>();
+      ImmutableMap.Builder<KeyT, ValueT> builder = ImmutableMap.builder();
       for (Map<KeyT, ValueT> map : iterable) {
-        output.putAll(map);
+        builder.putAll(map);
       }
-      return output.buildImmutable();
+      return builder.buildKeepingLast();
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/packages/TypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TypeTest.java
@@ -375,6 +375,37 @@ public class TypeTest {
   }
 
   @Test
+  public void testStringListDict_concat() throws Exception {
+    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of()))
+      .isEqualTo(ImmutableMap.of());
+
+    Map<String, List<String>> expected =
+      ImmutableMap.of(
+          "foo", Arrays.asList("foo", "bar"),
+          "wiz", Arrays.asList("bang"));
+    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of(expected)))
+    .isEqualTo(expected);
+    
+    Map<String, List<String>> map1 =
+      ImmutableMap.of(
+          "foo", Arrays.asList("a", "b"),
+          "bar", Arrays.asList("c", "d"));
+    Map<String, List<String>> map2 =
+      ImmutableMap.of(
+          "bar", Arrays.asList("x", "y"),
+          "baz", Arrays.asList("z"));
+    
+    Map<String, List<String>> expected_after_concat =
+      ImmutableMap.of(
+          "foo", Arrays.asList("a", "b"),
+          "bar", Arrays.asList("x", "y"),
+          "baz", Arrays.asList("z"));
+
+    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of(map1, map2)))
+      .isEqualTo(expected_after_concat);
+  }
+
+  @Test
   public void testStringListDictBadFirstElement() throws Exception {
     Object input =
         ImmutableMap.of(


### PR DESCRIPTION
Convert values to Starlark values when concating string_list_dict type.

This is because Dict checks that all the values put in it are Starlark valid values. But string_list_dict value is of type List<String>, when Java's List isn't a Starlark value.

Fixes #23065

My first PR to bazel :star_struck: Would love you to review the PR.
 Checked that the test didn't pass before the change and did after it.
