### PR TITLE
[7.4.0] Handle invalid base64 in SRI

### DIFF
--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -1311,8 +1311,8 @@ EOF
 }
 
 function test_integrity_ill_formed_base64() {
-  cat > $(setup_module_dot_bazel) <<EOF
-http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+  cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "repo",
     integrity = "sha256-Yab3Yqr2BlLL8zKHm43MLP2BviEpoGHalX0Dnq538L=",

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -1310,6 +1310,20 @@ EOF
   shutdown_server
 }
 
+function test_integrity_ill_formed_base64() {
+  cat > $(setup_module_dot_bazel) <<EOF
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "repo",
+    integrity = "sha256-Yab3Yqr2BlLL8zKHm43MLP2BviEpoGHalX0Dnq538L=",
+    url = "file:///dev/null",
+)
+EOF
+  bazel build @repo//... &> $TEST_log 2>&1 && fail "Expected to fail"
+  expect_log "Invalid base64 'Yab3Yqr2BlLL8zKHm43MLP2BviEpoGHalX0Dnq538L='"
+  shutdown_server
+}
+
 function test_same_name() {
   mkdir ext
   echo foo> ext/foo


### PR DESCRIPTION
Previously, invalid base64 would crash the Bazel server.

Closes #23410.

PiperOrigin-RevId: 667624565
Change-Id: I7b6b834fd291e9a3dae59df88b29bb378e7663a3

Commit https://github.com/bazelbuild/bazel/commit/1b0ed28013e99fc9b0c99dedbef09537cbf07c6b