### PR TITLE
[7.4.0] Allow ICMP sockets inside a sandbox.

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -485,6 +485,14 @@ static void SetupNetworking() {
       DIE("close");
     }
   }
+
+  if (opt.create_netns != NO_NETNS && opt.fake_root) {
+    // Allow IPPROTO_ICMP sockets when already allowed outside of the namespace.
+    // In a namespace, /proc/sys/net/ipv4/ping_group_range is reset to the
+    // default of 1 0, which does not match any groups. However, it can only be
+    // overridden when the namespace has a fake root. This may be a kernel bug.
+    WriteFile("/proc/sys/net/ipv4/ping_group_range", "0 0");
+  }
 }
 
 static void EnterWorkingDirectory() {


### PR DESCRIPTION
See discussion in https://github.com/bazelbuild/bazel/issues/23275.

Fixes #23275.

Fixes #23411.

PiperOrigin-RevId: 667906233
Change-Id: Id6dbaeca015297d1c70339f1e2ccdf2db20e0de7

Commit https://github.com/bazelbuild/bazel/commit/e88a7d982411e3d6bbfb658b88e76944ea5ed720