### PR TITLE
unix_cc_toolchain_config: macOS supports dynamic linker

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -1620,6 +1620,7 @@ def _impl(ctx):
             default_link_libs_feature,
             external_include_paths_feature,
             fdo_optimize_feature,
+            supports_dynamic_linker_feature,
             dbg_feature,
             opt_feature,
             user_compile_flags_feature,


### PR DESCRIPTION
MacOS CC toolchains based on `unix_cc_toolchain_config` (such as the one provided by `rules_nixpkgs`) can no longer build dynamically linked `cc_library` targets on Bazel 7 and newer.
I traced the problem back to [this check](https://cs.opensource.google/bazel/bazel/+/refs/tags/7.1.0:src/main/starlark/builtins_bzl/common/cc/cc_library.bzl;l=92-98) in the implementation of `cc_library`:

```starlark
create_dynamic_library = (not ctx.attr.linkstatic and
                          supports_dynamic_linker and
                          (not cc_helper.is_compilation_outputs_empty(compilation_outputs) or
                           cc_common.is_enabled(
                               feature_configuration = feature_configuration,
                               feature_name = "header_module_codegen",
                           )))
```

For the auto-detected toolchain on macOS, the `supports_dynamic_linker` feature is set, and both a static and dynamic library can be built.
When using `unix_cc_toolchain_config`, we currently only get a static library.

As an aside, I noticed that the macOS feature list is *a lot* shorter. I think at least some of the other features could be added here:

```diff
--- /tmp/linux_features.txt     2024-08-27 14:27:14.037053585 +0200
+++ /tmp/macos_features.txt     2024-08-27 14:31:06.010876046 +0200
@@ -1,35 +1,10 @@
 features = [
             cpp_modules_feature,
+            macos_minimum_os_feature,
+            macos_default_link_flags_feature,
             dependency_file_feature,
-            serialized_diagnostics_file_feature,
-            random_seed_feature,
-            pic_feature,
-            per_object_debug_info_feature,
-            preprocessor_defines_feature,
-            includes_feature,
-            include_paths_feature,
-            external_include_paths_feature,
-            fdo_instrument_feature,
-            cs_fdo_instrument_feature,
-            cs_fdo_optimize_feature,
-            thinlto_feature,
-            fdo_prefetch_hints_feature,
-            autofdo_feature,
-            build_interface_libraries_feature,
-            dynamic_library_linker_tool_feature,
-            generate_linkmap_feature,
-            shared_flag_feature,
-            linkstamps_feature,
-            output_execpath_flags_feature,
-            runtime_library_search_directories_feature,
-            library_search_directories_feature,
             libtool_feature,
             archiver_flags_feature,
-            force_pic_flags_feature,
-            fission_support_feature,
-            strip_debug_symbols_feature,
-            coverage_feature,
-            supports_pic_feature,
             asan_feature,
             tsan_feature,
             ubsan_feature,
@@ -40,14 +15,13 @@
                 supports_start_end_lib_feature,
             ] if ctx.attr.supports_start_end_lib else []
         ) + [
+            coverage_feature,
             default_compile_flags_feature,
             default_link_flags_feature,
-            libraries_to_link_feature,
             user_link_flags_feature,
             default_link_libs_feature,
-            static_libgcc_feature,
+            external_include_paths_feature,
             fdo_optimize_feature,
-            supports_dynamic_linker_feature,
             dbg_feature,
             opt_feature,
             user_compile_flags_feature,
@@ -57,4 +31,5 @@
             unfiltered_compile_flags_feature,
             treat_warnings_as_errors_feature,
             archive_param_file_feature,
-        ] + layering_check_features(ctx.attr.compiler, ctx.attr.extra_flags_per_feature, is_macos = False)
+            generate_linkmap_feature,
+        ] + layering_check_features(ctx.attr.compiler, ctx.attr.extra_flags_per_feature, is_macos = True)

```