### PR TITLE
Use retrieved nestedSet for symlink planting

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -898,6 +898,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:target_configured_event",
         "//src/main/java/com/google/devtools/build/lib/analysis:top_level_artifact_context",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/skyframe/config",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BuildDriverFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BuildDriverFunction.java
@@ -44,6 +44,7 @@ import com.google.devtools.build.lib.analysis.constraints.TopLevelConstraintSema
 import com.google.devtools.build.lib.analysis.constraints.TopLevelConstraintSemantics.PlatformCompatibility;
 import com.google.devtools.build.lib.analysis.constraints.TopLevelConstraintSemantics.TargetCompatibilityCheckException;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.packages.NoSuchTargetException;
 import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.packages.Target;
@@ -223,12 +224,13 @@ public class BuildDriverFunction implements SkyFunction {
       // It's possible that this code path is triggered AFTER the analysis cache clean up and the
       // transitive packages for package root resolution is already cleared. In such a case, the
       // symlinks should have already been planted.
-      if (configuredTargetValue.getTransitivePackages() != null) {
+      NestedSet<Package> transitivePackagesForSymlinkPlanting =
+          configuredTargetValue.getTransitivePackages();
+      if (transitivePackagesForSymlinkPlanting != null) {
         postEventIfNecessary(
             postedEventsTypes,
             env,
-            TopLevelTargetReadyForSymlinkPlanting.create(
-                configuredTargetValue.getTransitivePackages()));
+            TopLevelTargetReadyForSymlinkPlanting.create(transitivePackagesForSymlinkPlanting));
       }
 
       BuildConfigurationValue buildConfigurationValue =
@@ -570,10 +572,12 @@ public class BuildDriverFunction implements SkyFunction {
       // It's possible that this code path is triggered AFTER the analysis cache clean up and the
       // transitive packages for package root resolution is already cleared. In such a case, the
       // symlinks should have already been planted.
-      if (aspectValue.getTransitivePackages() != null && !symlinkPlantingEventsSent) {
+      NestedSet<Package> transitivePackagesForSymlinkPlanting =
+            aspectValue.getTransitivePackages();
+      if (transitivePackagesForSymlinkPlanting != null && !symlinkPlantingEventsSent) {
         env.getListener()
             .post(
-                TopLevelTargetReadyForSymlinkPlanting.create(aspectValue.getTransitivePackages()));
+                TopLevelTargetReadyForSymlinkPlanting.create(transitivePackagesForSymlinkPlanting));
       }
 
       aspectCompletionKeys.add(AspectCompletionKey.create(aspectKey, topLevelArtifactContext));


### PR DESCRIPTION
Prevent an NPE encountered when transitive packages are pruned before planting in BuildDriverFunction.

```
(13:13:58) FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'BuildDriverKey of ActionLookupKey: ConfiguredTargetKey{label=//autonomy/planning/corridor_map_generator:extended_corridor_location.orin, config=BuildConfigurationKey[eb69cd8e663e6b9c29ef248d6832d55cd81adb9501937e1bba8017d095e8d982]}' (requested by nodes )
        at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:550)
        at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:414)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.NullPointerException: Null transitivePackagesForSymlinkPlanting
        at com.google.devtools.build.lib.skyframe.AutoValue_TopLevelStatusEvents_TopLevelTargetReadyForSymlinkPlanting.<init>(AutoValue_TopLevelStatusEvents_TopLevelTargetReadyForSymlinkPlanting.java:15)
        at com.google.devtools.build.lib.skyframe.TopLevelStatusEvents$TopLevelTargetReadyForSymlinkPlanting.create(TopLevelStatusEvents.java:72)
        at com.google.devtools.build.lib.skyframe.BuildDriverFunction.compute(BuildDriverFunction.java:230)
        at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:461)
        ... 7 more
```

Closes #23400.

PiperOrigin-RevId: 666809249
Change-Id: Ibc257ec978d25273ea3e91e2cddeaba2fb19cd6d