### PR TITLE
[7.4.0] Download runfiles in CompletionFunction.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AspectCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AspectCompleteEvent.java
@@ -113,6 +113,10 @@ public final class AspectCompleteEvent
     return artifactOutputGroups.get(outputGroup);
   }
 
+  public ImmutableMap<String, ArtifactsInOutputGroup> getOutputs() {
+    return artifactOutputGroups;
+  }
+
   public CompletionContext getCompletionContext() {
     return completionContext;
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
@@ -103,6 +103,14 @@ public final class TargetCompleteEvent
     }
 
     @Nullable
+    public Runfiles getRunfiles() {
+      if (runfilesSupport != null) {
+        return runfilesSupport.getRunfiles();
+      }
+      return null;
+    }
+
+    @Nullable
     public Artifact getExecutable() {
       return executable;
     }
@@ -296,6 +304,10 @@ public final class TargetCompleteEvent
   @Nullable
   public ArtifactsInOutputGroup getOutputGroup(String outputGroup) {
     return outputs.get(outputGroup);
+  }
+
+  public ImmutableMap<String, ArtifactsInOutputGroup> getOutputs() {
+    return outputs;
   }
 
   // TODO(aehlig): remove as soon as we managed to get rid of the deprecated "important_output"


### PR DESCRIPTION
Note that I have slightly modified the code to make it work with `release-7.4.0` source tree because of missing other commits. More specifically, instead of using `inputMap.getRunfilesTrees()` to get runfiles, it uses `TargetCompleteEvent`.

Working towards #23434.

Original Description:

Previously, we download outputs of toplevel artifacts in CompletionFunction because intermediate targets might be promoted to toplevel by skymeld in the middle of the build. However, it didn't handle runfiles of the target. This CL fixes that.

A test case will be added in a followup CL because it requires changes to skymeld & BwoB to unveil the bug.

Working towards #22367.

PiperOrigin-RevId: 667532830
Change-Id: Idfe2a0b693f103d501c9b24a454c16186468667a
