### PR TITLE
[7.4.0] Avoid unnecessary copying in `getDirectoryEntries` implementations

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -141,11 +141,7 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
     } finally {
       profiler.logSimpleTask(startTime, ProfilerTask.VFS_DIR, name);
     }
-    Collection<String> result = new ArrayList<>(entries.length);
-    for (String entry : entries) {
-      result.add(entry);
-    }
-    return result;
+    return Arrays.asList(entries);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -31,7 +31,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import javax.annotation.Nullable;
 
@@ -92,7 +92,7 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   @Override
   protected Collection<String> getDirectoryEntries(PathFragment path) throws IOException {
     File file = getIoFile(path);
-    String[] entries = null;
+    String[] entries;
     long startTime = Profiler.nanoTimeMaybe();
     try {
       entries = file.list();
@@ -106,13 +106,7 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
     } finally {
       profiler.logSimpleTask(startTime, ProfilerTask.VFS_DIR, file.getPath());
     }
-    Collection<String> result = new ArrayList<>(entries.length);
-    for (String entry : entries) {
-      if (!entry.equals(".") && !entry.equals("..")) {
-        result.add(entry);
-      }
-    }
-    return result;
+    return Arrays.asList(entries);
   }
 
   @Override


### PR DESCRIPTION
`File#list` is documented to never return `"."` and `".."`.

Closes #23435.

PiperOrigin-RevId: 668327754
Change-Id: I0beb70a82232990a83671485dcd97208ea4bd147

Commit https://github.com/bazelbuild/bazel/commit/bf2eff89d514a4416f8203c2c676d043104fcf37