### PR TITLE
[7.4.0] Fix cache duration computation in CredentialCacheExpiry.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialCacheExpiry.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/credentialhelper/CredentialCacheExpiry.java
@@ -32,7 +32,7 @@ final class CredentialCacheExpiry implements Expiry<URI, GetCredentialsResponse>
     this.defaultCacheDuration = Preconditions.checkNotNull(duration);
   }
 
-  private Duration getExpirationTime(GetCredentialsResponse response) {
+  private Duration getExpirationTime(GetCredentialsResponse response, Instant currentTime) {
     Preconditions.checkNotNull(response);
 
     var expires = response.getExpires();
@@ -40,8 +40,7 @@ final class CredentialCacheExpiry implements Expiry<URI, GetCredentialsResponse>
       return defaultCacheDuration;
     }
 
-    var now = Instant.now();
-    return Duration.between(expires.get(), now);
+    return Duration.between(currentTime, expires.get());
   }
 
   @Override
@@ -49,7 +48,7 @@ final class CredentialCacheExpiry implements Expiry<URI, GetCredentialsResponse>
     Preconditions.checkNotNull(uri);
     Preconditions.checkNotNull(response);
 
-    return getExpirationTime(response).toNanos();
+    return getExpirationTime(response, Instant.ofEpochMilli(nanoToMilli(currentTime))).toNanos();
   }
 
   @Override
@@ -58,7 +57,7 @@ final class CredentialCacheExpiry implements Expiry<URI, GetCredentialsResponse>
     Preconditions.checkNotNull(uri);
     Preconditions.checkNotNull(response);
 
-    return getExpirationTime(response).toNanos();
+    return getExpirationTime(response, Instant.ofEpochMilli(nanoToMilli(currentTime))).toNanos();
   }
 
   @CanIgnoreReturnValue
@@ -70,5 +69,9 @@ final class CredentialCacheExpiry implements Expiry<URI, GetCredentialsResponse>
 
     // We don't extend the duration on access.
     return currentDuration;
+  }
+
+  private static final long nanoToMilli(long nano) {
+    return Duration.ofNanos(nano).toMillis();
   }
 }


### PR DESCRIPTION
Also use the supplied current time instead of calling Instant.now().

I don't know how to meaningfully test this; there's so little going on that the test would essentially mirror the implementation.

Fixes #23429.

PiperOrigin-RevId: 668351088
Change-Id: I12f1575e5280330c61361e4cf1b7d9f9231f16eb

Commit https://github.com/bazelbuild/bazel/commit/5209ce7587d4f8da37d7492d91d0aac1b91ab249