### PR TITLE
Write profiles to a unique path by default.

### DIFF
--- a/site/en/advanced/performance/json-trace-profile.md
+++ b/site/en/advanced/performance/json-trace-profile.md
@@ -8,13 +8,18 @@ Book: /_book.yaml
 The JSON trace profile can be very useful to quickly understand what Bazel spent
 time on during the invocation.
 
-By default, for all build-like commands and query Bazel writes such a profile to
-`command.profile.gz` in the output base. You can configure whether a profile is
-written with the
+By default, for all build-like commands and query, Bazel writes a profile into
+the output base named `command-$INOVCATION_ID.profile.gz`, where
+`$INOVCATION_ID` is the invocation identifier of the command. Bazel also creates
+a symlink called `command.profile.gz` in the output base that points the profile
+of the latest command. You can configure whether a profile is written with the
 [`--generate_json_trace_profile`](/reference/command-line-reference#flag--generate_json_trace_profile)
 flag, and the location it is written to with the
 [`--profile`](/docs/user-manual#profile) flag. Locations ending with `.gz` are
-compressed with GZIP.
+compressed with GZIP. Bazel keeps the last 5 profiles, configurable by
+[`--profiles_to_retain`](/reference/command-line-reference#flag--generate_json_trace_profile),
+in the output base by default for post-build analysis. Explicitly passing a
+profile path with `--profile` disables automatic garbage collection.
 
 ## Tools
 

--- a/src/main/java/com/google/devtools/build/lib/buildtool/buildevent/ProfilerStartedEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/buildevent/ProfilerStartedEvent.java
@@ -18,7 +18,7 @@ import com.google.devtools.build.lib.runtime.InstrumentationOutput;
 import javax.annotation.Nullable;
 
 /** This event is fired when the profiler is started. */
-public class ProfilerStartedEvent implements ExtendedEventHandler.Postable {
+public final class ProfilerStartedEvent implements ExtendedEventHandler.Postable {
   @Nullable private final InstrumentationOutput profile;
 
   public ProfilerStartedEvent(@Nullable InstrumentationOutput profile) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -732,6 +732,9 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
 
       try {
         Profiler.instance().stop();
+        if (profilerStartedEvent.getProfile() instanceof LocalInstrumentationOutput profile) {
+          profile.makeConvenienceLink();
+        }
       } catch (IOException e) {
         env.getReporter()
             .handle(Event.error("Error while writing profile file: " + e.getMessage()));

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -103,6 +103,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
+import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.worker.WorkerProcessMetricsCollector;
 import com.google.devtools.common.options.CommandNameCache;
 import com.google.devtools.common.options.InvocationPolicyParser;
@@ -124,6 +125,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -313,6 +315,38 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
     return buildEventArtifactUploaderFactoryMap.select(buildEventUploadStrategy).create(env);
   }
 
+  /**
+   * Implements automatic profile management.
+   *
+   * <ul>
+   *   <li>computes the path to write the profile for the current command to
+   *   <li>does garbage collection for profiles from previous commands based on the <code>
+   * --profiles_to_retain</code> flag
+   * </ul>
+   *
+   * @return the path this command's profile should be written to
+   */
+  @VisibleForTesting
+  static Path manageProfiles(Path dir, String commandId, int retentionWindow) throws IOException {
+    var prefix = "command-";
+    var suffix = ".profile.gz";
+    record PathAndMtime(Path path, long mtime) {}
+    var old = new ArrayList<PathAndMtime>();
+    for (var dirent : dir.readdir(Symlinks.FOLLOW)) {
+      if (dirent.getName().startsWith(prefix) && dirent.getName().endsWith(suffix)) {
+        var path = dir.getChild(dirent.getName());
+        old.add(new PathAndMtime(path, path.stat().getLastModifiedTime()));
+      }
+    }
+    old.sort(Comparator.comparingLong(PathAndMtime::mtime));
+    var toRemove = Math.max(old.size() - retentionWindow + 1, 0);
+    for (var i = 0; i < toRemove; i++) {
+      old.get(i).path().delete();
+    }
+    var profileName = prefix + commandId + suffix;
+    return dir.getChild(profileName);
+  }
+
   /** Configure profiling based on the provided options. */
   ProfilerStartedEvent initProfiler(
       boolean tracerEnabled,
@@ -328,7 +362,6 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
     boolean recordFullProfilerData = commandOptions.recordFullProfilerData;
     ImmutableSet.Builder<ProfilerTask> profiledTasksBuilder = ImmutableSet.builder();
     Profiler.Format format = Format.JSON_TRACE_FILE_FORMAT;
-    Path profilePath = null;
     InstrumentationOutput profile = null;
     try {
       if (tracerEnabled) {
@@ -342,23 +375,27 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
                     .setName(profileName)
                     .setUploader(newUploader(env, bepOptions.buildEventUploadStrategy))
                     .build();
-            out = profile.createOutputStream();
           } else {
-            profilePath = workspace.getOutputBase().getRelative(profileName);
+            var profilePath =
+                manageProfiles(
+                    workspace.getOutputBase(),
+                    env.getCommandId().toString(),
+                    commandOptions.profilesToRetain);
             profile =
                 instrumentationOutputFactory
                     .createLocalInstrumentationOutputBuilder()
                     .setName(profileName)
                     .setPath(profilePath)
+                    .setConvenienceName(profileName)
                     .build();
-            out = profile.createOutputStream();
           }
+          out = profile.createOutputStream();
         } else {
           format =
               commandOptions.profilePath.toString().endsWith(".gz")
                   ? Format.JSON_TRACE_FILE_COMPRESSED_FORMAT
                   : Format.JSON_TRACE_FILE_FORMAT;
-          profilePath = workspace.getWorkspace().getRelative(commandOptions.profilePath);
+          var profilePath = workspace.getWorkspace().getRelative(commandOptions.profilePath);
           profile =
               instrumentationOutputFactory
                   .createLocalInstrumentationOutputBuilder()

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -266,6 +266,17 @@ public class CommonCommandOptions extends OptionsBase {
   public boolean profileIncludeTargetConfiguration;
 
   @Option(
+      name = "profiles_to_retain",
+      defaultValue = "5",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.BAZEL_MONITORING},
+      help =
+          "Number of profiles to retain in the output base. If there are more than this number of"
+              + " profiles in the output base, the oldest are deleted until the total is under the"
+              + " limit.")
+  public int profilesToRetain;
+
+  @Option(
       name = "profile",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.LOGGING,

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1426,3 +1426,13 @@ sh_test(
     ],
     tags = ["no_windows"],
 )
+
+sh_test(
+    name = "profile_test",
+    size = "small",
+    srcs = ["profile_test.sh"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/src/test/shell/bazel/profile_test.sh
+++ b/src/test/shell/bazel/profile_test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Test profiles.
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+function test_profile_management_build() {
+  local uuid=7c859c8f-87fd-46d0-9e5c-669410812722
+  local output_base="$(bazel info output_base)"
+  bazel build --invocation_id="$uuid"
+  cmp "${output_base}/command-${uuid}.profile.gz" "${output_base}/command.profile.gz" || fail "profile not linked"
+}
+
+function test_profile_management_info() {
+  local uuid=e9d9df11-04a9-4f78-9f71-5a0153cb6f0c
+  local output_base="$(bazel info output_base --invocation_id=${uuid} --generate_json_trace_profile)"
+  ls -lh $output_base
+  cmp "${output_base}/command-${uuid}.profile.gz" "${output_base}/command.profile.gz" || fail "profile not linked"
+}
+
+run_suite "integration tests for the builtin profiler"


### PR DESCRIPTION
Profiles are now written into the output base with a file name that includes the invocation id. Old profiles are deleted automatically after a certain number accumulate.

Fixes https://github.com/bazelbuild/bazel/issues/18006.
Fixes https://github.com/bazelbuild/bazel/issues/23267.