### PR TITLE
Reduce verbosity of BulkTransferException

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -170,13 +170,7 @@ final class ByteStreamUploader {
     return Futures.catchingAsync(
         startAsyncUpload(context, digest, chunker),
         StatusRuntimeException.class,
-        (sre) ->
-            Futures.immediateFailedFuture(
-                new IOException(
-                    String.format(
-                        "Error while uploading artifact with digest '%s/%s'",
-                        digest.getHash(), digest.getSizeBytes()),
-                    sre)),
+        (sre) -> Futures.immediateFailedFuture(new IOException(sre)),
         MoreExecutors.directExecutor());
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -11,6 +11,7 @@ filegroup(
     testonly = 0,
     srcs = glob(["**"]) + [
         "//src/test/java/com/google/devtools/build/lib/remote/circuitbreaker:srcs",
+        "//src/test/java/com/google/devtools/build/lib/remote/common:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/disk:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/downloader:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/grpc:srcs",

--- a/src/test/java/com/google/devtools/build/lib/remote/common/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/common/BUILD
@@ -1,0 +1,29 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+package(
+    default_testonly = 1,
+    default_visibility = ["//src:__subpackages__"],
+)
+
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["**"]),
+    visibility = ["//src:__subpackages__"],
+)
+
+java_test(
+    name = "common",
+    srcs = glob(["*.java"]),
+    test_class = "com.google.devtools.build.lib.AllTests",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/common:bulk_transfer_exception",
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+        "//src/test/java/com/google/devtools/build/lib/testutil",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:mockito",
+        "//third_party:truth",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/remote/common/BulkTransferExceptionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/common/BulkTransferExceptionTest.java
@@ -1,0 +1,54 @@
+package com.google.devtools.build.lib.remote.common;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class BulkTransferExceptionTest {
+
+  @Test
+  public void shouldProvideGenericMessageIfNoAddedException() {
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    assertThat(bulkTransferException.getMessage()).isEqualTo("Unknown error during bulk transfer");
+  }
+
+  @Test
+  public void shouldPreserveMessageAsIsFromSingleException() {
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    bulkTransferException.add(new IOException("Failure Type A"));
+    assertThat(bulkTransferException.getMessage()).isEqualTo("Failure Type A");
+  }
+
+  @Test
+  public void shouldSortAndRemoveDuplicatesWhenAggregatingMessages() {
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    bulkTransferException.add(new IOException("Failure Type B"));
+    bulkTransferException.add(new IOException("Failure Type A"));
+    bulkTransferException.add(new IOException("Failure Type B"));
+    assertThat(bulkTransferException.getMessage()).isEqualTo("Multiple errors during bulk transfer:\n" +
+        "Failure Type A\n" +
+        "Failure Type B");
+  }
+
+  @Test
+  public void shouldProvideGenericMessageIfOnlyNullMessages() {
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    bulkTransferException.add(new IOException());
+    assertThat(bulkTransferException.getMessage()).isEqualTo("Unknown error during bulk transfer");
+  }
+
+  @Test
+  public void shouldIgnoreNullMessagesWhenGettingMessage() {
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    bulkTransferException.add(new IOException("Failure Type A"));
+    bulkTransferException.add(new IOException());
+    assertThat(bulkTransferException.getMessage()).isEqualTo("Failure Type A");
+  }
+}
+
+


### PR DESCRIPTION
BulkTransferException was sometimes overly verbose in the console, particularly when many transfers failed for the same reason.

This commit shortens and normalizes BulkTransferException messages to improve the efficiency of existing event deduplication, such as that performed by _RemoteExecutionService.report()_.

Normalization involves not mentioning individual digests in exception messages from ByteStreamUploader. Instead, we now wrap StatusRuntimeException directly in an IOException, which is a common pattern in the GrpcCacheClient.