### PR TITLE
[7.4.0] Fix an NPE with the SkymeldUiStateTracker.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTracker.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.runtime;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.buildtool.buildevent.BuildCompleteEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.ExecutionProgressReceiverAvailableEvent;
@@ -27,6 +26,7 @@ import com.google.devtools.build.lib.util.io.AnsiTerminalWriter;
 import com.google.devtools.build.lib.util.io.PositionAwareAnsiTerminalWriter;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
+import javax.annotation.concurrent.GuardedBy;
 
 /** Tracks the state of Skymeld builds and determines what to display at each state in the UI. */
 final class SkymeldUiStateTracker extends UiStateTracker {
@@ -48,7 +48,9 @@ final class SkymeldUiStateTracker extends UiStateTracker {
     BUILD_COMPLETED;
   }
 
-  @VisibleForTesting BuildStatus buildStatus = BuildStatus.BUILD_NOT_STARTED;
+  // Prevent a race condition with the thread that runs writeProgressBar.
+  @GuardedBy("this")
+  private BuildStatus buildStatus = BuildStatus.BUILD_NOT_STARTED;
 
   SkymeldUiStateTracker(Clock clock, int targetWidth) {
     super(clock, targetWidth);
@@ -157,23 +159,23 @@ final class SkymeldUiStateTracker extends UiStateTracker {
   }
 
   @Override
-  void mainRepoMappingComputationStarted() {
+  synchronized void mainRepoMappingComputationStarted() {
     buildStatus = BuildStatus.COMPUTING_MAIN_REPO_MAPPING;
   }
 
   @Override
-  void buildStarted() {
+  synchronized void buildStarted() {
     buildStatus = BuildStatus.BUILD_STARTED;
   }
 
   @Override
-  void loadingStarted(LoadingPhaseStartedEvent event) {
+  synchronized void loadingStarted(LoadingPhaseStartedEvent event) {
     buildStatus = BuildStatus.TARGET_PATTERN_PARSING;
     packageProgressReceiver = event.getPackageProgressReceiver();
   }
 
   @Override
-  void loadingComplete(LoadingPhaseCompleteEvent event) {
+  synchronized void loadingComplete(LoadingPhaseCompleteEvent event) {
     buildStatus = BuildStatus.LOADING_COMPLETE;
     int labelsCount = event.getLabels().size();
     if (labelsCount == 1) {
@@ -185,7 +187,7 @@ final class SkymeldUiStateTracker extends UiStateTracker {
   }
 
   @Override
-  void configurationStarted(ConfigurationPhaseStartedEvent event) {
+  synchronized void configurationStarted(ConfigurationPhaseStartedEvent event) {
     buildStatus = BuildStatus.CONFIGURATION;
     configuredTargetProgressReceiver = event.getConfiguredTargetProgressReceiver();
   }
@@ -230,13 +232,21 @@ final class SkymeldUiStateTracker extends UiStateTracker {
   }
 
   @Override
-  Event buildComplete(BuildCompleteEvent event) {
+  synchronized Event buildComplete(BuildCompleteEvent event) {
     buildStatus = BuildStatus.BUILD_COMPLETED;
     return super.buildComplete(event);
   }
 
+  synchronized BuildStatus getBuildStatus() {
+    return buildStatus;
+  }
+
+  synchronized void setBuildStatusForTestingOnly(BuildStatus newStatus) {
+    buildStatus = newStatus;
+  }
+
   @Override
-  protected boolean buildCompleted() {
+  protected synchronized boolean buildCompleted() {
     return BuildStatus.BUILD_COMPLETED.equals(buildStatus);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -91,7 +91,7 @@ class UiStateTracker {
   private int sampleSize = 3;
 
   protected String status;
-  protected String additionalMessage;
+  protected String additionalMessage = "";
   // Not null after the loading phase has completed.
   protected RepositoryMapping mainRepositoryMapping;
 

--- a/src/test/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/SkymeldUiStateTrackerTest.java
@@ -51,46 +51,43 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
     ManualClock clock = new ManualClock();
     SkymeldUiStateTracker uiStateTracker = new SkymeldUiStateTracker(clock);
 
-    assertThat(uiStateTracker.buildStatus).isEqualTo(BuildStatus.BUILD_NOT_STARTED);
+    assertThat(uiStateTracker.getBuildStatus()).isEqualTo(BuildStatus.BUILD_NOT_STARTED);
     uiStateTracker.buildStarted();
-    assertThat(uiStateTracker.buildStatus).isEqualTo(BuildStatus.BUILD_STARTED);
+    assertThat(uiStateTracker.getBuildStatus()).isEqualTo(BuildStatus.BUILD_STARTED);
   }
 
   @Test
   public void loadingStarted_stateChanges() {
     ManualClock clock = new ManualClock();
     SkymeldUiStateTracker uiStateTracker = new SkymeldUiStateTracker(clock);
-    uiStateTracker.buildStatus = BuildStatus.BUILD_STARTED;
 
     uiStateTracker.loadingStarted(
         new LoadingPhaseStartedEvent(mock(PackageProgressReceiver.class)));
 
-    assertThat(uiStateTracker.buildStatus).isEqualTo(BuildStatus.TARGET_PATTERN_PARSING);
+    assertThat(uiStateTracker.getBuildStatus()).isEqualTo(BuildStatus.TARGET_PATTERN_PARSING);
   }
 
   @Test
   public void loadingComplete_stateChanges() {
     ManualClock clock = new ManualClock();
     SkymeldUiStateTracker uiStateTracker = new SkymeldUiStateTracker(clock);
-    uiStateTracker.buildStatus = BuildStatus.TARGET_PATTERN_PARSING;
 
     uiStateTracker.loadingComplete(
         new LoadingPhaseCompleteEvent(
             ImmutableSet.of(), ImmutableSet.of(), RepositoryMapping.ALWAYS_FALLBACK));
 
-    assertThat(uiStateTracker.buildStatus).isEqualTo(BuildStatus.LOADING_COMPLETE);
+    assertThat(uiStateTracker.getBuildStatus()).isEqualTo(BuildStatus.LOADING_COMPLETE);
   }
 
   @Test
   public void configurationStarted_stateChanges() {
     ManualClock clock = new ManualClock();
     SkymeldUiStateTracker uiStateTracker = new SkymeldUiStateTracker(clock);
-    uiStateTracker.buildStatus = BuildStatus.LOADING_COMPLETE;
 
     uiStateTracker.configurationStarted(
         new ConfigurationPhaseStartedEvent(mock(ConfiguredTargetProgressReceiver.class)));
 
-    assertThat(uiStateTracker.buildStatus).isEqualTo(BuildStatus.CONFIGURATION);
+    assertThat(uiStateTracker.getBuildStatus()).isEqualTo(BuildStatus.CONFIGURATION);
   }
 
   @Test
@@ -98,7 +95,7 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
     ManualClock clock = new ManualClock();
     SkymeldUiStateTracker uiStateTracker = new SkymeldUiStateTracker(clock);
     String additionalMessage = "5 targets";
-    uiStateTracker.buildStatus = BuildStatus.CONFIGURATION;
+    uiStateTracker.setBuildStatusForTestingOnly(BuildStatus.CONFIGURATION);
     uiStateTracker.additionalMessage = additionalMessage;
 
     // First we need to set up the state tracker to already be analysing.
@@ -116,7 +113,7 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
     uiStateTracker.progressReceiverAvailable(
         new ExecutionProgressReceiverAvailableEvent(executionProgressReceiver));
 
-    assertThat(uiStateTracker.buildStatus).isEqualTo(BuildStatus.ANALYSIS_AND_EXECUTION);
+    assertThat(uiStateTracker.getBuildStatus()).isEqualTo(BuildStatus.ANALYSIS_AND_EXECUTION);
 
     LoggingTerminalWriter terminalWriter = new LoggingTerminalWriter(/*discardHighlight=*/ true);
     uiStateTracker.writeProgressBar(terminalWriter);
@@ -134,18 +131,16 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
   public void executionFromAnalysisAndExecution_stateChanges() {
     ManualClock clock = new ManualClock();
     SkymeldUiStateTracker uiStateTracker = new SkymeldUiStateTracker(clock);
-    uiStateTracker.buildStatus = BuildStatus.ANALYSIS_AND_EXECUTION;
 
     uiStateTracker.analysisComplete();
 
-    assertThat(uiStateTracker.buildStatus).isEqualTo(BuildStatus.EXECUTION);
+    assertThat(uiStateTracker.getBuildStatus()).isEqualTo(BuildStatus.EXECUTION);
   }
 
   @Test
   public void buildCompleted_stateChanges() {
     ManualClock clock = new ManualClock();
     SkymeldUiStateTracker uiStateTracker = new SkymeldUiStateTracker(clock);
-    uiStateTracker.buildStatus = BuildStatus.EXECUTION;
 
     BuildResult buildResult = new BuildResult(clock.currentTimeMillis());
     buildResult.setDetailedExitCode(DetailedExitCode.success());
@@ -153,7 +148,7 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
     buildResult.setStopTime(clock.currentTimeMillis());
     var unused = uiStateTracker.buildComplete(new BuildCompleteEvent(buildResult));
 
-    assertThat(uiStateTracker.buildStatus).isEqualTo(BuildStatus.BUILD_COMPLETED);
+    assertThat(uiStateTracker.getBuildStatus()).isEqualTo(BuildStatus.BUILD_COMPLETED);
   }
 
   @Test
@@ -193,7 +188,6 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
 
     // Mock starting loading.
     LoggingTerminalWriter terminalWriter = new LoggingTerminalWriter(/*discardHighlight=*/ false);
-    uiStateTracker.buildStatus = BuildStatus.TARGET_PATTERN_PARSING;
     uiStateTracker.packageProgressReceiver =
         mockPackageProgressReceiver(loadingState, loadingActivity);
 
@@ -243,7 +237,6 @@ public class SkymeldUiStateTrackerTest extends FoundationTestCase {
     // Mock starting configuration.
     uiStateTracker.configuredTargetProgressReceiver =
         mockConfiguredTargetProgressReceiver(configuredTargetProgressString);
-    uiStateTracker.buildStatus = BuildStatus.CONFIGURATION;
 
     // Output should contain both loading and analysis related output.
     uiStateTracker.writeLoadingAnalysisPhaseProgress(

--- a/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
@@ -225,7 +225,8 @@ public class UiStateTrackerTest extends FoundationTestCase {
         new LoadingPhaseCompleteEvent(ImmutableSet.of(), ImmutableSet.of(), MOCK_REPO_MAPPING));
     if (this.isSkymeld) {
       // SkymeldUiStateTracker needs to be in the configuration phase before the execution phase.
-      ((SkymeldUiStateTracker) uiStateTracker).buildStatus = BuildStatus.ANALYSIS_COMPLETE;
+      ((SkymeldUiStateTracker) uiStateTracker)
+          .setBuildStatusForTestingOnly(BuildStatus.ANALYSIS_COMPLETE);
       uiStateTracker.executionPhaseStarted();
     } else {
       String unused = uiStateTracker.analysisComplete();


### PR DESCRIPTION
A race condition can happen:

- Thread 1: `#writeProgressBar` is called due to `LoadingPhaseStartedEvent`, expecting `buildStatus` to be `TARGET_PATTERN_PARSING`
- Main thread: `LoadingPhaseCompleteEvent` arrives. **`buildStatus` is set to `LOADING_COMPLETE`**. additionalMessage is not yet updated and is still null.
- Thread 1: Seeing that `buildStatus` is now `LOADING_COMPLETE`, it moves forward with that code path => NPE when `additionMessage` is checked.

To fix this NPE, the CL made 2 changes:

1. Synchronize methods that touch `buildStatus`
2. Default `additionalMessage` to an empty string to make the code more robust.

PiperOrigin-RevId: 640061798
Change-Id: I5034fe7692e0641559fb7666eec09cb554e09545

#23484