### PR TITLE
[7.4.0] Include `sun.jnu.encoding` in `bazel info character-encoding` output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/CharacterEncodingInfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/CharacterEncodingInfoItem.java
@@ -34,7 +34,9 @@ public final class CharacterEncodingInfoItem extends InfoItem {
       Supplier<BuildConfigurationValue> configurationSupplier, CommandEnvironment env) {
     return print(
         String.format(
-            "file.encoding = %s, defaultCharset = %s",
-            System.getProperty("file.encoding", "unknown"), Charset.defaultCharset().name()));
+            "file.encoding = %s, defaultCharset = %s, sun.jnu.encoding = %s",
+            System.getProperty("file.encoding", "unknown"),
+            Charset.defaultCharset().name(),
+            System.getProperty("sun.jnu.encoding", "unknown")));
   }
 }


### PR DESCRIPTION
The `sun.jnu.encoding` is what really determines the encoding used by Java file system APIs (both .io and .nio) rather than `file.encoding`. Making it more visible via an info item helps diagnose encoding bugs.

Closes #23469.

PiperOrigin-RevId: 670824910
Change-Id: Icba80b926b63090b0a5e5631e7aff673c9b71457

Commit https://github.com/bazelbuild/bazel/commit/33ba589bfa20b850553935eca24639947787f6d5