### PR TITLE
[7.4.0] Exit if it wasn't possible to zip undeclared outputs because `zip` failed.

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -426,7 +426,8 @@ if [[ -n "$TEST_UNDECLARED_OUTPUTS_ZIP" ]] && cd "$TEST_UNDECLARED_OUTPUTS_DIR";
   UNDECLARED_OUTPUTS=(*)
   if [[ "${#UNDECLARED_OUTPUTS[@]}" != 0 ]]; then
     if ! zip_output="$(zip -qr "$TEST_UNDECLARED_OUTPUTS_ZIP" -- "${UNDECLARED_OUTPUTS[@]}")" ; then
-        echo >&2 "Could not create \"$TEST_UNDECLARED_OUTPUTS_ZIP\": $zip_output"
+      echo >&2 "Could not create \"$TEST_UNDECLARED_OUTPUTS_ZIP\": $zip_output"
+      exit 1
     fi
     # Use 'rm' instead of 'zip -m' so that we don't follow symlinks when deleting the
     # contents.


### PR DESCRIPTION
Fixes #23479.

PiperOrigin-RevId: 670894294
Change-Id: I40319db72123358770a56d217dafb4fc7fd0d467

Commit https://github.com/bazelbuild/bazel/commit/24d165e958fc32d222409a890cc5def7d0fbc9f4