### PR TITLE
Add dirname variants of predefined source/output path variables.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderIntegrationTest.java
@@ -181,10 +181,14 @@ public class LocationExpanderIntegrationTest extends BuildViewTestCase {
         .matches("foo .*-out/.*/expansion/foo\\.txt bar");
     assertThat(expander.expand("foo $(execpaths :foo) bar"))
         .matches("foo .*-out/.*/expansion/foo\\.txt bar");
+    assertThat(expander.expand("foo $(execpath_dirname :foo) bar"))
+        .matches("foo .*-out/.*/expansion bar");
     assertThat(expander.expand("foo $(rootpath :foo) bar"))
         .matches("foo expansion/foo.txt bar");
     assertThat(expander.expand("foo $(rootpaths :foo) bar"))
         .matches("foo expansion/foo.txt bar");
+    assertThat(expander.expand("foo $(rootpath_dirname :foo) bar"))
+        .matches("foo ./expansion bar");
     assertThat(expander.expand("foo $(rlocationpath :foo) bar"))
         .isEqualTo("foo " + ruleClassProvider.getRunfilesPrefix() + "/expansion/foo.txt bar");
     assertThat(expander.expand("foo $(rlocationpaths :foo) bar"))

--- a/src/test/java/com/google/devtools/build/lib/analysis/LocationFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/LocationFunctionTest.java
@@ -155,6 +155,18 @@ public class LocationFunctionTest {
   }
 
   @Test
+  public void execPathDirname() throws Exception {
+    LocationFunction func =
+        new LocationFunctionBuilder("//foo", true)
+            .setPathType(LocationFunction.PathType.EXEC)
+            .setDirnameOnly(true)
+            .add("//foo", "/exec/bar", "/exec/out/subdir/foobar")
+            .build();
+    assertThat(func.apply("//foo", RepositoryMapping.ALWAYS_FALLBACK, null))
+        .isEqualTo(". out/subdir");
+  }
+
+  @Test
   public void rlocationPath() throws Exception {
     LocationFunction func =
         new LocationFunctionBuilder("//foo", true)
@@ -195,16 +207,18 @@ final class LocationFunctionBuilder {
   private final boolean multiple;
   private LocationFunction.PathType pathType = LocationFunction.PathType.LOCATION;
   private boolean legacyExternalRunfiles;
+  private boolean dirnameOnly;
   private final Map<Label, Collection<Artifact>> labelMap = new HashMap<>();
 
   LocationFunctionBuilder(String rootLabel, boolean multiple) {
     this.root = Label.parseCanonicalUnchecked(rootLabel);
     this.multiple = multiple;
+    this.dirnameOnly = false;
   }
 
   public LocationFunction build() {
     return new LocationFunction(
-        root, Suppliers.ofInstance(labelMap), pathType, legacyExternalRunfiles, multiple);
+        root, Suppliers.ofInstance(labelMap), pathType, legacyExternalRunfiles, multiple, dirnameOnly);
   }
 
   @CanIgnoreReturnValue
@@ -216,6 +230,12 @@ final class LocationFunctionBuilder {
   @CanIgnoreReturnValue
   public LocationFunctionBuilder setLegacyExternalRunfiles(boolean legacyExternalRunfiles) {
     this.legacyExternalRunfiles = legacyExternalRunfiles;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public LocationFunctionBuilder setDirnameOnly(boolean dirnameOnly) {
+    this.dirnameOnly = dirnameOnly;
     return this;
   }
 


### PR DESCRIPTION
These are similar to existing `$(execpath)` and friends, but return the path of the artifact's directory rather than of the artifact itself.

Fixes https://github.com/bazelbuild/bazel/issues/23516