### PR TITLE
Add Build Event Protocol field for extension data

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -251,6 +251,9 @@ message BuildEventId {
   // Identifier of an event providing the ExecRequest of a run command.
   message ExecRequestId {}
 
+  // Identifier of an event providing custom event data.
+  message CustomEventDataId {}
+
   reserved 27;
 
   oneof id {
@@ -282,6 +285,7 @@ message BuildEventId {
     BuildMetadataId build_metadata = 24;
     ConvenienceSymlinksIdentifiedId convenience_symlinks_identified = 25;
     ExecRequestId exec_request = 28;
+    CustomEventDataId custom_event_data = 30;
   }
 }
 
@@ -1406,6 +1410,15 @@ message EnvironmentVariable {
   bytes value = 2;
 }
 
+// Event used to transmit custom data via the build event stream. This is
+// intended to be used for messages that need to be sent with forked versions
+// of Bazel, but that can for whatever reason not be added to the upstream
+// version. Reserving a message for custom data prevents field numbers in forked
+// Bazel versions from colliding with future upstream field numbers.
+message CustomEventData {
+  google.protobuf.Any data = 1;
+}
+
 // Message describing a build event. Events will have an identifier that
 // is unique within a given build invocation; they also announce follow-up
 // events as children. More details, which are specific to the kind of event
@@ -1442,5 +1455,6 @@ message BuildEvent {
     BuildMetadata build_metadata = 26;
     ConvenienceSymlinksIdentified convenience_symlinks_identified = 27;
     ExecRequestConstructed exec_request = 29;
+    CustomEventData custom_event_data = 31;
   }
 }


### PR DESCRIPTION
This is an example of how the feature request #22965 could be approached. 

The field CustomEventData has been added to the Build Event Protocol. This field can be used to wrap proprietary data that needs to be sent over the BEP, but that cannot be added to the upstream Bazel version. Dedicating a field to this is intended to prevent forked Bazel versions from becoming incompatible with future upstream Bazel versions.

This draft does not add any fields to the ID message, but this should probably contain some generic identifier to allow multiple custom messages in the event stream.

For example, `build_event_stream.proto` can be extended with custom messages like the following in forked Bazel versions:
```proto
// Some value that needs to be passed in the forked Bazel version
message MyCustomData {
  uint32 value = 1;
}
```

This custom message can be wrapped by a custom build event that uses CustomEventData:
```Java
public class MyCustomEvent implements BuildEvent {
  @Override
  public BuildEventStreamProtos.BuildEvent asStreamProto(BuildEventContext context) throws InterruptedException {
    Any myData = Any.pack(MyCustomData.newBuilder().setValue(42).build());
    CustomEventData customEventData = CustomEventData.newBuilder().setData(myData).build();
    return GenericBuildEvent.protoChaining(this).setCustomEventData(customEventData).build();
  }

  @Override
  public BuildEventStreamProtos.BuildEventId getEventId() {
    return BuildEventId.newBuilder().setCustomEventData(BuildEventId.CustomEventDataId.getDefaultInstance()).build();
  }

  @Override
  public Collection<BuildEventStreamProtos.BuildEventId> getChildrenEvents() {
    return ImmutableList.of();
  }
}
```

The custom event can then be passed via the event bus:
```Java
// ...
env.getEventBus().post(new MyCustomEvent());
// ...
```

The receiver of the build event stream can then check the type URL of the value and unpack it:
```Java
void handle(BuildEventStreamProtos.BuildEvent event) {
    Any data = event.getCustomEventData().getData();
    if (data.getTypeUrl().contains("build_event_stream.MyCustomData")) {
      try {
        MyCustomData myData = data.unpack(MyCustomData.class);
        // Use the unpacked value
      } catch(Exception e) {
        // Handle unpacking errors
      }
    }
  }
```