### PR TITLE
[7.4.0] Always use 0777 when creating directories, and leave group/other permission bits alone when making an already existing directory writable.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -332,6 +332,7 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   public boolean createDirectory(PathFragment path) throws IOException {
+    // Use 0777 so that the permissions can be overridden by umask(2).
     // Note: UNIX mkdir(2), FilesystemUtils.mkdir() and createDirectory all
     // have different ways of representing failure!
     if (NativePosixFiles.mkdir(path.toString(), 0755)) {
@@ -353,6 +354,7 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   public void createDirectoryAndParents(PathFragment path) throws IOException {
+    // Use 0777 so that the permissions can be overridden by umask(2).
     NativePosixFiles.mkdirs(path.toString(), 0755);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -199,7 +199,7 @@ public abstract class FileSystem {
       throw new IOException(path + " (Not a directory)");
     }
 
-    chmod(path, 0755);
+    chmod(path, 0777);
     return false;
   }
 


### PR DESCRIPTION
This is a revert (in spirit) of unknown commit and unknown commit. It restores the ability to use umask(2) to control the effective permissions for created directories, which was present before those changes.

Fixes #23405.

PiperOrigin-RevId: 667972097
Change-Id: I6b154d351d68d27a2470cc2b1c24293722625580