### PR TITLE
[7.4.0] Deduplicate calls to `config.is_sibling_repository_layout()`

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
@@ -346,7 +346,7 @@ def _init_cc_compilation_context(
             pic_header_module = _header_module_artifact(
                 actions,
                 label,
-                config.is_sibling_repository_layout(),
+                sibling_repo_layout,
                 "",
                 ".pic.pcm",
             )
@@ -354,7 +354,7 @@ def _init_cc_compilation_context(
             header_module = _header_module_artifact(
                 actions,
                 label,
-                config.is_sibling_repository_layout(),
+                sibling_repo_layout,
                 "",
                 ".pcm",
             )
@@ -364,7 +364,7 @@ def _init_cc_compilation_context(
                 separate_module = _header_module_artifact(
                     actions,
                     label,
-                    config.is_sibling_repository_layout(),
+                    sibling_repo_layout,
                     ".sep",
                     ".pcm",
                 )
@@ -372,7 +372,7 @@ def _init_cc_compilation_context(
                 separate_pic_module = _header_module_artifact(
                     actions,
                     label,
-                    config.is_sibling_repository_layout(),
+                    sibling_repo_layout,
                     ".sep",
                     ".pic.pcm",
                 )


### PR DESCRIPTION
This showed up in Starlark CPU profiles and is not negligible as it repeatedly checks allowlists.

Closes #23256.

PiperOrigin-RevId: 671444687
Change-Id: I6e64b0c94332a54fcc5d531ff0e3aab176b7bd0a

Commit https://github.com/bazelbuild/bazel/commit/b85db78de3b25cb7f5c9cb0c7afe388f75e040e3