### PR TITLE
Do not fail if cgroups cannot be written

### DIFF
--- a/src/main/tools/BUILD
+++ b/src/main/tools/BUILD
@@ -5,6 +5,7 @@ cc_binary(
     srcs = ["daemonize.cc"],
     deps = [
         ":process-tools",
+        ":logging",
     ],
 )
 

--- a/src/main/tools/daemonize.cc
+++ b/src/main/tools/daemonize.cc
@@ -328,11 +328,12 @@ static void MoveToCgroup(pid_t pid, const char* cgroup_path) {
       char* procs_path;
       asprintf(&procs_path, "%s%s/cgroup.procs", fs_file, cgroup_path);
       FILE* procs = fopen(procs_path, "w");
-      if (procs != NULL) {
-        fprintf(procs, "%d", pid);
-        fclose(procs);
-      } else {
-        PRINT_DEBUG("Failed to move server to cgroup %s", procs_path);
+      if (procs == NULL) {
+        PRINT_DEBUG("Failed to open %s. Falling back to running without cgroups", procs_path);
+      } else if (fprintf(procs, "%d", pid) < 0) {
+        PRINT_DEBUG("Failed to write %s. Falling back to running without cgroups", procs_path);
+      } else if (fclose(procs) < 0) {
+        PRINT_DEBUG("Failed to close %s. Falling back to running without cgroups", procs_path);
       }
       free(procs_path);
     }

--- a/src/main/tools/daemonize.cc
+++ b/src/main/tools/daemonize.cc
@@ -324,7 +324,11 @@ static void MoveToCgroup(pid_t pid, const char* cgroup_path) {
         strcmp(fs_vfstype, "cgroup2") == 0) {
       char* procs_path;
       asprintf(&procs_path, "%s%s/cgroup.procs", fs_file, cgroup_path);
-      WriteFile(procs_path, "%d", pid);
+      FILE* procs = fopen(procs_path, "w");
+      if (procs != NULL) {
+        fprintf(procs, "%d", pid);
+        fclose(procs);
+      }
       free(procs_path);
     }
   }

--- a/src/main/tools/daemonize.cc
+++ b/src/main/tools/daemonize.cc
@@ -50,6 +50,7 @@
 #include <unistd.h>
 
 #include "src/main/tools/process-tools.h"
+#include "src/main/tools/logging.h"
 
 // Configures std{in,out,err} of the current process to serve as a daemon.
 //
@@ -80,6 +81,8 @@ static void SetupStdio(const char* log_path, bool log_append) {
     err(EXIT_FAILURE, "dup failed");
   }
   assert(fd == STDERR_FILENO);
+
+  global_debug = stderr;
 }
 
 // Writes the given pid to a new file at pid_path.
@@ -328,6 +331,8 @@ static void MoveToCgroup(pid_t pid, const char* cgroup_path) {
       if (procs != NULL) {
         fprintf(procs, "%d", pid);
         fclose(procs);
+      } else {
+        PRINT_DEBUG("Failed to move server to cgroup %s", procs_path);
       }
       free(procs_path);
     }


### PR DESCRIPTION
From comment https://github.com/bazelbuild/bazel/pull/21618#issuecomment-2331031439: as per documentation
> It is not an error if the specified cgroup is not writable for one or more of the controllers

However WriteFile will fail if the file cannot be written, so it cannot be used in this context