### PR TITLE
Do no crash if a requested resource is not available

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -539,6 +539,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/worker:worker_key",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_pool",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_process_status",
+        "//src/main/protobuf:failure_details_java_proto",
         "//third_party:auto_value",
         "//third_party:error_prone_annotations",
         "//third_party:flogger",

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
+import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.worker.Worker;
 import com.google.devtools.build.lib.worker.WorkerKey;
 import com.google.devtools.build.lib.worker.WorkerPool;
@@ -368,7 +369,7 @@ public class ResourceManager implements ResourceEstimator {
    */
   public ResourceHandle acquireResources(
       ActionExecutionMetadata owner, ResourceSet resources, ResourcePriority priority)
-      throws InterruptedException, IOException {
+      throws InterruptedException, IOException, ExecException {
     Preconditions.checkNotNull(
         resources, "acquireResources called with resources == NULL during %s", owner);
     Preconditions.checkState(
@@ -376,6 +377,8 @@ public class ResourceManager implements ResourceEstimator {
 
     ResourceLatch resourceLatch = null;
 
+    // Validate requested resources exist before creating a request.
+    assertResourcesTracked(resources);
     ResourceRequest request =
         new ResourceRequest(owner, resources, priority, requestIdGenerator.getAndIncrement());
 
@@ -590,12 +593,26 @@ public class ResourceManager implements ResourceEstimator {
   }
 
   /** Throws an exception if requested extra resource isn't being tracked */
-  private void assertResourcesTracked(ResourceSet resources) throws NoSuchElementException {
+  private void assertResourcesTracked(ResourceSet resources) throws ExecException {
     for (Map.Entry<String, Double> resource : resources.getResources().entrySet()) {
       String key = resource.getKey();
       if (!availableResources.getResources().containsKey(key)) {
-        throw new NoSuchElementException(
-            "Resource " + key + " is not tracked in this resource set.");
+        StringBuilder message = new StringBuilder();
+        message.append("Resource ");
+        message.append(key);
+        message.append(" is not being tracked by the resource manager.");
+        message.append(" Available resources are: ");
+        message.append(String.join(", ", availableResources.getResources().keySet()));
+        throw new UserExecException(
+            FailureDetails.FailureDetail.newBuilder()
+                .setMessage(message.toString())
+                .setLocalExecution(
+                    FailureDetails.LocalExecution
+                        .newBuilder()
+                        .setCode(FailureDetails.LocalExecution.Code.UNTRACKED_RESOURCE)
+                        .build())
+                .build()
+        );
       }
     }
   }
@@ -624,10 +641,6 @@ public class ResourceManager implements ResourceEstimator {
     if (workerKey != null && !this.workerPool.hasAvailableQuota(workerKey)) {
       return false;
     }
-
-    // We test for tracking of extra resources whenever acquired and throw an
-    // exception before acquiring any untracked resource.
-    assertResourcesTracked(resources);
 
     if (usedResources.isEmpty() && usedLocalTestCount == 0) {
       return true;

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -750,6 +750,7 @@ message LocalExecution {
   enum Code {
     LOCAL_EXECUTION_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
     LOCKFREE_OUTPUT_PREREQ_UNMET = 1 [(metadata) = { exit_code: 2 }];
+    UNTRACKED_RESOURCE = 2 [(metadata) = { exit_code: 1 }];
   }
 
   Code code = 1;

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -95,17 +95,17 @@ public final class ResourceManagerTest {
   }
 
   private ResourceHandle acquire(double ram, double cpu, int tests, ResourcePriority priority)
-      throws InterruptedException, IOException {
+      throws InterruptedException, IOException, ExecException {
     return manager.acquireResources(resourceOwner, ResourceSet.create(ram, cpu, tests), priority);
   }
 
   private ResourceHandle acquire(double ram, double cpu, int tests)
-      throws InterruptedException, IOException {
+      throws InterruptedException, IOException, ExecException {
     return acquire(ram, cpu, tests, ResourcePriority.LOCAL);
   }
 
   private ResourceHandle acquire(double ram, double cpu, int tests, String mnemonic)
-      throws InterruptedException, IOException {
+      throws InterruptedException, IOException, ExecException {
 
     return manager.acquireResources(
         resourceOwner,
@@ -123,7 +123,7 @@ public final class ResourceManagerTest {
       ImmutableMap<String, Double> extraResources,
       int tests,
       ResourcePriority priority)
-      throws InterruptedException, IOException, NoSuchElementException {
+      throws InterruptedException, IOException, NoSuchElementException, ExecException {
     ImmutableMap.Builder<String, Double> resources = ImmutableMap.builder();
     resources.putAll(extraResources).put(ResourceSet.MEMORY, ram).put(ResourceSet.CPU, cpu);
     return manager.acquireResources(
@@ -133,7 +133,7 @@ public final class ResourceManagerTest {
   @CanIgnoreReturnValue
   private ResourceHandle acquire(
       double ram, double cpu, ImmutableMap<String, Double> extraResources, int tests)
-      throws InterruptedException, IOException, NoSuchElementException {
+      throws InterruptedException, IOException, NoSuchElementException, ExecException {
     return acquire(ram, cpu, extraResources, tests, ResourcePriority.LOCAL);
   }
 
@@ -665,7 +665,7 @@ public final class ResourceManagerTest {
         new TestThread(
             () ->
                 assertThrows(
-                    NoSuchElementException.class,
+                    UserExecException.class,
                     () -> acquire(0, 0, ImmutableMap.of("nonexisting", 1.0), 0)));
     thread1.start();
     thread1.joinAndAssertState(1000);
@@ -688,7 +688,7 @@ public final class ResourceManagerTest {
   }
 
   @Test
-  public void testInvalidateAndClose() throws IOException, InterruptedException {
+  public void testInvalidateAndClose() throws IOException, InterruptedException, ExecException {
     ResourceHandle handle;
     verify(workerStatus, times(0)).maybeUpdateStatus(any());
 


### PR DESCRIPTION
Before:
```
Caused by: java.util.NoSuchElementException: Resource foo is not tracked in this resource set.
    at com.google.devtools.build.lib.actions.ResourceManager.assertExtraResourcesTracked(ResourceManager.java:499)
    at com.google.devtools.build.lib.actions.ResourceManager.areResourcesAvailable(ResourceManager.java:540)
```
After:
```
ERROR: src/test/java/com/google/devtools/build/lib/actions/BUILD:102:10: Testing //src/test/java/com/google/devtools/build/lib/actions:ActionsTests failed: Resource foo is not being tracked by the resource manager. Available resources are: cpu, memory
```

Fixes #19572