### PR TITLE
Use default when `None` given to `tag_class` attribute

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Structure;
 import net.starlark.java.spelling.SpellChecker;
@@ -73,16 +74,20 @@ public class TypeCheckedTag implements Structure {
       }
       Attribute attr = tagClass.getAttributes().get(attrIndex);
       Object nativeValue;
-      try {
-        nativeValue =
-            attr.getType().convert(attrValue.getValue(), attr.getPublicName(), labelConverter);
-      } catch (ConversionException e) {
-        throw ExternalDepsException.withCauseAndMessage(
-            Code.BAD_MODULE,
-            e,
-            "in tag at %s, error converting value for attribute %s",
-            tag.getLocation(),
-            attr.getPublicName());
+      if (attr.getDefaultValueUnchecked() != null && attrValue.getValue() == Starlark.NONE) {
+        nativeValue = attr.getDefaultValueUnchecked();
+      } else {
+        try {
+          nativeValue =
+              attr.getType().convert(attrValue.getValue(), attr.getPublicName(), labelConverter);
+        } catch (ConversionException e) {
+          throw ExternalDepsException.withCauseAndMessage(
+              Code.BAD_MODULE,
+              e,
+              "in tag at %s, error converting value for attribute %s",
+              tag.getLocation(),
+              attr.getPublicName());
+        }
       }
 
       // Check that the value is actually allowed.

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTagTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTagTest.java
@@ -131,6 +131,28 @@ public class TypeCheckedTagTest {
   }
 
   @Test
+  public void stringListDict_defaultOnNone() throws Exception {
+    TypeCheckedTag typeCheckedTag =
+        TypeCheckedTag.create(
+            createTagClass(
+                attr("foo", Types.STRING_LIST_DICT)
+                    .value(ImmutableMap.of("key", ImmutableList.of("value1", "value2")))
+                    .build()),
+            buildTag("tag_name")
+                .addAttr("foo", Starlark.NONE)
+                .build(),
+            null,
+            "root module");
+    assertThat(typeCheckedTag.getFieldNames()).containsExactly("foo");
+    assertThat(getattr(typeCheckedTag, "foo"))
+        .isEqualTo(
+            Dict.builder()
+                .put("key", StarlarkList.immutableOf("value1", "value2"))
+                .buildImmutable());
+    assertThat(typeCheckedTag.isDevDependency()).isFalse();
+  }
+
+  @Test
   public void multipleAttributesAndDefaults() throws Exception {
     TypeCheckedTag typeCheckedTag =
         TypeCheckedTag.create(

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -212,6 +212,38 @@ public final class StarlarkRepositoryContextTest {
   }
 
   @Test
+  public void testAttr_default() throws Exception {
+    setUpContextForRule(
+        ImmutableMap.of("name", "test"),
+        ImmutableSet.of(),
+        ImmutableMap.of("FOO", "BAR"),
+        StarlarkSemantics.DEFAULT,
+        /* repoRemoteExecutor= */ null,
+        Attribute.attr("foo", Type.STRING)
+            .defaultValue("bar")
+            .build());
+
+    assertThat(context.getAttr().getFieldNames()).contains("foo");
+    assertThat(context.getAttr().getValue("foo")).isEqualTo("bar");
+  }
+
+  @Test
+  public void testAttr_defaultOnNone() throws Exception {
+    setUpContextForRule(
+        ImmutableMap.of("name", "test", "foo", Starlark.NONE),
+        ImmutableSet.of(),
+        ImmutableMap.of("FOO", "BAR"),
+        StarlarkSemantics.DEFAULT,
+        /* repoRemoteExecutor= */ null,
+        Attribute.attr("foo", Type.STRING)
+            .defaultValue("bar")
+            .build());
+
+    assertThat(context.getAttr().getFieldNames()).contains("foo");
+    assertThat(context.getAttr().getValue("foo")).isEqualTo("bar");
+  }
+
+  @Test
   public void testWhich() throws Exception {
     setUpContextForRule(
         ImmutableMap.of("name", "test"),


### PR DESCRIPTION
With this, code like the following is valid.

```starlark
pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
pip.parse(
    hub_name = "bazel_pip_dev_deps",
    python_version = "3.8",
    requirements_lock = "//:requirements.txt",
    parallel_download = None,
)
```

Like with `rule`s and `repository_rule`s, the default (`True` in the example) will be applied.