### PR TITLE
[7.4.0] Ignore overrides with `--ignore_dev_dependency`

### DIFF
--- a/site/en/external/migration.md
+++ b/site/en/external/migration.md
@@ -824,7 +824,7 @@ You can set the `dev_dependency` attribute to true for
 [`use_extension`](/rules/lib/globals/module#use_extension) directives so that
 they don't propagate to dependent projects. As the root module, you can use the
 [`--ignore_dev_dependency`][ignore_dev_dep_flag] flag to verify if your targets
-still build without dev dependencies.
+still build without dev dependencies and overrides.
 
 [ignore_dev_dep_flag]: /reference/command-line-reference#flag--ignore_dev_dependency
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -50,7 +50,7 @@ public class ModuleThreadContext {
   @Nullable private final ImmutableMap<String, CompiledModuleFile> includeLabelToCompiledModuleFile;
   private final Map<String, DepSpec> deps = new LinkedHashMap<>();
   private final List<ModuleExtensionUsageBuilder> extensionUsageBuilders = new ArrayList<>();
-  private final Map<String, ModuleOverride> overrides = new HashMap<>();
+  private final Map<String, ModuleOverride> overrides = new LinkedHashMap<>();
   private final Map<String, RepoNameUsage> repoNameUsages = new HashMap<>();
 
   public static ModuleThreadContext fromOrFail(StarlarkThread thread, String what)
@@ -231,6 +231,9 @@ public class ModuleThreadContext {
   }
 
   public void addOverride(String moduleName, ModuleOverride override) throws EvalException {
+    if (shouldIgnoreDevDeps()) {
+      return;
+    }
     ModuleOverride existingOverride = overrides.putIfAbsent(moduleName, override);
     if (existingOverride != null) {
       throw Starlark.errorf("multiple overrides for dep %s found", moduleName);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -336,6 +336,25 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
   }
 
   @Test
+  public void testRootModule_overridesIgnoredWithIgnoreDevDependency() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "bazel_dep(name='aaa')",
+        "single_version_override(module_name='ddd',version='18')",
+        "local_path_override(module_name='eee',path='somewhere/else')",
+        "multiple_version_override(module_name='fff',versions=['1.0','2.0'])",
+        "archive_override(module_name='ggg',urls=['https://hello.com/world.zip'])");
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    ModuleFileFunction.IGNORE_DEV_DEPS.set(differencer, true);
+
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).getOverrides()).isEmpty();
+  }
+
+  @Test
   public void testRootModule_include_good() throws Exception {
     scratch.overwriteFile(
         rootDirectory.getRelative("MODULE.bazel").getPathString(),


### PR DESCRIPTION
This makes it easier to realistically test how the root module would behave as a non-root module.

RELNOTES: Overrides in the root MODULE.bazel file are now ignored with `--ignore_dev_dependency`. (Overrides in non-root modules are already ignored.)

Closes #23520.

PiperOrigin-RevId: 672480499
Change-Id: Ifd3a99f4ed462061101fecf918d61989c9f60401

Commit https://github.com/bazelbuild/bazel/commit/bb7a54ceea34f901d415b096767070b0bd35a281