### PR TITLE
[7.4.0] Lazily get action cache in lease service.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/LeaseService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/LeaseService.java
@@ -23,22 +23,23 @@ import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.skyframe.MemoizingEvaluator;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /** A lease service that manages the lease of remote blobs. */
 public class LeaseService {
   private final MemoizingEvaluator memoizingEvaluator;
-  @Nullable private final ActionCache actionCache;
+  private final Supplier<ActionCache> actionCacheSupplier;
   private final AtomicBoolean leaseExtensionStarted = new AtomicBoolean(false);
   @Nullable LeaseExtension leaseExtension;
   private final AtomicBoolean hasMissingActionInputs = new AtomicBoolean(false);
 
   public LeaseService(
       MemoizingEvaluator memoizingEvaluator,
-      @Nullable ActionCache actionCache,
+      Supplier<ActionCache> actionCacheSupplier,
       @Nullable LeaseExtension leaseExtension) {
     this.memoizingEvaluator = memoizingEvaluator;
-    this.actionCache = actionCache;
+    this.actionCacheSupplier = actionCacheSupplier;
     this.leaseExtension = leaseExtension;
   }
 
@@ -97,6 +98,7 @@ public class LeaseService {
           return false;
         });
 
+    var actionCache = actionCacheSupplier.get();
     if (actionCache != null) {
       actionCache.removeIf(
           entry -> !entry.getOutputFiles().isEmpty() || !entry.getOutputTrees().isEmpty());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1074,7 +1074,7 @@ public final class RemoteModule extends BlazeModule {
       var leaseService =
           new LeaseService(
               env.getSkyframeExecutor().getEvaluator(),
-              env.getBlazeWorkspace().getPersistentActionCache(),
+              () -> env.getBlazeWorkspace().getPersistentActionCache(),
               leaseExtension);
       env.getEventBus().register(leaseService);
 


### PR DESCRIPTION
At construction time, the action cache is not loaded so it's always `null`. Change it to lazily get the action cache when cleaning up it.

Fixes #22220.

PiperOrigin-RevId: 672522144
Change-Id: I2de8b33ab78c04a690b17cd261d18d17f8b292ab

Commit https://github.com/bazelbuild/bazel/commit/9187a7ec011504befba2fea98481e37558d7998c