### PR TITLE
[7.4.0] Use disk cache for HTTP cache server.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -324,11 +324,15 @@ public class DiskCacheClient implements RemoteCacheClient {
 
   public Path toPath(Digest digest, Store store) {
     String hash = digest.getHash();
+    return toPath(hash, store);
+  }
+
+  public Path toPath(String hash, Store store) {
     // Create the file in a subfolder to bypass possible folder file count limits.
     return storeRootMap.get(store).getChild(hash.substring(0, 2)).getChild(hash);
   }
 
-  private void saveFile(Digest digest, Store store, InputStream in) throws IOException {
+  public void saveFile(Digest digest, Store store, InputStream in) throws IOException {
     Path path = toPath(digest, store);
 
     if (refresh(path)) {

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -46,7 +46,7 @@ import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.SyscallCache;
-import com.google.devtools.build.remote.worker.http.HttpCacheServerHandler;
+import com.google.devtools.build.remote.worker.http.InMemoryHttpCacheServerHandler;
 import com.google.devtools.common.options.Options;
 import com.google.protobuf.ByteString;
 import io.netty.bootstrap.ServerBootstrap;
@@ -359,7 +359,7 @@ public class HttpCacheClientTest {
     ServerChannel server = null;
     try {
       ConcurrentHashMap<String, byte[]> cacheContents = new ConcurrentHashMap<>();
-      server = testServer.start(new HttpCacheServerHandler(cacheContents));
+      server = testServer.start(new InMemoryHttpCacheServerHandler(cacheContents));
 
       HttpCacheClient blobStore =
           createHttpBlobStore(
@@ -385,7 +385,7 @@ public class HttpCacheClientTest {
     ServerChannel server = null;
     try {
       ConcurrentHashMap<String, byte[]> cacheContents = new ConcurrentHashMap<>();
-      server = testServer.start(new HttpCacheServerHandler(cacheContents));
+      server = testServer.start(new InMemoryHttpCacheServerHandler(cacheContents));
 
       HttpCacheClient blobStore =
           createHttpBlobStore(

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreCache.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.remote.worker;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 
 import build.bazel.remote.execution.v2.Digest;
@@ -97,5 +98,9 @@ class OnDiskBlobStoreCache extends RemoteCache {
   public ListenableFuture<Void> uploadFile(
       RemoteActionExecutionContext context, Digest digest, Path file) {
     return uploadFile(context, digest, file, /* force= */ true);
+  }
+
+  public DiskCacheClient getDiskCacheClient() {
+    return (DiskCacheClient) cacheProtocol;
   }
 }

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskHttpCacheServerHandler.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskHttpCacheServerHandler.java
@@ -1,0 +1,74 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.remote.worker;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.google.common.io.ByteStreams;
+import com.google.devtools.build.lib.remote.Store;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.remote.worker.http.AbstractHttpCacheServerHandler;
+import io.netty.channel.ChannelHandler.Sharable;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/** A simple HTTP REST disk cache used during test. */
+@Sharable
+public class OnDiskHttpCacheServerHandler extends AbstractHttpCacheServerHandler {
+  private final OnDiskBlobStoreCache cache;
+
+  public OnDiskHttpCacheServerHandler(OnDiskBlobStoreCache cache) {
+    this.cache = cache;
+  }
+
+  @Nullable
+  @Override
+  protected byte[] readFromCache(String uri) throws IOException {
+    var diskCache = cache.getDiskCacheClient();
+    Path path;
+    if (uri.startsWith("/ac/")) {
+      path = diskCache.toPath(uri.substring("/ac/".length()), Store.AC);
+    } else if (uri.startsWith("/cas/")) {
+      path = diskCache.toPath(uri.substring("/cas/".length()), Store.CAS);
+    } else {
+      throw new IOException("Invalid uri: " + uri);
+    }
+
+    try (var out = new ByteArrayOutputStream();
+        var in = path.getInputStream()) {
+      ByteStreams.copy(in, out);
+      return out.toByteArray();
+    }
+  }
+
+  @Override
+  protected void writeToCache(String uri, byte[] content) throws IOException {
+    var diskCache = cache.getDiskCacheClient();
+    Digest digest;
+    Store store;
+    if (uri.startsWith("/ac/")) {
+      digest = DigestUtil.buildDigest(uri.substring(4), content.length);
+      store = Store.AC;
+    } else if (uri.startsWith("/cas/")) {
+      digest = DigestUtil.buildDigest(uri.substring(5), content.length);
+      store = Store.CAS;
+    } else {
+      throw new IOException("Invalid uri: " + uri);
+    }
+
+    diskCache.saveFile(digest, store, new ByteArrayInputStream(content));
+  }
+}

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -323,7 +323,7 @@ public final class RemoteWorker {
       b.group(bossGroup, workerGroup)
           .channel(NioServerSocketChannel.class)
           .handler(new LoggingHandler(LogLevel.INFO))
-          .childHandler(new HttpCacheServerInitializer());
+          .childHandler(new HttpCacheServerInitializer(new OnDiskHttpCacheServerHandler(cache)));
       ch = b.bind(remoteWorkerOptions.httpListenPort).sync().channel();
       logger.atInfo().log(
           "Started HTTP cache server on port %d", remoteWorkerOptions.httpListenPort);

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/BUILD
@@ -17,7 +17,9 @@ java_library(
         "//src/tools/remote:__subpackages__",
     ],
     deps = [
+        "//third_party:flogger",
         "//third_party:guava",
+        "//third_party:jsr305",
         "//third_party:netty",
     ],
 )

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/HttpCacheServerInitializer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/HttpCacheServerInitializer.java
@@ -22,7 +22,11 @@ import io.netty.handler.codec.http.HttpServerCodec;
 
 /** The initializer used by the HttpCacheServerHandler. */
 public class HttpCacheServerInitializer extends ChannelInitializer<SocketChannel> {
-  private final HttpCacheServerHandler handler = new HttpCacheServerHandler();
+  private final AbstractHttpCacheServerHandler handler;
+
+  public HttpCacheServerInitializer(AbstractHttpCacheServerHandler handler) {
+    this.handler = handler;
+  }
 
   @Override
   protected void initChannel(SocketChannel ch) {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/InMemoryHttpCacheServerHandler.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/InMemoryHttpCacheServerHandler.java
@@ -1,0 +1,44 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.remote.worker.http;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import io.netty.channel.ChannelHandler.Sharable;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.Nullable;
+
+/** A simple HTTP REST in-memory cache used during testing the LRE. */
+@Sharable
+public class InMemoryHttpCacheServerHandler extends AbstractHttpCacheServerHandler {
+
+  private final ConcurrentMap<String, byte[]> cache;
+
+  @VisibleForTesting
+  public InMemoryHttpCacheServerHandler(ConcurrentMap<String, byte[]> cache) {
+    this.cache = Preconditions.checkNotNull(cache);
+  }
+
+  @Nullable
+  @Override
+  protected byte[] readFromCache(String uri) {
+    return cache.get(uri);
+  }
+
+  @Override
+  protected void writeToCache(String uri, byte[] content) {
+    cache.putIfAbsent(uri, content);
+  }
+}

--- a/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/AbstractHttpCacheServerHandlerTest.java
+++ b/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/AbstractHttpCacheServerHandlerTest.java
@@ -20,59 +20,62 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link com.google.devtools.build.remote.worker.http.HttpCacheServerHandler} */
+/**
+ * Unit tests for {@link
+ * com.google.devtools.build.remote.worker.http.AbstractHttpCacheServerHandler}
+ */
 @RunWith(JUnit4.class)
-public class HttpCacheServerHandlerTest {
+public class AbstractHttpCacheServerHandlerTest {
 
   @Test
   public void testValidUri() {
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "http://some-path.co.uk:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "http://127.12.12.0:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "http://localhost:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "https://localhost:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "localhost:8080/ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "ac/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
 
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "http://some-path.co.uk:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "http://127.12.12.0:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "http://localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "https://localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isTrue();
   }
@@ -80,20 +83,25 @@ public class HttpCacheServerHandlerTest {
   @Test
   public void testInvalidUri() {
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "http://localhost:8080/ac_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isFalse();
     assertThat(
-            HttpCacheServerHandler.isUriValid(
+            AbstractHttpCacheServerHandler.isUriValid(
                 "http://localhost:8080/cas_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         .isFalse();
-    assertThat(HttpCacheServerHandler.isUriValid("http://localhost:8080/ac/111111111111111111111"))
+    assertThat(
+            AbstractHttpCacheServerHandler.isUriValid(
+                "http://localhost:8080/ac/111111111111111111111"))
         .isFalse();
-    assertThat(HttpCacheServerHandler.isUriValid("http://localhost:8080/cas/111111111111111111111"))
+    assertThat(
+            AbstractHttpCacheServerHandler.isUriValid(
+                "http://localhost:8080/cas/111111111111111111111"))
         .isFalse();
-    assertThat(HttpCacheServerHandler.isUriValid("http://localhost:8080/cas/823rhf&*%OL%_^"))
+    assertThat(
+            AbstractHttpCacheServerHandler.isUriValid("http://localhost:8080/cas/823rhf&*%OL%_^"))
         .isFalse();
-    assertThat(HttpCacheServerHandler.isUriValid("http://localhost:8080/ac/823rhf&*%OL%_^"))
+    assertThat(AbstractHttpCacheServerHandler.isUriValid("http://localhost:8080/ac/823rhf&*%OL%_^"))
         .isFalse();
   }
 }

--- a/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/BUILD
+++ b/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/BUILD
@@ -14,9 +14,8 @@ filegroup(
 java_test(
     name = "http",
     srcs = glob(["*.java"]),
-    test_class = "com.google.devtools.build.remote.worker.http.HttpCacheServerHandlerTest",
+    test_class = "com.google.devtools.build.remote.worker.http.AbstractHttpCacheServerHandlerTest",
     deps = [
-        "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker",
         "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http",
         "//third_party:junit4",
         "//third_party:truth",


### PR DESCRIPTION
So that we can have proper cache eviction integration tests for HTTP cache later.

PiperOrigin-RevId: 672501366
Change-Id: I52048a4498601cfa98cc9695d5ddddc5b93f56b9