### PR TITLE
GrpcRemoteDownloader: optionally propagate credentials to remote server

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -148,6 +148,18 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public boolean remoteDownloaderLocalFallback;
 
   @Option(
+      name = "experimental_remote_downloader_propagate_credentials",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Whether to propagate credentials from netrc and credential helper to the remote"
+              + " downloader server. The server implementation needs to support the new"
+              + " `http_header_url:<url-index>:<header-key>` qualifier where the `<url-index>` is a"
+              + " 0-based position of the URL inside the FetchBlobRequest's `uris` field.")
+  public boolean remoteDownloaderPropagateCredentials;
+
+  @Option(
       name = "remote_header",
       converter = Converters.AssignmentConverter.class,
       defaultValue = "null",

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/BUILD
@@ -35,6 +35,7 @@ java_library(
         "//src/test/java/com/google/devtools/build/lib/remote/util",
         "//src/test/java/com/google/devtools/build/lib/testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
+        "//third_party:auth",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -17,10 +17,12 @@ package com.google.devtools.build.lib.remote.downloader;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import build.bazel.remote.asset.v1.FetchBlobRequest;
 import build.bazel.remote.asset.v1.FetchBlobResponse;
@@ -29,6 +31,7 @@ import build.bazel.remote.asset.v1.Qualifier;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ServerCapabilities;
+import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
@@ -69,6 +72,7 @@ import io.reactivex.rxjava3.core.Single;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -348,6 +352,7 @@ public class GrpcRemoteDownloaderTest {
     FetchBlobRequest request =
         GrpcRemoteDownloader.newFetchBlobRequest(
             "instance name",
+            false,
             ImmutableList.of(
                 new URL("http://example.com/a"),
                 new URL("http://example.com/b"),
@@ -359,7 +364,8 @@ public class GrpcRemoteDownloaderTest {
             DIGEST_UTIL.getDigestFunction(),
             ImmutableMap.of(
                 "Authorization", ImmutableList.of("Basic Zm9vOmJhcg=="),
-                "X-Custom-Token", ImmutableList.of("foo", "bar")));
+                "X-Custom-Token", ImmutableList.of("foo", "bar")),
+            StaticCredentials.EMPTY);
 
     assertThat(request)
         .isEqualTo(
@@ -383,6 +389,88 @@ public class GrpcRemoteDownloaderTest {
                     Qualifier.newBuilder()
                         .setName("http_header:X-Custom-Token")
                         .setValue("foo,bar"))
+                .build());
+  }
+
+  @Test
+  public void testFetchBlobRequest_withCredentialsPropagation() throws Exception {
+    var shouldPropagateCredentials = true;
+    var url = new URL("http://example.com/a");
+
+    Credentials credentials = mock(Credentials.class);
+    when(credentials.hasRequestMetadata()).thenReturn(true);
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("CredKey", singletonList("CredValue"));
+    when(credentials.getRequestMetadata(url.toURI())).thenReturn(headers);
+
+    FetchBlobRequest request =
+        GrpcRemoteDownloader.newFetchBlobRequest(
+            "instance name",
+            shouldPropagateCredentials,
+            ImmutableList.of(url),
+            Optional.<Checksum>of(
+                Checksum.fromSubresourceIntegrity(
+                    "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),
+            "canonical ID",
+            DIGEST_UTIL.getDigestFunction(),
+            ImmutableMap.of(),
+            credentials);
+
+    assertThat(request)
+        .isEqualTo(
+            FetchBlobRequest.newBuilder()
+                .setInstanceName("instance name")
+                .setDigestFunction(DIGEST_UTIL.getDigestFunction())
+                .addUris("http://example.com/a")
+                .addQualifiers(
+                    Qualifier.newBuilder()
+                        .setName("http_header_url:0:CredKey")
+                        .setValue("CredValue"))
+                .addQualifiers(
+                    Qualifier.newBuilder()
+                        .setName("checksum.sri")
+                        .setValue("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
+                .addQualifiers(
+                    Qualifier.newBuilder().setName("bazel.canonical_id").setValue("canonical ID"))
+                .build());
+  }
+
+  @Test
+  public void testFetchBlobRequest_withoutCredentialsPropagation() throws Exception {
+    var shouldPropagateCredentials = false;
+    var url = new URL("http://example.com/a");
+
+    Credentials credentials = mock(Credentials.class);
+    when(credentials.hasRequestMetadata()).thenReturn(true);
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put("CredKey", singletonList("CredValue"));
+    when(credentials.getRequestMetadata(url.toURI())).thenReturn(headers);
+
+    FetchBlobRequest request =
+        GrpcRemoteDownloader.newFetchBlobRequest(
+            "instance name",
+            shouldPropagateCredentials,
+            ImmutableList.of(url),
+            Optional.<Checksum>of(
+                Checksum.fromSubresourceIntegrity(
+                    "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")),
+            "canonical ID",
+            DIGEST_UTIL.getDigestFunction(),
+            ImmutableMap.of(),
+            credentials);
+
+    assertThat(request)
+        .isEqualTo(
+            FetchBlobRequest.newBuilder()
+                .setInstanceName("instance name")
+                .setDigestFunction(DIGEST_UTIL.getDigestFunction())
+                .addUris("http://example.com/a")
+                .addQualifiers(
+                    Qualifier.newBuilder()
+                        .setName("checksum.sri")
+                        .setValue("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
+                .addQualifiers(
+                    Qualifier.newBuilder().setName("bazel.canonical_id").setValue("canonical ID"))
                 .build());
   }
 }


### PR DESCRIPTION
In a multi-tenancy server deployment setup, the clients might want to
treat the remote downloader server as a pull-through proxy and use it to
download from private storage systems.

Currently, we do support it via --remote_downloader_headers. However
this scheme does not apply to the specific URL, while credentials and
authentication could sometimes be host/domain specific.

Add a flag to let users opt-in to credentials propagation to the remote
server. This is off by default as not all remote servers can be
trusted. When the flag is enabled, URL-specific credentials from Netrc
or a custom credentials helper can be propagated to the remote server.

The server implementation needs to support the new
`http_header_url:<url-index>:<header-key>` qualifier where the
`url-index` is a 0-based position of the URL inside the
FetchBlobRequest's uris field. This new qualifier is modeled after the
existing `http_header` qualifier.

Fixes #23499
