### PR TITLE
Document behaviour of `None` with `attr` related API

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -139,8 +139,9 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
       doc =
           """
           A callable value that may be invoked during evaluation of the WORKSPACE file or within \
-          the implementation function of a module extension to instantiate and return a \
-          repository rule.
+          the implementation function of a module extension to instantiate and return a repository \
+          rule. Created by \
+          <a href="../globals/bzl.html#repository_rule"><code>repository_rule()</code></a>.
           """)
   public static final class RepositoryRuleFunction
       implements StarlarkCallable, StarlarkExportable, RuleFunction {

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleFunction.java
@@ -23,10 +23,13 @@ import net.starlark.java.eval.StarlarkCallable;
     name = "rule",
     category = DocCategory.BUILTIN,
     doc =
-        "A callable value representing the type of a native or Starlark rule. Calling the value"
-            + " during evaluation of a package's BUILD file creates an instance of the rule and"
-            + " adds it to the package's target set. For more information, visit this page about"
-            + " <a href ='https://bazel.build/extending/rules'>Rules</a>.")
+        """
+        A callable value representing the type of a native or Starlark rule (created by \
+        <a href="../globals/bzl.html#rule"><code>rule()</code></a>). Calling the value during \
+        evaluation of a package's BUILD file creates an instance of the rule and adds it to the \
+        package's target set. For more information, visit this page about \
+        <a href ="https://bazel.build/extending/rules">Rules</a>.
+        """)
 public interface RuleFunction extends StarlarkCallable {
   RuleClass getRuleClass();
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkAspectApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkAspectApi.java
@@ -23,7 +23,9 @@ import net.starlark.java.eval.StarlarkValue;
     name = "Aspect",
     category = DocCategory.BUILTIN,
     doc =
-        "For more information about Aspects, please consult the <a"
-            + " href=\"../globals/bzl.html#aspect\">documentation of the aspect function</a> or the"
-            + " <a href=\"https://bazel.build/rules/aspects\">introduction to Aspects</a>.")
+        """
+        For more information about Aspects, please consult the
+        <a href="../globals/bzl.html#aspect">documentation of the aspect function</a> or the \
+        <a href="https://bazel.build/rules/aspects">introduction to Aspects</a>.
+        """)
 public interface StarlarkAspectApi extends StarlarkValue {}

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkAttrModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkAttrModuleApi.java
@@ -41,14 +41,19 @@ import net.starlark.java.eval.StarlarkValue;
     name = "attr",
     category = DocCategory.TOP_LEVEL_MODULE,
     doc =
-        "This is a top-level module for defining the attribute schemas of a rule or aspect. Each"
-            + " function returns an object representing the schema of a single attribute. These"
-            + " objects are used as the values of the <code>attrs</code> dictionary argument of <a"
-            + " href=\"../globals/bzl.html#rule\"><code>rule()</code></a> and <a"
-            + " href=\"../globals/bzl.html#aspect\"><code>aspect()</code></a>.<p>See the Rules page"
-            + " for more on <a href='https://bazel.build/extending/rules#attributes'>defining</a>"
-            + " and <a href='https://bazel.build/extending/rules#implementation_function'>using</a>"
-            + " attributes.")
+        """
+        This is a top-level module for defining the attribute schemas of a rule or aspect. Each \
+        function returns an object representing the schema of a single attribute. These objects \
+        are used as the values of the <code>attrs</code> dictionary argument of \
+        <a href="../globals/bzl.html#rule"><code>rule()</code></a>, \
+        <a href="../globals/bzl.html#aspect"><code>aspect()</code></a>, \
+        <a href="../globals/bzl.html#repository_rule"><code>repository_rule()</code></a> and \
+        <a href="../globals/bzl.html#tag_class"><code>tag_class()</code></a>. \
+        <p>See the Rules page \
+        for more on <a href="https://bazel.build/extending/rules#attributes">defining</a>
+        and <a href="https://bazel.build/extending/rules#implementation_function">using</a> \
+        attributes.</p>
+        """)
 public interface StarlarkAttrModuleApi extends StarlarkValue {
 
   // dependency and output attributes

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -334,16 +334,19 @@ targets defined by any rule finalizer, including this one.
             positional = false,
             defaultValue = "{}",
             doc =
-                "dictionary to declare all the attributes of the rule. It maps from an attribute"
-                    + " name to an attribute object (see <a href=\"../toplevel/attr.html\">attr</a>"
-                    + " module). Attributes starting with <code>_</code> are private, and can be"
-                    + " used to add an implicit dependency on a label. The attribute"
-                    + " <code>name</code> is implicitly added and must not be specified. Attributes"
-                    + " <code>visibility</code>, <code>deprecation</code>, <code>tags</code>,"
-                    + " <code>testonly</code>, and <code>features</code> are implicitly added and"
-                    + " cannot be overridden. Most rules need only a handful of attributes. To"
-                    + " limit memory usage, there is a cap on the number of attributes that may be"
-                    + " declared."),
+                """
+                A dictionary to declare all the attributes of the rule. It maps from an attribute \
+                name to an attribute object (see
+                <a href="../toplevel/attr.html"><code>attr</code></a> module). Attributes starting \
+                with <code>_</code> are private, and can be used to add an implicit dependency on \
+                a label. The attribute <code>name</code> is implicitly added and must not be \
+                specified. Attributes <code>visibility</code>, <code>deprecation</code>, \
+                <code>tags</code>, <code>testonly</code>, and <code>features</code> are implicitly \
+                added and cannot be overridden. Most rules need only a handful of attributes. To \
+                limit memory usage, there is a cap on the number of attributes that may be \
+                declared.
+                <p>Declared attributes will convert <code>None</code> to the default value.</p>
+                """),
         // TODO(bazel-team): need to give the types of these builtin attributes
         @Param(
             name = "outputs",
@@ -694,17 +697,20 @@ targets defined by any rule finalizer, including this one.
             named = true,
             defaultValue = "{}",
             doc =
-                "A dictionary declaring all the attributes of the aspect. It maps from an attribute"
-                    + " name to an attribute object, like `attr.label` or `attr.string` (see <a"
-                    + " href=\"../toplevel/attr.html\">attr</a> module). Aspect attributes are"
-                    + " available to implementation function as fields of <code>ctx</code>"
-                    + " parameter. <p>Implicit attributes starting with <code>_</code> must have"
-                    + " default values, and have type <code>label</code> or"
-                    + " <code>label_list</code>. <p>Explicit attributes must have type"
-                    + " <code>string</code>, and must use the <code>values</code> restriction."
-                    + " Explicit attributes restrict the aspect to only be used with rules that"
-                    + " have attributes of the same name, type, and valid values according to the"
-                    + " restriction."),
+                """
+                A dictionary declaring all the attributes of the aspect. It maps from an \
+                attribute name to an attribute object, like <code>attr.label</code> or \
+                <code>attr.string</code> (see \
+                <a href="../toplevel/attr.html"><code>attr</code></a> module). Aspect attributes \
+                are available to implementation function as fields of <code>ctx</code> parameter. \
+                <p>Implicit attributes starting with <code>_</code> must have default values, and \
+                have type <code>label</code> or <code>label_list</code>.</p> \
+                <p>Explicit attributes must have type <code>string</code>, and must use the \
+                <code>values</code> restriction. Explicit attributes restrict the aspect to only \
+                be used with rules that have attributes of the same name, type, and valid values \
+                according to the restriction.</p>
+                <p>Declared attributes will convert <code>None</code> to the default value.</p>
+                """),
         @Param(
             name = "required_providers",
             named = true,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/RepositoryModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/RepositoryModuleApi.java
@@ -40,10 +40,12 @@ public interface RepositoryModuleApi {
   @StarlarkMethod(
       name = "repository_rule",
       doc =
-          "Creates a new repository rule. Store it in a global value, so that it can be loaded and"
-              + " called from a <code><a href=\"#module_extension\">module extension</a></code>"
-              + " implementation function, or used by <code><a"
-              + " href=\"../globals/module.html#use_repo_rule\">use_repo_rule</a></code>.",
+          """
+          Creates a new repository rule. Store it in a global value, so that it can be loaded and \
+          called from a <a href="#module_extension"><code>module_extension()</code></a> \
+          implementation function, or used by \
+          <a href="../globals/module.html#use_repo_rule"><code>use_repo_rule()</code></a>.
+          """,
       parameters = {
         @Param(
             name = "implementation",
@@ -61,12 +63,16 @@ public interface RepositoryModuleApi {
             },
             defaultValue = "None",
             doc =
-                "dictionary to declare all the attributes of the rule. It maps from an attribute "
-                    + "name to an attribute object (see <a href=\"../toplevel/attr.html\">attr</a> "
-                    + "module). Attributes starting with <code>_</code> are private, and can be "
-                    + "used to add an implicit dependency on a label to a file (a repository "
-                    + "rule cannot depend on a generated artifact). The attribute "
-                    + "<code>name</code> is implicitly added and must not be specified.",
+                """
+                A dictionary to declare all the attributes of the repository rule. It maps from \
+                an attribute name to an attribute object (see
+                <a href="../toplevel/attr.html"><code>attr</code></a> module). Attributes \
+                starting with <code>_</code> are private, and can be used to add an implicit \
+                dependency on a label to a file (a repository rule cannot depend on a generated \
+                artifact). The attribute <code>name</code> is implicitly added and must not be \
+                specified.
+                <p>Declared attributes will convert <code>None</code> to the default value.</p>
+                """,
             named = true,
             positional = false),
         @Param(
@@ -213,9 +219,16 @@ public interface RepositoryModuleApi {
             defaultValue = "{}",
             named = true,
             doc =
-                "A dictionary to declare all the attributes of this tag class. It maps from an"
-                    + " attribute name to an attribute object (see <a"
-                    + " href=\"../toplevel/attr.html\">attr</a> module)."),
+                """
+                A dictionary to declare all the attributes of this tag class. It maps from an \
+                attribute name to an attribute object (see <a href="../toplevel/attr.html">
+                attr</a> module).
+                <p>Note that unlike <a href="../globals/bzl.html#rule"><code>rule()</code></a>, \
+                <a href="../globals/bzl.html#aspect"><code>aspect()</code></a> and \
+                <a href="../globals/bzl.html#repository_rule"><code>repository_rule()</code></a>,
+                declared attributes will not convert <code>None</code> to the default value. For \
+                the default to be used, the attribute must be omitted entirely by the caller.</p>
+                """),
         @Param(
             name = "doc",
             allowedTypes = {
@@ -238,7 +251,11 @@ public interface RepositoryModuleApi {
   @StarlarkBuiltin(
       name = "tag_class",
       category = DocCategory.BUILTIN,
-      doc = "Defines a schema of attributes for a tag.")
+      doc =
+          """
+          Defines a schema of attributes for a tag, created by \
+          <a href="../globals/bzl.html#tag_class"><code>tag_class()</code></a>.
+          """)
   interface TagClassApi extends StarlarkValue {}
 
   @StarlarkMethod(


### PR DESCRIPTION
Relates to #23547

`tag_class` is unique in a few ways to other functions that accept an attribute spec from the `attr` module.
1. It does not return a callable, but rather value containing metadata for `module_extension.tag_classes`.
2. The defined attributes outright reject `None` as a possible value, unlike `rule`, `aspect` and `repository_rule` which all fallback to the default as though no value were provided at all.

Supporting `None` makes sense for the other callable results as constructs such as `**kwargs` and functions/macros with default `None` arguments often expose them to such values. Allowing `None` to implicitly mean "use default" is useful in those contexts. This is not the case for `tag
_class`, which are interacted with in the extremely restricted context of `MODULE.bazel`.

This PR seeks to document how `None` is treated by declared attributes now that behaviour is (intentionally) inconsistent.

I also add links from builtin types such as `tag_class` to their factory function (`tag_class()`).