### PR TITLE
Add --ios_device flag for running iOS application on a physical device

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -49,6 +49,18 @@ public class ObjcCommandLineOptions extends FragmentOptions {
   public String iosSimulatorDevice;
 
   @Option(
+    name = "ios_device",
+    defaultValue = "null",
+    documentationCategory = OptionDocumentationCategory.TESTING,
+    effectTags = {OptionEffectTag.TEST_RUNNER},
+    help =
+        "The identifier, ECID, serial number, UDID, user-provided name, or DNS name of "
+            + "the device for running an iOS application. "
+            + "You can get a list of devices by running 'xcrun devicectl list "
+            + "devices'.")
+  public String iosDevice;
+
+  @Option(
     name = "ios_memleaks",
     defaultValue = "false",
     documentationCategory = OptionDocumentationCategory.TESTING,

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
@@ -53,6 +53,7 @@ public class ObjcConfiguration extends Fragment implements ObjcConfigurationApi 
 
   private final DottedVersion iosSimulatorVersion;
   private final String iosSimulatorDevice;
+  private final String iosDevice;
   private final boolean runMemleaks;
   private final CompilationMode compilationMode;
   private final ImmutableList<String> fastbuildOptions;
@@ -70,6 +71,7 @@ public class ObjcConfiguration extends Fragment implements ObjcConfigurationApi 
 
     this.iosSimulatorDevice = objcOptions.iosSimulatorDevice;
     this.iosSimulatorVersion = DottedVersion.maybeUnwrap(objcOptions.iosSimulatorVersion);
+    this.iosDevice = objcOptions.iosDevice;
     this.runMemleaks = objcOptions.runMemleaks;
     this.compilationMode = Preconditions.checkNotNull(options.compilationMode, "compilationMode");
     this.fastbuildOptions = ImmutableList.copyOf(objcOptions.fastbuildOptions);
@@ -96,6 +98,14 @@ public class ObjcConfiguration extends Fragment implements ObjcConfigurationApi 
   public DottedVersion getIosSimulatorVersion() {
     // TODO(bazel-team): Deprecate in favor of getSimulatorVersionForPlatformType(IOS).
     return iosSimulatorVersion;
+  }
+
+  /**
+   * Returns the device when running an application on a physical device.
+   */
+  @Override
+  public String getIosDevice() {
+    return iosDevice;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/ObjcConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/ObjcConfigurationApi.java
@@ -49,6 +49,14 @@ public interface ObjcConfigurationApi extends StarlarkValue {
   DottedVersionApi<?> getIosSimulatorVersion();
 
   @StarlarkMethod(
+      name = "ios_device",
+      structField = true,
+      allowReturnNones = true,
+      doc = "The device identifier to use when running an iOS application.")
+  @Nullable
+  String getIosDevice();
+
+  @StarlarkMethod(
       name = "run_memleaks",
       structField = true,
       doc = "Returns a boolean indicating whether memleaks should be run during tests or not.")


### PR DESCRIPTION
Related to this [PR](https://github.com/bazelbuild/rules_apple/pull/2527) in the [rules_apple](https://github.com/bazelbuild/rules_apple).

In Xcode 15, Apple introduced a new command-line tool that allows management of physical devices. This makes it possible to install and launch *_application targets on a physical device without third-party solutions.
It would be nice to have a Bazel flag to pass a device identifier for this.