### PR TITLE
[7.4.0] Convert values to Starlark values when concating string_list_dict type

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Type.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Type.java
@@ -626,11 +626,11 @@ public abstract class Type<T> {
 
     @Override
     public Map<KeyT, ValueT> concat(Iterable<Map<KeyT, ValueT>> iterable) {
-      Dict.Builder<KeyT, ValueT> output = new Dict.Builder<>();
+      ImmutableMap.Builder<KeyT, ValueT> builder = ImmutableMap.builder();
       for (Map<KeyT, ValueT> map : iterable) {
-        output.putAll(map);
+        builder.putAll(map);
       }
-      return output.buildImmutable();
+      return builder.buildKeepingLast();
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
@@ -31,7 +31,6 @@ import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.NoSuchTargetException;
 import com.google.devtools.build.lib.packages.RuleClass.ToolchainResolutionMode;
 import com.google.devtools.build.lib.packages.Type;
-import com.google.devtools.build.lib.packages.Types;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
 import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
 import com.google.devtools.build.lib.util.FileTypeSet;
@@ -170,7 +169,7 @@ public class ConfigurableAttributesTest extends BuildViewTestCase {
       () ->
           MockRule.define(
               "rule_with_string_list_dict_attr",
-              attr("string_list_dict_attr", Types.STRING_LIST_DICT));
+              attr("string_list_dict_attr", Type.STRING_LIST_DICT));
 
   @Override
   protected ConfiguredRuleClassProvider createRuleClassProvider() {
@@ -1953,7 +1952,7 @@ public class ConfigurableAttributesTest extends BuildViewTestCase {
     useConfiguration("--foo=b");
     ConfiguredTargetAndData ctad = getConfiguredTargetAndData("//foo:rule");
     AttributeMap attributes = getMapperFromConfiguredTargetAndTarget(ctad);
-    assertThat(attributes.get("string_list_dict_attr", Types.STRING_LIST_DICT))
+    assertThat(attributes.get("string_list_dict_attr", Type.STRING_LIST_DICT))
         .containsExactly("a", Arrays.asList("a.out"), "b", Arrays.asList("b.out"));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/TypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TypeTest.java
@@ -373,13 +373,13 @@ public class TypeTest {
 
   @Test
   public void testStringListDict_concat() throws Exception {
-    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of())).isEmpty();
+    assertThat(Type.STRING_LIST_DICT.concat(ImmutableList.of())).isEmpty();
 
     ImmutableMap<String, List<String>> expected =
         ImmutableMap.of(
             "foo", Arrays.asList("foo", "bar"),
             "wiz", Arrays.asList("bang"));
-    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of(expected))).isEqualTo(expected);
+    assertThat(Type.STRING_LIST_DICT.concat(ImmutableList.of(expected))).isEqualTo(expected);
 
     ImmutableMap<String, List<String>> map1 =
         ImmutableMap.of(
@@ -396,7 +396,7 @@ public class TypeTest {
             "bar", Arrays.asList("x", "y"),
             "baz", Arrays.asList("z"));
 
-    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of(map1, map2)))
+    assertThat(Type.STRING_LIST_DICT.concat(ImmutableList.of(map1, map2)))
         .isEqualTo(expectedAfterConcat);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/TypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TypeTest.java
@@ -372,6 +372,35 @@ public class TypeTest {
   }
 
   @Test
+  public void testStringListDict_concat() throws Exception {
+    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of())).isEmpty();
+
+    ImmutableMap<String, List<String>> expected =
+        ImmutableMap.of(
+            "foo", Arrays.asList("foo", "bar"),
+            "wiz", Arrays.asList("bang"));
+    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of(expected))).isEqualTo(expected);
+
+    ImmutableMap<String, List<String>> map1 =
+        ImmutableMap.of(
+            "foo", Arrays.asList("a", "b"),
+            "bar", Arrays.asList("c", "d"));
+    ImmutableMap<String, List<String>> map2 =
+        ImmutableMap.of(
+            "bar", Arrays.asList("x", "y"),
+            "baz", Arrays.asList("z"));
+
+    ImmutableMap<String, List<String>> expectedAfterConcat =
+        ImmutableMap.of(
+            "foo", Arrays.asList("a", "b"),
+            "bar", Arrays.asList("x", "y"),
+            "baz", Arrays.asList("z"));
+
+    assertThat(Types.STRING_LIST_DICT.concat(ImmutableList.of(map1, map2)))
+        .isEqualTo(expectedAfterConcat);
+  }
+
+  @Test
   public void testStringListDictBadFirstElement() throws Exception {
     Object input =
         ImmutableMap.of(


### PR DESCRIPTION
Convert values to Starlark values when concating string_list_dict type.

This is because Dict checks that all the values put in it are Starlark valid values. But string_list_dict value is of type List<String>, when Java's List isn't a Starlark value.

Fixes #23065

My first PR to bazel :star_struck: Would love you to review the PR.
 Checked that the test didn't pass before the change and did after it.

Closes #23424.

PiperOrigin-RevId: 673463108
Change-Id: Ib2cdce7d94243f4e3bda23203a196fee4e766189

Commit https://github.com/bazelbuild/bazel/commit/f1f8d5829a987854d49913058087765db68fc92c