### PR TITLE
[7.4.0] Gracefully handle setting the same header with --bes_header twice.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
@@ -64,7 +64,11 @@ public class BazelBuildEventServiceModule
       return new AutoValue_BazelBuildEventServiceModule_BackendConfig(
           besOptions.besBackend,
           besOptions.besProxy,
-          ImmutableMap.copyOf(besOptions.besHeaders).entrySet().asList(),
+          ImmutableMap.<String, String>builder()
+              .putAll(besOptions.besHeaders)
+              .buildKeepingLast()
+              .entrySet()
+              .asList(),
           authAndTLSOptions);
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModuleTest.java
@@ -24,7 +24,6 @@ import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -696,12 +695,16 @@ public final class BazelBuildEventServiceModuleTest extends BuildIntegrationTest
     besOptions.besBackend = "bes-backend";
     besOptions.besProxy = "bes-proxy";
     besOptions.besHeaders =
-        ImmutableMap.of("key1", "val1", "key2", "val2", "key3", "val3").entrySet().asList();
+        ImmutableList.of(
+            Map.entry("key1", "val1"),
+            Map.entry("key2", "val2"),
+            Map.entry("key3", "val3"),
+            Map.entry("key1", "val4"));
     BackendConfig newConfig = BackendConfig.create(besOptions, authAndTLSOptions);
 
     Metadata metadata = BazelBuildEventServiceModule.makeGrpcMetadata(newConfig);
     assertThat(metadata.get(Metadata.Key.of("key1", Metadata.ASCII_STRING_MARSHALLER)))
-        .isEqualTo("val1");
+        .isEqualTo("val4");
     assertThat(metadata.get(Metadata.Key.of("key2", Metadata.ASCII_STRING_MARSHALLER)))
         .isEqualTo("val2");
     assertThat(metadata.get(Metadata.Key.of("key3", Metadata.ASCII_STRING_MARSHALLER)))


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/20681

Closes #20684.

PiperOrigin-RevId: 595228741
Change-Id: I06bab1efa25deaa4085acfffd350dc62f9f73aa3