### PR TITLE
Heuristically path map copts and defines

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/PathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathMapper.java
@@ -128,6 +128,13 @@ public interface PathMapper {
   }
 
   /**
+   * Heuristically maps all path-like strings in the given argument.
+   */
+  default String mapHeuristically(String arg) {
+    return arg;
+  }
+
+  /**
    * Returns a {@link FileRootApi} representing the new root of the given artifact after mapping.
    *
    * <p>All objects returned by this method must be {@link Comparable} among each other.

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StrippingPathMapper.java
@@ -190,6 +190,11 @@ public final class StrippingPathMapper implements PathMapper {
   }
 
   @Override
+  public String mapHeuristically(String arg) {
+    return argStripper.strip(arg);
+  }
+
+  @Override
   public FileRootApi mapRoot(Artifact artifact) {
     if (Objects.equals(artifact.getRoot(), outputArtifactRoot)) {
       // The mapped root's path does not depend on the artifact, so we can share an instance.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -1043,7 +1043,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       ImmutableList.Builder<VariableValue> sequences =
           ImmutableList.builderWithExpectedSize(values.size());
       for (String value : values) {
-        sequences.add(new StringValue(value));
+        sequences.add(new StringValue(pathMapper.mapHeuristically(value)));
       }
       return sequences.build();
     }

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -530,6 +530,7 @@ cc_library(
     name = "utils",
     srcs = ["dir/utils.cc"],
     hdrs = ["dir/utils.h"],
+    defines = ["MY_FILE=\\\"+$(execpath dir/utils.cc)+\\\""],
     include_prefix = "other_dir",
     strip_include_prefix = "dir",
     visibility = ["//visibility:public"],
@@ -615,7 +616,13 @@ EOF
   cat > "$pkg/common/utils/utils.cc.tpl" <<'EOF'
 #include "utils.h"
 
+#include <cstdlib>
+#include <iostream>
+
 std::string AsGreeting(const std::string& name) {
+  if (std::string(MY_FILE).find("-out/cfg/") == std::string::npos) {
+    std::cerr << "Expected path to contain '-out/cfg/'" << std::endl;
+  }
   return "{GREETING}, " + name + "!";
 }
 EOF


### PR DESCRIPTION
This allows path mapping to apply to actions that reference execpaths in custom compiler options via location expansion.

Work towards #6526