### PR TITLE
GrpcRemoteDownloader: clarify header priority

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -86,6 +86,8 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
   private static final String QUALIFIER_HTTP_HEADER_PREFIX = "http_header:";
   // Same as HTTP_HEADER_PREFIX, but only apply for a specific URL.
   // The index starts from 0 and corresponds to the URL index in the request.
+  // Server should prefer using the URL-specific header value over the generic header
+  // value when both are present.
   private static final String QUALIFIER_HTTP_HEADER_URL_PREFIX = "http_header_url:";
 
   public GrpcRemoteDownloader(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -156,7 +156,8 @@ public final class RemoteOptions extends CommonRemoteOptions {
           "Whether to propagate credentials from netrc and credential helper to the remote"
               + " downloader server. The server implementation needs to support the new"
               + " `http_header_url:<url-index>:<header-key>` qualifier where the `<url-index>` is a"
-              + " 0-based position of the URL inside the FetchBlobRequest's `uris` field.")
+              + " 0-based position of the URL inside the FetchBlobRequest's `uris` field. The"
+              + " URL-specific headers should take precedence over the global headers.")
   public boolean remoteDownloaderPropagateCredentials;
 
   @Option(


### PR DESCRIPTION
When a header key is defined in both the generic headers and the
url-specific headers, the url-specific value should win.
