### PR TITLE
Change to pull_request

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: "PR Labeler"
 
 on:
-  pull_request_target:
+  pull_request:
     types: ["opened", "reopened", "ready_for_review"]
 
 permissions:

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -1,7 +1,7 @@
 name: Remove PR Labels
 
 on:
-  pull_request_target:
+  pull_request:
     types: ["closed"]
 
 permissions:


### PR DESCRIPTION
Fix Security Vulnerability with the labeler and remove label github actions.


GOOGLE:

As per the https://buganizer.corp.google.com/issues/364700434, there can be a potential risk when using `pull_request_target`. This change converts the `pull_request_target` to `pull_request` event trigger.

AUTOSUBMITTED_BY=pcloudy