### PR TITLE
Flip `--experimental_use_validation_aspect`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -185,7 +185,7 @@ public class BuildRequestOptions extends OptionsBase {
 
   @Option(
       name = "experimental_use_validation_aspect",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,
       effectTags = {OptionEffectTag.EXECUTION, OptionEffectTag.AFFECTS_OUTPUTS},
       help = "Whether to run validation actions using aspect (for parallelism with tests).")

--- a/src/test/java/com/google/devtools/build/lib/buildtool/TargetCompleteEventTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/TargetCompleteEventTest.java
@@ -429,7 +429,8 @@ public final class TargetCompleteEventTest extends BuildIntegrationTestCase {
   private static BuildEventStreamProtos.TargetComplete findTargetCompleteEventInBEPStream(File bep)
       throws IOException {
     for (BuildEvent buildEvent : parseBuildEventsFromBEPStream(bep)) {
-      if (buildEvent.getId().getIdCase() == IdCase.TARGET_COMPLETED) {
+      if (buildEvent.getId().getIdCase() == IdCase.TARGET_COMPLETED
+          && !buildEvent.getId().getTargetCompleted().getAspect().equals("ValidateTarget")) {
         return buildEvent.getCompleted();
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/rewinding/RewindingTestsHelper.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMulti
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.common.truth.Truth8.assertThat;
 import static com.google.devtools.build.lib.vfs.FileSystemUtils.readContentAsLatin1;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertThrows;
@@ -3312,7 +3313,15 @@ public class RewindingTestsHelper {
               || (isActionExecutionKey(key, lostLabel) && type == EventType.SET_VALUE)) {
             // Completion events for lost outputs should not be emitted until after rewinding
             // completes. Otherwise, we may publish stale artifact URIs to the BEP.
-            assertThat(events).isEmpty();
+            assertThat(
+                    events.entrySet().stream()
+                        .filter(
+                            e ->
+                                !(e.getValue() instanceof AspectCompleteEvent aspectCompleteEvent
+                                    && aspectCompleteEvent
+                                        .getAspectName()
+                                        .equals("ValidateTarget"))))
+                .isEmpty();
           }
         });
   }
@@ -3409,6 +3418,9 @@ public class RewindingTestsHelper {
               @SuppressWarnings("unused")
               public void accept(AspectCompleteEvent event) {
                 // If we need to track targets with multiple aspects, we could change the key type.
+                if (event.getAspectName().equals("ValidateTarget")) {
+                  return;
+                }
                 var prev = aspectCompleteEvents.put(event.getLabel(), event);
                 checkState(prev == null, "Duplicate AspectCompleteEvent for %s", event.getLabel());
               }

--- a/src/test/shell/integration/discard_analysis_cache_test.sh
+++ b/src/test/shell/integration/discard_analysis_cache_test.sh
@@ -192,7 +192,8 @@ EOF
   aspect_count="$(extract_histogram_count histo.txt 'lib.packages.Aspect$')"
   [[ "$ct_count" -ge 2 ]] \
       || fail "Too few configured targets: $ct_count. Did you move/rename the class?"
-  [[ "$aspect_count" -ge 1 ]] \
+  # ValidateTarget will always be around.
+  [[ "$aspect_count" -ge 2 ]] \
       || fail "Too few aspects: $aspect_count. Did you move/rename the class?"
   bazel --batch clean >& "$TEST_log" || fail "Expected success"
   server_pid="$(bazel info server_pid 2> /dev/null)"
@@ -205,7 +206,7 @@ EOF
   # Several top-level configured targets are allowed to stick around.
   [[ "$ct_count" -le 17 ]] \
       || fail "Too many configured targets: $ct_count"
-  [[ "$aspect_count" -eq 0 ]] || fail "Too many aspects: $aspect_count"
+  [[ "$aspect_count" -eq 1 ]] || fail "Too many aspects: $aspect_count"
   bazel --batch clean >& "$TEST_log" || fail "Expected success"
   server_pid="$(bazel info server_pid 2> /dev/null)"
   bazel build --discard_analysis_cache \
@@ -221,7 +222,7 @@ EOF
   ct_count="$(extract_histogram_count histo.txt 'RuleConfiguredTarget$')"
   aspect_count="$(extract_histogram_count histo.txt 'lib.packages.Aspect$')"
   # One top-level aspect is allowed to stick around.
-  [[ "$aspect_count" -le 1 ]] || fail "Too many aspects: $aspect_count"
+  [[ "$aspect_count" -le 2 ]] || fail "Too many aspects: $aspect_count"
   [[ "$ct_count" -le 17 ]] || fail "Too many configured targets: $ct_count"
 }
 

--- a/src/test/shell/integration/validation_actions_test.sh
+++ b/src/test/shell/integration/validation_actions_test.sh
@@ -234,11 +234,11 @@ function assert_not_exists() {
 
 #### Tests #####################################################################
 
-function test_validation_actions() {
+function test_validation_actions_without_validation_aspect() {
   setup_test_project
   setup_passing_validation_action
 
-  bazel build --run_validations \
+  bazel build --run_validations --noexperimental_use_validation_aspect \
       //validation_actions:foo0 >& "$TEST_log" || fail "Expected build to succeed"
 
   expect_log "Target //validation_actions:foo0 up-to-date:"
@@ -246,11 +246,11 @@ function test_validation_actions() {
   assert_exists bazel-bin/validation_actions/foo0.validation
 }
 
-function test_validation_actions_with_validation_aspect() {
+function test_validation_actions() {
   setup_test_project
   setup_passing_validation_action
 
-  bazel build --run_validations --experimental_use_validation_aspect \
+  bazel build --run_validations \
       //validation_actions:foo0 >& "$TEST_log" || fail "Expected build to succeed"
 
   # Console printout as if no aspects were running
@@ -278,7 +278,6 @@ EOF
 
   bazel build --run_validations \
       --show_result=2 \
-      --experimental_use_validation_aspect \
       --aspects=validation_actions/simpleaspect.bzl%simple_aspect \
       --output_groups=+aspect-out \
       //validation_actions:foo0 >& "$TEST_log" || fail "Expected build to succeed"
@@ -340,7 +339,7 @@ function test_failing_validation_action_fails_build_implicit_output() {
   setup_failing_validation_action
 
   bazel clean
-  bazel build --run_validations --experimental_use_validation_aspect \
+  bazel build --run_validations \
       //validation_actions:foo0.implicit >& "$TEST_log" && fail "Expected build to fail"
   expect_log "validation failed!"
   expect_log "Target //validation_actions:foo0.implicit failed to build"
@@ -351,7 +350,7 @@ function test_failing_validation_action_fails_build_genrule_output() {
   setup_failing_validation_action
 
   bazel build --run_validations \
-      --experimental_use_validation_aspect --aspects=ValidateTarget \
+      --aspects=ValidateTarget \
       //validation_actions:generated >& "$TEST_log" && fail "Expected build to fail"
   expect_log "validation failed!"
   expect_log "Target //validation_actions:generated failed to build"
@@ -395,8 +394,8 @@ function test_failing_validation_action_for_dep_from_test_fails_build() {
   # run with bazel test.
   bazel test --run_validations //validation_actions:test_with_rule_with_validation_in_deps >& "$TEST_log" && fail "Expected build to fail"
   expect_log "validation failed!"
-  expect_log "FAILED TO BUILD"
-  expect_log "out of 1 test: 1 fails to build."
+  expect_log "NO STATUS"
+  expect_log "out of 1 test: 1 was skipped."
 }
 
 function test_slow_failing_validation_action_for_dep_from_test_fails_build() {
@@ -407,7 +406,6 @@ function test_slow_failing_validation_action_for_dep_from_test_fails_build() {
   # with "bazel test", even though validation finishes after test
   bazel clean  # Clean out any previous test or validation outputs
   bazel test --run_validations \
-      --experimental_use_validation_aspect \
       //validation_actions:test_with_rule_with_validation_in_deps >& "$TEST_log" \
       && fail "Expected build to fail"
   expect_log "validation failed!"
@@ -426,6 +424,7 @@ function test_failing_validation_action_fails_multiple_tests() {
   # Validation actions in the deps of the test should fail the build when run
   # with bazel test.
   bazel test --run_validations \
+      --noexperimental_use_validation_aspect \
       //validation_actions:test_with_rule_with_validation_in_deps \
       //validation_actions:test_with_same_validation_in_deps >& "$TEST_log" \
       && fail "Expected build to fail"
@@ -443,7 +442,6 @@ function test_slow_failing_validation_action_fails_multiple_tests() {
   # with "bazel test", even though validation finishes after test
   bazel clean  # Clean out any previous test or validation outputs
   bazel test --run_validations \
-      --experimental_use_validation_aspect \
       //validation_actions:test_with_rule_with_validation_in_deps \
       //validation_actions:test_with_same_validation_in_deps >& "$TEST_log" \
       && fail "Expected build to fail"
@@ -463,7 +461,6 @@ function test_slow_failing_validation_action_fails_multiple_tests_keep_going() {
   # with "bazel test", even though validation finishes after test
   bazel clean  # Clean out any previous test or validation outputs
   bazel test -k --run_validations \
-      --experimental_use_validation_aspect \
       //validation_actions:test_with_rule_with_validation_in_deps \
       //validation_actions:test_with_same_validation_in_deps >& "$TEST_log" \
       && fail "Expected build to fail"
@@ -579,7 +576,6 @@ function test_validation_actions_in_rule_and_aspect_use_validation_aspect() {
   setup_passing_validation_action
 
   bazel build --run_validations --aspects=//aspect:def.bzl%validation_aspect \
-      --experimental_use_validation_aspect \
       //validation_actions:foo0 >& "$TEST_log" || fail "Expected build to succeed"
   expect_log "Target //validation_actions:foo0 up-to-date:"
   expect_log "validation_actions/foo0.main"
@@ -593,7 +589,6 @@ exit 1
 EOF
 
   bazel build --run_validations --aspects=//aspect:def.bzl%validation_aspect \
-      --experimental_use_validation_aspect \
       //validation_actions:foo0 >& "$TEST_log" && fail "Expected build to fail"
   expect_log "aspect validation failed!"
 }


### PR DESCRIPTION
RELNOTES: Validation actions registered by test rules now run concurrently with tests.