### PR TITLE
Intern `VectorArg`s more aggressively

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -55,7 +55,6 @@ import com.google.devtools.build.lib.starlarkbuildapi.DirectoryExpander;
 import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.FileRootApi;
 import com.google.devtools.build.lib.util.Fingerprint;
-import com.google.devtools.build.lib.util.HashCodes;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -66,7 +65,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -748,12 +746,13 @@ public class StarlarkCustomCommandLine extends CommandLine {
       }
       return features == that.features
           && stringificationType.equals(that.stringificationType)
-          && Objects.equals(starlarkSemantics, that.starlarkSemantics);
+          // There is only a single instance of StarlarkSemantics per build (see #internerFor).
+          && starlarkSemantics == that.starlarkSemantics;
     }
 
     @Override
     public int hashCode() {
-      return 31 * HashCodes.hashObjects(stringificationType, starlarkSemantics)
+      return 31 * (31 * stringificationType.hashCode() + System.identityHashCode(starlarkSemantics))
           + Integer.hashCode(features);
     }
   }


### PR DESCRIPTION
Path mapping requires turning `args.add(file.dirname)` into `args.add_all([file], map_each = _dirname)`. This usage can be made more memory efficient if we

* avoid storing the count of 1 by encoding it in `VectorArg#features`;
* intern `StarlarkSemantics` in `VectorArg` as a single instance is shared across the build. This saves 4 bytes for each `map_each` usage.