### PR TITLE
Support --target_pattern_file for fetch and vendor command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.KeepGoingOption;
 import com.google.devtools.build.lib.runtime.LoadingPhaseThreadsOption;
+import com.google.devtools.build.lib.runtime.commands.TargetPatternsHelper;
 import com.google.devtools.build.lib.runtime.commands.TestCommand;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
@@ -77,10 +78,7 @@ public final class FetchCommand implements BlazeCommand {
 
   @Override
   public void editOptions(OptionsParser optionsParser) {
-    // We only need to inject these options with fetch target (when there is a residue)
-    if (!optionsParser.getResidue().isEmpty()) {
-      TargetFetcher.injectNoBuildOption(optionsParser);
-    }
+    TargetFetcher.injectNoBuildOption(optionsParser);
   }
 
   @Override
@@ -112,9 +110,20 @@ public final class FetchCommand implements BlazeCommand {
 
     BlazeCommandResult result;
     LoadingPhaseThreadsOption threadsOption = options.getOptions(LoadingPhaseThreadsOption.class);
+    List<String> targets;
     try {
-      if (!options.getResidue().isEmpty()) {
-        result = fetchTarget(env, options, options.getResidue());
+      targets = TargetPatternsHelper.readFrom(env, options);
+    } catch (TargetPatternsHelper.TargetPatternsHelperException e) {
+      env.getReporter().handle(Event.error(e.getMessage()));
+      return BlazeCommandResult.failureDetail(e.getFailureDetail());
+    }
+    try {
+      if (!targets.isEmpty()) {
+        if (!fetchOptions.repos.isEmpty()) {
+          return createFailedBlazeCommandResult(
+              env.getReporter(), "Target patterns and --repo cannot both be specified");
+        }
+        result = fetchTarget(env, options, targets);
       } else if (!fetchOptions.repos.isEmpty()) {
         result = fetchRepos(env, threadsOption, fetchOptions.repos);
       } else { // --all, --configure, or just 'fetch'

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/VendorCommand.java
@@ -45,6 +45,7 @@ import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.KeepGoingOption;
 import com.google.devtools.build.lib.runtime.LoadingPhaseThreadsOption;
+import com.google.devtools.build.lib.runtime.commands.TargetPatternsHelper;
 import com.google.devtools.build.lib.runtime.commands.TestCommand;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
@@ -124,10 +125,7 @@ public final class VendorCommand implements BlazeCommand {
 
   @Override
   public void editOptions(OptionsParser optionsParser) {
-    // We only need to inject these options with fetch target (when there is a residue)
-    if (!optionsParser.getResidue().isEmpty()) {
-      TargetFetcher.injectNoBuildOption(optionsParser);
-    }
+    TargetFetcher.injectNoBuildOption(optionsParser);
   }
 
   @Override
@@ -159,9 +157,20 @@ public final class VendorCommand implements BlazeCommand {
     Path vendorDirectory =
         env.getWorkspace().getRelative(options.getOptions(RepositoryOptions.class).vendorDirectory);
     this.vendorManager = new VendorManager(vendorDirectory);
+    List<String> targets;
     try {
-      if (!options.getResidue().isEmpty()) {
-        result = vendorTargets(env, options, options.getResidue());
+      targets = TargetPatternsHelper.readFrom(env, options);
+    } catch (TargetPatternsHelper.TargetPatternsHelperException e) {
+      env.getReporter().handle(Event.error(e.getMessage()));
+      return BlazeCommandResult.failureDetail(e.getFailureDetail());
+    }
+    try {
+      if (!targets.isEmpty()) {
+        if (!vendorOptions.repos.isEmpty()) {
+          return createFailedBlazeCommandResult(
+              env.getReporter(), "Target patterns and --repo cannot both be specified");
+        }
+        result = vendorTargets(env, options, targets);
       } else if (!vendorOptions.repos.isEmpty()) {
         result = vendorRepos(env, threadsOption, vendorOptions.repos);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/TargetPatternsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/TargetPatternsHelper.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 /** Provides support for reading target patterns from a file or the command-line. */
-final class TargetPatternsHelper {
+public final class TargetPatternsHelper {
 
   private TargetPatternsHelper() {}
 
@@ -77,7 +77,7 @@ final class TargetPatternsHelper {
   }
 
   /** Thrown when target patterns couldn't be read. */
-  static class TargetPatternsHelperException extends Exception {
+  public static class TargetPatternsHelperException extends Exception {
     private final TargetPatterns.Code detailedCode;
 
     private TargetPatternsHelperException(String message, TargetPatterns.Code detailedCode) {
@@ -85,7 +85,7 @@ final class TargetPatternsHelper {
       this.detailedCode = detailedCode;
     }
 
-    FailureDetail getFailureDetail() {
+    public FailureDetail getFailureDetail() {
       return FailureDetail.newBuilder()
           .setMessage(getMessage())
           .setTargetPatterns(TargetPatterns.newBuilder().setCode(detailedCode))

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -639,6 +639,35 @@ class BazelVendorTest(test_base.TestBase):
     self.assertIn('bbb+', os.listdir(self._test_cwd + '/vendor'))
     self.assertNotIn('ccc+', os.listdir(self._test_cwd + '/vendor'))
 
+  def testVendorWithTargetPatternFile(self):
+    self.main_registry.createCcModule('aaa', '1.0').createCcModule(
+        'bbb', '1.0'
+    ).createCcModule('ccc', '1.0')
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "aaa", version = "1.0")',
+            'bazel_dep(name = "bbb", version = "1.0")',
+            'bazel_dep(name = "ccc", version = "1.0")',
+        ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile(
+        'targets.params',
+        [
+            '@aaa//:lib_aaa',
+            '@bbb//:lib_bbb',
+        ],
+    )
+
+    self.RunBazel(
+        ['vendor', '--target_pattern_file=targets.params', '--vendor_dir=vendor']
+    )
+    # Assert aaa & bbb and are vendored
+    self.assertIn('aaa+', os.listdir(self._test_cwd + '/vendor'))
+    self.assertIn('bbb+', os.listdir(self._test_cwd + '/vendor'))
+    self.assertNotIn('ccc+', os.listdir(self._test_cwd + '/vendor'))
+
   def testBuildVendoredTargetOffline(self):
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(
         'bbb', '1.0', {'aaa': '1.0'}


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/bazel/issues/23628

RELNOTES: Bazel fetch and vendor command now supports --target_pattern_file for specifying target patterns.