### PR TITLE
Make repo marker file parsing robust to version changes

### DIFF
--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2902,6 +2902,14 @@ EOF
   bazel shutdown
   bazel build @foo >& $TEST_log || fail "expected bazel to succeed"
   expect_log "I see: nothing"
+
+  # Test to clear the marker file.
+  echo > ${marker_file}
+
+  # Running Bazel again shouldn't crash, and should result in a refetch.
+  bazel shutdown
+  bazel build @foo >& $TEST_log || fail "expected bazel to succeed"
+  expect_log "I see: nothing"
 }
 
 function test_file_watching_in_undefined_repo() {


### PR DESCRIPTION
Bazel 7.1.0 and 7.2.0 contains a bug where + characters in labels in the repository marker files cannot be parsed. This was fixed in commit d62e0a0f32188e1875bb8e62ef4377ea4dc1aab2. To reduce the rusk of future bugs in the same area, this change skips parsing the file if the first line shows that the content will not be used anyway, which should be reasonably safe if introducing new formats.

Improves #23336 that fixed #23322.