### PR TITLE
Allow decompression of nupkg

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
@@ -102,7 +102,8 @@ public class DecompressorValue implements SkyValue {
     if (baseName.endsWith(".zip")
         || baseName.endsWith(".jar")
         || baseName.endsWith(".war")
-        || baseName.endsWith(".aar")) {
+        || baseName.endsWith(".aar")
+        || baseName.endsWith(".nupkg")) {
       return ZipDecompressor.INSTANCE;
     } else if (baseName.endsWith(".tar")) {
       return TarFunction.INSTANCE;
@@ -119,7 +120,7 @@ public class DecompressorValue implements SkyValue {
     } else {
       throw new RepositoryFunctionException(
           Starlark.errorf(
-              "Expected a file with a .zip, .jar, .war, .aar, .tar, .tar.gz, .tgz, .tar.xz, .txz,"
+              "Expected a file with a .zip, .jar, .war, .aar, .nupkg, .tar, .tar.gz, .tgz, .tar.xz, ,"
                   + " .tar.zst, .tzst, .tar.bz2, .tbz, .ar or .deb suffix (got %s)",
               archivePath),
           Transience.PERSISTENT);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -861,7 +861,7 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
                 The archive type of the downloaded file. By default, the archive type is \
                 determined from the file extension of the URL. If the file has no \
                 extension, you can explicitly specify either "zip", "jar", "war", \
-                "aar", "tar", "tar.gz", "tgz", "tar.xz", "txz", ".tar.zst", \
+                "aar", "nupkg", "tar", "tar.gz", "tgz", "tar.xz", "txz", ".tar.zst", \
                 ".tzst", "tar.bz2", ".tbz", ".ar", or ".deb" here.
                 """),
         @Param(

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/DecompressorValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/DecompressorValueTest.java
@@ -43,6 +43,8 @@ public class DecompressorValueTest {
     unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.zip");
     unused = DecompressorValue.getDecompressor(path);
+    path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.nupkg");
+    unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.gz");
     unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tgz");


### PR DESCRIPTION
In some (legacy) projects, nuget is used to handle C++ packages.
Nuget packages are working fine with WORKSPACE `http_archive` directives when explicitly specifying `type = "zip"`.

However, when migrating to bzlmod, we ran into issues when the url in source.json is a nupkg file.
This PR resolves that issue and allows consumption of nupkg archives as Bazel modules.