### PR TITLE
Make --noallow_discard_analysis_cache work when used twice in a seque…

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewForTesting.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewForTesting.java
@@ -62,7 +62,6 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
 import com.google.devtools.build.lib.events.Event;
-import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.StoredEventHandler;
 import com.google.devtools.build.lib.packages.NoSuchPackageException;
@@ -256,20 +255,11 @@ public class BuildViewForTesting {
   }
 
   /** Sets the configuration. Not thread-safe. */
-  public void setConfigurationForTesting(
-      EventHandler eventHandler, BuildConfigurationValue configuration) {
-    try {
-      skyframeBuildView.setConfiguration(
-          eventHandler,
-          configuration,
-          /* maxDifferencesToShow= */ -1, /* allowAnalysisCacheDiscards */
-          true);
-    } catch (InvalidConfigurationException e) {
-      throw new UnsupportedOperationException(
-          "InvalidConfigurationException was thrown and caught during a test, "
-              + "this case is not yet handled",
-          e);
-    }
+  public void setConfigurationForTesting(BuildConfigurationValue configuration) {
+    skyframeBuildView.setConfiguration(
+        configuration,
+        configuration.getOptions(),
+        true);
   }
 
   public ArtifactFactory getArtifactFactory() {

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -660,7 +660,7 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
     skyframeExecutor.handleAnalysisInvalidatingChange();
 
     view = new BuildViewForTesting(directories, ruleClassProvider, skyframeExecutor, null);
-    view.setConfigurationForTesting(event -> {}, targetConfig);
+    view.setConfigurationForTesting(targetConfig);
 
     view.setArtifactRoots(new PackageRootsNoSymlinkCreation(Root.fromPath(rootDirectory)));
   }


### PR DESCRIPTION
…nce.

This didn't work at HEAD because the check there compared the flags in the new configuration with the flags of the old configuration, but overwrote the old configuration with the new one, so running a command that discarded the analysis cache was allowed the second time.

The fix is not as trivial as moving checking the value before setting the new configuration because creating the new configuration entails a Skyframe evaluation, which is a waste if we end up erroring out. So the check is now done by checking the build options of the old configuration and the new build options, which doesn't require creating the new configuration first.

Fixes #23491.

RELNOTES: None.
PiperOrigin-RevId: 675555324
Change-Id: Ib402b699ed9ba9f04542896a40ff1180351471db