### PR TITLE
[7.4.0] Add `@rules_cc` to the default API allowlist

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
@@ -49,6 +49,10 @@ public final class BuiltinRestriction {
               BuiltinRestriction.allowlistEntry("rules_android", ""),
               BuiltinRestriction.allowlistEntry("build_bazel_rules_android", ""),
 
+              // Cc rules
+              BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_cc"),
+              BuiltinRestriction.allowlistEntry("rules_cc", ""),
+
               // Java rules
               BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_java"),
               BuiltinRestriction.allowlistEntry("rules_java", ""),

--- a/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
@@ -37,6 +37,8 @@ _PRIVATE_STARLARKIFICATION_ALLOWLIST = [
     ("rules_android", ""),
     ("", "rust/private"),
     ("rules_rust", "rust/private"),
+    ("", "third_party/bazel_rules/rules_cc"),
+    ("rules_cc", ""),
 ]
 
 _BUILTINS = [("_builtins", "")]


### PR DESCRIPTION
PiperOrigin-RevId: 673946235
Change-Id: If20c63df2877aa948032d97795d88d960d9fa6bc (cherry picked from commit ff2e950b7a8cb763f36d2a679978c5f668160c78)