### PR TITLE
Fix the documentation for `bazel fetch --configure`

### DIFF
--- a/site/en/extending/repo.md
+++ b/site/en/extending/repo.md
@@ -125,9 +125,9 @@ changes:
 There are two parameters of `repository_rule` that control when the repositories
 are re-fetched:
 
-*   If the `configure` flag is set, the repository is only re-fetched on `bazel
-    fetch` when the` --configure` parameter is passed to it (if the attribute is
-    unset, this command will not cause a re-fetch)
+*   If the `configure` flag is set, the repository is re-fetched on `bazel
+    fetch --force --configure` (non-`configure` repositories are not
+    re-fetched).
 *   If the `local` flag is set, in addition to the above cases, the repo is also
     re-fetched when the Bazel server restarts.
 
@@ -142,7 +142,7 @@ unconditionally by calling `bazel fetch --force --all`.
 Moreover, some repo rules inspect the local machine and might become outdated if
 the local machine was upgraded. Here you can ask Bazel to only refetch those
 external repos where the [`repository_rule`](/rules/lib/globals#repository_rule)
-definition has the `configure` attribute set, use `bazel fetch --all
+definition has the `configure` attribute set, use `bazel fetch --force
 --configure`.
 
 ## Examples

--- a/src/main/starlark/builtins_bzl/common/xcode/semantics.bzl.oss
+++ b/src/main/starlark/builtins_bzl/common/xcode/semantics.bzl.oss
@@ -14,4 +14,4 @@
 
 """Semantics for Bazel Xcode rules"""
 
-unavailable_xcode_message = "'bazel fetch --configure' (Bzlmod) or 'bazel sync --configure' (WORKSPACE)"
+unavailable_xcode_message = "'bazel fetch --force --configure' (Bzlmod) or 'bazel sync --configure' (WORKSPACE)"


### PR DESCRIPTION
With `bazel fetch`, `--configure` and `--force` are now independent and both need to be specified to refetch configure repos. The docs did not reflect this correctly.