### PR TITLE
Fix upb build with Clang 16

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -80,6 +80,7 @@ single_version_override(
     patch_strip = 1,
     patches = [
         "//third_party/upb:00_remove_toolchain_transition.patch",
+        "//third_party/upb:01_remove_werror.patch",
     ],
 )
 

--- a/third_party/upb/01_remove_werror.patch
+++ b/third_party/upb/01_remove_werror.patch
@@ -1,0 +1,19 @@
+diff --git a/bazel/upb_proto_library.bzl b/bazel/upb_proto_library.bzl
+--- a/bazel/build_defs.bzl
++++ b/bazel/build_defs.bzl
+@@ -34,13 +34,13 @@
+ _DEFAULT_CPPOPTS.extend([
+     "-Wextra",
+     # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
+-    "-Werror",
++    # "-Werror",
+     "-Wno-long-long",
+ ])
+ _DEFAULT_COPTS.extend([
+     "-std=c99",
+     "-pedantic",
+-    "-Werror=pedantic",
++    # "-Werror=pedantic",
+     "-Wall",
+     "-Wstrict-prototypes",
+     # GCC (at least) emits spurious warnings for this that cannot be fixed

--- a/third_party/upb/BUILD
+++ b/third_party/upb/BUILD
@@ -8,4 +8,5 @@ filegroup(
 
 exports_files([
     "00_remove_toolchain_transition.patch",
+    "01_remove_werror.patch",
 ])


### PR DESCRIPTION
With Xcode 16, `upb` fails its own `-Werror` check due to using Clang extensions.