### PR TITLE
[7.4.0] Fix deduping for `--extra_toolchains`.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.analysis;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -171,6 +173,30 @@ public class PlatformOptions extends FragmentOptions {
               + " 'test'.")
   public List<Map.Entry<RegexFilter, List<Label>>> targetFilterToAdditionalExecConstraints;
 
+  /**
+   * Deduplicate the given list, keeping the last copy of any duplicates.
+   *
+   * <p>Example: [a, b, a, c, b] -> [a, c, b]
+   */
+  protected static ImmutableList<String> dedupeKeepingLast(ImmutableList<String> values) {
+    // Check common cases.
+    if (values.size() <= 1) {
+      return values;
+    }
+
+    // Reverse the list and then deduplicate.
+    ImmutableList<String> reversedResult =
+        values.reverse().stream().distinct().collect(toImmutableList());
+
+    // If there were no duplicates, return the exact same instance we got.
+    if (reversedResult.size() == values.size()) {
+      return values;
+    }
+
+    // Reverse the result to get back to the original order.
+    return reversedResult.reverse();
+  }
+
   @Override
   public PlatformOptions getExec() {
     PlatformOptions exec = (PlatformOptions) getDefault();
@@ -188,7 +214,11 @@ public class PlatformOptions extends FragmentOptions {
   @Override
   public PlatformOptions getNormalized() {
     PlatformOptions result = (PlatformOptions) clone();
-    result.extraToolchains = dedupeOnly(result.extraToolchains);
+    result.extraToolchains =
+        dedupeKeepingLast(
+            result.extraToolchains == null
+                ? ImmutableList.of()
+                : ImmutableList.copyOf(result.extraToolchains));
     // Only the first entry of platforms is used (it should have been Label and not List<Label>)
     // So drop all but the first entry.
     if (result.platforms.size() > 1) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
@@ -93,30 +93,6 @@ public abstract class FragmentOptions extends OptionsBase implements Cloneable {
     return result.equals(values) ? values : result;
   }
 
-  /**
-   * Helper method for subclasses to remove duplicate values. When removing duplicates all but the
-   * first instance will be removed. This way the relative ordering of two values will match the
-   * relative ordering of their first instances.
-   *
-   * <p>Example: [a, b, a, c, b] -> [a, b, c]
-   */
-  protected static List<String> dedupeOnly(List<String> values) {
-    HashSet<String> alreadySeen = new HashSet<>();
-    List<String> result = new ArrayList<>();
-    for (String value : values) {
-      // Add to result only the first time we see the value
-      if (alreadySeen.add(value)) {
-        result.add(value);
-      }
-    }
-    // If there were no duplicates, return the exact same instance we got.
-    if (result.size() == values.size()) {
-      return values;
-    } else {
-      return result;
-    }
-  }
-
   /** Tracks limitations on referring to an option in a {@code config_setting}. */
   // TODO(bazel-team): There will likely also be a need to customize whether or not an option is
   // visible to users for setting on the command line (or perhaps even in a test of a Starlark

--- a/src/test/java/com/google/devtools/build/lib/analysis/PlatformOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/PlatformOptionsTest.java
@@ -41,7 +41,7 @@ public final class PlatformOptionsTest extends OptionsTestCase<PlatformOptions> 
 
   @Test
   public void testExtraToolchains_ordering() throws Exception {
-    // The ordering matters for tool chains, since we pick the first available toolchain.
+    // The ordering matters for tool chains, but the last one in the list has highest priority.
     PlatformOptions one = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "one", "two");
     PlatformOptions two = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "two", "one");
     assertDifferent(one, two);
@@ -52,6 +52,14 @@ public final class PlatformOptionsTest extends OptionsTestCase<PlatformOptions> 
     // Specifying the same tool chain multiple times is a no-op.
     PlatformOptions one = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "one", "one");
     PlatformOptions two = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "one");
+    assertSame(one, two);
+  }
+
+  @Test
+  public void testExtraToolchains_duplicates_keepLast() throws Exception {
+    // The last toolchain in the list has highest priority, so keep the last of any duplicates.
+    PlatformOptions one = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "one", "two", "one");
+    PlatformOptions two = createWithPrefix(EXTRA_TOOLCHAINS_PREFIX, "two", "one");
     assertSame(one, two);
   }
 


### PR DESCRIPTION
Because the semantics of `--extra_toolchains` are that the last entry has highest priority, when deduping we need to keep the **last** entry, not the first.

Since nothing else used `dedupeOnly`, remove that entirely.

Fixes #22912.

Closes #23093.

PiperOrigin-RevId: 655696234
Change-Id: Icb5f70c47814803a1455d6b8512d977fa5f13469

Fixes #23095