### PR TITLE
[7.4.0] Output reuse

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionMetadata.java
@@ -119,4 +119,14 @@ public interface ActionExecutionMetadata extends ActionAnalysisMetadata {
   default boolean mayInsensitivelyPropagateInputs() {
     return false;
   }
+
+  /**
+   * Returns true if the action may modify spawn outputs after the spawn has executed.
+   *
+   * <p>If this returns true, any kind of spawn output caching or reuse needs to happen
+   * synchronously directly after the spawn execution.
+   */
+  default boolean mayModifySpawnOutputsAfterExecution() {
+    return false;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
@@ -488,6 +488,149 @@ public interface SpawnResult {
     }
   }
 
+  /**
+   * A helper class for wrapping an existing {@link SpawnResult} and modifying a subset of its
+   * methods.
+   */
+  class DelegateSpawnResult implements SpawnResult {
+    private final SpawnResult delegate;
+
+    public DelegateSpawnResult(SpawnResult delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean setupSuccess() {
+      return delegate.setupSuccess();
+    }
+
+    @Override
+    public boolean isCatastrophe() {
+      return delegate.isCatastrophe();
+    }
+
+    @Override
+    public Status status() {
+      return delegate.status();
+    }
+
+    @Override
+    public int exitCode() {
+      return delegate.exitCode();
+    }
+
+    @Override
+    @Nullable
+    public FailureDetail failureDetail() {
+      return delegate.failureDetail();
+    }
+
+    @Override
+    @Nullable
+    public String getExecutorHostName() {
+      return delegate.getExecutorHostName();
+    }
+
+    @Override
+    public String getRunnerName() {
+      return delegate.getRunnerName();
+    }
+
+    @Override
+    public String getRunnerSubtype() {
+      return delegate.getRunnerSubtype();
+    }
+
+    @Override
+    @Nullable
+    public Instant getStartTime() {
+      return delegate.getStartTime();
+    }
+
+    @Override
+    public int getWallTimeInMs() {
+      return delegate.getWallTimeInMs();
+    }
+
+    @Override
+    public int getUserTimeInMs() {
+      return delegate.getUserTimeInMs();
+    }
+
+    @Override
+    public int getSystemTimeInMs() {
+      return delegate.getSystemTimeInMs();
+    }
+
+    @Override
+    @Nullable
+    public Long getNumBlockOutputOperations() {
+      return delegate.getNumBlockOutputOperations();
+    }
+
+    @Override
+    @Nullable
+    public Long getNumBlockInputOperations() {
+      return delegate.getNumBlockInputOperations();
+    }
+
+    @Override
+    @Nullable
+    public Long getNumInvoluntaryContextSwitches() {
+      return delegate.getNumInvoluntaryContextSwitches();
+    }
+
+    @Override
+    @Nullable
+    public Long getMemoryInKb() {
+      return delegate.getMemoryInKb();
+    }
+
+    @Override
+    public SpawnMetrics getMetrics() {
+      return delegate.getMetrics();
+    }
+
+    @Override
+    public boolean isCacheHit() {
+      return delegate.isCacheHit();
+    }
+
+    @Override
+    public String getFailureMessage() {
+      return delegate.getFailureMessage();
+    }
+
+    @Override
+    @Nullable
+    public InputStream getInMemoryOutput(ActionInput output) {
+      return delegate.getInMemoryOutput(output);
+    }
+
+    @Override
+    public String getDetailMessage(
+        String message, boolean catastrophe, boolean forciblyRunRemotely) {
+      return delegate.getDetailMessage(message, catastrophe, forciblyRunRemotely);
+    }
+
+    @Override
+    @Nullable
+    public MetadataLog getActionMetadataLog() {
+      return delegate.getActionMetadataLog();
+    }
+
+    @Override
+    public boolean wasRemote() {
+      return delegate.wasRemote();
+    }
+
+    @Override
+    @Nullable
+    public Digest getDigest() {
+      return delegate.getDigest();
+    }
+  }
+
   /** Builder class for {@link SpawnResult}. */
   final class Builder {
     private int exitCode;

--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
@@ -29,7 +29,6 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Instant;
 import java.util.Locale;
 import javax.annotation.Nullable;
@@ -38,7 +37,7 @@ import javax.annotation.Nullable;
 @SuppressWarnings("GoodTime") // Use ints instead of Durations to improve build time (cl/505728570)
 public interface SpawnResult {
 
-  int POSIX_TIMEOUT_EXIT_CODE = /*SIGNAL_BASE=*/ 128 + /*SIGALRM=*/ 14;
+  int POSIX_TIMEOUT_EXIT_CODE = /* SIGNAL_BASE= */ 128 + /* SIGALRM= */ 14;
 
   /** The status of the attempted Spawn execution. */
   enum Status {
@@ -262,14 +261,11 @@ public interface SpawnResult {
    * ExecutionRequirements#REMOTE_EXECUTION_INLINE_OUTPUTS}.
    */
   @Nullable
-  default InputStream getInMemoryOutput(ActionInput output) {
+  default ByteString getInMemoryOutput(ActionInput output) {
     return null;
   }
 
-  String getDetailMessage(
-      String message,
-      boolean catastrophe,
-      boolean forciblyRunRemotely);
+  String getDetailMessage(String message, boolean catastrophe, boolean forciblyRunRemotely);
 
   /** Returns a file path to the action metadata log. */
   @Nullable
@@ -434,11 +430,8 @@ public interface SpawnResult {
 
     @Override
     public String getDetailMessage(
-        String message,
-        boolean catastrophe,
-        boolean forciblyRunRemotely) {
-      TerminationStatus status = new TerminationStatus(
-          exitCode(), status() == Status.TIMEOUT);
+        String message, boolean catastrophe, boolean forciblyRunRemotely) {
+      TerminationStatus status = new TerminationStatus(exitCode(), status() == Status.TIMEOUT);
       String reason = "(" + status.toShortString() + ")"; // e.g. "(Exit 1)"
       String explanation = Strings.isNullOrEmpty(message) ? "" : ": " + message;
 
@@ -457,17 +450,18 @@ public interface SpawnResult {
         explanation += " (Remote action was terminated due to Out of Memory.)";
       }
       if (status() != Status.TIMEOUT && forciblyRunRemotely) {
-        explanation += " Action tagged as local was forcibly run remotely and failed - it's "
-            + "possible that the action simply doesn't work remotely";
+        explanation +=
+            " Action tagged as local was forcibly run remotely and failed - it's "
+                + "possible that the action simply doesn't work remotely";
       }
       return reason + explanation;
     }
 
     @Nullable
     @Override
-    public InputStream getInMemoryOutput(ActionInput output) {
+    public ByteString getInMemoryOutput(ActionInput output) {
       if (inMemoryOutputFile != null && inMemoryOutputFile.equals(output)) {
-        return inMemoryContents.newInput();
+        return inMemoryContents;
       }
       return null;
     }
@@ -603,7 +597,7 @@ public interface SpawnResult {
 
     @Override
     @Nullable
-    public InputStream getInMemoryOutput(ActionInput output) {
+    public ByteString getInMemoryOutput(ActionInput output) {
       return delegate.getInMemoryOutput(output);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.StarlarkAction.Code;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.protobuf.ByteString;
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -315,9 +316,9 @@ public class StarlarkAction extends SpawnAction {
       // Note: SpawnActionContext guarantees that the first list entry exists and corresponds to the
       // executed spawn.
       Artifact unusedInputsListArtifact = unusedInputsList.get();
-      InputStream inputStream = spawnResults.get(0).getInMemoryOutput(unusedInputsListArtifact);
-      if (inputStream != null) {
-        return inputStream;
+      ByteString content = spawnResults.get(0).getInMemoryOutput(unusedInputsListArtifact);
+      if (content != null) {
+        return content.newInput();
       }
       // Fallback to reading from disk.
       try {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -309,6 +309,16 @@ public class TestRunnerAction extends AbstractAction
     this.isExecutedOnWindows = isExecutedOnWindows;
   }
 
+  @Override
+  public boolean mayModifySpawnOutputsAfterExecution() {
+    // Test actions modify test spawn outputs after execution:
+    // - if there are multiple attempts (unavoidable);
+    // - in all cases due to appending any stray stderr output to the test log in
+    //   StandaloneTestStrategy.
+    // TODO: Get rid of the second case and only return true if there are multiple attempts.
+    return true;
+  }
+
   public boolean isExecutedOnWindows() {
     return isExecutedOnWindows;
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -221,7 +221,7 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
               ? resultMessage
               : CommandFailureUtils.describeCommandFailure(
                   executionOptions.verboseFailures, cwd, spawn);
-      throw new SpawnExecException(message, spawnResult, /*forciblyRunRemotely=*/ false);
+      throw new SpawnExecException(message, spawnResult, /* forciblyRunRemotely= */ false);
     }
     return ImmutableList.of(spawnResult);
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -225,6 +225,7 @@ java_library(
     deps = [
         ":spawn_runner",
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/profiler",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnCache.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import java.io.Closeable;
 import java.io.IOException;

--- a/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
@@ -52,6 +52,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
 import com.google.devtools.build.lib.vfs.SyscallCache;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
@@ -351,6 +352,7 @@ public class SpawnIncludeScanner {
    *     Otherwise "null"
    * @throws ExecException if scanning fails
    */
+  @Nullable
   private static InputStream spawnGrep(
       Artifact input,
       PathFragment outputExecPath,
@@ -412,7 +414,11 @@ public class SpawnIncludeScanner {
     }
 
     SpawnResult result = Iterables.getLast(results);
-    return result.getInMemoryOutput(output);
+    ByteString includesContent = result.getInMemoryOutput(output);
+    if (includesContent != null) {
+      return includesContent.newInput();
+    }
+    return null;
   }
 
   private static void dump(ActionExecutionContext fromContext, ActionExecutionContext toContext) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1406,6 +1406,14 @@ public class RemoteExecutionService {
   public static final class LocalExecution {
     private final RemoteAction action;
     private final SettableFuture<SpawnResult> spawnResultFuture;
+    private final Phaser spawnResultConsumers =
+        new Phaser(1) {
+          @Override
+          protected boolean onAdvance(int phase, int registeredParties) {
+            // We only use a single phase.
+            return true;
+          }
+        };
 
     private LocalExecution(RemoteAction action) {
       this.action = action;
@@ -1427,6 +1435,37 @@ public class RemoteExecutionService {
         return null;
       }
       return new LocalExecution(action);
+    }
+
+    /**
+     * Attempts to register a thread waiting for the {@link #spawnResultFuture} to become available
+     * and returns true if successful.
+     *
+     * <p>Every call to this method must be matched by a call to {@link #unregister()} via
+     * try-finally.
+     *
+     * <p>This always returns true for actions that do not modify their spawns' outputs after
+     * execution.
+     */
+    public boolean registerForOutputReuse() {
+      // We only use a single phase.
+      return spawnResultConsumers.register() == 0;
+    }
+
+    /**
+     * Unregisters a thread waiting for the {@link #spawnResultFuture}, either after successful
+     * reuse of the outputs or upon failure.
+     */
+    public void unregister() {
+      spawnResultConsumers.arriveAndDeregister();
+    }
+
+    /**
+     * Waits for all potential consumers of the {@link #spawnResultFuture} to be done with their
+     * output reuse.
+     */
+    public void awaitAllOutputReuse() {
+      spawnResultConsumers.arriveAndAwaitAdvance();
     }
 
     /**
@@ -1644,7 +1683,8 @@ public class RemoteExecutionService {
         SpawnResult.Status.SUCCESS.equals(spawnResult.status()) && spawnResult.exitCode() == 0,
         "shouldn't upload outputs of failed local action");
 
-    if (remoteOptions.remoteCacheAsync) {
+    if (remoteOptions.remoteCacheAsync
+        && !action.getSpawn().getResourceOwner().mayModifySpawnOutputsAfterExecution()) {
       Single.using(
               remoteCache::retain,
               remoteCache ->

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1495,55 +1495,67 @@ public class RemoteExecutionService {
         previousExecution.action.getSpawn().getOutputFiles().stream()
             .collect(toImmutableMap(output -> execRoot.getRelative(output.getExecPath()), o -> o));
     Map<Path, Path> realToTmpPath = new HashMap<>();
-    for (String output : action.getCommand().getOutputPathsList()) {
-      Path sourcePath =
-          previousExecution
-              .action
-              .getRemotePathResolver()
-              .outputPathToLocalPath(encodeBytestringUtf8(output));
-      ActionInput outputArtifact = previousOutputs.get(sourcePath);
-      Path tmpPath = tempPathGenerator.generateTempPath();
-      tmpPath.getParentDirectory().createDirectoryAndParents();
-      try {
-        if (outputArtifact.isDirectory()) {
-          tmpPath.createDirectory();
-          FileSystemUtils.copyTreesBelow(sourcePath, tmpPath, Symlinks.NOFOLLOW);
-        } else if (outputArtifact.isSymlink()) {
-          FileSystemUtils.ensureSymbolicLink(tmpPath, sourcePath.readSymbolicLink());
-        } else {
-          FileSystemUtils.copyFile(sourcePath, tmpPath);
-        }
-      } catch (FileNotFoundException e) {
-        // The spawn this action was deduplicated against failed to create an output file. If the
-        // output is mandatory, we cannot reuse the previous execution.
-        if (action.getSpawn().isMandatoryOutput(outputArtifact)) {
-          return null;
+    try {
+      for (String output : action.getCommand().getOutputPathsList()) {
+        Path sourcePath =
+            previousExecution
+                .action
+                .getRemotePathResolver()
+                .outputPathToLocalPath(encodeBytestringUtf8(output));
+        ActionInput outputArtifact = previousOutputs.get(sourcePath);
+        Path tmpPath = tempPathGenerator.generateTempPath();
+        tmpPath.getParentDirectory().createDirectoryAndParents();
+        try {
+          if (outputArtifact.isDirectory()) {
+            tmpPath.createDirectory();
+            FileSystemUtils.copyTreesBelow(sourcePath, tmpPath, Symlinks.NOFOLLOW);
+          } else if (outputArtifact.isSymlink()) {
+            FileSystemUtils.ensureSymbolicLink(tmpPath, sourcePath.readSymbolicLink());
+          } else {
+            FileSystemUtils.copyFile(sourcePath, tmpPath);
+          }
+
+          Path targetPath =
+              action.getRemotePathResolver().outputPathToLocalPath(encodeBytestringUtf8(output));
+          realToTmpPath.put(targetPath, tmpPath);
+        } catch (FileNotFoundException e) {
+          // The spawn this action was deduplicated against failed to create an output file. If the
+          // output is mandatory, we cannot reuse the previous execution.
+          if (action.getSpawn().isMandatoryOutput(outputArtifact)) {
+            return null;
+          }
         }
       }
 
-      Path targetPath =
-          action.getRemotePathResolver().outputPathToLocalPath(encodeBytestringUtf8(output));
-      realToTmpPath.put(targetPath, tmpPath);
+      // TODO: FileOutErr is action-scoped, not spawn-scoped, but this is not a problem for the
+      //  current use case of supporting deduplication of path mapped spawns:
+      //  1. Starlark and C++ compilation actions always create a single spawn.
+      //  2. Java compilation actions may run a fallback spawn, but reset the FileOutErr before
+      //     running it.
+      //  If this changes, we will need to introduce a spawn-scoped OutErr.
+      FileOutErr.dump(
+          previousExecution.action.getSpawnExecutionContext().getFileOutErr(),
+          action.getSpawnExecutionContext().getFileOutErr());
+
+      action
+          .getSpawnExecutionContext()
+          .lockOutputFiles(
+              previousSpawnResult.exitCode(),
+              previousSpawnResult.getFailureMessage(),
+              action.getSpawnExecutionContext().getFileOutErr());
+      // All outputs are created locally.
+      moveOutputsToFinalLocation(realToTmpPath.keySet(), realToTmpPath);
+    } catch (InterruptedException | IOException e) {
+      // Delete any copied output files.
+      try {
+        for (Path tmpPath : realToTmpPath.values()) {
+          tmpPath.delete();
+        }
+      } catch (IOException ignored) {
+        // Best effort, will be cleaned up at server restart.
+      }
+      throw e;
     }
-
-    // TODO: FileOutErr is action-scoped, not spawn-scoped, but this is not a problem for the
-    //  current use case of supporting deduplication of path mapped spawns:
-    //  1. Starlark and C++ compilation actions always create a single spawn.
-    //  2. Java compilation actions may run a fallback spawn, but reset the FileOutErr before
-    //     running it.
-    //  If this changes, we will need to introduce a spawn-scoped OutErr.
-    FileOutErr.dump(
-        previousExecution.action.getSpawnExecutionContext().getFileOutErr(),
-        action.getSpawnExecutionContext().getFileOutErr());
-
-    action
-        .getSpawnExecutionContext()
-        .lockOutputFiles(
-            previousSpawnResult.exitCode(),
-            previousSpawnResult.getFailureMessage(),
-            action.getSpawnExecutionContext().getFileOutErr());
-    // All outputs are created locally.
-    moveOutputsToFinalLocation(realToTmpPath.keySet(), realToTmpPath);
 
     return previousSpawnResult;
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.transform;
@@ -62,6 +63,7 @@ import com.google.common.collect.Maps;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
@@ -130,6 +132,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.core.SingleObserver;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -145,9 +148,11 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.Semaphore;
@@ -927,15 +932,12 @@ public class RemoteExecutionService {
     }
   }
 
-  /**
-   * Copies moves the downloaded outputs from their download location to their declared location.
-   */
+  /** Moves the locally created outputs from their temporary location to their declared location. */
   private void moveOutputsToFinalLocation(
-      List<FileMetadata> finishedDownloads, Map<Path, Path> realToTmpPath) throws IOException {
+      Iterable<Path> localOutputs, Map<Path, Path> realToTmpPath) throws IOException {
     // Move the output files from their temporary name to the actual output file name. Executable
     // bit is ignored since the file permission will be changed to 0555 after execution.
-    for (FileMetadata outputFile : finishedDownloads) {
-      Path realPath = outputFile.path();
+    for (Path realPath : localOutputs) {
       Path tmpPath = Preconditions.checkNotNull(realToTmpPath.get(realPath));
       realPath.getParentDirectory().createDirectoryAndParents();
       FileSystemUtils.moveFile(tmpPath, realPath);
@@ -1336,7 +1338,8 @@ public class RemoteExecutionService {
       // TODO(chiwang): Stage directories directly
       ((BazelOutputService) outputService).stageArtifacts(finishedDownloads);
     } else {
-      moveOutputsToFinalLocation(finishedDownloads, realToTmpPath);
+      moveOutputsToFinalLocation(
+          Iterables.transform(finishedDownloads, FileMetadata::path), realToTmpPath);
     }
 
     List<SymlinkMetadata> symlinksInDirectories = new ArrayList<>();
@@ -1397,6 +1400,152 @@ public class RemoteExecutionService {
     }
 
     return null;
+  }
+
+  /** An ongoing local execution of a spawn. */
+  public static final class LocalExecution {
+    private final RemoteAction action;
+    private final SettableFuture<SpawnResult> spawnResultFuture;
+
+    private LocalExecution(RemoteAction action) {
+      this.action = action;
+      this.spawnResultFuture = SettableFuture.create();
+    }
+
+    /**
+     * Creates a new {@link LocalExecution} instance tracking the potential local execution of the
+     * given {@link RemoteAction} if there is a chance that the same action will be executed by a
+     * different Spawn.
+     *
+     * <p>This is only done for local (as in, non-remote) execution as remote executors are expected
+     * to already have deduplication mechanisms for actions in place, perhaps even across different
+     * builds and clients.
+     */
+    @Nullable
+    public static LocalExecution createIfDeduplicatable(RemoteAction action) {
+      if (action.getSpawn().getPathMapper().isNoop()) {
+        return null;
+      }
+      return new LocalExecution(action);
+    }
+
+    /**
+     * Signals to all potential consumers of the {@link #spawnResultFuture} that this execution has
+     * been cancelled and that the result will not be available.
+     */
+    public void cancel() {
+      spawnResultFuture.cancel(true);
+    }
+  }
+
+  /**
+   * Makes the {@link SpawnResult} available to all parallel {@link Spawn}s for the same {@link
+   * RemoteAction} waiting for it or notifies them that the spawn failed.
+   *
+   * @return Whether the spawn result should be uploaded to the cache.
+   */
+  public boolean commitResultAndDecideWhetherToUpload(
+      SpawnResult result, @Nullable LocalExecution execution) {
+    if (result.status().equals(SpawnResult.Status.SUCCESS) && result.exitCode() == 0) {
+      if (execution != null) {
+        execution.spawnResultFuture.set(result);
+      }
+      return true;
+    } else {
+      if (execution != null) {
+        execution.spawnResultFuture.cancel(true);
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Reuses the outputs of a concurrent local execution of the same RemoteAction in a different
+   * spawn.
+   *
+   * <p>Since each output file is generated by a unique action and actions generally take care to
+   * run a unique spawn for each output file, this method is only useful with path mapping enabled,
+   * which allows different spawns in a single build to have the same RemoteAction.ActionKey.
+   *
+   * @return The {@link SpawnResult} of the previous execution if it was successful, otherwise null.
+   */
+  @Nullable
+  public SpawnResult waitForAndReuseOutputs(RemoteAction action, LocalExecution previousExecution)
+      throws InterruptedException, IOException {
+    checkState(!shutdown.get(), "shutdown");
+
+    SpawnResult previousSpawnResult;
+    try {
+      previousSpawnResult = previousExecution.spawnResultFuture.get();
+    } catch (CancellationException | ExecutionException e) {
+      if (e.getCause() != null) {
+        Throwables.throwIfInstanceOf(e.getCause(), InterruptedException.class);
+        Throwables.throwIfUnchecked(e.getCause());
+      }
+      // The spawn this action was deduplicated against failed due to an exception or
+      // non-zero exit code. Since it isn't possible to transparently replay its failure for the
+      // current spawn, we rerun the action instead.
+      return null;
+    }
+
+    Preconditions.checkArgument(
+        action.getActionKey().equals(previousExecution.action.getActionKey()));
+
+    ImmutableMap<Path, ActionInput> previousOutputs =
+        previousExecution.action.getSpawn().getOutputFiles().stream()
+            .collect(toImmutableMap(output -> execRoot.getRelative(output.getExecPath()), o -> o));
+    Map<Path, Path> realToTmpPath = new HashMap<>();
+    for (String output : action.getCommand().getOutputPathsList()) {
+      Path sourcePath =
+          previousExecution
+              .action
+              .getRemotePathResolver()
+              .outputPathToLocalPath(encodeBytestringUtf8(output));
+      ActionInput outputArtifact = previousOutputs.get(sourcePath);
+      Path tmpPath = tempPathGenerator.generateTempPath();
+      tmpPath.getParentDirectory().createDirectoryAndParents();
+      try {
+        if (outputArtifact.isDirectory()) {
+          tmpPath.createDirectory();
+          FileSystemUtils.copyTreesBelow(sourcePath, tmpPath, Symlinks.NOFOLLOW);
+        } else if (outputArtifact.isSymlink()) {
+          FileSystemUtils.ensureSymbolicLink(tmpPath, sourcePath.readSymbolicLink());
+        } else {
+          FileSystemUtils.copyFile(sourcePath, tmpPath);
+        }
+      } catch (FileNotFoundException e) {
+        // The spawn this action was deduplicated against failed to create an output file. If the
+        // output is mandatory, we cannot reuse the previous execution.
+        if (action.getSpawn().isMandatoryOutput(outputArtifact)) {
+          return null;
+        }
+      }
+
+      Path targetPath =
+          action.getRemotePathResolver().outputPathToLocalPath(encodeBytestringUtf8(output));
+      realToTmpPath.put(targetPath, tmpPath);
+    }
+
+    // TODO: FileOutErr is action-scoped, not spawn-scoped, but this is not a problem for the
+    //  current use case of supporting deduplication of path mapped spawns:
+    //  1. Starlark and C++ compilation actions always create a single spawn.
+    //  2. Java compilation actions may run a fallback spawn, but reset the FileOutErr before
+    //     running it.
+    //  If this changes, we will need to introduce a spawn-scoped OutErr.
+    FileOutErr.dump(
+        previousExecution.action.getSpawnExecutionContext().getFileOutErr(),
+        action.getSpawnExecutionContext().getFileOutErr());
+
+    action
+        .getSpawnExecutionContext()
+        .lockOutputFiles(
+            previousSpawnResult.exitCode(),
+            previousSpawnResult.getFailureMessage(),
+            action.getSpawnExecutionContext().getFileOutErr());
+    // All outputs are created locally.
+    moveOutputsToFinalLocation(realToTmpPath.keySet(), realToTmpPath);
+
+    return previousSpawnResult;
   }
 
   private boolean shouldDownload(RemoteActionResult result, PathFragment execPath) {
@@ -1473,7 +1622,7 @@ public class RemoteExecutionService {
   }
 
   /** Upload outputs of a remote action which was executed locally to remote cache. */
-  public void uploadOutputs(RemoteAction action, SpawnResult spawnResult)
+  public void uploadOutputs(RemoteAction action, SpawnResult spawnResult, Runnable onUploadComplete)
       throws InterruptedException, ExecException {
     checkState(!shutdown.get(), "shutdown");
     checkState(
@@ -1509,6 +1658,7 @@ public class RemoteExecutionService {
                   Profiler.instance()
                       .completeTask(startTime, ProfilerTask.UPLOAD_TIME, "upload outputs");
                   backgroundTaskPhaser.arriveAndDeregister();
+                  onUploadComplete.run();
                 }
 
                 @Override
@@ -1517,6 +1667,7 @@ public class RemoteExecutionService {
                       .completeTask(startTime, ProfilerTask.UPLOAD_TIME, "upload outputs");
                   backgroundTaskPhaser.arriveAndDeregister();
                   reportUploadError(e);
+                  onUploadComplete.run();
                 }
               });
     } else {
@@ -1526,6 +1677,8 @@ public class RemoteExecutionService {
         manifest.upload(action.getRemoteActionExecutionContext(), remoteCache, reporter);
       } catch (IOException e) {
         reportUploadError(e);
+      } finally {
+        onUploadComplete.run();
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -26,7 +26,6 @@ import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
-import com.google.devtools.build.lib.actions.SpawnResult.Status;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.events.Event;
@@ -35,9 +34,11 @@ import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.RemoteExecutionService.LocalExecution;
 import com.google.devtools.build.lib.remote.RemoteExecutionService.RemoteActionResult;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
@@ -45,6 +46,7 @@ import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
 
 /** A remote {@link SpawnCache} implementation. */
 @ThreadSafe // If the RemoteActionCache implementation is thread-safe.
@@ -55,6 +57,8 @@ final class RemoteSpawnCache implements SpawnCache {
   private final RemoteExecutionService remoteExecutionService;
   private final DigestUtil digestUtil;
   private final boolean verboseFailures;
+  private final ConcurrentHashMap<RemoteCacheClient.ActionKey, LocalExecution> inFlightExecutions =
+      new ConcurrentHashMap<>();
 
   RemoteSpawnCache(
       Path execRoot,
@@ -96,7 +100,19 @@ final class RemoteSpawnCache implements SpawnCache {
     context.setDigest(digestUtil.asSpawnLogProto(action.getActionKey()));
 
     Profiler prof = Profiler.instance();
+    LocalExecution thisExecution = null;
     if (shouldAcceptCachedResult) {
+      // With path mapping enabled, different Spawns in a single build can have the same ActionKey.
+      // When their result isn't in the cache and two of them are scheduled concurrently, neither
+      // will result in a cache hit before the other finishes and uploads its result, which results
+      // in unnecessary work. To avoid this, we keep track of in-flight executions as long as their
+      // results haven't been uploaded to the cache yet and deduplicate all of them against the
+      // first one.
+      LocalExecution previousExecution = null;
+      thisExecution = LocalExecution.createIfDeduplicatable(action);
+      if (shouldUploadLocalResults && thisExecution != null) {
+        previousExecution = inFlightExecutions.putIfAbsent(action.getActionKey(), thisExecution);
+      }
       // Metadata will be available in context.current() until we detach.
       // This is done via a thread-local variable.
       try {
@@ -146,9 +162,41 @@ final class RemoteSpawnCache implements SpawnCache {
           remoteExecutionService.report(Event.warn(errorMessage));
         }
       }
+      if (previousExecution != null) {
+        Stopwatch fetchTime = Stopwatch.createStarted();
+        SpawnResult previousResult;
+        try (SilentCloseable c = prof.profile(REMOTE_DOWNLOAD, "reuse outputs")) {
+          previousResult = remoteExecutionService.waitForAndReuseOutputs(action, previousExecution);
+        }
+        if (previousResult != null) {
+          spawnMetrics
+              .setFetchTimeInMs((int) fetchTime.elapsed().toMillis())
+              .setTotalTimeInMs((int) totalTime.elapsed().toMillis())
+              .setNetworkTimeInMs((int) action.getNetworkTime().getDuration().toMillis());
+          SpawnMetrics buildMetrics = spawnMetrics.build();
+          return SpawnCache.success(
+              new SpawnResult.DelegateSpawnResult(previousResult) {
+                @Override
+                public String getRunnerName() {
+                  return "deduplicated";
+                }
+
+                @Override
+                public SpawnMetrics getMetrics() {
+                  return buildMetrics;
+                }
+              });
+        }
+        // If we reach here, the previous execution was not successful (it encountered an exception
+        // or the spawn had an exit code != 0). Since it isn't possible to accurately recreate the
+        // failure without rerunning the action, we fall back to running the action locally. This
+        // means that we have introduced an unnecessary wait, but that can only happen in the case
+        // of a failing build with --keep_going.
+      }
     }
 
     if (shouldUploadLocalResults) {
+      final LocalExecution thisExecutionFinal = thisExecution;
       return new CacheHandle() {
         @Override
         public boolean hasResult() {
@@ -167,8 +215,8 @@ final class RemoteSpawnCache implements SpawnCache {
 
         @Override
         public void store(SpawnResult result) throws ExecException, InterruptedException {
-          boolean uploadResults = Status.SUCCESS.equals(result.status()) && result.exitCode() == 0;
-          if (!uploadResults) {
+          if (!remoteExecutionService.commitResultAndDecideWhetherToUpload(
+              result, thisExecutionFinal)) {
             return;
           }
 
@@ -185,11 +233,13 @@ final class RemoteSpawnCache implements SpawnCache {
             }
           }
 
-          remoteExecutionService.uploadOutputs(action, result);
+          // As soon as the result is in the cache, actions can get the result from it instead of
+          // from the first in-flight execution. Not keeping in-flight executions around
+          // indefinitely is important to avoid excessive memory pressure - Spawns can be very
+          // large.
+          remoteExecutionService.uploadOutputs(
+              action, result, () -> inFlightExecutions.remove(action.getActionKey()));
         }
-
-        @Override
-        public void close() {}
 
         private void checkForConcurrentModifications()
             throws IOException, ForbiddenActionInputException {
@@ -202,6 +252,13 @@ final class RemoteSpawnCache implements SpawnCache {
             if (metadata.wasModifiedSinceDigest(path)) {
               throw new IOException(path + " was modified during execution");
             }
+          }
+        }
+
+        @Override
+        public void close() {
+          if (thisExecutionFinal != null) {
+            thisExecutionFinal.cancel();
           }
         }
       };

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -695,7 +695,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
       }
     }
 
-    remoteExecutionService.uploadOutputs(action, result);
+    remoteExecutionService.uploadOutputs(action, result, () -> {});
     return result;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionInput;
-import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -76,12 +75,6 @@ public interface RemotePathResolver {
    */
   Path outputPathToLocalPath(String outputPath);
 
-  /** Resolves the local {@link Path} for the {@link ActionInput}. */
-  default Path outputPathToLocalPath(ActionInput actionInput) {
-    String outputPath = localPathToOutputPath(actionInput.getExecPath());
-    return outputPathToLocalPath(outputPath);
-  }
-
   /** Creates the default {@link RemotePathResolver}. */
   static RemotePathResolver createDefault(Path execRoot) {
     return new DefaultRemotePathResolver(execRoot);
@@ -138,11 +131,6 @@ public interface RemotePathResolver {
     @Override
     public Path outputPathToLocalPath(String outputPath) {
       return execRoot.getRelative(outputPath);
-    }
-
-    @Override
-    public Path outputPathToLocalPath(ActionInput actionInput) {
-      return ActionInputHelper.toInputPath(actionInput, execRoot);
     }
   }
 
@@ -224,10 +212,6 @@ public interface RemotePathResolver {
       return getBase().getRelative(outputPath);
     }
 
-    @Override
-    public Path outputPathToLocalPath(ActionInput actionInput) {
-      return ActionInputHelper.toInputPath(actionInput, execRoot);
-    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -96,6 +96,7 @@ import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.SkyframeLookupResult;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -1538,16 +1539,11 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   }
 
   @Nullable
-  private byte[] getDotDContents(SpawnResult spawnResult) throws EnvironmentalExecException {
+  private byte[] getDotDContents(SpawnResult spawnResult) {
     if (getDotdFile() != null) {
-      InputStream in = spawnResult.getInMemoryOutput(getDotdFile());
-      if (in != null) {
-        try {
-          return ByteStreams.toByteArray(in);
-        } catch (IOException e) {
-          throw new EnvironmentalExecException(
-              e, createFailureDetail("Reading in-memory .d file failed", Code.D_FILE_READ_FAILURE));
-        }
+      ByteString content = spawnResult.getInMemoryOutput(getDotdFile());
+      if (content != null) {
+        return content.toByteArray();
       }
     }
     return null;

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -82,6 +82,7 @@ import com.google.devtools.build.lib.util.OnDemandString;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.view.proto.Deps;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
 import java.io.IOException;
 import java.io.InputStream;
@@ -847,11 +848,11 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
       Artifact outputDepsProto,
       ActionExecutionContext actionExecutionContext)
       throws IOException {
-    InputStream inMemoryOutput = spawnResult.getInMemoryOutput(outputDepsProto);
+    ByteString inMemoryOutput = spawnResult.getInMemoryOutput(outputDepsProto);
     try (InputStream inputStream =
         inMemoryOutput == null
             ? actionExecutionContext.getInputPath(outputDepsProto).getInputStream()
-            : inMemoryOutput) {
+            : inMemoryOutput.newInput()) {
       return Deps.Dependencies.parseFrom(inputStream, ExtensionRegistry.getEmptyRegistry());
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -714,6 +714,14 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     return null;
   }
 
+  @Override
+  public boolean mayModifySpawnOutputsAfterExecution() {
+    // Causes of spawn output modification after execution:
+    // - Fallback to the full classpath with --experimental_java_classpath=bazel.
+    // - In-place rewriting of .jdeps files with --experimental_output_paths=strip.
+    return true;
+  }
+
   /**
    * Locally rewrites a .jdeps file to replace missing config prefixes.
    *

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -161,6 +161,14 @@ public final class JavaHeaderCompileAction extends SpawnAction {
     }
   }
 
+  @Override
+  public boolean mayModifySpawnOutputsAfterExecution() {
+    // Causes of spawn output modification after execution:
+    // - In-place rewriting of .jdeps files with --experimental_output_paths=strip.
+    // TODO: Use separate files as action and spawn output to avoid in-place modification.
+    return true;
+  }
+
   public static Builder newBuilder(RuleContext ruleContext) {
     return new Builder(ruleContext);
   }

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
@@ -66,7 +66,7 @@ public final class SpawnResultTest {
   }
 
   @Test
-  public void inMemoryContents() throws Exception {
+  public void inMemoryContents() {
     ActionInput output = ActionInputHelper.fromPath("/foo/bar");
     ByteString contents = ByteString.copyFromUtf8("hello world");
 
@@ -78,7 +78,7 @@ public final class SpawnResultTest {
             .setInMemoryOutput(output, contents)
             .build();
 
-    assertThat(ByteString.readFrom(r.getInMemoryOutput(output))).isEqualTo(contents);
+    assertThat(r.getInMemoryOutput(output)).isEqualTo(contents);
     assertThat(r.getInMemoryOutput(null)).isEqualTo(null);
     assertThat(r.getInMemoryOutput(ActionInputHelper.fromPath("/does/not/exist"))).isEqualTo(null);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -1647,7 +1647,7 @@ public class RemoteExecutionServiceTest {
 
     // act
     UploadManifest manifest = service.buildUploadManifest(action, spawnResult);
-    service.uploadOutputs(action, spawnResult);
+    service.uploadOutputs(action, spawnResult, () -> {});
 
     // assert
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
@@ -1694,7 +1694,7 @@ public class RemoteExecutionServiceTest {
 
     // act
     UploadManifest manifest = service.buildUploadManifest(action, spawnResult);
-    service.uploadOutputs(action, spawnResult);
+    service.uploadOutputs(action, spawnResult, () -> {});
 
     // assert
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
@@ -1768,7 +1768,7 @@ public class RemoteExecutionServiceTest {
 
     // act
     UploadManifest manifest = service.buildUploadManifest(action, spawnResult);
-    service.uploadOutputs(action, spawnResult);
+    service.uploadOutputs(action, spawnResult, () -> {});
 
     // assert
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
@@ -1804,7 +1804,7 @@ public class RemoteExecutionServiceTest {
 
     // act
     UploadManifest manifest = service.buildUploadManifest(action, spawnResult);
-    service.uploadOutputs(action, spawnResult);
+    service.uploadOutputs(action, spawnResult, () -> {});
 
     // assert
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
@@ -1856,7 +1856,7 @@ public class RemoteExecutionServiceTest {
             .build();
 
     // act
-    service.uploadOutputs(action, spawnResult);
+    service.uploadOutputs(action, spawnResult, () -> {});
 
     // assert
     assertThat(
@@ -1882,7 +1882,7 @@ public class RemoteExecutionServiceTest {
         .when(cache)
         .uploadActionResult(any(), any(), any());
 
-    service.uploadOutputs(action, spawnResult);
+    service.uploadOutputs(action, spawnResult, () -> {});
 
     assertThat(eventHandler.getEvents()).hasSize(1);
     Event evt = eventHandler.getEvents().get(0);
@@ -1907,7 +1907,7 @@ public class RemoteExecutionServiceTest {
             .setRunnerName("test")
             .build();
 
-    service.uploadOutputs(action, spawnResult);
+    service.uploadOutputs(action, spawnResult, () -> {});
 
     assertThat(eventHandler.getPosts())
         .containsAtLeast(
@@ -1934,7 +1934,7 @@ public class RemoteExecutionServiceTest {
             .setRunnerName("test")
             .build();
 
-    service.uploadOutputs(action, spawnResult);
+    service.uploadOutputs(action, spawnResult, () -> {});
 
     // assert
     assertThat(cache.getNumFindMissingDigests()).isEmpty();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,6 +53,7 @@ import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
+import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
 import com.google.devtools.build.lib.clock.JavaClock;
@@ -82,6 +84,7 @@ import com.google.devtools.build.lib.server.FailureDetails.Spawn.Code;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.OutputService;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -98,6 +101,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -119,7 +123,7 @@ public class RemoteSpawnCacheTest {
   private Path execRoot;
   private TempPathGenerator tempPathGenerator;
   private SimpleSpawn simpleSpawn;
-  private FakeActionInputFileCache fakeFileCache;
+  private SpawnExecutionContext simplePolicy;
   @Mock private RemoteCache remoteCache;
   private FileOutErr outErr;
 
@@ -128,101 +132,102 @@ public class RemoteSpawnCacheTest {
   private Reporter reporter;
   private RemotePathResolver remotePathResolver;
 
-  private final SpawnExecutionContext simplePolicy =
-      new SpawnExecutionContext() {
-        @Nullable private com.google.devtools.build.lib.exec.Protos.Digest digest;
+  private static SpawnExecutionContext createSpawnExecutionContext(
+      Spawn spawn, Path execRoot, FakeActionInputFileCache fakeFileCache, FileOutErr outErr) {
+    return new SpawnExecutionContext() {
+      @Nullable private com.google.devtools.build.lib.exec.Protos.Digest digest;
 
-        @Override
-        public int getId() {
-          return 0;
-        }
+      @Override
+      public int getId() {
+        return 0;
+      }
 
-        @Override
-        public void setDigest(com.google.devtools.build.lib.exec.Protos.Digest digest) {
-          checkState(this.digest == null);
-          this.digest = digest;
-        }
+      @Override
+      public void setDigest(com.google.devtools.build.lib.exec.Protos.Digest digest) {
+        checkState(this.digest == null);
+        this.digest = digest;
+      }
 
-        @Override
-        @Nullable
-        public com.google.devtools.build.lib.exec.Protos.Digest getDigest() {
-          return digest;
-        }
+      @Override
+      @Nullable
+      public com.google.devtools.build.lib.exec.Protos.Digest getDigest() {
+        return digest;
+      }
 
-        @Override
-        public ListenableFuture<Void> prefetchInputs() {
-          return immediateVoidFuture();
-        }
+      @Override
+      public ListenableFuture<Void> prefetchInputs() {
+        return immediateVoidFuture();
+      }
 
-        @Override
-        public void lockOutputFiles(int exitCode, String errorMessage, FileOutErr outErr) {}
+      @Override
+      public void lockOutputFiles(int exitCode, String errorMessage, FileOutErr outErr) {}
 
-        @Override
-        public boolean speculating() {
-          return false;
-        }
+      @Override
+      public boolean speculating() {
+        return false;
+      }
 
-        @Override
-        public InputMetadataProvider getInputMetadataProvider() {
-          return fakeFileCache;
-        }
+      @Override
+      public InputMetadataProvider getInputMetadataProvider() {
+        return fakeFileCache;
+      }
 
-        @Override
-        public ArtifactPathResolver getPathResolver() {
-          return ArtifactPathResolver.forExecRoot(execRoot);
-        }
+      @Override
+      public ArtifactPathResolver getPathResolver() {
+        return ArtifactPathResolver.forExecRoot(execRoot);
+      }
 
-        @Override
-        public ArtifactExpander getArtifactExpander() {
-          throw new UnsupportedOperationException();
-        }
+      @Override
+      public ArtifactExpander getArtifactExpander() {
+        throw new UnsupportedOperationException();
+      }
 
-        @Override
-        public SpawnInputExpander getSpawnInputExpander() {
-          return new SpawnInputExpander(execRoot, /*strict*/ false);
-        }
+      @Override
+      public SpawnInputExpander getSpawnInputExpander() {
+        return new SpawnInputExpander(execRoot, /*strict*/ false);
+      }
 
-        @Override
-        public Duration getTimeout() {
-          return Duration.ZERO;
-        }
+      @Override
+      public Duration getTimeout() {
+        return Duration.ZERO;
+      }
 
-        @Override
-        public FileOutErr getFileOutErr() {
-          return outErr;
-        }
+      @Override
+      public FileOutErr getFileOutErr() {
+        return outErr;
+      }
 
-        @Override
-        public SortedMap<PathFragment, ActionInput> getInputMapping(
-            PathFragment baseDirectory, boolean willAccessRepeatedly)
-            throws IOException, ForbiddenActionInputException {
-          return getSpawnInputExpander()
-              .getInputMapping(simpleSpawn, SIMPLE_ARTIFACT_EXPANDER, baseDirectory, fakeFileCache);
-        }
+      @Override
+      public SortedMap<PathFragment, ActionInput> getInputMapping(
+          PathFragment baseDirectory, boolean willAccessRepeatedly)
+          throws IOException, ForbiddenActionInputException {
+        return getSpawnInputExpander()
+            .getInputMapping(spawn, SIMPLE_ARTIFACT_EXPANDER, baseDirectory, fakeFileCache);
+      }
 
-        @Override
-        public void report(ProgressStatus progress) {
-        }
+      @Override
+      public void report(ProgressStatus progress) {}
 
-        @Override
-        public boolean isRewindingEnabled() {
-          return false;
-        }
+      @Override
+      public boolean isRewindingEnabled() {
+        return false;
+      }
 
-        @Override
-        public void checkForLostInputs() {}
+      @Override
+      public void checkForLostInputs() {}
 
-        @Override
-        public <T extends ActionContext> T getContext(Class<T> identifyingType) {
-          throw new UnsupportedOperationException();
-        }
+      @Override
+      public <T extends ActionContext> T getContext(Class<T> identifyingType) {
+        throw new UnsupportedOperationException();
+      }
 
-        @Nullable
-        @Override
-        public FileSystem getActionFileSystem() {
-          return null;
-        }
-      };
+      @Nullable
+      @Override
+      public FileSystem getActionFileSystem() {
+        return null;
+      }
+    };
+  }
 
   private static SimpleSpawn simpleSpawnWithExecutionInfo(
       ImmutableMap<String, String> executionInfo) {
@@ -235,6 +240,27 @@ public class RemoteSpawnCacheTest {
             Order.STABLE_ORDER, ActionInputHelper.fromPath("input")),
         /* outputs= */ ImmutableSet.of(ActionInputHelper.fromPath("/random/file")),
         ResourceSet.ZERO);
+  }
+
+  private static SimpleSpawn simplePathMappedSpawn(String configSegment) {
+    String inputPath = "bazel-bin/%s/bin/input";
+    String outputPath = "bazel-bin/%s/bin/output";
+    return new SimpleSpawn(
+        new FakeOwner("Mnemonic", "Progress Message", "//dummy:label"),
+        ImmutableList.of("cp", inputPath.formatted("cfg"), outputPath.formatted("cfg")),
+        ImmutableMap.of("VARIABLE", "value"),
+        ImmutableMap.of(ExecutionRequirements.SUPPORTS_PATH_MAPPING, ""),
+        /* runfilesSupplier= */ null,
+        /* filesetMappings= */ ImmutableMap.of(),
+        /* inputs= */ NestedSetBuilder.create(
+            Order.STABLE_ORDER, ActionInputHelper.fromPath(inputPath.formatted(configSegment))),
+        /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+        /* outputs= */ ImmutableSet.of(
+            ActionInputHelper.fromPath(outputPath.formatted(configSegment))),
+        /* mandatoryOutputs= */ null,
+        ResourceSet.ZERO,
+        execPath ->
+            execPath.subFragment(0, 1).getRelative("cfg").getRelative(execPath.subFragment(2)));
   }
 
   private RemoteSpawnCache createRemoteSpawnCache() {
@@ -273,7 +299,7 @@ public class RemoteSpawnCacheTest {
     execRoot = fs.getPath("/exec/root");
     execRoot.createDirectoryAndParents();
     tempPathGenerator = new TempPathGenerator(fs.getPath("/execroot/_tmp/actions/remote"));
-    fakeFileCache = new FakeActionInputFileCache(execRoot);
+    FakeActionInputFileCache fakeFileCache = new FakeActionInputFileCache(execRoot);
     simpleSpawn = simpleSpawnWithExecutionInfo(ImmutableMap.of());
 
     Path stdout = fs.getPath("/tmp/stdout");
@@ -286,6 +312,7 @@ public class RemoteSpawnCacheTest {
     reporter.addHandler(eventHandler);
 
     remotePathResolver = RemotePathResolver.createDefault(execRoot);
+    simplePolicy = createSpawnExecutionContext(simpleSpawn, execRoot, fakeFileCache, outErr);
 
     fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().getSingleton(), "xyz");
   }
@@ -338,7 +365,7 @@ public class RemoteSpawnCacheTest {
     verify(service)
         .downloadOutputs(
             any(), eq(RemoteActionResult.createFromCache(CachedActionResult.remote(actionResult))));
-    verify(service, never()).uploadOutputs(any(), any());
+    verify(service, never()).uploadOutputs(any(), any(), any());
     assertThat(result.getDigest())
         .isEqualTo(digestUtil.asSpawnLogProto(actionKeyCaptor.getValue()));
     assertThat(result.setupSuccess()).isTrue();
@@ -369,9 +396,9 @@ public class RemoteSpawnCacheTest {
             .setStatus(Status.SUCCESS)
             .setRunnerName("test")
             .build();
-    doNothing().when(service).uploadOutputs(any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any());
     entry.store(result);
-    verify(service).uploadOutputs(any(), any());
+    verify(service).uploadOutputs(any(), any(), any());
   }
 
   @Test
@@ -535,7 +562,7 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
     entry.store(result);
-    verify(service, never()).uploadOutputs(any(), any());
+    verify(service, never()).uploadOutputs(any(), any(), any());
   }
 
   @Test
@@ -558,9 +585,9 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
 
-    doNothing().when(service).uploadOutputs(any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any());
     entry.store(result);
-    verify(service).uploadOutputs(any(), eq(result));
+    verify(service).uploadOutputs(any(), eq(result), any());
 
     assertThat(eventHandler.getEvents()).hasSize(1);
     Event evt = eventHandler.getEvents().get(0);
@@ -606,9 +633,9 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
 
-    doNothing().when(service).uploadOutputs(any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any());
     entry.store(result);
-    verify(service).uploadOutputs(any(), eq(result));
+    verify(service).uploadOutputs(any(), eq(result), any());
     assertThat(eventHandler.getEvents()).isEmpty(); // no warning is printed.
   }
 
@@ -681,5 +708,142 @@ public class RemoteSpawnCacheTest {
     Event evt = eventHandler.getEvents().get(0);
     assertThat(evt.getKind()).isEqualTo(EventKind.WARNING);
     assertThat(evt.getMessage()).contains(downloadFailure.getMessage());
+  }
+
+  @Test
+  public void pathMappedActionIsDeduplicated() throws Exception {
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+
+    SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild");
+    FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
+    firstFakeFileCache.createScratchInput(firstSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext firstPolicy =
+        createSpawnExecutionContext(firstSpawn, execRoot, firstFakeFileCache, outErr);
+
+    SimpleSpawn secondSpawn = simplePathMappedSpawn("k8-opt");
+    FakeActionInputFileCache secondFakeFileCache = new FakeActionInputFileCache(execRoot);
+    secondFakeFileCache.createScratchInput(secondSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext secondPolicy =
+        createSpawnExecutionContext(secondSpawn, execRoot, secondFakeFileCache, outErr);
+
+    RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
+    Mockito.doCallRealMethod().when(remoteExecutionService).waitForAndReuseOutputs(any(), any());
+    // Simulate a very slow upload to the remote cache to ensure that the second spawn is
+    // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
+    // concurrency to this test.
+    Mockito.doNothing().when(remoteExecutionService).uploadOutputs(any(), any(), any());
+
+    // act
+    try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
+      FileSystemUtils.writeContent(
+          fs.getPath("/exec/root/bazel-bin/k8-fastbuild/bin/output"), UTF_8, "hello");
+      firstCacheHandle.store(
+          new SpawnResult.Builder()
+              .setExitCode(0)
+              .setStatus(Status.SUCCESS)
+              .setRunnerName("test")
+              .build());
+    }
+    CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
+
+    // assert
+    assertThat(secondCacheHandle.hasResult()).isTrue();
+    assertThat(secondCacheHandle.getResult().getRunnerName()).isEqualTo("deduplicated");
+    assertThat(
+            FileSystemUtils.readContent(
+                fs.getPath("/exec/root/bazel-bin/k8-opt/bin/output"), UTF_8))
+        .isEqualTo("hello");
+    assertThat(secondCacheHandle.willStore()).isFalse();
+  }
+
+  @Test
+  public void deduplicatedActionWithNonZeroExitCodeIsACacheMiss() throws Exception {
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+
+    SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild");
+    FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
+    firstFakeFileCache.createScratchInput(firstSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext firstPolicy =
+        createSpawnExecutionContext(firstSpawn, execRoot, firstFakeFileCache, outErr);
+
+    SimpleSpawn secondSpawn = simplePathMappedSpawn("k8-opt");
+    FakeActionInputFileCache secondFakeFileCache = new FakeActionInputFileCache(execRoot);
+    secondFakeFileCache.createScratchInput(secondSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext secondPolicy =
+        createSpawnExecutionContext(secondSpawn, execRoot, secondFakeFileCache, outErr);
+
+    RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
+    Mockito.doCallRealMethod().when(remoteExecutionService).waitForAndReuseOutputs(any(), any());
+    // Simulate a very slow upload to the remote cache to ensure that the second spawn is
+    // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
+    // concurrency to this test.
+    Mockito.doNothing().when(remoteExecutionService).uploadOutputs(any(), any(), any());
+
+    // act
+    try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
+      FileSystemUtils.writeContent(
+          fs.getPath("/exec/root/bazel-bin/k8-fastbuild/bin/output"), UTF_8, "hello");
+      firstCacheHandle.store(
+          new SpawnResult.Builder()
+              .setExitCode(1)
+              .setStatus(Status.NON_ZERO_EXIT)
+              .setFailureDetail(
+                  FailureDetail.newBuilder()
+                      .setMessage("test spawn failed")
+                      .setSpawn(
+                          FailureDetails.Spawn.newBuilder()
+                              .setCode(FailureDetails.Spawn.Code.NON_ZERO_EXIT))
+                      .build())
+              .setRunnerName("test")
+              .build());
+    }
+    CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
+
+    // assert
+    assertThat(secondCacheHandle.hasResult()).isFalse();
+    assertThat(secondCacheHandle.willStore()).isTrue();
+  }
+
+  @Test
+  public void deduplicatedActionWithMissingOutputIsACacheMiss() throws Exception {
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+
+    SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild");
+    FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
+    firstFakeFileCache.createScratchInput(firstSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext firstPolicy =
+        createSpawnExecutionContext(firstSpawn, execRoot, firstFakeFileCache, outErr);
+
+    SimpleSpawn secondSpawn = simplePathMappedSpawn("k8-opt");
+    FakeActionInputFileCache secondFakeFileCache = new FakeActionInputFileCache(execRoot);
+    secondFakeFileCache.createScratchInput(secondSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext secondPolicy =
+        createSpawnExecutionContext(secondSpawn, execRoot, secondFakeFileCache, outErr);
+
+    RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
+    Mockito.doCallRealMethod().when(remoteExecutionService).waitForAndReuseOutputs(any(), any());
+    // Simulate a very slow upload to the remote cache to ensure that the second spawn is
+    // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
+    // concurrency to this test.
+    Mockito.doNothing().when(remoteExecutionService).uploadOutputs(any(), any(), any());
+
+    // act
+    try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
+      // Do not create the output.
+      firstCacheHandle.store(
+          new SpawnResult.Builder()
+              .setExitCode(0)
+              .setStatus(Status.SUCCESS)
+              .setRunnerName("test")
+              .build());
+    }
+    CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
+
+    // assert
+    assertThat(secondCacheHandle.hasResult()).isFalse();
+    assertThat(secondCacheHandle.willStore()).isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -44,10 +44,12 @@ import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionContext;
+import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
@@ -93,7 +95,11 @@ import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Set;
 import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
@@ -243,10 +249,16 @@ public class RemoteSpawnCacheTest {
   }
 
   private static SimpleSpawn simplePathMappedSpawn(String configSegment) {
+    return simplePathMappedSpawn(
+        configSegment, new FakeOwner("Mnemonic", "Progress Message", "//dummy:label"));
+  }
+
+  private static SimpleSpawn simplePathMappedSpawn(
+      String configSegment, ActionExecutionMetadata owner) {
     String inputPath = "bazel-bin/%s/bin/input";
     String outputPath = "bazel-bin/%s/bin/output";
     return new SimpleSpawn(
-        new FakeOwner("Mnemonic", "Progress Message", "//dummy:label"),
+        owner,
         ImmutableList.of("cp", inputPath.formatted("cfg"), outputPath.formatted("cfg")),
         ImmutableMap.of("VARIABLE", "value"),
         ImmutableMap.of(ExecutionRequirements.SUPPORTS_PATH_MAPPING, ""),
@@ -748,6 +760,121 @@ public class RemoteSpawnCacheTest {
     CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
 
     // assert
+    assertThat(secondCacheHandle.hasResult()).isTrue();
+    assertThat(secondCacheHandle.getResult().getRunnerName()).isEqualTo("deduplicated");
+    assertThat(
+            FileSystemUtils.readContent(
+                fs.getPath("/exec/root/bazel-bin/k8-opt/bin/output"), UTF_8))
+        .isEqualTo("hello");
+    assertThat(secondCacheHandle.willStore()).isFalse();
+  }
+
+  @Test
+  public void pathMappedActionIsDeduplicatedWithSpawnOutputModification() throws Exception {
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+
+    ActionExecutionMetadata firstExecutionOwner =
+        new FakeOwner("Mnemonic", "Progress Message", "//dummy:label") {
+          @Override
+          public boolean mayModifySpawnOutputsAfterExecution() {
+            return true;
+          }
+        };
+    SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild", firstExecutionOwner);
+    FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
+    firstFakeFileCache.createScratchInput(firstSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext firstPolicy =
+        createSpawnExecutionContext(firstSpawn, execRoot, firstFakeFileCache, outErr);
+
+    SimpleSpawn secondSpawn = simplePathMappedSpawn("k8-opt");
+    FakeActionInputFileCache secondFakeFileCache = new FakeActionInputFileCache(execRoot);
+    secondFakeFileCache.createScratchInput(secondSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext secondPolicy =
+        createSpawnExecutionContext(secondSpawn, execRoot, secondFakeFileCache, outErr);
+
+    RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
+    CountDownLatch enteredWaitForAndReuseOutputs = new CountDownLatch(1);
+    CountDownLatch completeWaitForAndReuseOutputs = new CountDownLatch(1);
+    CountDownLatch enteredUploadOutputs = new CountDownLatch(1);
+    Set<Spawn> spawnsThatWaitedForOutputReuse = ConcurrentHashMap.newKeySet();
+    Mockito.doAnswer(
+            (Answer<SpawnResult>)
+                invocation -> {
+                  spawnsThatWaitedForOutputReuse.add(
+                      ((RemoteAction) invocation.getArgument(0)).getSpawn());
+                  enteredWaitForAndReuseOutputs.countDown();
+                  completeWaitForAndReuseOutputs.await();
+                  return (SpawnResult) invocation.callRealMethod();
+                })
+        .when(remoteExecutionService)
+        .waitForAndReuseOutputs(any(), any());
+    // Simulate a very slow upload to the remote cache to ensure that the second spawn is
+    // deduplicated rather than a cache hit. This is a slight hack, but also avoids introducing
+    // more concurrency to this test.
+    Mockito.doAnswer(
+            (Answer<Void>)
+                invocation -> {
+                  enteredUploadOutputs.countDown();
+                  return null;
+                })
+        .when(remoteExecutionService)
+        .uploadOutputs(any(), any(), any());
+
+    // act
+    // Simulate the first spawn writing to the output, but delay its completion.
+    CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy);
+    FileSystemUtils.writeContent(
+        fs.getPath("/exec/root/bazel-bin/k8-fastbuild/bin/output"), UTF_8, "hello");
+
+    // Start the second spawn and wait for it to deduplicate against the first one.
+    AtomicReference<CacheHandle> secondCacheHandleRef = new AtomicReference<>();
+    Thread lookupSecondSpawn =
+        new Thread(
+            () -> {
+              try {
+                secondCacheHandleRef.set(cache.lookup(secondSpawn, secondPolicy));
+              } catch (InterruptedException
+                  | IOException
+                  | ExecException
+                  | ForbiddenActionInputException e) {
+                throw new IllegalStateException(e);
+              }
+            });
+    lookupSecondSpawn.start();
+    enteredWaitForAndReuseOutputs.await();
+
+    // Complete the first spawn and immediately corrupt its outputs.
+    Thread completeFirstSpawn =
+        new Thread(
+            () -> {
+              try {
+                firstCacheHandle.store(
+                    new SpawnResult.Builder()
+                        .setExitCode(0)
+                        .setStatus(Status.SUCCESS)
+                        .setRunnerName("test")
+                        .build());
+                FileSystemUtils.writeContent(
+                    fs.getPath("/exec/root/bazel-bin/k8-fastbuild/bin/output"), UTF_8, "corrupted");
+              } catch (IOException | ExecException | InterruptedException e) {
+                throw new IllegalStateException(e);
+              }
+            });
+    completeFirstSpawn.start();
+    // Make it more likely to detect races by waiting for the first spawn to (fake) upload its
+    // outputs.
+    enteredUploadOutputs.await();
+
+    // Let the second spawn complete its output reuse.
+    completeWaitForAndReuseOutputs.countDown();
+    lookupSecondSpawn.join();
+    CacheHandle secondCacheHandle = secondCacheHandleRef.get();
+
+    completeFirstSpawn.join();
+
+    // assert
+    assertThat(spawnsThatWaitedForOutputReuse).containsExactly(secondSpawn);
     assertThat(secondCacheHandle.hasResult()).isTrue();
     assertThat(secondCacheHandle.getResult().getRunnerName()).isEqualTo("deduplicated");
     assertThat(

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -93,6 +93,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Set;
@@ -881,6 +882,53 @@ public class RemoteSpawnCacheTest {
             FileSystemUtils.readContent(
                 fs.getPath("/exec/root/bazel-bin/k8-opt/bin/output"), UTF_8))
         .isEqualTo("hello");
+    assertThat(secondCacheHandle.willStore()).isFalse();
+  }
+
+  @Test
+  public void pathMappedActionWithInMemoryOutputIsDeduplicated() throws Exception {
+    // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+
+    SimpleSpawn firstSpawn = simplePathMappedSpawn("k8-fastbuild");
+    FakeActionInputFileCache firstFakeFileCache = new FakeActionInputFileCache(execRoot);
+    firstFakeFileCache.createScratchInput(firstSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext firstPolicy =
+        createSpawnExecutionContext(firstSpawn, execRoot, firstFakeFileCache, outErr);
+
+    SimpleSpawn secondSpawn = simplePathMappedSpawn("k8-opt");
+    FakeActionInputFileCache secondFakeFileCache = new FakeActionInputFileCache(execRoot);
+    secondFakeFileCache.createScratchInput(secondSpawn.getInputFiles().getSingleton(), "xyz");
+    SpawnExecutionContext secondPolicy =
+        createSpawnExecutionContext(secondSpawn, execRoot, secondFakeFileCache, outErr);
+
+    RemoteExecutionService remoteExecutionService = cache.getRemoteExecutionService();
+    Mockito.doCallRealMethod().when(remoteExecutionService).waitForAndReuseOutputs(any(), any());
+    // Simulate a very slow upload to the remote cache to ensure that the second spawn is
+    // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
+    // concurrency to this test.
+    Mockito.doNothing().when(remoteExecutionService).uploadOutputs(any(), any(), any());
+
+    // act
+    try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
+      firstCacheHandle.store(
+          new SpawnResult.Builder()
+              .setExitCode(0)
+              .setStatus(Status.SUCCESS)
+              .setRunnerName("test")
+              .setInMemoryOutput(
+                  firstSpawn.getOutputFiles().getFirst(), ByteString.copyFromUtf8("in-memory"))
+              .build());
+    }
+    CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
+
+    // assert
+    ActionInput inMemoryOutput = secondSpawn.getOutputFiles().getFirst();
+    assertThat(secondCacheHandle.hasResult()).isTrue();
+    assertThat(secondCacheHandle.getResult().getRunnerName()).isEqualTo("deduplicated");
+    assertThat(secondCacheHandle.getResult().getInMemoryOutput(inMemoryOutput).toStringUtf8())
+        .isEqualTo("in-memory");
+    assertThat(execRoot.getRelative(inMemoryOutput.getExecPath()).exists()).isFalse();
     assertThat(secondCacheHandle.willStore()).isFalse();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -243,7 +243,7 @@ public class RemoteSpawnRunnerTest {
     // TODO(olaola): verify that the uploaded action has the doNotCache set.
 
     verify(service, never()).lookupCache(any());
-    verify(service, never()).uploadOutputs(any(), any());
+    verify(service, never()).uploadOutputs(any(), any(), any());
     verifyNoMoreInteractions(localRunner);
   }
 
@@ -318,7 +318,7 @@ public class RemoteSpawnRunnerTest {
 
     RemoteSpawnRunner runner = spy(newSpawnRunner());
     RemoteExecutionService service = runner.getRemoteExecutionService();
-    doNothing().when(service).uploadOutputs(any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any());
 
     // Throw an IOException to trigger the local fallback.
     when(executor.executeRemotely(
@@ -344,7 +344,7 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    verify(service).uploadOutputs(any(), eq(res));
+    verify(service).uploadOutputs(any(), eq(res), any());
   }
 
   @Test
@@ -377,7 +377,7 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    verify(service, never()).uploadOutputs(any(), any());
+    verify(service, never()).uploadOutputs(any(), any(), any());
   }
 
   @Test
@@ -404,7 +404,7 @@ public class RemoteSpawnRunnerTest {
             any(ExecuteRequest.class),
             any(OperationObserver.class)))
         .thenThrow(IOException.class);
-    doNothing().when(service).uploadOutputs(any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -422,7 +422,7 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    verify(service).uploadOutputs(any(), eq(result));
+    verify(service).uploadOutputs(any(), eq(result), any());
     verify(service, never()).downloadOutputs(any(), any());
   }
 


### PR DESCRIPTION
Cherry-picks the following changes to implement output reuse:
* Deduplicate locally executed path mapped spawns (#22556)
* Fix local execution deduplication to work with optional outputs (#23296)
* Force synchronous upload and reuse of possibly modified spawn outputs (#23382)
* Add support for in-memory outputs to output reuse (#23422)

Fixes #23377
Fixes #23444
Fixes #23457