### PR TITLE
[7.4.0] Allow unquoted canonical repository names with `query`

### DIFF
--- a/site/en/query/language.md
+++ b/site/en/query/language.md
@@ -86,7 +86,9 @@ tokens:
   hyphen, underscore, colon, dollar sign, tilde, left square brace, right square
   brace). However, unquoted words may not start with a hyphen `-` or asterisk `*`
   even though relative [target names](/concepts/labels#target-names) may start
-  with those characters.
+  with those characters. As a special rule meant to simplify the handling of
+  labels referring to external repositories, unquoted words that start with
+  `@@` may contain `+` characters.
 
   Unquoted words also may not include the characters plus sign `+` or equals
   sign `=`, even though those characters are permitted in target names. When

--- a/src/main/java/com/google/devtools/build/lib/query2/engine/Lexer.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/engine/Lexer.java
@@ -168,8 +168,10 @@ public final class Lexer {
     return kind == null ? TokenKind.WORD : kind;
   }
 
-  private String scanWord() {
+  private String scanWord(char firstChar) {
     int oldPos = pos - 1;
+    boolean startsWithDoubleAt =
+        firstChar == '@' && pos < input.length() && input.charAt(pos) == '@';
     while (pos < input.length()) {
       switch (input.charAt(pos)) {
         case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
@@ -192,6 +194,17 @@ public final class Lexer {
         case ']':
           pos++;
           break;
+        case '+':
+          if (startsWithDoubleAt) {
+            // Allow unquoted canonical labels such as
+            // @@rules_jvm_external++maven+maven//:bar, but still parse @foo+@bar as two separate
+            // labels (here @foo refers to the @foo//:foo target).
+            // If @@foo+bar is intended to mean @@foo + bar, it can be written as such with spaces.
+            pos++;
+          } else {
+            return bufferSlice(oldPos, pos);
+          }
+          break;
        default:
           return bufferSlice(oldPos, pos);
       }
@@ -202,13 +215,13 @@ public final class Lexer {
   /**
    * Scans a word or keyword.
    *
-   * ON ENTRY: 'pos' is 1 + the index of the first char in the word.
-   * ON EXIT: 'pos' is 1 + the index of the last char in the word.
+   * <p>ON ENTRY: 'pos' is 1 + the index of the first char in the word. ON EXIT: 'pos' is 1 + the
+   * index of the last char in the word.
    *
    * @return the word or keyword token.
    */
-  private Token wordOrKeyword() {
-    String word = scanWord();
+  private Token wordOrKeyword(char firstChar) {
+    String word = scanWord(firstChar);
     TokenKind kind = getTokenKindForWord(word);
     return kind == TokenKind.WORD ? new Token(word) : new Token(kind);
   }
@@ -260,7 +273,7 @@ public final class Lexer {
         break;
       }
       default: {
-        addToken(wordOrKeyword());
+            addToken(wordOrKeyword(c));
         break;
       } // default
       } // switch

--- a/src/test/java/com/google/devtools/build/lib/query2/engine/LexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/engine/LexerTest.java
@@ -141,4 +141,28 @@ public final class LexerTest {
     assertThat(tokens[6].kind).isEqualTo(Lexer.TokenKind.WORD);
     assertThat(tokens[7].kind).isEqualTo(Lexer.TokenKind.RPAREN);
   }
+
+  @Test
+  public void testUnquotedCanonicalLabels() throws QuerySyntaxException {
+    Lexer.Token[] tokens =
+        scan("somepath(@foo+@bar+//baz+@@foo +bar,  @@rules_jvm_external++maven+maven//:bar)");
+    assertThat(asString(tokens))
+        .isEqualTo(
+            "somepath ( @foo + @bar + //baz + @@foo + bar , @@rules_jvm_external++maven+maven//:bar"
+                + " ) EOF");
+    assertThat(tokens[0].kind).isEqualTo(Lexer.TokenKind.WORD);
+    assertThat(tokens[1].kind).isEqualTo(Lexer.TokenKind.LPAREN);
+    assertThat(tokens[2].kind).isEqualTo(Lexer.TokenKind.WORD);
+    assertThat(tokens[3].kind).isEqualTo(Lexer.TokenKind.PLUS);
+    assertThat(tokens[4].kind).isEqualTo(Lexer.TokenKind.WORD);
+    assertThat(tokens[5].kind).isEqualTo(Lexer.TokenKind.PLUS);
+    assertThat(tokens[6].kind).isEqualTo(Lexer.TokenKind.WORD);
+    assertThat(tokens[7].kind).isEqualTo(Lexer.TokenKind.PLUS);
+    assertThat(tokens[8].kind).isEqualTo(Lexer.TokenKind.WORD);
+    assertThat(tokens[9].kind).isEqualTo(Lexer.TokenKind.PLUS);
+    assertThat(tokens[10].kind).isEqualTo(Lexer.TokenKind.WORD);
+    assertThat(tokens[11].kind).isEqualTo(Lexer.TokenKind.COMMA);
+    assertThat(tokens[12].kind).isEqualTo(Lexer.TokenKind.WORD);
+    assertThat(tokens[13].kind).isEqualTo(Lexer.TokenKind.RPAREN);
+  }
 }


### PR DESCRIPTION
Unquoted `query` words that start with `@@` are no longer broken on `+`, which allows the usage of unquoted canonical labels in expressions. In the very rare case of a shorthand form of a canonical label referring to a WORKSPACE repo (which contains no `+`), the `+` can be separated by a space to get the original behavior (e.g. `@@foo+bar` no longer means `@@foo//:foo + //bar:bar`,  but `@@foo +bar` does.

Closes #23600.

PiperOrigin-RevId: 673763980
Change-Id: Ie5509647b4e04e2f72b908d609781c79cf7b06d4

Fixes #23601