### PR TITLE
[7.4.0] Only invalidate `configure` repos with `fetch --configure --force`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelFetchAllFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelFetchAllFunction.java
@@ -15,8 +15,8 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.stream.Collectors.toCollection;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -42,17 +42,17 @@ public class BazelFetchAllFunction implements SkyFunction {
   public SkyValue compute(SkyKey skyKey, Environment env) throws InterruptedException {
 
     // Collect all the repos we want to fetch here
-    List<RepositoryName> reposToFetch = new ArrayList<>();
+    List<RepositoryName> reposToFetch;
 
     // 1. Run resolution and collect the dependency graph repos except for main
     BazelDepGraphValue depGraphValue = (BazelDepGraphValue) env.getValue(BazelDepGraphValue.KEY);
     if (depGraphValue == null) {
       return null;
     }
-    reposToFetch.addAll(
+    reposToFetch =
         depGraphValue.getCanonicalRepoNameLookup().keySet().stream()
             .filter(repo -> !repo.isMain())
-            .collect(toImmutableList()));
+            .collect(toCollection(ArrayList::new));
 
     // 2. Run every extension found in the modules & collect its generated repos
     ImmutableSet<ModuleExtensionId> extensionIds =
@@ -103,8 +103,7 @@ public class BazelFetchAllFunction implements SkyFunction {
       }
     }
 
-    return BazelFetchAllValue.create(
-        ImmutableList.copyOf(reposToFetch), ImmutableList.copyOf(shouldVendor));
+    return BazelFetchAllValue.create(ImmutableList.copyOf(shouldVendor));
   }
 
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelFetchAllValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelFetchAllValue.java
@@ -38,13 +38,10 @@ public abstract class BazelFetchAllValue implements SkyValue {
     return BazelFetchAllValue.Key.create(configureEnabled);
   }
 
-  public abstract ImmutableList<RepositoryName> getFetchedRepos();
-
   public abstract ImmutableList<RepositoryName> getReposToVendor();
 
-  public static BazelFetchAllValue create(
-      ImmutableList<RepositoryName> fetchedRepos, ImmutableList<RepositoryName> reposToVendor) {
-    return new AutoValue_BazelFetchAllValue(fetchedRepos, reposToVendor);
+  public static BazelFetchAllValue create(ImmutableList<RepositoryName> reposToVendor) {
+    return new AutoValue_BazelFetchAllValue(reposToVendor);
   }
 
   /** Key type for BazelFetchAllValue. */

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchCommand.java
@@ -104,7 +104,10 @@ public final class FetchCommand implements BlazeCommand {
           .injectExtraPrecomputedValues(
               ImmutableList.of(
                   PrecomputedValue.injected(
-                      RepositoryDelegatorFunction.FORCE_FETCH, env.getCommandId().toString())));
+                      fetchOptions.configure
+                          ? RepositoryDelegatorFunction.FORCE_FETCH_CONFIGURE
+                          : RepositoryDelegatorFunction.FORCE_FETCH,
+                      env.getCommandId().toString())));
     }
 
     BlazeCommandResult result;
@@ -125,7 +128,7 @@ public final class FetchCommand implements BlazeCommand {
         result = fetchTarget(env, options, targets);
       } else if (!fetchOptions.repos.isEmpty()) {
         result = fetchRepos(env, threadsOption, fetchOptions.repos);
-      } else { // --all, --configure, or just 'fetch'
+      } else { // --all or just 'fetch' (equivalent) or --configure
         result = fetchAll(env, threadsOption, fetchOptions.configure);
       }
     } catch (InterruptedException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/FetchOptions.java
@@ -28,8 +28,9 @@ public class FetchOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.CHANGES_INPUTS},
       help =
-          "Fetches all external repositories necessary for building any target or repository. Only"
-              + " works when --enable_bzlmod is on.")
+          "Fetches all external repositories necessary for building any target or repository. "
+              + "This is the default if no other flags and arguments are provided. Only works "
+              + "when --enable_bzlmod is on.")
   public boolean all;
 
   @Option(

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -192,18 +192,18 @@ class BazelFetchTest(test_base.TestBase):
 
     _, _, stderr = self.RunBazel(['fetch', '--configure'])
     stderr = '\n'.join(stderr)
-    self.assertIn('Fetching ~ext~notConfig', stderr)
-    self.assertIn('Fetching ~ext~IamConfig', stderr)
+    self.assertIn('Fetching _main~ext~notConfig', stderr)
+    self.assertIn('Fetching _main~ext~IamConfig', stderr)
 
     _, stdout, _ = self.RunBazel(['info', 'output_base'])
     repos_fetched = os.listdir(stdout[0] + '/external')
-    self.assertIn('~ext~notConfig', repos_fetched)
-    self.assertIn('~ext~IamConfig', repos_fetched)
+    self.assertIn('_main~ext~notConfig', repos_fetched)
+    self.assertIn('_main~ext~IamConfig', repos_fetched)
 
     _, stdout, stderr = self.RunBazel(['fetch', '--configure', '--force'])
     stderr = '\n'.join(stderr)
-    self.assertNotIn('Fetching ~ext~notConfig', stderr)
-    self.assertIn('Fetching ~ext~IamConfig', stderr)
+    self.assertNotIn('Fetching _main~ext~notConfig', stderr)
+    self.assertIn('Fetching _main~ext~IamConfig', stderr)
 
   def testFetchFailsWithMultipleOptions(self):
     exit_code, _, stderr = self.RunBazel(

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -151,6 +151,60 @@ class BazelFetchTest(test_base.TestBase):
     self.assertNotIn('_main~ext~notConfig', repos_fetched)
     self.assertIn('_main~ext~IamConfig', repos_fetched)
 
+  def testFetchConfigForce(self):
+    self.main_registry.createCcModule('aaa', '1.0').createCcModule(
+        'bbb', '1.0', {'aaa': '1.0'}
+    )
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'bazel_dep(name = "aaa", version = "1.0")',
+            'ext = use_extension("extension.bzl", "ext")',
+            'use_repo(ext, "notConfig")',
+            'use_repo(ext, "IamConfig")',
+            'local_path_override(module_name="bazel_tools", path="tools_mock")',
+            'local_path_override(module_name="local_config_platform", ',
+            'path="platforms_mock")',
+        ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def _repo_rule_impl(ctx):',
+            '    print("Fetching {}".format(ctx.attr.name))',
+            '    if ctx.attr.name.endswith("IamConfig"):',
+            (
+                '       '
+                ' ctx.path(Label("@notConfig//:whatever")).dirname.readdir()'
+            ),
+            '    ctx.file("BUILD")',
+            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule2 = repository_rule(implementation=_repo_rule_impl, ',
+            'configure=True)',
+            '',
+            'def _ext_impl(ctx):',
+            '    repo_rule(name="notConfig")',
+            '    repo_rule2(name="IamConfig")',
+            'ext = module_extension(implementation=_ext_impl)',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(['fetch', '--configure'])
+    stderr = '\n'.join(stderr)
+    self.assertIn('Fetching +ext+notConfig', stderr)
+    self.assertIn('Fetching +ext+IamConfig', stderr)
+
+    _, stdout, _ = self.RunBazel(['info', 'output_base'])
+    repos_fetched = os.listdir(stdout[0] + '/external')
+    self.assertIn('+ext+notConfig', repos_fetched)
+    self.assertIn('+ext+IamConfig', repos_fetched)
+
+    _, stdout, stderr = self.RunBazel(['fetch', '--configure', '--force'])
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('Fetching +ext+notConfig', stderr)
+    self.assertIn('Fetching +ext+IamConfig', stderr)
+
   def testFetchFailsWithMultipleOptions(self):
     exit_code, _, stderr = self.RunBazel(
         ['fetch', '--all', '--configure'], allow_failure=True

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -192,18 +192,18 @@ class BazelFetchTest(test_base.TestBase):
 
     _, _, stderr = self.RunBazel(['fetch', '--configure'])
     stderr = '\n'.join(stderr)
-    self.assertIn('Fetching +ext+notConfig', stderr)
-    self.assertIn('Fetching +ext+IamConfig', stderr)
+    self.assertIn('Fetching ~ext~notConfig', stderr)
+    self.assertIn('Fetching ~ext~IamConfig', stderr)
 
     _, stdout, _ = self.RunBazel(['info', 'output_base'])
     repos_fetched = os.listdir(stdout[0] + '/external')
-    self.assertIn('+ext+notConfig', repos_fetched)
-    self.assertIn('+ext+IamConfig', repos_fetched)
+    self.assertIn('~ext~notConfig', repos_fetched)
+    self.assertIn('~ext~IamConfig', repos_fetched)
 
     _, stdout, stderr = self.RunBazel(['fetch', '--configure', '--force'])
     stderr = '\n'.join(stderr)
-    self.assertNotIn('Fetching +ext+notConfig', stderr)
-    self.assertIn('Fetching +ext+IamConfig', stderr)
+    self.assertNotIn('Fetching ~ext~notConfig', stderr)
+    self.assertIn('Fetching ~ext~IamConfig', stderr)
 
   def testFetchFailsWithMultipleOptions(self):
     exit_code, _, stderr = self.RunBazel(


### PR DESCRIPTION
Also cleans up an unused field on `BazelFetchAllValue`.

Closes #23644.

PiperOrigin-RevId: 676333873
Change-Id: Ida7149a1c5642facaeed7fb68bf9f451016c359c

Commit https://github.com/bazelbuild/bazel/commit/55346791e0a0711ef205c20bc022271c02e0c1c9