### PR TITLE
Raise default `--watchfs` event limit

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -426,6 +426,12 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
   result.push_back("-Duser.language=");
   result.push_back("-Duser.variant=");
 
+  // Allow more files to be watched per directory than the default limit of 500.
+  // The limit of 10,000 is arbitrary, but should be sufficient for most cases
+  // and can always be increased by the user if necessary.
+  // https://github.com/openjdk/jdk/blob/2faf8b8d582183275b1fdc92313a1c63c1753e80/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java#L40
+  result.push_back("-Djdk.nio.file.WatchService.maxEventsPerPoll=10000");
+
   if (startup_options.host_jvm_debug) {
     BAZEL_LOG(USER)
         << "Running host JVM under debugger (listening on TCP port 5005).";

--- a/src/test/shell/integration/watchfs_test.sh
+++ b/src/test/shell/integration/watchfs_test.sh
@@ -144,6 +144,11 @@ EOF
 }
 
 function test_large_number_of_files() {
+  if [[ "$PLATFORM" == "darwin" ]]; then
+    # Tests Linux-specific JVM flags.
+    return 0
+  fi
+
   local -r pkg=${FUNCNAME[0]}
   mkdir $pkg || fail "mkdir $pkg"
   cat > "$pkg/BUILD" << 'EOF'
@@ -159,12 +164,12 @@ filegroup(
     srcs = glob(["*.txt"]),
 )
 EOF
-  touch 1.txt
+  touch "$pkg/1.txt"
   bazel build --watchfs "//$pkg:gen" &> "$TEST_log" || fail "Expected success."
 
   # By default, the JVM will only report up to 500 changed files per directory before it overflows.
   # https://github.com/openjdk/jdk/blob/2faf8b8d582183275b1fdc92313a1c63c1753e80/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java#L40
-  touch {1..600}.txt
+  touch "$pkg/{1..600}.txt"
   bazel build --watchfs "//$pkg:gen" &> "$TEST_log" || fail "Expected success."
   expect_not_log "WARNING:"
 }


### PR DESCRIPTION
By default, the JDK only reports up to 500 events per `WatchKey` (and thus, per directory). This can be too low in large repos.

Work towards #13226

RELNOTES: On Linux, the default limit on the number of `--watchfs` file events per directory has been raised to 10,000 (from 500). If needed, it can be increased further via `--host_jvm_args=-Djdk.nio.file.WatchService.maxEventsPerPoll=<limit>`.