### PR TITLE
[7.4.0] Fetch extra action outputs with `--remote_download_toplevel`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -208,6 +208,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/analysis:extra_action_artifacts_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis:provider_collection",
         "//src/main/java/com/google/devtools/build/lib/analysis:top_level_artifact_context",
         "//src/main/java/com/google/devtools/build/lib/clock",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.actions.RemoteArtifactChecker;
 import com.google.devtools.build.lib.analysis.AnalysisResult;
 import com.google.devtools.build.lib.analysis.ConfiguredAspect;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.ExtraActionArtifactsProvider;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
 import com.google.devtools.build.lib.analysis.ProviderCollection;
 import com.google.devtools.build.lib.analysis.TopLevelArtifactContext;
@@ -170,6 +171,7 @@ public class RemoteOutputChecker implements RemoteArtifactChecker {
               .getImportantArtifacts();
       addOutputsToDownload(artifactsToBuild.toList());
       addRunfiles(target);
+      addExtraActionArtifacts(target);
     }
   }
 
@@ -202,6 +204,14 @@ public class RemoteOutputChecker implements RemoteArtifactChecker {
         continue;
       }
       addOutputToDownload(artifact);
+    }
+  }
+
+  private void addExtraActionArtifacts(ProviderCollection target) {
+    ExtraActionArtifactsProvider extraActionArtifactsProvider =
+        target.getProvider(ExtraActionArtifactsProvider.class);
+    if (extraActionArtifactsProvider != null) {
+      addOutputsToDownload(extraActionArtifactsProvider.getExtraActionArtifacts().toList());
     }
   }
 


### PR DESCRIPTION
This allows Kythe extraction to work with BwoB.

Closes #23669.

PiperOrigin-RevId: 676371827
Change-Id: I354cb9b9c0ec3511c6d866956fca1ff06a27cfab

Commit https://github.com/bazelbuild/bazel/commit/055314eb8694c827931340583aa125b40f0673bb