### PR TITLE
[7.4.0] Fix upb build with Clang 16

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,6 +69,13 @@ bazel_dep(name = "c-ares", version = "1.15.0")
 bazel_dep(name = "rules_go", version = "0.39.1")
 bazel_dep(name = "rules_kotlin", version = "1.9.0")
 bazel_dep(name = "upb", version = "0.0.0-20220923-a547704")
+single_version_override(
+    module_name = "upb",
+    patch_strip = 1,
+    patches = [
+        "//third_party/upb:01_remove_werror.patch",
+    ],
+)
 
 # =========================================
 # Java dependencies

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -35,6 +35,7 @@ filegroup(
         "//third_party/py/mock:srcs",
         "//third_party/py/six:srcs",
         "//third_party/remoteapis:srcs",
+        "//third_party/upb:srcs",
         "//third_party/zlib:srcs",
     ],
 )

--- a/third_party/upb/01_remove_werror.patch
+++ b/third_party/upb/01_remove_werror.patch
@@ -1,0 +1,19 @@
+diff --git a/bazel/upb_proto_library.bzl b/bazel/upb_proto_library.bzl
+--- a/bazel/build_defs.bzl
++++ b/bazel/build_defs.bzl
+@@ -34,13 +34,13 @@
+ _DEFAULT_CPPOPTS.extend([
+     "-Wextra",
+     # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
+-    "-Werror",
++    # "-Werror",
+     "-Wno-long-long",
+ ])
+ _DEFAULT_COPTS.extend([
+     "-std=c99",
+     "-pedantic",
+-    "-Werror=pedantic",
++    # "-Werror=pedantic",
+     "-Wall",
+     "-Wstrict-prototypes",
+     # GCC (at least) emits spurious warnings for this that cannot be fixed

--- a/third_party/upb/BUILD
+++ b/third_party/upb/BUILD
@@ -1,0 +1,11 @@
+licenses(["notice"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),  # glob everything to satisfy the compile.sh srcs test
+    visibility = ["//third_party:__pkg__"],
+)
+
+exports_files([
+    "01_remove_werror.patch",
+])


### PR DESCRIPTION
With Xcode 16, `upb` fails its own `-Werror` check due to using Clang extensions.

Closes #23667.

PiperOrigin-RevId: 676957876
Change-Id: I8e038b5f879077fefdb5811aff6ae5f56fb4f762

Closes #23668