### PR TITLE
[7.4.0] Wire up `internal-inline-outputs` requirement with RE API

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -72,6 +72,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -277,7 +278,10 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
 
   @Override
   public ListenableFuture<CachedActionResult> downloadActionResult(
-      RemoteActionExecutionContext context, ActionKey actionKey, boolean inlineOutErr) {
+      RemoteActionExecutionContext context,
+      ActionKey actionKey,
+      boolean inlineOutErr,
+      Set<String> inlineOutputFiles) {
     if (context.getSpawnExecutionContext() != null) {
       context.getSpawnExecutionContext().report(SPAWN_CHECKING_CACHE_EVENT);
     }
@@ -289,6 +293,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
             .setActionDigest(actionKey.getDigest())
             .setInlineStderr(inlineOutErr)
             .setInlineStdout(inlineOutErr)
+            .addAllInlineOutputFiles(inlineOutputFiles)
             .build();
     return Utils.refreshIfUnauthenticatedAsync(
         () ->

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
@@ -101,9 +102,13 @@ public class RemoteCache extends AbstractReferenceCounted {
   }
 
   public CachedActionResult downloadActionResult(
-      RemoteActionExecutionContext context, ActionKey actionKey, boolean inlineOutErr)
+      RemoteActionExecutionContext context,
+      ActionKey actionKey,
+      boolean inlineOutErr,
+      Set<String> inlineOutputFiles)
       throws IOException, InterruptedException {
-    return getFromFuture(cacheProtocol.downloadActionResult(context, actionKey, inlineOutErr));
+    return getFromFuture(
+        cacheProtocol.downloadActionResult(context, actionKey, inlineOutErr, inlineOutputFiles));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -25,6 +25,7 @@ import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.analysis.platform.PlatformUtils;
@@ -153,7 +154,11 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
     try (SilentCloseable c =
         Profiler.instance().profile(ProfilerTask.REMOTE_CACHE_CHECK, "check cache hit")) {
       cachedActionResult =
-          remoteCache.downloadActionResult(context, actionKey, /* inlineOutErr= */ true);
+          remoteCache.downloadActionResult(
+              context,
+              actionKey,
+              /* inlineOutErr= */ true,
+              /* inlineOutputFiles= */ ImmutableSet.of());
     }
     ActionResult actionResult = null;
     if (cachedActionResult != null) {

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteCacheClient.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -104,11 +105,16 @@ public interface RemoteCacheClient extends MissingDigestsFinder {
    * @param actionKey The digest of the {@link Action} that generated the action result.
    * @param inlineOutErr A hint to the server to inline the stdout and stderr in the {@code
    *     ActionResult} message.
+   * @param inlineOutputFiles A hint to the server to inline the specified output files in the
+   *     {@code ActionResult} message.
    * @return A Future representing pending download of an action result. If an action result for
    *     {@code actionKey} cannot be found the result of the Future is {@code null}.
    */
   ListenableFuture<CachedActionResult> downloadActionResult(
-      RemoteActionExecutionContext context, ActionKey actionKey, boolean inlineOutErr);
+      RemoteActionExecutionContext context,
+      ActionKey actionKey,
+      boolean inlineOutErr,
+      Set<String> inlineOutputFiles);
 
   /**
    * Uploads an action result for the {@code actionKey}.

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Instant;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
@@ -111,9 +112,8 @@ public class DiskCacheClient implements RemoteCacheClient {
    * deliberately use the mtime because the atime is more likely to be externally modified and may
    * be unavailable on some filesystems.
    *
-   * <p>Prefer calling {@link #downloadBlob} or {@link #downloadActionResult} instead, which will
-   * automatically update the mtime. This method should only be called by the remote worker
-   * implementation.
+   * <p>Prefer calling {@link #downloadBlob} instead, which will automatically update the mtime.
+   * This method should only be called by the remote worker implementation.
    *
    * @throws IOException if an I/O error other than a missing file occurs.
    */
@@ -240,7 +240,10 @@ public class DiskCacheClient implements RemoteCacheClient {
 
   @Override
   public ListenableFuture<CachedActionResult> downloadActionResult(
-      RemoteActionExecutionContext context, ActionKey actionKey, boolean inlineOutErr) {
+      RemoteActionExecutionContext context,
+      ActionKey actionKey,
+      boolean inlineOutErr,
+      Set<String> inlineOutputFiles) {
     if (context.getSpawnExecutionContext() != null) {
       context.getSpawnExecutionContext().report(SPAWN_CHECKING_CACHE_EVENT);
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -88,6 +88,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -621,7 +622,10 @@ public final class HttpCacheClient implements RemoteCacheClient {
 
   @Override
   public ListenableFuture<CachedActionResult> downloadActionResult(
-      RemoteActionExecutionContext context, ActionKey actionKey, boolean inlineOutErr) {
+      RemoteActionExecutionContext context,
+      ActionKey actionKey,
+      boolean inlineOutErr,
+      Set<String> inlineOutputFiles) {
     if (context.getSpawnExecutionContext() != null) {
       context.getSpawnExecutionContext().report(SPAWN_CHECKING_CACHE_EVENT);
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -53,6 +53,7 @@ import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
@@ -300,7 +301,8 @@ public class GrpcCacheClientTest {
             client.downloadActionResult(
                 context,
                 DIGEST_UTIL.asActionKey(DIGEST_UTIL.computeAsUtf8("key")),
-                /* inlineOutErr= */ false));
+                /* inlineOutErr= */ false,
+                /* inlineOutputFiles= */ ImmutableSet.of()));
 
     verify(context.getSpawnExecutionContext())
         .report(SpawnCheckingCacheEvent.create("remote-cache"));
@@ -802,7 +804,8 @@ public class GrpcCacheClientTest {
     remoteCache.downloadActionResult(
         context,
         DIGEST_UTIL.asActionKey(DIGEST_UTIL.computeAsUtf8("key")),
-        /* inlineOutErr= */ false);
+        /* inlineOutErr= */ false,
+        /* inlineOutputFiles= */ ImmutableSet.of());
   }
 
   @Test
@@ -1116,7 +1119,11 @@ public class GrpcCacheClientTest {
         });
     assertThat(
             getFromFuture(
-                client.downloadActionResult(context, actionKey, /* inlineOutErr= */ false)))
+                client.downloadActionResult(
+                    context,
+                    actionKey,
+                    /* inlineOutErr= */ false,
+                    /* inlineOutputFiles= */ ImmutableSet.of())))
         .isNull();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
@@ -25,6 +25,7 @@ import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.events.Reporter;
@@ -78,7 +79,11 @@ public class RemoteRepositoryRemoteExecutorTest {
 
     // Arrange
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
-    when(remoteCache.downloadActionResult(any(), any(), /* inlineOutErr= */ eq(true)))
+    when(remoteCache.downloadActionResult(
+            any(),
+            any(),
+            /* inlineOutErr= */ eq(true),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(CachedActionResult.remote(cachedResult));
 
     // Act
@@ -92,7 +97,9 @@ public class RemoteRepositoryRemoteExecutorTest {
             /* timeout= */ Duration.ZERO);
 
     // Assert
-    verify(remoteCache).downloadActionResult(any(), any(), anyBoolean());
+    verify(remoteCache)
+        .downloadActionResult(
+            any(), any(), anyBoolean(), /* inlineOutputFiles= */ eq(ImmutableSet.of()));
     // Don't fallback to execution
     verify(remoteExecutor, never()).executeRemotely(any(), any(), any());
 
@@ -105,7 +112,11 @@ public class RemoteRepositoryRemoteExecutorTest {
 
     // Arrange
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(1).build();
-    when(remoteCache.downloadActionResult(any(), any(), /* inlineOutErr= */ eq(true)))
+    when(remoteCache.downloadActionResult(
+            any(),
+            any(),
+            /* inlineOutErr= */ eq(true),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(CachedActionResult.remote(cachedResult));
 
     ExecuteResponse response = ExecuteResponse.newBuilder().setResult(cachedResult).build();
@@ -122,7 +133,9 @@ public class RemoteRepositoryRemoteExecutorTest {
             /* timeout= */ Duration.ZERO);
 
     // Assert
-    verify(remoteCache).downloadActionResult(any(), any(), anyBoolean());
+    verify(remoteCache)
+        .downloadActionResult(
+            any(), any(), anyBoolean(), /* inlineOutputFiles= */ eq(ImmutableSet.of()));
     // Fallback to execution
     verify(remoteExecutor).executeRemotely(any(), any(), any());
 
@@ -142,7 +155,11 @@ public class RemoteRepositoryRemoteExecutorTest {
             .setStdoutRaw(ByteString.copyFrom(stdout))
             .setStderrRaw(ByteString.copyFrom(stderr))
             .build();
-    when(remoteCache.downloadActionResult(any(), any(), /* inlineOutErr= */ eq(true)))
+    when(remoteCache.downloadActionResult(
+            any(),
+            any(),
+            /* inlineOutErr= */ eq(true),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(CachedActionResult.remote(cachedResult));
 
     ExecuteResponse response = ExecuteResponse.newBuilder().setResult(cachedResult).build();
@@ -159,7 +176,12 @@ public class RemoteRepositoryRemoteExecutorTest {
             /* timeout= */ Duration.ZERO);
 
     // Assert
-    verify(remoteCache).downloadActionResult(any(), any(), /* inlineOutErr= */ eq(true));
+    verify(remoteCache)
+        .downloadActionResult(
+            any(),
+            any(),
+            /* inlineOutErr= */ eq(true),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of()));
 
     assertThat(executionResult.exitCode()).isEqualTo(0);
     assertThat(executionResult.stdout()).isEqualTo(stdout);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -107,6 +107,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -340,7 +341,8 @@ public class RemoteSpawnCacheTest {
     when(remoteCache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             actionKeyCaptor.capture(),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenAnswer(
             new Answer<CachedActionResult>() {
               @Override
@@ -395,7 +397,10 @@ public class RemoteSpawnCacheTest {
     RemoteExecutionService service = cache.getRemoteExecutionService();
     ArgumentCaptor<ActionKey> actionKeyCaptor = ArgumentCaptor.forClass(ActionKey.class);
     when(remoteCache.downloadActionResult(
-            any(RemoteActionExecutionContext.class), actionKeyCaptor.capture(), anyBoolean()))
+            any(RemoteActionExecutionContext.class),
+            actionKeyCaptor.capture(),
+            anyBoolean(),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
 
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
@@ -461,7 +466,10 @@ public class RemoteSpawnCacheTest {
       CacheHandle entry = remoteSpawnCache.lookup(uncacheableSpawn, simplePolicy);
       verify(remoteCache, never())
           .downloadActionResult(
-              any(RemoteActionExecutionContext.class), any(ActionKey.class), anyBoolean());
+              any(RemoteActionExecutionContext.class),
+              any(ActionKey.class),
+              anyBoolean(),
+              ArgumentMatchers.<Set<String>>any());
       assertThat(simplePolicy.getDigest()).isNull();
       assertThat(entry.hasResult()).isFalse();
       SpawnResult result =
@@ -494,7 +502,8 @@ public class RemoteSpawnCacheTest {
           .downloadActionResult(
               any(RemoteActionExecutionContext.class),
               any(ActionKey.class),
-              /* inlineOutErr= */ eq(false));
+              /* inlineOutErr= */ eq(false),
+              /* inlineOutputFiles= */ eq(ImmutableSet.of()));
       assertThat(simplePolicy.getDigest()).isNull();
       assertThat(entry.hasResult()).isFalse();
       SpawnResult result =
@@ -515,7 +524,10 @@ public class RemoteSpawnCacheTest {
     RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
     ArgumentCaptor<ActionKey> actionKeyCaptor = ArgumentCaptor.forClass(ActionKey.class);
     when(remoteCache.downloadActionResult(
-            any(RemoteActionExecutionContext.class), actionKeyCaptor.capture(), anyBoolean()))
+            any(RemoteActionExecutionContext.class),
+            actionKeyCaptor.capture(),
+            anyBoolean(),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     SimpleSpawn cacheableSpawn =
         simpleSpawnWithExecutionInfo(ImmutableMap.of(ExecutionRequirements.NO_REMOTE_CACHE, ""));
@@ -528,7 +540,8 @@ public class RemoteSpawnCacheTest {
         .downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false));
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of()));
   }
 
   @Test
@@ -538,7 +551,10 @@ public class RemoteSpawnCacheTest {
         simpleSpawnWithExecutionInfo(ImmutableMap.of(ExecutionRequirements.NO_REMOTE_EXEC, ""));
     ArgumentCaptor<ActionKey> actionKeyCaptor = ArgumentCaptor.forClass(ActionKey.class);
     when(remoteCache.downloadActionResult(
-            any(RemoteActionExecutionContext.class), actionKeyCaptor.capture(), anyBoolean()))
+            any(RemoteActionExecutionContext.class),
+            actionKeyCaptor.capture(),
+            anyBoolean(),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
 
     cache.lookup(cacheableSpawn, simplePolicy);
@@ -549,7 +565,8 @@ public class RemoteSpawnCacheTest {
         .downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false));
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of()));
   }
 
   @Test
@@ -562,7 +579,8 @@ public class RemoteSpawnCacheTest {
         .downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false));
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of()));
     assertThat(entry.hasResult()).isFalse();
     SpawnResult result =
         new SpawnResult.Builder()
@@ -587,7 +605,8 @@ public class RemoteSpawnCacheTest {
         .downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false));
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of()));
 
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
     assertThat(entry.hasResult()).isFalse();
@@ -620,7 +639,8 @@ public class RemoteSpawnCacheTest {
     when(remoteCache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenAnswer(
             new Answer<CachedActionResult>() {
               @Override
@@ -659,7 +679,8 @@ public class RemoteSpawnCacheTest {
     when(remoteCache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(CachedActionResult.remote(actionResult));
 
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
@@ -676,7 +697,10 @@ public class RemoteSpawnCacheTest {
 
     ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
     when(remoteCache.downloadActionResult(
-            any(RemoteActionExecutionContext.class), any(), /* inlineOutErr= */ eq(false)))
+            any(RemoteActionExecutionContext.class),
+            any(),
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(CachedActionResult.remote(success));
     doReturn(null).when(cache.getRemoteExecutionService()).downloadOutputs(any(), any());
 
@@ -702,7 +726,10 @@ public class RemoteSpawnCacheTest {
 
     ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
     when(remoteCache.downloadActionResult(
-            any(RemoteActionExecutionContext.class), any(), /* inlineOutErr= */ eq(false)))
+            any(RemoteActionExecutionContext.class),
+            any(),
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(CachedActionResult.remote(success));
     doThrow(downloadFailure)
         .when(cache.getRemoteExecutionService())

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -393,7 +393,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(failedAction);
 
     RemoteSpawnRunner runner = spy(newSpawnRunner());
@@ -436,7 +437,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(failedAction);
 
     RemoteSpawnRunner runner = newSpawnRunner();
@@ -480,7 +482,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
 
     IOException err = new IOException("local execution error");
@@ -513,7 +516,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenThrow(new IOException());
 
     IOException err = new IOException("local execution error");
@@ -534,7 +538,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     when(executor.executeRemotely(
             any(RemoteActionExecutionContext.class),
@@ -758,7 +763,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(cachedResult);
     Exception downloadFailure =
         new BulkTransferException(new CacheNotFoundException(Digest.getDefaultInstance()));
@@ -806,7 +812,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     ActionResult execResult = ActionResult.newBuilder().setExitCode(31).build();
@@ -865,7 +872,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     ExecuteResponse resp =
         ExecuteResponse.newBuilder()
@@ -920,7 +928,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     ExecuteResponse resp =
         ExecuteResponse.newBuilder()
@@ -968,7 +977,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     ExecuteResponse resp =
         ExecuteResponse.newBuilder()
@@ -1010,7 +1020,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     ExecuteResponse failed =
         ExecuteResponse.newBuilder()
@@ -1051,7 +1062,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     when(executor.executeRemotely(
             any(RemoteActionExecutionContext.class),
@@ -1079,7 +1091,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenThrow(new IOException("reasons"));
 
     Spawn spawn = newSimpleSpawn();
@@ -1104,7 +1117,8 @@ public class RemoteSpawnRunnerTest {
     when(cache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
             any(ActionKey.class),
-            /* inlineOutErr= */ eq(false)))
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
         .thenReturn(null);
     when(executor.executeRemotely(
             any(RemoteActionExecutionContext.class),

--- a/src/test/java/com/google/devtools/build/lib/remote/UploadManifestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/UploadManifestTest.java
@@ -558,9 +558,9 @@ public class UploadManifestTest {
             digestUtil,
             remotePathResolver,
             result,
-            /*followSymlinks=*/ false,
-            /*allowDanglingSymlinks=*/ true,
-            /*allowAbsoluteSymlinks=*/ true);
+            /* followSymlinks= */ false,
+            /* allowDanglingSymlinks= */ true,
+            /* allowAbsoluteSymlinks= */ true);
     um.addFiles(ImmutableList.of(link));
     assertThat(um.getDigestToFile()).isEmpty();
 

--- a/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/disk/DiskCacheClientTest.java
@@ -30,6 +30,7 @@ import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.Tree;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.exec.SpawnCheckingCacheEvent;
@@ -89,7 +90,8 @@ public class DiskCacheClientTest {
             client.downloadActionResult(
                 context,
                 DIGEST_UTIL.asActionKey(DIGEST_UTIL.computeAsUtf8("key")),
-                /* inlineOutErr= */ false));
+                /* inlineOutErr= */ false,
+                /* inlineOutputFiles= */ ImmutableSet.of()));
 
     verify(context.getSpawnExecutionContext()).report(SpawnCheckingCacheEvent.create("disk-cache"));
   }
@@ -274,7 +276,12 @@ public class DiskCacheClientTest {
     Path path = populateAc(actionKey, actionResult);
 
     CachedActionResult result =
-        getFromFuture(client.downloadActionResult(context, actionKey, /* inlineOutErr= */ false));
+        getFromFuture(
+            client.downloadActionResult(
+                context,
+                actionKey,
+                /* inlineOutErr= */ false,
+                /* inlineOutputFiles= */ ImmutableSet.of()));
 
     assertThat(result).isEqualTo(CachedActionResult.disk(actionResult));
     assertThat(path.getLastModifiedTime()).isNotEqualTo(0);
@@ -285,7 +292,12 @@ public class DiskCacheClientTest {
     ActionKey actionKey = new ActionKey(getDigest("key"));
 
     CachedActionResult result =
-        getFromFuture(client.downloadActionResult(context, actionKey, /* inlineOutErr= */ false));
+        getFromFuture(
+            client.downloadActionResult(
+                context,
+                actionKey,
+                /* inlineOutErr= */ false,
+                /* inlineOutputFiles= */ ImmutableSet.of()));
 
     assertThat(result).isNull();
   }
@@ -316,7 +328,12 @@ public class DiskCacheClientTest {
     Path treeFileCasPath = populateCas(treeFileDigest, "tree file contents");
 
     CachedActionResult result =
-        getFromFuture(client.downloadActionResult(context, actionKey, /* inlineOutErr= */ false));
+        getFromFuture(
+            client.downloadActionResult(
+                context,
+                actionKey,
+                /* inlineOutErr= */ false,
+                /* inlineOutputFiles= */ ImmutableSet.of()));
 
     assertThat(result).isEqualTo(CachedActionResult.disk(actionResult));
     assertThat(acPath.getLastModifiedTime()).isNotEqualTo(0);
@@ -339,7 +356,12 @@ public class DiskCacheClientTest {
     populateAc(actionKey, actionResult);
 
     CachedActionResult result =
-        getFromFuture(client.downloadActionResult(context, actionKey, /* inlineOutErr= */ false));
+        getFromFuture(
+            client.downloadActionResult(
+                context,
+                actionKey,
+                /* inlineOutErr= */ false,
+                /* inlineOutputFiles= */ ImmutableSet.of()));
 
     assertThat(result).isNull();
   }
@@ -359,7 +381,12 @@ public class DiskCacheClientTest {
     populateCas(fileDigest, "contents");
 
     CachedActionResult result =
-        getFromFuture(client.downloadActionResult(context, actionKey, /* inlineOutErr= */ false));
+        getFromFuture(
+            client.downloadActionResult(
+                context,
+                actionKey,
+                /* inlineOutErr= */ false,
+                /* inlineOutputFiles= */ ImmutableSet.of()));
 
     assertThat(result).isNull();
   }
@@ -379,7 +406,12 @@ public class DiskCacheClientTest {
     populateCas(treeDigest, tree);
 
     CachedActionResult result =
-        getFromFuture(client.downloadActionResult(context, actionKey, /* inlineOutErr= */ false));
+        getFromFuture(
+            client.downloadActionResult(
+                context,
+                actionKey,
+                /* inlineOutErr= */ false,
+                /* inlineOutputFiles= */ ImmutableSet.of()));
 
     assertThat(result).isNull();
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -32,6 +32,7 @@ import build.bazel.remote.execution.v2.Digest;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -370,7 +371,8 @@ public class HttpCacheClientTest {
               blobStore.downloadActionResult(
                   remoteActionExecutionContext,
                   DIGEST_UTIL.asActionKey(DIGEST_UTIL.computeAsUtf8("key")),
-                  /* inlineOutErr= */ false));
+                  /* inlineOutErr= */ false,
+                  /* inlineOutputFiles= */ ImmutableSet.of()));
 
       verify(remoteActionExecutionContext.getSpawnExecutionContext())
           .report(SpawnCheckingCacheEvent.create("remote-cache"));
@@ -734,7 +736,10 @@ public class HttpCacheClientTest {
       RemoteCacheClient.CachedActionResult download =
           getFromFuture(
               blobStore.downloadActionResult(
-                  remoteActionExecutionContext, new RemoteCacheClient.ActionKey(DIGEST), false));
+                  remoteActionExecutionContext,
+                  new RemoteCacheClient.ActionKey(DIGEST),
+                  false,
+                  ImmutableSet.of()));
       assertThat(download.actionResult()).isEqualTo(action2);
     } finally {
       testServer.stop(server);

--- a/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/InMemoryCacheClient.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
@@ -118,7 +119,10 @@ public class InMemoryCacheClient implements RemoteCacheClient {
 
   @Override
   public ListenableFuture<CachedActionResult> downloadActionResult(
-      RemoteActionExecutionContext context, ActionKey actionKey, boolean inlineOutErr) {
+      RemoteActionExecutionContext context,
+      ActionKey actionKey,
+      boolean inlineOutErr,
+      Set<String> inlineOutputFiles) {
     ActionResult actionResult = ac.get(actionKey);
     if (actionResult == null) {
       return Futures.immediateFailedFuture(new CacheNotFoundException(actionKey.getDigest()));

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3426,4 +3426,153 @@ EOF
   expect_log "2 processes: 1 remote cache hit, 1 internal"
 }
 
+function setup_inlined_outputs() {
+  mkdir -p a
+  cat > a/input.txt <<'EOF'
+input
+EOF
+  cat > a/script.sh <<'EOF'
+#!/bin/sh
+cat $1 $1 > $2
+echo "$1" > $3
+EOF
+  chmod +x a/script.sh
+  cat > a/defs.bzl <<EOF
+def _my_rule_impl(ctx):
+  out = ctx.actions.declare_file(ctx.label.name)
+  unused = ctx.actions.declare_file(ctx.label.name + ".unused")
+  args = ctx.actions.args()
+  args.add(ctx.file.input)
+  args.add(out)
+  args.add(unused)
+  ctx.actions.run(
+    executable = ctx.executable._script,
+    inputs = [ctx.file.input],
+    outputs = [out, unused],
+    arguments = [args],
+    unused_inputs_list = unused,
+    execution_requirements = {
+      "supports-path-mapping": "",
+    },
+  )
+  return [DefaultInfo(files = depset([out]))]
+
+my_rule = rule(
+  implementation = _my_rule_impl,
+  attrs = {
+    "input": attr.label(allow_single_file = True),
+    "_script": attr.label(cfg = "exec", executable = True, default = ":script"),
+  },
+)
+EOF
+  cat > a/BUILD <<'EOF'
+load("//a:defs.bzl", "my_rule")
+
+my_rule(
+  name = "my_rule",
+  input = "input.txt",
+)
+
+sh_binary(
+  name = "script",
+  srcs = ["script.sh"],
+)
+EOF
+}
+
+function test_remote_cache_inlined_output() {
+  setup_inlined_outputs
+
+  # Populate the cache.
+  bazel build \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //a:my_rule >& $TEST_log || fail "Failed to build //a:my_rule"
+  expect_not_log "WARNING: Remote Cache:"
+  bazel clean --expunge
+  bazel shutdown
+
+  bazel build \
+    --remote_cache=grpc://localhost:${worker_port} \
+    --remote_grpc_log=grpc.log \
+    //a:my_rule >& $TEST_log || fail "Failed to build //a:my_rule"
+  expect_log "1 remote cache hit"
+  expect_not_log "WARNING: Remote Cache:"
+  assert_contains "input
+input" bazel-bin/a/my_rule
+
+  cat grpc.log > $TEST_log
+  # Assert that only the output is download as the unused_inputs_list is inlined.
+  # sha256 of "input\ninput\n"
+  expect_log "blobs/c88bd120ac840aa8d8a8fcedb6d620cd49c013730d387eb52be0c113bbcab640/12"
+  expect_log_n "google.bytestream.ByteStream/Read" 1
+
+  # Verify that the unused_inputs_list content is correct.
+  cat > a/input.txt <<'EOF'
+modified
+EOF
+
+  bazel build \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //a:my_rule >& $TEST_log || fail "Failed to build //a:my_rule"
+  assert_contains "input" bazel-bin/a/my_rule
+}
+
+function test_remote_execution_inlined_output() {
+  setup_inlined_outputs
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_grpc_log=grpc.log \
+    //a:my_rule >& $TEST_log || fail "Failed to build //a:my_rule"
+  expect_log "1 remote"
+  assert_contains "input
+input" bazel-bin/a/my_rule
+
+  cat grpc.log > $TEST_log
+  # Assert that only the output is download as the unused_inputs_list is inlined.
+  # sha256 of "input\ninput\n"
+  expect_log "blobs/c88bd120ac840aa8d8a8fcedb6d620cd49c013730d387eb52be0c113bbcab640/12"
+  expect_log_n "google.bytestream.ByteStream/Read" 1
+
+  # Verify that the unused_inputs_list content is correct.
+  cat > a/input.txt <<'EOF'
+modified
+EOF
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:my_rule >& $TEST_log || fail "Failed to build //a:my_rule"
+  assert_contains "input" bazel-bin/a/my_rule
+}
+
+function test_remote_execution_inlined_output_with_path_mapping() {
+  setup_inlined_outputs
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_grpc_log=grpc.log \
+    --experimental_output_paths=strip \
+    //a:my_rule >& $TEST_log || fail "Failed to build //a:my_rule"
+  expect_log "1 remote"
+  assert_contains "input
+input" bazel-bin/a/my_rule
+
+  cat grpc.log > $TEST_log
+  # Assert that only the output is download as the unused_inputs_list is inlined.
+  # sha256 of "input\ninput\n"
+  expect_log "blobs/c88bd120ac840aa8d8a8fcedb6d620cd49c013730d387eb52be0c113bbcab640/12"
+  expect_log_n "google.bytestream.ByteStream/Read" 1
+
+  # Verify that the unused_inputs_list content is correct.
+  cat > a/input.txt <<'EOF'
+modified
+EOF
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --experimental_output_paths=strip \
+    //a:my_rule >& $TEST_log || fail "Failed to build //a:my_rule"
+  assert_contains "input" bazel-bin/a/my_rule
+}
+
 run_suite "Remote execution and remote cache tests"


### PR DESCRIPTION
In-memory outputs marked with the `internal-inline-outputs` execution requirement are now added to the `inline_output_files` hint field of the remote execution and remote cache API, potentially saving a round trip on files that are unconditionally read by Bazel client after spawn execution.

Support for output file inlining has been added to the remote worker implementation.

Fixes #8421.

Closes #23428.

PiperOrigin-RevId: 673938116
Change-Id: Ieaea53502c43f9fc90b99f72dd4cdb4711239dd3 
(cherry picked from commit 56ad5d2551b37bf7ed2bd56c98ec1ce751685c38)

Closes #23511