### PR TITLE
[7.4.0] cquery: Factor RepositoryName into fetching ignored packages

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
 import com.google.devtools.build.lib.collect.compacthashset.CompactHashSet;
@@ -253,12 +254,12 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
         ((ConfiguredTargetValue) getConfiguredTargetValue(key)).getConfiguredTarget());
   }
 
-  public InterruptibleSupplier<ImmutableSet<PathFragment>>
-      getIgnoredPackagePrefixesPathFragments() {
+  public InterruptibleSupplier<ImmutableSet<PathFragment>> getIgnoredPackagePrefixesPathFragments(
+      RepositoryName repositoryName) {
     return () -> {
       IgnoredPackagePrefixesValue ignoredPackagePrefixesValue =
           (IgnoredPackagePrefixesValue)
-              walkableGraphSupplier.get().getValue(IgnoredPackagePrefixesValue.key());
+              walkableGraphSupplier.get().getValue(IgnoredPackagePrefixesValue.key(repositoryName));
       return ignoredPackagePrefixesValue == null
           ? ImmutableSet.of()
           : ignoredPackagePrefixesValue.getPatterns();

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
@@ -312,7 +312,7 @@ public class ActionGraphQueryEnvironment
         Futures.catchingAsync(
             patternToEval.evalAdaptedForAsync(
                 resolver,
-                getIgnoredPackagePrefixesPathFragments(),
+                getIgnoredPackagePrefixesPathFragments(patternToEval.getRepository()),
                 /* excludedSubdirectories= */ ImmutableSet.of(),
                 (Callback<Target>)
                     partialResult -> {

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -274,7 +274,7 @@ public class ConfiguredTargetQueryEnvironment extends PostAnalysisQueryEnvironme
         Futures.catchingAsync(
             patternToEval.evalAdaptedForAsync(
                 resolver,
-                getIgnoredPackagePrefixesPathFragments(),
+                getIgnoredPackagePrefixesPathFragments(patternToEval.getRepository()),
                 /* excludedSubdirectories= */ ImmutableSet.of(),
                 (Callback<Target>)
                     partialResult -> {

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -1435,6 +1435,36 @@ EOF
   expect_log "@repo//:japanese"
 }
 
+function test_external_repo_scope_with_bazelignore() {
+  if [ "${PRODUCT_NAME}" != "bazel" ]; then
+    # Tests of external repositories only work under bazel.
+    return 0
+  fi
+
+  local -r dir=$FUNCNAME
+
+  mkdir -p $dir/repo
+  touch $dir/repo/REPO.bazel
+  cat > $dir/repo/BUILD <<EOF
+sh_library(name='maple', deps=[':japanese'])
+sh_library(name='japanese')
+EOF
+
+  mkdir -p $dir/main
+  write_default_lockfile $dir/main/MODULE.bazel.lock
+  cat > $dir/main/WORKSPACE <<EOF
+local_repository(name = "repo", path = "../repo")
+EOF
+  touch $dir/main/BUILD
+  echo does_not_exist > $dir/main/.bazelignore
+
+  cd $dir/main
+  bazel cquery @repo//... &>"$TEST_log" || fail "Unexpected failure"
+  expect_not_log "no targets found beneath"
+  expect_log "@repo//:maple"
+  expect_log "@repo//:japanese"
+}
+
 function test_test_arg_in_bazelrc() {
   local -r pkg=$FUNCNAME
   mkdir -p $pkg


### PR DESCRIPTION
Previously this code was assuming that all cquery target patterns should use the root repository's .bazelignore contents which was incorrect.

Because the way this manifested itself was that when cquery drives populating the graph and when it queries it, it would use different keys, this led to misleading messages about packages not being in scope.

Closes #22142.

PiperOrigin-RevId: 628477138
Change-Id: I84e3381848b843ca9813acdd0762a3b3e4711a90