### PR TITLE
[7.4.0] Use NOW_SENTINEL_TIME when refreshing the mtime on a disk cache entry.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -48,7 +48,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -119,7 +118,9 @@ public class DiskCacheClient implements RemoteCacheClient {
    */
   public boolean refresh(Path path) throws IOException {
     try {
-      path.setLastModifiedTime(Instant.now().toEpochMilli());
+      // Use NOW_SENTINEL_TIME instead of obtaining the current time so that the operation succeeds
+      // even when the file has a different owner, as might be the case for a shared cache.
+      path.setLastModifiedTime(Path.NOW_SENTINEL_TIME);
     } catch (FileNotFoundException e) {
       return false;
     }


### PR DESCRIPTION
Fixes #23512.

PiperOrigin-RevId: 678162004
Change-Id: If94854fa02a4ae457507e3d2b20227871f88b068