### PR TITLE
[7.4.0] Use millisecond precision when setting the last modified time on Unix.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/unix/NativePosixFiles.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/NativePosixFiles.java
@@ -128,16 +128,17 @@ public final class NativePosixFiles {
   public static native ErrnoFileStatus errnoLstat(String path);
 
   /**
-   * Native wrapper around POSIX utime(2) syscall.
+   * Native wrapper around POSIX utimensat(2) syscall.
    *
-   * Note: negative file times are interpreted as unsigned time_t.
+   * <p>Note that, even though utimensat(2) supports up to nanosecond precision, this interface only
+   * allows millisecond precision, which is what Bazel uses internally.
    *
-   * @param path the file whose times to change.
-   * @param now if true, ignore actime/modtime parameters and use current time.
-   * @param modtime the file modification time in seconds since the UNIX epoch.
-   * @throws IOException if the utime() syscall failed.
+   * @param path the file whose modification time should be changed.
+   * @param now if true, ignore {@code epochMilli} and use the current time.
+   * @param epochMilli the file modification time in milliseconds since the UNIX epoch.
+   * @throws IOException if the operation failed.
    */
-  public static native void utime(String path, boolean now, int modtime) throws IOException;
+  public static native void utimensat(String path, boolean now, long epochMilli) throws IOException;
 
   /**
    * Native wrapper around POSIX mkdir(2) syscall.

--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -407,13 +407,7 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   public void setLastModifiedTime(PathFragment path, long newTime) throws IOException {
-    if (newTime == Path.NOW_SENTINEL_TIME) {
-      NativePosixFiles.utime(path.toString(), true, 0);
-    } else {
-      // newTime > MAX_INT => -ve unixTime
-      int unixTime = (int) (newTime / 1000);
-      NativePosixFiles.utime(path.toString(), false, unixTime);
-    }
+    NativePosixFiles.utimensat(path.toString(), newTime == Path.NOW_SENTINEL_TIME, newTime);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.vfs;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
@@ -61,12 +60,6 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   public JavaIoFileSystem(DigestHashFunction hashFunction) {
     super(hashFunction);
     this.clock = new JavaClock();
-  }
-
-  @VisibleForTesting
-  JavaIoFileSystem(Clock clock, DigestHashFunction hashFunction) {
-    super(hashFunction);
-    this.clock = clock;
   }
 
   protected File getIoFile(PathFragment path) {

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -43,6 +43,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
+import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -1177,6 +1178,31 @@ public abstract class FileSystemTest {
   }
 
   // Test the date functions
+
+  @Test
+  public void testSetLastModifiedTime() throws Exception {
+    Path file = absolutize("file");
+    FileSystemUtils.createEmptyFile(file);
+
+    file.setLastModifiedTime(1234567890L);
+    assertThat(file.getLastModifiedTime()).isEqualTo(1234567890L);
+  }
+
+  @Test
+  public void testSetLastModifiedTimeWithSentinel() throws Exception {
+    Path file = absolutize("file");
+    FileSystemUtils.createEmptyFile(file);
+
+    // To avoid sleeping, first set the modification time to the past.
+    long pastTime = Instant.now().minusSeconds(1).toEpochMilli();
+    file.setLastModifiedTime(pastTime);
+
+    // Even if we get the system time before the setLastModifiedTime call, getLastModifiedTime may
+    // return a time which is slightly behind. Simply check that it's greater than the past time.
+    file.setLastModifiedTime(Path.NOW_SENTINEL_TIME);
+    assertThat(file.getLastModifiedTime()).isGreaterThan(pastTime);
+  }
+
   @Test
   public void testCreateFileChangesTimeOfDirectory() throws Exception {
     storeReferenceTime(workingDir.getLastModifiedTime());

--- a/src/test/java/com/google/devtools/build/lib/vfs/JavaIoFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/JavaIoFileSystemTest.java
@@ -13,14 +13,11 @@
 // limitations under the License.
 package com.google.devtools.build.lib.vfs;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -42,12 +39,9 @@ import org.junit.Test;
  */
 public class JavaIoFileSystemTest extends SymlinkAwareFileSystemTest {
 
-  private ManualClock clock;
-
   @Override
   public FileSystem getFreshFileSystem(DigestHashFunction digestHashFunction) {
-    clock = new ManualClock();
-    return new JavaIoFileSystem(clock, digestHashFunction);
+    return new JavaIoFileSystem(digestHashFunction);
   }
 
   // Tests are inherited from the FileSystemTest
@@ -57,21 +51,6 @@ public class JavaIoFileSystemTest extends SymlinkAwareFileSystemTest {
   @Override
   @Test
   public void testBadPermissionsThrowsExceptionOnStatIfFound() {}
-
-  @Test
-  public void testSetLastModifiedTime() throws Exception {
-    Path file = xEmptyDirectory.getChild("new-file");
-    FileSystemUtils.createEmptyFile(file);
-
-    file.setLastModifiedTime(1000L);
-    assertThat(file.getLastModifiedTime()).isEqualTo(1000L);
-    file.setLastModifiedTime(0L);
-    assertThat(file.getLastModifiedTime()).isEqualTo(0L);
-
-    clock.advanceMillis(42000L);
-    file.setLastModifiedTime(-1L);
-    assertThat(file.getLastModifiedTime()).isEqualTo(42000L);
-  }
 
   @Override
   protected boolean isHardLinked(Path a, Path b) throws IOException {


### PR DESCRIPTION
Currently, we truncate to second precision. Instead, make use of utimensat(2), which can accommodate up to nanosecond precision, is part of POSIX, and is widely available (Linux, Darwin, OpenBSD, FreeBSD and NetBSD).

PiperOrigin-RevId: 678185275
Change-Id: I307dbc75c8f594e6d70b43ee0bde2226b3015611