### PR TITLE
[7.4.0] Add ubuntu2004_arm64 to .bazelci/build_bazel_binaries.yml

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -14,6 +14,13 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
+  ubuntu2004_arm64:
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_nojdk"
+    build_flags:
+      - "-c"
+      - "opt"
   ubuntu2204:
     build_targets:
       - "//src:bazel"


### PR DESCRIPTION
Working towards: https://github.com/bazelbuild/continuous-integration/issues/1402

PiperOrigin-RevId: 665794401
Change-Id: Iee2445c522d5e8e4f78f90703520e4baef0d17b4

Cherry pick of eee5ab3bc1
