### PR TITLE
Return a quoted string for `repr(repository_ctx.path(...))`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkPath.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkPath.java
@@ -31,6 +31,7 @@ import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkSemantics;
 import net.starlark.java.eval.StarlarkValue;
 import net.starlark.java.eval.Tuple;
 
@@ -200,7 +201,12 @@ public final class StarlarkPath implements StarlarkValue {
   }
 
   @Override
+  public void str(Printer printer, StarlarkSemantics semantics) {
+    printer.append(path.toString());
+  }
+
+  @Override
   public void repr(Printer printer) {
-    printer.append(toString());
+    printer.repr(path.toString());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkPathTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkPathTest.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import net.starlark.java.eval.Starlark;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,5 +51,11 @@ public class StarlarkPathTest {
     assertThat(ev.eval("wd.get_child('foo')")).isEqualTo(makePath(wd.getChild("foo")));
     assertThat(ev.eval("wd.get_child('a','b/c','/d/')"))
         .isEqualTo(makePath(wd.getRelative("a/b/c/d")));
+  }
+
+  @Test
+  public void testStarlarkPathStringifications() throws Exception {
+    assertThat(ev.eval("repr(wd)")).isEqualTo(Starlark.repr(wd.toString()));
+    assertThat(ev.eval("str(wd)")).isEqualTo(wd.toString());
   }
 }


### PR DESCRIPTION
This makes it easier to use `repository_ctx.path(...)` in BUILD file templating as it no longer differs from a path string.