### PR TITLE
Avoid char array allocation in Starlark `format`

### DIFF
--- a/src/test/java/net/starlark/java/eval/testdata/bench_string.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bench_string.star
@@ -16,3 +16,26 @@ _to_strip = "   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
 def bench_strip(b):
     for _ in range(b.n):
         _to_strip.strip()
+
+_sample_template = """
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+filegroup(
+  name="files",
+  srcs = {srcs},
+  visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+  name="archives",
+  srcs = [":files"],
+  strip_prefix = "{strip_prefix}",
+  package_dir = "{dirname}",
+  visibility = ["//visibility:public"],
+)
+
+"""
+
+def bench_format(b):
+    for _ in range(b.n):
+        "".format(srcs = "srcs", strip_prefix = "strip_prefix", dirname = "dirname")


### PR DESCRIPTION
Positional access via `String#charAt` is slightly faster than precreating the char array for Latin-1 strings and much faster for UTF-8 strings. It allocates less in both cases.

Also adds a `--latin1` flag to the `Benchmarks` tool that allows benchmarking against Bazel's way of parsing Starlark files.

Before:
```
INFO: Running command line: bazel-bin/src/test/java/net/starlark/java/eval/Benchmarks --filter bench_format --seconds 20
File src/test/java/net/starlark/java/eval/testdata/bench_string.star:
benchmark                        ops     cpu/op    wall/op   steps/op   alloc/op
bench_format               134217727      169ns      168ns          7       495B

INFO: Running command line: bazel-bin/src/test/java/net/starlark/java/eval/Benchmarks --filter bench_format --seconds 20 --latin1
File src/test/java/net/starlark/java/eval/testdata/bench_string.star:
benchmark                        ops     cpu/op    wall/op   steps/op   alloc/op
bench_format               268435455      122ns      121ns          7       495B
```

After:
```
INFO: Running command line: bazel-bin/src/test/java/net/starlark/java/eval/Benchmarks --filter bench_format --seconds 20
File src/test/java/net/starlark/java/eval/testdata/bench_string.star:
benchmark                        ops     cpu/op    wall/op   steps/op   alloc/op
bench_format               268435455      110ns      109ns          7       479B

INFO: Running command line: bazel-bin/src/test/java/net/starlark/java/eval/Benchmarks --filter bench_format --seconds 20 --latin1
File src/test/java/net/starlark/java/eval/testdata/bench_string.star:
benchmark                        ops     cpu/op    wall/op   steps/op   alloc/op
bench_format               268435455      113ns      112ns          7       479B
```