### PR TITLE
Add a benchmark for `count` and update a comment

### DIFF
--- a/src/main/java/net/starlark/java/eval/StringModule.java
+++ b/src/main/java/net/starlark/java/eval/StringModule.java
@@ -873,9 +873,10 @@ final class StringModule implements StarlarkValue {
     if (sub.isEmpty()) {
       return hi(indices) - lo(indices) + 1; // str.length() + 1
     }
-    // Unfortunately Java forces us to allocate here, even though
-    // String has a private indexOf method that accepts indices.
-    // Fortunately the common case is self[0:n].
+    // The allocation could be avoided by starting at lo(indices) and checking
+    // for index <= hi(indices) - sub.length() in the loop, but benchmarks show
+    // that the allocation can be faster (and it is a no-op in the common case
+    // of default values for start and end).
     String str = self.substring(lo(indices), hi(indices));
     int count = 0;
     int index = 0;

--- a/src/test/java/net/starlark/java/eval/testdata/bench_string.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bench_string.star
@@ -16,3 +16,9 @@ _to_strip = "   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
 def bench_strip(b):
     for _ in range(b.n):
         _to_strip.strip()
+
+_needle_to_count = "er"
+
+def bench_count(b):
+    for _ in range(b.n):
+        _haystack.count(_needle_to_count, 1, len(_haystack) - 1)

--- a/src/test/java/net/starlark/java/eval/testdata/string_misc.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_misc.star
@@ -150,6 +150,7 @@ assert_eq("abc".count("c", -1), 1)
 assert_eq("abc".count("c", 0, 5), 1)
 assert_eq("abc".count("c", 0, -1), 0)
 assert_eq("abc".count("a", 0, -1), 1)
+assert_eq("ababab".count("ab", 0, 5), 2)
 
 # isalpha
 assert_eq("".isalpha(), False)


### PR DESCRIPTION
I tried to optimize `count` by acting on the comment and avoiding allocations that way, but it turned out to be slower.

Also adds an interesting test case.