### PR TITLE
Avoid showing build error twice

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeErrorProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeErrorProcessor.java
@@ -911,7 +911,7 @@ public final class SkyframeErrorProcessor {
       throw new BuildFailedException(
           message,
           actionExecutionCause.isCatastrophe(),
-          /* errorAlreadyShown= */ !actionExecutionCause.showError(),
+          /* errorAlreadyShown= */ true,
           actionExecutionCause.getDetailedExitCode());
     }
     if (cause instanceof InputFileErrorException inputFileErrorException) {


### PR DESCRIPTION
By the time when `BuildFailedException` is thrown from SkyframeErrorProcessor, the error message is already printed out. The `errorAlreadyShown` field of `BuildFailedException` should be `true` to avoid printing build error twice. 

Fixes #12146

Before the PR:

```
➜  go-code-sparse git:(main) ✗ ~/Github/bazel/bazel-bin/src/bazel-dev build //foo/config:all 
...
INFO: Analyzed 4 targets (302 packages loaded, 14510 targets configured).
ERROR: /Users/zplin/Uber/go-code-sparse/foo/config/BUILD.bazel:16:8: GoCompilePkg foo/config/go_default_test.internal.a failed: (Exit 1): builder failed: error executing GoCompilePkg command (from target //foo/config:go_default_test) bazel-out/darwin_arm64-opt-exec-ST-a828a81199fe/bin/external/go_sdk/builder_reset/builder compilepkg -sdk external/go_sdk -goroot bazel-out/darwin_arm64-fastbuild/bin/external/io_bazel_rules_go/stdlib_ ... (remaining 42 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
foo/config/reader_test.go:29:2: undefined: require
foo/config/reader_test.go:30:2: undefined: require
foo/config/reader_test.go:63:2: undefined: require
compilepkg: error running subcommand external/go_sdk/pkg/tool/darwin_arm64/compile: exit status 2
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /Users/zplin/Uber/go-code-sparse/foo/config/BUILD.bazel:16:8 GoCompilePkg foo/config/go_default_test~testmain.a failed: (Exit 1): builder failed: error executing GoCompilePkg command (from target //foo/config:go_default_test) bazel-out/darwin_arm64-opt-exec-ST-a828a81199fe/bin/external/go_sdk/builder_reset/builder compilepkg -sdk external/go_sdk -goroot bazel-out/darwin_arm64-fastbuild/bin/external/io_bazel_rules_go/stdlib_ ... (remaining 42 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
INFO: Elapsed time: 9.903s, Critical Path: 0.62s
INFO: 2 processes: 228 action cache hit, 2 internal.
ERROR: Build did NOT complete successfully
```

After the PR:

```
➜  go-code-sparse git:(main) ✗ ~/Github/bazel/bazel-bin/src/bazel-dev build //foo/config:all
Starting local Bazel server and connecting to it...
INFO: Invocation ID: 259a9f58-45ef-4093-80c6-fc71c4180b13
WARNING: WORKSPACE support will be removed in Bazel 9 (late 2025), please migrate to Bzlmod, see https://bazel.build/external/migration.
DEBUG: /private/var/tmp/_bazel_zplin/5c6ae8d227961f237651c068f1e02828/external/rules_proto_grpc/internal/common.bzl:358:14: Bazel is not a release version, rules_proto_grpc requires at least 5.3.0
DEBUG: /private/var/tmp/_bazel_zplin/5c6ae8d227961f237651c068f1e02828/external/rules_proto_grpc/internal/common.bzl:358:14: Bazel is not a release version, rules_proto_grpc requires at least 5.3.0
DEBUG: /private/var/tmp/_bazel_zplin/5c6ae8d227961f237651c068f1e02828/external/rules_proto_grpc/internal/common.bzl:358:14: Bazel is not a release version, rules_proto_grpc requires at least 5.3.0
INFO: Analyzed 4 targets (302 packages loaded, 14510 targets configured).
ERROR: /Users/zplin/Uber/go-code-sparse/foo/config/BUILD.bazel:16:8: GoCompilePkg foo/config/go_default_test.internal.a failed: (Exit 1): builder failed: error executing GoCompilePkg command (from target //foo/config:go_default_test) bazel-out/darwin_arm64-opt-exec-ST-a828a81199fe/bin/external/go_sdk/builder_reset/builder compilepkg -sdk external/go_sdk -goroot bazel-out/darwin_arm64-fastbuild/bin/external/io_bazel_rules_go/stdlib_ ... (remaining 42 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
foo/config/reader_test.go:29:2: undefined: require
foo/config/reader_test.go:30:2: undefined: require
foo/config/reader_test.go:63:2: undefined: require
compilepkg: error running subcommand external/go_sdk/pkg/tool/darwin_arm64/compile: exit status 2
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 9.225s, Critical Path: 0.67s
INFO: 2 processes: 228 action cache hit, 2 internal.
ERROR: Build did NOT complete successfully
```