### PR TITLE
Automatically ignore vendor dir for finding packages

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -813,6 +813,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/io:inconsistent_filesystem_exception",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_directory_value",
+        "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_function",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredPackagePrefixesFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredPackagePrefixesFunction.java
@@ -89,8 +89,6 @@ public class IgnoredPackagePrefixesFunction implements SkyFunction {
         PathFragment vendorDir = null;
         if (VENDOR_DIRECTORY.get(env).isPresent()) {
           vendorDir = VENDOR_DIRECTORY.get(env).get().asFragment();
-          // Vendor dir should have been resolved to an absolute path.
-          Preconditions.checkArgument(vendorDir.isAbsolute());
         }
 
         for (Root packagePathEntry : pkgLocator.getPathEntries()) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredPackagePrefixesFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredPackagePrefixesFunction.java
@@ -36,7 +36,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -87,7 +86,6 @@ public class IgnoredPackagePrefixesFunction implements SkyFunction {
       }
 
       if (repositoryName.isMain()) {
-        // Always ignore the vendor dir for finding packages
         PathFragment vendorDir = null;
         if (VENDOR_DIRECTORY.get(env).isPresent()) {
           vendorDir = VENDOR_DIRECTORY.get(env).get().asFragment();

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -518,7 +518,9 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
     skyframeExecutor.injectExtraPrecomputedValues(
         ImmutableList.of(
             PrecomputedValue.injected(
-                RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE, Optional.empty())));
+                RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE, Optional.empty()),
+            PrecomputedValue.injected(
+                RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty())));
   }
 
   protected void setPackageOptions(String... options) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
@@ -805,6 +805,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util:util_internal",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
         "//third_party:guava",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/buildtool/ProjectResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/ProjectResolutionTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.Project;
+import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
@@ -60,6 +61,7 @@ public class ProjectResolutionTest extends BuildIntegrationTestCase {
             ImmutableMap.of(),
             QuiescingExecutorsImpl.forTesting(),
             new TimestampGranularityMonitor(null));
+    getSkyframeExecutor().injectExtraPrecomputedValues(AnalysisMock.get().getPrecomputedValues());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/packages/util/PackageLoadingTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/PackageLoadingTestCase.java
@@ -156,6 +156,10 @@ public abstract class PackageLoadingTestCase extends FoundationTestCase {
         ImmutableList.of(
             PrecomputedValue.injected(
                 RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE, Optional.empty())));
+    skyframeExecutor.injectExtraPrecomputedValues(
+        ImmutableList.of(
+            PrecomputedValue.injected(
+                RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty())));
     SkyframeExecutorTestHelper.process(skyframeExecutor);
     return skyframeExecutor;
   }

--- a/src/test/java/com/google/devtools/build/lib/pkgcache/IncrementalLoadingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/pkgcache/IncrementalLoadingTest.java
@@ -485,6 +485,9 @@ public class IncrementalLoadingTest {
           ImmutableList.of(
               PrecomputedValue.injected(
                   RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE,
+                  Optional.empty()),
+              PrecomputedValue.injected(
+                  RepositoryDelegatorFunction.VENDOR_DIRECTORY,
                   Optional.empty())));
       BuildLanguageOptions buildLanguageOptions = Options.getDefaults(BuildLanguageOptions.class);
       buildLanguageOptions.incompatibleAutoloadExternally = ImmutableList.of();

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GlobTestBase.java
@@ -125,6 +125,8 @@ public abstract class GlobTestBase {
     PrecomputedValue.STARLARK_SEMANTICS.set(differencer, StarlarkSemantics.DEFAULT);
     RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE.set(
         differencer, Optional.empty());
+    RepositoryDelegatorFunction.VENDOR_DIRECTORY.set(
+        differencer, Optional.empty());
 
     createTestFiles();
   }

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -671,6 +671,49 @@ class BazelVendorTest(test_base.TestBase):
     self.assertIn('bbb+', os.listdir(self._test_cwd + '/vendor'))
     self.assertNotIn('ccc+', os.listdir(self._test_cwd + '/vendor'))
 
+  def testVendorDirIsIgnored(self):
+    self.main_registry.createCcModule('aaa', '1.0')
+    self.ScratchFile(
+        'MODULE.bazel',
+        ['bazel_dep(name = "aaa", version = "1.0")'],
+    )
+    self.ScratchFile(
+        'BUILD',
+        [
+            'cc_binary(',
+            '  name = "main",',
+            '  srcs = ["main.cc"],',
+            '  deps = [',
+            '    "@aaa//:lib_aaa",',
+            '  ],',
+            ')',
+        ],
+    )
+    self.ScratchFile(
+        'main.cc',
+        [
+            '#include "aaa.h"',
+            'int main() {',
+            '    hello_aaa("Hello there!");',
+            '}',
+        ],
+    )
+
+    self.RunBazel([
+        'vendor',
+        '//...',
+        '--vendor_dir=vendor',
+    ])
+    # Assert aaa is vendored
+    self.assertIn('aaa+', os.listdir(self._test_cwd + '/vendor'))
+
+    # bazel build //... should succeed because vendor dir is ignored automatically.
+    self.RunBazel([
+        'build',
+        '//...',
+        '--vendor_dir=vendor',
+    ])
+
   def testBuildVendoredTargetOffline(self):
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(
         'bbb', '1.0', {'aaa': '1.0'}


### PR DESCRIPTION
- Adding `--vendor_dir` to ignored package prefixes as if it's added in the `.bazelignore` file.
- This allows users to do `bazel build //...` after vendoring external deps in the source root without manually adding the vendor dir in `.bazelignore`.

Fixes https://github.com/bazelbuild/bazel/issues/23521