### PR TITLE
Remove obsolete workaround for XML generation for flaky tests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -460,22 +459,13 @@ public class StandaloneTestStrategy extends TestStrategy {
       envBuilder.put("TEST_SHARD_INDEX", "0");
       envBuilder.put("TEST_TOTAL_SHARDS", "0");
     }
-    Map<String, String> executionInfo =
-        Maps.newHashMapWithExpectedSize(action.getExecutionInfo().size() + 1);
-    executionInfo.putAll(action.getExecutionInfo());
-    if (result.exitCode() != 0) {
-      // If the test is failed, the spawn shouldn't use remote cache since the test.xml file is
-      // renamed immediately after the spawn execution. If there is another test attempt, the async
-      // upload will fail because it cannot read the file at original position.
-      executionInfo.put(ExecutionRequirements.NO_REMOTE_CACHE, "");
-    }
     return new SimpleSpawn(
         action,
         args,
         envBuilder.buildOrThrow(),
         // Pass the execution info of the action which is identical to the supported tags set on the
         // test target. In particular, this does not set the test timeout on the spawn.
-        ImmutableMap.copyOf(executionInfo),
+        action.getExecutionInfo(),
         ImmutableMap.of(),
         /*inputs=*/ NestedSetBuilder.create(
             Order.STABLE_ORDER, action.getTestXmlGeneratorScript(), action.getTestLog()),


### PR DESCRIPTION
Partially reverts f5cf8b076bc913dbe021104d5f6837fb4a6cd8b3, which is no longer needed now that test actions opt out of async upload.