### PR TITLE
[7.4.0] Make `launcher_maker` cross-platform

### DIFF
--- a/src/tools/launcher/BUILD
+++ b/src/tools/launcher/BUILD
@@ -62,16 +62,19 @@ win_cc_library(
     deps = [":launcher_base"],
 )
 
-win_cc_binary(
+cc_binary(
     name = "launcher_maker",
     srcs = ["launcher_maker.cc"],
     visibility = [
         "//src:__pkg__",
         "//tools/launcher:__pkg__",
     ],
-    deps = [
-        "//src/main/cpp/util:filesystem",
-    ],
+    deps = select({
+        "@platforms//os:windows": [
+            "//src/main/cpp/util:filesystem",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 launcher_maker_test(name = "launcher_maker_test")

--- a/src/tools/launcher/launcher_maker.cc
+++ b/src/tools/launcher/launcher_maker.cc
@@ -19,7 +19,9 @@
 #include <fstream>
 #include <string>
 
+#ifdef _WIN32
 #include "src/main/cpp/util/path_platform.h"
+#endif  // _WIN32
 
 //  This is a replacement for
 //  third_party/bazel/src/main/java/com/google/devtools/build/lib/analysis/actions/LauncherFileWriteAction.java
@@ -34,7 +36,11 @@
 //  end, the size of the launch data written is appended as a long value (8
 //  bytes).
 
-std::wstring windows_path(char* path) {
+#ifdef _WIN32
+
+#define STRING_TYPE std::wstring
+#define STRING_FORMAT "%ls"
+std::wstring convert_path(char* path) {
   std::string error;
   std::wstring wpath;
   if (!blaze_util::AsAbsoluteWindowsPath(path, &wpath, &error)) {
@@ -45,34 +51,42 @@ std::wstring windows_path(char* path) {
   return wpath;
 }
 
+#else  // _WIN32
+
+#define STRING_TYPE std::string
+#define STRING_FORMAT "%s"
+std::string convert_path(char* path) { return path; }
+
+#endif  // _WIN32
+
 int main(int argc, char** argv) {
   if (argc < 4) {
     fprintf(stderr, "Expected 3 arguments, got %d\n", argc);
     return 1;
   }
 
-  std::wstring wlauncher_path = windows_path(argv[1]);
-  std::wstring winfo_params = windows_path(argv[2]);
-  std::wstring woutput_path = windows_path(argv[3]);
+  STRING_TYPE launcher_path = convert_path(argv[1]);
+  STRING_TYPE info_params = convert_path(argv[2]);
+  STRING_TYPE output_path = convert_path(argv[3]);
 
-  std::ifstream src(wlauncher_path.c_str(), std::ios::binary);
+  std::ifstream src(launcher_path.c_str(), std::ios::binary);
   if (!src.good()) {
-    fprintf(stderr, "Failed to open %ls: %s\n", wlauncher_path.c_str(),
-            strerror(errno));
+    fprintf(stderr, "Failed to open " STRING_FORMAT ": %s\n",
+            launcher_path.c_str(), strerror(errno));
     return 1;
   }
-  std::ofstream dst(woutput_path.c_str(), std::ios::binary);
+  std::ofstream dst(output_path.c_str(), std::ios::binary);
   if (!dst.good()) {
-    fprintf(stderr, "Failed to create %ls: %s\n", woutput_path.c_str(),
-            strerror(errno));
+    fprintf(stderr, "Failed to create " STRING_FORMAT ": %s\n",
+            output_path.c_str(), strerror(errno));
     return 1;
   }
   dst << src.rdbuf();
 
-  std::ifstream info_file(winfo_params.c_str());
+  std::ifstream info_file(info_params.c_str());
   if (!info_file.good()) {
-    fprintf(stderr, "Failed to open %ls: %s\n", winfo_params.c_str(),
-            strerror(errno));
+    fprintf(stderr, "Failed to open " STRING_FORMAT ": %s\n",
+            info_params.c_str(), strerror(errno));
     return 1;
   }
   int64_t bytes = 0;


### PR DESCRIPTION
`//tools/launcher:launcher_maker` produces launchers *for* Windows, but there is no reason why it must *run on* Windows. By making it runnable on all platforms, `*_binary` targets can be built *for* Windows from any platform assuming that a suitable cross-compiling C++ toolchain is available.

Closes #23731.

PiperOrigin-RevId: 679251350
Change-Id: I1b380d5b28a616ace88a3b049a2b4554aa209ae3

Commit https://github.com/bazelbuild/bazel/commit/108f1171c18387f80596e8709c7b7552c47fe457