### PR TITLE
Don't HTML escape `bazel mod` JSON output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/JsonOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/JsonOutputFormatter.java
@@ -44,7 +44,8 @@ public class JsonOutputFormatter extends OutputFormatter {
     seenExtensions = new HashSet<>();
     JsonObject root = printModule(ModuleKey.ROOT, null, IsExpanded.TRUE, IsIndirect.FALSE);
     root.addProperty("root", true);
-    printer.println(new GsonBuilder().setPrettyPrinting().create().toJson(root));
+    printer.println(
+        new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(root));
   }
 
   public String printKey(ModuleKey key) {


### PR DESCRIPTION
Otherwise `"<root>"` ends up being escaped with Unicode escape sequences, which is unnecessarily complex.

Work towards #22691