### PR TITLE
Include apparent names of deps in `bazel mod` JSON output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorFunction.java
@@ -106,7 +106,11 @@ public class BazelModuleInspectorFunction implements SkyFunction {
       AugmentedModule.Builder parentBuilder =
           depGraphAugmentBuilder
               .computeIfAbsent(
-                  parentKey, k -> AugmentedModule.builder(k).setName(parentModule.getName()))
+                  parentKey,
+                  k ->
+                      AugmentedModule.builder(k)
+                          .setName(parentModule.getName())
+                          .setRepoName(parentModule.getRepoName()))
               .setVersion(parentModule.getVersion())
               .setLoaded(true);
 
@@ -122,6 +126,7 @@ public class BazelModuleInspectorFunction implements SkyFunction {
           originalChildBuilder
               .setName(originalModule.getName())
               .setVersion(originalModule.getVersion())
+              .setRepoName(originalModule.getRepoName())
               .setLoaded(true);
         }
 
@@ -132,6 +137,7 @@ public class BazelModuleInspectorFunction implements SkyFunction {
                     AugmentedModule.builder(k)
                         .setName(module.getName())
                         .setVersion(module.getVersion())
+                        .setRepoName(module.getRepoName())
                         .setLoaded(true));
 
         // originalDependants and dependants can differ because

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorValue.java
@@ -89,6 +89,9 @@ public abstract class BazelModuleInspectorValue implements SkyValue {
     /** {@link ModuleKey} of this module. Same as in {@link Module} */
     public abstract ModuleKey getKey();
 
+    /** The apparent name used by the module to refer to its own repository. */
+    public abstract String getRepoName();
+
     /**
      * The set of modules in the resolved dep graph that depend on this module
      * <strong>after</strong> the module resolution.
@@ -154,6 +157,7 @@ public abstract class BazelModuleInspectorValue implements SkyValue {
       return new AutoValue_BazelModuleInspectorValue_AugmentedModule.Builder()
           .setName(key.name())
           .setVersion(key.version())
+          .setRepoName(key.name())
           .setKey(key)
           .setLoaded(false);
     }
@@ -166,6 +170,8 @@ public abstract class BazelModuleInspectorValue implements SkyValue {
       public abstract AugmentedModule.Builder setVersion(Version value);
 
       public abstract AugmentedModule.Builder setKey(ModuleKey value);
+
+      public abstract AugmentedModule.Builder setRepoName(String value);
 
       public abstract AugmentedModule.Builder setLoaded(boolean value);
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -193,7 +193,11 @@ public final class BzlmodTestUtil {
       AugmentedModuleBuilder myBuilder = new AugmentedModuleBuilder();
       myBuilder.key = key;
       myBuilder.builder =
-          AugmentedModule.builder(key).setName(name).setVersion(version).setLoaded(loaded);
+          AugmentedModule.builder(key)
+              .setName(name)
+              .setVersion(version)
+              .setRepoName(name)
+              .setLoaded(loaded);
       return myBuilder;
     }
 


### PR DESCRIPTION
This allows IDEs to query for the direct dependencies of the root module as well as how they can refer to them from the point of view of the root module.

Also always emit `name` and `version` so that consumers don't have to know how to parse module keys.

Work towards #22691