### PR TITLE
Disallow importing injected repos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -91,14 +91,21 @@ public class ModuleThreadContext extends StarlarkThreadContext {
     }
   }
 
-  record RepoNameUsage(String how, Location where) {}
+  record RepoNameUsage(String how, ImmutableList<StarlarkThread.CallStackEntry> stack) {
+    Location location() {
+      // Skip over the override_repo builtin frame.
+      return stack.reverse().get(1).location;
+    }
+  }
 
-  public void addRepoNameUsage(String repoName, String how, Location where) throws EvalException {
-    RepoNameUsage collision = repoNameUsages.put(repoName, new RepoNameUsage(how, where));
+  public void addRepoNameUsage(
+      String repoName, String how, ImmutableList<StarlarkThread.CallStackEntry> stack)
+      throws EvalException {
+    RepoNameUsage collision = repoNameUsages.put(repoName, new RepoNameUsage(how, stack));
     if (collision != null) {
       throw Starlark.errorf(
           "The repo name '%s' is already being used %s at %s",
-          repoName, collision.how(), collision.where());
+          repoName, collision.how(), collision.location());
     }
   }
 
@@ -176,16 +183,20 @@ public class ModuleThreadContext extends StarlarkThreadContext {
           && !this.isolate;
     }
 
-    void addImport(String localRepoName, String exportedName, String byWhat, Location location)
+    void addImport(
+        String localRepoName,
+        String exportedName,
+        String byWhat,
+        ImmutableList<StarlarkThread.CallStackEntry> stack)
         throws EvalException {
       RepositoryName.validateUserProvidedRepoName(localRepoName);
       RepositoryName.validateUserProvidedRepoName(exportedName);
-      context.addRepoNameUsage(localRepoName, byWhat, location);
+      context.addRepoNameUsage(localRepoName, byWhat, stack);
       if (imports.containsValue(exportedName)) {
         String collisionRepoName = imports.inverse().get(exportedName);
         throw Starlark.errorf(
             "The repo exported as '%s' by module extension '%s' is already imported at %s",
-            exportedName, extensionName, context.repoNameUsages.get(collisionRepoName).where());
+            exportedName, extensionName, context.repoNameUsages.get(collisionRepoName).location());
       }
       imports.put(localRepoName, exportedName);
     }
@@ -250,6 +261,15 @@ public class ModuleThreadContext extends StarlarkThreadContext {
         }
         String importedAs = imports.inverse().get(overriddenRepoName);
         if (importedAs != null) {
+          if (!override.getValue().mustExist) {
+            throw Starlark.errorf(
+                    "Cannot import repo '%s' that has been injected into module extension '%s' at %s. Please refer to @%s directly.",
+                    overriddenRepoName,
+                    extensionName,
+                    override.getValue().location(),
+                    overridingRepoName)
+                .withCallStack(context.repoNameUsages.get(importedAs).stack);
+          }
           context.overriddenRepos.put(importedAs, override.getValue());
         }
         context.overridingRepos.put(overridingRepoName, override.getValue());
@@ -308,7 +328,7 @@ public class ModuleThreadContext extends StarlarkThreadContext {
       }
       deps.put(builtinModule, DepSpec.create(builtinModule, Version.EMPTY, -1));
       try {
-        addRepoNameUsage(builtinModule, "as a built-in dependency", Location.BUILTIN);
+        addRepoNameUsage(builtinModule, "as a built-in dependency", ImmutableList.of());
       } catch (EvalException e) {
         throw new EvalException(
             e.getMessage()

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2048,6 +2048,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         "  'dev_as_non_dev_dep',",
         "  my_direct_dep = 'direct_dep',",
         ")",
+        "inject_repo(ext, my_data_repo = 'data_repo')",
         "ext_dev = use_extension('@ext//:defs.bzl', 'ext', dev_dependency = True)",
         "use_repo(",
         "  ext_dev,",
@@ -3250,7 +3251,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
         """
         bazel_dep(name = "data_repo", version = "1.0")
         ext = use_extension("//:defs.bzl","ext")
-        use_repo(ext, "bar", module_foo = "foo")
+        use_repo(ext, "bar")
         data_repo = use_repo_rule("@data_repo//:defs.bzl", "data_repo")
         data_repo(name = "foo", data = "overridden_data")
         inject_repo(ext, "foo")
@@ -3309,74 +3310,5 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     Object fooData = result.get(skyKey).getModule().getGlobal("foo_data");
     assertThat(fooData).isInstanceOf(String.class);
     assertThat(fooData).isEqualTo("overridden_data");
-  }
-
-  @Test
-  public void overrideRepo_inject_onExistingRepoFails() throws Exception {
-    scratch.file(
-        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
-        """
-        bazel_dep(name = "data_repo", version = "1.0")
-        ext = use_extension("//:defs.bzl","ext")
-        use_repo(ext, "bar", module_foo = "foo")
-        data_repo = use_repo_rule("@data_repo//:defs.bzl", "data_repo")
-        data_repo(name = "override", data = "overridden_data")
-        inject_repo(ext, foo = "override")
-        """);
-    scratch.file(workspaceRoot.getRelative("BUILD").getPathString());
-    scratch.file(
-        workspaceRoot.getRelative("data.bzl").getPathString(),
-        """
-        load("@bar//:list.bzl", _bar_list = "list")
-        load("@override//:data.bzl", _override_data = "data")
-        load("@module_foo//:data.bzl", _foo_data = "data")
-        bar_list = _bar_list
-        foo_data = _foo_data
-        override_data = _override_data
-        """);
-    scratch.file(
-        workspaceRoot.getRelative("defs.bzl").getPathString(),
-        """
-        load("@data_repo//:defs.bzl", "data_repo")
-        def _list_repo_impl(ctx):
-          ctx.file("WORKSPACE")
-          ctx.file("BUILD")
-          labels = [str(Label(l)) for l in ctx.attr.labels]
-          labels += [str(Label("@module_foo//:target3"))]
-          ctx.file("list.bzl", "list = " + repr(labels) + " + [str(Label('@foo//:target4'))]")
-        list_repo = repository_rule(
-          implementation = _list_repo_impl,
-          attrs = {
-            "labels": attr.label_list(),
-          },
-        )
-        def _fail_repo_impl(ctx):
-          fail("This rule should not be evaluated")
-        fail_repo = repository_rule(implementation = _fail_repo_impl)
-        def _ext_impl(ctx):
-          fail_repo(name = "foo")
-          list_repo(
-            name = "bar",
-            labels = [
-              # lazy extension implementation function repository mapping
-              "@foo//:target1",
-              # module repo repository mapping
-              "@module_foo//:target2",
-            ],
-          )
-        ext = module_extension(implementation = _ext_impl)
-        """);
-
-    SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
-    reporter.removeHandler(failFastHandler);
-    EvaluationResult<BzlLoadValue> result =
-        evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
-    assertThat(result.hasError()).isTrue();
-    assertThat(result.getError().getException())
-        .hasMessageThat()
-        .isEqualTo(
-            "module extension \"ext\" from \"//:defs.bzl\" generates repository \"foo\", yet it is"
-                + " injected via inject_repo() at /ws/MODULE.bazel:6:12. Use override_repo()"
-                + " instead to override an existing repository.");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -2036,7 +2036,9 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         ERROR /workspace/MODULE.bazel:5:9: Traceback (most recent call last):
         \tFile "/workspace/MODULE.bazel", line 5, column 9, in <toplevel>
         \t\tuse_repo(ext, bar = 'foo')
-        Error in use_repo: Cannot import repo 'foo' that has been injected into module extension 'ext' at /workspace/MODULE.bazel:4:12. Please refer to @my_repo directly.\
+        Error in use_repo: Cannot import repo 'foo' that has been injected into \
+        module extension 'ext' at /workspace/MODULE.bazel:4:12. Please refer \
+        to @my_repo directly.\
         """);
   }
 }


### PR DESCRIPTION
This ensures that there can't be two different apparent names for the same non-main repo (ignoring `override_repo`).

Also verify that `bazel mod tidy` doesn't suggest importing injected repos.