### PR TITLE
Support %workspace% in execution log paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -140,6 +140,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/test/shell/bazel/bazel_execlog_test.sh
+++ b/src/test/shell/bazel/bazel_execlog_test.sh
@@ -183,6 +183,26 @@ EOF
   grep "listedOutputs" output.json || fail "log does not contain listed outputs"
 }
 
+function test_nested_directory() {
+  mkdir d
+  cat > d/BUILD <<'EOF'
+genrule(
+      name = "action",
+      outs = ["out.txt"],
+      cmd = "echo hello > $(location out.txt)",
+      tags = ["no-remote-cache"],
+)
+EOF
+
+  cd d
+  bazel build //d:action --execution_log_json_file=%workspace%/output.json 2>&1 >> $TEST_log || fail "could not build"
+  [[ -e ../output.json ]] || fail "no json log produced"
+  bazel build //d:action --execution_log_binary_file=%workspace%/output.binary 2>&1 >> $TEST_log || fail "could not build"
+  [[ -e ../output.binary ]] || fail "no binary log produced"
+  bazel build //d:action --execution_log_compact_file=%workspace%/output.compact 2>&1 >> $TEST_log || fail "could not build"
+  [[ -e ../output.compact ]] || fail "no compact log produced"
+}
+
 function test_no_remote_cache() {
   cat > BUILD <<'EOF'
 genrule(


### PR DESCRIPTION
Previously the execution logs were always written to relative paths.
This caused an issue if you put this flag in your `.bazelrc` and
expected the log to be produced in a relative directory. You can now use
`%workspace%` to handle writing to the root of your workspace.

Fixes https://github.com/bazelbuild/bazel/issues/22267
