### PR TITLE
Correctly handle path encoding in DiskCacheLock.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -22,6 +22,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/server:idle_task",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:flogger",

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheLock.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheLock.java
@@ -14,12 +14,15 @@
 package com.google.devtools.build.lib.remote.disk;
 
 import static com.google.devtools.build.lib.util.StringUtil.reencodeInternalToExternal;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.charset.Charset;
 import java.nio.file.StandardOpenOption;
 
 /** Manages shared or exclusive access to the disk cache by concurrent processes. */
@@ -59,7 +62,7 @@ public final class DiskCacheLock implements AutoCloseable {
     FileChannel channel =
         FileChannel.open(
             // Correctly handle non-ASCII paths by converting from the internal string encoding.
-            java.nio.file.Path.of(reencodeInternalToExternal(path.getPathString())),
+            java.nio.file.Path.of(getPathStringForJavaIo(path)),
             StandardOpenOption.READ,
             StandardOpenOption.WRITE,
             StandardOpenOption.CREATE);
@@ -69,6 +72,12 @@ public final class DiskCacheLock implements AutoCloseable {
           "failed to acquire %s disk cache lock".formatted(shared ? "shared" : "exclusive"));
     }
     return new DiskCacheLock(channel, lock);
+  }
+
+  private static String getPathStringForJavaIo(Path path) {
+    return new String(
+        path.getPathString().getBytes(ISO_8859_1),
+        Charset.forName(System.getProperty("sun.jnu.encoding"), ISO_8859_1));
   }
 
   @VisibleForTesting


### PR DESCRIPTION
The earlier fix in 6922734a7bd6cc504cfc3390f4fa30e9438d1edd is wrong on Linux, where the native encoding is indicated by the sun.jnu.encoding property, and could be something other than UTF-8.