### PR TITLE
[7.4.0] Don't HTML escape `bazel mod` JSON output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/JsonOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/JsonOutputFormatter.java
@@ -44,7 +44,8 @@ public class JsonOutputFormatter extends OutputFormatter {
     seenExtensions = new HashSet<>();
     JsonObject root = printModule(ModuleKey.ROOT, null, IsExpanded.TRUE, IsIndirect.FALSE);
     root.addProperty("root", true);
-    printer.println(new GsonBuilder().setPrettyPrinting().create().toJson(root));
+    printer.println(
+        new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(root));
   }
 
   public String printKey(ModuleKey key) {


### PR DESCRIPTION
Otherwise `"<root>"` ends up being escaped with Unicode escape sequences, which is unnecessarily complex.

Work towards #22691

Closes #23785.

PiperOrigin-RevId: 680633877
Change-Id: Ic3c90c33bbf1209efa90be78b432e2132f0a1f05

Commit https://github.com/bazelbuild/bazel/commit/e959d78517abc0f50b2251e8225355a96e4c59d1