### PR TITLE
Remove struct provider from generate_cc.bzl

### DIFF
--- a/third_party/grpc/bazel/generate_cc.bzl
+++ b/third_party/grpc/bazel/generate_cc.bzl
@@ -141,7 +141,7 @@ def generate_cc_impl(ctx):
         use_default_shell_env = True,
     )
 
-    return struct(files = depset(out_files))
+    return DefaultInfo(files = depset(out_files))
 
 generate_cc = rule(
     attrs = {


### PR DESCRIPTION
This file seems to be only on github and prevents flipping incompatible_disallow_struct_provider_syntax