### PR TITLE
[7.4.0] Temporarily allow network access in sandbox for macos

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -81,7 +81,8 @@ test:ci-macos --test_env=TEST_INSTALL_BASE=/Users/buildkite/bazeltest/install_ba
 test:ci-macos --test_env=REPOSITORY_CACHE=/Users/buildkite/bazeltest/repo_cache
 test:ci-macos --test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80
 test:ci-macos --sandbox_writable_path=/Users/buildkite/bazeltest
-test:ci-macos --sandbox_default_allow_network=false
+# TODO(pcloudy): Revert to false once https://github.com/bazelbuild/bazel/issues/23726 is resolved.
+test:ci-macos --sandbox_default_allow_network=true
 test:ci-macos --test_tag_filters=-no_macos
 
 ## For Windows


### PR DESCRIPTION
Mitigating #23726

PiperOrigin-RevId: 678213406
Change-Id: I99ea19f3dcf56a359e39274ce9043a6b4f64b6a4

Backporting https://github.com/bazelbuild/bazel/commit/355b000accfff4ea29876a46321308fe9422a9d1#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832fR85