### PR TITLE
Expose main_output on cc_common.link

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
@@ -596,7 +596,6 @@ public interface CcModuleApi<
                     + "`output_type`",
             positional = false,
             named = true,
-            documented = false,
             defaultValue = "unbound",
             allowedTypes = {@ParamType(type = FileApi.class), @ParamType(type = NoneType.class)}),
         @Param(

--- a/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
@@ -74,7 +74,7 @@ def _link(
         always_link = _UNBOUND,
         only_for_dynamic_libs = _UNBOUND,
         link_artifact_name_suffix = _UNBOUND,
-        main_output = _UNBOUND,
+        main_output = None,
         use_shareable_artifact_factory = _UNBOUND,
         build_config = _UNBOUND,
         emit_interface_shared_library = _UNBOUND):
@@ -93,7 +93,6 @@ def _link(
        always_link != _UNBOUND or \
        only_for_dynamic_libs != _UNBOUND or \
        link_artifact_name_suffix != _UNBOUND or \
-       main_output != _UNBOUND or \
        use_shareable_artifact_factory != _UNBOUND or \
        build_config != _UNBOUND or \
        emit_interface_shared_library != _UNBOUND:
@@ -117,8 +116,6 @@ def _link(
         only_for_dynamic_libs = False
     if link_artifact_name_suffix == _UNBOUND:
         link_artifact_name_suffix = ""
-    if main_output == _UNBOUND:
-        main_output = None
     if use_shareable_artifact_factory == _UNBOUND:
         use_shareable_artifact_factory = False
     if build_config == _UNBOUND:


### PR DESCRIPTION
This field is useful for many situations, such as when you want to
create a native python extension, which doesn't follow the standard
library naming conventions.
