### PR TITLE
Add opt-in set_soname feature

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -827,7 +827,25 @@ def _impl(ctx):
                 ),
             ],
         )
-        set_install_name_feature = None
+        set_install_name_feature = feature(
+            name = "set_soname",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-Wl,-soname,%{runtime_solib_name}",
+                            ],
+                            expand_if_available = "runtime_solib_name",
+                        ),
+                    ],
+                ),
+            ],
+        )
     else:
         runtime_library_search_directories_feature = feature(
             name = "runtime_library_search_directories",
@@ -1804,6 +1822,7 @@ def _impl(ctx):
             unfiltered_compile_flags_feature,
             treat_warnings_as_errors_feature,
             archive_param_file_feature,
+            set_install_name_feature,
         ] + layering_check_features(ctx.attr.compiler, ctx.attr.extra_flags_per_feature, is_macos = False)
     else:
         # macOS artifact name patterns differ from the defaults only for dynamic


### PR DESCRIPTION
This allows correctly setting the `soname` for shared libraries on
Linux. This is useful for similar reasons to the macOS
`set_install_name` feature.

Fixes https://github.com/bazelbuild/bazel/issues/18798
