### PR TITLE
Flip `--incompatible_no_implicit_watch_label`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -287,7 +287,7 @@ public final class BuildLanguageOptions extends OptionsBase {
 
   @Option(
       name = "incompatible_no_implicit_watch_label",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       metadataTags = OptionMetadataTag.INCOMPATIBLE_CHANGE,
       effectTags = OptionEffectTag.LOADING_AND_ANALYSIS,
@@ -963,7 +963,7 @@ public final class BuildLanguageOptions extends OptionsBase {
   public static final String EXPERIMENTAL_ISOLATED_EXTENSION_USAGES =
       "-experimental_isolated_extension_usages";
   public static final String INCOMPATIBLE_NO_IMPLICIT_WATCH_LABEL =
-      "-incompatible_no_implicit_watch_label";
+      "+incompatible_no_implicit_watch_label";
   public static final String EXPERIMENTAL_GOOGLE_LEGACY_API = "-experimental_google_legacy_api";
   public static final String EXPERIMENTAL_PLATFORMS_API = "-experimental_platforms_api";
   public static final String EXPERIMENTAL_REPO_REMOTE_EXEC = "-experimental_repo_remote_exec";

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -516,7 +516,11 @@ public final class StarlarkRepositoryContextTest {
 
   @Test
   public void testNoIncompatibleNoImplicitWatchLabel() throws Exception {
-    setUpContextForRule("test");
+    setUpContextForRule(
+        "test",
+        StarlarkSemantics.DEFAULT.toBuilder()
+            .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_IMPLICIT_WATCH_LABEL, false)
+            .build());
     scratch.file(root.getRelative("foo").getPathString());
     StarlarkPath unusedPath = context.getPath(fakeFileLabel);
     String unusedRead = context.readFile(fakeFileLabel, "no", thread);


### PR DESCRIPTION
Fixes #23861

RELNOTES[inc]: `repository_ctx.path()` and `module_ctx.path()` no longer watch arguments of type `Label`. Use the `watch()` method or the `watch` parameter on other methods on these context objects instead. See https://github.com/bazelbuild/bazel/issues/23861 for details.