### PR TITLE
[7.4.0] Fix NPE in execlog when runfiles middleman are not top-level

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
@@ -194,13 +194,13 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
     Spawn firstSpawn =
         defaultSpawnBuilder()
             .withRunfilesSupplier(runfilesSupplier)
-            .withInputs(firstInput)
+            .withInputs(firstInput, runfilesMiddleman)
             .withTool(runfilesMiddleman)
             .build();
     Spawn secondSpawn =
         defaultSpawnBuilder()
             .withRunfilesSupplier(runfilesSupplier)
-            .withInputs(secondInput)
+            .withInputs(secondInput, runfilesMiddleman)
             .withTool(runfilesMiddleman)
             .build();
 


### PR DESCRIPTION
The cherry-pick of the compact execlog runfiles changes assumed that runfiles only appear in the top-level tool nested set, but this isn't true for genrules. Instead, as in Bazel 8, it can be assumed that all middleman are also contained in inputs, which makes it possible to remove the extra middleman parameter and pass all runfiles tree information down to transitive log calls.

Fixes #23884