### PR TITLE
Add execlog test with nested runfiles middleman

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
@@ -185,14 +185,14 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
 
     context.logSpawn(
         firstSpawn,
-        createInputMetadataProvider(toolRunfilesMiddleman, runfilesTree, firstInput),
+        createInputMetadataProvider(runfilesTree, toolRunfilesMiddleman, firstInput),
         createInputMap(runfilesTree, firstInput),
         fs,
         defaultTimeout(),
         defaultSpawnResult());
     context.logSpawn(
         secondSpawn,
-        createInputMetadataProvider(toolRunfilesMiddleman, runfilesTree, secondInput),
+        createInputMetadataProvider(runfilesTree, toolRunfilesMiddleman, secondInput),
         createInputMap(runfilesTree, secondInput),
         fs,
         defaultTimeout(),


### PR DESCRIPTION
Verifies that runfiles middlemen artifacts in non-top-level nested sets are handled. Also makes the tests more realistic by ensuring that tools are always a subset of inputs.

Related to #23884