### PR TITLE
Make `tee` ignore SIGINT in `test-setup.sh`

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -325,9 +325,9 @@ if [[ "${EXPERIMENTAL_SPLIT_XML_GENERATION}" == "1" ]]; then
 else
   set -o pipefail
   if [ -z "$COVERAGE_DIR" ]; then
-    ("${TEST_PATH}" "$@" 2>&1 | tee -a "${XML_OUTPUT_FILE}.log") <&0 &
+    ("${TEST_PATH}" "$@" 2>&1 | tee -ai "${XML_OUTPUT_FILE}.log") <&0 &
   else
-    ("$1" "$TEST_PATH" "${@:3}" 2>&1 | tee -a "${XML_OUTPUT_FILE}.log") <&0 &
+    ("$1" "$TEST_PATH" "${@:3}" 2>&1 | tee -ai "${XML_OUTPUT_FILE}.log") <&0 &
   fi
   set +o pipefail
 fi


### PR DESCRIPTION
When running `bazel run`, after `ctrl+c`, all output will be lost.

The reason is `tee` is killed by SIGINT before the running binary. All write operation to the pipe after that will fail.

see: https://stackoverflow.com/a/62849155/6191027

In this PR I add `-i, --ignore-interrupts` option to the `tee` command to fix this problem.