### PR TITLE
Add `protobuf` dep to `bazel_tools`

### DIFF
--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -37,6 +37,7 @@ use_repo(buildozer_binary, "buildozer_binary")
 
 # Dependencies used to auto-load removed symbols and rules from Bazel (due to Starlarkification)
 # See also:  --incompatible_autoload_externally, AutoloadSymbols
+bazel_dep(name = "protobuf", version = "29.0-rc1")
 bazel_dep(name = "rules_java", version = "8.0.1")
 bazel_dep(name = "rules_cc", version = "0.0.12")
 bazel_dep(name = "rules_python", version = "0.36.0")


### PR DESCRIPTION
This is needed to resolve the protobuf autoload.

Fixes #23907 