### PR TITLE
[7.4.0] Allow `rules_shell` to use private APIs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
@@ -64,7 +64,10 @@ public final class BuiltinRestriction {
               BuiltinRestriction.allowlistEntry("rules_rust", "rust/private"),
 
               // CUDA rules
-              BuiltinRestriction.allowlistEntry("", "third_party/gpus/cuda"));
+              BuiltinRestriction.allowlistEntry("", "third_party/gpus/cuda"),
+
+              // Shell rules
+              BuiltinRestriction.allowlistEntry("rules_shell", ""));
 
   private BuiltinRestriction() {}
 


### PR DESCRIPTION
Closes #23873.

PiperOrigin-RevId: 682416574
Change-Id: I531cbdadac035bb14585eafe5be093823bca2214

(cherry picked from commit cab7d45d39b01f5b3d668ecc747cc2c456330b18)

Closes #23874