### PR TITLE
[7.4.0] Do no crash if a requested resource is not available

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -488,6 +488,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/worker",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_key",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_pool",
+        "//src/main/protobuf:failure_details_java_proto",
         "//third_party:guava",
         "//third_party:jsr305",
     ],

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -718,6 +718,7 @@ message LocalExecution {
   enum Code {
     LOCAL_EXECUTION_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
     LOCKFREE_OUTPUT_PREREQ_UNMET = 1 [(metadata) = { exit_code: 2 }];
+    UNTRACKED_RESOURCE = 2 [(metadata) = { exit_code: 1 }];
   }
 
   Code code = 1;

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -99,17 +99,17 @@ public final class ResourceManagerTest {
   }
 
   private ResourceHandle acquire(double ram, double cpu, int tests, ResourcePriority priority)
-      throws InterruptedException, IOException {
+      throws InterruptedException, IOException, ExecException {
     return rm.acquireResources(resourceOwner, ResourceSet.create(ram, cpu, tests), priority);
   }
 
   private ResourceHandle acquire(double ram, double cpu, int tests)
-      throws InterruptedException, IOException {
+      throws InterruptedException, IOException, ExecException {
     return acquire(ram, cpu, tests, ResourcePriority.LOCAL);
   }
 
   private ResourceHandle acquire(double ram, double cpu, int tests, String mnemonic)
-      throws InterruptedException, IOException {
+      throws InterruptedException, IOException, ExecException {
 
     return rm.acquireResources(
         resourceOwner,
@@ -127,7 +127,7 @@ public final class ResourceManagerTest {
       ImmutableMap<String, Double> extraResources,
       int tests,
       ResourcePriority priority)
-      throws InterruptedException, IOException, NoSuchElementException {
+      throws InterruptedException, IOException, NoSuchElementException, ExecException {
     ImmutableMap.Builder<String, Double> resources = ImmutableMap.builder();
     resources.putAll(extraResources).put(ResourceSet.MEMORY, ram).put(ResourceSet.CPU, cpu);
     return rm.acquireResources(
@@ -137,7 +137,7 @@ public final class ResourceManagerTest {
   @CanIgnoreReturnValue
   private ResourceHandle acquire(
       double ram, double cpu, ImmutableMap<String, Double> extraResources, int tests)
-      throws InterruptedException, IOException, NoSuchElementException {
+      throws InterruptedException, IOException, NoSuchElementException, ExecException {
     return acquire(ram, cpu, extraResources, tests, ResourcePriority.LOCAL);
   }
 
@@ -676,7 +676,7 @@ public final class ResourceManagerTest {
         new TestThread(
             () ->
                 assertThrows(
-                    NoSuchElementException.class,
+                    UserExecException.class,
                     () -> acquire(0, 0, ImmutableMap.of("nonexisting", 1.0), 0)));
     thread1.start();
     thread1.joinAndAssertState(1000);


### PR DESCRIPTION
Before:
```
Caused by: java.util.NoSuchElementException: Resource foo is not tracked in this resource set.
    at com.google.devtools.build.lib.actions.ResourceManager.assertExtraResourcesTracked(ResourceManager.java:499)
    at com.google.devtools.build.lib.actions.ResourceManager.areResourcesAvailable(ResourceManager.java:540)
```
After:
```
ERROR: src/test/java/com/google/devtools/build/lib/actions/BUILD:102:10: Testing //src/test/java/com/google/devtools/build/lib/actions:ActionsTests failed: Resource foo is not being tracked by the resource manager. Available resources are: cpu, memory
```

Fixes #19572

Closes #23541.

PiperOrigin-RevId: 682282327
Change-Id: Ifdff5f85de9e45ac119c2a2cfd161c054a722546 
(cherry picked from commit e5ab94bfdebb4a08b8849befbb40d7592485e4ee)

Closes #23868