### PR TITLE
[7.4.0] Allow all characters in runfile source and target paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -75,10 +75,11 @@ public final class SourceManifestAction extends AbstractFileWriteAction
      *
      * @param manifestWriter the output stream
      * @param rootRelativePath path of an entry relative to the manifest's root
-     * @param symlink (optional) symlink that resolves the above path
+     * @param symlinkTarget target of the entry at {@code rootRelativePath} if it is a symlink,
+     *     otherwise {@code null}
      */
     void writeEntry(
-        Writer manifestWriter, PathFragment rootRelativePath, @Nullable Artifact symlink)
+        Writer manifestWriter, PathFragment rootRelativePath, @Nullable PathFragment symlinkTarget)
         throws IOException;
 
     /** Fulfills {@link com.google.devtools.build.lib.actions.AbstractAction#getMnemonic()} */
@@ -234,7 +235,16 @@ public final class SourceManifestAction extends AbstractFileWriteAction
     List<Map.Entry<PathFragment, Artifact>> sortedManifest = new ArrayList<>(output.entrySet());
     sortedManifest.sort(ENTRY_COMPARATOR);
     for (Map.Entry<PathFragment, Artifact> line : sortedManifest) {
-      manifestWriter.writeEntry(manifestFile, line.getKey(), line.getValue());
+      Artifact artifact = line.getValue();
+      PathFragment symlinkTarget;
+      if (artifact == null) {
+        symlinkTarget = null;
+      } else if (artifact.isSymlink()) {
+        symlinkTarget = artifact.getPath().readSymbolicLink();
+      } else {
+        symlinkTarget = artifact.getPath().asFragment();
+      }
+      manifestWriter.writeEntry(manifestFile, line.getKey(), symlinkTarget);
     }
 
     manifestFile.flush();
@@ -286,17 +296,16 @@ public final class SourceManifestAction extends AbstractFileWriteAction
      */
     SOURCE_SYMLINKS {
       @Override
-      public void writeEntry(Writer manifestWriter, PathFragment rootRelativePath, Artifact symlink)
+      public void writeEntry(
+          Writer manifestWriter,
+          PathFragment rootRelativePath,
+          @Nullable PathFragment symlinkTarget)
           throws IOException {
         manifestWriter.append(rootRelativePath.getPathString());
         // This trailing whitespace is REQUIRED to process the single entry line correctly.
         manifestWriter.append(' ');
-        if (symlink != null) {
-          if (symlink.isSymlink()) {
-            manifestWriter.append(symlink.getPath().readSymbolicLink().getPathString());
-          } else {
-            manifestWriter.append(symlink.getPath().getPathString());
-          }
+        if (symlinkTarget != null) {
+          manifestWriter.append(symlinkTarget.getPathString());
         }
         manifestWriter.append('\n');
       }
@@ -334,7 +343,10 @@ public final class SourceManifestAction extends AbstractFileWriteAction
      */
     SOURCES_ONLY {
       @Override
-      public void writeEntry(Writer manifestWriter, PathFragment rootRelativePath, Artifact symlink)
+      public void writeEntry(
+          Writer manifestWriter,
+          PathFragment rootRelativePath,
+          @Nullable PathFragment symlinkTarget)
           throws IOException {
         manifestWriter.append(rootRelativePath.getPathString());
         manifestWriter.append('\n');

--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -19,6 +19,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.escape.CharEscaperBuilder;
+import com.google.common.escape.Escaper;
 import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
@@ -61,7 +63,16 @@ public final class SourceManifestAction extends AbstractFileWriteAction
   private static final String GUID = "07459553-a3d0-4d37-9d78-18ed942470f4";
 
   private static final Comparator<Map.Entry<PathFragment, Artifact>> ENTRY_COMPARATOR =
-      (path1, path2) -> path1.getKey().getPathString().compareTo(path2.getKey().getPathString());
+      Comparator.comparing(path -> path.getKey().getPathString());
+  private static final Escaper ROOT_RELATIVE_PATH_ESCAPER =
+      new CharEscaperBuilder()
+          .addEscape(' ', "\\s")
+          .addEscape('\n', "\\n")
+          .addEscape('\\', "\\b")
+          .toEscaper();
+  private static final Escaper TARGET_PATH_ESCAPER =
+      new CharEscaperBuilder().addEscape('\n', "\\n").addEscape('\\', "\\b").toEscaper();
+
   private final Artifact repoMappingManifest;
   /**
    * Interface for defining manifest formatting and reporting specifics. Implementations must be
@@ -291,6 +302,9 @@ public final class SourceManifestAction extends AbstractFileWriteAction
      *
      * <p>[rootRelativePath] [resolvingSymlink]
      *
+     * <p>If rootRelativePath contains spaces, then each backslash is replaced with '\b', each space
+     * is replaced with '\s' and the line is prefixed with a space.
+     *
      * <p>This strategy is suitable for creating an input manifest to a source view tree. Its output
      * is a valid input to {@link com.google.devtools.build.lib.analysis.actions.SymlinkTreeAction}.
      */
@@ -301,11 +315,32 @@ public final class SourceManifestAction extends AbstractFileWriteAction
           PathFragment rootRelativePath,
           @Nullable PathFragment symlinkTarget)
           throws IOException {
-        manifestWriter.append(rootRelativePath.getPathString());
+        String rootRelativePathString = rootRelativePath.getPathString();
+        // Source paths with spaces require escaping. Target paths with spaces don't as consumers
+        // are expected to split on the first space. Newlines always need to be escaped.
+        // Note that if any of these characters are present, then we also need to escape the escape
+        // character (backslash) in both paths. We avoid doing so if none of the problematic
+        // characters are present for backwards compatibility with existing runfiles libraries. In
+        // particular, entries with a source path that contains neither spaces nor newlines and
+        // target paths that contain both spaces and backslashes require no escaping.
+        boolean needsEscaping =
+            rootRelativePathString.indexOf(' ') != -1
+                || rootRelativePathString.indexOf('\n') != -1
+                || (symlinkTarget != null && symlinkTarget.getPathString().indexOf('\n') != -1);
+        if (needsEscaping) {
+          manifestWriter.append(' ');
+          manifestWriter.append(ROOT_RELATIVE_PATH_ESCAPER.escape(rootRelativePathString));
+        } else {
+          manifestWriter.append(rootRelativePathString);
+        }
         // This trailing whitespace is REQUIRED to process the single entry line correctly.
         manifestWriter.append(' ');
         if (symlinkTarget != null) {
-          manifestWriter.append(symlinkTarget.getPathString());
+          if (needsEscaping) {
+            manifestWriter.append(TARGET_PATH_ESCAPER.escape(symlinkTarget.getPathString()));
+          } else {
+            manifestWriter.append(symlinkTarget.getPathString());
+          }
         }
         manifestWriter.append('\n');
       }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -164,18 +164,6 @@ public final class BlazeOptionHandler {
     }
 
     Path workspacePath = workspace.getWorkspace();
-    // TODO(kchodorow): Remove this once spaces are supported.
-    if (workspacePath.getPathString().contains(" ")) {
-      String message =
-          runtime.getProductName()
-              + " does not currently work properly from paths "
-              + "containing spaces ("
-              + workspacePath
-              + ").";
-      eventHandler.handle(Event.error(message));
-      return createDetailedExitCode(message, Code.SPACES_IN_WORKSPACE_PATH);
-    }
-
     if (workspacePath.getParentDirectory() != null) {
       Path doNotBuild =
           workspacePath.getParentDirectory().getRelative(BlazeWorkspace.DO_NOT_BUILD_FILE_NAME);

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -566,7 +566,7 @@ message Command {
     STARLARK_OPTIONS_PARSE_FAILURE = 10 [(metadata) = { exit_code: 2 }];
     ARGUMENTS_NOT_RECOGNIZED = 11 [(metadata) = { exit_code: 2 }];
     NOT_IN_WORKSPACE = 12 [(metadata) = { exit_code: 2 }];
-    SPACES_IN_WORKSPACE_PATH = 13 [(metadata) = { exit_code: 36 }];
+    reserved 13;
     IN_OUTPUT_DIRECTORY = 14 [(metadata) = { exit_code: 2 }];
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -340,10 +340,10 @@ java_test(
     srcs = ["SourceManifestActionTest.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
-        "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/test/java/com/google/devtools/build/lib/actions/util",

--- a/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
@@ -25,7 +25,6 @@ import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifactType;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
-import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.SourceManifestAction.ManifestType;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
@@ -34,7 +33,6 @@ import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
-import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -54,38 +52,33 @@ import org.junit.runners.JUnit4;
 public final class SourceManifestActionTest extends BuildViewTestCase {
 
   private Map<PathFragment, Artifact> fakeManifest;
-
-  private Path pythonSourcePath;
-  private Artifact pythonSourceFile;
-  private Path buildFilePath;
   private Artifact buildFile;
   private Artifact relativeSymlink;
   private Artifact absoluteSymlink;
-
-  private Path manifestOutputPath;
   private Artifact manifestOutputFile;
 
   @Before
-  public final void createFiles() throws Exception  {
+  public void createFiles() throws Exception {
     analysisMock.pySupport().setup(mockToolsConfig);
     // Test with a raw manifest Action.
     fakeManifest = new LinkedHashMap<>();
     ArtifactRoot trivialRoot =
         ArtifactRoot.asSourceRoot(Root.fromPath(rootDirectory.getRelative("trivial")));
-    buildFilePath = scratch.file("trivial/BUILD",
-                                "py_binary(name='trivial', srcs =['trivial.py'])");
+    Path buildFilePath =
+        scratch.file("trivial/BUILD", "py_binary(name='trivial', srcs =['trivial.py'])");
     buildFile = ActionsTestUtil.createArtifact(trivialRoot, buildFilePath);
 
-    pythonSourcePath = scratch.file("trivial/trivial.py",
-                                   "#!/usr/bin/python \n print 'Hello World'");
-    pythonSourceFile = ActionsTestUtil.createArtifact(trivialRoot, pythonSourcePath);
+    Path pythonSourcePath =
+        scratch.file("trivial/trivial.py", "#!/usr/bin/python \n print 'Hello World'");
+    Artifact pythonSourceFile = ActionsTestUtil.createArtifact(trivialRoot, pythonSourcePath);
     fakeManifest.put(buildFilePath.relativeTo(rootDirectory), buildFile);
     fakeManifest.put(pythonSourcePath.relativeTo(rootDirectory), pythonSourceFile);
     ArtifactRoot outputDir =
         ArtifactRoot.asDerivedRoot(rootDirectory, RootType.Output, "blaze-output");
     outputDir.getRoot().asPath().createDirectoryAndParents();
-    manifestOutputPath = rootDirectory.getRelative("blaze-output/trivial.runfiles_manifest");
-    manifestOutputFile = ActionsTestUtil.createArtifact(outputDir, manifestOutputPath);
+    manifestOutputFile =
+        ActionsTestUtil.createArtifact(
+            outputDir, rootDirectory.getRelative("blaze-output/trivial.runfiles_manifest"));
 
     Path relativeSymlinkPath = outputDir.getRoot().asPath().getChild("relative_symlink");
     relativeSymlinkPath.createSymbolicLink(PathFragment.create("../some/relative/path"));
@@ -123,28 +116,29 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
     return new SourceManifestAction(type, NULL_ACTION_OWNER, manifestOutputFile, builder.build());
   }
 
-  /**
-   * Manifest writer that validates an expected call sequence.
-   */
-  private class MockManifestWriter implements SourceManifestAction.ManifestWriter {
-    private List<Map.Entry<PathFragment, Artifact>> expectedSequence = new ArrayList<>();
+  /** Manifest writer that validates an expected call sequence. */
+  private final class MockManifestWriter implements SourceManifestAction.ManifestWriter {
+    private final List<Map.Entry<PathFragment, Artifact>> expectedSequence = new ArrayList<>();
 
-    public MockManifestWriter() {
+    MockManifestWriter() {
       expectedSequence.addAll(fakeManifest.entrySet());
     }
 
     @Override
-    public void writeEntry(Writer manifestWriter, PathFragment rootRelativePath,
-        @Nullable Artifact symlink) throws IOException {
-      assertWithMessage("Expected manifest input to be exhausted").that(expectedSequence)
+    public void writeEntry(
+        Writer manifestWriter,
+        PathFragment rootRelativePath,
+        @Nullable PathFragment symlinkTarget) {
+      assertWithMessage("Expected manifest input to be exhausted")
+          .that(expectedSequence)
           .isNotEmpty();
       Map.Entry<PathFragment, Artifact> expectedEntry = expectedSequence.remove(0);
       assertThat(rootRelativePath)
           .isEqualTo(PathFragment.create("TESTING").getRelative(expectedEntry.getKey()));
-      assertThat(symlink).isEqualTo(expectedEntry.getValue());
+      assertThat(symlinkTarget).isEqualTo(expectedEntry.getValue().getPath().asFragment());
     }
 
-    public int unconsumedInputs() {
+    int unconsumedInputs() {
       return expectedSequence.size();
     }
 
@@ -191,9 +185,11 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
     String manifestContents = createSymlinkAction().getFileContents(reporter);
     assertThat(manifestContents)
         .isEqualTo(
-            "TESTING/trivial/BUILD /workspace/trivial/BUILD\n"
-                + "TESTING/trivial/__init__.py \n"
-                + "TESTING/trivial/trivial.py /workspace/trivial/trivial.py\n");
+            """
+            TESTING/trivial/BUILD /workspace/trivial/BUILD
+            TESTING/trivial/__init__.py\s
+            TESTING/trivial/trivial.py /workspace/trivial/trivial.py
+            """);
   }
 
   /**
@@ -205,9 +201,11 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
     String manifestContents = createSourceOnlyAction().getFileContents(reporter);
     assertThat(manifestContents)
         .isEqualTo(
-            "TESTING/trivial/BUILD\n"
-                + "TESTING/trivial/__init__.py\n"
-                + "TESTING/trivial/trivial.py\n");
+            """
+            TESTING/trivial/BUILD
+            TESTING/trivial/__init__.py
+            TESTING/trivial/trivial.py
+            """);
   }
 
   /**
@@ -239,7 +237,7 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testGetMnemonic() throws Exception {
+  public void testGetMnemonic() {
     assertThat(createSymlinkAction().getMnemonic()).isEqualTo("SourceSymlinkManifest");
     assertThat(createAction(ManifestType.SOURCE_SYMLINKS, false).getMnemonic())
         .isEqualTo("SourceSymlinkManifest");
@@ -247,7 +245,7 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testSymlinkProgressMessage() throws Exception {
+  public void testSymlinkProgressMessage() {
     String progress = createSymlinkAction().getProgressMessage();
     assertWithMessage("null action not found in " + progress)
         .that(progress.contains("//null/action:owner"))
@@ -255,7 +253,7 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testSymlinkProgressMessageNoPyInitFiles() throws Exception {
+  public void testSymlinkProgressMessageNoPyInitFiles() {
     String progress = createAction(ManifestType.SOURCE_SYMLINKS, false).getProgressMessage();
     assertWithMessage("null action not found in " + progress)
         .that(progress.contains("//null/action:owner"))
@@ -263,7 +261,7 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testSourceOnlyProgressMessage() throws Exception {
+  public void testSourceOnlyProgressMessage() {
     SourceManifestAction action =
         new SourceManifestAction(
             ManifestType.SOURCES_ONLY,
@@ -277,7 +275,7 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testRootSymlinksAffectKey() throws Exception {
+  public void testRootSymlinksAffectKey() {
     Artifact manifest1 = getBinArtifactWithNoOwner("manifest1");
     Artifact manifest2 = getBinArtifactWithNoOwner("manifest2");
 
@@ -304,7 +302,7 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
 
   // Regression test for b/116254698.
   @Test
-  public void testEmptyFilesAffectKey() throws Exception {
+  public void testEmptyFilesAffectKey() {
     Artifact manifest1 = getBinArtifactWithNoOwner("manifest1");
     Artifact manifest2 = getBinArtifactWithNoOwner("manifest2");
 
@@ -383,15 +381,16 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
 
     assertThat(action.getFileContents(reporter))
         .isEqualTo(
-            "TESTING/BUILD /workspace/trivial/BUILD\n"
-                + "TESTING/absolute_symlink /absolute/path\n"
-                + "TESTING/relative_symlink ../some/relative/path\n");
+            """
+            TESTING/BUILD /workspace/trivial/BUILD
+            TESTING/absolute_symlink /absolute/path
+            TESTING/relative_symlink ../some/relative/path
+            """);
   }
 
-  private String computeKey(SourceManifestAction action)
-      throws CommandLineExpansionException, InterruptedException {
+  private String computeKey(SourceManifestAction action) {
     Fingerprint fp = new Fingerprint();
-    action.computeKey(actionKeyContext, /*artifactExpander=*/ null, fp);
+    action.computeKey(actionKeyContext, /* artifactExpander= */ null, fp);
     return fp.hexDigestAndReset();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.analysis.SourceManifestAction.ManifestType;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -386,6 +387,78 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
             TESTING/absolute_symlink /absolute/path
             TESTING/relative_symlink ../some/relative/path
             """);
+  }
+
+  @Test
+  public void testEscaping() throws Exception {
+    Artifact manifest = getBinArtifactWithNoOwner("manifest1");
+
+    ArtifactRoot trivialRoot =
+        ArtifactRoot.asSourceRoot(Root.fromPath(rootDirectory.getRelative("trivial")));
+    Path fileWithSpaceAndBackslashPath = scratch.file("trivial/file with sp\\ace", "foo");
+    Artifact fileWithSpaceAndBackslash =
+        ActionsTestUtil.createArtifact(trivialRoot, fileWithSpaceAndBackslashPath);
+    Path fileWithNewlineAndBackslashPath = scratch.file("trivial/file\nwith\\newline", "foo");
+    Artifact fileWithNewlineAndBackslash =
+        ActionsTestUtil.createArtifact(trivialRoot, fileWithNewlineAndBackslashPath);
+
+    SourceManifestAction action =
+        new SourceManifestAction(
+            ManifestType.SOURCE_SYMLINKS,
+            NULL_ACTION_OWNER,
+            manifest,
+            new Runfiles.Builder("TESTING", false)
+                .addSymlink(PathFragment.create("no/sp\\ace"), buildFile)
+                .addSymlink(PathFragment.create("also/no/sp\\ace"), fileWithSpaceAndBackslash)
+                .addSymlink(PathFragment.create("still/no/sp\\ace"), fileWithNewlineAndBackslash)
+                .addSymlink(PathFragment.create("with sp\\ace"), buildFile)
+                .addSymlink(PathFragment.create("also/with sp\\ace"), fileWithSpaceAndBackslash)
+                .addSymlink(PathFragment.create("more/with sp\\ace"), fileWithNewlineAndBackslash)
+                .addSymlink(PathFragment.create("with\nnew\\line"), buildFile)
+                .addSymlink(PathFragment.create("also/with\nnewline"), fileWithSpaceAndBackslash)
+                .addSymlink(PathFragment.create("more/with\nnewline"), fileWithNewlineAndBackslash)
+                .addSymlink(PathFragment.create("with\nnew\\line and space"), buildFile)
+                .addSymlink(
+                    PathFragment.create("also/with\nnewline and space"), fileWithSpaceAndBackslash)
+                .addSymlink(
+                    PathFragment.create("more/with\nnewline and space"),
+                    fileWithNewlineAndBackslash)
+                .build());
+    if (OS.getCurrent().equals(OS.WINDOWS)) {
+      assertThat(action.getFileContents(reporter))
+          .isEqualTo(
+              """
+              TESTING/also/no/sp/ace /workspace/trivial/file with sp/ace
+               TESTING/also/with\\nnewline /workspace/trivial/file with sp/ace
+               TESTING/also/with\\nnewline\\sand\\sspace /workspace/trivial/file with sp/ace
+               TESTING/also/with\\ssp/ace /workspace/trivial/file with sp/ace
+               TESTING/more/with\\nnewline /workspace/trivial/file\\nwith/newline
+               TESTING/more/with\\nnewline\\sand\\sspace /workspace/trivial/file\\nwith/newline
+               TESTING/more/with\\ssp/ace /workspace/trivial/file\\nwith/newline
+              TESTING/no/sp/ace /workspace/trivial/BUILD
+               TESTING/still/no/sp/ace /workspace/trivial/file\\nwith/newline
+               TESTING/with\\nnew/line /workspace/trivial/BUILD
+               TESTING/with\\nnew/line\\sand\\sspace /workspace/trivial/BUILD
+               TESTING/with\\ssp/ace /workspace/trivial/BUILD
+              """);
+    } else {
+      assertThat(action.getFileContents(reporter))
+          .isEqualTo(
+              """
+              TESTING/also/no/sp\\ace /workspace/trivial/file with sp\\ace
+               TESTING/also/with\\nnewline /workspace/trivial/file with sp\\bace
+               TESTING/also/with\\nnewline\\sand\\sspace /workspace/trivial/file with sp\\bace
+               TESTING/also/with\\ssp\\bace /workspace/trivial/file with sp\\bace
+               TESTING/more/with\\nnewline /workspace/trivial/file\\nwith\\bnewline
+               TESTING/more/with\\nnewline\\sand\\sspace /workspace/trivial/file\\nwith\\bnewline
+               TESTING/more/with\\ssp\\bace /workspace/trivial/file\\nwith\\bnewline
+              TESTING/no/sp\\ace /workspace/trivial/BUILD
+               TESTING/still/no/sp\\bace /workspace/trivial/file\\nwith\\bnewline
+               TESTING/with\\nnew\\bline /workspace/trivial/BUILD
+               TESTING/with\\nnew\\bline\\sand\\sspace /workspace/trivial/BUILD
+               TESTING/with\\ssp\\bace /workspace/trivial/BUILD
+              """);
+    }
   }
 
   private String computeKey(SourceManifestAction action) {

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -61,7 +61,8 @@ function hash_outputs() {
 }
 
 function test_determinism()  {
-    local workdir="${TEST_TMPDIR}/workdir"
+    # Verify that Bazel can build itself under a path with spaces.
+    local workdir="${TEST_TMPDIR}/work dir"
     mkdir "${workdir}" || fail "Could not create work directory"
     cd "${workdir}" || fail "Could not change to work directory"
     unzip -q "${DISTFILE}"

--- a/src/test/shell/bazel/workspace_test.sh
+++ b/src/test/shell/bazel/workspace_test.sh
@@ -73,7 +73,7 @@ function test_path_with_spaces() {
   cd "$ws"
   create_workspace_with_default_repos WORKSPACE
 
-  bazel info &> $TEST_log && fail "Info succeeeded"
+  bazel info &> $TEST_log || fail "Info failed"
   bazel help &> $TEST_log || fail "Help failed"
 }
 

--- a/src/test/shell/integration/runfiles_test.sh
+++ b/src/test/shell/integration/runfiles_test.sh
@@ -511,4 +511,272 @@ EOF
     || fail "MANIFEST file not recreated"
 }
 
+function setup_special_chars_in_runfiles_source_paths() {
+  mkdir -p pkg
+  if "$is_windows"; then
+    cat > pkg/constants.bzl <<'EOF'
+NAME = "pkg/a b .txt"
+EOF
+  else
+    cat > pkg/constants.bzl <<'EOF'
+NAME = "pkg/a \n \\ b .txt"
+EOF
+  fi
+  cat > pkg/defs.bzl <<'EOF'
+load(":constants.bzl", "NAME")
+def _special_chars_impl(ctx):
+    out = ctx.actions.declare_file("data.txt")
+    ctx.actions.write(out, "my content")
+    runfiles = ctx.runfiles(
+        symlinks = {
+            NAME: out,
+        },
+    )
+    return [DefaultInfo(files = depset([out]), runfiles = runfiles)]
+
+spaces = rule(
+    implementation = _special_chars_impl,
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "spaces")
+spaces(name = "spaces")
+sh_test(
+    name = "foo",
+    srcs = ["foo.sh"],
+    data = [":spaces"],
+)
+EOF
+  if "$is_windows"; then
+    cat > pkg/foo.sh <<'EOF'
+#!/bin/bash
+if [[ "$(cat $'pkg/a b .txt')" != "my content" ]]; then
+  echo "unexpected content or not found"
+  exit 1
+fi
+EOF
+  else
+    cat > pkg/foo.sh <<'EOF'
+#!/bin/bash
+if [[ "$(cat $'pkg/a \n \\ b .txt')" != "my content" ]]; then
+  echo "unexpected content or not found"
+  exit 1
+fi
+EOF
+  fi
+  chmod +x pkg/foo.sh
+}
+
+function test_special_chars_in_runfiles_source_paths_out_of_process() {
+  setup_special_chars_in_runfiles_source_paths
+  bazel test --noexperimental_inprocess_symlink_creation \
+    --test_output=errors \
+    //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "test failed"
+}
+
+function test_special_chars_in_runfiles_source_paths_in_process() {
+  setup_special_chars_in_runfiles_source_paths
+  bazel test --experimental_inprocess_symlink_creation \
+    --test_output=errors \
+    //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "test failed"
+}
+
+function setup_special_chars_in_runfiles_target_paths() {
+  mkdir -p pkg
+  if "$is_windows"; then
+    cat > pkg/constants.bzl <<'EOF'
+NAME = "pkg/a b .txt"
+EOF
+  else
+    cat > pkg/constants.bzl <<'EOF'
+NAME = "pkg/a \n \\ b .txt"
+EOF
+  fi
+  cat > pkg/defs.bzl <<'EOF'
+load(":constants.bzl", "NAME")
+def _special_chars_impl(ctx):
+    out = ctx.actions.declare_file(NAME)
+    ctx.actions.write(out, "my content")
+    runfiles = ctx.runfiles(
+        symlinks = {
+            "pkg/data.txt": out,
+        },
+    )
+    return [DefaultInfo(files = depset([out]), runfiles = runfiles)]
+
+spaces = rule(
+    implementation = _special_chars_impl,
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "spaces")
+spaces(name = "spaces")
+sh_test(
+    name = "foo",
+    srcs = ["foo.sh"],
+    data = [":spaces"],
+)
+EOF
+  cat > pkg/foo.sh <<'EOF'
+#!/bin/bash
+if [[ "$(cat pkg/data.txt)" != "my content" ]]; then
+  echo "unexpected content or not found"
+  exit 1
+fi
+EOF
+  chmod +x pkg/foo.sh
+}
+
+function test_special_chars_in_runfiles_target_paths_out_of_process() {
+  setup_special_chars_in_runfiles_target_paths
+  bazel test --noexperimental_inprocess_symlink_creation \
+    --test_output=errors \
+    //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "test failed"
+}
+
+function test_special_chars_in_runfiles_target_paths_in_process() {
+  setup_special_chars_in_runfiles_target_paths
+  bazel test --experimental_inprocess_symlink_creation \
+    --test_output=errors \
+    //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "test failed"
+}
+
+function setup_special_chars_in_runfiles_source_and_target_paths() {
+  mkdir -p pkg
+  if "$is_windows"; then
+    cat > pkg/constants.bzl <<'EOF'
+NAME = "a b .txt"
+EOF
+  else
+    cat > pkg/constants.bzl <<'EOF'
+NAME = "a \n \\ b .txt"
+EOF
+  fi
+  cat > pkg/defs.bzl <<'EOF'
+load(":constants.bzl", "NAME")
+def _special_chars_impl(ctx):
+    out = ctx.actions.declare_file(NAME)
+    ctx.actions.write(out, "my content")
+    return [DefaultInfo(files = depset([out]))]
+
+spaces = rule(
+    implementation = _special_chars_impl,
+)
+EOF
+  cat > pkg/BUILD <<'EOF'
+load(":defs.bzl", "spaces")
+spaces(name = "spaces")
+sh_test(
+    name = "foo",
+    srcs = ["foo.sh"],
+    data = [":spaces"],
+)
+EOF
+  if "$is_windows"; then
+    cat > pkg/foo.sh <<'EOF'
+#!/bin/bash
+if [[ "$(cat $'pkg/a b .txt')" != "my content" ]]; then
+  echo "unexpected content or not found"
+  exit 1
+fi
+EOF
+  else
+    cat > pkg/foo.sh <<'EOF'
+#!/bin/bash
+if [[ "$(cat $'pkg/a \n \\ b .txt')" != "my content" ]]; then
+  echo "unexpected content or not found"
+  exit 1
+fi
+EOF
+  fi
+  chmod +x pkg/foo.sh
+}
+
+function test_special_chars_in_runfiles_source_and_target_paths_out_of_process() {
+  setup_special_chars_in_runfiles_source_and_target_paths
+  bazel test --noexperimental_inprocess_symlink_creation \
+    --test_output=errors \
+    //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "test failed"
+}
+
+function test_special_chars_in_runfiles_source_and_target_paths_in_process() {
+  setup_special_chars_in_runfiles_source_and_target_paths
+  bazel test --experimental_inprocess_symlink_creation \
+    --test_output=errors \
+    //pkg:foo $EXTRA_BUILD_FLAGS >&$TEST_log || fail "test failed"
+}
+
+# Verify that Bazel's runfiles manifest is compatible with v3 of the Bash
+# runfiles library snippet, even if the workspace path contains a space and
+# a backslash.
+function test_compatibility_with_bash_runfiles_library_snippet() {
+  if [[ "${PRODUCT_NAME}" != "bazel" ]]; then
+    # This test is only relevant for Bazel.
+    return
+  fi
+  # Create a workspace path with a space.
+  WORKSPACE="$(mktemp -d jar_manifest.XXXXXXXX)/my w\orkspace"
+  trap "rm -fr '$WORKSPACE'" EXIT
+  mkdir -p "$WORKSPACE"
+  cd "$WORKSPACE" || fail "failed to cd to $WORKSPACE"
+  cat > MODULE.bazel <<'EOF'
+module(name = "my_module")
+EOF
+
+  mkdir pkg
+  cat > pkg/BUILD <<'EOF'
+sh_binary(
+    name = "tool",
+    srcs = ["tool.sh"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+genrule(
+    name = "gen",
+    outs = ["out"],
+    tools = [":tool"],
+    cmd = "$(execpath :tool) $@",
+)
+EOF
+  cat > pkg/tool.sh <<'EOF'
+#!/bin/bash
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+if [[ ! -z "${RUNFILES_DIR+x}" ]]; then
+  echo "RUNFILES_DIR is set"
+  exit 1
+fi
+
+if [[ -z "${RUNFILES_MANIFEST_FILE+x}" ]]; then
+  echo "RUNFILES_MANIFEST_FILE is not set"
+  exit 1
+fi
+
+if [[ -z "$(rlocation "my_module/pkg/tool.sh")" ]]; then
+  echo "rlocation failed"
+  exit 1
+fi
+
+touch $1
+EOF
+  chmod +x pkg/tool.sh
+
+  bazel build --noenable_runfiles \
+    --enable_bzlmod \
+    --noenable_workspace \
+    --spawn_strategy=local \
+    --action_env=RUNFILES_LIB_DEBUG=1 \
+    //pkg:gen >&$TEST_log || fail "build failed"
+}
+
 run_suite "runfiles"

--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -357,7 +357,25 @@ function runfiles_rlocation_checked() {
     if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
       echo >&2 "INFO[runfiles.bash]: rlocation($1): looking in RUNFILES_MANIFEST_FILE ($RUNFILES_MANIFEST_FILE)"
     fi
-    local -r result=$(__runfiles_maybe_grep -m1 "^$1 " "${RUNFILES_MANIFEST_FILE}" | cut -d ' ' -f 2-)
+    # If the rlocation path contains a space or newline, it needs to be prefixed
+    # with a space and spaces, newlines, and backslashes have to be escaped as
+    # \s, \n, and \b.
+    if [[ "$1" == *" "* || "$1" == *$'\n'* ]]; then
+      local search_prefix=" $(echo -n "$1" | sed 's/\\/\\b/g; s/ /\\s/g')"
+      search_prefix="${search_prefix//$'\n'/\\n}"
+      local escaped=true
+      if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
+        echo >&2 "INFO[runfiles.bash]: rlocation($1): using escaped search prefix ($search_prefix)"
+      fi
+    else
+      local search_prefix="$1"
+      local escaped=false
+    fi
+    # The extra space below is added because cut counts from 1.
+    local trim_length=$(echo -n "$search_prefix  " | wc -c)
+    # Escape the search prefix for use in the grep regex below *after*
+    # determining the trim length.
+    local result=$(__runfiles_maybe_grep -m1 "^$(echo -n "$search_prefix" | sed 's/[.[\*^$]/\\&/g') " "${RUNFILES_MANIFEST_FILE}" | cut -b ${trim_length}-)
     if [[ -z "$result" ]]; then
       # If path references a runfile that lies under a directory that itself
       # is a runfile, then only the directory is listed in the manifest. Look
@@ -370,7 +388,27 @@ function runfiles_rlocation_checked() {
         new_prefix="${prefix%/*}"
         [[ "$new_prefix" == "$prefix" ]] && break
         prefix="$new_prefix"
-        prefix_result=$(__runfiles_maybe_grep -m1 "^$prefix " "${RUNFILES_MANIFEST_FILE}" | cut -d ' ' -f 2-)
+        if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
+          echo >&2 "INFO[runfiles.bash]: rlocation($1): looking for prefix ($prefix)"
+        fi
+        if [[ "$prefix" == *" "* || "$prefix" == *$'\n'* ]]; then
+          search_prefix=" $(echo -n "$prefix" | sed 's/\\/\\b/g; s/ /\\s/g')"
+          search_prefix="${search_prefix//$'\n'/\\n}"
+          escaped=true
+          if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
+            echo >&2 "INFO[runfiles.bash]: rlocation($1): using escaped search prefix ($search_prefix)"
+          fi
+        else
+          search_prefix="$prefix"
+          escaped=false
+        fi
+        # The extra space below is added because cut counts from 1.
+        trim_length=$(echo -n "$search_prefix  " | wc -c)
+        prefix_result=$(__runfiles_maybe_grep -m1 "$(echo -n "$search_prefix" | sed 's/[.[\*^$]/\\&/g') " "${RUNFILES_MANIFEST_FILE}" | cut -b ${trim_length}-)
+        if [[ "$escaped" = true ]]; then
+          prefix_result="${prefix_result//\\n/$'\n'}"
+          prefix_result="${prefix_result//\\b/\\}"
+        fi
         [[ -z "$prefix_result" ]] && continue
         local -r candidate="${prefix_result}${1#"${prefix}"}"
         if [[ -e "$candidate" ]]; then
@@ -400,6 +438,10 @@ function runfiles_rlocation_checked() {
       fi
       echo ""
     else
+      if [[ "$escaped" = true ]]; then
+        result="${result//\\n/$'\n'}"
+        result="${result//\\b/\\}"
+      fi
       if [[ -e "$result" ]]; then
         if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
           echo >&2 "INFO[runfiles.bash]: rlocation($1): found in manifest as ($result)"

--- a/tools/bash/runfiles/runfiles_test.bash
+++ b/tools/bash/runfiles/runfiles_test.bash
@@ -141,6 +141,11 @@ e/f $tmpdir/g h
 y $tmpdir/y
 c/dir $tmpdir/dir
 unresolved $tmpdir/unresolved
+ h/\si $tmpdir/ j k
+ h/\s\bi $tmpdir/ j k b
+ h/\n\bi $tmpdir/ \bnj k \na
+ dir\swith\sspaces $tmpdir/dir with spaces
+ space\snewline\nbackslash\b_dir $tmpdir/space newline\nbackslash\ba
 EOF
   mkdir "${tmpdir}/c"
   mkdir "${tmpdir}/y"
@@ -149,7 +154,17 @@ EOF
   touch "${tmpdir}/dir/file"
   ln -s /does/not/exist "${tmpdir}/dir/unresolved"
   touch "${tmpdir}/dir/deeply/nested/file"
+  touch "${tmpdir}/dir/deeply/nested/file with spaces"
   ln -s /does/not/exist "${tmpdir}/unresolved"
+  touch "${tmpdir}/ j k"
+  touch "${tmpdir}/ j k b"
+  mkdir -p "${tmpdir}/dir with spaces/nested"
+  touch "${tmpdir}/dir with spaces/nested/file"
+  if ! is_windows; then
+    touch "${tmpdir}/ \nj k "$'\n'a
+    mkdir -p "${tmpdir}/space newline"$'\n'"backslash\a"
+    touch "${tmpdir}/space newline"$'\n'"backslash\a/f i\le"
+  fi
 
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE=$tmpdir/foo.runfiles_manifest
@@ -166,14 +181,32 @@ EOF
   [[ "$(rlocation c/dir/file || echo failed)" == "$tmpdir/dir/file" ]] || fail
   [[ -z "$(rlocation c/dir/unresolved || echo failed)" ]] || fail
   [[ "$(rlocation c/dir/deeply/nested/file || echo failed)" == "$tmpdir/dir/deeply/nested/file" ]] || fail
+  [[ "$(rlocation "c/dir/deeply/nested/file with spaces" || echo failed)" == "$tmpdir/dir/deeply/nested/file with spaces" ]] || fail
   [[ -z "$(rlocation unresolved || echo failed)" ]] || fail
-  rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y" "$tmpdir/dir" "$tmpdir/unresolved"
+  [[ "$(rlocation "h/ i" || echo failed)" == "$tmpdir/ j k" ]] || fail
+  [[ "$(rlocation "h/ \i" || echo failed)" == "$tmpdir/ j k b" ]] || fail
+  [[ "$(rlocation "dir with spaces" || echo failed)" == "$tmpdir/dir with spaces" ]] || fail
+  [[ "$(rlocation "dir with spaces/nested/file" || echo failed)" == "$tmpdir/dir with spaces/nested/file" ]] || fail
+  if ! is_windows; then
+    [[ "$(rlocation $'h/\n\\i' || echo failed)" == "$tmpdir/ \nj k "$'\n'a ]] || fail
+    [[ "$(rlocation "space newline"$'\n'"backslash\_dir/f i\le" || echo failed)" == "${tmpdir}/space newline"$'\n'"backslash\a/f i\le" ]] || fail
+  fi
+
+  rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y" "$tmpdir/dir" "$tmpdir/unresolved" "$tmpdir/ j k" "$tmpdir/dir with spaces"
+  if ! is_windows; then
+    rm -r "$tmpdir/ \nj k "$'\n'a "${tmpdir}/space newline"$'\n'"backslash\a"
+    [[ -z "$(rlocation $'h/\n\\i' || echo failed)" ]] || fail
+    [[ -z "$(rlocation "space newline"$'\n'"backslash\_dir/f i\le" || echo failed)" ]] || fail
+  fi
   [[ -z "$(rlocation a/b || echo failed)" ]] || fail
   [[ -z "$(rlocation e/f || echo failed)" ]] || fail
   [[ -z "$(rlocation y || echo failed)" ]] || fail
   [[ -z "$(rlocation c/dir || echo failed)" ]] || fail
   [[ -z "$(rlocation c/dir/file || echo failed)" ]] || fail
   [[ -z "$(rlocation c/dir/deeply/nested/file || echo failed)" ]] || fail
+  [[ -z "$(rlocation "h/ i" || echo failed)" ]] || fail
+  [[ -z "$(rlocation "dir with spaces" || echo failed)" ]] || fail
+  [[ -z "$(rlocation "dir with spaces/nested/file" || echo failed)" ]] || fail
 }
 
 function test_manifest_based_envvars() {

--- a/tools/java/runfiles/testing/RunfilesTest.java
+++ b/tools/java/runfiles/testing/RunfilesTest.java
@@ -247,14 +247,23 @@ public final class RunfilesTest {
             ImmutableList.of(
                 "Foo/runfile1 C:/Actual Path\\runfile1",
                 "Foo/Bar/runfile2 D:\\the path\\run file 2.txt",
-                "Foo/Bar/Dir E:\\Actual Path\\Directory"));
+                "Foo/Bar/Dir E:\\Actual Path\\bDirectory",
+                " h/\\si F:\\bjk",
+                " dir\\swith\\sspaces F:\\bj k\\bdir with spaces",
+                " h/\\s\\n\\bi F:\\bjk\\nb"));
     Runfiles r = Runfiles.createManifestBasedForTesting(mf.toString()).withSourceRepository("");
     assertThat(r.rlocation("Foo/runfile1")).isEqualTo("C:/Actual Path\\runfile1");
     assertThat(r.rlocation("Foo/Bar/runfile2")).isEqualTo("D:\\the path\\run file 2.txt");
-    assertThat(r.rlocation("Foo/Bar/Dir")).isEqualTo("E:\\Actual Path\\Directory");
-    assertThat(r.rlocation("Foo/Bar/Dir/File")).isEqualTo("E:\\Actual Path\\Directory/File");
+    assertThat(r.rlocation("Foo/Bar/Dir")).isEqualTo("E:\\Actual Path\\bDirectory");
+    assertThat(r.rlocation("Foo/Bar/Dir/File")).isEqualTo("E:\\Actual Path\\bDirectory/File");
     assertThat(r.rlocation("Foo/Bar/Dir/Deeply/Nested/File"))
-        .isEqualTo("E:\\Actual Path\\Directory/Deeply/Nested/File");
+        .isEqualTo("E:\\Actual Path\\bDirectory/Deeply/Nested/File");
+    assertThat(r.rlocation("Foo/Bar/Dir/Deeply/Nested/File With Spaces"))
+        .isEqualTo("E:\\Actual Path\\bDirectory/Deeply/Nested/File With Spaces");
+    assertThat(r.rlocation("h/ i")).isEqualTo("F:\\jk");
+    assertThat(r.rlocation("h/ \n\\i")).isEqualTo("F:\\jk\nb");
+    assertThat(r.rlocation("dir with spaces")).isEqualTo("F:\\j k\\dir with spaces");
+    assertThat(r.rlocation("dir with spaces/file")).isEqualTo("F:\\j k\\dir with spaces/file");
     assertThat(r.rlocation("unknown")).isNull();
   }
 


### PR DESCRIPTION
(contains the refactor in f311efc565c8e0eeddd5283834df69f69c860601 to reduce merge conflicts)

Adds support for spaces and newlines in source and target paths of runfiles symlinks to `build-runfiles` as well as to the Bash, C++, and Java runfiles libraries (the Python runfiles library has moved out of the repo).

If a symlink has spaces or newlines in its source path, it is prefixed with a space in the manifest and spaces, newlines, and backslashes in the source path are escaped with `\s`, `\n`, and `\b` respectively. This scheme has been chosen as it has the following properties:
1. There is no change to the format of manifest lines for entries whose source and target paths don't contain a space. This ensures compatibility with existing runfiles libraries.
2. There is even no change to the format of manifest lines for entries whose target path contains spaces but whose source path does not. These manifests previously failed in `build-runfiles`, but were usable on Windows and supported by the official runfiles libraries. This also ensures that the initialization snippet for the Bash runfiles library doesn't need to change, even when used on Unix with a space in the output base path.
3. The scheme is fully reversible and only depends on the source path, which gives runfiles libraries a choice between reversing the escaping when parsing the manifest (C++, Java) or applying the escaping when searching the manifest (Bash).

Fixes https://github.com/bazelbuild/bazel/issues/4327

RELNOTES: Bazel now supports all characters in the rlocation and target paths of runfiles and can be run from workspaces with a space in their full path.

Closes https://github.com/bazelbuild/bazel/pull/23331.

PiperOrigin-RevId: 683362776
Change-Id: I1eb79217dcd53cef0089d62a7ba477b1d8f52c21

(cherry picked from commits https://github.com/bazelbuild/bazel/commit/7407cef3837b4fe14e48e1a925f9b886c0cc945d and f311efc565c8e0eeddd5283834df69f69c860601)

Closes #23715 