### PR TITLE
[7.4.0] Automatically ignore vendor dir for finding packages

### DIFF
--- a/bazel_downloader.cfg
+++ b/bazel_downloader.cfg
@@ -4,3 +4,5 @@ rewrite (maven.google.com)/(.*) https://mirror.bazel.build/$1/$2
 rewrite (maven.google.com)/(.*) https://$1/$2
 rewrite (cdn.azul.com)/(.*) https://mirror.bazel.build/$1/$2
 rewrite (cdn.azul.com)/(.*) https://$1/$2
+rewrite (aka.ms)/(.*) https://mirror.bazel.build/$1/$2
+rewrite (aka.ms)/(.*) https://$1/$2

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -798,6 +798,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/io:inconsistent_filesystem_exception",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_directory_value",
+        "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_function",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe",

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -526,7 +526,9 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
     skyframeExecutor.injectExtraPrecomputedValues(
         ImmutableList.of(
             PrecomputedValue.injected(
-                RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE, Optional.empty())));
+                RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE, Optional.empty()),
+            PrecomputedValue.injected(
+                RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty())));
   }
 
   protected void setPackageOptions(String... options) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/packages/util/PackageLoadingTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/PackageLoadingTestCase.java
@@ -149,6 +149,10 @@ public abstract class PackageLoadingTestCase extends FoundationTestCase {
         ImmutableList.of(
             PrecomputedValue.injected(
                 RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE, Optional.empty())));
+    skyframeExecutor.injectExtraPrecomputedValues(
+        ImmutableList.of(
+            PrecomputedValue.injected(
+                RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty())));
     SkyframeExecutorTestHelper.process(skyframeExecutor);
     return skyframeExecutor;
   }

--- a/src/test/java/com/google/devtools/build/lib/pkgcache/IncrementalLoadingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/pkgcache/IncrementalLoadingTest.java
@@ -474,8 +474,9 @@ public class IncrementalLoadingTest {
       skyframeExecutor.injectExtraPrecomputedValues(
           ImmutableList.of(
               PrecomputedValue.injected(
-                  RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE,
-                  Optional.empty())));
+                  RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE, Optional.empty()),
+              PrecomputedValue.injected(
+                  RepositoryDelegatorFunction.VENDOR_DIRECTORY, Optional.empty())));
       skyframeExecutor.preparePackageLoading(
           new PathPackageLocator(
               outputBase,

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GlobFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GlobFunctionTest.java
@@ -126,6 +126,8 @@ public class GlobFunctionTest {
     PrecomputedValue.STARLARK_SEMANTICS.set(differencer, StarlarkSemantics.DEFAULT);
     RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE.set(
         differencer, Optional.empty());
+    RepositoryDelegatorFunction.VENDOR_DIRECTORY.set(
+        differencer, Optional.empty());
 
     createTestFiles();
   }

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -705,7 +705,7 @@ class BazelVendorTest(test_base.TestBase):
         '--vendor_dir=vendor',
     ])
     # Assert aaa is vendored
-    self.assertIn('aaa+', os.listdir(self._test_cwd + '/vendor'))
+    self.assertIn('aaa~', os.listdir(self._test_cwd + '/vendor'))
 
     # bazel build //... should succeed because vendor dir is ignored.
     self.RunBazel([


### PR DESCRIPTION
- Adding `--vendor_dir` to ignored package prefixes as if it's added in the `.bazelignore` file.
- This allows users to do `bazel build //...` after vendoring external deps in the source root without manually adding the vendor dir in `.bazelignore`.

Fixes https://github.com/bazelbuild/bazel/issues/23521

Closes #23771.

PiperOrigin-RevId: 680994986
Change-Id: I9c8b76ca20b9060232dfe05460a8fc857c92e93f

Backporting https://github.com/bazelbuild/bazel/commit/d42301b0714ab80aa376715995bc73849a451638