### PR TITLE
Remove java_import for databinding exec.jar. Keep the jar for now bec…

### DIFF
--- a/third_party/java/android_databinding/BUILD
+++ b/third_party/java/android_databinding/BUILD
@@ -26,9 +26,3 @@ filegroup(
         "//third_party/java/android_databinding/v3_4_0:srcs",
     ],
 )
-
-# Executable for the databinding resource compiler.
-alias(
-    name = "exec",
-    actual = "//third_party/java/android_databinding/v3_4_0:exec",
-)

--- a/third_party/java/android_databinding/v3_4_0/BUILD
+++ b/third_party/java/android_databinding/v3_4_0/BUILD
@@ -16,9 +16,5 @@ filegroup(
 )
 
 # Resource processor implementation.
-# Built from https://cs.android.com/androidx/platform/frameworks/data-binding/+/mirror-goog-studio-master-dev:exec/src
-java_import(
-    name = "exec",
-    jars = ["exec.jar"],
-    deps = ["@maven_android//:androidx_databinding_databinding_compiler"],
-)
+# exec.jar is built from https://cs.android.com/androidx/platform/frameworks/data-binding/+/mirror-goog-studio-master-dev:exec/src
+# and depends on "androidx.databinding:databinding-compiler:3.4.0-alpha10" in https://dl.google.com/android/maven2


### PR DESCRIPTION
…ause some tooling that has been moved to rules_android still requires this jar, we can delete the jar once we find a good way to depend on this jar.