### PR TITLE
fix deps in gtest example (cpp-use-cases.md)

### DIFF
--- a/site/en/tutorials/cpp-use-cases.md
+++ b/site/en/tutorials/cpp-use-cases.md
@@ -137,7 +137,8 @@ cc_test(
       "-Iexternal/gtest/googletest",
     ],
     deps = [
-        "@googletest//:main",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
         "//main:hello-greet",
     ],
 )


### PR DESCRIPTION


reference:

https://google.github.io/googletest/quickstart-bazel.html
```
cc_test(
    name = "hello_test",
    size = "small",
    srcs = ["hello_test.cc"],
    deps = [
        "@googletest//:gtest",
        "@googletest//:gtest_main",
    ],
)
```