### PR TITLE
Fix version resolution in `AutoloadSymbols`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
@@ -405,7 +405,7 @@ public class AutoloadSymbols {
                   toImmutableMap(
                       ModuleKey::name,
                       moduleKey -> moduleKey,
-                      (m1, m2) -> m1.version().compareTo(m2.version()) >= 0 ? m1 : m1));
+                      (m1, m2) -> m1.version().compareTo(m2.version()) >= 0 ? m1 : m2));
       RepositoryMapping repositoryMapping =
           RepositoryMapping.create(
               highestVersions.entrySet().stream()


### PR DESCRIPTION
The logic picked the first instead of the highest version due to a typo.