### PR TITLE
[8.0.0] Add additional_compiler_inputs support to local_defines/defines

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -1142,11 +1142,11 @@ def _linkopts(ctx, additional_make_variable_substitutions, cc_toolchain):
         fail("in linkopts attribute of cc_library rule {}: Apple builds do not support statically linked binaries".format(ctx.label))
     return tokens
 
-def _defines_attribute(ctx, additional_make_variable_substitutions, attr_name):
+def _defines_attribute(ctx, additional_make_variable_substitutions, attr_name, additional_targets):
     defines = getattr(ctx.attr, attr_name, [])
     if len(defines) == 0:
         return []
-    targets = []
+    targets = list(additional_targets)
     for dep in ctx.attr.deps:
         targets.append(dep)
     result = []
@@ -1164,10 +1164,10 @@ def _defines_attribute(ctx, additional_make_variable_substitutions, attr_name):
     return result
 
 def _defines(ctx, additional_make_variable_substitutions):
-    return _defines_attribute(ctx, additional_make_variable_substitutions, "defines")
+    return _defines_attribute(ctx, additional_make_variable_substitutions, "defines", [])
 
 def _local_defines(ctx, additional_make_variable_substitutions):
-    return _defines_attribute(ctx, additional_make_variable_substitutions, "local_defines")
+    return _defines_attribute(ctx, additional_make_variable_substitutions, "local_defines", getattr(ctx.attr, "additional_compiler_inputs", []))
 
 def _linker_scripts(ctx):
     result = []

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2502,4 +2502,26 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     assertThat(action.getInputs().toList()).contains(getSourceArtifact("foo/compiler_input.txt"));
     assertThat(action.getArguments()).contains("foo/compiler_input.txt");
   }
+
+  @Test
+  public void testAdditionalCompilerInputsArePassedToCompileFromLocalDefines() throws Exception {
+    AnalysisMock.get().ccSupport().setupCcToolchainConfig(mockToolsConfig);
+    scratch.file(
+        "foo/BUILD",
+        """
+        cc_library(
+            name = 'foo',
+            srcs = ['hello.cc'],
+            local_defines = ['FOO=$(location compiler_input.txt)'],
+            additional_compiler_inputs = ['compiler_input.txt'],
+        )
+        """);
+    scratch.file("foo/compiler_input.txt", "hello world!");
+
+    ConfiguredTarget lib = getConfiguredTarget("//foo:foo");
+    Artifact artifact = getBinArtifact("_objs/foo/hello.o", lib);
+    CppCompileAction action = (CppCompileAction) getGeneratingAction(artifact);
+    assertThat(action.getInputs().toList()).contains(getSourceArtifact("foo/compiler_input.txt"));
+    assertThat(action.getArguments()).contains("-DFOO=foo/compiler_input.txt");
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/23885

Closes #23102.

PiperOrigin-RevId: 684433748
Change-Id: I12cdb9a04f930a52e57bbd8551c8f2559a15932a

Commit https://github.com/bazelbuild/bazel/commit/c2d316b4d3f832d0c5677f0abc63c27d059873b8