### PR TITLE
[8.0.0] Fix version resolution in `AutoloadSymbols`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
@@ -405,7 +405,7 @@ public class AutoloadSymbols {
                   toImmutableMap(
                       ModuleKey::name,
                       moduleKey -> moduleKey,
-                      (m1, m2) -> m1.version().compareTo(m2.version()) >= 0 ? m1 : m1));
+                      (m1, m2) -> m1.version().compareTo(m2.version()) >= 0 ? m1 : m2));
       RepositoryMapping repositoryMapping =
           RepositoryMapping.create(
               highestVersions.entrySet().stream()


### PR DESCRIPTION
The logic picked the first instead of the highest version due to a typo.

Closes #23936.

PiperOrigin-RevId: 684528776
Change-Id: Ic61c84ca2f3489e43fc71944824e7e2311543ab9

Commit https://github.com/bazelbuild/bazel/commit/4e6a28acbe11e50e2c3336d42c8075293e26b0af