### PR TITLE
[8.0.0] Re-enable tests that were disabled due CI infra flake

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -217,14 +217,6 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
       # Disable android tests since we are moving Android rules out of Bazel repo.
       - "-//src/test/shell/bazel:bazel_android_tools_test"
-      # https://github.com/bazelbuild/bazel/issues/23726
-      - "-//src/test/shell/bazel:bazel_determinism_test"
-      - "-//src/test/shell/bazel:bazel_bootstrap_distfile_tar_test"
-      - "-//src/test/shell/bazel:bazel_bootstrap_distfile_test"
-      # Temporarily disable python and shell integration tests
-      # TODO(pcloudy): Re-enable these tests after fixing https://github.com/bazelbuild/bazel/issues/23726
-      - "-//src/test/shell/..."
-      - "-//src/test/py/..."
     include_json_profile:
       - build
       - test

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -910,7 +910,7 @@ sh_test(
 
 sh_test(
     name = "disk_cache_test",
-    size = "small",
+    size = "medium",
     srcs = ["disk_cache_test.sh"],
     data = [":test-deps"],
     tags = ["no_windows"],


### PR DESCRIPTION
Tests on macOS arm64 should be much more stable after bumping VM specs.

Also bumped the size of disk_cache_test as it sometimes timeout on Linux.

Closes https://github.com/bazelbuild/bazel/issues/23726

PiperOrigin-RevId: 684412631
Change-Id: I5485f839aee0c3a1012196c6628eda9535985b82

Commit https://github.com/bazelbuild/bazel/commit/efa030314ec5f7340d770b6ae9736a9e24d29ee3