### PR TITLE
docs(module): fix list of bullet points not rendering

### DIFF
--- a/site/en/external/module.md
+++ b/site/en/external/module.md
@@ -206,6 +206,7 @@ multiple versions of the module in the entire dependency graph (see
 Note that **the canonical name format** is not an API you should depend on and
 **is subject to change at any time**. Instead of hard-coding the canonical name,
 use a supported way to get it directly from Bazel:
+
 *    In BUILD and `.bzl` files, use
      [`Label.repo_name`](/rules/lib/builtins/Label#repo_name) on a `Label` instance
      constructed from a label string given by the apparent name of the repo, e.g.,


### PR DESCRIPTION
Looks like f6687ad45eccfa7928c9a54f3db2e3c660d9bbce didn't fully fix things, based on looking at https://bazel.build/external/module today:

<img width="907" alt="Screenshot 2024-10-15 at 1 13 37 PM" src="https://github.com/user-attachments/assets/800487d4-0845-418d-8042-bd2c4bad017c">
