### PR TITLE
Fix input root creation for path mapped workers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFilesHash.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFilesHash.java
@@ -90,7 +90,9 @@ public class WorkerFilesHash {
               throw new MissingInputException(localArtifact);
             }
             if (metadata.getType().isFile()) {
-              workerFilesMap.put(root.getRelative(mapping.getKey()), metadata.getDigest());
+              workerFilesMap.put(
+                  spawn.getPathMapper().map(root.getRelative(mapping.getKey())),
+                  metadata.getDigest());
             }
           }
         }
@@ -103,7 +105,8 @@ public class WorkerFilesHash {
         throw new MissingInputException(tool);
       }
       workerFilesMap.put(
-          tool.getExecPath(), actionInputFileCache.getInputMetadata(tool).getDigest());
+          spawn.getPathMapper().map(tool.getExecPath()),
+          actionInputFileCache.getInputMetadata(tool).getDigest());
     }
 
     return workerFilesMap;

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.worker;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Stopwatch;
@@ -72,7 +71,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -532,12 +530,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
                 String.format("Worker #%d preparing execution", worker.getWorkerId()))) {
       // We consider `prepareExecution` to be also part of setup.
       Stopwatch prepareExecutionStopwatch = Stopwatch.createStarted();
-      Set<PathFragment> workerFiles = key.getWorkerFilesWithDigests().keySet();
-      if (!spawn.getPathMapper().isNoop()) {
-        workerFiles =
-            workerFiles.stream().map(spawn.getPathMapper()::map).collect(toImmutableSet());
-      }
-      worker.prepareExecution(inputFiles, outputs, workerFiles);
+      worker.prepareExecution(inputFiles, outputs, key.getWorkerFilesWithDigests().keySet());
       initializeMetrics(key, worker);
       spawnMetrics.addSetupTimeInMs((int) prepareExecutionStopwatch.elapsed().toMillis());
     } catch (IOException e) {


### PR DESCRIPTION
The set of worker files wasn't path mapped, which resulted in build failures when using a generated multiplex worker.

Fixes #23990