### PR TITLE
[8.0.0] Mark `cc_static_library` as experimental in docs

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/experimental_cc_static_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/experimental_cc_static_library.bzl
@@ -244,6 +244,9 @@ def _cc_static_library_impl(ctx):
 cc_static_library = rule(
     implementation = _cc_static_library_impl,
     doc = """
+<b>This rule is currently experimental and can only be used with the <code>
+--experimental_cc_static_library</code> flag.</b>
+
 Produces a static library from a list of targets and their transitive dependencies.
 
 <p>The resulting static library contains the object files of the targets listed in


### PR DESCRIPTION
Closes #23800.

PiperOrigin-RevId: 684529045
Change-Id: I14dc53b6f2e39c7a05ee3a8b872eb220af45cef9

Commit https://github.com/bazelbuild/bazel/commit/ed37f39206f2981ade87897eec4bfdab3db055a1