### PR TITLE
Add `repository_ctx.rename()` for renaming files or directories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -17,6 +17,7 @@ import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.ExtractEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.FileEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.OsEvent;
+import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.RenameEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.SymlinkEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.TemplateEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.WhichEvent;
@@ -252,6 +253,24 @@ public final class WorkspaceRuleEvent implements Postable {
     WorkspaceLogProtos.WorkspaceEvent.Builder result =
         WorkspaceLogProtos.WorkspaceEvent.newBuilder();
     result = result.setOsEvent(e);
+    if (location != null) {
+      result = result.setLocation(location.toString());
+    }
+    if (context != null) {
+      result = result.setContext(context);
+    }
+    return new WorkspaceRuleEvent(result.build());
+  }
+
+  /** Creates a new WorkspaceRuleEvent for a rename event. */
+  public static WorkspaceRuleEvent newRenameEvent(
+      String src, String dst, String context, Location location) {
+    RenameEvent e =
+        WorkspaceLogProtos.RenameEvent.newBuilder().setSrc(src).setDst(dst).build();
+
+    WorkspaceLogProtos.WorkspaceEvent.Builder result =
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder();
+    result = result.setRenameEvent(e);
     if (location != null) {
       result = result.setLocation(location.toString());
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -115,6 +115,14 @@ message OsEvent {
   // Takes no inputs
 }
 
+// Information on "rename" event in repository_ctx.
+message RenameEvent {
+  // The path of the existing file or directory to rename.
+  string src = 1;
+  // The new name of the file or directory.
+  string dst = 2;
+}
+
 // Information on "symlink" event in repository_ctx.
 message SymlinkEvent {
   // path to which the symlink will point to
@@ -162,5 +170,6 @@ message WorkspaceEvent {
     ReadEvent read_event = 12;
     DeleteEvent delete_event = 13;
     PatchEvent patch_event = 14;
+    RenameEvent rename_event = 15;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -398,7 +398,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
           """
           Renames the file or directory from <code>src</code> to <code>dst</code>. \
           Parent directories are created as needed. Fails if the destination path
-          already exists.
+          already exists. Both paths must be located within the repository.
           """,
       useStarlarkThread = true,
       parameters = {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -393,6 +393,84 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
   }
 
   @StarlarkMethod(
+      name = "rename",
+      doc =
+          """
+          Renames the file or directory from <code>src</code> to <code>dst</code>. \
+          Parent directories are created as needed. Fails if the destination path
+          already exists.
+          """,
+      useStarlarkThread = true,
+      parameters = {
+        @Param(
+            name = "src",
+            allowedTypes = {
+              @ParamType(type = String.class),
+              @ParamType(type = Label.class),
+              @ParamType(type = StarlarkPath.class)
+            },
+            doc =
+                """
+                The path of the existing file or directory to rename, relative
+                to the repository directory.
+                """),
+        @Param(
+            name = "dst",
+            allowedTypes = {
+              @ParamType(type = String.class),
+              @ParamType(type = Label.class),
+              @ParamType(type = StarlarkPath.class)
+            },
+            doc = """
+            The new name to which the file or directory will be renamed to,
+            relative to the repository directory.
+            """),
+      })
+  public void rename(Object srcName, Object dstName, StarlarkThread thread)
+      throws RepositoryFunctionException, EvalException, InterruptedException {
+    StarlarkPath srcPath = getPath(srcName);
+    StarlarkPath dstPath = getPath(dstName);
+    WorkspaceRuleEvent w =
+        WorkspaceRuleEvent.newRenameEvent(
+            srcPath.toString(),
+            dstPath.toString(),
+            identifyingStringForLogging,
+            thread.getCallerLocation());
+    env.getListener().post(w);
+    try {
+      checkInOutputDirectory("write", srcPath);
+      checkInOutputDirectory("write", dstPath);
+      if (dstPath.exists()) {
+        throw new RepositoryFunctionException(
+            new IOException(
+                "Could not rename "
+                    + srcPath
+                    + " to "
+                    + dstPath
+                    + ": already exists"),
+            Transience.TRANSIENT);
+      }
+      makeDirectories(dstPath.getPath());
+      srcPath.getPath().renameTo(dstPath.getPath());
+    } catch (IOException e) {
+      throw new RepositoryFunctionException(
+          new IOException(
+              "Could not rename "
+                  + srcPath
+                  + " to "
+                  + dstPath
+                  + ": "
+                  + e.getMessage(),
+              e),
+          Transience.TRANSIENT);
+    } catch (InvalidPathException e) {
+      throw new RepositoryFunctionException(
+          Starlark.errorf("Could not rename %s to %s: %s", srcPath, dstPath, e.getMessage()),
+          Transience.PERSISTENT);
+    }
+  }
+
+  @StarlarkMethod(
       name = "patch",
       doc =
           """


### PR DESCRIPTION
This allows the directory structure of third-party archives to be rearranged without platform-specific commands, and without requiring symlink support from the platform.