### PR TITLE
Set `LANG=C.UTF-8` for actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -103,9 +103,10 @@ public class BazelRuleClassProvider {
           .buildOrThrow();
 
   /**
-   * {@link BuildConfigurationFunction} constructs {@link BuildOptions} out of the options required
-   * by the registered fragments. We create and register this fragment exclusively to ensure {@link
-   * StrictActionEnvOptions} is always available.
+   * {@link com.google.devtools.build.lib.skyframe.config.BuildConfigurationFunction} constructs
+   * {@link BuildOptions} out of the options required by the registered fragments. We create and
+   * register this fragment exclusively to ensure {@link StrictActionEnvOptions} is always
+   * available.
    */
   @RequiresOptions(options = {StrictActionEnvOptions.class})
   public static class StrictActionEnvConfiguration extends Fragment {
@@ -173,6 +174,14 @@ public class BazelRuleClassProvider {
           // and fell back to a hard-coded "/bin:/usr/bin" if PATH was not set.
           env.put("PATH", null);
         }
+
+        // An otherwise empty environment would force a fallback to the C locale, which only
+        // supports ASCII file paths. C.UTF-8 is now the de facto standard UTF-8 locale for all
+        // reasonably modern Unix systems (and doesn't cause any harm on Windows) and also a common
+        // default value for LANG.
+        // Set LANG instead of LC_CTYPE or LC_ALL to match what most distributions do and also make
+        // it easier for the user to override (e.g. back to C).
+        env.put("LANG", "C.UTF-8");
 
         // Shell environment variables specified via options take precedence over the
         // ones inherited from the fragments. In the long run, these fragments will

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaSemantics.java
@@ -26,11 +26,10 @@ import java.util.List;
 public class BazelJavaSemantics implements JavaSemantics {
 
   /**
-   * {@code C.UTF-8} is now the universally accepted standard UTF-8 locale, to the point where some
-   * minimal distributions no longer ship with {@code en_US.UTF-8}.
+   * Bazel sets {@code LANG=C.UTF-8} in the environment for all actions and thus doesn't need
+   * special handling for Java compilation actions.
    */
-  private static final ImmutableMap<String, String> UTF8_ENVIRONMENT =
-      ImmutableMap.of("LC_CTYPE", "C.UTF-8");
+  private static final ImmutableMap<String, String> UTF8_ENVIRONMENT = ImmutableMap.of();
 
   @SerializationConstant public static final BazelJavaSemantics INSTANCE = new BazelJavaSemantics();
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -94,22 +94,6 @@ function is_macos() {
   [[ "${OSTYPE}" =~ darwin* ]]
 }
 
-function available_utf8_locale() {
-  # Both C.UTF-8 and en_US.UTF-8 do not cause any language-specific effects
-  # when set as LC_CTYPE, but neither is certain to exist on all systems.
-  #
-  # https://github.com/bazelbuild/bazel/pull/17670: Note that the use of "env"
-  # is important in these calls. Without "env", bash itself seems to pick up
-  # the LC_CTYPE change as soon as the variable is defined and may emit a
-  # warning when the locale files are not present. By using "env", bash never
-  # sees the change and the 2>/dev/null redirection does the right thing.
-  if [[ "$(env LC_CTYPE=C.UTF-8 locale charmap 2>/dev/null)" == "UTF-8" ]]; then
-    echo "C.UTF-8"
-  elif [[ "$(env LC_CTYPE=en_US.UTF-8 locale charmap 2>/dev/null)" == "UTF-8" ]]; then
-    echo "en_US.UTF-8"
-  fi
-}
-
 # Parse arguments sequentially until the first unrecognized arg is encountered.
 # Scan the remaining args for --wrapper_script_flag=X options and process them.
 ARGS=()
@@ -380,17 +364,6 @@ if [ -z "$CLASSPATH_LIMIT" ]; then
   # Windows per-arg limit MAX_ARG_STRLEN == 8k
   # Linux per-arg limit MAX_ARG_STRLEN == 128k
   is_windows && CLASSPATH_LIMIT=7000 || CLASSPATH_LIMIT=120000
-fi
-
-# On non-macOS Unix, without any locale variable set, the JVM would use
-# using ASCII rather than UTF-8 as the encoding for file system paths.
-if ! is_macos; then
-  if [ -z ${LC_CTYPE+x} ] && [ -z ${LC_ALL+x} ] && [ -z ${LANG+x} ]; then
-    UTF8_LOCALE=$(available_utf8_locale)
-    if [[ -n "$UTF8_LOCALE" ]]; then
-      export LC_CTYPE="$UTF8_LOCALE"
-    fi
-  fi
 fi
 
 if (("${#CLASSPATH}" > ${CLASSPATH_LIMIT})); then

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -150,8 +150,12 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
         """);
     JavaCompileAction action =
         (JavaCompileAction) getGeneratingActionForLabel("//java/com/google/test:liba.jar");
-    assertThat(action.getIncompleteEnvironmentForTesting())
-        .containsEntry("LC_CTYPE", analysisMock.isThisBazel() ? "C.UTF-8" : "en_US.UTF-8");
+    if (analysisMock.isThisBazel()) {
+      assertThat(action.getIncompleteEnvironmentForTesting()).containsEntry("LANG", "C.UTF-8");
+    } else {
+      assertThat(action.getIncompleteEnvironmentForTesting())
+          .containsEntry("LC_CTYPE", "en_US.UTF-8");
+    }
   }
 
   @Test

--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -1293,4 +1293,21 @@ EOF
   expect_log "in copy of external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
 }
 
+function test_utf8_charmap_default() {
+  cat > BUILD <<'EOF'
+genrule(
+    name = "gen",
+    outs = ["out"],
+    cmd = """
+got="$$(locale charmap)"
+want="UTF-8"
+[[ "$$got" == "$$want" ]] || { echo "got $$got, want $$want" >&2; exit 1; }
+touch $@
+""",
+)
+EOF
+
+  bazel build //:gen &> $TEST_log || fail "Build should succeed"
+}
+
 run_suite "rules test"

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -1116,4 +1116,22 @@ EOF
   expect_log "-- Test exited prematurely (TEST_PREMATURE_EXIT_FILE exists) --"
 }
 
+function test_utf8_charmap_default() {
+  cat <<'EOF' > BUILD
+sh_test(
+    name = 'x',
+    srcs = ['x.sh'],
+)
+EOF
+  cat <<'EOF' > x.sh
+#!/bin/sh
+got="$(locale charmap)"
+want="UTF-8"
+[[ "$got" == "$want" ]] || { echo "got $got, want $want" >&2; exit 1; }
+EOF
+  chmod +x x.sh
+
+  bazel test //:x --test_output=errors &> $TEST_log || fail "expected success"
+}
+
 run_suite "bazel test tests"

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1946,7 +1946,7 @@ EOF
   bazel build -s --process_headers_in_dependencies --features parse_headers \
     //pkg:lib &> "$TEST_log" && fail "Build should have failed due to unclean headers"
   expect_log "Compiling pkg/lib.h"
-  expect_log "error:.*'uint8_t'"
+  expect_log "error:.*uint8_t"
 
   bazel build -s --process_headers_in_dependencies \
     //pkg:lib &> "$TEST_log" || fail "Build should have passed"


### PR DESCRIPTION
RELNOTES[inc]: Bazel now sets `LANG=C.UTF-8` for all actions to avoid a fallback to the ASCII charset for locale-sensitive tools due to the absence of any locale variables. To restore the old behavior, pass `--action_env=LANG=C` or add the line `common --action_env=LANG=C` to `.bazelrc`.