### PR TITLE
Cherry-pick quiet mode (fix for #4867) to 8.0.0

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1502,7 +1502,14 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
   StartupOptions *startup_options = option_processor->GetParsedStartupOptions();
   startup_options->MaybeLogStartupOptionWarnings();
 
-  SetDebugLog(startup_options->client_debug);
+  if (startup_options->client_debug) {
+    SetDebugLog(blaze_util::LOGGINGDETAIL_DEBUG);
+  } else if (startup_options->quiet) {
+    SetDebugLog(blaze_util::LOGGINGDETAIL_QUIET);
+  } else {
+    SetDebugLog(blaze_util::LOGGINGDETAIL_USER);
+  }
+
   // If client_debug was false, this is ignored, so it's accurate.
   BAZEL_LOG(INFO) << "Debug logging requested, sending all client log "
                      "statements to stderr";

--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -189,17 +189,12 @@ bool AwaitServerProcessTermination(int pid, const blaze_util::Path& output_base,
   return true;
 }
 
-// For now, we don't have the client set up to log to a file. If --client_debug
-// is passed, however, all BAZEL_LOG statements will be output to stderr.
-// If/when we switch to logging these to a file, care will have to be taken to
-// either log to both stderr and the file in the case of --client_debug, or be
-// ok that these log lines will only go to one stream.
-void SetDebugLog(bool enabled) {
-  if (enabled) {
-    blaze_util::SetLoggingOutputStreamToStderr();
+void SetDebugLog(blaze_util::LoggingDetail detail) {
+  if (detail == blaze_util::LOGGINGDETAIL_DEBUG) {
+    blaze_util::SetLoggingDetail(blaze_util::LOGGINGDETAIL_DEBUG, &std::cerr);
     absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
   } else {
-    blaze_util::SetLoggingOutputStream(nullptr);
+    blaze_util::SetLoggingDetail(detail, nullptr);
 
     // Disable absl debug logging, since that gets printed to stderr due to us
     // not setting up a log file. We don't use absl but one of our dependencies

--- a/src/main/cpp/blaze_util.h
+++ b/src/main/cpp/blaze_util.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "src/main/cpp/util/logging.h"
 #include "src/main/cpp/util/path.h"
 
 namespace blaze {
@@ -92,7 +93,7 @@ extern const unsigned int kPostKillGracePeriodSeconds;
 
 // Control the output of debug information by debug_log.
 // Revisit once client logging is fixed (b/32939567).
-void SetDebugLog(bool enabled);
+void SetDebugLog(blaze_util::LoggingDetail detail);
 
 // Returns true if this Bazel instance is running inside of a Bazel test.
 // This method observes the TEST_TMPDIR envvar.

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -514,6 +514,13 @@ blaze_exit_code::ExitCode OptionProcessor::ParseOptions(
 
   blazerc_and_env_command_args_ =
       GetBlazercAndEnvCommandArgs(cwd, rc_file_ptrs, GetProcessedEnv());
+  // This is necessary because some code at Google both links in this code and
+  // needs to be ready for old versions of Bazel that don't support this
+  // argument yet.
+  if (startup_options_->quiet) {
+    blazerc_and_env_command_args_.push_back(
+        "--default_override=0:common=--quiet");
+  }
   return blaze_exit_code::SUCCESS;
 }
 

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -85,6 +85,7 @@ StartupOptions::StartupOptions(const string &product_name,
       connect_timeout_secs(30),
       local_startup_timeout_secs(120),
       have_invocation_policy_(false),
+      quiet(false),
       client_debug(false),
       preemptible(false),
       java_logging_formatter(
@@ -136,6 +137,7 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterNullaryStartupFlag("batch", &batch);
   RegisterNullaryStartupFlag("batch_cpu_scheduling", &batch_cpu_scheduling);
   RegisterNullaryStartupFlag("block_for_lock", &block_for_lock);
+  RegisterNullaryStartupFlag("quiet", &quiet);
   RegisterNullaryStartupFlag("client_debug", &client_debug);
   RegisterNullaryStartupFlag("preemptible", &preemptible);
   RegisterNullaryStartupFlag("fatal_event_bus_exceptions",

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -242,6 +242,9 @@ class StartupOptions {
   // Invocation policy can only be specified once.
   bool have_invocation_policy_;
 
+  // Whether to emit as little output as possible.
+  bool quiet;
+
   // Whether to output addition debugging information in the client.
   bool client_debug;
 

--- a/src/main/cpp/util/logging.cc
+++ b/src/main/cpp/util/logging.cc
@@ -15,13 +15,11 @@
 // This file is based off the logging work by the protobuf team
 #include "src/main/cpp/util/logging.h"
 
-#include <cstdio>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 
 #include "src/main/cpp/util/exit_code.h"
-#include "src/main/cpp/util/strings.h"
 
 namespace blaze_util {
 
@@ -100,14 +98,15 @@ void SetLogHandler(std::unique_ptr<LogHandler> new_handler) {
   internal::log_handler_ = std::move(new_handler);
 }
 
-void SetLoggingOutputStream(std::unique_ptr<std::ostream> output_stream) {
+void SetLoggingDetail(LoggingDetail detail, std::ostream* debug_stream) {
   if (internal::log_handler_ != nullptr) {
-    internal::log_handler_->SetOutputStream(std::move(output_stream));
+    internal::log_handler_->SetLoggingDetail(detail, debug_stream);
   }
 }
-void SetLoggingOutputStreamToStderr() {
+
+void CloseLogging() {
   if (internal::log_handler_ != nullptr) {
-    internal::log_handler_->SetOutputStreamToStderr();
+    internal::log_handler_->Close();
   }
 }
 

--- a/src/main/cpp/util/logging.h
+++ b/src/main/cpp/util/logging.h
@@ -14,6 +14,7 @@
 #ifndef BAZEL_SRC_MAIN_CPP_LOGGING_H_
 #define BAZEL_SRC_MAIN_CPP_LOGGING_H_
 
+#include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -145,6 +146,13 @@ inline bool IsOk(bool status) {
 
 #endif  // !NDEBUG
 
+// How much to print on the terminal.
+enum LoggingDetail {
+  LOGGINGDETAIL_QUIET,  // Only errors
+  LOGGINGDETAIL_USER,   // Messages intended for the user (level USER and above)
+  LOGGINGDETAIL_DEBUG   // Debug logging
+};
+
 class LogHandler {
  public:
   virtual ~LogHandler() {}
@@ -152,8 +160,12 @@ class LogHandler {
                              int line, const std::string& message,
                              int exit_code) = 0;
 
-  virtual void SetOutputStream(std::unique_ptr<std::ostream> output_stream) = 0;
-  virtual void SetOutputStreamToStderr() = 0;
+  // See ::SetLoggingDetail()
+  virtual void SetLoggingDetail(LoggingDetail detail,
+                                std::ostream* debug_stream) = 0;
+
+  // See ::CloseLogging()
+  virtual void Close() = 0;
 };
 
 // Sets the log handler that routes all log messages.
@@ -161,9 +173,14 @@ class LogHandler {
 // at initialization time, and probably not from library code.
 void SetLogHandler(std::unique_ptr<LogHandler> new_handler);
 
-// Set the stream to which all log statements will be sent.
-void SetLoggingOutputStream(std::unique_ptr<std::ostream> output_stream);
-void SetLoggingOutputStreamToStderr();
+// Sets the logging detail for the currently set log handler. Prints the log
+// messages to `debug_stream` if not null. It doesn't affect non-debug messages
+// and is only used for testing.
+void SetLoggingDetail(LoggingDetail detail, std::ostream* debug_stream);
+
+// Closes the logging. Buffers are flushed and no more log messages will be
+// printed.
+void CloseLogging();
 
 }  // namespace blaze_util
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -379,6 +379,16 @@ public class BlazeServerStartupOptions extends OptionsBase {
   public boolean clientDebug;
 
   @Option(
+      name = "quiet",
+      defaultValue = "false", // NOTE: only for documentation, actual flag is in UiOptions
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS, OptionEffectTag.BAZEL_MONITORING},
+      help =
+          "If true, no informational messages are emitted on the console, only errors. Changing "
+              + "this option will not cause the server to restart.")
+  public boolean quiet;
+
+  @Option(
       name = "preemptible",
       defaultValue = "false", // NOTE: only for documentation, value is set and used by the client.
       documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiOptions.java
@@ -128,6 +128,14 @@ public class UiOptions extends OptionsBase {
   }
 
   @Option(
+      name = "quiet",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "If set, Bazel prints as little output as possible.")
+  public boolean quiet;
+
+  @Option(
       name = "show_progress",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -748,4 +748,17 @@ function test_exit_code_reported() {
   expect_log '//pkg:false (Exit 1) (see'
 }
 
+function test_quiet_mode() {
+  mkdir -p foo
+  cat > foo/BUILD <<'EOF'
+genrule(name="g", srcs=[], outs=["go"], cmd="echo GO > $@")
+EOF
+
+  bazel shutdown
+  bazel --quiet build &> "$TEST_log" || fail "build failed"
+  expect_not_log "and connecting to it"
+  expect_not_log "Analyzed"
+  expect_not_log "Build completed successfully"
+
+}
 run_suite "Integration tests for ${PRODUCT_NAME}'s UI"


### PR DESCRIPTION
Implement "quiet mode"
This change adds a "--quiet" startup option, which causes Blaze not to print any status messages, progress messages, info messages or warnings of any kind. Error messages are still emitted as usual.

Fixes https://github.com/bazelbuild/bazel/issues/4867.

RELNOTES[NEW]: The "blaze --quiet" command line option can now be used to make Blaze emit much less output.

PiperOrigin-RevId: 686784300
Change-Id: Ibaa0b6a1788b43863337dce6fc16da09defb6724