### PR TITLE
Fix clang-tidy issues in C++ code

### DIFF
--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -68,7 +68,7 @@ string GetOutputRoot() {
     char buf[2048];
     struct passwd pwbuf;
     struct passwd *pw = nullptr;
-    int uid = getuid();
+    uid_t uid = getuid();
     int r = getpwuid_r(uid, &pwbuf, buf, 2048, &pw);
     if (r == 0 && pw != nullptr) {
       xdg_cache_home = blaze_util::JoinPath(pw->pw_dir, ".cache");

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -53,7 +53,7 @@ string GetOutputRoot() {
       char buf[2048];
       struct passwd pwbuf;
       struct passwd *pw = nullptr;
-      int uid = getuid();
+      uid_t uid = getuid();
       int r = getpwuid_r(uid, &pwbuf, buf, 2048, &pw);
       if (r == 0 && pw != nullptr) {
         home = pw->pw_dir;

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -428,17 +428,17 @@ int ExecuteDaemon(const blaze_util::Path& exe,
   }
 
   posix_spawn_file_actions_t file_actions;
-  if (posix_spawn_file_actions_init(&file_actions) == -1) {
+  if (posix_spawn_file_actions_init(&file_actions) != 0) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
       << "Failed to create posix_spawn_file_actions: " << GetLastErrorString();
   }
-  if (posix_spawn_file_actions_addclose(&file_actions, fds[0]) == -1) {
+  if (posix_spawn_file_actions_addclose(&file_actions, fds[0]) != 0) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
       << "Failed to modify posix_spawn_file_actions: "<< GetLastErrorString();
   }
 
   posix_spawnattr_t attrp;
-  if (posix_spawnattr_init(&attrp) == -1) {
+  if (posix_spawnattr_init(&attrp) != 0) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
         << "Failed to create posix_spawnattr: " << GetLastErrorString();
   }
@@ -449,7 +449,7 @@ int ExecuteDaemon(const blaze_util::Path& exe,
 
   pid_t transient_pid;
   if (posix_spawn(&transient_pid, daemonize.c_str(), &file_actions, &attrp,
-                  CharPP(daemonize_args).get(), CharPP(env).get()) == -1) {
+                  CharPP(daemonize_args).get(), CharPP(env).get()) != 0) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
       << "Failed to execute JVM via " << daemonize
       << ": " << GetLastErrorString();


### PR DESCRIPTION
* Use `uid_t` for `getuid` return value.
* Actually report errors returned by `posix_*` functions, which never return a negative value.