### PR TITLE
[7.4.0] Blaze/Bazel changes for Java 17 Record desugaring

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
@@ -1892,7 +1892,13 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
               ruleContext.getUniqueDirectory("dexfiles"), ruleContext.getBinOrGenfilesDirectory());
       FilesToRunProvider dexMerger = ruleContext.getExecutablePrerequisite("$dexmerger");
       createTemplatedMergerActions(
-          ruleContext, multidexShards, shardsToMerge, dexopts, dexMerger, minSdkVersion);
+          ruleContext,
+          multidexShards,
+          shardsToMerge,
+          dexopts,
+          dexMerger,
+          minSdkVersion,
+          null /* desugarGlobals */);
       // TODO(b/69431301): avoid this action and give the files to apk build action directly
       createZipMergeAction(ruleContext, multidexShards, classesDex);
     }
@@ -2024,7 +2030,8 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
       SpecialArtifact inputTree,
       List<String> dexopts,
       FilesToRunProvider executable,
-      int minSdkVersion) {
+      int minSdkVersion,
+      Object desugarGlobals) {
     SpawnActionTemplate.Builder dexmerger =
         new SpawnActionTemplate.Builder(inputTree, outputTree)
             .setExecutable(executable)
@@ -2043,6 +2050,12 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
                         dexopts, Predicates.not(Predicates.equalTo(DX_MINIMAL_MAIN_DEX_OPTION)))));
     if (minSdkVersion > 0) {
       commandLine.add("--min_sdk_version", Integer.toString(minSdkVersion));
+    }
+    Artifact desugarGlobalsArtifact =
+        AndroidStarlarkData.fromNoneable(desugarGlobals, Artifact.class);
+    if (desugarGlobalsArtifact != null) {
+      dexmerger.addCommonInputs(ImmutableList.of(desugarGlobalsArtifact));
+      commandLine.addPath("--global_synthetics_path", desugarGlobalsArtifact.getExecPath());
     }
     dexmerger.setCommandLineTemplate(commandLine.build());
     ruleContext.registerAction(dexmerger.build(ruleContext.getActionOwner()));

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkCommon.java
@@ -89,7 +89,8 @@ public class AndroidStarlarkCommon
       Artifact input,
       Sequence<?> dexopts, // <String> expected.
       FilesToRunProvider dexmerger,
-      StarlarkInt minSdkVersion)
+      StarlarkInt minSdkVersion,
+      Object desugarGlobals)
       throws EvalException, RuleErrorException {
     AndroidBinary.createTemplatedMergerActions(
         starlarkRuleContext.getRuleContext(),
@@ -97,7 +98,8 @@ public class AndroidStarlarkCommon
         (SpecialArtifact) input,
         Sequence.cast(dexopts, String.class, "dexopts"),
         dexmerger,
-        minSdkVersion.toInt("min_sdk_version"));
+        minSdkVersion.toInt("min_sdk_version"),
+        desugarGlobals);
   }
 
   @StarlarkMethod(name = AndroidIdeInfoProviderApi.NAME, structField = true, documented = false)

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidStarlarkCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidStarlarkCommonApi.java
@@ -27,6 +27,7 @@ import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.NoneType;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkValue;
@@ -154,7 +155,17 @@ public interface AndroidStarlarkCommonApi<
             defaultValue = "0",
             allowedTypes = {
               @ParamType(type = StarlarkInt.class),
-            })
+            }),
+        @Param(
+            name = "desugar_globals",
+            doc = "The D8 desugar globals file.",
+            positional = false,
+            named = true,
+            defaultValue = "None",
+            allowedTypes = {
+              @ParamType(type = FileApi.class),
+              @ParamType(type = NoneType.class),
+            }),
       })
   void createDexMergerActions(
       StarlarkRuleContextT starlarkRuleContext,
@@ -162,6 +173,7 @@ public interface AndroidStarlarkCommonApi<
       FileT input,
       Sequence<?> dexopts, // <String> expected.
       FilesToRunProviderT dexmerger,
-      StarlarkInt minSdkVersion)
+      StarlarkInt minSdkVersion,
+      Object desugarGlobals)
       throws EvalException, RuleErrorException;
 }


### PR DESCRIPTION
createDexMergerActions continues to be exposed to Starlark due to it's use for SpawnActionTemplate which is not exposed to Starlark. We must pass a file containing global information to the final dexmerging step in order to support Java 17 Record desugaring. This change adds an optional parameter to the Starlark interface to forward the globals file to the Dex Merger.

PiperOrigin-RevId: 660045021
Change-Id: Ie3b961ff2687f48ca29a94e67180c0e5875ddbe3

Commit https://github.com/bazelbuild/bazel/commit/2daa0a3d893a3c18021e7c1191d4cacc270dd062