### PR TITLE
[8.0.0] Rename `stripPrefix=` to `strip_prefix=`

### DIFF
--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -1922,7 +1922,7 @@ def _rule_impl(ctx):
   result = ctx.download_and_extract(
     url = [],
     type = "zip",
-    stripPrefix="ext",
+    strip_prefix="ext",
     sha256 = ctx.attr.sha256,
     allow_fail = True,
   )


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/16496

Closes #24019.

RELNOTES: The stripPrefix parameter of repository_ctx.download_and_extract()
and repository_ctx.extract() has been renamed to strip_prefix; the deprecated
stripPrefix name remains usable for compatibility.
PiperOrigin-RevId: 687224164
Change-Id: Iffaba2e65c049a2ff8bb98d1fba52e0bba9e5a02

Commit https://github.com/bazelbuild/bazel/commit/49d7bb661296c6e494d502ee7c3ab43f3df17fe1