### PR TITLE
Performance optimization for isSymbolicLink() calls on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -139,6 +139,11 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
+  protected boolean isSymbolicLink(PathFragment path) {
+    return fileIsSymbolicLink(getIoFile(path));
+  }
+
+  @Override
   protected FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
     File file = getIoFile(path);
     final DosFileAttributes attributes;

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -139,11 +139,6 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
-  protected boolean isSymbolicLink(PathFragment path) {
-    return fileIsSymbolicLink(getIoFile(path));
-  }
-
-  @Override
   protected FileStatus stat(PathFragment path, boolean followSymlinks) throws IOException {
     File file = getIoFile(path);
     final DosFileAttributes attributes;
@@ -153,14 +148,14 @@ public class WindowsFileSystem extends JavaIoFileSystem {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
     }
 
-    final boolean isSymbolicLink = !followSymlinks && fileIsSymbolicLink(file);
-    final long lastChangeTime =
-        WindowsFileOperations.getLastChangeTime(getNioPath(path).toString(), followSymlinks);
     FileStatus status =
         new FileStatus() {
+          volatile Boolean isSymbolicLink;
+          volatile long lastChangeTime = -1;
+
           @Override
           public boolean isFile() {
-            return !isSymbolicLink && (attributes.isRegularFile() || isSpecialFile());
+            return !isSymbolicLink() && (attributes.isRegularFile() || isSpecialFile());
           }
 
           @Override
@@ -168,16 +163,17 @@ public class WindowsFileSystem extends JavaIoFileSystem {
             // attributes.isOther() returns false for symlinks but returns true for junctions.
             // Bazel treats junctions like symlinks. So let's return false here for junctions.
             // This fixes https://github.com/bazelbuild/bazel/issues/9176
-            return !isSymbolicLink && attributes.isOther();
+            return !isSymbolicLink() && attributes.isOther();
           }
 
           @Override
           public boolean isDirectory() {
-            return !isSymbolicLink && attributes.isDirectory();
+            return !isSymbolicLink() && attributes.isDirectory();
           }
 
           @Override
           public boolean isSymbolicLink() {
+            if (isSymbolicLink == null) { isSymbolicLink = !followSymlinks && fileIsSymbolicLink(file); }
             return isSymbolicLink;
           }
 
@@ -192,7 +188,8 @@ public class WindowsFileSystem extends JavaIoFileSystem {
           }
 
           @Override
-          public long getLastChangeTime() {
+          public long getLastChangeTime() throws IOException {
+            if (lastChangeTime == -1) { lastChangeTime = WindowsFileOperations.getLastChangeTime(getNioPath(path).toString(), followSymlinks); }
             return lastChangeTime;
           }
 
@@ -210,6 +207,11 @@ public class WindowsFileSystem extends JavaIoFileSystem {
         };
 
     return status;
+  }
+
+  @Override
+  protected boolean isSymbolicLink(PathFragment path) {
+    return fileIsSymbolicLink(getIoFile(path));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.attribute.DosFileAttributes;
+import javax.annotation.Nullable;
 
 /** File system implementation for Windows. */
 @ThreadSafe
@@ -150,7 +151,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
     FileStatus status =
         new FileStatus() {
-          volatile Boolean isSymbolicLink;
+          @Nullable volatile Boolean isSymbolicLink; // null if not yet known
           volatile long lastChangeTime = -1;
 
           @Override
@@ -173,7 +174,9 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
           @Override
           public boolean isSymbolicLink() {
-            if (isSymbolicLink == null) { isSymbolicLink = !followSymlinks && fileIsSymbolicLink(file); }
+            if (isSymbolicLink == null) {
+              isSymbolicLink = !followSymlinks && fileIsSymbolicLink(file);
+            }
             return isSymbolicLink;
           }
 
@@ -189,7 +192,9 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
           @Override
           public long getLastChangeTime() throws IOException {
-            if (lastChangeTime == -1) { lastChangeTime = WindowsFileOperations.getLastChangeTime(getNioPath(path).toString(), followSymlinks); }
+            if (lastChangeTime == -1) {
+              lastChangeTime = WindowsFileOperations.getLastChangeTime(getNioPath(path).toString(), followSymlinks);
+            }
             return lastChangeTime;
           }
 


### PR DESCRIPTION
Current implementation for WindowsFileSystem.isSymbolicLink() makes unnecessary system calls which significantly affect the performance. Original code goes through the following:
- AbstractFileSystemWithCustomStat.isSymbolicLink
  - WindowsFileSystem.stat
    - WindowsFileSystem.getIoFile
    - JavaIoFileSystem.getNioPath
    - Files.readAttributes
    - WindowsFileSystem.fileIsSymbolicLink
    - WindowsFileOperations.getLastChangeTime
This implementation skips most of them.
