### PR TITLE
[8.0.0] Move `--fat_apk_cpu` to the flag graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.util.ResourceFileLoader;
+import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -424,6 +425,16 @@ public final class BazelRulesModule extends BlazeModule {
         help = "No-op",
         deprecationWarning = ANDROID_FLAG_DEPRECATION)
     public boolean incompatibleUseToolchainResolution;
+
+    @Option(
+        name = "fat_apk_cpu",
+        converter = Converters.CommaSeparatedOptionSetConverter.class,
+        defaultValue = "armeabi-v7a",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        help = "No-op",
+        deprecationWarning = ANDROID_FLAG_DEPRECATION)
+    public List<String> fatApkCpus;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -235,25 +235,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
                 + "'off' means that all libraries will be linked in mostly static mode.")
     public DynamicMode dynamicMode;
 
-    // TODO(bazel-team): Maybe merge this with --android_cpu above.
-    // TODO(blaze-configurability): Mark this as deprecated in favor of --android_platforms.
-    @Option(
-        name = "fat_apk_cpu",
-        converter = Converters.CommaSeparatedOptionSetConverter.class,
-        defaultValue = "armeabi-v7a",
-        documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
-        effectTags = {
-          OptionEffectTag.AFFECTS_OUTPUTS,
-          OptionEffectTag.LOADING_AND_ANALYSIS,
-          OptionEffectTag.LOSES_INCREMENTAL_STATE,
-        },
-        help =
-            "Setting this option enables fat APKs, which contain native binaries for all "
-                + "specified target architectures, e.g., --fat_apk_cpu=x86,armeabi-v7a. If this "
-                + "flag is specified, then --android_cpu is ignored for dependencies of "
-                + "android_binary rules.")
-    public List<String> fatApkCpus;
-
     @Option(
         name = "android_platforms",
         converter = LabelOrderedSetConverter.class,
@@ -713,15 +694,6 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
             "If enabled, direct usage of the native Android rules is disabled. Please use the"
                 + " Starlark Android rules from https://github.com/bazelbuild/rules_android")
     public boolean disableNativeAndroidRules;
-
-    @Option(
-        name = "android hwasan", // Space is so that this cannot be set on the command line
-        defaultValue = "false",
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-        effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-        metadataTags = {OptionMetadataTag.INTERNAL},
-        help = "Whether HWASAN is enabled.")
-    public boolean hwasan;
 
     @Option(
         name = "experimental_filter_r_jars_from_android_test",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -153,13 +153,9 @@ bazel_fragments["AndroidConfiguration.Options"] = fragment(
         "//command_line_option:experimental_objc_provider_from_linked",
     ],
     outputs = [
-        "//command_line_option:android hwasan",
-        "//command_line_option:fat_apk_cpu",
         "//command_line_option:Android configuration distinguisher",
     ],
     func = lambda settings: {
-        "//command_line_option:android hwasan": False,
-        "//command_line_option:fat_apk_cpu": [],
         "//command_line_option:Android configuration distinguisher": "main",
     },
 )

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
@@ -52,6 +52,7 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/build_configuration",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/build_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/core_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/configuration_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
@@ -375,9 +375,7 @@ public class CcCommonTest extends BuildViewTestCase {
         .setupCcToolchainConfig(
             mockToolsConfig,
             CcToolchainConfig.builder().withFeatures(CppRuleClasses.SUPPORTS_START_END_LIB));
-    useConfiguration(
-        // Prevent Android from trying to setup ARM crosstool by forcing it on system cpu.
-        "--fat_apk_cpu=k8", "--start_end_lib");
+    useConfiguration("--start_end_lib");
     scratch.file(
         "test/BUILD",
         """


### PR DESCRIPTION
The flag is a no-op and has been removed from Bazel.