### PR TITLE
Add --run_env to bazel run

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -92,6 +92,7 @@ import com.google.devtools.build.lib.util.OptionsUtils;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -164,6 +165,22 @@ public class RunCommand implements BlazeCommand {
             "If true, includes paths to replace in ExecRequest to make the resulting paths"
                 + " portable.")
     public boolean portablePaths;
+
+    @Option(
+        name = "run_env",
+        converter = Converters.OptionalAssignmentConverter.class,
+        allowMultiple = true,
+        defaultValue = "null",
+        documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+        effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+        help =
+            "Specifies the set of environment variables available to actions with target"
+                + " configuration. Variables can be either specified by name, in which case the"
+                + " value will be taken from the invocation environment, or by the name=value pair"
+                + " which sets the value independent of the invocation environment. This option can"
+                + " be used multiple times; for options given for the same variable, the latest"
+                + " wins, options for different variables accumulate.")
+    public List<Map.Entry<String, String>> runEnvironment;
   }
 
   private static final String NO_TARGET_MESSAGE = "No targets found to run";
@@ -267,6 +284,11 @@ public class RunCommand implements BlazeCommand {
       // Only necessary in --batch since the command runs as a subprocess of the java server.
       finalRunEnv.putAll(env.getClientEnv());
     }
+
+    for (Map.Entry<String, String> entry : runOptions.runEnvironment) {
+        finalRunEnv.put(entry.getKey(), entry.getValue());
+    }
+
     ExecRequest.Builder execRequest;
     try {
       boolean shouldRunTarget = runOptions.scriptPath == null && runOptions.runBuiltTarget;


### PR DESCRIPTION
This allows passing through env in a similar way to doing `FOO=bar bazel
run` but also allows you to put this in a `.bazelrc`, and allows you to
bypass any environment filtering done when launching bazel.
