### PR TITLE
[8.0.0] Allow implicit creation of input files within a macro's namespace

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/TargetRecorder.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetRecorder.java
@@ -172,6 +172,18 @@ public final class TargetRecorder {
     return macroMap;
   }
 
+  /**
+   * Returns whether there exists a macro with the given name.
+   *
+   * <p>There may be more than one such macro, nested in a chain of main submacros.
+   */
+  public boolean hasMacroWithName(String name) {
+    // Macros are indexed by id, not name, so we can't just use macroMap.get() directly.
+    // Instead, we reason that if at least one macro by the given name exists, then there is one
+    // with an id suffix of ":1".
+    return macroMap.containsKey(name + ":1");
+  }
+
   public List<Label> getRuleLabels(Rule rule) {
     return (ruleLabels != null) ? ruleLabels.get(rule) : rule.getLabels();
   }
@@ -651,11 +663,7 @@ public final class TargetRecorder {
    * <p>{@code what} must be either "macro" or "target".
    */
   private void checkForExistingMacroName(String name, String what) throws NameConflictException {
-    // Macros are indexed by id, not name, so we can't just use macroMap.get() directly.
-    // Instead, we reason that if at least one macro by the given name exists, then there is one
-    // with an id suffix of ":1".
-    MacroInstance existing = macroMap.get(name + ":1");
-    if (existing == null) {
+    if (!hasMacroWithName(name)) {
       return;
     }
 


### PR DESCRIPTION
Recent experience with symbolic macro migration showed that we need to relax the restrictions on the implicit creation of input files.

Previously it was an error to refer to a non-existent target `"foo_input"` if there happened to be a symbolic macro named `"foo"` in the package. The rationale was that we don't want to have to evaluate `foo` just to decide whether or not `foo_input` is in fact an `InputFile`.

But this restriction means that the common idiom:

```starlark
bzl_library(
    name = "foo",
    srcs = ["foo.bzl"],
)
```

blocks `bzl_library` from being a symbolic macro (e.g. wrapping the underlying rule). We believe this will be a common blocker well beyond this one example.

Therefore, we will now only block the implicit creation of input files when they collide exactly with a target or macro, and not when they merely fall within a macro's namespace.

A consequence of this design change is that it complicates how input files are handled when we have lazy macro evaluation. But we'll deal with that when the time comes.

Package.java
- Update and clarify javadoc for `createAssumedInputFiles()` and `maybeCreateAssumedInput()`. Update check in the latter to only care about exact matches of macro names.

TargetRecorder.java
- Factor out an accessor for checking whether a macro with the given name exists (insulating the caller from having to worry about the detail of how macro ids are constructed).

PackageFactoryTest.java
- Make implicit-input-file-creation tests more orthogonal and uniformly named, and update for the semantics change in this CL. (It may be easier to review this file by ignoring the diff and just reviewing the new test content.)

Fixes #24064.

PiperOrigin-RevId: 689374256
Change-Id: I218338af9f9638e1ec03c34e57e7c9f6e10beaaa

Commit https://github.com/bazelbuild/bazel/commit/2d4c8eb79ea7d373127889e5e289ff0a99fd59c4