### PR TITLE
[8.0.0] Add additional info to the error when subrules use toolchains and must enable AEGs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubrule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubrule.java
@@ -382,7 +382,9 @@ public class StarlarkSubrule implements StarlarkExportable, StarlarkCallable, St
             /* resolveToolchainDataFunc= */ ruleContext::getToolchainInfo,
             /* resolvedToolchainTypeLabels= */ getAutomaticExecGroupLabels());
       } else {
-        throw Starlark.errorf("subrules using toolchains must enable automatic exec-groups");
+        throw Starlark.errorf(
+            "subrules using toolchains must enable automatic exec-groups. For more info, see"
+                + " https://bazel.build/extending/auto-exec-groups#migration-aegs");
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -987,7 +987,10 @@ declared.
                 "If set, the set of toolchains this subrule requires. The list can contain String,"
                     + " Label, or StarlarkToolchainTypeApi objects, in any combination. Toolchains"
                     + " will be found by checking the current platform, and provided to the subrule"
-                    + " implementation via <code>ctx.toolchains</code>."),
+                    + " implementation via <code>ctx.toolchains</code>. Note that AEGs need to be"
+                    + " enabled on the consuming rule(s) if this parameter is set. In case you"
+                    + " haven't migrated to AEGs yet, see"
+                    + " https://bazel.build/extending/auto-exec-groups#migration-aegs."),
         @Param(
             name = "fragments",
             allowedTypes = {@ParamType(type = Sequence.class, generic1 = String.class)},


### PR DESCRIPTION
This fixes https://github.com/bazelbuild/bazel/issues/24067.

PiperOrigin-RevId: 689389370
Change-Id: I9fd31e1d5d51f8c2938a9d249177ddcac7cf1a7e

Commit https://github.com/bazelbuild/bazel/commit/acef637c9555eca9e454b48500137917f1a607c6