### PR TITLE
[7.4.1] Expose last remaining private APIs for java rules migration

### DIFF
--- a/src/main/starlark/builtins_bzl/common/java/java_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_common.bzl
@@ -313,6 +313,9 @@ def _internal_exports():
         check_provider_instances = _java_common_internal.check_provider_instances,
         incompatible_java_info_merge_runtime_module_flags = _java_common_internal._incompatible_java_info_merge_runtime_module_flags,
         check_java_toolchain_is_declared_on_rule = _java_common_internal._check_java_toolchain_is_declared_on_rule,
+        create_header_compilation_action = _java_common_internal.create_header_compilation_action,
+        create_compilation_action = _java_common_internal.create_compilation_action,
+        tokenize_javacopts = _java_common_internal.tokenize_javacopts,
     )
 
 def _make_java_common():


### PR DESCRIPTION
PiperOrigin-RevId: 688955616
Change-Id: I408da72cfe409db7feb1978762fc6848f8fe118f (cherry picked from commit 38833e15f5795d493c50f1030dd5a7724f70a2b2)