### PR TITLE
Allow `use_repo_rule` repos to load from each other

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -318,7 +318,6 @@ java_library(
         "//src/main/java/net/starlark/java/spelling",
         "//src/main/java/net/starlark/java/syntax",
         "//src/main/protobuf:failure_details_java_proto",
-        "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",
     ],

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -181,6 +181,9 @@ public class BazelDepGraphFunction implements SkyFunction {
   private static String makeUniqueNameCandidate(ModuleExtensionId id, int attempt) {
     Preconditions.checkArgument(attempt >= 1);
     String extensionNameDisambiguator = attempt == 1 ? "" : String.valueOf(attempt);
+    // An innate extension name is of the form @repo//path/to/defs.bzl%repo_rule_name, which cannot
+    // be part of a valid repo name.
+    String extensionName = id.isInnate() ? "_repo_rules" : id.getExtensionName();
     return id.getIsolationKey()
         .map(
             isolationKey ->
@@ -191,7 +194,7 @@ public class BazelDepGraphFunction implements SkyFunction {
                     // case of an exported symbol cannot start with "_".
                     "%s+_%s%s+%s+%s+%s",
                     id.getBzlFileLabel().getRepository().getName(),
-                    id.getExtensionName(),
+                    extensionName,
                     extensionNameDisambiguator,
                     isolationKey.getModule().name(),
                     isolationKey.getModule().version(),
@@ -199,7 +202,7 @@ public class BazelDepGraphFunction implements SkyFunction {
         .orElse(
             id.getBzlFileLabel().getRepository().getName()
                 + "+"
-                + id.getExtensionName()
+                + extensionName
                 + extensionNameDisambiguator);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionId.java
@@ -35,12 +35,6 @@ public abstract class ModuleExtensionId {
               ModuleExtensionId::getIsolationKey,
               emptiesFirst(IsolationKey.LEXICOGRAPHIC_COMPARATOR));
 
-  /**
-   * The "magical" name of innate extensions, which are fabricated extensions that modules with
-   * usages of {@code use_repo_rule} have.
-   */
-  public static final String INNATE_EXTENSION_NAME = "_repo_rules";
-
   /** A unique identifier for a single isolated usage of a fixed module extension. */
   @AutoValue
   abstract static class IsolationKey {
@@ -82,7 +76,7 @@ public abstract class ModuleExtensionId {
   }
 
   public final boolean isInnate() {
-    return getExtensionName().equals(INNATE_EXTENSION_NAME);
+    return getExtensionName().contains("%");
   }
 
   public String asTargetString() {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2903,6 +2903,49 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
   }
 
   @Test
+  public void innate_repoRuleDependencies() throws Exception {
+    scratch.file(
+        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "bazel_dep(name='foo',version='1.0')",
+        "gen_data_repo = use_repo_rule('@foo//:repo.bzl', 'gen_data_repo')",
+        "gen_data_repo(name='gen_data_repo')",
+        "data_repo = use_repo_rule('@gen_data_repo//:repo.bzl', 'data_repo')",
+        "data_repo(name='data', data='get up at 6am.')");
+    scratch.file(workspaceRoot.getRelative("BUILD").getPathString());
+    scratch.file(
+        workspaceRoot.getRelative("data.bzl").getPathString(),
+        "load('@data//:data.bzl', _data='data')",
+        "data=_data");
+
+    registry.addModule(
+        createModuleKey("foo", "1.0"),
+        "module(name='foo',version='1.0')",
+        "bazel_dep(name='data_repo', version='1.0')");
+    scratch.file(modulesRoot.getRelative("foo+1.0/WORKSPACE").getPathString());
+    scratch.file(modulesRoot.getRelative("foo+1.0/BUILD").getPathString());
+    scratch.file(
+        modulesRoot.getRelative("foo+1.0/repo.bzl").getPathString(),
+        "def _gen_data_repo_impl(ctx):",
+        "  ctx.file('BUILD.bazel')",
+        "  ctx.file('repo.bzl', '''",
+        "load('{data_repo_defs}', _data_repo='data_repo')",
+        "data_repo=_data_repo",
+        "'''.format(data_repo_defs = Label('@data_repo//:defs.bzl')))",
+        "gen_data_repo = repository_rule(implementation=_gen_data_repo_impl)");
+
+    SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
+    EvaluationResult<BzlLoadValue> result =
+        evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
+    if (result.hasError()) {
+      if (result.getError().getException() != null) {
+        throw result.getError().getException();
+      }
+      throw new IllegalStateException("Cycle: " + result.getError().getCycleInfo());
+    }
+    assertThat(result.get(skyKey).getModule().getGlobal("data")).isEqualTo("get up at 6am.");
+  }
+
+  @Test
   public void innate_noSuchRepoRule() throws Exception {
     scratch.file(
         workspaceRoot.getRelative("MODULE.bazel").getPathString(),
@@ -3003,7 +3046,6 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
             "error creating repo data requested at /ws/MODULE.bazel:3:10: failed to instantiate"
                 + " 'data_repo' from this module extension");
   }
-
   @Test
   public void extensionRepoMapping() throws Exception {
     scratch.file(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -1673,6 +1673,8 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         evaluator.evaluate(
             ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
     assertThat(result.hasError()).isFalse();
+    assertThat(result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).getModule().getExtensionUsages())
+        .isEmpty();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -1184,7 +1184,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 .addExtensionUsage(
                     ModuleExtensionUsage.builder()
                         .setExtensionBzlFile("//:MODULE.bazel")
-                        .setExtensionName("_repo_rules")
+                        .setExtensionName("//:repo.bzl%repo")
                         .setIsolationKey(Optional.empty())
                         .setRepoOverrides(ImmutableMap.of())
                         .addProxy(
@@ -1196,6 +1196,26 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                                 .setContainingModuleFilePath(
                                     LabelConstants.MODULE_DOT_BAZEL_FILE_NAME)
                                 .build())
+                        .addTag(
+                            Tag.builder()
+                                .setTagName("repo")
+                                .setAttributeValues(
+                                    AttributeValues.create(
+                                        Dict.<String, Object>builder()
+                                            .put("name", "repo_name")
+                                            .put("value", "something")
+                                            .buildImmutable()))
+                                .setDevDependency(false)
+                                .setLocation(
+                                    Location.fromFileLineColumn("/workspace/MODULE.bazel", 2, 5))
+                                .build())
+                        .build())
+                .addExtensionUsage(
+                    ModuleExtensionUsage.builder()
+                        .setExtensionBzlFile("//:MODULE.bazel")
+                        .setExtensionName("@bazel_tools//:http.bzl%http_archive")
+                        .setIsolationKey(Optional.empty())
+                        .setRepoOverrides(ImmutableMap.of())
                         .addProxy(
                             ModuleExtensionUsage.Proxy.builder()
                                 .setLocation(
@@ -1216,20 +1236,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                                 .build())
                         .addTag(
                             Tag.builder()
-                                .setTagName("//:repo.bzl%repo")
-                                .setAttributeValues(
-                                    AttributeValues.create(
-                                        Dict.<String, Object>builder()
-                                            .put("name", "repo_name")
-                                            .put("value", "something")
-                                            .buildImmutable()))
-                                .setDevDependency(false)
-                                .setLocation(
-                                    Location.fromFileLineColumn("/workspace/MODULE.bazel", 2, 5))
-                                .build())
-                        .addTag(
-                            Tag.builder()
-                                .setTagName("@bazel_tools//:http.bzl%http_archive")
+                                .setTagName("repo")
                                 .setAttributeValues(
                                     AttributeValues.create(
                                         Dict.<String, Object>builder()
@@ -1242,7 +1249,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                                 .build())
                         .addTag(
                             Tag.builder()
-                                .setTagName("@bazel_tools//:http.bzl%http_archive")
+                                .setTagName("repo")
                                 .setAttributeValues(
                                     AttributeValues.create(
                                         Dict.<String, Object>builder()

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
@@ -118,7 +118,7 @@ public class BazelEmbeddedStarlarkBlackBoxTest extends AbstractBlackBoxTest {
     // now build the target from http_archive
     bazel.build("@ext//:" + RepoWithRuleWritingTextGenerator.TARGET);
 
-    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rules+ext2/out");
+    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rules2+ext/out");
     WorkspaceTestUtils.assertLinesExactly(xPath, HELLO_FROM_EXTERNAL_REPOSITORY);
 
     // and use the rule from http_archive in the main repository

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
@@ -118,7 +118,7 @@ public class BazelEmbeddedStarlarkBlackBoxTest extends AbstractBlackBoxTest {
     // now build the target from http_archive
     bazel.build("@ext//:" + RepoWithRuleWritingTextGenerator.TARGET);
 
-    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rules+ext/out");
+    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rules+ext2/out");
     WorkspaceTestUtils.assertLinesExactly(xPath, HELLO_FROM_EXTERNAL_REPOSITORY);
 
     // and use the rule from http_archive in the main repository

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2985,8 +2985,8 @@ EOF
   expect_log "I see: nothing"
 
   local marker_file=$(bazel info output_base)/external/@+_repo_rules+foo.marker
-  # the marker file for this repo should contain a reference to "@@+_repo_rules+bar". Mangle that.
-  sed -i'' -e 's/@@+_repo_rules+bar/@@LOL@@LOL/g' ${marker_file}
+  # the marker file for this repo should contain a reference to "@@+_repo_rules2+bar". Mangle that.
+  sed -i'' -e 's/@@+_repo_rules2+bar/@@LOL@@LOL/g' ${marker_file}
 
   # Running Bazel again shouldn't crash, and should result in a refetch.
   bazel shutdown
@@ -3013,7 +3013,7 @@ EOF
 def _foo(rctx):
   rctx.file("BUILD", "filegroup(name='foo')")
   # this repo might not have been defined yet
-  rctx.watch("../+_repo_rules+bar/BUILD")
+  rctx.watch("../+_repo_rules2+bar/BUILD")
   print("I see something!")
 foo=repository_rule(_foo)
 EOF


### PR DESCRIPTION
Generate one synthetic "innate" module extension per repo rule class instead of a single one for all `use_repo_rule` usages in a given module. This avoids load cycles if one repo rule definition loads another one.