### PR TITLE
[8.0.0] Expose config.none to Starlark.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -2221,6 +2221,7 @@ java_library(
         ":config/transitions/transition_factory",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec:serialization-constant",
+        "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config:configuration_transition_api",
         "//third_party:auto_value",
         "//third_party:guava",
     ],
@@ -2642,6 +2643,7 @@ java_library(
     srcs = ["starlark/StarlarkConfig.java"],
     deps = [
         ":config/execution_transition_factory",
+        ":config/transitions/no_config_transition",
         ":config/transitions/no_transition",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/transitions/NoConfigTransition.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/transitions/NoConfigTransition.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
+import com.google.devtools.build.lib.starlarkbuildapi.config.ConfigurationTransitionApi;
 
 /**
  * Transitions to a stable, empty configuration for rules that don't rely on configuration.
@@ -46,6 +47,15 @@ public class NoConfigTransition implements PatchTransition {
   private static final TransitionFactory<? extends TransitionFactory.Data> FACTORY_INSTANCE =
       new AutoValue_NoConfigTransition_Factory<>();
 
+  /**
+   * Returns {@code true} if the given {@link TransitionFactory} is an instance of the no
+   * transition.
+   */
+  public static <T extends TransitionFactory.Data> boolean isInstance(
+      TransitionFactory<T> instance) {
+    return instance instanceof Factory;
+  }
+
   private NoConfigTransition() {}
 
   @Override
@@ -67,7 +77,8 @@ public class NoConfigTransition implements PatchTransition {
 
   /** A {@link TransitionFactory} implementation that generates the transition. */
   @AutoValue
-  abstract static class Factory<T extends TransitionFactory.Data> implements TransitionFactory<T> {
+  abstract static class Factory<T extends TransitionFactory.Data>
+      implements TransitionFactory<T>, ConfigurationTransitionApi {
     @Override
     public PatchTransition create(T unused) {
       return INSTANCE;

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkConfig.java
@@ -20,6 +20,7 @@ import static com.google.devtools.build.lib.packages.Type.STRING;
 import static com.google.devtools.build.lib.packages.Types.STRING_LIST;
 
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
+import com.google.devtools.build.lib.analysis.config.transitions.NoConfigTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
 import com.google.devtools.build.lib.packages.BuildSetting;
 import com.google.devtools.build.lib.starlarkbuildapi.config.ConfigurationTransitionApi;
@@ -64,6 +65,11 @@ public class StarlarkConfig implements StarlarkConfigApi {
   @Override
   public ConfigurationTransitionApi target() {
     return (ConfigurationTransitionApi) NoTransition.getFactory();
+  }
+
+  @Override
+  public ConfigurationTransitionApi none() {
+    return (ConfigurationTransitionApi) NoConfigTransition.getFactory();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/StarlarkConfigApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/StarlarkConfigApi.java
@@ -166,6 +166,14 @@ public interface StarlarkConfigApi extends StarlarkValue {
               + " Equivalent to <code>cfg = \"target\"</code> in <code>attr.label()</code>.")
   ConfigurationTransitionApi target();
 
+  @StarlarkMethod(
+      name = "none",
+      doc =
+          "Creates a no_config transition. This is a transition that unsets all flags, intended for"
+              + " the case where a dependency is data-only and contains no code that needs to be"
+              + " built, but should only be analyzed once.")
+  ConfigurationTransitionApi none();
+
   /** The api for exec transitions. */
   @StarlarkBuiltin(
       name = "ExecTransitionFactory",

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/StarlarkConfigApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/config/StarlarkConfigApi.java
@@ -169,7 +169,7 @@ public interface StarlarkConfigApi extends StarlarkValue {
   @StarlarkMethod(
       name = "none",
       doc =
-          "Creates a no_config transition. This is a transition that unsets all flags, intended for"
+          "Creates a transition which removes all configuration, unsetting all flags. Intended for"
               + " the case where a dependency is data-only and contains no code that needs to be"
               + " built, but should only be analyzed once.")
   ConfigurationTransitionApi none();

--- a/src/test/java/com/google/devtools/build/lib/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlark/BUILD
@@ -127,6 +127,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/toolchain_type_requirement",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/no_config_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/no_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:starlark/starlark_config",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
+import com.google.devtools.build.lib.analysis.config.transitions.NoConfigTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkAttrModule;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkConfig;
@@ -1375,6 +1376,12 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
   public void testAttrCfgTarget_object() throws Exception {
     Attribute attr = buildAttribute("a1", "attr.label(cfg = config.target(), allow_files = True)");
     assertThat(NoTransition.isInstance(attr.getTransitionFactory())).isTrue();
+  }
+
+  @Test
+  public void testAttrCfgNone() throws Exception {
+    Attribute attr = buildAttribute("a1", "attr.label(cfg = config.none(), allow_files = True)");
+    assertThat(NoConfigTransition.isInstance(attr.getTransitionFactory())).isTrue();
   }
 
   private void writeRuleCfgTestRule(String cfg) throws Exception {


### PR DESCRIPTION
RELNOTES: A transition that removes all configuration is now available as `config.none()`.