### PR TITLE
[8.0.0] Implement File.is_symlink.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -1341,6 +1341,11 @@ public class StarlarkCustomCommandLine extends CommandLine {
     }
 
     @Override
+    public boolean isSymlink() {
+      return false;
+    }
+
+    @Override
     public String getRunfilesPathString() {
       PathFragment relativePath = execPath.relativeTo(fileset.getExecPath());
       return fileset.getRunfilesPath().getRelative(relativePath).getPathString();

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/FileApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/FileApi.java
@@ -90,8 +90,20 @@ public interface FileApi extends StarlarkValue {
   @StarlarkMethod(
       name = "is_directory",
       structField = true,
-      doc = "Returns true if this is a directory.")
+      doc =
+          "Returns true if this is a directory. This reflects the type the file was declared as"
+              + " (i.e. ctx.actions.declare_directory), not its type on the filesystem, which might"
+              + " differ.")
   boolean isDirectory();
+
+  @StarlarkMethod(
+      name = "is_symlink",
+      structField = true,
+      doc =
+          "Returns true if this is a directory. This reflects the type the file was declared as"
+              + " (i.e. ctx.actions.declare_symlink), not its type on the filesystem, which might"
+              + " differ.")
+  boolean isSymlink();
 
   @StarlarkMethod(
       name = "short_path",


### PR DESCRIPTION
For symmetry with File.is_directory.

Fixes #11209.

PiperOrigin-RevId: 690652872
Change-Id: I4e93cb18e2469819cfa46f3c0685376093fc455e

Commit https://github.com/bazelbuild/bazel/commit/66a1038a128fbde9331598580f57afb513e4fa36