### PR TITLE
[7.4.1] fix: Fix trim_length in runfiles.bash

### DIFF
--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -372,10 +372,10 @@ function runfiles_rlocation_checked() {
       local escaped=false
     fi
     # The extra space below is added because cut counts from 1.
-    local trim_length=$(echo -n "$search_prefix  " | wc -c)
+    local trim_length=$(echo -n "$search_prefix  " | wc -c | tr -d ' ')
     # Escape the search prefix for use in the grep regex below *after*
     # determining the trim length.
-    local result=$(__runfiles_maybe_grep -m1 "^$(echo -n "$search_prefix" | sed 's/[.[\*^$]/\\&/g') " "${RUNFILES_MANIFEST_FILE}" | cut -b ${trim_length}-)
+    local result=$(__runfiles_maybe_grep -m1 "^$(echo -n "$search_prefix" | sed 's/[.[\*^$]/\\&/g') " "${RUNFILES_MANIFEST_FILE}" | cut -b "${trim_length}-")
     if [[ -z "$result" ]]; then
       # If path references a runfile that lies under a directory that itself
       # is a runfile, then only the directory is listed in the manifest. Look


### PR DESCRIPTION
`wc -c` has leading spaces that needs to be removed, otherwise trim_length would become `      29` for example.

~I'm not very sure how test cases could work but this fails in our repo.~ I understand it now. We set `IFS=$'\\n\\t'` in our script, which makes this trick stops working `cut -b ${trim_length}-` (note that there are no quotes around `${trim_length}`. Although we could fix our `IFS`, this still seems to be a bug because it is not "portable".

Closes #24076.

PiperOrigin-RevId: 690707015
Change-Id: I728b7462994a6ffdb9b88c3cbea3ec044a8b0134

Commit https://github.com/bazelbuild/bazel/commit/bf666fb0cb7d74a1005e49cd48bfc790cf46d3a4