### PR TITLE
[8.0.0] Allowlist mac indexing directory

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -67,8 +67,11 @@ import javax.annotation.Nullable;
 /** This module provides the Sandbox spawn strategy. */
 public final class SandboxModule extends BlazeModule {
 
+  private static final String MAC_INDEX_FILE = ".DS_Store";
+
   private static final ImmutableSet<String> SANDBOX_BASE_PERSISTENT_DIRS =
       ImmutableSet.of(
+          MAC_INDEX_FILE,
           SandboxStash.SANDBOX_STASH_BASE,
           SandboxStash.TEMPORARY_SANDBOX_STASH_BASE,
           AsynchronousTreeDeleter.MOVED_TRASH_DIR);


### PR DESCRIPTION
We were checking every directory in the sandbox to make sure we keep track of
everything that is stored there. On macOS .DS_Store is a valid
file that shouldn't trigger a crash.

Fixes #23963

RELNOTES:none
PiperOrigin-RevId: 691061742
Change-Id: I085a38fa174cd71682bb599ab3cb1ade0dcd350d

Commit https://github.com/bazelbuild/bazel/commit/e297727fae5ad496ef34ae25cde4846f2374def0