### PR TITLE
[8.0.0] Fix input root creation for path mapped workers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFilesHash.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFilesHash.java
@@ -85,7 +85,9 @@ public class WorkerFilesHash {
               throw new MissingInputException(localArtifact);
             }
             if (metadata.getType().isFile()) {
-              workerFilesMap.put(root.getRelative(mapping.getKey()), metadata.getDigest());
+              workerFilesMap.put(
+                  spawn.getPathMapper().map(root.getRelative(mapping.getKey())),
+                  metadata.getDigest());
             }
           }
         }
@@ -98,7 +100,8 @@ public class WorkerFilesHash {
         throw new MissingInputException(tool);
       }
       workerFilesMap.put(
-          tool.getExecPath(), actionInputFileCache.getInputMetadata(tool).getDigest());
+          spawn.getPathMapper().map(tool.getExecPath()),
+          actionInputFileCache.getInputMetadata(tool).getDigest());
     }
 
     return workerFilesMap;


### PR DESCRIPTION
The set of worker files wasn't path mapped, which resulted in build failures when using a generated multiplex worker.

Fixes #23990

Closes #23991.

PiperOrigin-RevId: 691114049
Change-Id: I50cc2daa1c9fe7102ba99893aa878fb4c6b1c3d3

Commit https://github.com/bazelbuild/bazel/commit/9d51ede01f47f385382f7e66d7247d0f1aa929b1