### PR TITLE
[8.0.0] Allow `external` top-level dir in Bzlmod-managed non-main repos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -253,20 +253,6 @@ public final class RepositoryName {
     }
   }
 
-  // Must only be called if isVisible() returns true.
-  public String getOwnerModuleDisplayString() {
-    Preconditions.checkNotNull(ownerRepoIfNotVisible);
-    if (ownerRepoIfNotVisible.isMain()) {
-      return "root module";
-    } else {
-      return String.format(
-          "module '%s'",
-          ownerRepoIfNotVisible
-              .getName()
-              .substring(0, ownerRepoIfNotVisible.getName().indexOf('+')));
-    }
-  }
-
   /** Returns if this is the main repository. */
   public boolean isMain() {
     return equals(MAIN);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ProcessPackageDirectory.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ProcessPackageDirectory.java
@@ -282,9 +282,11 @@ public final class ProcessPackageDirectory {
       }
       String basename = dirent.getName();
       PathFragment subdirectory = rootRelativePath.getRelative(basename);
-      if (!siblingRepositoryLayout && subdirectory.equals(LabelConstants.EXTERNAL_PACKAGE_NAME)) {
-        // Subpackages under //external can be processed only when
-        // --experimental_sibling_repository_layout is set.
+      if (!siblingRepositoryLayout
+          && subdirectory.equals(LabelConstants.EXTERNAL_PACKAGE_NAME)
+          && repositoryName.isMain()) {
+        // Subpackages under //external in the main repo can be processed only
+        // when --experimental_sibling_repository_layout is set.
         continue;
       }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -109,7 +109,6 @@ import com.google.devtools.build.lib.bazel.bzlmod.FakeRegistry;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileFunction;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.Label;
-import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
@@ -1279,12 +1278,7 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
       throws Exception {
     // Allow to create the BUILD file also in the top package.
     String buildFilePathString = packageName.isEmpty() ? "BUILD" : packageName + "/BUILD";
-    if (packageName.equals(LabelConstants.EXTERNAL_PACKAGE_NAME.getPathString())) {
-      buildFilePathString = "WORKSPACE";
-      scratch.overwriteFile(buildFilePathString, lines);
-    } else {
-      scratch.file(buildFilePathString, lines);
-    }
+    scratch.file(buildFilePathString, lines);
     skyframeExecutor.invalidateFilesUnderPathForTesting(
         reporter,
         new ModifiedFileSet.Builder().modify(PathFragment.create(buildFilePathString)).build(),


### PR DESCRIPTION
Also remove an unused method.

RELNOTES: External repositories that are managed by Bzlmod can now contain a top-level `external` directory or package.

Closes #24126.

PiperOrigin-RevId: 691521324
Change-Id: I84d11f2163ce5a6e34578afb6a2cc9793d78f0b1

Commit https://github.com/bazelbuild/bazel/commit/0e2bcda6c3b97c7ecc9b1359157360ace8b40d89