### PR TITLE
[7.4.1] Add missing private API for tokenizing javacopts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -472,6 +472,12 @@ public class JavaStarlarkCommon
     }
   }
 
+  @Override
+  public Sequence<?> tokenizeJavacOpts(Sequence<?> opts) throws EvalException {
+    return StarlarkList.immutableCopyOf(
+        JavaHelper.tokenizeJavaOptions(Sequence.noneableCast(opts, String.class, "opts")));
+  }
+
   static boolean isInstanceOfProvider(Object obj, Provider provider) {
     if (obj instanceof NativeInfo) {
       return ((NativeInfo) obj).getProvider().getKey().equals(provider.getKey());

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -751,4 +751,10 @@ public interface JavaCommonApi<
   Sequence<?> expandJavaOpts(
       StarlarkRuleContextT ctx, String attr, boolean tokenize, boolean execPaths)
       throws EvalException, InterruptedException;
+
+  @StarlarkMethod(
+      name = "tokenize_javacopts",
+      documented = false,
+      parameters = {@Param(name = "opts")})
+  Sequence<?> tokenizeJavacOpts(Sequence<?> opts) throws EvalException, InterruptedException;
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
@@ -3752,6 +3752,7 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
     "{api: _incompatible_depset_for_java_output_source_jars}",
     "{api: wrap_java_info}",
     "{api: intern_javac_opts}",
+    "{api: tokenize_javacopts}",
   })
   public void testJavaCommonPrivateApis_areNotVisibleToPublicStarlark(String api) throws Exception {
     // validate that this api is present on the module, so this test fails when the API is deleted


### PR DESCRIPTION
PiperOrigin-RevId: 587638256
Change-Id: I4aa6b9c2009323e9c4adc7f6e8b5e335a637ed1c

(cherry picked from commit fb446e6366b50a93f794118cb3b77bb55f189325)