### PR TITLE
Implement `debugPrint` for built-in file providers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -803,6 +803,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi",
+        "//src/main/java/net/starlark/java/eval",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/FileProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/FileProvider.java
@@ -21,6 +21,8 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.starlarkbuildapi.FileProviderApi;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkThread;
 
 /**
  * A representation of the concept "this transitive info provider builds these files".
@@ -51,6 +53,13 @@ public final class FileProvider implements TransitiveInfoProvider, FileProviderA
   @Override
   public Depset /*<Artifact>*/ getFilesToBuildForStarlark() {
     return Depset.of(Artifact.class, filesToBuild);
+  }
+
+  @Override
+  public void debugPrint(Printer printer, StarlarkThread thread) {
+    printer.append("<FileProvider files_to_build=");
+    printer.repr(getFilesToBuildForStarlark());
+    printer.append(">");
   }
 
   public NestedSet<Artifact> getFilesToBuild() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/FileProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/FileProvider.java
@@ -57,7 +57,7 @@ public final class FileProvider implements TransitiveInfoProvider, FileProviderA
 
   @Override
   public void debugPrint(Printer printer, StarlarkThread thread) {
-    printer.append("file_provider(files_to_build = ");
+    printer.append("FileProvider(files_to_build = ");
     printer.debugPrint(getFilesToBuildForStarlark(), thread);
     printer.append(")");
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/FileProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/FileProvider.java
@@ -57,9 +57,9 @@ public final class FileProvider implements TransitiveInfoProvider, FileProviderA
 
   @Override
   public void debugPrint(Printer printer, StarlarkThread thread) {
-    printer.append("<FileProvider files_to_build=");
-    printer.repr(getFilesToBuildForStarlark());
-    printer.append(">");
+    printer.append("file_provider(files_to_build = ");
+    printer.debugPrint(getFilesToBuildForStarlark(), thread);
+    printer.append(")");
   }
 
   public NestedSet<Artifact> getFilesToBuild() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/FilesToRunProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/FilesToRunProvider.java
@@ -23,6 +23,8 @@ import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.starlarkbuildapi.FilesToRunProviderApi;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkThread;
 
 /** Returns information about executables produced by a target and the files needed to run it. */
 @Immutable
@@ -104,6 +106,17 @@ public class FilesToRunProvider implements TransitiveInfoProvider, FilesToRunPro
   public Artifact getRepoMappingManifest() {
     var runfilesSupport = getRunfilesSupport();
     return runfilesSupport != null ? runfilesSupport.getRepoMappingManifest() : null;
+  }
+
+  @Override
+  public void debugPrint(Printer printer, StarlarkThread thread) {
+    printer.append("<FilesToRunProvider executable=");
+    printer.repr(getExecutable());
+    printer.append(", runfiles_manifest=");
+    printer.repr(getRunfilesManifest());
+    printer.append(", repo_mapping_manifest=");
+    printer.repr(getRepoMappingManifest());
+    printer.append(">");
   }
 
   /** A single executable. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/FilesToRunProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/FilesToRunProvider.java
@@ -110,13 +110,13 @@ public class FilesToRunProvider implements TransitiveInfoProvider, FilesToRunPro
 
   @Override
   public void debugPrint(Printer printer, StarlarkThread thread) {
-    printer.append("<FilesToRunProvider executable=");
-    printer.repr(getExecutable());
-    printer.append(", runfiles_manifest=");
-    printer.repr(getRunfilesManifest());
-    printer.append(", repo_mapping_manifest=");
-    printer.repr(getRepoMappingManifest());
-    printer.append(">");
+    printer.append("FilesToRunProvider(executable = ");
+    printer.debugPrint(getExecutable(), thread);
+    printer.append(", repo_mapping_manifest = ");
+    printer.debugPrint(getRepoMappingManifest(), thread);
+    printer.append(", runfiles_manifest = ");
+    printer.debugPrint(getRunfilesManifest(), thread);
+    printer.append(")");
   }
 
   /** A single executable. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
@@ -1154,7 +1154,7 @@ public final class Runfiles implements RunfilesApi {
 
   @Override
   public void debugPrint(Printer printer, StarlarkThread thread) {
-    printer.append("runfiles(empty_files = ");
+    printer.append("Runfiles(empty_files = ");
     printer.debugPrint(getEmptyFilenamesForStarlark(), thread);
     printer.append(", files = ");
     printer.debugPrint(getArtifactsForStarlark(), thread);

--- a/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
@@ -1154,14 +1154,14 @@ public final class Runfiles implements RunfilesApi {
 
   @Override
   public void debugPrint(Printer printer, StarlarkThread thread) {
-    printer.append("<runfiles files=");
-    printer.repr(getArtifactsForStarlark());
-    printer.append(", symlinks=");
-    printer.repr(getSymlinksForStarlark());
-    printer.append(", root_symlinks=");
-    printer.repr(getRootSymlinksForStarlark());
-    printer.append(", empty_files=");
-    printer.repr(getEmptyFilenamesForStarlark());
-    printer.append(">");
+    printer.append("runfiles(empty_files = ");
+    printer.debugPrint(getEmptyFilenamesForStarlark(), thread);
+    printer.append(", files = ");
+    printer.debugPrint(getArtifactsForStarlark(), thread);
+    printer.append(", root_symlinks = ");
+    printer.debugPrint(getRootSymlinksForStarlark(), thread);
+    printer.append(", symlinks = ");
+    printer.debugPrint(getSymlinksForStarlark(), thread);
+    printer.append(")");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
@@ -58,6 +58,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -1149,5 +1150,18 @@ public final class Runfiles implements RunfilesApi {
                     : RUNFILES_AND_EXEC_PATH_MAP_FN,
                 artifacts))
         + String.format("emptyFilesSupplier: %s\n", emptyFilesSupplier.getClass().getName());
+  }
+
+  @Override
+  public void debugPrint(Printer printer, StarlarkThread thread) {
+    printer.append("<runfiles files=");
+    printer.repr(getArtifactsForStarlark());
+    printer.append(", symlinks=");
+    printer.repr(getSymlinksForStarlark());
+    printer.append(", root_symlinks=");
+    printer.repr(getRootSymlinksForStarlark());
+    printer.append(", empty_files=");
+    printer.repr(getEmptyFilenamesForStarlark());
+    printer.append(">");
   }
 }


### PR DESCRIPTION
Simplifies `print` style debugging.