### PR TITLE
Acknowledge `TASTY` as known ClassFile attribute in ijar

### DIFF
--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -1563,6 +1563,7 @@ void HasAttrs::ReadAttrs(const u1 *&p) {
     } else if (attr_name == "Scala" ||
                attr_name == "ScalaSig" ||
                attr_name == "ScalaInlineInfo" ||
+               attr_name == "TASTY" ||
                attr_name == "TurbineTransitiveJar") {
       // These are opaque blobs, so can be handled with a general
       // attribute handler


### PR DESCRIPTION
Currently producing `ijar` using Scala 3 produces the following warnings: 
```
ijar: skipping unknown attribute: "TASTY".
```

TASTY is a Scala 3 specific ClassFile attribute and informs that for given `.class` file there is also emmited as `.tasty` file (these were handled in https://github.com/bazelbuild/bazel/pull/12529). It can be consumed in the same way as currently handled `Scala` and `ScalaSig` attributes. 
Handling that should remove redundant warnings

Here's example on how this attribute is emmited:
https://github.com/scala/scala3/blob/91ef92159c628eaeab8311dc82bed7ed4fe03c63/compiler/src/dotty/tools/backend/jvm/CodeGen.scala#L92-L110

