### PR TITLE
[8.0.0] Open the client lock file with O_CLOEXEC so we don't have to call fcntl(F_SETFD) later.

### DIFF
--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -15,7 +15,8 @@
 #ifndef BAZEL_SRC_MAIN_CPP_BLAZE_UTIL_PLATFORM_H_
 #define BAZEL_SRC_MAIN_CPP_BLAZE_UTIL_PLATFORM_H_
 
-#include <cinttypes>
+#include <stdint.h>
+
 #include <map>
 #include <memory>
 #include <string>
@@ -206,7 +207,7 @@ struct BlazeLock {
 };
 
 // Acquires a lock on the output base. Exits if the lock cannot be acquired.
-// Sets ``lock`` to a value that can subsequently be passed to ReleaseLock().
+// Sets `blaze_lock` to a value that can be later passed to ReleaseLock().
 // Returns the number of milliseconds spent with waiting for the lock.
 uint64_t AcquireLock(const blaze_util::Path& output_base, bool batch_mode,
                      bool block, BlazeLock* blaze_lock);

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -24,6 +24,7 @@
 #include <signal.h>
 #include <spawn.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
@@ -636,22 +637,19 @@ static int setlk(int fd, struct flock *lock) {
 uint64_t AcquireLock(const blaze_util::Path& output_base, bool batch_mode,
                      bool block, BlazeLock* blaze_lock) {
   blaze_util::Path lockfile = output_base.GetRelative("lock");
-  int lockfd = open(lockfile.AsNativePath().c_str(), O_CREAT | O_RDWR, 0644);
 
+  int flags = O_CREAT | O_RDWR;
+  // Keep server from inheriting a useless fd if we are not in batch mode.
+  if (!batch_mode) {
+    flags |= O_CLOEXEC;
+  }
+
+  int lockfd = open(lockfile.AsNativePath().c_str(), flags, 0644);
   if (lockfd < 0) {
     string err = GetLastErrorString();
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "cannot open lockfile '" << lockfile.AsPrintablePath()
         << "' for writing: " << err;
-  }
-
-  // Keep server from inheriting a useless fd if we are not in batch mode
-  if (!batch_mode) {
-    string err = GetLastErrorString();
-    if (fcntl(lockfd, F_SETFD, FD_CLOEXEC) == -1) {
-      BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-          << "fcntl(F_SETFD) failed for lockfile: " << err;
-    }
   }
 
   struct flock lock = {};


### PR DESCRIPTION
PiperOrigin-RevId: 692885000
Change-Id: I8f41cd60336a50ec4885c6119d7a9a80304a12f9