### PR TITLE
[8.0.0] Fix empty package in AutoBazelRepositoryProcessor

### DIFF
--- a/tools/java/runfiles/AutoBazelRepositoryProcessor.java
+++ b/tools/java/runfiles/AutoBazelRepositoryProcessor.java
@@ -96,7 +96,11 @@ public final class AutoBazelRepositoryProcessor extends AbstractProcessor {
     try (PrintWriter out =
         new PrintWriter(
             processingEnv.getFiler().createSourceFile(generatedClassName).openWriter())) {
-      out.printf("package %s;\n", generatedClassPackage);
+
+      if (!generatedClassPackage.isEmpty()) {
+        // This annotation may exist on a class which is at the root package
+        out.printf("package %s;\n", generatedClassPackage);
+      }
       out.printf("\n");
       out.printf("class %s {\n", generatedClassSimpleName);
       out.printf("  /**\n");


### PR DESCRIPTION
Add support for when the AutoBazelRepository annotation is placed on a file in a root package (ie. one where there is no package)

fixes #24150

Closes #24161.

PiperOrigin-RevId: 692888334
Change-Id: Idd85e79250f64cf50ca709cf6ad8d025a0db032c

Commit https://github.com/bazelbuild/bazel/commit/156004739c1298fa37f844dc7ccef9c8ee330416