### PR TITLE
Delete grpc-java bazel_dep.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,6 @@ module(
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "grpc", version = "1.66.0.bcr.2", repo_name = "com_github_grpc_grpc")
-bazel_dep(name = "grpc-java", version = "1.66.0")
 bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_pkg", version = "1.0.1")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -253,7 +253,7 @@
     "@@googleapis+//:extensions.bzl%switched_rules": {
       "general": {
         "bzlTransitiveDigest": "vG6fuTzXD8MMvHWZEQud0MMH7eoC4GXY0va7VrFFh04=",
-        "usagesDigest": "K4YY5ETECHnMxBMo0wSPRtC5QWXIqMORcJNRf9NVrrY=",
+        "usagesDigest": "0srqqXr6CspRMV8yklLEdrXOPUbHkDo0hIoL+1EzhvY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1349,7 +1349,7 @@
     "@@rules_jvm_external+//:extensions.bzl%maven": {
       "general": {
         "bzlTransitiveDigest": "q0U9qdK3cxV9KQ2ZaERVngkEhZiqkwI698IL2JM77LA=",
-        "usagesDigest": "cH1kuZb6lO92i001oL7xc1+qZFmvBQc8sOkPEIXvERU=",
+        "usagesDigest": "GDKiKkW86cx8AVMzCq4OrdXWd7g8CbLkPGpiWP/RSB0=",
         "recordedFileInputs": {
           "@@rules_jvm_external+//rules_jvm_external_deps_install.json": "cafb5d2d8119391eb2b322ce3840d3352ea82d496bdb8cbd4b6779ec4d044dda",
           "@@stardoc+//maven_install.json": "25f3c138ca52c61e0e7a564fe21f5709261b33d78d35427b6c18d7aa202d973b",
@@ -1365,8 +1365,8 @@
               "user_provided_name": "maven",
               "repositories": [
                 "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }",
-                "{ \"repo_url\": \"https://repo.maven.apache.org/maven2/\" }",
-                "{ \"repo_url\": \"https://repo.maven.apache.org/maven2\" }"
+                "{ \"repo_url\": \"https://repo.maven.apache.org/maven2\" }",
+                "{ \"repo_url\": \"https://repo.maven.apache.org/maven2/\" }"
               ],
               "artifacts": [
                 "{ \"group\": \"com.google.guava\", \"artifact\": \"guava-testlib\", \"version\": \"33.2.1-jre\", \"testonly\": true }",
@@ -1475,6 +1475,18 @@
                 "{ \"group\": \"tools.profiler\", \"artifact\": \"async-profiler\", \"version\": \"3.0\" }",
                 "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
                 "{ \"group\": \"org.hamcrest\", \"artifact\": \"hamcrest-core\", \"version\": \"1.3\" }",
+                "{ \"group\": \"com.google.caliper\", \"artifact\": \"caliper\", \"version\": \"1.0-beta-3\" }",
+                "{ \"group\": \"com.google.code.findbugs\", \"artifact\": \"jsr305\", \"version\": \"3.0.2\" }",
+                "{ \"group\": \"com.google.code.gson\", \"artifact\": \"gson\", \"version\": \"2.8.9\" }",
+                "{ \"group\": \"com.google.errorprone\", \"artifact\": \"error_prone_annotations\", \"version\": \"2.5.1\" }",
+                "{ \"group\": \"com.google.j2objc\", \"artifact\": \"j2objc-annotations\", \"version\": \"2.8\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava\", \"version\": \"32.0.1-jre\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava-testlib\", \"version\": \"32.0.1-jre\" }",
+                "{ \"group\": \"com.google.truth\", \"artifact\": \"truth\", \"version\": \"1.1.2\" }",
+                "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
+                "{ \"group\": \"org.mockito\", \"artifact\": \"mockito-core\", \"version\": \"4.3.1\" }",
+                "{ \"group\": \"biz.aQute.bnd\", \"artifact\": \"biz.aQute.bndlib\", \"version\": \"6.4.0\" }",
+                "{ \"group\": \"info.picocli\", \"artifact\": \"picocli\", \"version\": \"4.6.3\" }",
                 "{ \"group\": \"com.google.android\", \"artifact\": \"annotations\", \"version\": \"4.1.1.4\" }",
                 "{ \"group\": \"com.google.api.grpc\", \"artifact\": \"proto-google-common-protos\", \"version\": \"2.29.0\" }",
                 "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-credentials\", \"version\": \"1.23.0\" }",
@@ -1510,19 +1522,7 @@
                 "{ \"group\": \"io.perfmark\", \"artifact\": \"perfmark-api\", \"version\": \"0.27.0\" }",
                 "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
                 "{ \"group\": \"org.apache.tomcat\", \"artifact\": \"annotations-api\", \"version\": \"6.0.53\" }",
-                "{ \"group\": \"org.codehaus.mojo\", \"artifact\": \"animal-sniffer-annotations\", \"version\": \"1.24\" }",
-                "{ \"group\": \"com.google.caliper\", \"artifact\": \"caliper\", \"version\": \"1.0-beta-3\" }",
-                "{ \"group\": \"com.google.code.findbugs\", \"artifact\": \"jsr305\", \"version\": \"3.0.2\" }",
-                "{ \"group\": \"com.google.code.gson\", \"artifact\": \"gson\", \"version\": \"2.8.9\" }",
-                "{ \"group\": \"com.google.errorprone\", \"artifact\": \"error_prone_annotations\", \"version\": \"2.5.1\" }",
-                "{ \"group\": \"com.google.j2objc\", \"artifact\": \"j2objc-annotations\", \"version\": \"2.8\" }",
-                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava\", \"version\": \"32.0.1-jre\" }",
-                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava-testlib\", \"version\": \"32.0.1-jre\" }",
-                "{ \"group\": \"com.google.truth\", \"artifact\": \"truth\", \"version\": \"1.1.2\" }",
-                "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
-                "{ \"group\": \"org.mockito\", \"artifact\": \"mockito-core\", \"version\": \"4.3.1\" }",
-                "{ \"group\": \"biz.aQute.bnd\", \"artifact\": \"biz.aQute.bndlib\", \"version\": \"6.4.0\" }",
-                "{ \"group\": \"info.picocli\", \"artifact\": \"picocli\", \"version\": \"4.6.3\" }"
+                "{ \"group\": \"org.codehaus.mojo\", \"artifact\": \"animal-sniffer-annotations\", \"version\": \"1.24\" }"
               ],
               "fail_on_missing_checksum": true,
               "fetch_sources": false,
@@ -3666,8 +3666,8 @@
               "user_provided_name": "maven",
               "repositories": [
                 "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }",
-                "{ \"repo_url\": \"https://repo.maven.apache.org/maven2/\" }",
-                "{ \"repo_url\": \"https://repo.maven.apache.org/maven2\" }"
+                "{ \"repo_url\": \"https://repo.maven.apache.org/maven2\" }",
+                "{ \"repo_url\": \"https://repo.maven.apache.org/maven2/\" }"
               ],
               "artifacts": [
                 "{ \"group\": \"com.google.guava\", \"artifact\": \"guava-testlib\", \"version\": \"33.2.1-jre\", \"testonly\": true }",
@@ -3776,6 +3776,18 @@
                 "{ \"group\": \"tools.profiler\", \"artifact\": \"async-profiler\", \"version\": \"3.0\" }",
                 "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
                 "{ \"group\": \"org.hamcrest\", \"artifact\": \"hamcrest-core\", \"version\": \"1.3\" }",
+                "{ \"group\": \"com.google.caliper\", \"artifact\": \"caliper\", \"version\": \"1.0-beta-3\" }",
+                "{ \"group\": \"com.google.code.findbugs\", \"artifact\": \"jsr305\", \"version\": \"3.0.2\" }",
+                "{ \"group\": \"com.google.code.gson\", \"artifact\": \"gson\", \"version\": \"2.8.9\" }",
+                "{ \"group\": \"com.google.errorprone\", \"artifact\": \"error_prone_annotations\", \"version\": \"2.5.1\" }",
+                "{ \"group\": \"com.google.j2objc\", \"artifact\": \"j2objc-annotations\", \"version\": \"2.8\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava\", \"version\": \"32.0.1-jre\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava-testlib\", \"version\": \"32.0.1-jre\" }",
+                "{ \"group\": \"com.google.truth\", \"artifact\": \"truth\", \"version\": \"1.1.2\" }",
+                "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
+                "{ \"group\": \"org.mockito\", \"artifact\": \"mockito-core\", \"version\": \"4.3.1\" }",
+                "{ \"group\": \"biz.aQute.bnd\", \"artifact\": \"biz.aQute.bndlib\", \"version\": \"6.4.0\" }",
+                "{ \"group\": \"info.picocli\", \"artifact\": \"picocli\", \"version\": \"4.6.3\" }",
                 "{ \"group\": \"com.google.android\", \"artifact\": \"annotations\", \"version\": \"4.1.1.4\" }",
                 "{ \"group\": \"com.google.api.grpc\", \"artifact\": \"proto-google-common-protos\", \"version\": \"2.29.0\" }",
                 "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-credentials\", \"version\": \"1.23.0\" }",
@@ -3811,19 +3823,7 @@
                 "{ \"group\": \"io.perfmark\", \"artifact\": \"perfmark-api\", \"version\": \"0.27.0\" }",
                 "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
                 "{ \"group\": \"org.apache.tomcat\", \"artifact\": \"annotations-api\", \"version\": \"6.0.53\" }",
-                "{ \"group\": \"org.codehaus.mojo\", \"artifact\": \"animal-sniffer-annotations\", \"version\": \"1.24\" }",
-                "{ \"group\": \"com.google.caliper\", \"artifact\": \"caliper\", \"version\": \"1.0-beta-3\" }",
-                "{ \"group\": \"com.google.code.findbugs\", \"artifact\": \"jsr305\", \"version\": \"3.0.2\" }",
-                "{ \"group\": \"com.google.code.gson\", \"artifact\": \"gson\", \"version\": \"2.8.9\" }",
-                "{ \"group\": \"com.google.errorprone\", \"artifact\": \"error_prone_annotations\", \"version\": \"2.5.1\" }",
-                "{ \"group\": \"com.google.j2objc\", \"artifact\": \"j2objc-annotations\", \"version\": \"2.8\" }",
-                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava\", \"version\": \"32.0.1-jre\" }",
-                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava-testlib\", \"version\": \"32.0.1-jre\" }",
-                "{ \"group\": \"com.google.truth\", \"artifact\": \"truth\", \"version\": \"1.1.2\" }",
-                "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
-                "{ \"group\": \"org.mockito\", \"artifact\": \"mockito-core\", \"version\": \"4.3.1\" }",
-                "{ \"group\": \"biz.aQute.bnd\", \"artifact\": \"biz.aQute.bndlib\", \"version\": \"6.4.0\" }",
-                "{ \"group\": \"info.picocli\", \"artifact\": \"picocli\", \"version\": \"4.6.3\" }"
+                "{ \"group\": \"org.codehaus.mojo\", \"artifact\": \"animal-sniffer-annotations\", \"version\": \"1.24\" }"
               ],
               "fetch_sources": false,
               "fetch_javadoc": false,

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -32,7 +32,6 @@ DIST_ARCHIVE_REPOS = [get_canonical_repo_name(repo) for repo in [
     "c-ares",
     "com_github_grpc_grpc",
     "googleapis",
-    "grpc-java",
     "io_bazel_skydoc",
     "platforms",
     "protobuf",


### PR DESCRIPTION
This dep is transitively brought in by `grpc`, and unnecessary as a top level dep.