### PR TITLE
Revert "[7.4.0] Fix ml path for Windows clang-cl cc toolchain (#23406)"

### DIFF
--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -775,61 +775,26 @@ class BazelWindowsCppTest(test_base.TestBase):
         '  "@local_config_cc//:cc-toolchain-x64_windows-clang-cl",',
         ')',
     ])
-    self.ScratchFile(
-        'BUILD',
-        [
-            'platform(',
-            '  name = "windows_clang",',
-            '  constraint_values = [',
-            '    "@platforms//cpu:x86_64",',
-            '    "@platforms//os:windows",',
-            '    "@bazel_tools//tools/cpp:clang-cl",',
-            '  ]',
-            ')',
-            '',
-            'cc_binary(',
-            '  name = "main",',
-            '  srcs = [    "main.cc",',
-            '    "inc.asm",',  # Test assemble action_config
-            '    "dec.S",',  # Test preprocess-assemble action_config
-            '  ],',
-            ')',
-        ],
-    )
-    self.ScratchFile(
-        'main.cc',
-        [
-            'int main() {',
-            '  return 0;',
-            '}',
-        ],
-    )
-    self.ScratchFile(
-        'inc.asm',
-        [
-            '.code',
-            'PUBLIC increment',
-            'increment PROC x:WORD',
-            '  xchg rcx,rax',
-            '  inc rax',
-            '  ret',
-            'increment EndP',
-            'END',
-        ],
-    )
-    self.ScratchFile(
-        'dec.S',
-        [
-            '.code',
-            'PUBLIC decrement',
-            'decrement PROC x:WORD',
-            '  xchg rcx,rax',
-            '  dec rax',
-            '  ret',
-            'decrement EndP',
-            'END',
-        ],
-    )
+    self.ScratchFile('BUILD', [
+        'platform(',
+        '  name = "windows_clang",',
+        '  constraint_values = [',
+        '    "@platforms//cpu:x86_64",',
+        '    "@platforms//os:windows",',
+        '    "@bazel_tools//tools/cpp:clang-cl",',
+        '  ]',
+        ')',
+        '',
+        'cc_binary(',
+        '  name = "main",',
+        '  srcs = ["main.cc"],',
+        ')',
+    ])
+    self.ScratchFile('main.cc', [
+        'int main() {',
+        '  return 0;',
+        '}',
+    ])
     exit_code, _, stderr = self.RunBazel([
         'build', '-s', '--incompatible_enable_cc_toolchain_resolution=true',
         '//:main'

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -793,8 +793,7 @@ def _get_clang_cl_vars(repository_ctx, paths, msvc_vars, target_arch):
         "%{clang_cl_cl_path_" + target_arch + "}": clang_cl_path,
         "%{clang_cl_link_path_" + target_arch + "}": lld_link_path,
         "%{clang_cl_lib_path_" + target_arch + "}": llvm_lib_path,
-        # clang-cl does not support assembly files as input.
-        "%{clang_cl_ml_path_" + target_arch + "}": msvc_vars["%{msvc_ml_path_" + target_arch + "}"],
+        "%{clang_cl_ml_path_" + target_arch + "}": clang_cl_path,
         # LLVM's lld-link.exe doesn't support /DEBUG:FASTLINK.
         "%{clang_cl_dbg_mode_debug_flag_" + target_arch + "}": "/DEBUG",
         "%{clang_cl_fastbuild_mode_debug_flag_" + target_arch + "}": "/DEBUG",


### PR DESCRIPTION
This reverts commit cb1bc28f3731b07380a37be600f6ba8108b2a7a7.

Closes https://github.com/bazelbuild/bazel/issues/24158

Related https://github.com/bazelbuild/bazel/issues/24152