### PR TITLE
Remove DownloadManager instance from RegistryFactoryImpl.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -161,6 +161,9 @@ public class BazelRepositoryModule extends BlazeModule {
   private List<String> allowedYankedVersions = ImmutableList.of();
   private boolean disableNativeRepoRules;
   private SingleExtensionEvalFunction singleExtensionEvalFunction;
+  private ModuleFileFunction moduleFileFunction;
+  private RepoSpecFunction repoSpecFunction;
+  private YankedVersionsFunction yankedVersionsFunction;
 
   private final VendorCommand vendorCommand = new VendorCommand(clientEnvironmentSupplier);
   private final RegistryFactoryImpl registryFactory =
@@ -248,14 +251,14 @@ public class BazelRepositoryModule extends BlazeModule {
       builtinModules = ModuleFileFunction.getBuiltinModules(directories.getEmbeddedBinariesRoot());
     }
 
+    moduleFileFunction =
+      new ModuleFileFunction(runtime.getRuleClassProvider().getBazelStarlarkEnvironment(), directories.getWorkspace(), builtinModules);
+    repoSpecFunction = new RepoSpecFunction();
+    yankedVersionsFunction = new YankedVersionsFunction();
+
     builder
         .addSkyFunction(SkyFunctions.REPOSITORY_DIRECTORY, repositoryDelegatorFunction)
-        .addSkyFunction(
-            SkyFunctions.MODULE_FILE,
-            new ModuleFileFunction(
-                runtime.getRuleClassProvider().getBazelStarlarkEnvironment(),
-                directories.getWorkspace(),
-                builtinModules))
+        .addSkyFunction(SkyFunctions.MODULE_FILE, moduleFileFunction)
         .addSkyFunction(SkyFunctions.BAZEL_DEP_GRAPH, new BazelDepGraphFunction())
         .addSkyFunction(
             SkyFunctions.BAZEL_LOCK_FILE, new BazelLockFileFunction(directories.getWorkspace()))
@@ -269,8 +272,8 @@ public class BazelRepositoryModule extends BlazeModule {
         .addSkyFunction(
             SkyFunctions.REGISTRY,
             new RegistryFunction(registryFactory, directories.getWorkspace()))
-        .addSkyFunction(SkyFunctions.REPO_SPEC, new RepoSpecFunction())
-        .addSkyFunction(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction())
+        .addSkyFunction(SkyFunctions.REPO_SPEC, repoSpecFunction)
+        .addSkyFunction(SkyFunctions.YANKED_VERSIONS, yankedVersionsFunction)
         .addSkyFunction(
             SkyFunctions.VENDOR_FILE,
             new VendorFileFunction(runtime.getRuleClassProvider().getBazelStarlarkEnvironment()))
@@ -305,8 +308,10 @@ public class BazelRepositoryModule extends BlazeModule {
     DownloadManager downloadManager =
         new DownloadManager(repositoryCache, env.getDownloaderDelegate(), env.getHttpDownloader());
     this.starlarkRepositoryFunction.setDownloadManager(downloadManager);
+    this.moduleFileFunction.setDownloadManager(downloadManager);
+    this.repoSpecFunction.setDownloadManager(downloadManager);
+    this.yankedVersionsFunction.setDownloadManager(downloadManager);
     this.vendorCommand.setDownloadManager(downloadManager);
-    this.registryFactory.setDownloadManager(downloadManager);
 
     clientEnvironmentSupplier.set(env.getRepoEnv());
     PackageOptions pkgOptions = env.getOptions().getOptions(PackageOptions.class);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -85,7 +85,6 @@ public class IndexRegistry implements Registry {
   }
 
   private final URI uri;
-  private final DownloadManager downloadManager;
   private final Map<String, String> clientEnv;
   private final Gson gson;
   private final ImmutableMap<String, Optional<Checksum>> knownFileHashes;
@@ -99,14 +98,12 @@ public class IndexRegistry implements Registry {
 
   public IndexRegistry(
       URI uri,
-      DownloadManager downloadManager,
       Map<String, String> clientEnv,
       ImmutableMap<String, Optional<Checksum>> knownFileHashes,
       KnownFileHashesMode knownFileHashesMode,
       ImmutableMap<ModuleKey, String> previouslySelectedYankedVersions,
       Optional<Path> vendorDir) {
     this.uri = uri;
-    this.downloadManager = downloadManager;
     this.clientEnv = clientEnv;
     this.gson =
         new GsonBuilder()
@@ -136,9 +133,9 @@ public class IndexRegistry implements Registry {
 
   /** Grabs a file from the given URL. Returns {@link Optional#empty} if the file doesn't exist. */
   private Optional<byte[]> grabFile(
-      String url, ExtendedEventHandler eventHandler, boolean useChecksum)
+      String url, ExtendedEventHandler eventHandler, DownloadManager downloadManager, boolean useChecksum)
       throws IOException, InterruptedException {
-    var maybeContent = doGrabFile(url, eventHandler, useChecksum);
+    var maybeContent = doGrabFile(downloadManager, url, eventHandler, useChecksum);
     if ((knownFileHashesMode == KnownFileHashesMode.USE_AND_UPDATE
             || knownFileHashesMode == KnownFileHashesMode.USE_IMMUTABLE_AND_UPDATE)
         && useChecksum) {
@@ -148,7 +145,7 @@ public class IndexRegistry implements Registry {
   }
 
   private Optional<byte[]> doGrabFile(
-      String rawUrl, ExtendedEventHandler eventHandler, boolean useChecksum)
+      DownloadManager downloadManager, String rawUrl, ExtendedEventHandler eventHandler, boolean useChecksum)
       throws IOException, InterruptedException {
     Optional<Checksum> checksum;
     if (knownFileHashesMode != KnownFileHashesMode.IGNORE && useChecksum) {
@@ -225,11 +222,11 @@ public class IndexRegistry implements Registry {
   }
 
   @Override
-  public Optional<ModuleFile> getModuleFile(ModuleKey key, ExtendedEventHandler eventHandler)
+  public Optional<ModuleFile> getModuleFile(ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
       throws IOException, InterruptedException {
     String url =
         constructUrl(getUrl(), "modules", key.name(), key.version().toString(), "MODULE.bazel");
-    Optional<byte[]> maybeContent = grabFile(url, eventHandler, /* useChecksum= */ true);
+    Optional<byte[]> maybeContent = grabFile(url, eventHandler, downloadManager, /* useChecksum= */ true);
     return maybeContent.map(content -> ModuleFile.create(content, url));
   }
 
@@ -276,9 +273,9 @@ public class IndexRegistry implements Registry {
    * if the file doesn't exist.
    */
   private Optional<String> grabJsonFile(
-      String url, ExtendedEventHandler eventHandler, boolean useChecksum)
+      String url, ExtendedEventHandler eventHandler, DownloadManager downloadManager, boolean useChecksum)
       throws IOException, InterruptedException {
-    return grabFile(url, eventHandler, useChecksum).map(value -> new String(value, UTF_8));
+    return grabFile(url, eventHandler, downloadManager, useChecksum).map(value -> new String(value, UTF_8));
   }
 
   /**
@@ -286,9 +283,9 @@ public class IndexRegistry implements Registry {
    * T}. Returns {@link Optional#empty} if the file doesn't exist.
    */
   private <T> Optional<T> grabJson(
-      String url, Class<T> klass, ExtendedEventHandler eventHandler, boolean useChecksum)
+      String url, Class<T> klass, ExtendedEventHandler eventHandler, DownloadManager downloadManager, boolean useChecksum)
       throws IOException, InterruptedException {
-    Optional<String> jsonString = grabJsonFile(url, eventHandler, useChecksum);
+    Optional<String> jsonString = grabJsonFile(url, eventHandler, downloadManager, useChecksum);
     if (jsonString.isEmpty() || jsonString.get().isBlank()) {
       return Optional.empty();
     }
@@ -306,10 +303,10 @@ public class IndexRegistry implements Registry {
   }
 
   @Override
-  public RepoSpec getRepoSpec(ModuleKey key, ExtendedEventHandler eventHandler)
+  public RepoSpec getRepoSpec(ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
       throws IOException, InterruptedException {
     String jsonUrl = getSourceJsonUrl(key);
-    Optional<String> jsonString = grabJsonFile(jsonUrl, eventHandler, /* useChecksum= */ true);
+    Optional<String> jsonString = grabJsonFile(jsonUrl, eventHandler, downloadManager, /* useChecksum= */ true);
     if (jsonString.isEmpty()) {
       throw new FileNotFoundException(
           String.format(
@@ -320,12 +317,12 @@ public class IndexRegistry implements Registry {
       case "archive" -> {
         ArchiveSourceJson typedSourceJson =
             parseJson(jsonString.get(), jsonUrl, ArchiveSourceJson.class);
-        return createArchiveRepoSpec(typedSourceJson, getBazelRegistryJson(eventHandler), key);
+        return createArchiveRepoSpec(typedSourceJson, getBazelRegistryJson(eventHandler, downloadManager), key);
       }
       case "local_path" -> {
         LocalPathSourceJson typedSourceJson =
             parseJson(jsonString.get(), jsonUrl, LocalPathSourceJson.class);
-        return createLocalPathRepoSpec(typedSourceJson, getBazelRegistryJson(eventHandler), key);
+        return createLocalPathRepoSpec(typedSourceJson, getBazelRegistryJson(eventHandler, downloadManager), key);
       }
       case "git_repository" -> {
         GitRepoSourceJson typedSourceJson =
@@ -343,7 +340,7 @@ public class IndexRegistry implements Registry {
         getUrl(), "modules", key.name(), key.version().toString(), SOURCE_JSON_FILENAME);
   }
 
-  private Optional<BazelRegistryJson> getBazelRegistryJson(ExtendedEventHandler eventHandler)
+  private Optional<BazelRegistryJson> getBazelRegistryJson(ExtendedEventHandler eventHandler, DownloadManager downloadManager)
       throws IOException, InterruptedException {
     if (bazelRegistryJson == null || bazelRegistryJsonEvents == null) {
       synchronized (this) {
@@ -355,6 +352,7 @@ public class IndexRegistry implements Registry {
                   constructUrl(getUrl(), "bazel_registry.json"),
                   BazelRegistryJson.class,
                   storedEventHandler,
+                  downloadManager,
                   /* useChecksum= */ true);
           bazelRegistryJsonEvents = storedEventHandler;
         }
@@ -484,13 +482,14 @@ public class IndexRegistry implements Registry {
 
   @Override
   public Optional<ImmutableMap<Version, String>> getYankedVersions(
-      String moduleName, ExtendedEventHandler eventHandler)
+      String moduleName, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
       throws IOException, InterruptedException {
     Optional<MetadataJson> metadataJson =
         grabJson(
             constructUrl(getUrl(), "modules", moduleName, "metadata.json"),
             MetadataJson.class,
             eventHandler,
+            downloadManager,
             // metadata.json is not immutable
             /* useChecksum= */ false);
     if (metadataJson.isEmpty()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Registry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Registry.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.skyframe.NotComparableSkyValue;
 import java.io.IOException;
@@ -31,14 +32,14 @@ public interface Registry extends NotComparableSkyValue {
    * Retrieves the contents of the module file of the module identified by {@code key} from the
    * registry. Returns {@code Optional.empty()} when the module is not found in this registry.
    */
-  Optional<ModuleFile> getModuleFile(ModuleKey key, ExtendedEventHandler eventHandler)
+  Optional<ModuleFile> getModuleFile(ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
       throws IOException, InterruptedException;
 
   /**
    * Retrieves the {@link RepoSpec} object that indicates how the contents of the module identified
    * by {@code key} should be materialized as a repo.
    */
-  RepoSpec getRepoSpec(ModuleKey key, ExtendedEventHandler eventHandler)
+  RepoSpec getRepoSpec(ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
       throws IOException, InterruptedException;
 
   /**
@@ -46,7 +47,7 @@ public interface Registry extends NotComparableSkyValue {
    * Returns {@code Optional.empty()} when the information is not found in the registry.
    */
   Optional<ImmutableMap<Version, String>> getYankedVersions(
-      String moduleName, ExtendedEventHandler eventHandler)
+      String moduleName, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
       throws IOException, InterruptedException;
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegistryFactoryImpl.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.bzlmod.IndexRegistry.KnownFileHashesMode;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
-import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.vfs.Path;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -30,15 +29,10 @@ import javax.annotation.Nullable;
 
 /** Prod implementation of {@link RegistryFactory}. */
 public class RegistryFactoryImpl implements RegistryFactory {
-  @Nullable private DownloadManager downloadManager;
   private final Supplier<Map<String, String>> clientEnvironmentSupplier;
 
   public RegistryFactoryImpl(Supplier<Map<String, String>> clientEnvironmentSupplier) {
     this.clientEnvironmentSupplier = clientEnvironmentSupplier;
-  }
-
-  public void setDownloadManager(DownloadManager downloadManager) {
-    this.downloadManager = downloadManager;
   }
 
   @Override
@@ -76,7 +70,6 @@ public class RegistryFactoryImpl implements RegistryFactory {
         };
     return new IndexRegistry(
         uri,
-        downloadManager,
         clientEnvironmentSupplier.get(),
         knownFileHashes,
         knownFileHashesMode,

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/YankedVersionsFunction.java
@@ -15,6 +15,7 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
@@ -31,6 +32,7 @@ import javax.annotation.Nullable;
  * Registry}.
  */
 public class YankedVersionsFunction implements SkyFunction {
+  @Nullable private DownloadManager downloadManager;
 
   @Override
   @Nullable
@@ -47,7 +49,7 @@ public class YankedVersionsFunction implements SkyFunction {
             .profile(
                 ProfilerTask.BZLMOD, () -> "getting yanked versions: " + key.getModuleName())) {
       return YankedVersionsValue.create(
-          registry.getYankedVersions(key.getModuleName(), env.getListener()));
+          registry.getYankedVersions(key.getModuleName(), env.getListener(), downloadManager));
     } catch (IOException e) {
       env.getListener()
           .handle(
@@ -59,5 +61,9 @@ public class YankedVersionsFunction implements SkyFunction {
       // fetched.
       return YankedVersionsValue.create(Optional.empty());
     }
+  }
+
+  public void setDownloadManager(DownloadManager downloadManager) {
+    this.downloadManager = downloadManager;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
@@ -140,15 +140,11 @@ public class BazelPackageLoader extends AbstractPackageLoader {
           new DownloadManager(repositoryCache, httpDownloader, httpDownloader);
       RegistryFactoryImpl registryFactory =
           new RegistryFactoryImpl(Suppliers.ofInstance(ImmutableMap.of()));
-      registryFactory.setDownloadManager(downloadManager);
 
       // Allow tests to override the following functions to use fake registry or custom built-in
       // modules
       if (!this.extraSkyFunctions.containsKey(SkyFunctions.MODULE_FILE)) {
-        addExtraSkyFunctions(
-            ImmutableMap.of(
-                SkyFunctions.MODULE_FILE,
-                new ModuleFileFunction(
+        ModuleFileFunction moduleFileFunction = new ModuleFileFunction(
                     ruleClassProvider.getBazelStarlarkEnvironment(),
                     directories.getWorkspace(),
                     ModuleFileFunction.getBuiltinModules(directories.getEmbeddedBinariesRoot())
@@ -156,7 +152,10 @@ public class BazelPackageLoader extends AbstractPackageLoader {
                         .stream()
                         .filter(e -> e.getKey().equals("bazel_tools"))
                         .collect(
-                            ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))));
+                            ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+        addExtraSkyFunctions(ImmutableMap.of(SkyFunctions.MODULE_FILE, moduleFileFunction));
+        moduleFileFunction.setDownloadManager(downloadManager);
       }
       if (!this.extraSkyFunctions.containsKey(SkyFunctions.REGISTRY)) {
         addExtraSkyFunctions(
@@ -166,6 +165,12 @@ public class BazelPackageLoader extends AbstractPackageLoader {
       }
       StarlarkRepositoryFunction starlarkRepositoryFunction = new StarlarkRepositoryFunction();
       starlarkRepositoryFunction.setDownloadManager(downloadManager);
+
+      RepoSpecFunction repoSpecFunction = new RepoSpecFunction();
+      repoSpecFunction.setDownloadManager(downloadManager);
+
+      YankedVersionsFunction yankedVersionsFunction = new YankedVersionsFunction();
+      yankedVersionsFunction.setDownloadManager(downloadManager);
 
       addExtraSkyFunctions(
           ImmutableMap.<SkyFunctionName, SkyFunction>builder()
@@ -194,8 +199,8 @@ public class BazelPackageLoader extends AbstractPackageLoader {
                   new BazelLockFileFunction(directories.getWorkspace()))
               .put(SkyFunctions.BAZEL_DEP_GRAPH, new BazelDepGraphFunction())
               .put(SkyFunctions.BAZEL_MODULE_RESOLUTION, new BazelModuleResolutionFunction())
-              .put(SkyFunctions.REPO_SPEC, new RepoSpecFunction())
-              .put(SkyFunctions.YANKED_VERSIONS, new YankedVersionsFunction())
+              .put(SkyFunctions.REPO_SPEC, repoSpecFunction)
+              .put(SkyFunctions.YANKED_VERSIONS, yankedVersionsFunction)
               .buildOrThrow());
 
       return new BazelPackageLoader(this);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
@@ -20,8 +20,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
+import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -65,7 +66,7 @@ public class FakeRegistry implements Registry {
   }
 
   @Override
-  public Optional<ModuleFile> getModuleFile(ModuleKey key, ExtendedEventHandler eventHandler) {
+  public Optional<ModuleFile> getModuleFile(ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager) {
     String uri = String.format("%s/modules/%s/%s/MODULE.bazel", url, key.name(), key.version());
     var maybeContent = Optional.ofNullable(modules.get(key)).map(value -> value.getBytes(UTF_8));
     eventHandler.post(RegistryFileDownloadEvent.create(uri, maybeContent));
@@ -73,7 +74,7 @@ public class FakeRegistry implements Registry {
   }
 
   @Override
-  public RepoSpec getRepoSpec(ModuleKey key, ExtendedEventHandler eventHandler) {
+  public RepoSpec getRepoSpec(ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager) {
     RepoSpec repoSpec =
         RepoSpec.builder()
             .setRuleClassName("local_repository")
@@ -94,7 +95,7 @@ public class FakeRegistry implements Registry {
 
   @Override
   public Optional<ImmutableMap<Version, String>> getYankedVersions(
-      String moduleName, ExtendedEventHandler eventHandler) {
+      String moduleName, ExtendedEventHandler eventHandler, DownloadManager downloadManager) {
     return Optional.ofNullable(yankedVersionMap.get(moduleName));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -88,7 +88,6 @@ public class IndexRegistryTest extends FoundationTestCase {
     HttpDownloader httpDownloader = new HttpDownloader();
     downloadManager = new DownloadManager(repositoryCache, httpDownloader, httpDownloader);
     registryFactory = new RegistryFactoryImpl(Suppliers.ofInstance(ImmutableMap.of()));
-    registryFactory.setDownloadManager(downloadManager);
   }
 
   @Test
@@ -103,11 +102,11 @@ public class IndexRegistryTest extends FoundationTestCase {
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty());
-    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .hasValue(
             ModuleFile.create(
                 "lol".getBytes(UTF_8), server.getUrl() + "/myreg/modules/foo/1.0/MODULE.bazel"));
-    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter)).isEmpty();
+    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter, downloadManager)).isEmpty();
   }
 
   @Test
@@ -129,7 +128,7 @@ public class IndexRegistryTest extends FoundationTestCase {
     var e =
         assertThrows(
             IOException.class,
-            () -> registry.getModuleFile(createModuleKey("foo", "1.0"), reporter));
+            () -> registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
@@ -137,11 +136,11 @@ public class IndexRegistryTest extends FoundationTestCase {
                 .formatted(server.getUrl() + "/myreg/modules/foo/1.0/MODULE.bazel"));
 
     downloadManager.setNetrcCreds(new NetrcCredentials(netrc));
-    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .hasValue(
             ModuleFile.create(
                 "lol".getBytes(UTF_8), server.getUrl() + "/myreg/modules/foo/1.0/MODULE.bazel"));
-    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter)).isEmpty();
+    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter, downloadManager)).isEmpty();
   }
 
   @Test
@@ -159,9 +158,9 @@ public class IndexRegistryTest extends FoundationTestCase {
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty());
-    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .hasValue(ModuleFile.create("lol".getBytes(UTF_8), file.toURI().toString()));
-    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter)).isEmpty();
+    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter, downloadManager)).isEmpty();
   }
 
   @Test
@@ -212,7 +211,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty());
-    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .isEqualTo(
             new ArchiveRepoSpecBuilder()
                 .setUrls(
@@ -226,7 +225,7 @@ public class IndexRegistryTest extends FoundationTestCase {
                 .setOverlay(ImmutableMap.of())
                 .setRemotePatchStrip(0)
                 .build());
-    assertThat(registry.getRepoSpec(createModuleKey("bar", "2.0"), reporter))
+    assertThat(registry.getRepoSpec(createModuleKey("bar", "2.0"), reporter, downloadManager))
         .isEqualTo(
             new ArchiveRepoSpecBuilder()
                 .setUrls(
@@ -244,7 +243,7 @@ public class IndexRegistryTest extends FoundationTestCase {
                 .setRemotePatchStrip(3)
                 .setOverlay(ImmutableMap.of())
                 .build());
-    assertThat(registry.getRepoSpec(createModuleKey("baz", "3.0"), reporter))
+    assertThat(registry.getRepoSpec(createModuleKey("baz", "3.0"), reporter, downloadManager))
         .isEqualTo(
             new ArchiveRepoSpecBuilder()
                 .setUrls(
@@ -285,7 +284,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty());
-    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .isEqualTo(
             RepoSpec.builder()
                 .setRuleClassName("local_repository")
@@ -313,7 +312,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty());
-    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .isEqualTo(
             new ArchiveRepoSpecBuilder()
                 .setUrls(ImmutableList.of("http://mysite.com/thing.zip"))
@@ -352,7 +351,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             ImmutableMap.of(),
             Optional.empty());
     assertThrows(
-        IOException.class, () -> registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter));
+        IOException.class, () -> registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter, downloadManager));
   }
 
   @Test
@@ -385,7 +384,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             ImmutableMap.of(),
             Optional.empty());
     Optional<ImmutableMap<Version, String>> yankedVersion =
-        registry.getYankedVersions("red-pill", reporter);
+        registry.getYankedVersions("red-pill", reporter, downloadManager);
     assertThat(yankedVersion)
         .hasValue(
             ImmutableMap.of(
@@ -411,7 +410,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             ImmutableMap.of(),
             ImmutableMap.of(),
             Optional.empty());
-    assertThat(registry.getRepoSpec(createModuleKey("archive_type", "1.0"), reporter))
+    assertThat(registry.getRepoSpec(createModuleKey("archive_type", "1.0"), reporter, downloadManager))
         .isEqualTo(
             new ArchiveRepoSpecBuilder()
                 .setUrls(ImmutableList.of("https://mysite.com/thing?format=zip"))
@@ -445,15 +444,15 @@ public class IndexRegistryTest extends FoundationTestCase {
             knownFiles,
             ImmutableMap.of(),
             Optional.empty());
-    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .hasValue(
             ModuleFile.create(
                 "old".getBytes(UTF_8), server.getUrl() + "/myreg/modules/foo/1.0/MODULE.bazel"));
-    assertThat(registry.getModuleFile(createModuleKey("foo", "2.0"), reporter))
+    assertThat(registry.getModuleFile(createModuleKey("foo", "2.0"), reporter, downloadManager))
         .hasValue(
             ModuleFile.create(
                 "new".getBytes(UTF_8), server.getUrl() + "/myreg/modules/foo/2.0/MODULE.bazel"));
-    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter)).isEmpty();
+    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter, downloadManager)).isEmpty();
 
     var recordedChecksums = eventRecorder.getRecordedHashes();
     assertThat(
@@ -480,15 +479,15 @@ public class IndexRegistryTest extends FoundationTestCase {
     server.unserve("/myreg/modules/foo/1.0/MODULE.bazel");
     server.unserve("/myreg/modules/foo/2.0/MODULE.bazel");
     server.serve("/myreg/modules/bar/1.0/MODULE.bazel", "no longer 404");
-    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .hasValue(
             ModuleFile.create(
                 "old".getBytes(UTF_8), server.getUrl() + "/myreg/modules/foo/1.0/MODULE.bazel"));
-    assertThat(registry.getModuleFile(createModuleKey("foo", "2.0"), reporter))
+    assertThat(registry.getModuleFile(createModuleKey("foo", "2.0"), reporter, downloadManager))
         .hasValue(
             ModuleFile.create(
                 "new".getBytes(UTF_8), server.getUrl() + "/myreg/modules/foo/2.0/MODULE.bazel"));
-    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter)).isEmpty();
+    assertThat(registry.getModuleFile(createModuleKey("bar", "1.0"), reporter, downloadManager)).isEmpty();
   }
 
   @Test
@@ -512,7 +511,7 @@ public class IndexRegistryTest extends FoundationTestCase {
     var e =
         assertThrows(
             IOException.class,
-            () -> registry.getModuleFile(createModuleKey("foo", "1.0"), reporter));
+            () -> registry.getModuleFile(createModuleKey("foo", "1.0"), reporter, downloadManager));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
@@ -550,7 +549,7 @@ public class IndexRegistryTest extends FoundationTestCase {
     Registry registry =
         registryFactory.createRegistry(
             server.getUrl(), LockfileMode.UPDATE, knownFiles, ImmutableMap.of(), Optional.empty());
-    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .isEqualTo(
             RepoSpec.builder()
                 .setRuleClassName("local_repository")
@@ -578,7 +577,7 @@ public class IndexRegistryTest extends FoundationTestCase {
     // changes.
     server.unserve("/bazel_registry.json");
     server.unserve("/modules/foo/1.0/source.json");
-    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter))
+    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter, downloadManager))
         .isEqualTo(
             RepoSpec.builder()
                 .setRuleClassName("local_repository")
@@ -620,7 +619,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             server.getUrl(), LockfileMode.UPDATE, knownFiles, ImmutableMap.of(), Optional.empty());
     var e =
         assertThrows(
-            IOException.class, () -> registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter));
+            IOException.class, () -> registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter, downloadManager));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
@@ -664,7 +663,7 @@ public class IndexRegistryTest extends FoundationTestCase {
             server.getUrl(), LockfileMode.UPDATE, knownFiles, ImmutableMap.of(), Optional.empty());
     var e =
         assertThrows(
-            IOException.class, () -> registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter));
+            IOException.class, () -> registry.getRepoSpec(createModuleKey("foo", "1.0"), reporter, downloadManager));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(


### PR DESCRIPTION
This PR removes the DownloadManager from the registry factory implementation. As the registry created by the factory is cached by the SkyFunction mechanism, the DownloadManager instance was living too long - it is supposed to be re-created for every command instantiation to respect changes in command line options, but for the registry, it ignored those changes.

Instead, the DownloadManager is set directly into the affected SkyFunctions that require access to it. This way, the per-command DownloadManager instance is correctly used.

This fixes https://github.com/bazelbuild/bazel/issues/24166.

Note for reviewers: This is my first time touching code with SkyFunctions, so I don't really know what I'm doing.