### PR TITLE
Allow the creation of relative symlinks on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileOperations.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.lib.jni.JniLoader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
+import java.nio.file.Path;
 
 /** File operations on Windows. */
 public class WindowsFileOperations {
@@ -200,6 +201,15 @@ public class WindowsFileOperations {
         : path.replace('/', '\\');
   }
 
+  static String asLongPathIfAbsolute(String path) {
+    String withBackslashes = path.replace('/', '\\');
+    if (Path.of(withBackslashes).isAbsolute()) {
+      return asLongPath(withBackslashes);
+    } else {
+      return withBackslashes;
+    }
+  }
+
   private static String removeUncPrefixAndUseSlashes(String p) {
     if (p.length() >= 4
         && p.charAt(0) == '\\'
@@ -250,7 +260,7 @@ public class WindowsFileOperations {
 
   public static void createSymlink(String name, String target) throws IOException {
     String[] error = new String[] {null};
-    switch (nativeCreateSymlink(asLongPath(name), asLongPath(target), error)) {
+    switch (nativeCreateSymlink(asLongPath(name), asLongPathIfAbsolute(target), error)) {
       case CREATE_SYMLINK_SUCCESS:
         return;
       case CREATE_SYMLINK_TARGET_IS_DIRECTORY:

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -492,31 +492,22 @@ int CreateSymlink(const wstring& symlink_name, const wstring& symlink_target,
     }
     return CreateSymlinkResult::kError;
   }
-  if (!IsAbsoluteNormalizedWindowsPath(symlink_target)) {
-    if (error) {
-      *error = MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"CreateSymlink", symlink_target,
-          L"expected an absolute Windows path for symlink_target");
-    }
-    return CreateSymlinkResult::kError;
-  }
 
   const wstring name = AddUncPrefixMaybe(symlink_name);
-  const wstring target = AddUncPrefixMaybe(symlink_target);
 
-  DWORD attrs = GetFileAttributesW(target.c_str());
+  DWORD attrs = GetFileAttributesW(symlink_target.c_str());
   if ((attrs != INVALID_FILE_ATTRIBUTES) &&
       (attrs & FILE_ATTRIBUTE_DIRECTORY)) {
     // Instead of creating a symlink to a directory use a Junction.
     return CreateSymlinkResult::kTargetIsDirectory;
   }
 
-  if (!CreateSymbolicLinkW(name.c_str(), target.c_str(),
+  if (!CreateSymbolicLinkW(name.c_str(), symlink_target.c_str(),
                            symlinkPrivilegeFlag)) {
     if (GetLastError() == ERROR_INVALID_PARAMETER) {
       // We are on a version of Windows that does not support this flag.
       // Retry without the flag and return to error handling if necessary.
-      if (CreateSymbolicLinkW(name.c_str(), target.c_str(), 0)) {
+      if (CreateSymbolicLinkW(name.c_str(), symlink_target.c_str(), 0)) {
         return CreateSymlinkResult::kSuccess;
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -351,6 +351,17 @@ public class WindowsFileSystemTest {
   }
 
   @Test
+  public void testReadSymbolicLinkWithRelativeRealSymlinks() throws Exception {
+    fs = new WindowsFileSystem(DigestHashFunction.SHA256, /* createSymbolicLinks= */ true);
+    PathFragment targetFragment = PathFragment.create("../some/nonexistent/file.txt");
+    Path linkPath = scratchRoot.getRelative("link.txt");
+    fs.createSymbolicLink(linkPath.asFragment(), targetFragment);
+
+    assertThat(linkPath.isSymbolicLink()).isTrue();
+    assertThat(linkPath.readSymbolicLink()).isEqualTo(targetFragment);
+  }
+
+  @Test
   public void testReadJunction() throws Exception {
     testUtil.scratchFile("dir\\hello.txt", "hello");
     testUtil.createJunctions(ImmutableMap.of("junc", "dir"));

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -355,6 +355,7 @@ public class WindowsFileSystemTest {
     fs = new WindowsFileSystem(DigestHashFunction.SHA256, /* createSymbolicLinks= */ true);
     PathFragment targetFragment = PathFragment.create("../some/nonexistent/file.txt");
     Path linkPath = scratchRoot.getRelative("link.txt");
+    linkPath.getParentDirectory().createDirectoryAndParents();
     fs.createSymbolicLink(linkPath.asFragment(), targetFragment);
 
     assertThat(linkPath.isSymbolicLink()).isTrue();


### PR DESCRIPTION
Fixes #14224 

RELNOTES: Symlinks created via `ctx.actions.symlink(..., target_path = "...")` with `--windows_enable_symlinks` can now be relative on Windows.