### PR TITLE
Parse Starlark files as raw bytes for Bzlmod

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/CompiledModuleFile.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/CompiledModuleFile.java
@@ -63,7 +63,8 @@ public record CompiledModuleFile(
       ExtendedEventHandler eventHandler)
       throws ExternalDepsException {
     StarlarkFile starlarkFile =
-        StarlarkFile.parse(ParserInput.fromUTF8(moduleFile.getContent(), moduleFile.getLocation()));
+        StarlarkFile.parse(
+            ParserInput.fromLatin1(moduleFile.getContent(), moduleFile.getLocation()));
     if (!starlarkFile.ok()) {
       Event.replayEventsOn(eventHandler, starlarkFile.errors());
       throw ExternalDepsException.withMessage(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorFileFunction.java
@@ -156,7 +156,7 @@ public class VendorFileFunction implements SkyFunction {
           new IOException("error reading VENDOR.bazel file", e), Transience.TRANSIENT);
     }
     StarlarkFile starlarkFile =
-        StarlarkFile.parse(ParserInput.fromUTF8(contents, path.getPathString()));
+        StarlarkFile.parse(ParserInput.fromLatin1(contents, path.getPathString()));
     if (!starlarkFile.ok()) {
       Event.replayEventsOn(env.getListener(), starlarkFile.errors());
       throw new VendorFileFunctionException(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepoFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepoFileFunction.java
@@ -108,7 +108,7 @@ public class RepoFileFunction implements SkyFunction {
           new IOException("error reading REPO.bazel file at " + path, e), Transience.TRANSIENT);
     }
     StarlarkFile starlarkFile =
-        StarlarkFile.parse(ParserInput.fromUTF8(contents, path.getPathString()));
+        StarlarkFile.parse(ParserInput.fromLatin1(contents, path.getPathString()));
     if (!starlarkFile.ok()) {
       Event.replayEventsOn(env.getListener(), starlarkFile.errors());
       throw new RepoFileFunctionException(

--- a/src/test/py/bazel/bzlmod/test_utils.py
+++ b/src/test/py/bazel/bzlmod/test_utils.py
@@ -30,8 +30,8 @@ import zipfile
 
 def download(url):
   """Download a file and return its content in bytes."""
-  response = urllib.request.urlopen(url)
-  return response.read()
+  with urllib.request.urlopen(url) as response:
+    return response.read()
 
 
 def read(path):

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -16,7 +16,6 @@
 
 """Bazel Python integration test framework."""
 
-import locale
 import os
 import shutil
 import socket
@@ -313,7 +312,7 @@ class TestBase(absltest.TestCase):
     if os.path.exists(abspath) and not os.path.isfile(abspath):
       raise IOError('"%s" (%s) exists and is not a file' % (path, abspath))
     self.ScratchDir(os.path.dirname(path))
-    with open(abspath, 'w') as f:
+    with open(abspath, 'w', encoding='utf-8') as f:
       if lines:
         for l in lines:
           f.write(l)
@@ -445,7 +444,7 @@ class TestBase(absltest.TestCase):
 
     self._worker_stdout.seek(0)
     stdout_lines = [
-        l.decode(locale.getpreferredencoding()).strip()
+        l.decode('utf-8').strip()
         for l in self._worker_stdout.readlines()
     ]
     if stdout_lines:
@@ -455,7 +454,7 @@ class TestBase(absltest.TestCase):
 
     self._worker_stderr.seek(0)
     stderr_lines = [
-        l.decode(locale.getpreferredencoding()).strip()
+        l.decode('utf-8').strip()
         for l in self._worker_stderr.readlines()
     ]
     if stderr_lines:
@@ -509,18 +508,14 @@ class TestBase(absltest.TestCase):
 
         stdout.seek(0)
         stdout_lines = [
-            l.decode(locale.getpreferredencoding()).rstrip()
-            if rstrip
-            else l.decode(locale.getpreferredencoding()).strip()
-            for l in stdout.readlines()
+          l.decode('utf-8').rstrip() if rstrip else l.decode('utf-8').strip()
+          for l in stdout.readlines()
         ]
 
         stderr.seek(0)
         stderr_lines = [
-            l.decode(locale.getpreferredencoding()).rstrip()
-            if rstrip
-            else l.decode(locale.getpreferredencoding()).strip()
-            for l in stderr.readlines()
+          l.decode('utf-8').rstrip() if rstrip else l.decode('utf-8').strip()
+          for l in stderr.readlines()
         ]
 
         if not allow_failure:


### PR DESCRIPTION
As long as Bazel internally represents strings as raw bytes "encoded" in Latin-1, the same must be true for all Starlark files that may contain file system paths.

Also includes changes to the Python test setup:
* `ScratchFile` now always writes files as UTF-8
* `RunProgram` encodes and decodes stdin/stderr/stdout as UTF-8
* `download` no longer leaks a file