### PR TITLE
Let repo rules remove env vars for subprocesses

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkExecutionResult.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkExecutionResult.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
@@ -155,6 +156,13 @@ final class StarlarkExecutionResult implements StarlarkValue {
     @CanIgnoreReturnValue
     Builder addEnvironmentVariables(Map<String, String> variables) {
       this.envBuilder.putAll(variables);
+      return this;
+    }
+
+    /** Ensure that an environment variable is not passed to the process. */
+    @CanIgnoreReturnValue
+    Builder removeEnvironmentVariables(Set<String> removeEnvVariables) {
+      removeEnvVariables.forEach(envBuilder::remove);
       return this;
     }
 

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -874,6 +874,7 @@ sh_test(
     data = [
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
+        "@local_jdk//:jdk",
     ],
     shard_count = 10,
     tags = [


### PR DESCRIPTION
RELNOTES: `repository_ctx.execute` can now remove an environment variable when executing a process by associating it with the value `None` in the `environment` argument.