### PR TITLE
[8.0.0] Observe --noexperimental_check_output_files even for `run` commands.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -519,12 +519,9 @@ public class ExecutionTool {
       informedOutputServiceToStartTheBuild = true;
     }
     if (!request.getPackageOptions().checkOutputFiles) {
-      // Do not skip output invalidation in the following cases:
-      // 1. If the output tree is empty: this can happen after it's cleaned or corrupted.
-      // 2. For a run command: so that outputs are downloaded even if they were previously built
-      //    with --remote_download_minimal. See https://github.com/bazelbuild/bazel/issues/20843.
-      if (!modifiedOutputFiles.treatEverythingAsDeleted()
-          && !request.getCommandName().equals("run")) {
+      // Do not skip output invalidation if the output tree is empty: this can happen after it's
+      // cleaned or corrupted.
+      if (!modifiedOutputFiles.treatEverythingAsDeleted()) {
         return ModifiedFileSet.NOTHING_MODIFIED;
       }
     }


### PR DESCRIPTION
This reverts the functional changes introduced by https://github.com/bazelbuild/bazel/commit/2f899ef8b39935d9ca131b71a24e67ef286bc378. They're no longer required because https://github.com/bazelbuild/bazel/commit/4c42edb2e8b2e8169da294591f3b45d369432f14 also happened to fix incremental fetching of top-level outputs for `run` commands. The integration test added by the former CL remains in place.

Fixes #20843.

PiperOrigin-RevId: 693664834
Change-Id: I64c1b0d14ae54f3906b9f7d916dbbb4f0204a1b9