### PR TITLE
[8.0.0] Don't check main repo name for auto-load when bzlmod is disabled.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunction.java
@@ -190,7 +190,8 @@ public class StarlarkBuiltinsFunction implements SkyFunction {
       return null;
     }
 
-    if (autoloadSymbols.isEnabled()) {
+    if (autoloadSymbols.isEnabled()
+        && starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_BZLMOD)) {
       // We can't do autoloads where the rules are implemented (disabling them when running in
       // main repository named rules_python)
       ModuleFileValue mainModule =


### PR DESCRIPTION
PiperOrigin-RevId: 693692713
Change-Id: I65db496e79b30952525dd7995080109fcfc4f9f5

Commit https://github.com/bazelbuild/bazel/commit/764ba19ea5b935d7dd8b112a02dcbe05e4d9a5d5