### PR TITLE
[8.0.0] Include apparent names of deps in `bazel mod` JSON output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorFunction.java
@@ -106,7 +106,11 @@ public class BazelModuleInspectorFunction implements SkyFunction {
       AugmentedModule.Builder parentBuilder =
           depGraphAugmentBuilder
               .computeIfAbsent(
-                  parentKey, k -> AugmentedModule.builder(k).setName(parentModule.getName()))
+                  parentKey,
+                  k ->
+                      AugmentedModule.builder(k)
+                          .setName(parentModule.getName())
+                          .setRepoName(parentModule.getRepoName()))
               .setVersion(parentModule.getVersion())
               .setLoaded(true);
 
@@ -122,6 +126,7 @@ public class BazelModuleInspectorFunction implements SkyFunction {
           originalChildBuilder
               .setName(originalModule.getName())
               .setVersion(originalModule.getVersion())
+              .setRepoName(originalModule.getRepoName())
               .setLoaded(true);
         }
 
@@ -132,6 +137,7 @@ public class BazelModuleInspectorFunction implements SkyFunction {
                     AugmentedModule.builder(k)
                         .setName(module.getName())
                         .setVersion(module.getVersion())
+                        .setRepoName(module.getRepoName())
                         .setLoaded(true));
 
         // originalDependants and dependants can differ because

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorValue.java
@@ -89,6 +89,9 @@ public abstract class BazelModuleInspectorValue implements SkyValue {
     /** {@link ModuleKey} of this module. Same as in {@link Module} */
     public abstract ModuleKey getKey();
 
+    /** The apparent name used by the module to refer to its own repository. */
+    public abstract String getRepoName();
+
     /**
      * The set of modules in the resolved dep graph that depend on this module
      * <strong>after</strong> the module resolution.
@@ -154,6 +157,7 @@ public abstract class BazelModuleInspectorValue implements SkyValue {
       return new AutoValue_BazelModuleInspectorValue_AugmentedModule.Builder()
           .setName(key.name())
           .setVersion(key.version())
+          .setRepoName(key.name())
           .setKey(key)
           .setLoaded(false);
     }
@@ -166,6 +170,8 @@ public abstract class BazelModuleInspectorValue implements SkyValue {
       public abstract AugmentedModule.Builder setVersion(Version value);
 
       public abstract AugmentedModule.Builder setKey(ModuleKey value);
+
+      public abstract AugmentedModule.Builder setRepoName(String value);
 
       public abstract AugmentedModule.Builder setLoaded(boolean value);
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/JsonOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/modcommand/JsonOutputFormatter.java
@@ -34,6 +34,7 @@ import com.google.gson.JsonObject;
 import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /** Outputs graph-based results of {@link ModExecutor} in JSON format. */
 public class JsonOutputFormatter extends OutputFormatter {
@@ -89,17 +90,22 @@ public class JsonOutputFormatter extends OutputFormatter {
 
   // Depth-first traversal to display modules (while explicitly detecting cycles)
   JsonObject printModule(
-      ModuleKey key, ModuleKey parent, IsExpanded expanded, IsIndirect indirect) {
+      ModuleKey key, @Nullable ModuleKey parent, IsExpanded expanded, IsIndirect indirect) {
     ResultNode node = result.get(key);
     AugmentedModule module = depGraph.get(key);
     JsonObject json = new JsonObject();
     json.addProperty("key", printKey(key));
-    if (!key.name().equals(module.getName())) {
-      json.addProperty("name", module.getName());
+    json.addProperty("name", module.getName());
+    json.addProperty("version", module.getVersion().toString());
+    String apparentName;
+    if (parent != null) {
+      // The apparent repository name under which parent refers to key.
+      apparentName = depGraph.get(parent).getDeps().inverse().get(key);
+    } else {
+      // The apparent repository name under which key refers to itself.
+      apparentName = module.getRepoName();
     }
-    if (!key.version().equals(module.getVersion())) {
-      json.addProperty("version", module.getVersion().toString());
-    }
+    json.addProperty("apparentName", apparentName);
 
     if (indirect == IsIndirect.FALSE && options.verbose && parent != null) {
       Explanation explanation = getExtraResolutionExplanation(key, parent);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -193,7 +193,11 @@ public final class BzlmodTestUtil {
       AugmentedModuleBuilder myBuilder = new AugmentedModuleBuilder();
       myBuilder.key = key;
       myBuilder.builder =
-          AugmentedModule.builder(key).setName(name).setVersion(version).setLoaded(loaded);
+          AugmentedModule.builder(key)
+              .setName(name)
+              .setVersion(version)
+              .setRepoName(name)
+              .setLoaded(loaded);
       return myBuilder;
     }
 


### PR DESCRIPTION
This allows IDEs to query for the direct dependencies of the root module as well as how they can refer to them from the point of view of the root module.

Also always emit `name` and `version` so that consumers don't have to know how to parse module keys.

Work towards #22691

Closes #23787.

PiperOrigin-RevId: 693453084
Change-Id: Ie3fd5e89301d8e83d0eaa686188634923853f01a

Commit https://github.com/bazelbuild/bazel/commit/1003d2c31bf4f90ded7015b1b7ed570d50ed6a63