### PR TITLE
[8.0.0] Let repo rules remove env vars for subprocesses

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkExecutionResult.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkExecutionResult.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
@@ -155,6 +156,13 @@ final class StarlarkExecutionResult implements StarlarkValue {
     @CanIgnoreReturnValue
     Builder addEnvironmentVariables(Map<String, String> variables) {
       this.envBuilder.putAll(variables);
+      return this;
+    }
+
+    /** Ensure that an environment variable is not passed to the process. */
+    @CanIgnoreReturnValue
+    Builder removeEnvironmentVariables(Set<String> removeEnvVariables) {
+      removeEnvVariables.forEach(envBuilder::remove);
       return this;
     }
 

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -874,6 +874,7 @@ sh_test(
     data = [
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
+        "@local_jdk//:jdk",
     ],
     shard_count = 10,
     tags = [

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3448,4 +3448,42 @@ EOF
     expect_log "my_second_repo: @my_first_repo//:foo @@+_repo_rules+my_first_repo//:foo"
 }
 
+function test_execute_environment_remove_vars() {
+  cat >> $(setup_module_dot_bazel)  <<'EOF'
+my_repo = use_repo_rule("//:repo.bzl", "my_repo")
+my_repo(name="repo")
+EOF
+  touch BUILD
+  cat > repo.bzl <<'EOF'
+def _impl(ctx):
+  st = ctx.execute(
+    ["env"],
+    environment = {
+      "CLIENT_ENV_REMOVED": None,
+      "REPO_ENV_REMOVED": None,
+    },
+  )
+  if st.return_code:
+    fail("Command did not succeed")
+  vars = {line.partition("=")[0]: line.partition("=")[-1] for line in st.stdout.split("\n")}
+  if "CLIENT_ENV_REMOVED" in vars:
+    fail("CLIENT_ENV_REMOVED should not be in the environment")
+  if "REPO_ENV_REMOVED" in vars:
+    fail("REPO_ENV_REMOVED should not be in the environment")
+  if vars.get("CLIENT_ENV_PRESENT") != "value1":
+    fail("CLIENT_ENV_PRESENT has wrong value: " + vars.get("CLIENT_ENV_PRESENT"))
+  if vars.get("REPO_ENV_PRESENT") != "value3":
+    fail("REPO_ENV_PRESENT has wrong value: " + vars.get("REPO_ENV_PRESENT"))
+
+  ctx.file("BUILD", "exports_files(['data.txt'])")
+
+my_repo = repository_rule(_impl)
+EOF
+
+  CLIENT_ENV_PRESENT=value1 CLIENT_ENV_REMOVED=value2 \
+   bazel build \
+    --repo_env=REPO_ENV_PRESENT=value3 --repo_env=REPO_ENV_REMOVED=value4 \
+    @repo//... &> $TEST_log || fail "expected Bazel to succeed"
+}
+
 run_suite "local repository tests"


### PR DESCRIPTION
RELNOTES: `repository_ctx.execute` can now remove an environment variable when executing a process by associating it with the value `None` in the `environment` argument.

Closes #24221.

PiperOrigin-RevId: 694048622
Change-Id: Ia779e9133411745c9cfe93845c13839d05731c7c

Commit https://github.com/bazelbuild/bazel/commit/21a12c72d84e9108142421d9a8526edf8dceb78c