### PR TITLE
[8.0.0] Add `repository_ctx.rename()` for renaming files or directories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -17,6 +17,7 @@ import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.ExtractEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.FileEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.OsEvent;
+import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.RenameEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.SymlinkEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.TemplateEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.WhichEvent;
@@ -261,6 +262,23 @@ public final class WorkspaceRuleEvent implements Postable {
     return new WorkspaceRuleEvent(result.build());
   }
 
+  /** Creates a new WorkspaceRuleEvent for a rename event. */
+  public static WorkspaceRuleEvent newRenameEvent(
+      String src, String dst, String context, Location location) {
+    RenameEvent e = WorkspaceLogProtos.RenameEvent.newBuilder().setSrc(src).setDst(dst).build();
+
+    WorkspaceLogProtos.WorkspaceEvent.Builder result =
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder();
+    result = result.setRenameEvent(e);
+    if (location != null) {
+      result = result.setLocation(location.toString());
+    }
+    if (context != null) {
+      result = result.setContext(context);
+    }
+    return new WorkspaceRuleEvent(result.build());
+  }
+
   /** Creates a new WorkspaceRuleEvent for a symlink event. */
   public static WorkspaceRuleEvent newSymlinkEvent(
       String from, String to, String context, Location location) {
@@ -324,7 +342,7 @@ public final class WorkspaceRuleEvent implements Postable {
     return new WorkspaceRuleEvent(result.build());
   }
 
-  /*
+  /**
    * @return a message to log for this event
    */
   public String logMessage() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -115,6 +115,14 @@ message OsEvent {
   // Takes no inputs
 }
 
+// Information on "rename" event in repository_ctx.
+message RenameEvent {
+  // The path of the existing file or directory to rename.
+  string src = 1;
+  // The new name of the file or directory.
+  string dst = 2;
+}
+
 // Information on "symlink" event in repository_ctx.
 message SymlinkEvent {
   // path to which the symlink will point to
@@ -162,5 +170,6 @@ message WorkspaceEvent {
     ReadEvent read_event = 12;
     DeleteEvent delete_event = 13;
     PatchEvent patch_event = 14;
+    RenameEvent rename_event = 15;
   }
 }


### PR DESCRIPTION
This allows the directory structure of third-party archives to be rearranged without platform-specific commands, and without requiring symlink support from the platform.

Closes #24020.

PiperOrigin-RevId: 694246834
Change-Id: I4831d610c5fb841640af1b1b864172ee38319a6b

Commit https://github.com/bazelbuild/bazel/commit/467ea0cd6e6189e73991f3344d108883e0cf5dd3