### PR TITLE
[8.0.0] Match --worker_extra_flag against the worker key mnemonic, not the action mnemonic, as is the case for other worker flags taking a mnemonic.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -211,7 +211,7 @@ public class WorkerParser {
     ImmutableList.Builder<String> mnemonicFlags = ImmutableList.builder();
 
     workerOptions.workerExtraFlags.stream()
-        .filter(entry -> entry.getKey().equals(spawn.getMnemonic()))
+        .filter(entry -> entry.getKey().equals(Spawns.getWorkerKeyMnemonic(spawn)))
         .forEach(entry -> mnemonicFlags.add(entry.getValue()));
 
     return workerArgs.add("--persistent_worker").addAll(mnemonicFlags.build()).build();

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorker.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorker.java
@@ -125,6 +125,7 @@ public final class ExampleWorker {
 
   public static void main(String[] args) throws Exception {
     if (ImmutableSet.copyOf(args).contains("--persistent_worker")) {
+      System.err.printf("Worker args: %s\n", String.join(" ", args));
       OptionsParser parser =
           OptionsParser.builder()
               .optionsClasses(ExampleWorkerOptions.class)

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
@@ -78,6 +78,7 @@ public class ExampleWorkerMultiplexer {
 
   public static void main(String[] args) throws Exception {
     if (ImmutableSet.copyOf(args).contains("--persistent_worker")) {
+      System.err.printf("Worker args: %s\n", String.join(" ", args));
       OptionsParser parser =
           OptionsParser.builder()
               .optionsClasses(ExampleWorkerMultiplexerOptions.class)

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerOptions.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerOptions.java
@@ -163,6 +163,14 @@ public class ExampleWorkerOptions extends OptionsBase {
       help = "Don't send a response until receiving a cancel request.")
   public boolean waitForCancel;
 
+  @Option(
+      name = "ignored_argument",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "false",
+      help = "An argument that does nothing, but whose presence can be asserted in a test.")
+  public boolean ignoredArgument;
+
   /** Enum converter for --worker_protocol. */
   public static class WorkerProtocolEnumConverter
       extends EnumConverter<ExecutionRequirements.WorkerProtocolFormat> {


### PR DESCRIPTION
Fixes #24237.

RELNOTES[INC]: The mnemonic passed to --worker_extra_flag is now matched against the worker key mnemonic when one is available, instead of the action mnemonic. This makes it consistent with other worker flags taking a mnemonic.

PiperOrigin-RevId: 694436563
Change-Id: I7c6e6ede5e3ef2f53aeb847bbfe173042c528d68

Commit https://github.com/bazelbuild/bazel/commit/8357fbab5c8e5a1125b68fce6dc790c73dbf31ce