### PR TITLE
[Doc] Fix indirection link to --run_under

### DIFF
--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -1757,7 +1757,7 @@ a user-friendly way.
 
 ### Options for `bazel run` {:#bazel-run-options}
 
-#### `--run_under={{ "<var>" }}command-prefix{{ "</var>" }}` {:#run-under}
+#### `--run_under={{ "<var>" }}command-prefix{{ "</var>" }}` {:#run-run-under}
 
 This has the same effect as the `--run_under` option for
 `bazel test` ([see above](#run-under)),

--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -1659,7 +1659,7 @@ command.
 The environment can be accessed from within a test by using
 `System.getenv("var")` (Java), `getenv("var")` (C or C++),
 
-#### `--run_under={{ "<var>" }}command-prefix{{ "</var>" }}` {:#run_under}
+#### `--run_under={{ "<var>" }}command-prefix{{ "</var>" }}` {:#test-run-under}
 
 This specifies a prefix that the test runner will insert in front
 of the test command before running it. The
@@ -1760,7 +1760,7 @@ a user-friendly way.
 #### `--run_under={{ "<var>" }}command-prefix{{ "</var>" }}` {:#run-run-under}
 
 This has the same effect as the `--run_under` option for
-`bazel test` ([see above](#run-under)),
+`bazel test` ([see above](#test-run-under)),
 except that it applies to the command being run by `bazel
 run` rather than to the tests being run by `bazel test`
 and cannot run under label.


### PR DESCRIPTION
Change the anchor of `bazel run --run_under` to not collide with the label for `bazel test --run_under`.