### PR TITLE
[8.0.0] Handle unresolved symlinks correctly when replacing an existing entry in a runfiles tree.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeHelperTest.java
@@ -15,25 +15,44 @@
 package com.google.devtools.build.lib.exec;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.testutil.TestConstants.WORKSPACE_NAME;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.shell.Command;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import java.util.HashMap;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link SymlinkTreeHelper}. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public final class SymlinkTreeHelperTest {
+
   private final FileSystem fs = new InMemoryFileSystem(DigestHashFunction.SHA256);
+  private final Path execRoot = fs.getPath("/execroot");
+  private final ArtifactRoot outputRoot =
+      ArtifactRoot.asDerivedRoot(execRoot, RootType.Output, "out");
+
+  @Before
+  public void setUp() throws Exception {
+    outputRoot.getRoot().asPath().createDirectoryAndParents();
+  }
 
   @Test
   public void checkCreatedSpawn() {
@@ -103,5 +122,49 @@ public final class SymlinkTreeHelperTest {
             execRoot.getRelative("path"),
             PathFragment.create("workspace2/rel2"),
             PathFragment.create("/path"));
+  }
+
+  @Test
+  public void createSymlinksDirectly(@TestParameter boolean replace) throws Exception {
+    Path treeRoot = execRoot.getRelative("foo.runfiles");
+    Path inputManifestPath = execRoot.getRelative("foo.runfiles_manifest");
+    SymlinkTreeHelper helper =
+        new SymlinkTreeHelper(execRoot, inputManifestPath, treeRoot, false, WORKSPACE_NAME);
+
+    Artifact file = ActionsTestUtil.createArtifact(outputRoot, "file");
+    Artifact symlink = ActionsTestUtil.createUnresolvedSymlinkArtifact(outputRoot, "symlink");
+
+    FileSystemUtils.writeContent(file.getPath(), UTF_8, "content");
+    FileSystemUtils.ensureSymbolicLink(symlink.getPath(), "/path/to/target");
+
+    HashMap<PathFragment, Artifact> symlinkMap = new HashMap<>();
+    symlinkMap.put(PathFragment.create(WORKSPACE_NAME + "/empty"), null);
+    symlinkMap.put(PathFragment.create(WORKSPACE_NAME + "/file"), file);
+    symlinkMap.put(PathFragment.create(WORKSPACE_NAME + "/symlink"), symlink);
+
+    Path treeWorkspace = treeRoot.getRelative(WORKSPACE_NAME);
+    Path treeEmpty = treeWorkspace.getRelative("empty");
+    Path treeFile = treeWorkspace.getRelative("file");
+    Path treeSymlink = treeWorkspace.getRelative("symlink");
+    Path treeMissing = treeWorkspace.getRelative("missing");
+
+    if (replace) {
+      treeEmpty.createDirectoryAndParents();
+      treeFile.createDirectoryAndParents();
+      treeSymlink.createDirectoryAndParents();
+      treeMissing.createDirectoryAndParents();
+    }
+
+    helper.createSymlinksDirectly(symlinkMap);
+
+    assertThat(treeRoot.isDirectory()).isTrue();
+    assertThat(treeWorkspace.isDirectory()).isTrue();
+    assertThat(treeEmpty.isFile()).isTrue();
+    assertThat(FileSystemUtils.readContent(treeEmpty)).isEmpty();
+    assertThat(treeFile.isSymbolicLink()).isTrue();
+    assertThat(treeFile.readSymbolicLink()).isEqualTo(file.getPath().asFragment());
+    assertThat(treeSymlink.isSymbolicLink()).isTrue();
+    assertThat(treeSymlink.readSymbolicLink()).isEqualTo(PathFragment.create("/path/to/target"));
+    assertThat(treeMissing.exists()).isFalse();
   }
 }


### PR DESCRIPTION
This edge case was missing from https://github.com/bazelbuild/bazel/commit/51d7a3c7e549780a7f162bfe6525fffc4c529ae0.

Also add minimal unit test coverage for in-process symlink creation.

PiperOrigin-RevId: 694504600
Change-Id: Ida73afa1ce5730e885bc970eafd07211d1816e93