### PR TITLE
[8.0.0] Symbolic macro attribute inheritance

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -109,6 +109,7 @@ import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.skyframe.BzlLoadValue;
 import com.google.devtools.build.lib.skyframe.serialization.AbstractExportedStarlarkSymbolCodec;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
+import com.google.devtools.build.lib.starlarkbuildapi.MacroFunctionApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkRuleFunctionsApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkSubruleApi;
 import com.google.devtools.build.lib.starlarkbuildapi.config.ConfigurationTransitionApi;
@@ -214,6 +215,8 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
 
   public static final ImmutableSet<AllowlistEntry> ALLOWLIST_RULE_EXTENSION_API_EXPERIMENTAL =
       ImmutableSet.of(allowlistEntry("", "initializer_testing/builtins"));
+
+  private static final String COMMON_ATTRIBUTES_NAME = "common";
 
   /** Parent rule class for test Starlark rules. */
   public static RuleClass getTestBaseRule(RuleDefinitionEnvironment env) {
@@ -356,9 +359,10 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
   }
 
   @Override
-  public StarlarkCallable macro(
+  public MacroFunctionApi macro(
       StarlarkFunction implementation,
       Dict<?, ?> attrs,
+      Object inheritAttrs,
       boolean finalizer,
       Object doc,
       StarlarkThread thread)
@@ -373,17 +377,38 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     }
 
     MacroClass.Builder builder = new MacroClass.Builder(implementation);
-    // "name" and "visibility" attributes are added automatically by the builder.
-    for (Map.Entry<String, Descriptor> descriptorEntry :
-        Dict.cast(attrs, String.class, Descriptor.class, "attrs").entrySet()) {
-      String attrName = descriptorEntry.getKey();
-      Descriptor descriptor = descriptorEntry.getValue();
+    for (Map.Entry<?, ?> uncheckedEntry : attrs.entrySet()) {
+      String attrName;
+      @Nullable Descriptor descriptor;
+      try {
+        // Dict.cast() does not support none-able values - so we type-check manually, and translate
+        // Starlark None to Java null.
+        attrName = (String) uncheckedEntry.getKey();
+        checkAttributeName(attrName);
+        descriptor =
+            uncheckedEntry.getValue() != Starlark.NONE
+                ? (Descriptor) uncheckedEntry.getValue()
+                : null;
+      } catch (
+          @SuppressWarnings("UnusedException")
+          ClassCastException e) {
+        throw Starlark.errorf(
+            "got dict<%s, %s> for 'attrs', want dict<string, Attribute|None>",
+            Starlark.type(uncheckedEntry.getKey()), Starlark.type(uncheckedEntry.getValue()));
+      }
 
+      // "name" and "visibility" attributes are added automatically by the builder.
       if (MacroClass.RESERVED_MACRO_ATTR_NAMES.contains(attrName)) {
         throw Starlark.errorf("Cannot declare a macro attribute named '%s'", attrName);
       }
 
+      if (descriptor == null) {
+        // a None descriptor should ignored.
+        continue;
+      }
+
       if (!descriptor.getValueSource().equals(AttributeValueSource.DIRECT)) {
+        // Note that inherited native attributes may have a computed default, e.g. testonly.
         throw Starlark.errorf(
             "In macro attribute '%s': Macros do not support computed defaults or late-bound"
                 + " defaults",
@@ -392,6 +417,20 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
 
       Attribute attr = descriptor.build(attrName);
       builder.addAttribute(attr);
+    }
+    for (Attribute attr : getInheritedAttrs(inheritAttrs)) {
+      String attrName = attr.getName();
+      if (attr.isPublic()
+          // isDocumented() is false only for generator_* magic attrs (for which isPublic() is true)
+          && attr.isDocumented()
+          && !MacroClass.RESERVED_MACRO_ATTR_NAMES.contains(attrName)
+          && !attrs.containsKey(attrName)) {
+        builder.addAttribute(attr);
+      }
+    }
+    if (inheritAttrs != Starlark.NONE && !implementation.hasKwargs()) {
+      throw Starlark.errorf(
+          "If inherit_attrs is set, implementation function must have a **kwargs parameter");
     }
 
     if (finalizer) {
@@ -402,6 +441,22 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
         builder,
         Starlark.toJavaOptional(doc, String.class).map(Starlark::trimDocString),
         getBzlKeyToken(thread, "Macros"));
+  }
+
+  private static ImmutableList<Attribute> getInheritedAttrs(Object inheritAttrs)
+      throws EvalException {
+    if (inheritAttrs == Starlark.NONE) {
+      return ImmutableList.of();
+    } else if (inheritAttrs instanceof RuleFunction ruleFunction) {
+      return ruleFunction.getRuleClass().getAttributes();
+    } else if (inheritAttrs instanceof MacroFunction macroFunction) {
+      return macroFunction.getMacroClass().getAttributes().values().asList();
+    } else if (inheritAttrs.equals(COMMON_ATTRIBUTES_NAME)) {
+      return baseRule.getAttributes();
+    }
+    throw Starlark.errorf(
+        "Invalid 'inherit_attrs' value %s; expected a rule, a macro, or \"common\"",
+        Starlark.repr(inheritAttrs));
   }
 
   private static Symbol<BzlLoadValue.Key> getBzlKeyToken(StarlarkThread thread, String onBehalfOf) {
@@ -1315,7 +1370,9 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
    * <p>This object is not usable until it has been {@link #export exported}. Calling an unexported
    * macro function results in an {@link EvalException}.
    */
-  public static final class MacroFunction implements StarlarkExportable, StarlarkCallable {
+  // Ideally, we'd want to merge this with {@link MacroFunctionApi}, but that would cause a circular
+  // dependency between packages and starlarkbuildapi.
+  public static final class MacroFunction implements StarlarkExportable, MacroFunctionApi {
 
     // Initially non-null, then null once exported.
     @Nullable private MacroClass.Builder builder;

--- a/src/main/java/com/google/devtools/build/lib/packages/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/packages/BUILD
@@ -46,15 +46,16 @@ java_library(
     srcs = glob(
         ["*.java"],
         exclude = [
+            "AutoloadSymbols.java",
             "BuilderFactoryForTesting.java",  # see builder_factory_for_testing
             "BzlVisibility.java",
+            "ConfiguredAttributeMapper.java",
+            "ExecGroup.java",
             "Globber.java",
             "GlobberUtils.java",
-            "ExecGroup.java",
-            "ConfiguredAttributeMapper.java",
             "LabelPrinter.java",
             "PackageSpecification.java",
-            "AutoloadSymbols.java",
+            "RuleClassUtils.java",
         ],
     ),
     deps = [
@@ -207,5 +208,18 @@ java_library(
     srcs = ["RuleClassId.java"],
     deps = [
         "//third_party:auto_value",
+    ],
+)
+
+java_library(
+    name = "rule_class_utils",
+    srcs = ["RuleClassUtils.java"],
+    deps = [
+        ":packages",
+        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:starlark_builtins_value",
+        "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi",
+        "//src/main/java/net/starlark/java/eval",
+        "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
@@ -273,11 +273,14 @@ public final class MacroClass {
         throw Starlark.errorf(
             "missing value for mandatory attribute '%s' in '%s' macro", attr.getName(), name);
       } else {
-        // Already validated at schema creation time that the default is not a computed default or
-        // late-bound default
         Object defaultValue = attr.getDefaultValueUnchecked();
-        if (defaultValue == null) {
-          // Null values can occur for some types of attributes (e.g. LabelType).
+        if (defaultValue == null || forceDefaultToNone(attr)) {
+          // Set the default value as None if:
+          // 1. The native attribute value is null (e.g. LabelType); or
+          // 2. The attribute is an inherited non-Starlark-defined attribute and with a non-direct
+          // default or is a legacy native type.
+          // Note that for Starlark-defined attributes, we already validated at schema creation time
+          // that the default is not a computed default or late-bound default.
           defaultValue = Starlark.NONE;
         }
         attrValues.put(attr.getName(), defaultValue);
@@ -292,6 +295,10 @@ public final class MacroClass {
       String attrName = entry.getKey();
       Object value = entry.getValue();
       Attribute attribute = attributes.get(attrName);
+      if (value.equals(Starlark.NONE) && forceDefaultToNone(attribute)) {
+        // Skip normalization, since None may violate the attribute's type checking.
+        continue;
+      }
       Object normalizedValue =
           // copyAndLiftStarlarkValue ensures immutability.
           BuildType.copyAndLiftStarlarkValue(
@@ -315,6 +322,23 @@ public final class MacroClass {
             : parentMacroFrame.macroInstance.getSameNameDepth() + 1;
 
     return pkgBuilder.createMacro(this, attrValues, sameNameDepth);
+  }
+
+  /**
+   * Returns true if the given inherited attribute should be forced to have a default value of
+   * {@code None}, skipping usual normalization.
+   *
+   * <p>This is the case for non-direct defaults and legacy licenses and distribs attributes,
+   * because None may (depending on attribute type) violate type checking - and that is ok, since
+   * the macro implementation will pass the None to the rule function, which will then set the
+   * default as expected.
+   */
+  private static boolean forceDefaultToNone(Attribute attr) {
+    return attr.hasComputedDefault()
+        || attr.isLateBound()
+        || attr.isMaterializing()
+        || attr.getType() == BuildType.LICENSE
+        || attr.getType() == BuildType.DISTRIBUTIONS;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -2083,7 +2083,7 @@ public class RuleClass implements RuleClassData {
    * Returns an (immutable) list of all Attributes defined for this class of rule, ordered by
    * increasing index.
    */
-  public List<Attribute> getAttributes() {
+  public ImmutableList<Attribute> getAttributes() {
     return attributes;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClassUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClassUtils.java
@@ -1,0 +1,79 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.packages;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
+import com.google.devtools.build.lib.skyframe.StarlarkBuiltinsValue;
+import com.google.devtools.build.lib.starlarkbuildapi.MacroFunctionApi;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Map;
+import net.starlark.java.eval.StarlarkFunction;
+
+/** Rule class utilities. */
+public final class RuleClassUtils {
+
+  /**
+   * Returns the sorted list of all builtin rule classes.
+   *
+   * <p>Unlike {@link RuleClassProvider#getRuleClassMap}, this method returns real Starlark builtins
+   * instead of stub overridden native rules.
+   *
+   * @param includeMacroWrappedRules if true, include rule classes for rules wrapped in macros.
+   */
+  public static ImmutableList<RuleClass> getBuiltinRuleClasses(
+      StarlarkBuiltinsValue builtins,
+      RuleClassProvider ruleClassProvider,
+      boolean includeMacroWrappedRules) {
+    ImmutableMap<String, RuleClass> nativeRuleClasses = ruleClassProvider.getRuleClassMap();
+    // The conditional for selecting whether or not to load symbols from @_builtins is the same as
+    // in PackageFunction.compileBuildFile
+    if (builtins
+        .starlarkSemantics
+        .get(BuildLanguageOptions.EXPERIMENTAL_BUILTINS_BZL_PATH)
+        .isEmpty()) {
+      return ImmutableList.sortedCopyOf(
+          Comparator.comparing(RuleClass::getName), nativeRuleClasses.values());
+    } else {
+      ArrayList<RuleClass> ruleClasses = new ArrayList<>(builtins.predeclaredForBuild.size());
+      for (Map.Entry<String, Object> entry : builtins.predeclaredForBuild.entrySet()) {
+        if (entry.getValue() instanceof RuleFunction) {
+          ruleClasses.add(((RuleFunction) entry.getValue()).getRuleClass());
+        } else if ((entry.getValue() instanceof StarlarkFunction
+                || entry.getValue() instanceof MacroFunctionApi)
+            && includeMacroWrappedRules) {
+          // entry.getValue() is a macro in @_builtins which overrides a native rule and wraps a
+          // instantiation of a rule target. We cannot get at that main target's rule class
+          // directly, so we attempt heuristics.
+          // Note that we do not rely on the StarlarkFunction or MacroFunction object's name because
+          // the name under which the macro was defined may not match the name under which
+          // @_builtins re-exported it.
+          if (builtins.exportedToJava.containsKey(entry.getKey() + "_rule_function")) {
+            ruleClasses.add(
+                ((RuleFunction) builtins.exportedToJava.get(entry.getKey() + "_rule_function"))
+                    .getRuleClass());
+          } else if (nativeRuleClasses.containsKey(entry.getKey())) {
+            ruleClasses.add(nativeRuleClasses.get(entry.getKey()));
+          }
+        }
+      }
+      return ImmutableList.sortedCopyOf(Comparator.comparing(RuleClass::getName), ruleClasses);
+    }
+  }
+
+  private RuleClassUtils() {}
+}

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleFunction.java
@@ -14,22 +14,11 @@
 
 package com.google.devtools.build.lib.packages;
 
-import com.google.devtools.build.docgen.annot.DocCategory;
-import net.starlark.java.annot.StarlarkBuiltin;
-import net.starlark.java.eval.StarlarkCallable;
+import com.google.devtools.build.lib.starlarkbuildapi.RuleFunctionApi;
 
 /** Interface for a native or Starlark rule function. */
-@StarlarkBuiltin(
-    name = "rule",
-    category = DocCategory.BUILTIN,
-    doc =
-        """
-        A callable value representing the type of a native or Starlark rule (created by \
-        <a href="../globals/bzl.html#rule"><code>rule()</code></a>). Calling the value during \
-        evaluation of a package's BUILD file creates an instance of the rule and adds it to the \
-        package's target set. For more information, visit this page about \
-        <a href ="https://bazel.build/extending/rules">Rules</a>.
-        """)
-public interface RuleFunction extends StarlarkCallable {
+// Ideally, this interface should be merged with RuleFunctionApi, but that would cause a circular
+// dependency between packages and starlarkbuildapi.
+public interface RuleFunction extends RuleFunctionApi {
   RuleClass getRuleClass();
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BUILD
@@ -24,6 +24,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/packages:rule_class_utils",
         "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/MacroFunctionApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/MacroFunctionApi.java
@@ -1,0 +1,36 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.starlarkbuildapi;
+
+import com.google.devtools.build.docgen.annot.DocCategory;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.eval.StarlarkCallable;
+
+/** The interface for a Starlark symbolic macro. */
+@StarlarkBuiltin(
+    name = "macro",
+    category = DocCategory.BUILTIN,
+    doc =
+        """
+A callable Starlark value representing a symbolic macro; in other words, the return value of
+<a href="../globals/bzl.html#macro"><code>macro()</code></a>. Invoking this value during package
+construction time will instantiate the macro, and cause the macro's implementation function to be
+evaluated (in a separate context, different from the context in which the macro value was invoked),
+in most cases causing targets to be added to the package's target set. For more information, see
+<a href="https://bazel.build/extending/macros">Macros</a>.
+""")
+// Ideally, this interface should be merged with MacroFunction, but that would cause a circular
+// dependency between packages and starlarkbuildapi.
+public interface MacroFunctionApi extends StarlarkCallable {}

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/RuleFunctionApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/RuleFunctionApi.java
@@ -1,0 +1,35 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.starlarkbuildapi;
+
+import com.google.devtools.build.docgen.annot.DocCategory;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.eval.StarlarkCallable;
+
+/** Interface for a native or Starlark rule function. */
+@StarlarkBuiltin(
+    name = "rule",
+    category = DocCategory.BUILTIN,
+    doc =
+        """
+        A callable value representing the type of a native or Starlark rule (created by
+        <a href="../globals/bzl.html#rule"><code>rule()</code></a>). Calling the value during
+        evaluation of a package's BUILD file creates an instance of the rule and adds it to the
+        package's target set. For more information, visit this page about
+        <a href ="https://bazel.build/extending/rules">Rules</a>.
+        """)
+// Ideally, this interface should be merged with RuleFunction, but that would cause a circular
+// dependency between packages and starlarkbuildapi.
+public interface RuleFunctionApi extends StarlarkCallable {}

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -218,9 +218,12 @@ public interface StarlarkRuleFunctionsApi {
             defaultValue = "{}",
             doc =
                 """
-A dictionary of the attributes this macro supports, analogous to <a href="#rule.attrs">rule.attrs
-</a>. Keys are attribute names, and values are attribute objects like <code>attr.label_list(...)
-</code> (see the <a href=\"../toplevel/attr.html\">attr</a> module).
+A dictionary of the attributes this macro supports, analogous to
+<a href="#rule.attrs">rule.attrs</a>. Keys are attribute names, and values are either attribute
+objects like <code>attr.label_list(...)</code> (see the <a href=\"../toplevel/attr.html\">attr</a>
+module), or <code>None</code>. A <code>None</code> entry means that the macro does not have an
+attribute by that name, even if it would have otherwise inherited one via <code>inherit_attrs</code>
+(see below).
 
 <p>The special <code>name</code> attribute is predeclared and must not be included in the
 dictionary. The <code>visibility</code> attribute name is reserved and must not be included in the
@@ -248,6 +251,70 @@ site of the rule. Such attributes can be assigned a default value (as in
 </ul>
 
 <p>To limit memory usage, there is a cap on the number of attributes that may be declared.
+"""),
+        @Param(
+            name = "inherit_attrs",
+            allowedTypes = {
+              @ParamType(type = RuleFunctionApi.class),
+              @ParamType(type = MacroFunctionApi.class),
+              @ParamType(type = String.class),
+              @ParamType(type = NoneType.class)
+            },
+            positional = false,
+            named = true,
+            defaultValue = "None",
+            doc =
+                """
+A rule symbol, macro symbol, or the name of a built-in common attribute list (see below) from which
+the macro should inherit attributes.
+
+<p>If <code>inherit_attrs</code> is set, the macro's implementation function <em>must</em> have a
+<code>**kwargs</code> residual keyword parameter.
+
+<p>If <code>inherit_attrs</code> is set to the string <code>"common"</code>, the macro will inherit
+<a href="/reference/be/common-definitions#common-attributes">common rule attribute definitions</a>
+used by all Starlark rules.
+
+<p>By convention, a macro should pass inherited, non-overridden attributes unchanged to the "main"
+rule or macro symbol which the macro is wrapping. Typically, most inherited attributes will not have
+a parameter in the implementation function's parameter list, and will simply be passed via
+<code>**kwargs</code>. However, it may be convenient for the implementation function to have
+explicit parameters for some inherited attributes (most commonly, <code>tags</code> and
+<code>testonly</code>) if the macro needs to pass those attributes to both "main" and non-"main"
+targets.
+
+<p>The inheritance mechanism works as follows:</p>
+<ol>
+  <li>The special <code>name</code> and <code>visibility</code> attributes are never inherited;
+  <li>Hidden attributes (ones whose name starts with <code>"_"</code>) are never inherited;
+  <li>The remaining inherited attributes are merged with the <code>attrs</code> dictionary, with
+    the entries in <code>attrs</code> dictionary taking precedence in case of conflicts.
+</ol>
+
+<p>For example, the following macro inherits all attributes from <code>native.cc_library</code>, except
+for <code>cxxopts</code> (which is removed from the attribute list) and <code>copts</code> (which is
+given a new definition):
+
+<pre class="language-python">
+def _my_cc_library_impl(name, visibility, **kwargs):
+    ...
+
+my_cc_library = macro(
+    implementation = _my_cc_library_impl,
+    inherit_attrs = native.cc_library,
+    attrs = {
+        "cxxopts": None,
+        "copts": attr.string_list(default = ["-D_FOO"]),
+    },
+)
+</pre>
+
+<p>Note that a macro may inherit a non-hidden attribute with a computed default (for example,
+<a href="/reference/be/common-definitions#common.testonly"><code>testonly</code></a>); normally,
+macros do not allow attributes with computed defaults. If such an attribute is unset in a macro
+invocation, the value passed to the implementation function will be <code>None</code>, and the
+<code>None</code> may be safely passed on to the corresponding attribute of a rule target, causing
+the rule to compute the default as expected.
 """),
         // TODO: #19922 - Make a concepts page for symbolic macros, migrate some details like the
         // list of disallowed APIs to there.
@@ -288,9 +355,10 @@ targets defined by any rule finalizer, including this one.
                     + "tools.")
       },
       useStarlarkThread = true)
-  StarlarkCallable macro(
+  MacroFunctionApi macro(
       StarlarkFunction implementation,
       Dict<?, ?> attrs,
+      Object inheritAttrs,
       boolean finalizer,
       Object doc,
       StarlarkThread thread)

--- a/src/test/java/com/google/devtools/build/docgen/StarlarkDocumentationTest.java
+++ b/src/test/java/com/google/devtools/build/docgen/StarlarkDocumentationTest.java
@@ -54,8 +54,7 @@ import org.junit.runners.JUnit4;
 public class StarlarkDocumentationTest {
 
   private static final ImmutableList<String>
-      DEPRECATED_OR_EXPERIMENTAL_UNDOCUMENTED_TOP_LEVEL_SYMBOLS =
-          ImmutableList.of("Actions", "macro");
+      DEPRECATED_OR_EXPERIMENTAL_UNDOCUMENTED_TOP_LEVEL_SYMBOLS = ImmutableList.of("Actions");
 
   private static final StarlarkDocExpander expander =
       new StarlarkDocExpander(null) {

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BUILD
@@ -95,6 +95,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/packages:configured_attribute_mapper",
+        "//src/main/java/com/google/devtools/build/lib/packages:rule_class_utils",
         "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/local_repository_rule",

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis.util;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
@@ -132,7 +133,9 @@ import com.google.devtools.build.lib.packages.PackageOverheadEstimator;
 import com.google.devtools.build.lib.packages.PackageValidator;
 import com.google.devtools.build.lib.packages.RawAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
+import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClassProvider;
+import com.google.devtools.build.lib.packages.RuleClassUtils;
 import com.google.devtools.build.lib.packages.StarlarkInfo;
 import com.google.devtools.build.lib.packages.StarlarkProvider;
 import com.google.devtools.build.lib.packages.Target;
@@ -702,6 +705,21 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
         reporter,
         env,
         starlarkBuiltinsValue);
+  }
+
+  /**
+   * Returns the sorted list of all rule classes available in builtins, following the logic of
+   * {@code bazel info build-language}.
+   *
+   * @param includeMacroWrappedRules if true, include rule classes for rules wrapped in macros.
+   */
+  protected ImmutableList<RuleClass> getBuiltinRuleClasses(boolean includeMacroWrappedRules)
+      throws Exception {
+    SkyFunction.Environment env = new SkyFunctionEnvironmentForTesting(reporter, skyframeExecutor);
+    StarlarkBuiltinsValue builtins =
+        (StarlarkBuiltinsValue) checkNotNull(env.getValue(StarlarkBuiltinsValue.key()));
+    return RuleClassUtils.getBuiltinRuleClasses(
+        builtins, ruleClassProvider, includeMacroWrappedRules);
   }
 
   /**


### PR DESCRIPTION
Allows the following syntax:

```
my_cc_library = macro(
    # inherit all attributes from a given rule or macro symbol (or "common" for
    # the set of common Starlark rule attributes)
    inherit_attrs = native.cc_library,
    attrs = {
        # remove cxxopts from inherited attrs list
        "cxxopts": None,
        # override the copts attribute inherited from native.cc_library
        "copts": attr.string_list(default = ["-D_FOO"]),
    },
    ...
)
```

Fixes https://github.com/bazelbuild/bazel/issues/24066

Tricky parts:
* Some common rule attributes ("testonly", "size", etc.) have computed defaults;
  native rule "license" and "distribs" attrs have defaults which fail type check if
  lifted. The only sane way of handling such attrs, if the attribute is unset in
  the macro function call, to pass the value as None to the implementation function
  so that the implementation function will pass None to the rule function, which
  will thus set the default appropriately.
* We need RuleFunctionApi and MacroFunctionApi interfaces (yet more interfaces,
  alas, or we get a circular dependency) to express the type of inherit_attrs param
* Iterating over all native rules (for testing inheritance from them) is tricky: we
  need to look at builtins (since the ConfiguredRuleClassProvider may have stubs for
  java rules overridden by builtins). This is already correctly handled by
  `bazel info build-language`, so let's move the logic into a utility class.

RELNOTES: Add inherit_attrs param to macro() to allow symbolic macros to
inherit attributes from rules or other symbolic macros.
PiperOrigin-RevId: 694154352
Change-Id: I849a7f16b4da8eb2829cdbc6a131d85a28bc4740

Commit https://github.com/bazelbuild/bazel/commit/eec5305db8e9c495951aaeda6c45d504fe95cee5