### PR TITLE
Use `java_proto_library` from `@proto` to match the `proto_library` f…

### DIFF
--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -1,4 +1,5 @@
 load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@protobuf//bazel:py_proto_library.bzl", "py_proto_library")
 load("//third_party/grpc:build_defs.bzl", "java_grpc_library")


### PR DESCRIPTION
…rom `@proto`, otherwise the `ProtoInfo` providers don't match:

`in deps attribute of java_proto_library rule @@bazel_tools//src/main/protobuf:java_compilation_java_proto: '@@bazel_tools//src/main/protobuf:java_compilation_proto' does not have mandatory providers: 'ProtoInfo'`

PiperOrigin-RevId: 695525449
Change-Id: Idf30a8ac1838409d39bb17822830be63115148d2