### PR TITLE
[8.0.0] Bazel bootstrap: use MODULE.bazel to get the version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@
 
 module(
     name = "bazel",
+    version = "8.0.0",
     repo_name = "io_bazel",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -253,7 +253,7 @@
     "@@googleapis+//:extensions.bzl%switched_rules": {
       "general": {
         "bzlTransitiveDigest": "vG6fuTzXD8MMvHWZEQud0MMH7eoC4GXY0va7VrFFh04=",
-        "usagesDigest": "uYQNfFrBVxWtH6yUF3NICvGxQi7HVUcOL/ibsn4/BWc=",
+        "usagesDigest": "j8fHsgO+aNMh/Z+YD89CYnrB0Auw7X8No5mV6rskRlE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1268,7 +1268,7 @@
     "@@rules_graalvm+//:extensions.bzl%graalvm": {
       "general": {
         "bzlTransitiveDigest": "h5NoLe6qf+ziboLGAdcXrD+fgwCizx5PmMd0VH19SXY=",
-        "usagesDigest": "9ti2DgD4vux69Lw+Y5sosEyWg4oi/gn5Z/rh7kXzpDY=",
+        "usagesDigest": "Bm/wfVXwbTI4i7wzT0+ghwVWZb+0rwPnPZQkXZoAcVE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1306,7 +1306,7 @@
     "@@rules_jvm_external+//:extensions.bzl%maven": {
       "general": {
         "bzlTransitiveDigest": "6gDYyySuiGewh893nm2Hweq//l1UzIzMRE42K/CxHdc=",
-        "usagesDigest": "jW5Zm/JG2f6S1+udGjUnWyD+iuZEqVmoV1dZ/Rpn+1c=",
+        "usagesDigest": "ianLViHd9awrCPzKwZSGPYrPkoTOokyDOWGy3yk6kAE=",
         "recordedFileInputs": {
           "@@rules_jvm_external+//rules_jvm_external_deps_install.json": "cafb5d2d8119391eb2b322ce3840d3352ea82d496bdb8cbd4b6779ec4d044dda",
           "@@stardoc+//maven_install.json": "25f3c138ca52c61e0e7a564fe21f5709261b33d78d35427b6c18d7aa202d973b",

--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -265,9 +265,8 @@ function git_date() {
 # Get the latest release version and append the date of
 # the last commit if any.
 function get_last_version() {
-  if [ -f "CHANGELOG.md" ]; then
-    local version="$(fgrep -m 1 '## Release' CHANGELOG.md \
-                       | sed -E 's|.*Release (.*) \(.*\)|\1|')"
+  if [ -f "MODULE.bazel" ]; then
+    local version=$(grep "version =" MODULE.bazel | head -n 1 | sed 's/.*version = "\(.*\)".*/\1/' | cut -d '"' -f2)
   else
     local version=""
   fi


### PR DESCRIPTION
This is more reliable than parsing CHANGELOG.md, which is not always the latest.

This requires us to maintain the Bazel version number in MODULE.bazel, which should be updated once a year on the master branch, but every time we do a minor/patch release.

PiperOrigin-RevId: 695747413
Change-Id: I63d572445d8cb6a76a3e079c2ea6f083257216b0