### PR TITLE
Get MODULE.bazel from patches of archive_override/git_override

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -611,6 +611,7 @@ public class ModuleFileFunction implements SkyFunction {
       // A module with a non-registry override always has a unique version across the entire dep
       // graph.
       RepositoryName canonicalRepoName = key.getCanonicalRepoNameWithoutVersion();
+
       Label moduleFileLabel =
           Label.createUnvalidated(
               PackageIdentifier.create(canonicalRepoName, PathFragment.EMPTY_FRAGMENT),
@@ -738,6 +739,7 @@ public class ModuleFileFunction implements SkyFunction {
       throws InterruptedException, ModuleFileFunctionException {
     var moduleFile =
         moduleFileBytes == null ? null : ModuleFile.create(moduleFileBytes, moduleFileLocation);
+
     ImmutableList<Label> patches;
     int patchStrip;
     switch (override) {
@@ -757,6 +759,7 @@ public class ModuleFileFunction implements SkyFunction {
         return moduleFile;
       }
     }
+
     var patchesInMainRepo =
         patches.stream().filter(label -> label.getRepository().isMain()).collect(toImmutableList());
     if (patchesInMainRepo.isEmpty()) {
@@ -823,8 +826,7 @@ public class ModuleFileFunction implements SkyFunction {
       }
       for (var patchPath : patchPaths) {
         try {
-          PatchUtil.applyToSingleFile(
-              patchPath.asPath(), patchStrip, moduleRoot, moduleFilePath, moduleFileBytes != null);
+          PatchUtil.applyToSingleFile(patchPath.asPath(), patchStrip, moduleRoot, moduleFilePath);
         } catch (PatchFailedException e) {
           throw errorf(
               Code.BAD_MODULE,

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -611,6 +611,26 @@ public class ModuleFileFunction implements SkyFunction {
       // A module with a non-registry override always has a unique version across the entire dep
       // graph.
       RepositoryName canonicalRepoName = key.getCanonicalRepoNameWithoutVersion();
+      Label moduleFileLabel =
+          Label.createUnvalidated(
+              PackageIdentifier.create(canonicalRepoName, PathFragment.EMPTY_FRAGMENT),
+              LabelConstants.MODULE_DOT_BAZEL_FILE_NAME.getBaseName());
+
+      // Try to extract a MODULE.bazel file from the patches without
+      // triggering the underlying repository rule.
+      ModuleFile moduleFileFromPatches = maybePatchModuleFile(
+          null,
+          moduleFileLabel.getUnambiguousCanonicalForm(),
+          override,
+          env);
+      if (moduleFileFromPatches != null) {
+        return new GetModuleFileResult(
+            moduleFileFromPatches,
+            /* registry= */ null,
+            new StoredEventHandler());
+      }
+
+      // Otherwise use the MODULE.bazel from the repository
       RepositoryDirectoryValue repoDir =
           (RepositoryDirectoryValue) env.getValue(RepositoryDirectoryValue.key(canonicalRepoName));
       if (repoDir == null) {
@@ -622,10 +642,6 @@ public class ModuleFileFunction implements SkyFunction {
       if (env.getValue(FileValue.key(moduleFilePath)) == null) {
         return null;
       }
-      Label moduleFileLabel =
-          Label.createUnvalidated(
-              PackageIdentifier.create(canonicalRepoName, PathFragment.EMPTY_FRAGMENT),
-              LabelConstants.MODULE_DOT_BAZEL_FILE_NAME.getBaseName());
       return new GetModuleFileResult(
           ModuleFile.create(
               readModuleFile(moduleFilePath.asPath()),
@@ -684,7 +700,11 @@ public class ModuleFileFunction implements SkyFunction {
         if (maybeModuleFile.isEmpty()) {
           continue;
         }
-        ModuleFile moduleFile = maybePatchModuleFile(maybeModuleFile.get(), override, env);
+        ModuleFile moduleFile = maybePatchModuleFile(
+            maybeModuleFile.get().getContent(),
+            maybeModuleFile.get().getLocation(),
+            override,
+            env);
         if (moduleFile == null) {
           return null;
         }
@@ -715,13 +735,30 @@ public class ModuleFileFunction implements SkyFunction {
    */
   @Nullable
   private ModuleFile maybePatchModuleFile(
-      ModuleFile moduleFile, ModuleOverride override, Environment env)
+      @Nullable byte[] moduleFileBytes, String moduleFileLocation, ModuleOverride override, Environment env)
       throws InterruptedException, ModuleFileFunctionException {
-    if (!(override instanceof SingleVersionOverride singleVersionOverride)) {
-      return moduleFile;
+    var moduleFile = moduleFileBytes == null ? null : ModuleFile.create(moduleFileBytes, moduleFileLocation);
+    ImmutableList<Label> patches;
+    int patchStrip;
+    switch (override) {
+      case SingleVersionOverride singleVersionOverride -> {
+        patches = singleVersionOverride.getPatches();
+        patchStrip = singleVersionOverride.getPatchStrip();
+      }
+      case ArchiveOverride archiveOverride -> {
+        patches = archiveOverride.getPatches();
+        patchStrip = archiveOverride.getPatchStrip();
+      }
+      case GitOverride gitOverride -> {
+        patches = gitOverride.getPatches();
+        patchStrip = gitOverride.getPatchStrip();
+      }
+      case null, default -> {
+        return moduleFile;
+      }
     }
     var patchesInMainRepo =
-        singleVersionOverride.getPatches().stream()
+        patches.stream()
             .filter(label -> label.getRepository().isMain())
             .collect(toImmutableList());
     if (patchesInMainRepo.isEmpty()) {
@@ -783,14 +820,17 @@ public class ModuleFileFunction implements SkyFunction {
       Path moduleRoot = patchFs.getPath("/module");
       moduleRoot.createDirectoryAndParents();
       Path moduleFilePath = moduleRoot.getChild("MODULE.bazel");
-      FileSystemUtils.writeContent(moduleFilePath, moduleFile.getContent());
+      if (moduleFileBytes != null) {
+        FileSystemUtils.writeContent(moduleFilePath, moduleFileBytes);
+      }
       for (var patchPath : patchPaths) {
         try {
           PatchUtil.applyToSingleFile(
               patchPath.asPath(),
-              singleVersionOverride.getPatchStrip(),
+              patchStrip,
               moduleRoot,
-              moduleFilePath);
+              moduleFilePath,
+              moduleFileBytes != null);
         } catch (PatchFailedException e) {
           throw errorf(
               Code.BAD_MODULE,
@@ -799,8 +839,13 @@ public class ModuleFileFunction implements SkyFunction {
               e.getMessage());
         }
       }
+      // Allow returning null if no module file was provided and one was
+      // not created by the patches.
+      if (moduleFile == null && !moduleFilePath.exists()) {
+        return null;
+      }
       return ModuleFile.create(
-          FileSystemUtils.readContent(moduleFilePath), moduleFile.getLocation());
+          FileSystemUtils.readContent(moduleFilePath), moduleFileLocation);
     } catch (IOException e) {
       throw errorf(
           Code.BAD_MODULE,

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -618,16 +618,11 @@ public class ModuleFileFunction implements SkyFunction {
 
       // Try to extract a MODULE.bazel file from the patches without
       // triggering the underlying repository rule.
-      ModuleFile moduleFileFromPatches = maybePatchModuleFile(
-          null,
-          moduleFileLabel.getUnambiguousCanonicalForm(),
-          override,
-          env);
+      ModuleFile moduleFileFromPatches =
+          maybePatchModuleFile(null, moduleFileLabel.getUnambiguousCanonicalForm(), override, env);
       if (moduleFileFromPatches != null) {
         return new GetModuleFileResult(
-            moduleFileFromPatches,
-            /* registry= */ null,
-            new StoredEventHandler());
+            moduleFileFromPatches, /* registry= */ null, new StoredEventHandler());
       }
 
       // Otherwise use the MODULE.bazel from the repository
@@ -700,11 +695,12 @@ public class ModuleFileFunction implements SkyFunction {
         if (maybeModuleFile.isEmpty()) {
           continue;
         }
-        ModuleFile moduleFile = maybePatchModuleFile(
-            maybeModuleFile.get().getContent(),
-            maybeModuleFile.get().getLocation(),
-            override,
-            env);
+        ModuleFile moduleFile =
+            maybePatchModuleFile(
+                maybeModuleFile.get().getContent(),
+                maybeModuleFile.get().getLocation(),
+                override,
+                env);
         if (moduleFile == null) {
           return null;
         }
@@ -735,9 +731,13 @@ public class ModuleFileFunction implements SkyFunction {
    */
   @Nullable
   private ModuleFile maybePatchModuleFile(
-      @Nullable byte[] moduleFileBytes, String moduleFileLocation, ModuleOverride override, Environment env)
+      @Nullable byte[] moduleFileBytes,
+      String moduleFileLocation,
+      ModuleOverride override,
+      Environment env)
       throws InterruptedException, ModuleFileFunctionException {
-    var moduleFile = moduleFileBytes == null ? null : ModuleFile.create(moduleFileBytes, moduleFileLocation);
+    var moduleFile =
+        moduleFileBytes == null ? null : ModuleFile.create(moduleFileBytes, moduleFileLocation);
     ImmutableList<Label> patches;
     int patchStrip;
     switch (override) {
@@ -758,9 +758,7 @@ public class ModuleFileFunction implements SkyFunction {
       }
     }
     var patchesInMainRepo =
-        patches.stream()
-            .filter(label -> label.getRepository().isMain())
-            .collect(toImmutableList());
+        patches.stream().filter(label -> label.getRepository().isMain()).collect(toImmutableList());
     if (patchesInMainRepo.isEmpty()) {
       return moduleFile;
     }
@@ -826,11 +824,7 @@ public class ModuleFileFunction implements SkyFunction {
       for (var patchPath : patchPaths) {
         try {
           PatchUtil.applyToSingleFile(
-              patchPath.asPath(),
-              patchStrip,
-              moduleRoot,
-              moduleFilePath,
-              moduleFileBytes != null);
+              patchPath.asPath(), patchStrip, moduleRoot, moduleFilePath, moduleFileBytes != null);
         } catch (PatchFailedException e) {
           throw errorf(
               Code.BAD_MODULE,
@@ -844,8 +838,7 @@ public class ModuleFileFunction implements SkyFunction {
       if (moduleFile == null && !moduleFilePath.exists()) {
         return null;
       }
-      return ModuleFile.create(
-          FileSystemUtils.readContent(moduleFilePath), moduleFileLocation);
+      return ModuleFile.create(FileSystemUtils.readContent(moduleFilePath), moduleFileLocation);
     } catch (IOException e) {
       throw errorf(
           Code.BAD_MODULE,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -421,7 +421,8 @@ public class PatchUtil {
    */
   public static void apply(Path patchFile, int strip, Path outputDirectory)
       throws IOException, PatchFailedException {
-    applyInternal(patchFile, strip, outputDirectory, /* singleFile= */ null, /* singleFileExists= */ false);
+    applyInternal(
+        patchFile, strip, outputDirectory, /* singleFile= */ null, /* singleFileExists= */ false);
   }
 
   /**
@@ -433,8 +434,8 @@ public class PatchUtil {
    * @param outputDirectory the directory to apply the patch file to
    * @param singleFile only apply the parts of the patch file that apply to this file. Renaming the
    *     file is not supported in this case.
-   * @param singleFileExists true if the singleFile already exists, false if the file is expected
-   *     to be created by the patches.
+   * @param singleFileExists true if the singleFile already exists, false if the file is expected to
+   *     be created by the patches.
    */
   public static void applyToSingleFile(
       Path patchFile, int strip, Path outputDirectory, Path singleFile, boolean singleFileExists)
@@ -443,7 +444,11 @@ public class PatchUtil {
   }
 
   private static void applyInternal(
-      Path patchFile, int strip, Path outputDirectory, @Nullable Path singleFile, boolean singleFileExists)
+      Path patchFile,
+      int strip,
+      Path outputDirectory,
+      @Nullable Path singleFile,
+      boolean singleFileExists)
       throws IOException, PatchFailedException {
     if (!patchFile.exists()) {
       throw new PatchFailedException("Cannot find patch file: " + patchFile.getPathString());
@@ -597,10 +602,9 @@ public class PatchUtil {
               }
             }
 
-            if (singleFile == null || (
-                singleFile.equals(newFile) &&
-                (singleFile.equals(oldFile) || (oldFile == null && !singleFileExists))
-            )) {
+            if (singleFile == null
+                || (singleFile.equals(newFile)
+                    && (singleFile.equals(oldFile) || (oldFile == null && !singleFileExists)))) {
               Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchContent);
               checkFilesStatusForPatching(
                   patch, oldFile, newFile, oldFileStr, newFileStr, patchStartLocation);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -421,8 +421,7 @@ public class PatchUtil {
    */
   public static void apply(Path patchFile, int strip, Path outputDirectory)
       throws IOException, PatchFailedException {
-    applyInternal(
-        patchFile, strip, outputDirectory, /* singleFile= */ null, /* singleFileExists= */ false);
+    applyInternal(patchFile, strip, outputDirectory, /* singleFile= */ null);
   }
 
   /**
@@ -434,21 +433,15 @@ public class PatchUtil {
    * @param outputDirectory the directory to apply the patch file to
    * @param singleFile only apply the parts of the patch file that apply to this file. Renaming the
    *     file is not supported in this case.
-   * @param singleFileExists true if the singleFile already exists, false if the file is expected to
-   *     be created by the patches.
    */
   public static void applyToSingleFile(
-      Path patchFile, int strip, Path outputDirectory, Path singleFile, boolean singleFileExists)
+      Path patchFile, int strip, Path outputDirectory, Path singleFile)
       throws IOException, PatchFailedException {
-    applyInternal(patchFile, strip, outputDirectory, singleFile, singleFileExists);
+    applyInternal(patchFile, strip, outputDirectory, singleFile);
   }
 
   private static void applyInternal(
-      Path patchFile,
-      int strip,
-      Path outputDirectory,
-      @Nullable Path singleFile,
-      boolean singleFileExists)
+      Path patchFile, int strip, Path outputDirectory, @Nullable Path singleFile)
       throws IOException, PatchFailedException {
     if (!patchFile.exists()) {
       throw new PatchFailedException("Cannot find patch file: " + patchFile.getPathString());
@@ -604,13 +597,12 @@ public class PatchUtil {
 
             if (singleFile == null
                 || (singleFile.equals(newFile)
-                    && (singleFile.equals(oldFile) || (oldFile == null && !singleFileExists)))) {
+                    && (singleFile.equals(oldFile) || (oldFile == null && !singleFile.exists())))) {
               Patch<String> patch = UnifiedDiffUtils.parseUnifiedDiff(patchContent);
               checkFilesStatusForPatching(
                   patch, oldFile, newFile, oldFileStr, newFileStr, patchStartLocation);
 
               applyPatchToFile(patch, oldFile, newFile, isRenaming, filePermission);
-              singleFileExists = true;
             }
           }
 


### PR DESCRIPTION
PoC

It's common for `archive_override` and `git_override` modules to contain the entire `MODULE.bazel` file in their patches. In this case it's possible to provide the `MODULE.bazel` file for version resolution without executing the underlying repository rule.

Luckily most of the code for this already exists to apply the patches to the `MODULE.bazel` for a `single_version_override`, we just have to allow doing the same for `archive_override`/`git_override` and run the patch application without an existing file.