### PR TITLE
[8.0.0] Don't crash when repo rule throws `InterruptedException`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
@@ -231,6 +231,7 @@ final class RegularRunnableExtension implements RunnableExtension {
                     workerEnv, usagesValue, starlarkSemantics, extensionId, mainRepositoryMapping));
       } catch (ExecutionException e) {
         Throwables.throwIfInstanceOf(e.getCause(), ExternalDepsException.class);
+        Throwables.throwIfInstanceOf(e.getCause(), InterruptedException.class);
         Throwables.throwIfUnchecked(e.getCause());
         throw new IllegalStateException(
             "unexpected exception type: " + e.getCause().getClass(), e.getCause());

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -151,6 +151,7 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
             });
       } catch (ExecutionException e) {
         Throwables.throwIfInstanceOf(e.getCause(), RepositoryFunctionException.class);
+        Throwables.throwIfInstanceOf(e.getCause(), InterruptedException.class);
         Throwables.throwIfUnchecked(e.getCause());
         throw new IllegalStateException(
             "unexpected exception type: " + e.getCause().getClass(), e.getCause());


### PR DESCRIPTION
Should fix a server crash due to `unexpected exception type: java.lang.InterruptedException` when interrupting a repo rule fetch.

Closes #24278.

PiperOrigin-RevId: 696043083
Change-Id: I44c95fb6b0043c89de8aa526c2ff9cf014ce9447

Commit https://github.com/bazelbuild/bazel/commit/21d8b02fb26f89ec7bf3e7dd978c6ecf1d258ad0