### PR TITLE
[8.0.0] Trim Workspace Status values

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
@@ -142,7 +142,7 @@ public class BazelWorkspaceStatusModule extends BlazeModule {
       for (String line : input.trim().split("\n")) {
         String[] splitLine = line.split(" ", 2);
         if (splitLine.length >= 2) {
-          result.put(splitLine[0], splitLine[1]);
+          result.put(splitLine[0], splitLine[1].trim());
         }
       }
 


### PR DESCRIPTION
On windows, bazel will run the workspace_status_command, and receive carriage return characters \r even if the workspace_status_command did not include them.

Fixes https://github.com/bazelbuild/bazel/issues/13442

PiperOrigin-RevId: 684055158
Change-Id: Idd3bd9c954d64b0a2d674dd7d90cf61c00955917