### PR TITLE
Apply the main repo mapping in `BuildIntegrationTestCase`

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BUILD
@@ -81,6 +81,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_execution_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:build_result_listener",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:repository_mapping_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skymeld_module",
         "//src/main/java/com/google/devtools/build/lib/standalone",

--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BuildIntegrationTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BuildIntegrationTestCase.java
@@ -70,6 +70,8 @@ import com.google.devtools.build.lib.buildtool.BuildTool;
 import com.google.devtools.build.lib.buildtool.buildevent.BuildStartingEvent;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventCollector;
@@ -114,6 +116,7 @@ import com.google.devtools.build.lib.shell.CommandException;
 import com.google.devtools.build.lib.skyframe.ActionExecutionValue;
 import com.google.devtools.build.lib.skyframe.BuildResultListener;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
+import com.google.devtools.build.lib.skyframe.RepositoryMappingValue;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
 import com.google.devtools.build.lib.skyframe.SkymeldModule;
 import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
@@ -755,7 +758,7 @@ public abstract class BuildIntegrationTestCase {
           InterruptedException,
           TransitionException,
           InvalidConfigurationException {
-    getPackageManager().getTarget(events.reporter(), Label.parseCanonical(target));
+    getPackageManager().getTarget(events.reporter(), label(target));
     return getSkyframeExecutor()
         .getConfiguredTargetForTesting(events.reporter(), label(target), getTargetConfiguration());
   }
@@ -847,8 +850,15 @@ public abstract class BuildIntegrationTestCase {
   }
 
   /** Utility function: parse a string as a label. */
-  protected static Label label(String labelString) throws LabelSyntaxException {
-    return Label.parseCanonical(labelString);
+  protected Label label(String labelString) throws LabelSyntaxException, InterruptedException {
+    RepositoryMapping mainRepoMapping =
+        ((RepositoryMappingValue)
+                getSkyframeExecutor()
+                    .getEvaluator()
+                    .getExistingValue(RepositoryMappingValue.key(RepositoryName.MAIN)))
+            .getRepositoryMapping();
+    return Label.parseWithRepoContext(
+        labelString, Label.RepoContext.of(RepositoryName.MAIN, mainRepoMapping));
   }
 
   protected String run(Artifact executable, String... arguments) throws Exception {


### PR DESCRIPTION
Some `get*` methods worked with apparent repo names, others didn't, which is a hurdle to contributions in this area (as observed while working on #24328).