### PR TITLE
Fix builtins_bzl_zip build when io_bazel is not the root module

### DIFF
--- a/src/main/starlark/builtins_bzl/BUILD
+++ b/src/main/starlark/builtins_bzl/BUILD
@@ -13,6 +13,9 @@ filegroup(
 
 # A zipfile containing the builtins_bzl/ directory, to be bundled as a Java
 # resource with BazelRuleClassProvider.
+# Uses `dirname $(execpath :BUILD)` to find source directory for both these cases:
+# - io_bazel is the root-module (src/main/starlark/builtins_bzl)
+# - io_bazel is used as a dependency (external/<repo_name>/src/main/starlark/builtins_bzl)
 genrule(
     name = "builtins_bzl_zip",
     srcs = glob(["**/*.bzl"]),
@@ -20,10 +23,10 @@ genrule(
     # builtins_zip.sh zip output builtins_root files...
     cmd = "$(location //src:zip_builtins)" +
           " ''" +  # system zip
-          " $@ src/main/starlark/builtins_bzl $(SRCS)",
+          " $@ `dirname $(execpath :BUILD)` $(SRCS)",
     message = "Building builtins_bzl.zip",
     output_to_bindir = 1,
-    tools = ["//src:zip_builtins"],
+    tools = ["//src:zip_builtins", ":BUILD"],
     visibility = [
         "//src/main/java/com/google/devtools/build/lib/bazel/rules:__pkg__",
     ],


### PR DESCRIPTION
When building bazel as a non root module the path needed by zip_builtins is external/%repo%/src/main/starlark/builtins_bzl instead of src/main/starlark/builtins_bzl.

This patch gives the zip_builtins script the dirname of the package build file and uses $location to resolve correct path.