### PR TITLE
[8.0.0] Refactor RuleVisibility validation and concatenation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
@@ -228,8 +228,7 @@ public abstract class CommonPrerequisiteValidator implements PrerequisiteValidat
     // same-logical-package as this location, a property that doesn't apply to targets created in
     // symbolic macros. Calling isSameLogicalPackage() takes care of both of these checks. Note that
     // we don't need to worry about the package's default_visibility at this stage because
-    // it is already accounted for at loading time by the target's getVisibility() accessor (or
-    // earlier).
+    // it is already accounted for at loading time by the target's getVisibility() accessor.
     //
     // TODO: #19922 - The same-logical-package logic should also be applied in the loading phase, to
     // the propagated visibility attribute inside symbolic macros, so that it applies to targets

--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/InputFileConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/InputFileConfiguredTarget.java
@@ -48,7 +48,7 @@ public final class InputFileConfiguredTarget extends FileConfiguredTarget {
   public InputFileConfiguredTarget(TargetContext targetContext, SourceArtifact artifact) {
     super(targetContext, artifact);
     this.licenses = makeLicenses(targetContext.getTarget());
-    this.isCreatedInSymbolicMacro = targetContext.getTarget().getDeclaringMacro() != null;
+    this.isCreatedInSymbolicMacro = targetContext.getTarget().isCreatedInSymbolicMacro();
     checkArgument(targetContext.getTarget() instanceof InputFile, targetContext.getTarget());
     checkArgument(getConfigurationKey() == null, getLabel());
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
@@ -136,7 +136,7 @@ public final class RuleConfiguredTarget extends AbstractConfiguredTarget {
     this(
         ruleContext.getOwner(),
         ruleContext.getVisibility(),
-        /* isCreatedInSymbolicMacro= */ ruleContext.getRule().getDeclaringMacro() != null,
+        /* isCreatedInSymbolicMacro= */ ruleContext.getRule().isCreatedInSymbolicMacro(),
         providers,
         ruleContext.getConfigConditions(),
         Util.findImplicitDeps(ruleContext),

--- a/src/main/java/com/google/devtools/build/lib/packages/EnvironmentGroup.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/EnvironmentGroup.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import net.starlark.java.syntax.Location;
 
 /**
@@ -306,8 +307,17 @@ public class EnvironmentGroup implements Target {
   }
 
   @Override
+  @Nullable
+  public RuleVisibility getRawVisibility() {
+    return null;
+  }
+
+  @Override
   public RuleVisibility getVisibility() {
-    return RuleVisibility.PRIVATE; // No rule should be referencing an environment_group.
+    // No rule should be referencing an environment_group.
+    // (We override getRawVisibility() separately so as to not display this value during
+    // introspection.)
+    return RuleVisibility.PRIVATE;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/packages/InputFile.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/InputFile.java
@@ -64,8 +64,9 @@ public class InputFile extends FileTarget {
   }
 
   @Override
-  public RuleVisibility getVisibility() {
-    return pkg.getPackageArgs().defaultVisibility();
+  @Nullable
+  public RuleVisibility getRawVisibility() {
+    return null;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
@@ -250,18 +250,11 @@ public final class MacroClass {
       parsedVisibility = RuleVisibility.parse(liftedVisibility);
     }
     // Concatenate the visibility (as previously populated) with the instantiation site's location.
-    PackageIdentifier instantiatingLoc;
-    if (parentMacroFrame == null) {
-      instantiatingLoc = pkgBuilder.getPackageIdentifier();
-    } else {
-      instantiatingLoc =
-          parentMacroFrame
-              .macroInstance
-              .getMacroClass()
-              .getDefiningBzlLabel()
-              .getPackageIdentifier();
-    }
-    parsedVisibility = RuleVisibility.concatWithPackage(parsedVisibility, instantiatingLoc);
+    PackageIdentifier instantiatingLoc =
+        parentMacroFrame == null
+            ? pkgBuilder.getPackageIdentifier()
+            : parentMacroFrame.macroInstance.getDefinitionPackage();
+    parsedVisibility = parsedVisibility.concatWithPackage(instantiatingLoc);
     attrValues.put("visibility", parsedVisibility.getDeclaredLabels());
 
     // Populate defaults for the rest, and validate that no mandatory attr was missed.

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
@@ -230,6 +230,9 @@ public final class MacroClass {
     }
 
     // Special processing of the "visibility" attribute.
+    // TODO(brandjon): When we add introspection of attributes of symbolic macros, we'll want to
+    // distinguish between the different types of visibility a la Target#getRawVisibility /
+    // #getVisibility / #getActualVisibility.
     @Nullable MacroFrame parentMacroFrame = pkgBuilder.getCurrentMacroFrame();
     @Nullable Object rawVisibility = attrValues.get("visibility");
     RuleVisibility parsedVisibility;
@@ -254,8 +257,8 @@ public final class MacroClass {
         parentMacroFrame == null
             ? pkgBuilder.getPackageIdentifier()
             : parentMacroFrame.macroInstance.getDefinitionPackage();
-    parsedVisibility = parsedVisibility.concatWithPackage(instantiatingLoc);
-    attrValues.put("visibility", parsedVisibility.getDeclaredLabels());
+    RuleVisibility actualVisibility = parsedVisibility.concatWithPackage(instantiatingLoc);
+    attrValues.put("visibility", actualVisibility.getDeclaredLabels());
 
     // Populate defaults for the rest, and validate that no mandatory attr was missed.
     for (Attribute attr : attributes.values()) {

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
@@ -181,21 +181,14 @@ public final class MacroInstance {
   }
 
   /**
-   * Returns a {@code RuleVisibility} representing the result of concatenating this macro's {@link
-   * MacroClass}'s definition location to the given {@code visibility}.
+   * Returns the package containing the .bzl file from which this macro instance's macro class was
+   * exported.
    *
-   * <p>The definition location of a macro class is the package containing the .bzl file from which
-   * the macro class was exported.
-   *
-   * <p>Logically, this represents the visibility that a target would have, if it were passed the
-   * given value for its {@code visibility} attribute, and if the target were declared directly in
-   * this macro (i.e. not in a submacro).
+   * <p>This is considered to be the place where the macro's code lives, and is used as the place
+   * where a target is instantiated for the purposes of Macro-Aware Visibility.
    */
-  // TODO: #19922 - Maybe refactor this to getDefinitionLocation and let the caller do the concat,
-  // so we don't have to basically repeat it in MacroClass#instantiateMacro.
-  public RuleVisibility concatDefinitionLocationToVisibility(RuleVisibility visibility) {
-    PackageIdentifier macroLocation = macroClass.getDefiningBzlLabel().getPackageIdentifier();
-    return RuleVisibility.concatWithPackage(visibility, macroLocation);
+  public PackageIdentifier getDefinitionPackage() {
+    return macroClass.getDefiningBzlLabel().getPackageIdentifier();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
@@ -155,7 +155,7 @@ public final class MacroInstance {
   }
 
   /**
-   * Returns the visibility of this macro instance.
+   * Returns the visibility of this macro instance, analogous to {@link Target#getActualVisibility}.
    *
    * <p>This value will be observed as the {@code visibility} parameter of the implementation
    * function. It is not necessarily the same as the {@code visibility} value passed in when
@@ -164,7 +164,7 @@ public final class MacroInstance {
    *
    * <p>It can be assumed that the returned list satisfies {@link RuleVisibility#validate}.
    */
-  public ImmutableList<Label> getVisibility() {
+  public ImmutableList<Label> getActualVisibility() {
     @SuppressWarnings("unchecked")
     List<Label> visibility = (List<Label>) Preconditions.checkNotNull(attrValues.get("visibility"));
     return ImmutableList.copyOf(visibility);

--- a/src/main/java/com/google/devtools/build/lib/packages/OutputFile.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/OutputFile.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.packages;
 
 import com.google.devtools.build.lib.cmdline.Label;
 import java.util.List;
+import javax.annotation.Nullable;
 import net.starlark.java.syntax.Location;
 
 /** A generated file that is the output of a rule. */
@@ -50,6 +51,17 @@ public abstract class OutputFile extends FileTarget {
     super(generatingRule.getPackage(), label);
     this.generatingRule = generatingRule;
     this.outputKey = outputKey;
+  }
+
+  @Override
+  @Nullable
+  public final RuleVisibility getRawVisibility() {
+    return generatingRule.getRawVisibility();
+  }
+
+  @Override
+  public final RuleVisibility getDefaultVisibility() {
+    return generatingRule.getDefaultVisibility();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -228,7 +228,9 @@ public class Package {
 
   /**
    * A map from names of targets declared in a symbolic macro to the (innermost) macro instance
-   * where they were declared.
+   * where they were declared. Omits targets not declared in symbolic macros.
+   *
+   * <p>Null for packages produced by deserialization.
    */
   // TODO: #19922 - If this field were made serializable (currently it's not), it would subsume
   // macroNamespaceViolatingTargets, since we can just map the target to its macro and then check
@@ -246,7 +248,16 @@ public class Package {
   //      macro's namespace, we could just look them up in the trie. This assumes we already know
   //      whether the target is well-named, which we wouldn't if we got rid of
   //      macroNamespaceViolatingTargets.
-  private ImmutableMap<String, MacroInstance> targetsToDeclaringMacros;
+  @Nullable private ImmutableMap<String, MacroInstance> targetsToDeclaringMacro;
+
+  /**
+   * A map from names of targets declared in a symbolic macro to the package where the macro that
+   * declared it was defined, as per {@link MacroInstance#getDefinitionPackage}. Omits targets not
+   * declared in symbolic macros.
+   *
+   * <p>Null for packages not produced by deserialization.
+   */
+  @Nullable private ImmutableMap<String, PackageIdentifier> targetsToDeclaringPackage;
 
   // ==== Constructor ====
 
@@ -563,6 +574,22 @@ public class Package {
   }
 
   /**
+   * Returns a map from names of targets declared in a symbolic macro to the package containing said
+   * macro's .bzl code.
+   */
+  ImmutableMap<String, PackageIdentifier> getTargetsToDeclaringPackage() {
+    if (targetsToDeclaringPackage != null) {
+      return targetsToDeclaringPackage;
+    } else {
+      ImmutableMap.Builder<String, PackageIdentifier> result = ImmutableMap.builder();
+      for (Map.Entry<String, MacroInstance> entry : targetsToDeclaringMacro.entrySet()) {
+        result.put(entry.getKey(), entry.getValue().getDefinitionPackage());
+      }
+      return result.buildOrThrow();
+    }
+  }
+
+  /**
    * Throws {@link MacroNamespaceViolationException} if the given target (which must be a member of
    * this package) violates macro naming rules.
    */
@@ -663,11 +690,43 @@ public class Package {
 
   /**
    * Returns the (innermost) symbolic macro instance that declared the given target, or null if the
-   * target was not created in a symbolic macro or no such target by the given name exists.
+   * target was not created in a symbolic macro.
+   *
+   * <p>Throws {@link IllegalArgumentException} if the given name is not a target in this package.
+   *
+   * <p>For packages produced by deserialization, this information is not available and {@code
+   * IllegalStateException} is thrown.
    */
   @Nullable
   public MacroInstance getDeclaringMacroForTarget(String target) {
-    return targetsToDeclaringMacros.get(target);
+    Preconditions.checkState(
+        targetsToDeclaringMacro != null,
+        "Cannot retrieve MacroInstance information from deserialized packages");
+    Preconditions.checkArgument(targets.containsKey(target), "unknown target '%s'", target);
+    return targetsToDeclaringMacro.get(target);
+  }
+
+  /**
+   * Returns the id of the package where the (innermost) macro that declared the given target was
+   * defined (as per {@link MacroInstance#getDefinitionLocation}), or null if the target was not
+   * created in a symbolic macro.
+   *
+   * <p>The caller should interpret a null result to mean that the declaration location of the
+   * target is this package.
+   *
+   * <p>Throws {@link IllegalArgumentException} if the given name is not a target in this package.
+   */
+  @Nullable
+  public PackageIdentifier getDeclaringPackageForTargetIfInMacro(String target) {
+    Preconditions.checkArgument(targets.containsKey(target), "unknown target '%s'", target);
+    // Exactly one of targetsToDeclaringMacro and targetsToDeclaringPackage is non-null, depending
+    // on whether this package was produced by deserialization.
+    if (targetsToDeclaringMacro != null) {
+      MacroInstance macro = targetsToDeclaringMacro.get(target);
+      return macro != null ? macro.getDefinitionPackage() : null;
+    } else {
+      return targetsToDeclaringPackage.get(target);
+    }
   }
 
   // ==== Initialization ====
@@ -733,8 +792,14 @@ public class Package {
     this.macros = ImmutableSortedMap.copyOf(builder.recorder.getMacroMap());
     this.macroNamespaceViolatingTargets =
         ImmutableMap.copyOf(builder.recorder.getMacroNamespaceViolatingTargets());
-    this.targetsToDeclaringMacros =
-        ImmutableSortedMap.copyOf(builder.recorder.getTargetsToDeclaringMacros());
+    this.targetsToDeclaringMacro =
+        builder.recorder.getTargetsToDeclaringMacro() != null
+            ? ImmutableSortedMap.copyOf(builder.recorder.getTargetsToDeclaringMacro())
+            : null;
+    this.targetsToDeclaringPackage =
+        builder.recorder.getTargetsToDeclaringPackage() != null
+            ? ImmutableSortedMap.copyOf(builder.recorder.getTargetsToDeclaringPackage())
+            : null;
     this.failureDetail = builder.getFailureDetail();
     this.registeredExecutionPlatforms = ImmutableList.copyOf(builder.registeredExecutionPlatforms);
     this.registeredToolchains = ImmutableList.copyOf(builder.registeredToolchains);
@@ -883,7 +948,8 @@ public class Package {
       // TODO(bazel-team): See Builder() constructor comment about use of null for this param.
       @Nullable ConfigSettingVisibilityPolicy configSettingVisibilityPolicy,
       @Nullable Globber globber,
-      boolean enableNameConflictChecking) {
+      boolean enableNameConflictChecking,
+      boolean trackFullMacroInformation) {
     // Determine whether this is for a repo rule package. We shouldn't actually have to do this
     // because newPackageBuilder() is supposed to only be called for normal packages. Unfortunately
     // serialization still uses the same code path for deserializing BUILD and WORKSPACE files,
@@ -914,7 +980,8 @@ public class Package {
         packageOverheadEstimator,
         generatorMap,
         globber,
-        enableNameConflictChecking);
+        enableNameConflictChecking,
+        trackFullMacroInformation);
   }
 
   public static Builder newExternalPackageBuilder(
@@ -947,7 +1014,8 @@ public class Package {
         packageOverheadEstimator,
         /* generatorMap= */ null,
         /* globber= */ null,
-        /* enableNameConflictChecking= */ true);
+        /* enableNameConflictChecking= */ true,
+        /* trackFullMacroInformation= */ true);
   }
 
   public static Builder newExternalPackageBuilderForBzlmod(
@@ -977,7 +1045,8 @@ public class Package {
             PackageOverheadEstimator.NOOP_ESTIMATOR,
             /* generatorMap= */ null,
             /* globber= */ null,
-            /* enableNameConflictChecking= */ true)
+            /* enableNameConflictChecking= */ true,
+            /* trackFullMacroInformation= */ true)
         .setLoads(ImmutableList.of());
   }
 
@@ -1095,7 +1164,8 @@ public class Package {
         PackageOverheadEstimator packageOverheadEstimator,
         @Nullable ImmutableMap<Location, String> generatorMap,
         @Nullable Globber globber,
-        boolean enableNameConflictChecking) {
+        boolean enableNameConflictChecking,
+        boolean trackFullMacroInformation) {
       super(
           metadata,
           new Package(metadata),
@@ -1106,7 +1176,8 @@ public class Package {
           cpuBoundSemaphore,
           generatorMap,
           globber,
-          enableNameConflictChecking);
+          enableNameConflictChecking,
+          trackFullMacroInformation);
       this.precomputeTransitiveLoads = precomputeTransitiveLoads;
       this.noImplicitFileExport = noImplicitFileExport;
       this.packageOverheadEstimator = packageOverheadEstimator;
@@ -1442,6 +1513,10 @@ public class Package {
     // For Package deserialization.
     void putAllMacroNamespaceViolatingTargets(Map<String, String> macroNamespaceViolatingTargets) {
       recorder.putAllMacroNamespaceViolatingTargets(macroNamespaceViolatingTargets);
+    }
+
+    void putAllTargetsToDeclaringPackage(Map<String, PackageIdentifier> targetsToDeclaringPackage) {
+      recorder.putAllTargetsToDeclaringPackage(targetsToDeclaringPackage);
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageFactory.java
@@ -257,7 +257,8 @@ public final class PackageFactory {
         generatorMap,
         configSettingVisibilityPolicy,
         globber,
-        /* enableNameConflictChecking= */ true);
+        /* enableNameConflictChecking= */ true,
+        /* trackFullMacroInformation= */ true);
   }
 
   /** Returns a new {@link NonSkyframeGlobber}. */

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageGroup.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageGroup.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import net.starlark.java.syntax.Location;
 
 /**
@@ -148,10 +149,18 @@ public class PackageGroup implements Target {
   }
 
   @Override
+  @Nullable
+  public RuleVisibility getRawVisibility() {
+    return null;
+  }
+
+  @Override
   public RuleVisibility getVisibility() {
     // Package groups are always public to avoid a PackageGroupConfiguredTarget
     // needing itself for the visibility check. It may work, but I did not
     // think it over completely.
+    // (We override getRawVisibility() separately so as to not display this value during
+    // introspection.)
     return RuleVisibility.PUBLIC;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageGroupsRuleVisibility.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageGroupsRuleVisibility.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /** A rule visibility that allows visibility to a list of package groups. */
 @AutoValue
-public abstract class PackageGroupsRuleVisibility implements RuleVisibility {
+public abstract class PackageGroupsRuleVisibility extends RuleVisibility {
   public abstract ImmutableList<Label> getPackageGroups();
 
   public abstract PackageGroupContents getDirectPackages();

--- a/src/main/java/com/google/devtools/build/lib/packages/Rule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Rule.java
@@ -1072,40 +1072,45 @@ public class Rule implements Target, DependencyFilter.AttributeInfoProvider {
   }
 
   /**
-   * Returns the effective visibility of this rule target, as best as can be determined at loading
-   * time.
-   *
-   * <p>Conceptually, this is taken from the target's {@code visibility} attribute, with a few
-   * caveats described below. The actual visibility check is based on analysis-time information that
-   * traverses possibly multiple levels of {@code package_group} definitions; see {@link
-   * VisibilityProvider}.
-   *
-   * <p>Under the Macro-Aware Visibility model, targets are always visible to the location of the
-   * code of the symbolic macro in which they are declared, or the target's package if they are not
-   * in a symbolic macro. For targets in symbolic macros, we realize this by automatically appending
-   * this location to {@code visibility} when the target is created (see {@link
-   * RuleFactory#createRule}).
-   *
-   * <p>However, for targets created by the BUILD file and legacy macros (i.e. outside any symbolic
-   * macro), we do not append anything, because that would be a backwards incompatible change (as
-   * well as a minor memory regression). So instead, when checking visibility at analysis time, we
-   * simply implicitly allow the target's own package anytime the target was not created in a
-   * symbolic macro.
-   *
-   * <p>The package's {@code default_visibility} is used as the starting point for targets that are
-   * not created in any symbolic macro and that do not specify an explicit {@code visibility}.
+   * Implementation of {@link #getRawVisibility} that avoids constructing a {@code RuleVisibility}.
    */
-  // TODO: #19922 - Technically, I think the fact that we munge visibility for targets in symbolic
-  // macros means that they appear as though they were explicitly specified
-  // (AttributeMap#isAttributeValueExplicitlySpecified). I doubt this matters in practice, as most
-  // logic should not be relying on that bit.
+  @Nullable
+  @SuppressWarnings("unchecked")
+  private List<Label> getRawVisibilityLabels() {
+    Integer visibilityIndex = ruleClass.getAttributeIndex("visibility");
+    if (visibilityIndex == null) {
+      return null;
+    }
+    return (List<Label>) getAttrIfStored(visibilityIndex);
+  }
+
   @Override
-  public RuleVisibility getVisibility() {
+  @Nullable
+  public RuleVisibility getRawVisibility() {
     List<Label> rawLabels = getRawVisibilityLabels();
-    return rawLabels == null
-        ? getDefaultVisibility()
-        // The attribute value was already validated when it was set, so call the unchecked method.
-        : RuleVisibility.parseUnchecked(rawLabels);
+    // The attribute value was already validated when it was set, so call the unchecked method.
+    return rawLabels != null ? RuleVisibility.parseUnchecked(rawLabels) : null;
+  }
+
+  /**
+   * Retrieves the package's default visibility, or for certain rule classes, injects a different
+   * default visibility.
+   */
+  @Override
+  public RuleVisibility getDefaultVisibility() {
+    if (ruleClass.getName().equals("bind")) {
+      return RuleVisibility.PUBLIC; // bind rules are always public.
+    }
+    // Temporary logic to relax config_setting's visibility enforcement while depot migrations set
+    // visibility settings properly (legacy code may have visibility settings that would break if
+    // enforced). See https://github.com/bazelbuild/bazel/issues/12669. Ultimately this entire
+    // conditional should be removed.
+    if (ruleClass.getName().equals("config_setting")
+        && pkg.getConfigSettingVisibilityPolicy() == ConfigSettingVisibilityPolicy.DEFAULT_PUBLIC) {
+      return RuleVisibility.PUBLIC; // Default: //visibility:public.
+    }
+
+    return Target.super.getDefaultVisibility();
   }
 
   @Override
@@ -1125,39 +1130,7 @@ public class Rule implements Target, DependencyFilter.AttributeInfoProvider {
   @Override
   public List<Label> getVisibilityDeclaredLabels() {
     List<Label> rawLabels = getRawVisibilityLabels();
-    return rawLabels == null ? getDefaultVisibility().getDeclaredLabels() : rawLabels;
-  }
-
-  @Nullable
-  @SuppressWarnings("unchecked")
-  private List<Label> getRawVisibilityLabels() {
-    Integer visibilityIndex = ruleClass.getAttributeIndex("visibility");
-    if (visibilityIndex == null) {
-      return null;
-    }
-    return (List<Label>) getAttrIfStored(visibilityIndex);
-  }
-
-  private RuleVisibility getDefaultVisibility() {
-    // TODO: #19922 - This logic is only reached from getVisibility() when the visibility attribute
-    // is not set on this target. But since we munge the visibility attribute to be non-empty for
-    // all targets created in symbolic macros, this logic is bypassed anytime the target is in a
-    // symbolic macro. The likely fix is to factor this out into something that can be consulted by
-    // RuleFactory#getModifiedVisibility in place of accessing the package's default_visibility
-    // (which isn't supposed to be consulted inside symbolic macros anyway).
-
-    if (ruleClass.getName().equals("bind")) {
-      return RuleVisibility.PUBLIC; // bind rules are always public.
-    }
-    // Temporary logic to relax config_setting's visibility enforcement while depot migrations set
-    // visibility settings properly (legacy code may have visibility settings that would break if
-    // enforced). See https://github.com/bazelbuild/bazel/issues/12669. Ultimately this entire
-    // conditional should be removed.
-    if (ruleClass.getName().equals("config_setting")
-        && pkg.getConfigSettingVisibilityPolicy() == ConfigSettingVisibilityPolicy.DEFAULT_PUBLIC) {
-      return RuleVisibility.PUBLIC; // Default: //visibility:public.
-    }
-    return pkg.getPackageArgs().defaultVisibility();
+    return rawLabels != null ? rawLabels : getDefaultVisibility().getDeclaredLabels();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
@@ -311,7 +311,7 @@ public class RuleFactory {
       }
     }
 
-    return currentMacro.concatDefinitionLocationToVisibility(visibility).getDeclaredLabels();
+    return visibility.concatWithPackage(currentMacro.getDefinitionPackage()).getDeclaredLabels();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
@@ -24,7 +24,6 @@ import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
 import com.google.devtools.build.lib.packages.TargetRecorder.NameConflictException;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -85,22 +84,15 @@ public class RuleFactory {
           ruleClass + " cannot be in the WORKSPACE file " + "(used by " + label + ")");
     }
 
-    // Add the generator_name attribute, and possibly append the declaration location to the
-    // visibility attribute.
+    // Add the generator_name attribute.
     BuildLangTypedAttributeValuesMap processedAttributes;
     @Nullable String generatorName = getGeneratorName(pkgBuilder, attributeValues, callstack);
-    @Nullable List<Label> modifiedVisibility = getModifiedVisibility(pkgBuilder, attributeValues);
     // Don't bother copying anything if nothing changed.
-    if (generatorName != null || modifiedVisibility != null) {
+    if (generatorName != null) {
       ImmutableMap.Builder<String, Object> builder =
-          ImmutableMap.builderWithExpectedSize(attributeValues.attributeValues.size() + 2);
+          ImmutableMap.builderWithExpectedSize(attributeValues.attributeValues.size() + 1);
       builder.putAll(attributeValues.attributeValues);
-      if (generatorName != null) {
-        builder.put("generator_name", generatorName);
-      }
-      if (modifiedVisibility != null) {
-        builder.put("visibility", modifiedVisibility);
-      }
+      builder.put("generator_name", generatorName);
       processedAttributes = new BuildLangTypedAttributeValuesMap(builder.buildKeepingLast());
     } else {
       processedAttributes = attributeValues;
@@ -272,46 +264,6 @@ public class RuleFactory {
       generatorName = (String) args.getAttributeValue("name");
     }
     return generatorName;
-  }
-
-  /**
-   * Given the attribute values of the rule being instantiated, computes and returns the new value
-   * for its visibility attribute, or null if no change is needed.
-   *
-   * <p>For targets created inside one or more symbolic macros, the new visibility value is whatever
-   * the original visibility attribute was (possibly the package's default visibility), unioned with
-   * the package where the innermost currently executing symbolic macro was exported.
-   *
-   * <p>For targets not created inside one or more symbolic macros, no change is made to the
-   * visibility attribute. The visibility check will account for this by permitting access to the
-   * target from locations in the same package as the target.
-   */
-  @Nullable
-  private static List<Label> getModifiedVisibility(
-      Package.Builder pkgBuilder, BuildLangTypedAttributeValuesMap args) {
-    MacroInstance currentMacro = pkgBuilder.currentMacro();
-    if (currentMacro == null) {
-      return null;
-    }
-
-    RuleVisibility visibility = null;
-    Object uncheckedVisibilityAttr = args.getAttributeValue("visibility");
-    if (uncheckedVisibilityAttr == null) {
-      visibility = RuleVisibility.PRIVATE;
-    } else {
-      try {
-        List<Label> visibilityAttr =
-            BuildType.LABEL_LIST.convert(
-                uncheckedVisibilityAttr, "visibility attribute", pkgBuilder.getLabelConverter());
-        visibility = RuleVisibility.parse(visibilityAttr);
-      } catch (EvalException ex) {
-        // Can't modify the visibility attribute because it's invalid. Let it be caught in
-        // RuleClass#populateDefinedRuleAttributeValues.
-        return null;
-      }
-    }
-
-    return visibility.concatWithPackage(currentMacro.getDefinitionPackage()).getDeclaredLabels();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java
@@ -555,7 +555,7 @@ public class StarlarkNativeModule implements StarlarkNativeModuleApi {
                     visibilityO, "'exports_files' operand", pkgBuilder.getLabelConverter()));
     MacroInstance currentMacro = pkgBuilder.currentMacro();
     if (currentMacro != null) {
-      visibility = currentMacro.concatDefinitionLocationToVisibility(visibility);
+      visibility = visibility.concatWithPackage(currentMacro.getDefinitionPackage());
     }
 
     // TODO(bazel-team): is licenses plural or singular?

--- a/src/main/java/com/google/devtools/build/lib/packages/Target.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Target.java
@@ -85,9 +85,61 @@ public interface Target extends TargetApi, TargetData {
   /** Returns the set of distribution types associated with this target. */
   Set<DistributionType> getDistributions();
 
-  /** Returns the visibility of this target. */
+  /**
+   * Returns the visibility that was supplied at the point of this target's declaration -- e.g. the
+   * {@code visibility} attribute/argument for a rule target or {@code exports_files()} declaration)
+   * -- or null if none was given.
+   *
+   * <p>Although this value is "raw", it is still normalized through {@link
+   * RuleVisibility#validateAndSimplify RuleVisibility parsing}, e.g. eliminating redundant {@code
+   * //visibility:private} items and replacing the list with a single {@code //visibility:public}
+   * item if at least one such item appears.
+   *
+   * <p>This value may be useful to tooling that wants to introspect a target's visibility via
+   * {@code bazel query} and feed the result back into a modified target declaration, without
+   * picking up the package's default visibility, or the added location of the package or symbolic
+   * macro the target was declared in. It is not useful as a direct input to the visibility
+   * semantics; for that see {@link #getActualVisibility}.
+   *
+   * <p>This is also the value that is introspected through {@code native.existing_rules()}, except
+   * that null is replaced by an empty visibility.
+   */
+  @Nullable
+  RuleVisibility getRawVisibility();
+
+  /**
+   * Returns the default visibility value to fall back on if this target does not have a raw
+   * visibility.
+   *
+   * <p>Usually this is just the package's default visibility value for targets not declared in
+   * symbolic macros, and private for targets within symbolic macros. (In other words, a package's
+   * default visibility does not propagate to within a symbolic macro.) However, some targets may
+   * inject additional default visibility behavior here.
+   */
+  default RuleVisibility getDefaultVisibility() {
+    return isCreatedInSymbolicMacro()
+        ? RuleVisibility.PRIVATE
+        : getPackage().getPackageArgs().defaultVisibility();
+  }
+
+  /**
+   * Returns the {@link #getRawVisibility raw visibility} of this target, falling back on a {@link
+   * #getDefaultVisibility default value} if no raw visibility was supplied.
+   *
+   * <p>Due to the fallback, the result cannot be null.
+   *
+   * <p>This value may be useful for introspecting a target's visibility and reporting it in a
+   * context where the package's default visibility is not known. It is not useful as a direct input
+   * to the visibility semantics; for that see {@link #getActualVisibility}.
+   */
+  // TODO(brandjon): Perhaps the default value within a symbolic macro should be the value of the
+  // `--default_visibility` flag / PrecomputedValue. This would ensure targets within macros are
+  // always visible within unit tests or escape-hatched builds.
   // TODO(jhorvitz): Usually one of the following two methods suffice. Try to remove this.
-  RuleVisibility getVisibility();
+  default RuleVisibility getVisibility() {
+    RuleVisibility result = getRawVisibility();
+    return result != null ? result : getDefaultVisibility();
+  }
 
   /**
    * Equivalent to calling {@link RuleVisibility#getDependencyLabels} on the value returned by
@@ -109,6 +161,27 @@ public interface Target extends TargetApi, TargetData {
    */
   default List<Label> getVisibilityDeclaredLabels() {
     return getVisibility().getDeclaredLabels();
+  }
+
+  /**
+   * Returns the visibility of this target, as understood by the visibility semantics.
+   *
+   * <p>This is the result of {@link #getVisibility} unioned with the package where this target was
+   * instantiated (which can differ from the package where this target lives if the target was
+   * created inside a symbolic macro).
+   *
+   * <p>This is the value that feeds into visibility checking in the analysis phase. See {@link
+   * ConfiguredTargetFactory#convertVisibility} and {@link
+   * CommonPrerequisiteValidator#isVisibleToLocation}.
+   */
+  default RuleVisibility getActualVisibility() {
+    RuleVisibility visibility = getVisibility();
+    MacroInstance declaringMacro = getDeclaringMacro();
+    PackageIdentifier instantiatingLoc =
+        declaringMacro == null
+            ? getPackage().getPackageIdentifier()
+            : declaringMacro.getDefinitionPackage();
+    return visibility.concatWithPackage(instantiatingLoc);
   }
 
   /** Returns whether this target type can be configured (e.g. accepts non-null configurations). */

--- a/src/main/java/com/google/devtools/build/lib/packages/Target.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Target.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.packages;
 
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.packages.License.DistributionType;
 import com.google.devtools.build.lib.starlarkbuildapi.TargetApi;
 import java.util.List;
@@ -36,12 +37,35 @@ public interface Target extends TargetApi, TargetData {
    * Returns the innermost symbolic macro that declared this target, or null if it was declared
    * outside any symbolic macro (i.e. directly in a BUILD file or only in one or more legacy
    * macros).
+   *
+   * <p>For targets in deserialized packages, throws {@link IllegalStateException}.
    */
+  @Nullable
   default MacroInstance getDeclaringMacro() {
     // TODO: #19922 - We might replace Package#getDeclaringMacroForTarget by storing a reference to
     // the declaring macro in implementations of this interface (sharing memory with the field for
     // the package).
     return getPackage().getDeclaringMacroForTarget(getName());
+  }
+
+  /**
+   * Returns the package that is considered to be the declaring location of this target.
+   *
+   * <p>For targets created inside a symbolic macro, this is the package containing the .bzl code of
+   * the innermost running symbolic macro. For targets not in any symbolic macro, this is the same
+   * as the package the target lives in.
+   */
+  default PackageIdentifier getDeclaringPackage() {
+    PackageIdentifier pkgId = getPackage().getDeclaringPackageForTargetIfInMacro(getName());
+    return pkgId != null ? pkgId : getPackage().getPackageIdentifier();
+  }
+
+  /**
+   * Returns true if this target was declared within one or more symbolic macros, or false if it was
+   * the product of running only a BUILD file and the legacy macros it called.
+   */
+  default boolean isCreatedInSymbolicMacro() {
+    return getPackage().getDeclaringPackageForTargetIfInMacro(getName()) != null;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetDefinitionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetDefinitionContext.java
@@ -176,7 +176,8 @@ public abstract class TargetDefinitionContext extends StarlarkThreadContext {
       @Nullable Semaphore cpuBoundSemaphore,
       @Nullable ImmutableMap<Location, String> generatorMap,
       @Nullable Globber globber,
-      boolean enableNameConflictChecking) {
+      boolean enableNameConflictChecking,
+      boolean trackFullMacroInformation) {
     super(() -> mainRepositoryMapping);
     this.metadata = metadata;
     this.pkg = pkg;
@@ -204,7 +205,7 @@ public abstract class TargetDefinitionContext extends StarlarkThreadContext {
     this.generatorMap = (generatorMap == null) ? ImmutableMap.of() : generatorMap;
     this.globber = globber;
 
-    this.recorder = new TargetRecorder(enableNameConflictChecking);
+    this.recorder = new TargetRecorder(enableNameConflictChecking, trackFullMacroInformation);
 
     // Add target for the BUILD file itself.
     // (This may be overridden by an exports_file declaration.)

--- a/src/main/java/com/google/devtools/build/lib/packages/VisibilityLicenseSpecifiedInputFile.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/VisibilityLicenseSpecifiedInputFile.java
@@ -43,12 +43,9 @@ public final class VisibilityLicenseSpecifiedInputFile extends InputFile {
   }
 
   @Override
-  public RuleVisibility getVisibility() {
-    if (visibility != null) {
-      return visibility;
-    } else {
-      return getPackage().getPackageArgs().defaultVisibility();
-    }
+  @Nullable
+  public RuleVisibility getRawVisibility() {
+    return visibility;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/query2/compat/FakeLoadTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/compat/FakeLoadTarget.java
@@ -80,7 +80,7 @@ public class FakeLoadTarget implements Target {
   }
 
   @Override
-  public RuleVisibility getVisibility() {
+  public RuleVisibility getRawVisibility() {
     return RuleVisibility.PUBLIC;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
@@ -327,6 +327,9 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
         input.setPackageContainsErrors(inputFile.getPackage().containsErrors());
       }
 
+      // TODO(bazel-team): We're being inconsistent about whether we include the package's
+      // default_visibility in the target. For files we do, but for rules we don't.
+
       for (Label visibilityDependency : target.getVisibilityDependencyLabels()) {
         input.addPackageGroup(labelPrinter.toString(visibilityDependency));
       }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/XmlOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/XmlOutputFormatter.java
@@ -222,6 +222,8 @@ class XmlOutputFormatter extends AbstractUnorderedFormatter {
             String.valueOf(inputFile.getPackage().containsErrors()));
       }
 
+      // TODO(bazel-team): We're being inconsistent about whether we include the package's
+      // default_visibility in the target. For files we do, but for rules we don't.
       addPackageGroupsToElement(doc, elem, inputFile, labelPrinter);
     } else if (target instanceof EnvironmentGroup envGroup) {
       elem = doc.createElement("environment-group");

--- a/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
@@ -105,8 +105,9 @@ public final class AliasConfiguredTarget implements ConfiguredTarget, Structure 
                 VisibilityProvider.class,
                 new VisibilityProviderImpl(
                     visibility,
-                    /* isCreatedInSymbolicMacro= */ ruleContext.getRule().getDeclaringMacro()
-                        != null));
+                    /* isCreatedInSymbolicMacro= */ ruleContext
+                        .getRule()
+                        .isCreatedInSymbolicMacro()));
     if (ruleContext.getRequiredConfigFragments() != null) {
       // This causes "blaze cquery --show_config_fragments=direct" to only show the
       // fragments/options the alias directly uses, not those of its actual target. Since alias

--- a/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
@@ -61,6 +61,9 @@ import net.starlark.java.eval.Structure;
  *   <li>{@code actual} has a self transition. Self transitions don't get applied to the alias rule,
  *       and so the configuration keys actually differ.
  * </ul>
+ *
+ * <p>An {@code alias} target may not be used to redirect a {@code package_group} target in a {@code
+ * visibility} declaration or a {@code package_group}'s {@code includes} attribute.
  */
 @Immutable
 public final class AliasConfiguredTarget implements ConfiguredTarget, Structure {

--- a/src/test/java/com/google/devtools/build/lib/analysis/SymbolicMacroTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SymbolicMacroTest.java
@@ -87,7 +87,7 @@ public final class SymbolicMacroTest extends BuildViewTestCase {
       throws Exception {
     Target target = pkg.getTarget(name);
     assertThat(target).isNotNull();
-    return asStringList(target.getVisibility().getDeclaredLabels());
+    return asStringList(target.getActualVisibility().getDeclaredLabels());
   }
 
   /**
@@ -95,7 +95,7 @@ public final class SymbolicMacroTest extends BuildViewTestCase {
    * package.
    */
   private static ImmutableList<String> getMacroVisibility(Package pkg, String id) throws Exception {
-    return asStringList(getMacroById(pkg, id).getVisibility());
+    return asStringList(getMacroById(pkg, id).getActualVisibility());
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/analysis/VisibilityProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/VisibilityProviderTest.java
@@ -200,7 +200,6 @@ public final class VisibilityProviderTest extends BuildViewTestCase {
     // Check the provider of an alias target declared in a BUILD file referencing an actual target
     // in a macro, and vice versa.
     defineSimpleRule();
-    scratch.file("lib/BUILD");
     scratch.file(
         // Put the .bzl in //pkg so we don't have to declare //pkg:__pkg__ in visibility.
         "pkg/macro.bzl",

--- a/src/test/java/com/google/devtools/build/lib/graph/DigraphTest.java
+++ b/src/test/java/com/google/devtools/build/lib/graph/DigraphTest.java
@@ -90,7 +90,7 @@ public class DigraphTest {
     }
 
     @Override
-    public RuleVisibility getVisibility() {
+    public RuleVisibility getRawVisibility() {
       return null;
     }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/PackageTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/PackageTest.java
@@ -179,7 +179,8 @@ public class PackageTest {
         /* generatorMap= */ null,
         /* configSettingVisibilityPolicy= */ null,
         /* globber= */ null,
-        /* enableNameConflictChecking= */ true);
+        /* enableNameConflictChecking= */ true,
+        /* trackFullMacroInformation= */ false);
   }
 
   private static Rule addRule(Package.Builder pkgBuilder, Label label, RuleClass ruleClass)


### PR DESCRIPTION
This CL simplifies RuleVisibility concatenation by inlining concatWithElement() into concatWithPackage(). The latter was the only caller of the former in production. The implementation no longer has to handle the case where the RHS is public or private -- something that was not needed in practice, but which was required in abstract for the deleted method's API to be correct. It also now doesn't need to parse an untrusted label, so there's no need to catch or throw EvalException.

concatWithPackage() is also made non-static, which looks nicer at the call sites.

The validate() method is renamed to checkForVisibilityMisspelling(), since that's the only thing it does now. (A previous CL removed its other job of detecting formerly illegal combinations of public/private visibility with other items in a list.)

Added an equals() and hashCode() while we're at it, to avoid depending on singleton identity (I'm not sure whether @SerializationConstant lets us assume that). It's based on just getDeclaredLabels() since that should superset any information returned by getDependencyLabels(). Changed RuleVisibility from an interface to an abstract class too -- I would've made it `sealed`, but the singleton PUBLIC and PRIVATE anonymous subclasses prevent that and it's not worth making them named classes.

MacroInstance.java
- Implement the TODO. (I went with "getDefinitionPackage" over "getDefiningPackage" because the latter might be confused with the package that defines the macro *instance*.)

MacroClass.java
- Condense to if-expr form now that the else branch is more concise.

RuleVisibilityTest.java
- Add pkg() helper for concatenation() test case.
- Remove assertEqual() now that we have a RuleVisibility#equals() method.
- Rename "B" -> "B_PG" for clarity/contrast with "A" and "C".
- Delete test cases for concatWithElement that are no longer applicable (where the RHS is public or private visibility)

Work toward https://github.com/bazelbuild/bazel/issues/23855.

PiperOrigin-RevId: 689400241
Change-Id: I6b7a1c9f87c4b3c9e5cd99d5dc4d906b5d798d28

Commit https://github.com/bazelbuild/bazel/commit/bd273e537cc52e41194a5e0c67c1673467bbe1eb