### PR TITLE
[8.0.0] Preserve analysis cache through `--run_under` command changes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1700,10 +1700,12 @@ java_library(
         ":config/run_under",
         ":config/starlark_defined_config_transition",
         ":platform_options",
+        ":test/test_configuration",
         "//src/main/java/com/google/devtools/build/lib/actions:action_environment",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:build_configuration_event",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_limits",
+        "//src/main/java/com/google/devtools/build/lib/analysis:test/test_trimming_logic",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
@@ -2037,7 +2039,10 @@ java_library(
 java_library(
     name = "config/run_under",
     srcs = ["config/RunUnder.java"],
-    deps = ["//src/main/java/com/google/devtools/build/lib/cmdline"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//third_party:jsr305",
+    ],
 )
 
 java_library(
@@ -2800,9 +2805,11 @@ java_library(
     deps = [
         ":config/build_options",
         ":config/core_option_converters",
+        ":config/core_options",
         ":config/fragment",
         ":config/fragment_options",
         ":config/per_label_options",
+        ":config/run_under",
         ":options_diff_predicate",
         ":test/coverage_configuration",
         ":test/test_sharding_strategy",
@@ -2834,17 +2841,31 @@ java_library(
     deps = [
         ":analysis_cluster",
         ":config/build_options",
-        ":config/build_options_cache",
-        ":config/core_options",
         ":config/fragment_options",
         ":config/transitions/no_transition",
         ":config/transitions/patch_transition",
         ":config/transitions/transition_factory",
         ":test/test_configuration",
+        ":test/test_trimming_logic",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/common/options",
+        "//third_party:guava",
+    ],
+)
+
+java_library(
+    name = "test/test_trimming_logic",
+    srcs = ["test/TestTrimmingLogic.java"],
+    deps = [
+        ":config/build_options",
+        ":config/build_options_cache",
+        ":config/core_options",
+        ":config/fragment_options",
+        ":config/run_under",
+        ":test/coverage_configuration",
+        ":test/test_configuration",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.analysis.PlatformOptions;
+import com.google.devtools.build.lib.analysis.test.TestConfiguration;
+import com.google.devtools.build.lib.analysis.test.TestTrimmingLogic;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.server.FailureDetails.BuildConfiguration.Code;
 import com.google.devtools.build.lib.util.Fingerprint;
@@ -298,6 +300,10 @@ public final class OutputPathMnemonicComputer {
       return "";
     }
 
+    if (!toOptions.contains(TestConfiguration.TestOptions.class)) {
+      baselineOptions = TestTrimmingLogic.trim(baselineOptions);
+    }
+
     // TODO(blaze-configurability-team): As a mild performance update, getFirst already includes
     //   details of the corresponding option. Could incorporate this instead of hashChosenOptions
     //   regenerating the OptionDefinitions and values.
@@ -307,8 +313,8 @@ public final class OutputPathMnemonicComputer {
     //   trimmings. See longform note in {@link ConfiguredTargetKey} for details.
     ImmutableSet<String> chosenNativeOptions =
         diff.getFirst().keySet().stream()
-            .filter(optionDef -> !explicitInOutputPathOptions.contains(optionDef.getOptionName()))
             .map(OptionDefinition::getOptionName)
+            .filter(optionName -> !explicitInOutputPathOptions.contains(optionName))
             .collect(toImmutableSet());
     // Note: getChangedStarlarkOptions includes all changed options, added options and removed
     //   options between baselineOptions and toOptions. This is necessary since there is no current

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnder.java
@@ -14,7 +14,7 @@
 package com.google.devtools.build.lib.analysis.config;
 
 import com.google.devtools.build.lib.cmdline.Label;
-import java.util.List;
+import javax.annotation.Nullable;
 
 /** Components of the {@code --run_under} option. */
 public interface RunUnder {
@@ -37,6 +37,22 @@ public interface RunUnder {
    * @return if the first word (according to shell tokenization) passed to
    *         --run_under starts with {@code "//"} returns {@code null}
    *         otherwise the first word
+   * Returns a new instance that only retains the information that is relevant for the analysis of
+   * non-test targets.
+   */
+  @Nullable
+  static RunUnder trimForNonTestConfiguration(@Nullable RunUnder runUnder) {
+    return switch (runUnder) {
+      case LabelRunUnder labelRunUnder ->
+          new LabelRunUnder("", ImmutableList.of(), labelRunUnder.label());
+      case null, default -> null;
+    };
+  }
+
+  /**
+   * Represents a value of {@code --run_under} whose first word (according to shell tokenization)
+   * starts with {@code "//"} or {@code "@"}. It is treated as a label referencing a target that
+   * should be used as the {@code --run_under} executable.
    */
   String getCommand();
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTrimmingLogic.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTrimmingLogic.java
@@ -1,0 +1,78 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.analysis.test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.analysis.config.BuildOptionsCache;
+import com.google.devtools.build.lib.analysis.config.BuildOptionsView;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
+import com.google.devtools.build.lib.analysis.config.FragmentOptions;
+import com.google.devtools.build.lib.analysis.config.RunUnder;
+import com.google.devtools.build.lib.analysis.test.CoverageConfiguration.CoverageOptions;
+import com.google.devtools.build.lib.analysis.test.TestConfiguration.TestOptions;
+
+/**
+ * Contains the pure logic for trimming test configuration from non-test targets that backs {@link
+ * com.google.devtools.build.lib.analysis.test.TestTrimmingTransitionFactory}.
+ */
+public final class TestTrimmingLogic {
+
+  static final ImmutableSet<Class<? extends FragmentOptions>> REQUIRED_FRAGMENTS =
+      ImmutableSet.of(CoreOptions.class, TestOptions.class);
+
+  // This cache is to prevent major slowdowns when using --trim_test_configuration. This
+  // transition is always invoked on every target in the top-level invocation. Thus, a wide
+  // invocation, like //..., will cause the transition to be invoked on a large number of targets
+  // leading to significant performance degradation. (Notably, the transition itself is somewhat
+  // fast; however, the post-processing of the BuildOptions into the actual BuildConfigurationValue
+  // takes a significant amount of time).
+  //
+  // Test any caching changes for performance impact in a longwide scenario with
+  // --trim_test_configuration on versus off.
+  // LINT.IfChange
+  private static final BuildOptionsCache<Boolean> CACHE =
+      new BuildOptionsCache<>(
+          (options, unused, unusedNonEventHandler) -> {
+            BuildOptions.Builder builder = options.underlying().toBuilder();
+            builder.removeFragmentOptions(TestOptions.class);
+            builder.removeFragmentOptions(CoverageOptions.class);
+            // Only the label of the --run_under target (if any) needs to be part of the
+            // configuration for non-test targets, all other information is directly obtained
+            // from the options in RunCommand.
+            CoreOptions coreOptions = builder.getFragmentOptions(CoreOptions.class);
+            coreOptions.runUnder = RunUnder.trimForNonTestConfiguration(coreOptions.runUnder);
+            return builder.build();
+          });
+
+  // LINT.ThenChange(TestConfiguration.java)
+
+  /** Returns a new {@link BuildOptions} instance with test configuration removed. */
+  public static BuildOptions trim(BuildOptions buildOptions) {
+    return trim(new BuildOptionsView(buildOptions, REQUIRED_FRAGMENTS));
+  }
+
+  /** Returns a new {@link BuildOptions} instance with test configuration removed. */
+  static BuildOptions trim(BuildOptionsView buildOptions) {
+    try {
+      return CACHE.applyTransition(buildOptions, Boolean.TRUE, /* eventHandler= */ null);
+    } catch (InterruptedException e) {
+      // The transition logic doesn't throw InterruptedException.
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private TestTrimmingLogic() {}
+}

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
@@ -113,6 +113,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:platform_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:required_config_fragments_provider",
+        "//src/main/java/com/google/devtools/build/lib/analysis:test/coverage_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/test_configuration",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleTransitionProviderTest.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.analysis.PlatformOptions;
 import com.google.devtools.build.lib.analysis.RequiredConfigFragmentsProvider;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.transitions.ConfigurationTransition;
+import com.google.devtools.build.lib.analysis.test.CoverageConfiguration.CoverageOptions;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration.TestOptions;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.analysis.util.DummyTestFragment;
@@ -1353,11 +1354,12 @@ public final class StarlarkRuleTransitionProviderTest extends BuildViewTestCase 
 
         my_rule(name = "test")
         """);
-    // --trim_test_configuration means only the top-level configuration has TestOptions.
+    // --trim_test_configuration means only the top-level configuration has CoverageOptions and
+    // TestOptions.
     assertConfigurationsEqual(
         getConfiguration(getConfiguredTarget("//test")),
         targetConfig,
-        ImmutableSet.of(TestOptions.class));
+        ImmutableSet.of(CoverageOptions.class, TestOptions.class));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubruleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubruleTest.java
@@ -1200,7 +1200,10 @@ public class StarlarkSubruleTest extends BuildViewTestCase {
         my_rule(name = "foo")
         """);
     // TODO: b/293304174 - use a custom fragment instead of coverage
-    useConfiguration("--collect_code_coverage", "--coverage_output_generator=//my:tool");
+    useConfiguration(
+        "--collect_code_coverage",
+        "--coverage_output_generator=//my:tool",
+        "--notrim_test_configuration");
 
     StructImpl provider =
         getProvider("//subrule_testing:foo", "//subrule_testing:myrule.bzl", "MyInfo");


### PR DESCRIPTION
Along the way, also trim `CoverageOptions` as part of the test trimming configuration, matching the logic in `TestConfiguration#SHOULD_INVALIDATE_FOR_OPTION_DIFF`. Also refactor `RunUnder` into a sealed interface implemented by two records.

Work towards #3325
Fixes #10782

RELNOTES: Changing any part of `--run_under` that isn't the label (such as the shell command) no longer invalidates the analysis cache.

Closes #24303.

PiperOrigin-RevId: 696887935
Change-Id: I79a2c153862c33b2ff25eefa4069bc11e99ea9d6

Commit https://github.com/bazelbuild/bazel/commit/4515bb6c932ce62c7889cf322319a3b49158acad