### PR TITLE
[8.0.0] Test with non-Latin-1 Unicode characters on Windows

### DIFF
--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -201,20 +201,7 @@ function test_script_file_generation {
 }
 
 function test_consistent_command_line_encoding {
-  if "$is_windows"; then
-    # The JVM sets sun.jnu.encoding, which is used to encode command-line
-    # arguments to java.exe, based on the return value of GetACP() on Windows.
-    # On Windows with an English locale, GetACP() returns 1252, which is a
-    # variant of ISO 8859-1 that can represent the characters below, but not
-    # the full Unicode range.
-    # TODO: Fix this by patching the fusion manifest of the embedded java.exe to
-    #  force GetACP() to return 65001 (UTF-8).
-    # äöüÄÖÜß in UTF8
-    local arg=$(echo -e '\xC3\xA4\xC3\xB6\xC3\xBC\xC3\x84\xC3\x96\xC3\x9C\xC3\x9F')
-  else
-    # äöüÄÖÜß🌱 in UTF8
-    local arg=$(echo -e '\xC3\xA4\xC3\xB6\xC3\xBC\xC3\x84\xC3\x96\xC3\x9C\xC3\x9F\xF0\x9F\x8C\xB1')
-  fi
+  local -r arg="äöüÄÖÜß🌱"
 
   mkdir -p foo || fail "mkdir foo failed"
   echo 'sh_binary(name = "foo", srcs = ["foo.sh"])' > foo/BUILD
@@ -240,13 +227,7 @@ EOF
 }
 
 function test_consistent_env_var_encoding {
-  if "$is_windows"; then
-    # äöüÄÖÜß in UTF8
-    local env=$(echo -e '\xC3\xA4\xC3\xB6\xC3\xBC\xC3\x84\xC3\x96\xC3\x9C\xC3\x9F')
-  else
-    # äöüÄÖÜß🌱 in UTF8
-    local env=$(echo -e '\xC3\xA4\xC3\xB6\xC3\xBC\xC3\x84\xC3\x96\xC3\x9C\xC3\x9F\xF0\x9F\x8C\xB1')
-  fi
+  local -r env="äöüÄÖÜß🌱"
 
   mkdir -p foo || fail "mkdir foo failed"
   cat > foo/BUILD <<EOF
@@ -287,13 +268,7 @@ EOF
 }
 
 function test_consistent_working_directory_encoding {
-  if "$is_windows"; then
-    # äöüÄÖÜß in UTF8
-    local unicode_string=$(echo -e '\xC3\xA4\xC3\xB6\xC3\xBC\xC3\x84\xC3\x96\xC3\x9C\xC3\x9F')
-  else
-    # äöüÄÖÜß🌱 in UTF8
-    local unicode_string=$(echo -e '\xC3\xA4\xC3\xB6\xC3\xBC\xC3\x84\xC3\x96\xC3\x9C\xC3\x9F\xF0\x9F\x8C\xB1')
-  fi
+  local -r unicode_string="äöüÄÖÜß🌱"
 
   mkdir -p foo || fail "mkdir foo failed"
   cat > foo/BUILD <<EOF


### PR DESCRIPTION
CI runners have been updated in https://github.com/bazelbuild/continuous-integration/commit/bd271932189c4b5e14ab17f1ff004c84b386e4be to a Windows version that supports the approach taken in 7bb8d2b648d533c4352452f2c4dbe9ddb1374434 to start the JVM with UTF-8 as the system encoding.

Closes #24270.

PiperOrigin-RevId: 697541108
Change-Id: I175a52b917667afe4129ad23ccb50171be1d2a59

Commit https://github.com/bazelbuild/bazel/commit/27ab1ef1a2f1f78ecd81f56a113a1a69dec70648