### PR TITLE
Sort recorded inputs in lockfile entries of module extensions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -244,10 +244,8 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                       .setUsagesDigest(
                           SingleExtensionUsagesValue.hashForEvaluation(
                               GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON, usagesValue))
-                      .setRecordedFileInputs(
-                          ImmutableSortedMap.copyOf(moduleExtensionResult.recordedFileInputs()))
-                      .setRecordedDirentsInputs(
-                          ImmutableSortedMap.copyOf(moduleExtensionResult.recordedDirentsInputs()))
+                      .setRecordedFileInputs(moduleExtensionResult.recordedFileInputs())
+                      .setRecordedDirentsInputs(moduleExtensionResult.recordedDirentsInputs())
                       .setEnvVariables(ImmutableSortedMap.copyOf(envVariables))
                       .setGeneratedRepoSpecs(generatedRepoSpecs)
                       .setModuleExtensionMetadata(moduleExtensionMetadata)

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -244,8 +244,10 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                       .setUsagesDigest(
                           SingleExtensionUsagesValue.hashForEvaluation(
                               GsonTypeAdapterUtil.SINGLE_EXTENSION_USAGES_VALUE_GSON, usagesValue))
-                      .setRecordedFileInputs(moduleExtensionResult.recordedFileInputs())
-                      .setRecordedDirentsInputs(moduleExtensionResult.recordedDirentsInputs())
+                      .setRecordedFileInputs(
+                          ImmutableSortedMap.copyOf(moduleExtensionResult.recordedFileInputs()))
+                      .setRecordedDirentsInputs(
+                          ImmutableSortedMap.copyOf(moduleExtensionResult.recordedDirentsInputs()))
                       .setEnvVariables(ImmutableSortedMap.copyOf(envVariables))
                       .setGeneratedRepoSpecs(generatedRepoSpecs)
                       .setModuleExtensionMetadata(moduleExtensionMetadata)

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -265,11 +265,11 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
 
   /** Returns the file digests used by this context object so far. */
   public ImmutableMap<RepoRecordedInput.File, String> getRecordedFileInputs() {
-    return ImmutableMap.copyOf(recordedFileInputs);
+    return ImmutableSortedMap.copyOf(recordedFileInputs);
   }
 
   public ImmutableMap<Dirents, String> getRecordedDirentsInputs() {
-    return ImmutableMap.copyOf(recordedDirentsInputs);
+    return ImmutableSortedMap.copyOf(recordedDirentsInputs);
   }
 
   public ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> getRecordedEnvVarInputs()

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -386,9 +386,9 @@
         "bzlTransitiveDigest": "Qo8I+jJhY9crwCWPwrJTnKD3vchTMDZVHV9mT061v5E=",
         "usagesDigest": "Nyolt29Er1COmUWRZ60rxE2yyfWcwvGeGr2L6USit+M=",
         "recordedFileInputs": {
-          "@@rules_python+//tools/publish/requirements_windows.txt": "15472d5a28e068d31ba9e2dc389459698afaff366e9db06e15890283a3ea252e",
+          "@@rules_python+//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a",
           "@@rules_python+//tools/publish/requirements_darwin.txt": "61cf602ff33b58c5f42a6cee30112985e9b502209605314e313157f8aad679f9",
-          "@@rules_python+//tools/publish/requirements.txt": "031e35d03dde03ae6305fe4b3d1f58ad7bdad857379752deede0f93649991b8a"
+          "@@rules_python+//tools/publish/requirements_windows.txt": "15472d5a28e068d31ba9e2dc389459698afaff366e9db06e15890283a3ea252e"
         },
         "recordedDirentsInputs": {},
         "envVariables": {


### PR DESCRIPTION
Order doesn't matter for these inputs and sorting them can only help decrease merge conflicts in the lockfile.