### PR TITLE
[8.0.0] Symbolic macro documentation & attribute inheritance cherry picks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -425,6 +425,12 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
           && attr.isDocumented()
           && !MacroClass.RESERVED_MACRO_ATTR_NAMES.contains(attrName)
           && !attrs.containsKey(attrName)) {
+        // Force the default value of optional inherited attributes to None.
+        if (!attr.isMandatory()
+            && attr.getDefaultValueUnchecked() != null
+            && attr.getDefaultValueUnchecked() != Starlark.NONE) {
+          attr = attr.cloneBuilder().defaultValueNone().build();
+        }
         builder.addAttribute(attr);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -418,7 +418,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
       Attribute attr = descriptor.build(attrName);
       builder.addAttribute(attr);
     }
-    for (Attribute attr : getInheritedAttrs(inheritAttrs)) {
+    for (Attribute attr : getAttrsOf(inheritAttrs)) {
       String attrName = attr.getName();
       if (attr.isPublic()
           // isDocumented() is false only for generator_* magic attrs (for which isPublic() is true)
@@ -443,20 +443,31 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
         getBzlKeyToken(thread, "Macros"));
   }
 
-  private static ImmutableList<Attribute> getInheritedAttrs(Object inheritAttrs)
-      throws EvalException {
-    if (inheritAttrs == Starlark.NONE) {
+  private static ImmutableList<Attribute> getAttrsOf(Object inheritAttrsArg) throws EvalException {
+    if (inheritAttrsArg == Starlark.NONE) {
       return ImmutableList.of();
-    } else if (inheritAttrs instanceof RuleFunction ruleFunction) {
+    } else if (inheritAttrsArg instanceof RuleFunction ruleFunction) {
+      verifyInheritAttrsArgExportedIfExportable(ruleFunction);
       return ruleFunction.getRuleClass().getAttributes();
-    } else if (inheritAttrs instanceof MacroFunction macroFunction) {
+    } else if (inheritAttrsArg instanceof MacroFunction macroFunction) {
+      verifyInheritAttrsArgExportedIfExportable(macroFunction);
       return macroFunction.getMacroClass().getAttributes().values().asList();
-    } else if (inheritAttrs.equals(COMMON_ATTRIBUTES_NAME)) {
+    } else if (inheritAttrsArg.equals(COMMON_ATTRIBUTES_NAME)) {
       return baseRule.getAttributes();
     }
     throw Starlark.errorf(
         "Invalid 'inherit_attrs' value %s; expected a rule, a macro, or \"common\"",
-        Starlark.repr(inheritAttrs));
+        Starlark.repr(inheritAttrsArg));
+  }
+
+  private static void verifyInheritAttrsArgExportedIfExportable(Object inheritAttrsArg)
+      throws EvalException {
+    // Note that the value of 'inherit_attrs' can be non-exportable (e.g. native rule).
+    if (inheritAttrsArg instanceof StarlarkExportable exportable && !exportable.isExported()) {
+      throw Starlark.errorf(
+          "Invalid 'inherit_attrs' value: a rule or macro callable must be assigned to a global"
+              + " variable in a .bzl file before it can be inherited from");
+    }
   }
 
   private static Symbol<BzlLoadValue.Key> getBzlKeyToken(StarlarkThread thread, String onBehalfOf) {

--- a/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
@@ -710,6 +710,18 @@ public final class Attribute implements Comparable<Attribute> {
       return defaultValue(defaultValue, null, null);
     }
 
+    /**
+     * Force the default value to be {@code None}. This method is meant only for usage by symbolic
+     * macro machinery.
+     */
+    @CanIgnoreReturnValue
+    public Builder<TYPE> defaultValueNone() {
+      value = null;
+      valueSet = true;
+      valueSource = AttributeValueSource.DIRECT;
+      return this;
+    }
+
     /** Returns where the value of this attribute comes from. Useful only for Starlark. */
     public AttributeValueSource getValueSource() {
       return valueSource;

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -277,6 +277,10 @@ the macro should inherit attributes.
 <a href="/reference/be/common-definitions#common-attributes">common rule attribute definitions</a>
 used by all Starlark rules.
 
+<p>Note that if the return value of <code>rule()</code> or <code>macro()</code> was not assigned to
+a global variable in a .bzl file, then such a value has not been registered as a rule or macro
+symbol, and therefore cannot be used for <code>inherit_attrs</code>.
+
 <p>By convention, a macro should pass inherited, non-overridden attributes unchanged to the "main"
 rule or macro symbol which the macro is wrapping. Typically, most inherited attributes will not have
 a parameter in the implementation function's parameter list, and will simply be passed via

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -270,9 +270,6 @@ site of the rule. Such attributes can be assigned a default value (as in
 A rule symbol, macro symbol, or the name of a built-in common attribute list (see below) from which
 the macro should inherit attributes.
 
-<p>If <code>inherit_attrs</code> is set, the macro's implementation function <em>must</em> have a
-<code>**kwargs</code> residual keyword parameter.
-
 <p>If <code>inherit_attrs</code> is set to the string <code>"common"</code>, the macro will inherit
 <a href="/reference/be/common-definitions#common-attributes">common rule attribute definitions</a>
 used by all Starlark rules.
@@ -281,29 +278,41 @@ used by all Starlark rules.
 a global variable in a .bzl file, then such a value has not been registered as a rule or macro
 symbol, and therefore cannot be used for <code>inherit_attrs</code>.
 
-<p>By convention, a macro should pass inherited, non-overridden attributes unchanged to the "main"
-rule or macro symbol which the macro is wrapping. Typically, most inherited attributes will not have
-a parameter in the implementation function's parameter list, and will simply be passed via
-<code>**kwargs</code>. However, it may be convenient for the implementation function to have
-explicit parameters for some inherited attributes (most commonly, <code>tags</code> and
-<code>testonly</code>) if the macro needs to pass those attributes to both "main" and non-"main"
-targets.
-
 <p>The inheritance mechanism works as follows:</p>
 <ol>
   <li>The special <code>name</code> and <code>visibility</code> attributes are never inherited;
   <li>Hidden attributes (ones whose name starts with <code>"_"</code>) are never inherited;
-  <li>The remaining inherited attributes are merged with the <code>attrs</code> dictionary, with
-    the entries in <code>attrs</code> dictionary taking precedence in case of conflicts.
+  <li>Attributes whose names are already defined in the <code>attrs</code> dictionary are never
+    inherited (the entry in <code>attrs</code> takes precedence; note that an entry may be set to
+    <code>None</code> to ensure that no attribute by that name gets defined on the macro);
+  <li>All other attributes are inherited from the rule or macro and effectively merged into the
+    <code>attrs</code> dict.
 </ol>
 
-<p>For example, the following macro inherits all attributes from <code>native.cc_library</code>, except
-for <code>cxxopts</code> (which is removed from the attribute list) and <code>copts</code> (which is
-given a new definition):
+<p>When a non-mandatory attribute is inherited, the default value of the attribute is overridden
+to be <code>None</code>, regardless of what it was specified in the original rule or macro. This
+ensures that when the macro forwards the attribute's value to an instance of the wrapped rule or
+macro &ndash; such as by passing in the unmodified <code>**kwargs</code> &ndash; a value that was
+absent from the outer macro's call will also be absent in the inner rule or macro's call (since
+passing <code>None</code> to an attribute is treated the same as omitting the attribute).
+This is important because omitting an attribute has subtly different semantics from passing
+its apparent default value. In particular, omitted attributes are not shown in some <code>bazel
+query</code> output formats, and computed defaults only execute when the value is omitted. If the
+macro needs to examine or modify an inherited attribute &ndash; for example, to add a value to an
+inherited <code>tags</code> attribute &ndash; you must make sure to handle the <code>None</code>
+case in the macro's implementation function.
+
+<p>For example, the following macro inherits all attributes from <code>native.cc_library</code>,
+except for <code>cxxopts</code> (which is removed from the attribute list) and <code>copts</code>
+(which is given a new definition). It also takes care to checks for the default <code>None</code>
+value of the inherited <code>tags</code> attribute before appending an additional tag.
 
 <pre class="language-python">
-def _my_cc_library_impl(name, visibility, **kwargs):
-    ...
+def _my_cc_library_impl(name, visibility, tags, **kwargs):
+    # Append a tag; tags attr is inherited from native.cc_library, and therefore is None unless
+    # explicitly set by the caller of my_cc_library()
+    my_tags = (tags or []) + ["my_custom_tag"]
+    native.cc_library(name = name, visibility = visibility, tags = my_tags, **kwargs)
 
 my_cc_library = macro(
     implementation = _my_cc_library_impl,
@@ -315,12 +324,17 @@ my_cc_library = macro(
 )
 </pre>
 
-<p>Note that a macro may inherit a non-hidden attribute with a computed default (for example,
-<a href="/reference/be/common-definitions#common.testonly"><code>testonly</code></a>); normally,
-macros do not allow attributes with computed defaults. If such an attribute is unset in a macro
-invocation, the value passed to the implementation function will be <code>None</code>, and the
-<code>None</code> may be safely passed on to the corresponding attribute of a rule target, causing
-the rule to compute the default as expected.
+<p>If <code>inherit_attrs</code> is set, the macro's implementation function <em>must</em> have a
+<code>**kwargs</code> residual keyword parameter.
+
+<p>By convention, a macro should pass inherited, non-overridden attributes unchanged to the "main"
+rule or macro symbol which the macro is wrapping. Typically, most inherited attributes will not have
+a parameter in the implementation function's parameter list, and will simply be passed via
+<code>**kwargs</code>. It can be convenient for the implementation function to have explicit
+parameters for some inherited attributes (most commonly, <code>tags</code> and
+<code>testonly</code>) if the macro needs to pass those attributes to both "main" and non-"main"
+targets &ndash; but if the macro also needs to examine or manipulate those attributes, you must take
+care to handle the <code>None</code> default value of non-mandatory inherited attributes.
 """),
         // TODO: #19922 - Make a concepts page for symbolic macros, migrate some details like the
         // list of disallowed APIs to there.

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -973,6 +973,47 @@ public final class ModuleInfoExtractorTest {
   }
 
   @Test
+  public void macroInheritedAttributes() throws Exception {
+    Module module =
+        execWithOptions(
+            ImmutableList.of("--experimental_enable_macro_inherit_attrs"),
+            """
+def _my_rule_impl(ctx):
+    pass
+
+_my_rule = rule(
+    implementation = _my_rule_impl,
+    attrs = {
+       "srcs": attr.label_list(doc = "My rule sources"),
+    },
+)
+
+def _my_macro_impl(name, visibility, srcs, **kwargs):
+    _my_rule(name = name, visibility = visibility, srcs = srcs, **kwargs)
+
+my_macro = macro(
+    inherit_attrs = _my_rule,
+    implementation = _my_macro_impl,
+)
+""");
+    ModuleInfo moduleInfo = getExtractor().extractFrom(module);
+    assertThat(moduleInfo.getMacroInfoList().get(0).getAttributeList())
+        .containsExactly(
+            IMPLICIT_MACRO_NAME_ATTRIBUTE_INFO, // name comes first
+            // TODO(arostovtsev): for macros, we ought to also document the visibility attr
+            AttributeInfo.newBuilder()
+                .setName("srcs")
+                .setType(AttributeType.LABEL_LIST)
+                .setDocString("My rule sources")
+                .setDefaultValue("None") // Default value of inherited attributes is always None
+                .build()
+            // TODO(arostovtsev): currently, non-Starlark-defined attributes don't get documented.
+            // This is a reasonable behavior for rules, but we probably ought to document them in
+            // macros with inherited attributes.
+            );
+  }
+
+  @Test
   public void unexportedMacro_notDocumented() throws Exception {
     Module module =
         exec(


### PR DESCRIPTION
This contains the following 3 cherry picks, which I'm providing in one PR because they must be applied in order:

1. Explicitly ban attribute inheritance from unexported rules/macros

Cherry-pick of
https://github.com/bazelbuild/bazel/commit/372980c4a7e68cfd0b6593172249b7c19c3fe3cb
PiperOrigin-RevId: 696954211
Change-Id: Ia205fe4e6686d51248c1389e1cf7b826650908e8

2. Force the default value of symbolic macro's optional inherited attributes to None

Cherry-pick of
https://github.com/bazelbuild/bazel/commit/a2f1f58cdff07d240c9f715d5091672bd9abd03f

PiperOrigin-RevId: 697301269
Change-Id: I47563898c511a1f065d117f51a7a3a227e23260e

3. Update symbolic macro docs

Cherry-pick of
https://github.com/bazelbuild/bazel/commit/ebeab8ce6607f0ea8448178219c61a935535be6a

PiperOrigin-RevId: 697741975
Change-Id: I511580e75ad4366d7895d3a791c62d5f8dc756a4