### PR TITLE
[8.0.0] Let `genquery` honor `--consistent_labels`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
@@ -203,6 +203,10 @@ public class CommonQueryOptions extends OptionsBase {
         : LabelPrinter.displayForm(mainRepoMapping);
   }
 
+  public LabelPrinter getLabelPrinterLegacy(StarlarkSemantics starlarkSemantics) {
+    return emitConsistentLabels ? LabelPrinter.starlark(starlarkSemantics) : LabelPrinter.LEGACY;
+  }
+
   ///////////////////////////////////////////////////////////
   // PROTO OUTPUT FORMATTER OPTIONS                        //
   ///////////////////////////////////////////////////////////

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/BUILD
@@ -38,7 +38,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
-        "//src/main/java/com/google/devtools/build/lib/packages:label_printer",
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/query2",

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
@@ -50,7 +50,6 @@ import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.BuildType;
-import com.google.devtools.build.lib.packages.LabelPrinter;
 import com.google.devtools.build.lib.packages.NoSuchPackageException;
 import com.google.devtools.build.lib.packages.NoSuchTargetException;
 import com.google.devtools.build.lib.packages.Package;
@@ -328,7 +327,8 @@ public class GenQuery implements RuleConfiguredTargetFactory {
               /* extraFunctions= */ ImmutableList.of(),
               /* packagePath= */ null,
               /* useGraphlessQuery= */ graphlessQuery,
-              LabelPrinter.legacy());
+              queryOptions.getLabelPrinterLegacy(
+                  ruleContext.getAnalysisEnvironment().getStarlarkSemantics()));
       QueryExpression expr = QueryExpression.parse(query, queryEnvironment);
       formatter.verifyCompatible(queryEnvironment, expr);
       targets =

--- a/src/test/java/com/google/devtools/build/lib/buildtool/GenQueryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/GenQueryIntegrationTest.java
@@ -931,6 +931,29 @@ public class GenQueryIntegrationTest extends BuildIntegrationTestCase {
     assertThat(decompressedOut.toString(UTF_8)).isEqualTo("//fruits:melon\n//fruits:papaya\n");
   }
 
+  @Test
+  public void testConsistentLabels() throws Exception {
+    write(
+        "fruits/BUILD",
+        """
+        load('//test_defs:foo_library.bzl', 'foo_library')
+        foo_library(
+            name = "melon",
+            deps = [":papaya"],
+        )
+
+        foo_library(name = "papaya")
+
+        genquery(
+            name = "q",
+            expression = "deps(//fruits:melon)",
+            scope = [":melon"],
+            opts = ["--consistent_labels"],
+        )
+        """);
+    assertQueryResult("//fruits:q", "@@//fruits:melon", "@@//fruits:papaya");
+  }
+
   private void assertQueryResult(String queryTarget, String... expected) throws Exception {
     assertThat(getQueryResult(queryTarget).split("\n"))
         .asList()


### PR DESCRIPTION
Fixes #24325

Closes #24326.

PiperOrigin-RevId: 697842646
Change-Id: Ied25448861c5133aae6f266000fe983625f48963

Commit https://github.com/bazelbuild/bazel/commit/5141c06f62ed1e435dec40aaed1dfb98f2f9b399