### PR TITLE
[8.0.0] Sort recorded inputs in lockfile entries of module extensions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -264,11 +264,11 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
 
   /** Returns the file digests used by this context object so far. */
   public ImmutableMap<RepoRecordedInput.File, String> getRecordedFileInputs() {
-    return ImmutableMap.copyOf(recordedFileInputs);
+    return ImmutableSortedMap.copyOf(recordedFileInputs);
   }
 
   public ImmutableMap<Dirents, String> getRecordedDirentsInputs() {
-    return ImmutableMap.copyOf(recordedDirentsInputs);
+    return ImmutableSortedMap.copyOf(recordedDirentsInputs);
   }
 
   public ImmutableMap<RepoRecordedInput.EnvVar, Optional<String>> getRecordedEnvVarInputs()


### PR DESCRIPTION
Order doesn't matter for these inputs and sorting them can only help decrease merge conflicts in the lockfile.

Closes #24367.

PiperOrigin-RevId: 697924458
Change-Id: Ie29e4c05204b974f10db571d61f38969411da03b

Commit https://github.com/bazelbuild/bazel/commit/34cc02ae8e73a9a1d2f00277da09c27924dd626b