### PR TITLE
[8.0.0] Bump lockfile version after changes to canonical names

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -38,7 +38,7 @@ public abstract class BazelLockFileValue implements SkyValue {
   // https://cs.opensource.google/bazel/bazel/+/release-7.3.0:src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java;l=120-127;drc=5f5355b75c7c93fba1e15f6658f308953f4baf51
   // While this hack exists on 7.x, lockfile version increments should be done 2 at a time (i.e.
   // keep this number even).
-  public static final int LOCK_FILE_VERSION = 12;
+  public static final int LOCK_FILE_VERSION = 14;
 
   @SerializationConstant public static final SkyKey KEY = () -> SkyFunctions.BAZEL_LOCK_FILE;
 

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 12,
+  "lockFileVersion": 14,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",


### PR DESCRIPTION
aa7317f changed the canonical name of repositories generated by `use_repo_rule`, which should have been accompanied by a bump of the lockfile version.

Should fix https://github.com/bazelbuild/bazel/pull/24171#issuecomment-2482949080

Closes #24363.

PiperOrigin-RevId: 697924369
Change-Id: I3b2876ea3fab86d5ab9c7e08f8c9ce607573c56c

Commit https://github.com/bazelbuild/bazel/commit/71227bf00cf803f931f126ed5ad6df5b2a073a27