### PR TITLE
[8.0.0] Check the current OS and only collect worker metrics on Linux and MacOS.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/CollectLocalResourceUsage.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/CollectLocalResourceUsage.java
@@ -137,7 +137,10 @@ public class CollectLocalResourceUsage implements LocalResourceCollector {
     collectors.add(new SystemCpuUsageCollector(osBean));
     collectors.add(new SystemMemoryUsageCollector(osBean));
 
-    if (collectWorkerDataInProfiler) {
+    if (collectWorkerDataInProfiler
+        && (OS.getCurrent() == OS.LINUX || OS.getCurrent() == OS.DARWIN)) {
+      // Enabling the WorkerMemoryUsageCollector will cause hangs on Windows. We should only enable
+      // it on Linux and Darwin.
       collectors.add(new WorkerMemoryUsageCollector(workerProcessMetricsCollector));
     }
     if (collectLoadAverage) {

--- a/src/test/java/com/google/devtools/build/lib/profiler/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/profiler/BUILD
@@ -30,6 +30,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/profiler:collect_local_resource_usage",
         "//src/main/java/com/google/devtools/build/lib/profiler:profiler-output",
         "//src/main/java/com/google/devtools/build/lib/profiler:system_network_stats",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_process_metrics",
         "//src/main/java/com/google/devtools/build/lib/worker:worker_process_status",
         "//src/main/java/com/google/devtools/build/skyframe",

--- a/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.profiler.Profiler.SlowTask;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.TestUtils;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.worker.WorkerProcessMetrics;
 import com.google.devtools.build.lib.worker.WorkerProcessMetricsCollector;
 import com.google.devtools.build.lib.worker.WorkerProcessStatus;
@@ -302,6 +303,11 @@ public final class ProfilerTest {
 
   @Test
   public void testProfilerWorkerMetrics() throws Exception {
+    if (OS.getCurrent() != OS.LINUX && OS.getCurrent() != OS.DARWIN) {
+      // We disable the WorkerMemoryUsageCollector on Windows, so we should skip the test if the
+      // current OS is not Linux and Darwin.
+      return;
+    }
     Instant collectionTime = BlazeClock.instance().now();
     WorkerProcessMetrics workerMetric1 =
         new WorkerProcessMetrics(


### PR DESCRIPTION
This metric shouldn't be collected on Windows.

Fixes https://github.com/bazelbuild/bazel/issues/23952

PiperOrigin-RevId: 698007958
Change-Id: I4d05e81e180467488a87a7839d879f916f9494b1

Commit https://github.com/bazelbuild/bazel/commit/8f9a5038dd9dbaffffdde38e4f61d5afa0bd76ac