### PR TITLE
[8.0.0] Fix duration measurement issues in the client

### DIFF
--- a/src/main/cpp/archive_utils.h
+++ b/src/main/cpp/archive_utils.h
@@ -15,9 +15,11 @@
 #ifndef BAZEL_SRC_MAIN_CPP_ARCHIVE_UTILS_H_
 #define BAZEL_SRC_MAIN_CPP_ARCHIVE_UTILS_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/util/logging.h"
 
@@ -28,28 +30,6 @@ namespace blaze {
 void DetermineArchiveContents(const std::string &archive_path,
                               std::vector<std::string> *files,
                               std::string *install_md5);
-
-struct DurationMillis {
- public:
-  const uint64_t millis;
-
-  DurationMillis() : millis(kUnknownDuration) {}
-  DurationMillis(const uint64_t ms) : millis(ms) {}
-
-  bool IsUnknown() const { return millis == kUnknownDuration; }
-
- private:
-  // Value representing that a timing event never occurred or is unknown.
-  static constexpr uint64_t kUnknownDuration = 0;
-};
-
-// DurationMillis that tracks if an archive was extracted.
-struct ExtractionDurationMillis : DurationMillis {
-  const bool archive_extracted;
-  ExtractionDurationMillis() : DurationMillis(), archive_extracted(false) {}
-  ExtractionDurationMillis(const uint64_t ms, const bool archive_extracted)
-      : DurationMillis(ms), archive_extracted(archive_extracted) {}
-};
 
 // The reason for a blaze server restart.
 // Keep in sync with logging.proto.
@@ -94,7 +74,7 @@ struct LoggingInfo {
 // BlessFiles. If the install base, the location the archive is unpacked,
 // already exists, extraction is skipped. Kills the client if an error is
 // encountered.
-ExtractionDurationMillis ExtractData(
+std::optional<DurationMillis> ExtractData(
     const std::string &self_path,
     const std::vector<std::string> &archive_contents,
     const std::string &expected_install_md5,

--- a/src/main/cpp/blaze_util.h
+++ b/src/main/cpp/blaze_util.h
@@ -131,6 +131,24 @@ class WithEnvVars {
   ~WithEnvVars();
 };
 
+struct DurationMillis {
+ public:
+  const uint64_t millis;
+
+  DurationMillis(const uint64_t start, const uint64_t end)
+      : millis(ComputeDuration(start, end)) {}
+
+ private:
+  static uint64_t ComputeDuration(const uint64_t start, const uint64_t end) {
+    if (end < start) {
+      BAZEL_LOG(WARNING) << "Invalid duration: start=" << start
+                         << ", end=" << end;
+      return 0;
+    }
+    return end - start;
+  }
+};
+
 }  // namespace blaze
 
 #endif  // BAZEL_SRC_MAIN_CPP_BLAZE_UTIL_H_

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -19,12 +19,13 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/server_process_info.h"
-#include "src/main/cpp/util/path.h"
 #include "src/main/cpp/util/port.h"
 
 namespace blaze {
@@ -208,12 +209,12 @@ enum class LockMode {
 // Acquires a `mode` lock on `path`, busy-waiting until it becomes available if
 // `block` is true, and releasing it on exec if `batch_mode` is false.
 // Crashes if the lock cannot be acquired. Returns a handle that can be
-// subsequently passed to ReleaseLock. Sets `wait_time` to the number of
-// milliseconds spent waiting for the lock. The `name` argument is used to
-// distinguish it from other locks in human-readable error messages.
-LockHandle AcquireLock(const std::string& name, const blaze_util::Path& path,
-                       LockMode mode, bool batch_mode, bool block,
-                       uint64_t* wait_time);
+// subsequently passed to ReleaseLock as well as the time spent waiting for the
+// lock, if any. The `name` argument is used to distinguish it from other locks
+// in human-readable error messages.
+std::pair<LockHandle, std::optional<DurationMillis>> AcquireLock(
+    const std::string& name, const blaze_util::Path& path, LockMode mode,
+    bool batch_mode, bool block);
 
 // Releases a lock previously obtained from AcquireLock.
 void ReleaseLock(LockHandle lock_handle);

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// clang-format off
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+// clang-format on
 
 #include <fcntl.h>
 #include <io.h>            // _open
@@ -28,10 +30,12 @@
 #include <cstdlib>
 #include <memory>
 #include <mutex>  // NOLINT
+#include <optional>
 #include <set>
 #include <sstream>
 #include <thread>       // NOLINT (to silence Google-internal linter)
 #include <type_traits>  // static_assert
+#include <utility>
 #include <vector>
 
 #include "src/main/cpp/blaze_util.h"
@@ -1087,9 +1091,9 @@ uint64_t WindowsClock::GetMilliseconds() const {
   return GetMillisecondsAsLargeInt(kFrequency).QuadPart;
 }
 
-LockHandle AcquireLock(const std::string& name, const blaze_util::Path& path,
-                       LockMode mode, bool batch_mode, bool block,
-                       uint64_t* wait_time) {
+std::pair<LockHandle, std::optional<DurationMillis>> AcquireLock(
+    const std::string& name, const blaze_util::Path& path, LockMode mode,
+    bool batch_mode, bool block) {
   DWORD desired_access = GENERIC_READ;
   if (mode == LockMode::kExclusive) {
     desired_access |= GENERIC_WRITE;
@@ -1164,8 +1168,8 @@ LockHandle AcquireLock(const std::string& name, const blaze_util::Path& path,
   // a concurrent process can read and display it. On Windows we can't do so
   // because locks are mandatory, thus we cannot read the file concurrently.
 
-  *wait_time = GetMillisecondsMonotonic() - start_time;
-  return reinterpret_cast<LockHandle>(handle);
+  return std::make_pair(reinterpret_cast<LockHandle>(handle),
+                        DurationMillis(start_time, GetMillisecondsMonotonic()));
 }
 
 void ReleaseLock(LockHandle lock_handle) {

--- a/src/test/cpp/blaze_archive_test.cc
+++ b/src/test/cpp/blaze_archive_test.cc
@@ -13,8 +13,13 @@
 // limitations under the License.
 #include <stdlib.h>
 
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
 #include <vector>
 
+#include "file/base/filesystem.h"
 #include "file/base/helpers.h"
 #include "file/base/path.h"
 #include "file/util/temp_path.h"
@@ -25,8 +30,12 @@
 #include "googletest/include/gtest/gtest.h"
 #include "absl/strings/escaping.h"
 #include "src/main/cpp/blaze.h"
+#include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/blaze_util_platform.h"
+#include "src/main/cpp/util/exit_code.h"
 #include "src/main/cpp/util/file_platform.h"
+#include "src/main/cpp/workspace_layout.h"
+#include "util/task/status_macros.h"
 
 using ::testing::Gt;
 using ::testing::status::IsOkAndHolds;
@@ -122,11 +131,14 @@ TEST_F(BlazeArchiveTest, TestZipExtractionAndFarOutMTimes) {
   set_startup_options(startup_options, blaze_path, output_dir);
   LoggingInfo logging_info(blaze_path, blaze::GetMillisecondsMonotonic());
 
-  ExtractionDurationMillis extraction_time =
+std::optional<DurationMillis> extraction_time =
       ExtractData(blaze_path, archive_contents, expected_install_md5,
                   startup_options, &logging_info);
 
-  ASSERT_TRUE(extraction_time.archive_extracted);
+ASSERT_TRUE(extraction_time
+.
+has_value()
+);
 
   const std::string foo_path = file::JoinPath(output_dir, "foo");
   const std::string bar_path = file::JoinPath(output_dir, "bar");
@@ -157,15 +169,20 @@ TEST_F(BlazeArchiveTest, TestNoDataExtractionIfInstallBaseExists) {
   set_startup_options(startup_options, blaze_path, output_dir);
   LoggingInfo logging_info(blaze_path, blaze::GetMillisecondsMonotonic());
 
-  ExtractionDurationMillis extraction_time_one =
+std::optional<DurationMillis> extraction_time_one =
       ExtractData(blaze_path, archive_contents, expected_install_md5,
                   startup_options, &logging_info);
-  ASSERT_TRUE(extraction_time_one.archive_extracted);
+ASSERT_TRUE(extraction_time_one
+.
+has_value()
+);
 
-  ExtractionDurationMillis extraction_time_two =
+std::optional<DurationMillis> extraction_time_two =
       ExtractData(blaze_path, archive_contents, expected_install_md5,
                   startup_options, &logging_info);
-
-  ASSERT_FALSE(extraction_time_two.archive_extracted);
+ASSERT_FALSE(extraction_time_two
+.
+has_value()
+);
 }
 }  // namespace blaze


### PR DESCRIPTION
Even with `CLOCK_MONOTONIC`, we are still seeing Bazel servers fail to start up occasionally due to start time being larger than end time. Make this non-fatal by truncating to 0 and emitting a warning with start and end time to facilitate further investigation.

Also flip the conditions for command and extraction wait time, which previously were only included if *not* known.

Closes #24344.

PiperOrigin-RevId: 697932531
Change-Id: Ia124a1e10640fde909ec377ab493f1654b5933e7

Fixes #24395