### PR TITLE
Add `--strict_repo_env` option

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -91,6 +91,7 @@ import com.google.devtools.build.lib.rules.repository.RepositoryFunction;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.BlazeRuntime;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
+import com.google.devtools.build.lib.runtime.CommonCommandOptions;
 import com.google.devtools.build.lib.runtime.InfoItem;
 import com.google.devtools.build.lib.runtime.ProcessWrapper;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
@@ -145,6 +146,8 @@ public class BazelRepositoryModule extends BlazeModule {
   private final StarlarkRepositoryFunction starlarkRepositoryFunction;
   private final RepositoryCache repositoryCache = new RepositoryCache();
   private final MutableSupplier<Map<String, String>> clientEnvironmentSupplier =
+      new MutableSupplier<>();
+  private final MutableSupplier<Map<String, String>> repoEnvironmentSupplier =
       new MutableSupplier<>();
   private ImmutableMap<RepositoryName, PathFragment> overrides = ImmutableMap.of();
   private ImmutableMap<String, PathFragment> injections = ImmutableMap.of();
@@ -243,11 +246,11 @@ public class BazelRepositoryModule extends BlazeModule {
             repositoryHandlers,
             starlarkRepositoryFunction,
             isFetch,
-            clientEnvironmentSupplier,
+            repoEnvironmentSupplier,
             directories,
             BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER);
     singleExtensionEvalFunction =
-        new SingleExtensionEvalFunction(directories, clientEnvironmentSupplier);
+        new SingleExtensionEvalFunction(directories, repoEnvironmentSupplier);
 
     if (builtinModules == null) {
       builtinModules = ModuleFileFunction.getBuiltinModules(directories.getEmbeddedBinariesRoot());
@@ -318,6 +321,12 @@ public class BazelRepositoryModule extends BlazeModule {
     this.yankedVersionsFunction.setDownloadManager(downloadManager);
     this.vendorCommand.setDownloadManager(downloadManager);
 
+    CommonCommandOptions commandOptions = env.getOptions().getOptions(CommonCommandOptions.class);
+    if (commandOptions.useStrictRepoEnv) {
+      repoEnvironmentSupplier.set(env.getRepoEnvFromOptions());
+    } else {
+      repoEnvironmentSupplier.set(env.getRepoEnv());
+    }
     clientEnvironmentSupplier.set(env.getRepoEnv());
     PackageOptions pkgOptions = env.getOptions().getOptions(PackageOptions.class);
     isFetch.set(pkgOptions != null && pkgOptions.fetch);
@@ -416,7 +425,7 @@ public class BazelRepositoryModule extends BlazeModule {
             CredentialHelperEnvironment.newBuilder()
                 .setEventReporter(env.getReporter())
                 .setWorkspacePath(env.getWorkspace())
-                .setClientEnvironment(env.getClientEnv())
+                .setClientEnvironment(env.getClientEnv())//
                 .setHelperExecutionTimeout(authAndTlsOptions.credentialHelperTimeout)
                 .build();
         CredentialHelperProvider credentialHelperProvider =

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
@@ -73,7 +73,7 @@ final class RegularRunnableExtension implements RunnableExtension {
   private final ModuleExtension extension;
   private final ImmutableMap<String, Optional<String>> staticEnvVars;
   private final BlazeDirectories directories;
-  private final Supplier<Map<String, String>> clientEnvironmentSupplier;
+  private final Supplier<Map<String, String>> repoEnvironmentSupplier;
   private final double timeoutScaling;
   @Nullable private final ProcessWrapper processWrapper;
   @Nullable private final RepositoryRemoteExecutor repositoryRemoteExecutor;
@@ -84,7 +84,7 @@ final class RegularRunnableExtension implements RunnableExtension {
       ModuleExtension extension,
       ImmutableMap<String, Optional<String>> staticEnvVars,
       BlazeDirectories directories,
-      Supplier<Map<String, String>> clientEnvironmentSupplier,
+      Supplier<Map<String, String>> repoEnvironmentSupplier,
       double timeoutScaling,
       @Nullable ProcessWrapper processWrapper,
       @Nullable RepositoryRemoteExecutor repositoryRemoteExecutor,
@@ -93,7 +93,7 @@ final class RegularRunnableExtension implements RunnableExtension {
     this.extension = extension;
     this.staticEnvVars = staticEnvVars;
     this.directories = directories;
-    this.clientEnvironmentSupplier = clientEnvironmentSupplier;
+    this.repoEnvironmentSupplier = repoEnvironmentSupplier;
     this.timeoutScaling = timeoutScaling;
     this.processWrapper = processWrapper;
     this.repositoryRemoteExecutor = repositoryRemoteExecutor;
@@ -141,7 +141,7 @@ final class RegularRunnableExtension implements RunnableExtension {
       StarlarkSemantics starlarkSemantics,
       Environment env,
       BlazeDirectories directories,
-      Supplier<Map<String, String>> clientEnvironmentSupplier,
+      Supplier<Map<String, String>> repoEnvironmentSupplier,
       double timeoutScaling,
       @Nullable ProcessWrapper processWrapper,
       @Nullable RepositoryRemoteExecutor repositoryRemoteExecutor,
@@ -186,7 +186,7 @@ final class RegularRunnableExtension implements RunnableExtension {
         extension,
         envVars,
         directories,
-        clientEnvironmentSupplier,
+        repoEnvironmentSupplier,
         timeoutScaling,
         processWrapper,
         repositoryRemoteExecutor,
@@ -357,7 +357,7 @@ final class RegularRunnableExtension implements RunnableExtension {
         workingDirectory,
         directories,
         env,
-        clientEnvironmentSupplier.get(),
+        repoEnvironmentSupplier.get(),
         downloadManager,
         timeoutScaling,
         processWrapper,

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -59,7 +59,7 @@ import net.starlark.java.eval.StarlarkSemantics;
  */
 public class SingleExtensionEvalFunction implements SkyFunction {
   private final BlazeDirectories directories;
-  private final Supplier<Map<String, String>> clientEnvironmentSupplier;
+  private final Supplier<Map<String, String>> repoEnvironmentSupplier;
 
   private double timeoutScaling = 1.0;
   @Nullable private ProcessWrapper processWrapper = null;
@@ -67,9 +67,9 @@ public class SingleExtensionEvalFunction implements SkyFunction {
   @Nullable private DownloadManager downloadManager = null;
 
   public SingleExtensionEvalFunction(
-      BlazeDirectories directories, Supplier<Map<String, String>> clientEnvironmentSupplier) {
+      BlazeDirectories directories, Supplier<Map<String, String>> repoEnvironmentSupplier) {
     this.directories = directories;
-    this.clientEnvironmentSupplier = clientEnvironmentSupplier;
+    this.repoEnvironmentSupplier = repoEnvironmentSupplier;
   }
 
   public void setDownloadManager(DownloadManager downloadManager) {
@@ -123,7 +123,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                 starlarkSemantics,
                 env,
                 directories,
-                clientEnvironmentSupplier,
+                repoEnvironmentSupplier,
                 timeoutScaling,
                 processWrapper,
                 repositoryRemoteExecutor,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -232,7 +232,7 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
                 outputDirectory,
                 ignoredSubdirectories.asIgnoredSubdirectories(),
                 env,
-                ImmutableMap.copyOf(clientEnvironment),
+                ImmutableMap.copyOf(repoEnvironment),
                 downloadManager,
                 timeoutScaling,
                 processWrapper,

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -105,19 +105,19 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
   private final AtomicBoolean isFetch;
   private final BlazeDirectories directories;
   private final ExternalPackageHelper externalPackageHelper;
-  private final Supplier<Map<String, String>> clientEnvironmentSupplier;
+  private final Supplier<Map<String, String>> repoEnvironmentSupplier;
 
   public RepositoryDelegatorFunction(
       ImmutableMap<String, RepositoryFunction> handlers,
       @Nullable RepositoryFunction starlarkHandler,
       AtomicBoolean isFetch,
-      Supplier<Map<String, String>> clientEnvironmentSupplier,
+      Supplier<Map<String, String>> repoEnvironmentSupplier,
       BlazeDirectories directories,
       ExternalPackageHelper externalPackageHelper) {
     this.handlers = handlers;
     this.starlarkHandler = starlarkHandler;
     this.isFetch = isFetch;
-    this.clientEnvironmentSupplier = clientEnvironmentSupplier;
+    this.repoEnvironmentSupplier = repoEnvironmentSupplier;
     this.directories = directories;
     this.externalPackageHelper = externalPackageHelper;
   }
@@ -391,7 +391,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       handler = handlers.get(rule.getRuleClass());
     }
     if (handler != null) {
-      handler.setClientEnvironment(clientEnvironmentSupplier.get());
+      handler.setRepoEnvironment(repoEnvironmentSupplier.get());
     }
 
     return handler;

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -84,7 +84,7 @@ import net.starlark.java.eval.Starlark;
  */
 public abstract class RepositoryFunction {
 
-  protected Map<String, String> clientEnvironment;
+  protected Map<String, String> repoEnvironment;
 
   /**
    * Exception thrown when something goes wrong accessing a remote repository.
@@ -409,8 +409,8 @@ public abstract class RepositoryFunction {
   }
 
   /** Sets up a mapping of environment variables to use. */
-  public void setClientEnvironment(Map<String, String> clientEnvironment) {
-    this.clientEnvironment = clientEnvironment;
+  public void setRepoEnvironment(Map<String, String> repoEnvironment) {
+    this.repoEnvironment = repoEnvironment;
   }
 
   /** Returns the RuleDefinition class for this type of repository. */

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -912,9 +912,17 @@ public class CommandEnvironment {
     }
   }
 
-  /** Returns the client environment with all settings from --action_env and --repo_env. */
+  /**
+   * Returns the repository environment created from the client environment, `--action_env and
+   * --repo_env.
+   */
   public Map<String, String> getRepoEnv() {
     return Collections.unmodifiableMap(repoEnv);
+  }
+
+  /** Returns the repository environment created from `--action_env` and `--repo_env` */
+  public Map<String, String> getRepoEnvFromOptions() {
+    return Collections.unmodifiableMap(repoEnvFromOptions);
   }
 
   /** Returns the file cache to use during this build. */

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -536,11 +536,27 @@ public class CommonCommandOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
       help =
-          "Specifies additional environment variables to be available only for repository rules."
-              + " Note that repository rules see the full environment anyway, but in this way"
-              + " configuration information can be passed to repositories through options without"
-              + " invalidating the action graph.")
+          """
+          Specifies additional environment variables to be available only for repository rules.
+          Note that by default repository rules see the full environment anyway, but in this way \
+          configuration information can be passed to repositories through options without \
+          invalidating the action graph.
+          """)
   public List<Map.Entry<String, String>> repositoryEnvironment;
+
+  @Option(
+      name = "strict_repo_env",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      help =
+          """
+          If true, repository rules and module extensions will not inherit the client environment.
+          <br>
+          Use <code>--repo_env=NAME</code> to inherit specific environment variables and
+          <code>--repo_env=NAME=VALUE</code> to set a static value.
+          """)
+    public boolean useStrictRepoEnv;
 
   @Option(
       name = "heuristically_drop_nodes",

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -139,7 +139,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
             repositoryHandlers,
             new StarlarkRepositoryFunction(),
             /* isFetch= */ new AtomicBoolean(true),
-            /* clientEnvironmentSupplier= */ ImmutableMap::of,
+            /* repoEnvironmentSupplier= */ ImmutableMap::of,
             directories,
             BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER);
     AtomicReference<PathPackageLocator> pkgLocator =

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3573,4 +3573,37 @@ EOF
     @repo//... &> $TEST_log || fail "expected Bazel to succeed"
 }
 
+function test_execute_environment_strict_vars() {
+  cat >> $(setup_module_dot_bazel)  <<'EOF'
+my_repo = use_repo_rule("//:repo.bzl", "my_repo")
+my_repo(name="repo")
+EOF
+  touch BUILD
+  cat > repo.bzl <<'EOF'
+def _impl(ctx):
+  st = ctx.execute(
+    ["env"],
+  )
+  if st.return_code:
+    fail("Command did not succeed")
+  vars = {line.partition("=")[0]: line.partition("=")[-1] for line in st.stdout.strip().split("\n")}
+  if "CLIENT_ENV_REMOVED" in vars:
+    fail("CLIENT_ENV_REMOVED should not be in the environment")
+  if vars.get("REPO_ENV_PRESENT") != "value2":
+    fail("REPO_ENV_PRESENT has wrong value: " + vars.get("REPO_ENV_PRESENT"))
+  if len(vars.keys()) > 1:
+    fail("More variables than expected: " + json.encode(vars))
+
+  ctx.file("BUILD", "exports_files(['data.txt'])")
+
+my_repo = repository_rule(_impl)
+EOF
+
+  CLIENT_ENV_REMOVED=value1 \
+   bazel build \
+    --strict_repo_env \
+    --repo_env=REPO_ENV_PRESENT=value2 \
+    @repo//... &> $TEST_log || fail "expected Bazel to succeed"
+}
+
 run_suite "local repository tests"


### PR DESCRIPTION
This PR introduces a new flag `--strict_repo_env` which stops repository rules and module extensions from inheriting the client environment (making `--repo_env=NAME` more than just an advisory notice).

See `test_execute_environment_strict_vars` in `src/test/shell/bazel/starlark_repository_test.sh` for a demonstration.

Note that the behavior is different to the similarly named `--incompatible_strict_action_env`, which stops _all_ environment variables (`--action_env` affects actions with `use_default_shell_env = True`) except those specified within the defining rule. Given the entity targeted by the new flag is a repo rule, I think this makes sense and any further strictness (like blocking implicit usage of variables without establishing a dependency) would be better addressed independently. Same goes for regular rules which can have some counterintuitive behaviors (e.g. only `--[host_]action_env=X=Y` is accessible, `--[host_]action_env=Y` will be missing, at least last I checked).

Addresses #10996