### PR TITLE
StandaloneTestStrategy: add lcov_merger to tools of TestRunner spawns

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -248,7 +248,6 @@ public final class TestActionBuilder {
     int shardCount = getShardCount(ruleContext);
 
     NestedSetBuilder<Artifact> lcovMergerFilesToRun = NestedSetBuilder.compileOrder();
-    Artifact lcovMergerRunfilesTree = null;
 
     TestTargetExecutionSettings executionSettings;
     if (collectCodeCoverage) {
@@ -307,9 +306,6 @@ public final class TestActionBuilder {
           extraTestEnv.put(LCOV_MERGER, lcovFilesToRun.getExecutable().getExecPathString());
           inputsBuilder.addTransitive(lcovFilesToRun.getFilesToRun());
           lcovMergerFilesToRun.addTransitive(lcovFilesToRun.getFilesToRun());
-          if (lcovFilesToRun.getRunfilesSupport() != null) {
-            lcovMergerRunfilesTree = lcovFilesToRun.getRunfilesSupport().getRunfilesTreeArtifact();
-          }
         } else {
           NestedSet<Artifact> filesToBuild =
               lcovMerger.getProvider(FileProvider.class).getFilesToBuild();
@@ -439,7 +435,6 @@ public final class TestActionBuilder {
                 cancelConcurrentTests,
                 splitCoveragePostProcessing,
                 lcovMergerFilesToRun,
-                lcovMergerRunfilesTree,
                 // Network allowlist only makes sense in workspaces which explicitly add it, use an
                 // empty one as a fallback.
                 MoreObjects.firstNonNull(

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -167,7 +167,6 @@ public class TestRunnerAction extends AbstractAction
 
   private final boolean splitCoveragePostProcessing;
   private final NestedSetBuilder<Artifact> lcovMergerFilesToRun;
-  @Nullable private final Artifact lcovMergerRunfilesTree;
 
   // TODO(b/192694287): Remove once we migrate all tests from the allowlist.
   private final PackageSpecificationProvider networkAllowlist;
@@ -213,7 +212,6 @@ public class TestRunnerAction extends AbstractAction
       boolean cancelConcurrentTestsOnSuccess,
       boolean splitCoveragePostProcessing,
       NestedSetBuilder<Artifact> lcovMergerFilesToRun,
-      @Nullable Artifact lcovMergerRunfilesTree,
       PackageSpecificationProvider networkAllowlist) {
     super(
         owner,
@@ -271,7 +269,6 @@ public class TestRunnerAction extends AbstractAction
     this.cancelConcurrentTestsOnSuccess = cancelConcurrentTestsOnSuccess;
     this.splitCoveragePostProcessing = splitCoveragePostProcessing;
     this.lcovMergerFilesToRun = lcovMergerFilesToRun;
-    this.lcovMergerRunfilesTree = lcovMergerRunfilesTree;
     this.networkAllowlist = networkAllowlist;
 
     // Mark all possible test outputs for deletion before test execution.
@@ -328,11 +325,6 @@ public class TestRunnerAction extends AbstractAction
   @Override
   public final ActionEnvironment getEnvironment() {
     return configuration.getActionEnvironment();
-  }
-
-  @Nullable
-  public Artifact getLcovMergerRunfilesTree() {
-    return lcovMergerRunfilesTree;
   }
 
   public BuildConfigurationValue getConfiguration() {

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -136,7 +136,9 @@ public class StandaloneTestStrategy extends TestStrategy {
             ImmutableMap.copyOf(executionInfo),
             ImmutableMap.of(),
             /* inputs= */ action.getInputs(),
-            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            /* tools= */ NestedSetBuilder.<ActionInput>compileOrder()
+              .addTransitive(action.getLcovMergerFilesToRun().build())
+              .build(),
             ImmutableSet.copyOf(action.getSpawnOutputs()),
             /* mandatoryOutputs= */ ImmutableSet.of(),
             localResourcesSupplier);
@@ -509,7 +511,9 @@ public class StandaloneTestStrategy extends TestStrategy {
             .add(action.getCoverageManifest())
             .addTransitive(action.getLcovMergerFilesToRun().build())
             .build(),
-        /* tools= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+        /* tools= */ NestedSetBuilder.<ActionInput>compileOrder()
+          .addTransitive(action.getLcovMergerFilesToRun().build())
+          .build(),
         /* outputs= */ ImmutableSet.of(
             ActionInputHelper.fromPath(action.getCoverageData().getExecPath())),
         /* mandatoryOutputs= */ null,


### PR DESCRIPTION
The default lcov_merger (@bazel_tools//tools/test:lcov_merger) is a java_binary that requires runfiles to work.
In StandaloneTestStrategy, it was added to the inputs of TestRunner spawns, but not to tools.
This prevents the runfiles from being available to the action, preventing coverage to be collected during remote execution.

Fixes #4033