### PR TITLE
[8.0.0] Apply the main repo mapping in `BuildIntegrationTestCase`

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BUILD
@@ -81,6 +81,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_execution_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:build_result_listener",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:repository_mapping_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skymeld_module",
         "//src/main/java/com/google/devtools/build/lib/standalone",


### PR DESCRIPTION
Some `get*` methods worked with apparent repo names, others didn't, which is a hurdle to contributions in this area (as observed while working on #24328).

Closes #24329.

PiperOrigin-RevId: 697548136
Change-Id: I24c3624875d1d1110ee8685656b88fffe3be6d95 
(cherry picked from commit 9534199d79c0089123bc8f46a0268432f8e0f3b8)

Closes #24347