### PR TITLE
Fix Unicode encoding issues in Bazel's use of Starlark

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -770,6 +770,14 @@ public final class BuildLanguageOptions extends OptionsBase {
               + " number of files is not 1.")
   public boolean incompatibleLocationsPrefersExecutable;
 
+  @Option(
+      name = "internal_starlark_utf_8_byte_strings",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {OptionMetadataTag.HIDDEN})
+  public boolean internalStarlarkUtf8ByteStrings;
+
   /** An enum for specifying different modes for UTF-8 checking of Starlark files. */
   public enum Utf8EnforcementMode {
     OFF,
@@ -815,6 +823,7 @@ public final class BuildLanguageOptions extends OptionsBase {
     // This function connects command-line flags to their corresponding StarlarkSemantics keys.
     StarlarkSemantics semantics =
         StarlarkSemantics.builder()
+            .setBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS, true)
             .setBool(EXPERIMENTAL_JAVA_LIBRARY_EXPORT, experimentalJavaLibraryExport)
             .setBool(
                 INCOMPATIBLE_STOP_EXPORTING_LANGUAGE_MODULES,
@@ -912,6 +921,9 @@ public final class BuildLanguageOptions extends OptionsBase {
                 INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE, incompatibleLocationsPrefersExecutable)
             .setBool(
                 StarlarkSemantics.EXPERIMENTAL_ENABLE_STARLARK_SET, experimentalEnableStarlarkSet)
+            .setBool(
+                StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS,
+                internalStarlarkUtf8ByteStrings)
             .build();
     return INTERNER.intern(semantics);
   }

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -823,7 +823,6 @@ public final class BuildLanguageOptions extends OptionsBase {
     // This function connects command-line flags to their corresponding StarlarkSemantics keys.
     StarlarkSemantics semantics =
         StarlarkSemantics.builder()
-            .setBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS, true)
             .setBool(EXPERIMENTAL_JAVA_LIBRARY_EXPORT, experimentalJavaLibraryExport)
             .setBool(
                 INCOMPATIBLE_STOP_EXPORTING_LANGUAGE_MODULES,

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -775,7 +775,10 @@ public final class BuildLanguageOptions extends OptionsBase {
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
-      metadataTags = {OptionMetadataTag.HIDDEN})
+      metadataTags = {OptionMetadataTag.HIDDEN},
+      help =
+          "Internal use only. Forces the Starlark implementation to operate on strings as raw"
+              + " UTF-8 byte arrays, matching Bazel's internal string encoding.")
   public boolean internalStarlarkUtf8ByteStrings;
 
   /** An enum for specifying different modes for UTF-8 checking of Starlark files. */

--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -585,6 +585,7 @@ public final class Starlark {
    * processors interpreting indented parts of the original string as special formatting (e.g. code
    * blocks in the case of Markdown).
    */
+  // TODO: Pass in StarlarkSemantics as an argument rather than using StarlarkSemantics.DEFAULT.
   public static String trimDocString(String docString) {
     ImmutableList<String> lines = expandTabs(docString, 8).lines().collect(toImmutableList());
     if (lines.isEmpty()) {

--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -591,11 +591,12 @@ public final class Starlark {
       return "";
     }
     // First line is special: we fully strip it and ignore it for leading spaces calculation
-    String firstLineTrimmed = StringModule.INSTANCE.strip(lines.get(0), NONE);
+    String firstLineTrimmed =
+        StringModule.INSTANCE.stripSemantics(lines.get(0), NONE, StarlarkSemantics.DEFAULT);
     Iterable<String> subsequentLines = Iterables.skip(lines, 1);
     int minLeadingSpaces = Integer.MAX_VALUE;
     for (String line : subsequentLines) {
-      String strippedLeading = StringModule.INSTANCE.lstrip(line, NONE);
+      String strippedLeading = StringModule.INSTANCE.lstripSemantics(line, NONE, StarlarkSemantics.DEFAULT);
       if (!strippedLeading.isEmpty()) {
         int leadingSpaces = line.length() - strippedLeading.length();
         minLeadingSpaces = min(leadingSpaces, minLeadingSpaces);
@@ -613,11 +614,13 @@ public final class Starlark {
         result.append("\n");
       }
       if (line.length() > minLeadingSpaces) {
-        result.append(StringModule.INSTANCE.rstrip(line.substring(minLeadingSpaces), NONE));
+        result.append(
+            StringModule.INSTANCE.rstripSemantics(
+                line.substring(minLeadingSpaces), NONE, StarlarkSemantics.DEFAULT));
       }
     }
     // Remove trailing empty lines
-    return StringModule.INSTANCE.rstrip(result.toString(), NONE);
+    return StringModule.INSTANCE.rstripSemantics(result.toString(), NONE, StarlarkSemantics.DEFAULT);
   }
 
   /**

--- a/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
@@ -174,6 +174,9 @@ public class StarlarkSemantics {
 
     /** Returns an immutable StarlarkSemantics. */
     public StarlarkSemantics build() {
+      if (map.isEmpty()) {
+        return DEFAULT;
+      }
       return new StarlarkSemantics(ImmutableMap.copyOf(map));
     }
   }
@@ -259,4 +262,7 @@ public class StarlarkSemantics {
 
   /** Whether StarlarkSet objects may be constructed by the interpreter. */
   public static final String EXPERIMENTAL_ENABLE_STARLARK_SET = "+experimental_enable_starlark_set";
+
+  public static final String INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS =
+      "-internal_bazel_only_utf_8_byte_strings";
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -97,7 +97,11 @@ public class ConsistencyTest {
   @Test
   public void checkDefaultsMatch() {
     BuildLanguageOptions defaultOptions = Options.getDefaults(BuildLanguageOptions.class);
-    StarlarkSemantics defaultSemantics = StarlarkSemantics.DEFAULT;
+    StarlarkSemantics defaultSemantics =
+        StarlarkSemantics.DEFAULT.toBuilder()
+            // This flag must be false in Starlark, but true in Bazel by default.
+            .setBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS, true)
+            .build();
     StarlarkSemantics semanticsFromOptions = defaultOptions.toStarlarkSemantics();
     assertThat(semanticsFromOptions).isEqualTo(defaultSemantics);
   }
@@ -155,6 +159,7 @@ public class ConsistencyTest {
         "--incompatible_use_cc_configure_from_rules_cc=" + rand.nextBoolean(),
         "--incompatible_unambiguous_label_stringification=" + rand.nextBoolean(),
         "--internal_starlark_flag_test_canary=" + rand.nextBoolean(),
+        "--internal_starlark_utf_8_byte_strings=" + rand.nextBoolean(),
         "--max_computation_steps=" + rand.nextLong());
   }
 
@@ -210,6 +215,7 @@ public class ConsistencyTest {
         .setBool(
             BuildLanguageOptions.INCOMPATIBLE_UNAMBIGUOUS_LABEL_STRINGIFICATION, rand.nextBoolean())
         .setBool(StarlarkSemantics.PRINT_TEST_MARKER, rand.nextBoolean())
+        .setBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS, rand.nextBoolean())
         .set(BuildLanguageOptions.MAX_COMPUTATION_STEPS, rand.nextLong())
         .build();
   }

--- a/src/test/java/net/starlark/java/eval/BUILD
+++ b/src/test/java/net/starlark/java/eval/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_binary", "java_test")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
 
 package(default_testonly = 1)
 

--- a/src/test/java/net/starlark/java/eval/BUILD
+++ b/src/test/java/net/starlark/java/eval/BUILD
@@ -49,13 +49,10 @@ java_test(
     ],
 )
 
-# Script-based tests of the Starlark interpreter.
-java_test(
-    name = "ScriptTest",
+java_library(
+    name = "ScriptTest_lib",
     srcs = ["ScriptTest.java"],
     data = glob(["testdata/*.star"]),
-    jvm_flags = ["-Dfile.encoding=UTF8"],
-    use_testrunner = False,
     deps = [
         "//src/main/java/net/starlark/java/annot",
         "//src/main/java/net/starlark/java/eval",
@@ -63,6 +60,25 @@ java_test(
         "//src/main/java/net/starlark/java/syntax",
         "//third_party:error_prone_annotations",
         "//third_party:guava",
+    ],
+)
+
+# Script-based tests of the Starlark interpreter.
+java_test(
+    name = "ScriptTest",
+    use_testrunner = False,
+    runtime_deps = [
+        ":ScriptTest_lib",
+    ],
+)
+
+java_test(
+    name = "ScriptTest_Latin1",
+    jvm_flags = ["-Dnet.starlark.java.eval.ScriptTest.utf8ByteStrings=true"],
+    main_class = "net.starlark.java.eval.ScriptTest",
+    use_testrunner = False,
+    runtime_deps = [
+        ":ScriptTest_lib",
     ],
 )
 

--- a/src/test/java/net/starlark/java/eval/testdata/json.star
+++ b/src/test/java/net/starlark/java/eval/testdata/json.star
@@ -26,10 +26,13 @@ assert_eq(json.encode("/"), '"/"')
 assert_eq(json.encode("\\"), r'"\\"')
 assert_eq(json.encode(""), '""')
 # TODO: Invalid UTF-8 byte sequences are not replaced with U+FFFD.
-(
-    assert_eq(json.encode("😹"[:1]), '"\360"') # first byte of 0xF0 0x9F 0x98 0xB9 in octal
-    if _utf8_byte_strings
-    else assert_eq(json.encode("😹"[:1]), '"�"') # invalid UTF-16 -> replacement char U+FFFD
+assert_eq(
+    json.encode("😹"[:1]),
+    (
+        '"\360"' # first byte of 0xF0 0x9F 0x98 0xB9 in octal
+        if _utf8_byte_strings else
+        '"�"' # invalid UTF-16 -> replacement char U+FFFD
+    )
 )
 assert_eq(json.encode("¼Δ"), "\"¼Δ\"") # 2 byte UTF-8 encoding, single UTF-16 character
 assert_eq(json.encode("😹"), "\"😹\"") # 4 byte UTF-8 encoding, two UTF-16 characters (surrogate pair)
@@ -92,11 +95,12 @@ assert_eq(json.decode('{"one": 1, "two": 2}'), dict(one = 1, two = 2))
 assert_eq(json.decode('{"foo\\u0000bar": 42}'), {"foo\0bar": 42})
 assert_eq(json.decode('"\\ud83d\\ude39\\ud83d\\udc8d"'), "😹💍")
 assert_eq(json.decode('"\\u0123"'), "ģ")
+
 # Illegal UTF-16 encodings
 assert_eq(json.decode('"\\udc8d\\ud83d"'), "��") # swapped surrogates
 assert_eq(json.decode('"\\udc8d"'), "�") # unpaired high surrogate
 assert_eq(json.decode('"\\ud83d"'), "�") # unpaired low surrogate
-assert_eq(json.decode('"\\udc8d\\u0123"'), "���") # unpaired high surrogate followed by non-surrogate
+assert_eq(json.decode('"\\udc8d\\u0123"'), "�ģ") # unpaired high surrogate followed by non-surrogate
 
 #assert_eq(json.decode('"\x7f"'), "\x7f")
 assert_eq(json.decode("\t[\t1,\r2,\n3]\n"), [1, 2, 3])  # whitespace other than ' '

--- a/src/test/java/net/starlark/java/eval/testdata/json.star
+++ b/src/test/java/net/starlark/java/eval/testdata/json.star
@@ -26,11 +26,13 @@ assert_eq(json.encode("/"), '"/"')
 assert_eq(json.encode("\\"), r'"\\"')
 assert_eq(json.encode(""), '""')
 # TODO: Invalid UTF-8 byte sequences are not replaced with U+FFFD.
-assert_eq(json.encode("😹"[:1]), '"�"') if not _utf8_byte_strings else None # invalid UTF-16 -> replacement char U+FFFD
-# 2 byte UTF-8 encoding, single UTF-16 character
-assert_eq(json.encode("¼Δ"), "\"¼Δ\"")
-# 4 byte UTF-8 encoding, two UTF-16 characters (surrogate pair)
-assert_eq(json.encode("😹"), "\"😹\"")
+(
+    assert_eq(json.encode("😹"[:1]), '"\360"') # first byte of 0xF0 0x9F 0x98 0xB9 in octal
+    if _utf8_byte_strings
+    else assert_eq(json.encode("😹"[:1]), '"�"') # invalid UTF-16 -> replacement char U+FFFD
+)
+assert_eq(json.encode("¼Δ"), "\"¼Δ\"") # 2 byte UTF-8 encoding, single UTF-16 character
+assert_eq(json.encode("😹"), "\"😹\"") # 4 byte UTF-8 encoding, two UTF-16 characters (surrogate pair)
 
 assert_eq(json.encode([1, 2, 3]), "[1,2,3]")
 assert_eq(json.encode((1, 2, 3)), "[1,2,3]")
@@ -90,8 +92,11 @@ assert_eq(json.decode('{"one": 1, "two": 2}'), dict(one = 1, two = 2))
 assert_eq(json.decode('{"foo\\u0000bar": 42}'), {"foo\0bar": 42})
 assert_eq(json.decode('"\\ud83d\\ude39\\ud83d\\udc8d"'), "😹💍")
 assert_eq(json.decode('"\\u0123"'), "ģ")
-# Low surrogate followed by high surrogate (illegal)
-assert_eq(json.decode('"\\udc8d\\ud83d"'), "��")
+# Illegal UTF-16 encodings
+assert_eq(json.decode('"\\udc8d\\ud83d"'), "��") # swapped surrogates
+assert_eq(json.decode('"\\udc8d"'), "�") # unpaired high surrogate
+assert_eq(json.decode('"\\ud83d"'), "�") # unpaired low surrogate
+assert_eq(json.decode('"\\udc8d\\u0123"'), "���") # unpaired high surrogate followed by non-surrogate
 
 #assert_eq(json.decode('"\x7f"'), "\x7f")
 assert_eq(json.decode("\t[\t1,\r2,\n3]\n"), [1, 2, 3])  # whitespace other than ' '

--- a/src/test/java/net/starlark/java/eval/testdata/json.star
+++ b/src/test/java/net/starlark/java/eval/testdata/json.star
@@ -27,6 +27,10 @@ assert_eq(json.encode("\\"), r'"\\"')
 assert_eq(json.encode(""), '""')
 # TODO: Invalid UTF-8 byte sequences are not replaced with U+FFFD.
 assert_eq(json.encode("😹"[:1]), '"�"') if not _utf8_byte_strings else None # invalid UTF-16 -> replacement char U+FFFD
+# 2 byte UTF-8 encoding, single UTF-16 character
+assert_eq(json.encode("¼Δ"), "\"¼Δ\"")
+# 4 byte UTF-8 encoding, two UTF-16 characters (surrogate pair)
+assert_eq(json.encode("😹"), "\"😹\"")
 
 assert_eq(json.encode([1, 2, 3]), "[1,2,3]")
 assert_eq(json.encode((1, 2, 3)), "[1,2,3]")
@@ -86,6 +90,8 @@ assert_eq(json.decode('{"one": 1, "two": 2}'), dict(one = 1, two = 2))
 assert_eq(json.decode('{"foo\\u0000bar": 42}'), {"foo\0bar": 42})
 assert_eq(json.decode('"\\ud83d\\ude39\\ud83d\\udc8d"'), "😹💍")
 assert_eq(json.decode('"\\u0123"'), "ģ")
+# Low surrogate followed by high surrogate (illegal)
+assert_eq(json.decode('"\\udc8d\\ud83d"'), "��")
 
 #assert_eq(json.decode('"\x7f"'), "\x7f")
 assert_eq(json.decode("\t[\t1,\r2,\n3]\n"), [1, 2, 3])  # whitespace other than ' '

--- a/src/test/java/net/starlark/java/eval/testdata/json.star
+++ b/src/test/java/net/starlark/java/eval/testdata/json.star
@@ -25,7 +25,8 @@ assert_eq(json.encode("\""), r'"\""')
 assert_eq(json.encode("/"), '"/"')
 assert_eq(json.encode("\\"), r'"\\"')
 assert_eq(json.encode(""), '""')
-assert_eq(json.encode("😹"[:1]), '"�"')  # invalid UTF-16 -> replacement char U+FFFD
+# TODO: Invalid UTF-8 byte sequences are not replaced with U+FFFD.
+assert_eq(json.encode("😹"[:1]), '"�"') if not _utf8_byte_strings else None # invalid UTF-16 -> replacement char U+FFFD
 
 assert_eq(json.encode([1, 2, 3]), "[1,2,3]")
 assert_eq(json.encode((1, 2, 3)), "[1,2,3]")

--- a/src/test/java/net/starlark/java/eval/testdata/sorted.star
+++ b/src/test/java/net/starlark/java/eval/testdata/sorted.star
@@ -96,12 +96,15 @@ assert_([d1] <= [d2])  # distinct objects
 assert_([d1] <= [d1, d2])
 assert_([None] <= [None])
 
-# Starlark/Java Strings are ordered lexicographically by elements (chars).
-# With UTF-16, this is not the same as code point order, because
-# surrogates DXXX are not at the top of the 16-bit range. For example:
+# Starlark/Java Strings are ordered lexicographically by elements.
+# With UTF-16, where elements are chars, this is not the same as code point
+# order, because surrogates DXXX are not at the top of the 16-bit range.
+# For example:
 #  U+FFFD  � 	= [FFFD]       REPLACEMENT CHAR
 #  U+1F33F 🌿	= [D83C DF3F]  HERB
 # The first compares greater than the second.
+# With UTF-8 byte strings, the order is just the lexicographic order of the
+# bytes.
 assert_eq(sorted(["�", "🌿"]), ["�", "🌿"] if _utf8_byte_strings else ["🌿", "�"])
 
 assert_(False < True)

--- a/src/test/java/net/starlark/java/eval/testdata/sorted.star
+++ b/src/test/java/net/starlark/java/eval/testdata/sorted.star
@@ -102,7 +102,7 @@ assert_([None] <= [None])
 #  U+FFFD  � 	= [FFFD]       REPLACEMENT CHAR
 #  U+1F33F 🌿	= [D83C DF3F]  HERB
 # The first compares greater than the second.
-assert_eq(sorted(["�", "🌿"]), ["🌿", "�"])
+assert_eq(sorted(["�", "🌿"]), ["�", "🌿"] if _utf8_byte_strings else ["🌿", "�"])
 
 assert_(False < True)
 assert_fails(lambda: False < 1, "unsupported comparison: bool <=> int")

--- a/src/test/java/net/starlark/java/eval/testdata/string_misc.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_misc.star
@@ -187,10 +187,12 @@ assert_eq("".removeprefix(""), "")
 assert_eq("".removeprefix("a"), "")
 assert_eq("Apricot".removeprefix("pr"), "Apricot")
 assert_eq("AprApricot".removeprefix("Apr"), "Apricot")
+
 def removeprefix_self_unmodified():
     original_string = "Apricot"
     assert_eq(original_string.removeprefix("Apr"), "icot")
     assert_eq(original_string, "Apricot")
+
 removeprefix_self_unmodified()
 assert_fails(lambda: "1234".removeprefix(1), "got value of type 'int', want 'string")
 
@@ -203,9 +205,17 @@ assert_eq("".removesuffix(""), "")
 assert_eq("".removesuffix("a"), "")
 assert_eq("Apricot".removesuffix("co"), "Apricot")
 assert_eq("Apricotcot".removesuffix("cot"), "Apricot")
+
 def removesuffix_self_unmodified():
     original_string = "Apricot"
     assert_eq(original_string.removesuffix("cot"), "Apri")
     assert_eq(original_string, "Apricot")
+
 removesuffix_self_unmodified()
 assert_fails(lambda: "1234".removesuffix(4), "got value of type 'int', want 'string")
+
+# strip
+assert_eq("  abc  ".strip(), "abc")
+assert_eq("薠".strip(), "薠")
+assert_eq("薠".lstrip(), "薠")
+assert_eq("薠".rstrip(), "薠")


### PR DESCRIPTION
Bazel internally uses `String` as a container for raw bytes assumed to be UTF-8, which differs from ordinary usage of `String` as a container for UTF-16 characters. This requires special implementations of certain Starlark functions that care about the notion of a "character":

* `{l,r,}strip` must not strip non-ASCII whitespace as it may be part of a UTF-8-encoded non-whitespace character.
* `json.decode` has to emit UTF-8 bytes rather than UTF-16 characters.

Compatibility is verified by running all script-based tests both parsed as UTF-8 and using Bazel's internal encoding.