### PR TITLE
[8.0.0] Suppress warnings for all external repos

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -49,6 +49,14 @@ build:macos --host_cxxopt=-std=c++17
 build:windows --cxxopt=/std:c++17
 build:windows --host_cxxopt=/std:c++17
 
+# Suppress warnings from external repos, we have no direct control on them anyway.
+build:linux --per_file_copt=external/.*@-w
+build:linux --host_per_file_copt=external/.*@-w
+build:macos --per_file_copt=external/.*@-w
+build:macos --host_per_file_copt=external/.*@-w
+build:windows --per_file_copt=external/.*@/w
+build:windows --host_per_file_copt=external/.*@/w
+
 # Enable Java 21 language features
 build --java_runtime_version=21
 build --java_language_version=21


### PR DESCRIPTION
Make the buildkite log viewable again

Addressing https://buildkite.com/bazel/bazel-bazel/builds/30048#01930c44-35d3-4c13-aa34-c7d610643e8d

PiperOrigin-RevId: 694528361
Change-Id: I17bde53d954e4a6991fd4af9b563736c5c813011