### PR TITLE
List modules which contributed dependency conflicting with root

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -323,10 +323,10 @@ class BazelModuleTest(test_base.TestBase):
     )
     stderr = '\n'.join(stderr)
     self.assertIn(
-        'WARNING: For repository \'aaa\', the root module requires module version aaa@1.0, but got aaa@1.1 in the resolved dependency graph.',
+        'WARNING: For repository \'aaa\', the root module requires module version aaa@1.0, but got aaa@1.1 in the resolved dependency graph. Source module(s): bbb@1.1, ccc@1.1',
         stderr)
     self.assertIn(
-        'WARNING: For repository \'bbb\', the root module requires module version bbb@1.0, but got bbb@1.1 in the resolved dependency graph.',
+        'WARNING: For repository \'bbb\', the root module requires module version bbb@1.0, but got bbb@1.1 in the resolved dependency graph. Source module(s): ccc@1.1',
         stderr)
     self.assertIn('main function => aaa@1.1', stdout)
     self.assertIn('main function => bbb@1.1', stdout)
@@ -338,10 +338,10 @@ class BazelModuleTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 48, stderr)
     stderr = '\n'.join(stderr)
     self.assertIn(
-        'ERROR: For repository \'aaa\', the root module requires module version aaa@1.0, but got aaa@1.1 in the resolved dependency graph.',
+        'ERROR: For repository \'aaa\', the root module requires module version aaa@1.0, but got aaa@1.1 in the resolved dependency graph. Source module(s): bbb@1.1, ccc@1.1',
         stderr)
     self.assertIn(
-        'ERROR: For repository \'bbb\', the root module requires module version bbb@1.0, but got bbb@1.1 in the resolved dependency graph.',
+        'ERROR: For repository \'bbb\', the root module requires module version bbb@1.0, but got bbb@1.1 in the resolved dependency graph. Source module(s): ccc@1.1',
         stderr)
 
   def testRepositoryRuleErrorInModuleExtensionFailsTheBuild(self):


### PR DESCRIPTION
With `--check_direct_dependencies=warning|error` the reason for errors is not given, complicating investigation.

This PR adds logic to find the "source modules" that brought the resolved version into the graph.

```
# BEFORE
ERROR: For repository 'rules_proto', the root module requires module version rules_proto@5.3.0-21.7, but got rules_proto@6.0.0
in the resolved dependency graph. ...
# AFTER
ERROR: For repository 'rules_proto', the root module requires module version rules_proto@5.3.0-21.7, but got rules_proto@6.0.0
in the resolved dependency graph. Source module(s): aspect_rules_ts@3.1.0 ...
```

This same information can be retrieved with `bazel mod` commands, however this relies on;
* `MODULE.bazel.lock` existing
* `MODULE.bazel.lock` being in sync with `MODULE.bazel`

Neither of which is necessarily true when the check direct deps error/warning is shown.

If nothing else, this saves time.