### PR TITLE
[8.0.0] Fix `@rules_java` autoload configs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/FlagConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/FlagConstants.java
@@ -25,7 +25,14 @@ class FlagConstants {
   public static final String DEFAULT_EXPERIMENTAL_RULE_EXTENSION_API_NAME = "+experimental_rule_extension_api";
 
   // TODO - ilist@: once Java providers are removed, the whole line can be compressed to "@rules_java"
-  public static final String DEFAULT_INCOMPATIBLE_AUTOLOAD_EXTERNALLY = "+@rules_python,+JavaInfo,+JavaPluginInfo,ProguardSpecProvider,java_binary,java_import,java_library,java_plugin,java_test,+java_runtime,+java_toolchain,+java_package_configuration,@com_google_protobuf,@rules_shell,+@rules_android";
+  public static final String DEFAULT_INCOMPATIBLE_AUTOLOAD_EXTERNALLY =
+      "+@rules_python," +
+      "+java_common,+JavaInfo,+JavaPluginInfo,ProguardSpecProvider," +
+      "java_binary,java_import,java_library,java_plugin,java_test," +
+      "java_runtime,java_toolchain,java_package_configuration," +
+      "@com_google_protobuf," +
+      "@rules_shell," +
+      "+@rules_android";
 
   public static final String DEFAULT_INCOMPATIBLE_PACKAGE_GROUP_HAS_PUBLIC_SYNTAX = "true";
   public static final String DEFAULT_INCOMPATIBLE_FIX_PACKAGE_GROUP_REPOROOT_SYNTAX = "true";


### PR DESCRIPTION
Enable autoloading of `java_common`

PiperOrigin-RevId: 698696053
Change-Id: Id64c3b024294d97ebc9aed808d6e210065f79825 (cherry picked from commit 06c1ae9f5298e312906366464022551f5d17f648)