### PR TITLE
Get `--repo_env=NAME` value from client environment (not server).

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -340,7 +340,7 @@ public class CommandEnvironment {
       String name = entry.getKey();
       String value = entry.getValue();
       if (value == null) {
-        value = System.getenv(name);
+        value = clientEnv.get(name);
       }
       if (value != null) {
         repoEnv.put(name, value);


### PR DESCRIPTION
Fixes issue where server process would "cache" environment variables. Broken since 3ebf658cba43bbab1efc36518f0795a7d65e2d46 (v5).