### PR TITLE
BazelTestRunner: exit with 137 on OOMs

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BUILD
@@ -15,6 +15,7 @@ java_library(
     deps = [
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner/internal",
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4",
+        "//third_party:junit4",
     ],
 )
 

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BazelTestRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BazelTestRunner.java
@@ -24,6 +24,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import org.junit.runner.Result;
 
 /**
  * A class to run JUnit tests in a controlled environment.
@@ -44,6 +45,11 @@ public class BazelTestRunner {
    */
   static final String TEST_SUITE_PROPERTY_NAME = "bazel.test_suite";
 
+  private static final int EXIT_CODE_SUCCESS = 0;
+  private static final int EXIT_CODE_TEST_FAILURE_OTHER = 1;
+  private static final int EXIT_CODE_TEST_RUNNER_FAILURE = 2;
+  private static final int EXIT_CODE_TEST_FAILURE_OOM = 137;
+
   private BazelTestRunner() {
     // utility class; should not be instantiated
   }
@@ -59,6 +65,7 @@ public class BazelTestRunner {
    * <p>Return codes:
    * <ul>
    * <li>Test runner failure, bad arguments, etc.: exit code of 2</li>
+   * <li>Test failure that included an OutOfMemoryException: exit code of 137</li>
    * <li>Normal test failure: exit code of 1</li>
    * <li>All tests pass: exit code of 0</li>
    * </ul>
@@ -68,7 +75,7 @@ public class BazelTestRunner {
 
     String suiteClassName = System.getProperty(TEST_SUITE_PROPERTY_NAME);
     if (!checkTestSuiteProperty(suiteClassName)) {
-      System.exit(2);
+      System.exit(EXIT_CODE_TEST_RUNNER_FAILURE);
     }
 
     int exitCode;
@@ -79,7 +86,8 @@ public class BazelTestRunner {
       // logged
       // by the executing strategy, and return a failure, so this process can gracefully shut down.
       e.printStackTrace();
-      exitCode = 1;
+      exitCode =
+          e instanceof OutOfMemoryError ? EXIT_CODE_TEST_FAILURE_OOM : EXIT_CODE_TEST_FAILURE_OTHER;
     }
 
     System.err.printf("%nBazelTestRunner exiting with a return value of %d%n", exitCode);
@@ -135,14 +143,21 @@ public class BazelTestRunner {
       // No class found corresponding to the system property passed in from Bazel
       if (args.length == 0 && suiteClassName != null) {
         System.err.printf("Class not found: [%s]%n", suiteClassName);
-        return 2;
+        return EXIT_CODE_TEST_RUNNER_FAILURE;
       }
     }
 
     // TODO(kush): Use a new classloader for the following instantiation.
     JUnit4Runner runner =
         JUnit4Bazel.builder().suiteClass(suite).config(new Config(args)).build().runner();
-    return runner.run().wasSuccessful() ? 0 : 1;
+    Result result = runner.run();
+    if (result.wasSuccessful()) {
+      return EXIT_CODE_SUCCESS;
+    }
+    return result.getFailures().stream()
+        .anyMatch(failure -> failure.getException() instanceof OutOfMemoryError)
+        ? EXIT_CODE_TEST_FAILURE_OOM
+        : EXIT_CODE_TEST_FAILURE_OTHER;
   }
 
   private static Class<?> getTestClass(String name) {

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/JUnit4TestbridgeExercises.java
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/JUnit4TestbridgeExercises.java
@@ -29,12 +29,12 @@ public class JUnit4TestbridgeExercises {
   public void testPass() {}
 
   @Test
-  public void testFailOnce() {
+  public void testFailAssertion() {
     fail();
   }
 
   @Test
-  public void testFailAgain() {
-    fail();
+  public void testFailWithOom() {
+    throw new OutOfMemoryError("testing");
   }
 }

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/JUnit4TestbridgeOomExercises.java
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/JUnit4TestbridgeOomExercises.java
@@ -1,4 +1,4 @@
-// Copyright 2015 The Bazel Authors. All Rights Reserved.
+// Copyright 2024 The Bazel Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,17 +24,17 @@ import org.junit.runners.JUnit4;
  * A JUnit4-style test meant to be invoked by junit4_testbridge_tests.sh.
  */
 @RunWith(JUnit4.class)
-public class JUnit4TestbridgeExercises {
+public class JUnit4TestbridgeOomExercises {
   @Test
   public void testPass() {}
 
   @Test
-  public void testFailOnce() {
+  public void testFailAssertion() {
     fail();
   }
 
   @Test
-  public void testFailAgain() {
-    fail();
+  public void testFailWithOom() {
+    throw new OutOfMemoryError("testing");
   }
 }


### PR DESCRIPTION
Motivation: Make it easier to detect whether a test failed due to an OutOfMemoryException

Current behavior:
The test runner exited with a code 1 on any test failure. This can make it hard to programmatically differentiate whether a test failed due to an actual test failure, or because the test was aborted due to an OutOfMemoryException.

Proposed change:
If a run of a test suite fails, the failures are checked for any OOMs. If at least one failure was caused by an OOM, the program exits with a code 137, rather than 1. Additionally, this is also the exit code if the test runner itself OOMs.

This distinction can help with automatically detecting OOMs and then retrying the execution with more memory available, and is especially helpful in the context of remote execution, where the action may be retried on a larger executor.