### PR TITLE
[8.0.0] Get `--repo_env=NAME` value from client environment (not server).

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -340,7 +340,7 @@ public class CommandEnvironment {
       String name = entry.getKey();
       String value = entry.getValue();
       if (value == null) {
-        value = System.getenv(name);
+        value = clientEnv.get(name);
       }
       if (value != null) {
         repoEnv.put(name, value);


### PR DESCRIPTION
Fixes issue where server process would "cache" environment variables. Broken since 3ebf658cba43bbab1efc36518f0795a7d65e2d46 (v5).

Closes #24433.

PiperOrigin-RevId: 698847238
Change-Id: I51d4ec811ee9d78717ff816d9988b4ad0f533265

Commit https://github.com/bazelbuild/bazel/commit/a590cfcc93f5ec1f9498e4b100f10172da537a1f