### PR TITLE
[8.0.0] Fix NPE in the Starlark debugger

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -187,10 +187,10 @@ public final class StarlarkThread {
       if (fn instanceof StarlarkFunction) {
         for (int i = 0; i < locals.length; i++) {
           Object local = locals[i];
+          if (local instanceof StarlarkFunction.Cell) {
+            local = ((StarlarkFunction.Cell) local).x;
+          }
           if (local != null) {
-            if (local instanceof StarlarkFunction.Cell) {
-              local = ((StarlarkFunction.Cell) local).x;
-            }
             env.put(((StarlarkFunction) fn).rfn.getLocals().get(i).getName(), local);
           }
         }


### PR DESCRIPTION
If we breakpoint at a line before a local (that is a cell) has been intialized, cell.x is null, which we shouldn't attempt to add to the returned map of locals.

Fixes https://github.com/bazelbuild/bazel/issues/24339

PiperOrigin-RevId: 698316990
Change-Id: Ifb45650fb41471c47605292af9873e9f66b7f7d7

Commit https://github.com/bazelbuild/bazel/commit/ae330a2d1efa3e4eda0b518492d7215a549cc032