### PR TITLE
Use different UTF-8 locales for Java compilation depending on exec OS

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BUILD
@@ -17,9 +17,12 @@ java_library(
     name = "bazel_java_semantics",
     srcs = ["BazelJavaSemantics.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/analysis:constraints/constraint_constants",
+        "//src/main/java/com/google/devtools/build/lib/analysis/platform",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/rules/java:java-compilation",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec:serialization-constant",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompilationHelper.java
@@ -289,7 +289,7 @@ public final class JavaCompilationHelper {
     builder.setSourceFiles(sourceFiles);
     builder.setSourceJars(sourceJars);
     builder.setJavacOpts(javacopts);
-    builder.setUtf8Environment(semantics.utf8Environment());
+    builder.setUtf8Environment(semantics.utf8Environment(ruleContext.getExecutionPlatform()));
     builder.setJavacExecutionInfo(executionInfoInterner.intern(getExecutionInfo()));
     builder.setCompressJar(true);
     builder.setExtraData(JavaCommon.computePerPackageData(ruleContext, javaToolchain));
@@ -462,7 +462,7 @@ public final class JavaCompilationHelper {
     builder.setAdditionalInputs(additionalInputsForDatabinding);
     builder.setToolsJars(javaToolchain.getTools());
     builder.setExecGroup(execGroup);
-    builder.setUtf8Environment(semantics.utf8Environment());
+    builder.setUtf8Environment(semantics.utf8Environment(ruleContext.getExecutionPlatform()));
     return builder;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaSemantics.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.OutputGroupInfo;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
+import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.Attribute.LabelListLateBoundDefault;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
@@ -78,6 +79,6 @@ public interface JavaSemantics {
    */
   PathFragment getDefaultJavaResourcePath(PathFragment path);
 
-  /** Environment variable that sets the UTF-8 charset. */
-  ImmutableMap<String, String> utf8Environment();
+  /** Environment variable that sets the UTF-8 charset for the given execution platform. */
+  ImmutableMap<String, String> utf8Environment(PlatformInfo executionPlatform);
 }


### PR DESCRIPTION
Linux doesn't have `en_US.UTF-8` (anymore), macOS doesn't have `C.UTF-8`.

Fixes #24459