### PR TITLE
[8.0.0] Cherry-pick two new logs to provide more information in dynamic execution.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/dynamic/RemoteBranch.java
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/RemoteBranch.java
@@ -29,10 +29,10 @@ import com.google.devtools.build.lib.actions.SandboxedSpawnStrategy;
 import com.google.devtools.build.lib.actions.SandboxedSpawnStrategy.StopConcurrentSpawns;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
-import com.google.devtools.build.lib.actions.SpawnStrategy;
 import com.google.devtools.build.lib.dynamic.DynamicExecutionModule.IgnoreFailureCheck;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.util.io.FileOutErr;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -121,6 +121,17 @@ class RemoteBranch extends Branch {
           }
           if (!future.isCancelled()) {
             localBranch.cancel();
+          }
+          if (options.debugSpawnScheduler) {
+            logger.atInfo().log(
+                "In listener callback, the future of the remote branch is %s",
+                future.state().name());
+            try {
+              future.get();
+            } catch (InterruptedException | ExecutionException e) {
+              logger.atInfo().withCause(e).log(
+                  "The future of the remote branch failed with an exception.");
+            }
           }
         },
         MoreExecutors.directExecutor());


### PR DESCRIPTION
RELNOTE: None
PiperOrigin-RevId: 700286030
Change-Id: I9c9f32f2d3e35b3cf6563a162d31ec35b8ea7e64

Commit https://github.com/bazelbuild/bazel/commit/6f8f372b6ce305b99952cff4bec5c3e41f30748f