### PR TITLE
Use correct types in EnumMapCodec to avoid red highlighting in IntelliJ

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/EnumMapCodec.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/EnumMapCodec.java
@@ -81,7 +81,7 @@ class EnumMapCodec extends AsyncObjectCodec<EnumMap> {
 
     MapBuffer buffer = new MapBuffer(result, size);
 
-    Object[] enums = clazz.getEnumConstants();
+    Enum[] enums = (Enum[]) clazz.getEnumConstants();
     for (int i = 0; i < size; i++) {
       int ordinal = codedIn.readInt32();
       buffer.setEnum(i, enums[ordinal]);
@@ -97,14 +97,14 @@ class EnumMapCodec extends AsyncObjectCodec<EnumMap> {
   /** Buffers the entry elements and populates the map once all values are done. */
   private static class MapBuffer implements Runnable {
     private final EnumMap result;
-    private final Object[] enums;
+    private final Enum[] enums;
     private final Object[] values;
 
     private final AtomicInteger remaining;
 
     private MapBuffer(EnumMap result, int size) {
       this.result = result;
-      this.enums = new Object[size];
+      this.enums = new Enum[size];
       this.values = new Object[size];
       this.remaining = new AtomicInteger(size);
     }
@@ -118,7 +118,7 @@ class EnumMapCodec extends AsyncObjectCodec<EnumMap> {
       }
     }
 
-    private void setEnum(int index, Object enumKey) {
+    private void setEnum(int index, Enum enumKey) {
       enums[index] = enumKey;
     }
   }


### PR DESCRIPTION
Motivation:

![image](https://github.com/user-attachments/assets/fb265187-8f8f-4029-b246-7b1016f3909d)
