### PR TITLE
[Rolling release] Automated rollback of commit b406bdcbe95dd23ca623f807d5113f18b724611a.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/objc/AppleBootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/objc/AppleBootstrap.java
@@ -17,8 +17,9 @@ package com.google.devtools.build.lib.starlarkbuildapi.objc;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.starlarkbuildapi.core.Bootstrap;
-import com.google.devtools.build.lib.starlarkbuildapi.core.ContextGuardedValue;
+import com.google.devtools.build.lib.starlarkbuildapi.core.ContextAndFlagGuardedValue;
 import net.starlark.java.eval.Starlark;
 
 /** {@link Bootstrap} for Starlark objects related to apple rules. */
@@ -27,22 +28,17 @@ public class AppleBootstrap implements Bootstrap {
   private static final ImmutableSet<PackageIdentifier> allowedRepositories =
       ImmutableSet.of(
           PackageIdentifier.createUnchecked("_builtins", ""),
-          PackageIdentifier.createUnchecked("apple_support", ""),
           PackageIdentifier.createUnchecked("bazel_tools", ""),
-          PackageIdentifier.createUnchecked("local_config_cc", ""),
           PackageIdentifier.createUnchecked("rules_apple", ""),
-          PackageIdentifier.createUnchecked("rules_cc", ""),
-          PackageIdentifier.createUnchecked("rules_go", ""),
-          PackageIdentifier.createUnchecked("rules_ios", ""),
-          PackageIdentifier.createUnchecked("rules_swift", ""),
-          PackageIdentifier.createUnchecked("stardoc", ""),
-          PackageIdentifier.createUnchecked("tulsi", ""),
-          PackageIdentifier.createUnchecked("", "test_starlark"),
-          PackageIdentifier.createUnchecked("", "tools/osx"));
+          PackageIdentifier.createUnchecked("", "tools/build_defs/apple"));
 
   @Override
   public void addBindingsToBuilder(ImmutableMap.Builder<String, Object> builder) {
     builder.put(
-        "apple_common", ContextGuardedValue.onlyInAllowedRepos(Starlark.NONE, allowedRepositories));
+        "apple_common",
+        ContextAndFlagGuardedValue.onlyInAllowedReposOrWhenIncompatibleFlagIsFalse(
+            BuildLanguageOptions.INCOMPATIBLE_STOP_EXPORTING_LANGUAGE_MODULES,
+            Starlark.NONE,
+            allowedRepositories));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/apple/XcodeVersionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/apple/XcodeVersionTest.java
@@ -41,9 +41,9 @@ public final class XcodeVersionTest extends BuildViewTestCase {
 
   @Test
   public void testXcodeVersionCanBeReadFromStarlark() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         MyInfo = provider()
 
@@ -72,7 +72,7 @@ public final class XcodeVersionTest extends BuildViewTestCase {
     scratch.file(
         "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "my_rule")
+        load("//examples/rule:apple_rules.bzl", "my_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -95,7 +95,7 @@ public final class XcodeVersionTest extends BuildViewTestCase {
         (RuleConfiguredTarget) getConfiguredTarget("//examples/apple_starlark:my_target");
     Provider.Key key =
         new StarlarkProvider.Key(
-            keyForBuild(Label.parseCanonical("//test_starlark/rule:apple_rules.bzl")), "MyInfo");
+            keyForBuild(Label.parseCanonical("//examples/rule:apple_rules.bzl")), "MyInfo");
     StructImpl myInfo = (StructImpl) starlarkTarget.get(key);
     assertThat((String) myInfo.getValue("xcode_version")).isEqualTo("8");
     assertThat((String) myInfo.getValue("ios_version")).isEqualTo("9.0");

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkTest.java
@@ -65,9 +65,9 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
   @Test
   @SuppressWarnings("unchecked")
   public void testStarlarkRuleCanDependOnNativeAppleRule() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -90,11 +90,11 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
             },
         )
         """);
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "my_rule")
+        load("//examples/rule:apple_rules.bzl", "my_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -110,8 +110,7 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     StructImpl myInfo = getMyInfoFromTarget(starlarkTarget);
     List<Artifact> starlarkHdrs = (List<Artifact>) myInfo.getValue("found_hdrs");
     List<Artifact> starlarkLibraries = (List<Artifact>) myInfo.getValue("found_libs");
@@ -122,9 +121,9 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
 
   @Test
   public void testStarlarkProviderRetrievalNoneIfNoProvider() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         def my_rule_impl(ctx):
             dep = ctx.attr.deps[0]
@@ -138,11 +137,11 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
             },
         )
         """);
-    scratch.file("test_starlark/apple_starlark/a.cc");
+    scratch.file("examples/apple_starlark/a.cc");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "my_rule")
+        load("//examples/rule:apple_rules.bzl", "my_rule")
         package(default_visibility = ["//visibility:public"])
 
         my_rule(
@@ -158,29 +157,27 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         """);
     AssertionError e =
         assertThrows(
-            AssertionError.class,
-            () -> getConfiguredTarget("//test_starlark/apple_starlark:my_target"));
+            AssertionError.class, () -> getConfiguredTarget("//examples/apple_starlark:my_target"));
+    assertThat(e)
+        .hasMessageThat()
+        .contains("apple_starlark/BUILD:4:8: in my_rule rule //examples/apple_starlark:my_target:");
     assertThat(e)
         .hasMessageThat()
         .contains(
-            "apple_starlark/BUILD:4:8: in my_rule rule //test_starlark/apple_starlark:my_target:");
-    assertThat(e)
-        .hasMessageThat()
-        .contains(
-            "File \"/workspace/test_starlark/rule/apple_rules.bzl\", line 3, column 24, in"
+            "File \"/workspace/examples/rule/apple_rules.bzl\", line 3, column 24, in"
                 + " my_rule_impl");
     assertThat(e)
         .hasMessageThat()
         .contains(
-            "<target //test_starlark/apple_starlark:lib> (rule 'cc_library') "
+            "<target //examples/apple_starlark:lib> (rule 'cc_library') "
                 + "doesn't contain declared provider 'ObjcInfo'");
   }
 
   @Test
   public void testStarlarkProviderCanCheckForExistenceOfObjcProvider() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -196,12 +193,12 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
             },
         )
         """);
-    scratch.file("test_starlark/apple_starlark/a.cc");
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.cc");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "my_rule")
+        load("//examples/rule:apple_rules.bzl", "my_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -223,8 +220,7 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
             srcs = ["a.cc"],
         )
         """);
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     StructImpl myInfo = getMyInfoFromTarget(starlarkTarget);
     boolean ccResult = (boolean) myInfo.getValue("cc_has_provider");
     boolean objcResult = (boolean) myInfo.getValue("objc_has_provider");
@@ -234,9 +230,9 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
 
   @Test
   public void testStarlarkExportsObjcProviderToNativeRule() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         def my_rule_impl(ctx):
             dep = ctx.attr.deps[0]
@@ -254,12 +250,12 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     addAppleBinaryStarlarkRule(scratch);
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "swift_library")
+        load("//examples/rule:apple_rules.bzl", "swift_library")
         load("//test_starlark:apple_binary_starlark.bzl", "apple_binary_starlark")
 
         package(default_visibility = ["//visibility:public"])
@@ -281,7 +277,7 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    ConfiguredTarget binaryTarget = getConfiguredTarget("//test_starlark/apple_starlark:bin");
+    ConfiguredTarget binaryTarget = getConfiguredTarget("//examples/apple_starlark:bin");
     StructImpl executableProvider =
         (StructImpl) binaryTarget.get(APPLE_EXECUTABLE_BINARY_PROVIDER_KEY);
     CcLinkingContext ccLinkingContext =
@@ -290,14 +286,14 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
     assertThat(
             Artifact.toRootRelativePaths(
                 ccLinkingContext.getStaticModeParamsForDynamicLibraryLibraries()))
-        .contains("test_starlark/apple_starlark/liblib.a");
+        .contains("examples/apple_starlark/liblib.a");
   }
 
   @Test
   public void testObjcRuleCanDependOnArbitraryStarlarkRuleThatProvidesCcInfo() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         def my_rule_impl(ctx):
             return [CcInfo()]
@@ -308,12 +304,12 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     addAppleBinaryStarlarkRule(scratch);
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "my_rule")
+        load("//examples/rule:apple_rules.bzl", "my_rule")
         load("//test_starlark:apple_binary_starlark.bzl", "apple_binary_starlark")
 
         package(default_visibility = ["//visibility:public"])
@@ -335,15 +331,15 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    ConfiguredTarget libTarget = getConfiguredTarget("//test_starlark/apple_starlark:lib");
+    ConfiguredTarget libTarget = getConfiguredTarget("//examples/apple_starlark:lib");
     assertThat(libTarget.get(CcInfo.PROVIDER)).isNotNull();
   }
 
   @Test
   public void testStarlarkCanAccessAppleConfiguration() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -390,11 +386,11 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "swift_binary")
+        load("//examples/rule:apple_rules.bzl", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -404,8 +400,7 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         """);
 
     useConfiguration("--apple_platform_type=ios", "--ios_multi_cpus=x86_64", "--xcode_version=7.3");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     StructImpl myInfo = getMyInfoFromTarget(starlarkTarget);
 
     Object iosCpu = myInfo.getValue("cpu");
@@ -426,9 +421,9 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
 
   @Test
   public void testDefaultJ2objcDeadCodeReport() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -452,11 +447,11 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "swift_binary")
+        load("//examples/rule:apple_rules.bzl", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -466,17 +461,16 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         """);
 
     useConfiguration();
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
 
     assertThat(getMyInfoFromTarget(starlarkTarget).getValue("dead_code_report")).isEqualTo("None");
   }
 
   @Test
   public void testCustomJ2objcDeadCodeReport() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -506,11 +500,11 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "dead_code_report", "swift_binary")
+        load("//examples/rule:apple_rules.bzl", "dead_code_report", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -521,18 +515,17 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         dead_code_report(name = "dead_code_report")
         """);
 
-    useConfiguration("--j2objc_dead_code_report=//test_starlark/apple_starlark:dead_code_report");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    useConfiguration("--j2objc_dead_code_report=//examples/apple_starlark:dead_code_report");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
 
     assertThat(getMyInfoFromTarget(starlarkTarget).getValue("dead_code_report")).isEqualTo("bar");
   }
 
   @Test
   public void testStarlarkCanAccessJ2objcTranslationFlags() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -548,11 +541,11 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "swift_binary")
+        load("//examples/rule:apple_rules.bzl", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -562,8 +555,7 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         """);
 
     useConfiguration("--j2objc_translation_flags=-DTestJ2ObjcFlag");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
 
     @SuppressWarnings("unchecked")
     List<String> flags =
@@ -574,9 +566,9 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
 
   @Test
   public void testStarlarkCanAccessApplePlatformNames() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -593,9 +585,9 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         """);
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "test_rule")
+        load("//examples/rule:apple_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -605,8 +597,7 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         """);
 
     useConfiguration("--ios_multi_cpus=x86_64", "--apple_platform_type=ios");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
 
     Object name = getMyInfoFromTarget(starlarkTarget).getValue("name");
     assertThat(name).isEqualTo("iPhoneSimulator");
@@ -614,9 +605,9 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
 
   @Test
   public void testStarlarkCanAccessAppleToolchain() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -636,11 +627,11 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         )
         """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "swift_binary")
+        load("//examples/rule:apple_rules.bzl", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -650,8 +641,7 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
         """);
 
     useConfiguration("--apple_platform_type=ios", "--ios_multi_cpus=x86_64");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     StructImpl myInfo = getMyInfoFromTarget(starlarkTarget);
 
     String platformDevFrameworksDir = (String) myInfo.getValue("platform_developer_framework_dir");
@@ -666,9 +656,9 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
 
   @Test
   public void testStarlarkCanAccessSdkAndMinimumOs() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
 load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -706,11 +696,11 @@ swift_binary = rule(
 )
 """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "swift_binary")
+        load("//examples/rule:apple_rules.bzl", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -728,8 +718,7 @@ swift_binary = rule(
         "--tvos_minimum_os=3.0",
         "--macos_sdk_version=4.1",
         "--minimum_os_version=5.1");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     StructImpl myInfo = getMyInfoFromTarget(starlarkTarget);
 
     assertThat(myInfo.getValue("ios_sdk_version")).isEqualTo("1.1");
@@ -746,7 +735,7 @@ swift_binary = rule(
         "--watchos_sdk_version=2.1",
         "--tvos_sdk_version=3.1",
         "--macos_sdk_version=4.1");
-    starlarkTarget = getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     myInfo = getMyInfoFromTarget(starlarkTarget);
 
     assertThat(myInfo.getValue("ios_sdk_version")).isEqualTo("1.1");
@@ -760,9 +749,9 @@ swift_binary = rule(
 
   @Test
   public void testStarlarkCanAccessObjcConfiguration() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/objc_rules.bzl",
+        "examples/rule/objc_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -784,11 +773,11 @@ swift_binary = rule(
         )
         """);
 
-    scratch.file("test_starlark/objc_starlark/a.m");
+    scratch.file("examples/objc_starlark/a.m");
     scratch.file(
-        "test_starlark/objc_starlark/BUILD",
+        "examples/objc_starlark/BUILD",
         """
-        load("//test_starlark/rule:objc_rules.bzl", "swift_binary")
+        load("//examples/rule:objc_rules.bzl", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -802,8 +791,7 @@ swift_binary = rule(
         "--ios_simulator_device='iPhone 6'",
         "--ios_simulator_version=8.4",
         "--ios_signing_cert_name='Apple Developer'");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/objc_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/objc_starlark:my_target");
     StructImpl myInfo = getMyInfoFromTarget(starlarkTarget);
 
     @SuppressWarnings("unchecked")
@@ -820,9 +808,9 @@ swift_binary = rule(
 
   @Test
   public void testSigningCertificateNameCanReturnNone() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/objc_rules.bzl",
+        "examples/rule/objc_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -838,11 +826,11 @@ swift_binary = rule(
         )
         """);
 
-    scratch.file("test_starlark/objc_starlark/a.m");
+    scratch.file("examples/objc_starlark/a.m");
     scratch.file(
-        "test_starlark/objc_starlark/BUILD",
+        "examples/objc_starlark/BUILD",
         """
-        load("//test_starlark/rule:objc_rules.bzl", "my_rule")
+        load("//examples/rule:objc_rules.bzl", "my_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -851,8 +839,7 @@ swift_binary = rule(
         )
         """);
 
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/objc_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/objc_starlark:my_target");
 
     Object signingCertificateName =
         getMyInfoFromTarget(starlarkTarget).getValue("signing_certificate_name");
@@ -861,9 +848,9 @@ swift_binary = rule(
 
   @Test
   public void testUsesDebugEntitlementsIsTrueIfCompilationModeIsNotOpt() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/objc_rules.bzl",
+        "examples/rule/objc_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -879,11 +866,11 @@ swift_binary = rule(
         )
         """);
 
-    scratch.file("test_starlark/objc_starlark/a.m");
+    scratch.file("examples/objc_starlark/a.m");
     scratch.file(
-        "test_starlark/objc_starlark/BUILD",
+        "examples/objc_starlark/BUILD",
         """
-        load("//test_starlark/rule:objc_rules.bzl", "test_rule")
+        load("//examples/rule:objc_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -893,8 +880,7 @@ swift_binary = rule(
         """);
 
     useConfiguration("--compilation_mode=dbg");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/objc_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/objc_starlark:my_target");
 
     boolean usesDeviceDebugEntitlements =
         (boolean) getMyInfoFromTarget(starlarkTarget).getValue("uses_device_debug_entitlements");
@@ -903,9 +889,9 @@ swift_binary = rule(
 
   @Test
   public void testUsesDebugEntitlementsIsFalseIfFlagIsExplicitlyFalse() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/objc_rules.bzl",
+        "examples/rule/objc_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -921,11 +907,11 @@ swift_binary = rule(
         )
         """);
 
-    scratch.file("test_starlark/objc_starlark/a.m");
+    scratch.file("examples/objc_starlark/a.m");
     scratch.file(
-        "test_starlark/objc_starlark/BUILD",
+        "examples/objc_starlark/BUILD",
         """
-        load("//test_starlark/rule:objc_rules.bzl", "test_rule")
+        load("//examples/rule:objc_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -935,8 +921,7 @@ swift_binary = rule(
         """);
 
     useConfiguration("--compilation_mode=dbg", "--nodevice_debug_entitlements");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/objc_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/objc_starlark:my_target");
 
     boolean usesDeviceDebugEntitlements =
         (boolean) getMyInfoFromTarget(starlarkTarget).getValue("uses_device_debug_entitlements");
@@ -945,9 +930,9 @@ swift_binary = rule(
 
   @Test
   public void testUsesDebugEntitlementsIsFalseIfCompilationModeIsOpt() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/objc_rules.bzl",
+        "examples/rule/objc_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -963,11 +948,11 @@ swift_binary = rule(
         )
         """);
 
-    scratch.file("test_starlark/objc_starlark/a.m");
+    scratch.file("examples/objc_starlark/a.m");
     scratch.file(
-        "test_starlark/objc_starlark/BUILD",
+        "examples/objc_starlark/BUILD",
         """
-        load("//test_starlark/rule:objc_rules.bzl", "test_rule")
+        load("//examples/rule:objc_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -977,8 +962,7 @@ swift_binary = rule(
         """);
 
     useConfiguration("--compilation_mode=opt");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/objc_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/objc_starlark:my_target");
 
     boolean usesDeviceDebugEntitlements =
         (boolean) getMyInfoFromTarget(starlarkTarget).getValue("uses_device_debug_entitlements");
@@ -999,12 +983,12 @@ swift_binary = rule(
             },
             String.class);
 
-    scratch.file("test_starlark/rule/BUILD");
-    scratch.file("test_starlark/rule/objc_rules.bzl", impl);
+    scratch.file("examples/rule/BUILD");
+    scratch.file("examples/rule/objc_rules.bzl", impl);
     scratch.file(
-        "test_starlark/objc_starlark/BUILD",
+        "examples/objc_starlark/BUILD",
         """
-        load("//test_starlark/rule:objc_rules.bzl", "swift_binary")
+        load("//examples/rule:objc_rules.bzl", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1019,7 +1003,7 @@ swift_binary = rule(
         )
         """);
 
-    return getConfiguredTarget("//test_starlark/objc_starlark:my_target");
+    return getConfiguredTarget("//examples/objc_starlark:my_target");
   }
 
   @Test
@@ -1048,24 +1032,24 @@ swift_binary = rule(
     assertThat(getStrictInclude(starlarkProvider)).containsExactly("path");
 
     scratch.file(
-        "test_starlark/objc_starlark2/BUILD",
+        "examples/objc_starlark2/BUILD",
         """
         objc_library(
             name = "direct_dep",
-            deps = ["//test_starlark/objc_starlark:my_target"],
+            deps = ["//examples/objc_starlark:my_target"],
         )
         """);
 
     StarlarkInfo starlarkProviderDirectDepender =
-        getObjcInfo(getConfiguredTarget("//test_starlark/objc_starlark2:direct_dep"));
+        getObjcInfo(getConfiguredTarget("//examples/objc_starlark2:direct_dep"));
     assertThat(getStrictInclude(starlarkProviderDirectDepender)).isEmpty();
   }
 
   @Test
   public void testStarlarkCanCreateObjcProviderFromObjcProvider() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/objc_rules.bzl",
+        "examples/rule/objc_rules.bzl",
         """
         def library_impl(ctx):
             lib = ctx.label.name + ".a"
@@ -1099,9 +1083,9 @@ swift_binary = rule(
         """);
 
     scratch.file(
-        "test_starlark/objc_starlark/BUILD",
+        "examples/objc_starlark/BUILD",
         """
-        load("//test_starlark/rule:objc_rules.bzl", "binary", "library")
+        load("//examples/rule:objc_rules.bzl", "binary", "library")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1115,7 +1099,7 @@ swift_binary = rule(
         )
         """);
 
-    ConfiguredTarget starlarkTarget = getConfiguredTarget("//test_starlark/objc_starlark:bin");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/objc_starlark:bin");
 
     StarlarkInfo dependerProvider = getObjcInfo(starlarkTarget);
     ImmutableList<Artifact> libraries =
@@ -1142,9 +1126,9 @@ swift_binary = rule(
 
   @Test
   public void testEmptyObjcProviderKeysArePresent() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -1167,11 +1151,11 @@ swift_binary = rule(
         )
         """);
 
-    scratch.file("test_starlark/apple_starlark/a.m");
+    scratch.file("examples/apple_starlark/a.m");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "swift_binary")
+        load("//examples/rule:apple_rules.bzl", "swift_binary")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1185,8 +1169,7 @@ swift_binary = rule(
             srcs = ["a.m"],
         )
         """);
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     NestedSet<Artifact> emptyValue =
         Depset.cast(
             getMyInfoFromTarget(starlarkTarget).getValue("empty_value"),
@@ -1197,9 +1180,9 @@ swift_binary = rule(
 
   @Test
   public void testStarlarkCanAccessAndUseApplePlatformTypes() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -1221,9 +1204,9 @@ swift_binary = rule(
         """);
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "test_rule")
+        load("//examples/rule:apple_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1233,8 +1216,7 @@ swift_binary = rule(
         """);
 
     useConfiguration("--ios_multi_cpus=arm64,armv7", "--watchos_cpus=armv7k", "--tvos_cpus=arm64");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     StructImpl myInfo = getMyInfoFromTarget(starlarkTarget);
 
     Object iosPlatform = myInfo.getValue("ios_platform");
@@ -1248,9 +1230,9 @@ swift_binary = rule(
 
   @Test
   public void testPlatformIsDeviceReturnsTrueForDevicePlatforms() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -1268,9 +1250,9 @@ swift_binary = rule(
         """);
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "test_rule")
+        load("//examples/rule:apple_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1280,8 +1262,7 @@ swift_binary = rule(
         """);
 
     useConfiguration("--ios_multi_cpus=arm64,armv7");
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
 
     Boolean isDevice = (Boolean) getMyInfoFromTarget(starlarkTarget).getValue("is_device");
     assertThat(isDevice).isTrue();
@@ -1289,9 +1270,9 @@ swift_binary = rule(
 
   @Test
   public void testPlatformIsDeviceReturnsFalseForSimulatorPlatforms() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -1309,9 +1290,9 @@ swift_binary = rule(
         """);
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "test_rule")
+        load("//examples/rule:apple_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1320,8 +1301,7 @@ swift_binary = rule(
         )
         """);
 
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
 
     Boolean isDevice = (Boolean) getMyInfoFromTarget(starlarkTarget).getValue("is_device");
     assertThat(isDevice).isFalse();
@@ -1340,9 +1320,9 @@ swift_binary = rule(
 
   @Test
   public void testDottedVersion() throws Exception {
-    scratch.file("test_starlark/rule/BUILD", "exports_files(['test_artifact'])");
+    scratch.file("examples/rule/BUILD", "exports_files(['test_artifact'])");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -1356,9 +1336,9 @@ swift_binary = rule(
         """);
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "test_rule")
+        load("//examples/rule:apple_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1367,8 +1347,7 @@ swift_binary = rule(
         )
         """);
 
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
 
     DottedVersion version = (DottedVersion) getMyInfoFromTarget(starlarkTarget).getValue("version");
     assertThat(version).isEqualTo(DottedVersion.fromString("5.4"));
@@ -1376,9 +1355,9 @@ swift_binary = rule(
 
   @Test
   public void testDottedVersion_invalid() throws Exception {
-    scratch.file("test_starlark/rule/BUILD", "exports_files(['test_artifact'])");
+    scratch.file("examples/rule/BUILD", "exports_files(['test_artifact'])");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -1392,9 +1371,9 @@ swift_binary = rule(
         """);
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "test_rule")
+        load("//examples/rule:apple_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1405,8 +1384,7 @@ swift_binary = rule(
 
     AssertionError e =
         assertThrows(
-            AssertionError.class,
-            () -> getConfiguredTarget("//test_starlark/apple_starlark:my_target"));
+            AssertionError.class, () -> getConfiguredTarget("//examples/apple_starlark:my_target"));
     assertThat(e)
         .hasMessageThat()
         .contains("Dotted version components must all start with the form");
@@ -1420,9 +1398,9 @@ swift_binary = rule(
    */
   @Test
   public void testObjcProviderStarlarkConstructor() throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         def my_rule_impl(ctx):
             dep = ctx.attr.deps[0]
@@ -1436,11 +1414,11 @@ swift_binary = rule(
             },
         )
         """);
-    scratch.file("test_starlark/apple_starlark/a.cc");
+    scratch.file("examples/apple_starlark/a.cc");
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "my_rule")
+        load("//examples/rule:apple_rules.bzl", "my_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1456,16 +1434,15 @@ swift_binary = rule(
         )
         """);
 
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
     StarlarkInfo dependerProvider = getObjcInfo(starlarkTarget);
     assertThat(dependerProvider).isNotNull();
   }
 
   private void checkStarlarkRunMemleaksWithExpectedValue(boolean expectedValue) throws Exception {
-    scratch.file("test_starlark/rule/BUILD");
+    scratch.file("examples/rule/BUILD");
     scratch.file(
-        "test_starlark/rule/apple_rules.bzl",
+        "examples/rule/apple_rules.bzl",
         """
         load("//myinfo:myinfo.bzl", "MyInfo")
 
@@ -1480,9 +1457,9 @@ swift_binary = rule(
         """);
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
-        load("//test_starlark/rule:apple_rules.bzl", "test_rule")
+        load("//examples/rule:apple_rules.bzl", "test_rule")
 
         package(default_visibility = ["//visibility:public"])
 
@@ -1491,8 +1468,7 @@ swift_binary = rule(
         )
         """);
 
-    ConfiguredTarget starlarkTarget =
-        getConfiguredTarget("//test_starlark/apple_starlark:my_target");
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
 
     boolean runMemleaks = (boolean) getMyInfoFromTarget(starlarkTarget).getValue("run_memleaks");
     assertThat(runMemleaks).isEqualTo(expectedValue);
@@ -1503,7 +1479,7 @@ swift_binary = rule(
     useConfiguration("--incompatible_disallow_sdk_frameworks_attributes");
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
         objc_library(
             name = "lib",
@@ -1516,12 +1492,12 @@ swift_binary = rule(
         """);
     AssertionError e =
         assertThrows(
-            AssertionError.class, () -> getConfiguredTarget("//test_starlark/apple_starlark:lib"));
+            AssertionError.class, () -> getConfiguredTarget("//examples/apple_starlark:lib"));
     assertThat(e)
         .hasMessageThat()
         .contains(
-            "ERROR /workspace/test_starlark/apple_starlark/BUILD:1:13: "
-                + "in objc_library rule //test_starlark/apple_starlark:lib:");
+            "ERROR /workspace/examples/apple_starlark/BUILD:1:13: "
+                + "in objc_library rule //examples/apple_starlark:lib:");
 
     assertContainsEvent(
         "sdk_frameworks attribute is disallowed. Use explicit dependencies instead.");
@@ -1532,7 +1508,7 @@ swift_binary = rule(
     useConfiguration("--incompatible_disallow_sdk_frameworks_attributes");
 
     scratch.file(
-        "test_starlark/apple_starlark/BUILD",
+        "examples/apple_starlark/BUILD",
         """
         objc_library(
             name = "lib",
@@ -1542,12 +1518,12 @@ swift_binary = rule(
         """);
     AssertionError e =
         assertThrows(
-            AssertionError.class, () -> getConfiguredTarget("//test_starlark/apple_starlark:lib"));
+            AssertionError.class, () -> getConfiguredTarget("//examples/apple_starlark:lib"));
     assertThat(e)
         .hasMessageThat()
         .contains(
-            "ERROR /workspace/test_starlark/apple_starlark/BUILD:1:13: "
-                + "in objc_library rule //test_starlark/apple_starlark:lib:");
+            "ERROR /workspace/examples/apple_starlark/BUILD:1:13: "
+                + "in objc_library rule //examples/apple_starlark:lib:");
 
     assertContainsEvent(
         "weak_sdk_frameworks attribute is disallowed. Use explicit dependencies instead.");


### PR DESCRIPTION
*** Reason for rollback ***

This breaks rules_go and rules_swift because they refer to themselves by alias depot names: https://github.com/bazelbuild/bazel/issues/24375

*** Original change description ***

In AppleBootstrap.java give several rule repos access to apple_common that need it, and activate the access restriction independent of INCOMPATIBLE_STOP_EXPORTING_LANGUAGE_MODULES

PiperOrigin-RevId: 698310431
Change-Id: I88973163cadca29021af9575d410fcae1eb6c066