### PR TITLE
[8.0.0] Update concept docs for symbolic macros and visibility

### DIFF
--- a/site/en/extending/macros.md
+++ b/site/en/extending/macros.md
@@ -216,7 +216,8 @@ Symbolic macros
 *   may not call `native.environment_group()`
 *   must create targets whose names adhere to the [naming schema](#naming)
 *   can't refer to input files that weren't declared or passed in as an argument
-    (see [visibility and macros](#visibility) for more details).
+*   can't refer to private targets of their callers (see
+    [visibility and macros](#visibility) for more details).
 
 ### Visibility and macros {:#visibility}
 
@@ -331,7 +332,7 @@ All visibility checking is done with respect to the innermost currently running
 symbolic macro. However, there is a visibility delegation mechanism: If a macro
 passes a label as an attribute value to an inner macro, any usages of the label
 in the inner macro are checked with respect to the outer macro. See the
-visibility page for more details.
+[visibility page](/concepts/visibility#symbolic-macros) for more details.
 
 Remember that legacy macros are entirely transparent to the visibility system,
 and behave as though their location is whatever BUILD file or symbolic macro

--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/visibility.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/visibility.html
@@ -1,11 +1,20 @@
 <p>List of <a href="${link build-ref#labels}">labels</a>;
   <a href="#configurable-attributes">nonconfigurable</a>;
-  default is <code><a href="${link package.default_visibility}">default_visibility</a></code> from
-  <a href="${link package}">package</a> if specified, or <code>"//visibility:private"</code>
-  otherwise</p>
+  default varies
+</p>
 
 <p>
-The <code>visibility</code> attribute on a target controls whether the target
-can be used in other packages. See the documentation for
-<a href="${link visibility}">visibility</a>.
+  The <code>visibility</code> attribute controls whether the target can be
+  depended on by targets in other locations. See the documentation for
+  <a href="${link visibility}">visibility</a>.
+</p>
+
+<p>
+  For targets declared directly in a BUILD file or in legacy macros called from
+  a BUILD file, the default value is the package's
+  <code><a href="${link package.default_visibility}">default_visibility</a></code>
+  if specified, or else <code>["//visibility:private"]</code>. For targets
+  declared in one or more symbolic macros, the default value is always just
+  <code>["//visibility:private"]</code> (which makes it useable only within the
+  package containing the macro's code).
 </p>

--- a/src/main/java/com/google/devtools/build/docgen/templates/be/functions.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/functions.vm
@@ -70,14 +70,16 @@ file, before any rule.</p>
       <td id="package.default_visibility"><code>default_visibility</code></td>
       <td>
         <p>List of <a href="$expander.expandRef("build-ref#labels")">labels</a>; default is <code>[]</code></p>
-        <p>The default visibility of the rules in this package.</p>
-        <p>Every rule in this package has the visibility specified in this
-        attribute, unless otherwise specified in the <code>visibility</code>
-        attribute of the rule. For detailed information about the syntax of this
-        attribute, see the documentation of <a href="$expander.expandRef("visibility")">visibility</a>.
-        The package default visibility does not apply to
-        <a href="#exports_files">exports_files</a>, which is
-        public by default.</p>
+        <p>The default visibility of the top-level rule targets and symbolic
+        macros in this package &mdash; that is, the targets and symbolic macros
+        that are not themselves declared inside a symbolic macro. This attribute
+        is ignored if the target or macro specifies a <code>visibility</code>
+        value.</p>
+        <p>For detailed information about the syntax of this attribute, see the
+        documentation of <a href="$expander.expandRef("visibility")">
+        visibility</a>. The package default visibility does not apply to
+        <a href="#exports_files">exports_files</a>, which is public by default.
+        </p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
These were meant to be included with #23857 (forked in #23945).