### PR TITLE
Enable ignore_root_user_error for Python toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -266,6 +266,7 @@ python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     is_default = True,
     python_version = "3.11",
+    ignore_root_user_error = True,
 )
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")


### PR DESCRIPTION
Our CI fails to build Bazel, producing this error: "The current user is root, please run as non-root when using the hermetic Python interpreter. See https://github.com/bazelbuild/rules_python/pull/713."

The workaround was suggested at https://github.com/bazelbuild/rules_python/issues/1169#issuecomment-1513804247