### PR TITLE
[8.0.0] Make the removed java symbols compatible with `WORKSPACE` loading

### DIFF
--- a/src/main/starlark/builtins_bzl/bazel/exports.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/exports.bzl
@@ -15,10 +15,14 @@
 """Exported builtins symbols that are specific to OSS Bazel."""
 
 load("@_builtins//:common/python/py_internal.bzl", "py_internal")
+load(":common/java/java_common.bzl", "java_common_export_for_bazel")
 
 exported_toplevels = {
     "py_internal": py_internal,
     "proto_common_do_not_use": struct(INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION = _builtins.toplevel.proto_common_do_not_use.incompatible_enable_proto_toolchain_resolution()),
+    "java_common": java_common_export_for_bazel,
+    "JavaInfo": java_common_export_for_bazel.provider,
+    "JavaPluginInfo": java_common_export_for_bazel.JavaPluginInfo,
 }
 exported_rules = {}
 exported_to_java = {}

--- a/src/main/starlark/builtins_bzl/common/exports.bzl
+++ b/src/main/starlark/builtins_bzl/common/exports.bzl
@@ -36,7 +36,6 @@ load(":common/cc/fdo/fdo_prefetch_hints.bzl", "fdo_prefetch_hints")
 load(":common/cc/fdo/fdo_profile.bzl", "fdo_profile")
 load(":common/cc/fdo/memprof_profile.bzl", "memprof_profile")
 load(":common/cc/fdo/propeller_optimize.bzl", "propeller_optimize")
-load(":common/java/java_common.bzl", "java_common")
 load(":common/objc/apple_common.bzl", "apple_common")
 load(":common/objc/objc_common.bzl", "objc_common")
 
@@ -48,7 +47,6 @@ exported_toplevels = {
     "CcSharedLibraryInfo": CcSharedLibraryInfo,
     "CcSharedLibraryHintInfo": CcSharedLibraryHintInfo,
     "cc_common": cc_common,
-    "java_common": struct(internal_DO_NOT_USE = java_common.internal_DO_NOT_USE),
     "apple_common": apple_common,
 }
 

--- a/src/main/starlark/builtins_bzl/common/java/java_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/java/java_common.bzl
@@ -346,3 +346,21 @@ def _make_java_common():
     return struct(**methods)
 
 java_common = _make_java_common()
+
+_FakeJavaInfo = provider()  # buildifier: disable=provider-params
+_FakeJavaPluginInfo = provider()  # buildifier: disable=provider-params
+_FakeJavaToolchainInfo = provider()  # buildifier: disable=provider-params
+_FakeJavaRuntimeInfo = provider()  # buildifier: disable=provider-params
+_FakeBootClassPathInfo = provider()  # buildifier: disable=provider-params
+_FakeJavaRuntimeClasspathInfo = provider()  # buildifier: disable=provider-params
+
+java_common_export_for_bazel = struct(
+    internal_DO_NOT_USE = _internal_exports,
+    # fake exports for WORKSPACE loading
+    provider = _FakeJavaInfo,
+    JavaPluginInfo = _FakeJavaPluginInfo,
+    JavaToolchainInfo = _FakeJavaToolchainInfo,
+    JavaRuntimeInfo = _FakeJavaRuntimeInfo,
+    BootClassPathInfo = _FakeBootClassPathInfo,
+    JavaRuntimeClasspathInfo = _FakeJavaRuntimeClasspathInfo,
+)


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/24551

Context: https://github.com/bazelbuild/rules_scala/issues/1652#issuecomment-2507453047

This will fix the issue in Bazel@HEAD, and the primary motivation is to turn downstream CI green.

On the off-chance we are making a new Bazel 8 RC, we can include this. Otherwise, maybe this can go in 8.1.0

PiperOrigin-RevId: 701260369
Change-Id: If62eb015b5220b574ce34a26a194d2722021082f (cherry picked from commit 15b8e3f7e07e1d286fa73e73c55da45e7508d73d)