### PR TITLE
[8.0.0] Change `@bazel_tools//tools/jdk` references to `@rules_java//toolchains` in docs

### DIFF
--- a/site/en/docs/bazel-and-java.md
+++ b/site/en/docs/bazel-and-java.md
@@ -164,7 +164,7 @@ system and CPU architecture are given, the first one is used.
 Example configuration of local JVM:
 
 ```python
-load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_repository")
+load("@rules_java//toolchains:local_java_repository.bzl", "local_java_repository")
 
 local_java_repository(
   name = "additionaljdk",          # Can be used with --java_runtime_version=additionaljdk, --java_runtime_version=11 or --java_runtime_version=additionaljdk_11
@@ -176,7 +176,7 @@ local_java_repository(
 Example configuration of remote JVM:
 
 ```python
-load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+load("@rules_java//toolchains:remote_java_repository.bzl", "remote_java_repository")
 
 remote_java_repository(
   name = "openjdk_canary_linux_arm",
@@ -244,7 +244,7 @@ Example toolchain configuration:
 
 ```python
 load(
-  "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
+  "@rules_java//toolchains:default_java_toolchain.bzl",
   "default_java_toolchain", "DEFAULT_TOOLCHAIN_CONFIGURATION", "BASE_JDK9_JVM_OPTS", "DEFAULT_JAVACOPTS"
 )
 
@@ -252,7 +252,7 @@ default_java_toolchain(
   name = "repository_default_toolchain",
   configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,        # One of predefined configurations
                                                           # Other parameters are from java_toolchain rule:
-  java_runtime = "@bazel_tools//tools/jdk:remote_jdk11", # JDK to use for compilation and toolchain's tools execution
+  java_runtime = "@rules_java//toolchains:remote_jdk11", # JDK to use for compilation and toolchain's tools execution
   jvm_opts = BASE_JDK9_JVM_OPTS + ["--enable_preview"],   # Additional JDK options
   javacopts = DEFAULT_JAVACOPTS + ["--enable_preview"],   # Additional javac options
   source_version = "9",
@@ -292,7 +292,7 @@ files using `package_configuration` attribute of `default_java_toolchain`.
 Please refer to the example below.
 
 ```python
-load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
 
 # This is a convenience macro that inherits values from Bazel's default java_toolchain
 default_java_toolchain(

--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/toolchains.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/toolchains.html
@@ -9,7 +9,7 @@
 
 <ul>
     <li><code>@bazel_tools//tools/cpp:current_cc_toolchain</code>
-  <li><code>@bazel_tools//tools/jdk:current_java_runtime</code>
+  <li><code>@rules_java//toolchains:current_java_runtime</code>
   </ul>
 
 <p>

--- a/src/main/java/com/google/devtools/build/docgen/templates/be/make-variables.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/make-variables.vm
@@ -452,8 +452,8 @@
 <p>
   The following are defined in Java toolchain rules and available to any rule
   that sets <code>toolchains =
-["@bazel_tools//tools/jdk:current_java_runtime"]</code> (or
-  <code>"@bazel_tools//tools/jdk:current_host_java_runtime"</code>
+["@rules_java//toolchains:current_java_runtime"]</code> (or
+  <code>"@rules_java//toolchains:current_host_java_runtime"</code>
   for the host toolchain equivalent).
 </p>
 


### PR DESCRIPTION
The targets being referenced in `@bazel_tools` were just aliases to `@rules_java`.

PiperOrigin-RevId: 700949569
Change-Id: Ief4bb0e4e3a66a337d4a949587e2a391115a76c5

(cherry-picked from f001ef1a8a2af31abd879598a6def9eb22d3433f)