### PR TITLE
[8.0.0] Enable ignore_root_user_error for Python toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -263,7 +263,7 @@ use_repo(
 # =========================================
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.11", is_default = True)
+python.toolchain(python_version = "3.11", is_default = True, ignore_root_user_error = True)
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(


### PR DESCRIPTION
Our CI fails to build Bazel, producing this error: "The current user is root, please run as non-root when using the hermetic Python interpreter. See https://github.com/bazelbuild/rules_python/pull/713."

The workaround was suggested at https://github.com/bazelbuild/rules_python/issues/1169#issuecomment-1513804247

Closes #24549.

PiperOrigin-RevId: 702362811
Change-Id: Ib6d4da1e09fd2b7dfd68af02bbb0eb997e8f427c