### PR TITLE
Document and enforce filename restrictions for module file segments

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -858,7 +858,8 @@ public class ModuleFileGlobals {
             doc =
                 "The label pointing to the file to include. The label must point to a file in the"
                     + " main repo; in other words, it <strong>must<strong> start with double"
-                    + " slashes (<code>//</code>)."),
+                    + " slashes (<code>//</code>). The name of the file must end with"
+                    + " <code>.MODULE.bazel</code> and must not start with <code>.</code>."),
       },
       useStarlarkThread = true)
   public void include(String label, StarlarkThread thread)

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -458,6 +458,23 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
   }
 
   @Test
+  public void testRootModule_include_bad_startsWithPeriod() throws Exception {
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa')",
+        "include('//pkg:dir/.MODULE.bazel')");
+    FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    EvaluationResult<RootModuleFileValue> result =
+        evaluator.evaluate(
+            ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
+    assertThat(result.hasError()).isTrue();
+    assertThat(result.getError().toString())
+        .contains("the name of the file to be included must not start with '.'");
+  }
+
+  @Test
   public void testRootModule_include_bad_badLabelSyntax() throws Exception {
     scratch.overwriteFile(
         rootDirectory.getRelative("MODULE.bazel").getPathString(),


### PR DESCRIPTION
Included module file segments already had to have a `.MODULE.bazel` suffix, but this wasn't documented. Also prohibit a filename starting with a `.`, which would hide the file on Unix.