### PR TITLE
Don't fall back to `help` command when command is empty

### DIFF
--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -153,7 +153,11 @@ std::unique_ptr<CommandLine> OptionProcessor::SplitCommandLine(
   string& command = args[i];
   // Distinguish an empty command from the case of no command above.
   if (command.empty()) {
-    blaze_util::StringPrintf(error, "Command cannot be the empty string (try 'help')");
+    blaze_util::StringPrintf(
+        error,
+        "Command cannot be the empty string.\n"
+        "  For more info, run '%s help'.",
+        lowercase_product_name.c_str());
     return nullptr;
   }
 

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -151,6 +151,11 @@ std::unique_ptr<CommandLine> OptionProcessor::SplitCommandLine(
         std::move(path_to_binary), std::move(startup_args), "", {}));
   }
   string& command = args[i];
+  // Distinguish an empty command from the case of no command above.
+  if (command.empty()) {
+    blaze_util::StringPrintf(error, "Command cannot be the empty string (try 'help')");
+    return nullptr;
+  }
 
   // The rest are the command arguments.
   vector<string> command_args(std::make_move_iterator(args.begin() + i + 1),

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -567,7 +567,7 @@ function test_no_arguments() {
 
 function test_empty_command() {
   bazel '' >&$TEST_log && fail "Expected non-zero exit"
-  expect_log "Command cannot be the empty string (try 'help')"
+  expect_log "Command cannot be the empty string."
 }
 
 function test_local_startup_timeout() {

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -565,6 +565,11 @@ function test_no_arguments() {
   expect_log "Usage: b\\(laze\\|azel\\)"
 }
 
+function test_empty_command() {
+  bazel '' >&$TEST_log && fail "Expected non-zero exit"
+  expect_log "Command cannot be the empty string (try 'help')"
+}
+
 function test_local_startup_timeout() {
   local output_base=$(bazel info output_base 2>"$TEST_log") ||
     fail "bazel info failed"


### PR DESCRIPTION
This masked issues in Bazel wrappers in a very confusing way.

Fixes #24577