### PR TITLE
Add missing rules_apple allowlist alias

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
@@ -52,6 +52,7 @@ public final class BuiltinRestriction {
               // Apple rules
               BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_apple"),
               BuiltinRestriction.allowlistEntry("rules_apple", ""),
+              BuiltinRestriction.allowlistEntry("build_bazel_rules_apple", ""),
 
               // Cc rules
               BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_cc"),

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/objc/AppleBootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/objc/AppleBootstrap.java
@@ -31,6 +31,7 @@ public class AppleBootstrap implements Bootstrap {
           PackageIdentifier.createUnchecked("apple_support", ""),
           PackageIdentifier.createUnchecked("bazel_tools", ""),
           PackageIdentifier.createUnchecked("build_bazel_rules_swift", ""), // alias for rules_swift
+          PackageIdentifier.createUnchecked("build_bazel_rules_apple", ""), // alias for rules_apple
           PackageIdentifier.createUnchecked("io_bazel_rules_go", ""), // alias for rules_go
           PackageIdentifier.createUnchecked("local_config_cc", ""),
           PackageIdentifier.createUnchecked("rules_apple", ""),


### PR DESCRIPTION
If this is used from a WORKSPACE, or used in bzlmod with the repo name
overridden to the old name, rules_apple isn't correct for this
allowlist.
