### PR TITLE
[8.0.0] Create intermediate directories when moving deeply nested undeclared outputs.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -182,7 +182,7 @@ public class StandaloneTestStrategy extends TestStrategy {
 
         // e.g. /attemptsDir/attempt_1.dir/file
         destinationPath = attemptsDir.getRelative(destinationPathFragment);
-        destinationPath.getParentDirectory().createDirectory();
+        destinationPath.getParentDirectory().createDirectoryAndParents();
       }
 
       // Move to the destination.


### PR DESCRIPTION
Fixes #24578.

PiperOrigin-RevId: 703513880
Change-Id: I3f95a92ead3e64007974e45362185738b5927cee

Commit https://github.com/bazelbuild/bazel/commit/d93c1cb3b804e012ca8b27c905a99fa7c0ea431c