### PR TITLE
[8.0.0] Bazel Docs: Fix version selector in release docs

### DIFF
--- a/scripts/docs/rewriter.py
+++ b/scripts/docs/rewriter.py
@@ -85,17 +85,23 @@ def _fix_yaml_paths(content, rel_path, version):
 
 
 _PURE_HTML_FIXES = [_fix_html_links, _fix_html_metadata]
-_PURE_MD_FIXES = [_fix_md_links_and_images, _fix_md_metadata, _set_header_vars]
+_PURE_MD_FIXES = [_fix_md_links_and_images, _fix_md_metadata]
 _PURE_YAML_FIXES = [_fix_yaml_paths]
+_MD_AND_HTML_ONLY_FIXES = [_set_header_vars]
 
 _FIXES = {
-    ".html": _PURE_HTML_FIXES,
-    ".md": _PURE_MD_FIXES + _PURE_HTML_FIXES,
+    ".html": _PURE_HTML_FIXES + _MD_AND_HTML_ONLY_FIXES,
+    ".md": _PURE_MD_FIXES + _PURE_HTML_FIXES + _MD_AND_HTML_ONLY_FIXES,
     ".yaml": _PURE_YAML_FIXES + _PURE_HTML_FIXES,
 }
 
 
 def _get_fixes(path):
+  # Ignore _buttons.html since it's updated by //scripts/docs:gen_new_toc
+  # (src/main/java/com/google/devtools/build/docgen/release/TableOfContentsUpdater.java).
+  if "_buttons.html" in path:
+    return None
+
   _, ext = os.path.splitext(path)
   return _FIXES.get(ext)
 

--- a/site/command-line-reference-prefix.html
+++ b/site/command-line-reference-prefix.html
@@ -7,6 +7,9 @@
 
 <h1 class="page-title">Command-Line Reference</h1>
 
+{% dynamic setvar source_file "site/command-line-reference-prefix.html" %}
+{% include "_buttons.html" %}
+
 <pre>
 bazel [&lt;startup options&gt;] &lt;command&gt; [&lt;args&gt;]
 </pre>


### PR DESCRIPTION
- Ensure that rewriter.py also processes generated docs in order to set metadata required by the version selector
- Enable version selector for the command line reference

PiperOrigin-RevId: 703532562
Change-Id: I77664bd6e14b59d2ef0b749f85a52a09c291f6e8

Commit https://github.com/bazelbuild/bazel/commit/19047be2a9294b001e16cb10ec811414aac0eff2