### PR TITLE
Remove autoload warnings, improve errors and fix legacy repo name support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
@@ -616,6 +616,15 @@ public class AutoloadSymbols {
       return Label.parseCanonicalUnchecked(loadLabel()).getRepository().getName();
     }
 
+    String getWorkspaceRepoName() {
+      String moduleName = getModuleName();
+      return switch (moduleName) {
+        case "apple_support" -> "bazel_build_apple_support";
+        case "protobuf" -> "com_google_protobuf";
+        default -> moduleName;
+      };
+    }
+
     Label getLabel(RepoContext repoContext) throws InterruptedException {
       try {
         return Label.parseWithRepoContext(loadLabel(), repoContext);

--- a/src/test/shell/integration/incompatible_autoload_externally_test.sh
+++ b/src/test/shell/integration/incompatible_autoload_externally_test.sh
@@ -173,7 +173,7 @@ EOF
 }
 
 function test_missing_unnecessary_repo_doesnt_fail() {
-  # Intentionally not adding apple_support to MODULE.bazel (and it's not in MODULE.tools)
+  # Intentionally not adding rules_android to MODULE.bazel (and it's not in MODULE.tools)
   cat > WORKSPACE << EOF
 workspace(name = "test")
 EOF
@@ -183,7 +183,7 @@ filegroup(
     srcs = [],
 )
 EOF
-  bazel build --incompatible_autoload_externally=xcode_version :filegroup >&$TEST_log 2>&1 || fail "build failed"
+  bazel build --incompatible_autoload_externally=+@rules_android :filegroup >&$TEST_log 2>&1 || fail "build failed"
 }
 
 function test_removed_rule_loaded() {


### PR DESCRIPTION
This reduces noise while giving users more actionable information when they actually use a symbol that failed to autoload.

Also ensures that modules with legacy repo names (`com_google_protobuf` and `build_bazel_apple_support`) are handled correctly.

Fixes #23929 
Fixes #24597 