### PR TITLE
xml test output: support scientific notation without decimal

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/TestXmlOutputParser.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestXmlOutputParser.java
@@ -161,14 +161,15 @@ public final class TestXmlOutputParser {
    * Parses a time in test.xml format.
    *
    * @throws NumberFormatException if the time is malformed (i.e. is neither an integer nor a
-   *     decimal fraction with '.' as the fraction separator)
+   *     decimal fraction with '.' as the fraction separator or a decimal with 'e' scientific
+   *     notation)
    */
   private long parseTime(String string) {
 
     // This is ugly. For Historical Reasons, we have to check whether the number
     // contains a decimal point or not. If it does, the number is expressed in
-    // milliseconds, otherwise, in seconds.
-    if (string.contains(".")) {
+    // in seconds, otherwise milliseconds.
+    if (string.contains(".") || string.contains("e")) {
       return Math.round(Float.parseFloat(string) * 1000);
     } else {
       return Long.parseLong(string);


### PR DESCRIPTION
Boost test when writing XML files may sometimes omit the decimal point,
but still write in scientific notation as floating point seconds. To
support reading these XML files, if the string contains an `e`, then
try to parse as a float in hopes it's a floating point number. Since
parseLong will not support a `e` character this seems like a safe change
that is unlikely to break anything.

NOTE: I was not able to easily find tests for this behavior, but if tests
are desired I am happy to add them with a little guidance on the best place
for them.

Fixes: #24605
