### PR TITLE
Fix googletest target name

### DIFF
--- a/site/en/tutorials/cpp-use-cases.md
+++ b/site/en/tutorials/cpp-use-cases.md
@@ -137,7 +137,7 @@ cc_test(
       "-Iexternal/gtest/googletest",
     ],
     deps = [
-        "@googletest//:main",
+        "@googletest//:gtest_main",
         "//main:hello-greet",
     ],
 )


### PR DESCRIPTION
 I was following the tutorial and hit a wall here. 
```
 bazel test //test:hello-test
ERROR: /home/eriff/.cache/bazel/_bazel_eriff/f6bb6ff4e6e38165bb9ceee09de6c8af/external/googletest+/BUILD.bazel: no such target '@@googletest+//:main': target 'main' not declared in package '' defined by /home/eriff/.cache/bazel/_bazel_eriff/f6bb6ff4e6e38165bb9ceee09de6c8af/external/googletest+/BUILD.bazel
ERROR: /home/eriff/repos/bazel-examples/cpp-tutorial/stage3/test/BUILD:1:8: no such target '@@googletest+//:main': target 'main' not declared in package '' defined by /home/eriff/.cache/bazel/_bazel_eriff/f6bb6ff4e6e38165bb9ceee09de6c8af/external/googletest+/BUILD.bazel and referenced by '//test:hello-test'
ERROR: Analysis of target '//test:hello-test' failed; build aborted: Analysis failed
```

Turns out the target name was wrong