### PR TITLE
Allow ~/home in downloaderConfig of RepositoryOptions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -394,9 +394,8 @@ public class BazelRepositoryModule extends BlazeModule {
                 Event.warn(String.format("Error parsing the .netrc file: %s.", e.getMessage())));
       }
       try {
-        UrlRewriter rewriter =
-            UrlRewriter.getDownloaderUrlRewriter(
-                env.getWorkspace(), repoOptions.downloaderConfig, env.getReporter());
+        UrlRewriter rewriter = UrlRewriter.getDownloaderUrlRewriter(
+            env.getWorkspace(), repoOptions.downloaderConfig, env.getReporter());
         downloadManager.setUrlRewriter(rewriter);
       } catch (UrlRewriterParseException e) {
         // It's important that the build stops ASAP, because this config file may be required for

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -207,6 +207,7 @@ public class RepositoryOptions extends OptionsBase {
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
+      converter = OptionsUtils.PathFragmentConverter.class,
       help =
           "Specify a file to configure the remote downloader with. This file consists of lines, "
               + "each of which starts with a directive (`allow`, `block` or `rewrite`) followed "
@@ -214,7 +215,7 @@ public class RepositoryOptions extends OptionsBase {
               + "against, and one to use as a substitute URL, with back-references starting from "
               + "`$1`. It is possible for multiple `rewrite` directives for the same URL to be "
               + "give, and in this case multiple URLs will be returned.")
-  public String downloaderConfig;
+  public PathFragment downloaderConfig;
 
   /** See {@link #workerForRepoFetching}. */
   public enum WorkerForRepoFetching {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -86,11 +87,11 @@ public class UrlRewriter {
    * @param reporter Used for logging when URLs are rewritten.
    */
   public static UrlRewriter getDownloaderUrlRewriter(
-      Path workspaceRoot, String configPath, Reporter reporter) throws UrlRewriterParseException {
+      Path workspaceRoot, @Nullable PathFragment configPath, Reporter reporter) throws UrlRewriterParseException {
     Consumer<String> log = str -> reporter.handle(Event.info(str));
 
     // "empty" UrlRewriter shouldn't alter auth headers
-    if (Strings.isNullOrEmpty(configPath)) {
+    if (configPath == null || configPath.isEmpty()) {
       return new UrlRewriter(log, "", new StringReader(""));
     }
 
@@ -101,13 +102,13 @@ public class UrlRewriter {
 
     if (!actualConfigPath.exists()) {
       throw new UrlRewriterParseException(
-          String.format("Unable to find downloader config file %s", configPath));
+          String.format("Unable to find downloader config file %s", configPath.getPathString()));
     }
 
     try (InputStream inputStream = actualConfigPath.getInputStream();
         Reader inputStreamReader = new InputStreamReader(inputStream);
         Reader reader = new BufferedReader(inputStreamReader)) {
-      return new UrlRewriter(log, configPath, reader);
+      return new UrlRewriter(log, configPath.getPathString(), reader);
     } catch (IOException e) {
       throw new UrlRewriterParseException(e.getMessage());
     }


### PR DESCRIPTION
Similar to `--distdir` it makes sense to provide a `--experimental_downloader_config` from `~/.bazelrc` where it is more convenient to address a file in ones home directory by using `~/...` syntax instead of on absolute path.