### PR TITLE
[8.0.1] Symbolic macro Stardoc proto cherry picks

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
@@ -561,7 +561,7 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
     private final ExtractorContext extractorContext =
         ExtractorContext.builder()
             .labelRenderer(LabelRenderer.DEFAULT)
-            .extractNonStarlarkAttrs(true)
+            .extractNativelyDefinedAttrs(true)
             .build();
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/starlarkdocextract/ExtractorContext.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdocextract/ExtractorContext.java
@@ -28,7 +28,7 @@ import com.google.devtools.build.lib.packages.StarlarkProviderIdentifier;
 public record ExtractorContext(
     LabelRenderer labelRenderer,
     ImmutableMap<StarlarkProvider.Key, String> providerQualifiedNames,
-    boolean extractNonStarlarkAttrs) {
+    boolean extractNativelyDefinedAttrs) {
 
   public ExtractorContext {
     checkNotNull(labelRenderer, "labelRenderer cannot be null.");
@@ -39,7 +39,14 @@ public record ExtractorContext(
   public static Builder builder() {
     return new AutoBuilder_ExtractorContext_Builder()
         .providerQualifiedNames(ImmutableMap.of())
-        .extractNonStarlarkAttrs(false);
+        .extractNativelyDefinedAttrs(false);
+  }
+
+  public Builder toBuilder() {
+    return builder()
+        .labelRenderer(labelRenderer)
+        .providerQualifiedNames(providerQualifiedNames)
+        .extractNativelyDefinedAttrs(extractNativelyDefinedAttrs);
   }
 
   /** Builder for {@link ExtractorContext}. */
@@ -50,7 +57,7 @@ public record ExtractorContext(
     Builder providerQualifiedNames(
         ImmutableMap<StarlarkProvider.Key, String> providerQualifiedNames);
 
-    Builder extractNonStarlarkAttrs(boolean extractNonStarlarkAttrs);
+    Builder extractNativelyDefinedAttrs(boolean extractNativelyDefinedAttrs);
 
     ExtractorContext build();
   }

--- a/src/main/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractor.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractor.java
@@ -71,6 +71,8 @@ public final class ModuleInfoExtractor {
               .setName("visibility")
               .setType(AttributeType.LABEL_LIST)
               .setMandatory(false)
+              .setNonconfigurable(true)
+              .setNativelyDefined(true)
               .setDocString(
                   "The visibility to be passed to this macro's exported targets. It always"
                       + " implicitly includes the location where this macro is instantiated, so"

--- a/src/main/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractor.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractor.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.starlarkdocextract;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleClassFunctions.MacroFunction;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleClassFunctions.StarlarkRuleFunction;
@@ -55,14 +54,41 @@ public final class ModuleInfoExtractor {
   private final LabelRenderer labelRenderer;
 
   @VisibleForTesting
-  public static final ImmutableList<AttributeInfo> IMPLICIT_REPOSITORY_RULE_ATTRIBUTES =
-      ImmutableList.of(
+  public static final ImmutableMap<String, AttributeInfo> IMPLICIT_MACRO_ATTRIBUTES =
+      ImmutableMap.of(
+          "name",
+          AttributeInfo.newBuilder()
+              .setName("name")
+              .setType(AttributeType.NAME)
+              .setMandatory(true)
+              .setDocString(
+                  "A unique name for this macro instance. Normally, this is also the name for the"
+                      + " macro's main or only target. The names of any other targets that this"
+                      + " macro might create will be this name with a string suffix.")
+              .build(),
+          "visibility",
+          AttributeInfo.newBuilder()
+              .setName("visibility")
+              .setType(AttributeType.LABEL_LIST)
+              .setMandatory(false)
+              .setDocString(
+                  "The visibility to be passed to this macro's exported targets. It always"
+                      + " implicitly includes the location where this macro is instantiated, so"
+                      + " this attribute only needs to be explicitly set if you want the macro's"
+                      + " targets to be additionally visible somewhere else.")
+              .build());
+
+  @VisibleForTesting
+  public static final ImmutableMap<String, AttributeInfo> IMPLICIT_REPOSITORY_RULE_ATTRIBUTES =
+      ImmutableMap.of(
+          "name",
           AttributeInfo.newBuilder()
               .setName("name")
               .setType(AttributeType.NAME)
               .setMandatory(true)
               .setDocString("A unique name for this repository.")
               .build(),
+          "repo_mapping",
           AttributeInfo.newBuilder()
               .setName("repo_mapping")
               .setType(AttributeType.STRING_DICT)
@@ -346,10 +372,19 @@ public final class ModuleInfoExtractor {
       macroFunction.getDocumentation().ifPresent(macroInfoBuilder::setDocString);
 
       MacroClass macroClass = macroFunction.getMacroClass();
-      // inject the name attribute; addDocumentableAttributes skips non-Starlark-defined attributes.
-      macroInfoBuilder.addAttribute(AttributeInfoExtractor.IMPLICIT_MACRO_NAME_ATTRIBUTE_INFO);
+      if (macroClass.isFinalizer()) {
+        macroInfoBuilder.setFinalizer(true);
+      }
+      // For symbolic macros, always extract non-Starlark attributes (to support inherit_attrs).
+      ExtractorContext contextForImplicitMacroAttributes =
+          context.extractNativelyDefinedAttrs()
+              ? context
+              : context.toBuilder().extractNativelyDefinedAttrs(true).build();
       AttributeInfoExtractor.addDocumentableAttributes(
-          context, macroClass.getAttributes().values(), macroInfoBuilder::addAttribute);
+          contextForImplicitMacroAttributes,
+          IMPLICIT_MACRO_ATTRIBUTES,
+          macroClass.getAttributes().values(),
+          macroInfoBuilder::addAttribute);
 
       moduleInfoBuilder.addMacroInfo(macroInfoBuilder);
     }
@@ -419,10 +454,8 @@ public final class ModuleInfoExtractor {
           aspectInfoBuilder.addAspectAttribute(aspectAttribute);
         }
       }
-      aspectInfoBuilder.addAttribute(
-          AttributeInfoExtractor.IMPLICIT_NAME_ATTRIBUTE_INFO); // name comes first
       AttributeInfoExtractor.addDocumentableAttributes(
-          context, aspect.getAttributes(), aspectInfoBuilder::addAttribute);
+          context, ImmutableMap.of(), aspect.getAttributes(), aspectInfoBuilder::addAttribute);
       moduleInfoBuilder.addAspectInfo(aspectInfoBuilder);
     }
 
@@ -446,7 +479,10 @@ public final class ModuleInfoExtractor {
         tagClassInfoBuilder.setTagName(entry.getKey());
         entry.getValue().doc().ifPresent(tagClassInfoBuilder::setDocString);
         AttributeInfoExtractor.addDocumentableAttributes(
-            context, entry.getValue().attributes(), tagClassInfoBuilder::addAttribute);
+            context,
+            ImmutableMap.of(),
+            entry.getValue().attributes(),
+            tagClassInfoBuilder::addAttribute);
         moduleExtensionInfoBuilder.addTagClass(tagClassInfoBuilder);
       }
       moduleInfoBuilder.addModuleExtensionInfo(moduleExtensionInfoBuilder);
@@ -460,15 +496,15 @@ public final class ModuleInfoExtractor {
       repositoryRuleInfoBuilder.setRuleName(qualifiedName);
       repositoryRuleFunction.getDocumentation().ifPresent(repositoryRuleInfoBuilder::setDocString);
       RuleClass ruleClass = repositoryRuleFunction.getRuleClass();
-      repositoryRuleInfoBuilder
-          .setOriginKey(
-              OriginKey.newBuilder()
-                  .setName(ruleClass.getName())
-                  .setFile(
-                      context.labelRenderer().render(repositoryRuleFunction.getExtensionLabel())))
-          .addAllAttribute(IMPLICIT_REPOSITORY_RULE_ATTRIBUTES);
+      repositoryRuleInfoBuilder.setOriginKey(
+          OriginKey.newBuilder()
+              .setName(ruleClass.getName())
+              .setFile(context.labelRenderer().render(repositoryRuleFunction.getExtensionLabel())));
       AttributeInfoExtractor.addDocumentableAttributes(
-          context, ruleClass.getAttributes(), repositoryRuleInfoBuilder::addAttribute);
+          context,
+          IMPLICIT_REPOSITORY_RULE_ATTRIBUTES,
+          ruleClass.getAttributes(),
+          repositoryRuleInfoBuilder::addAttribute);
       if (ruleClass.hasAttr("$environ", Types.STRING_LIST)) {
         repositoryRuleInfoBuilder.addAllEnviron(
             Types.STRING_LIST.cast(ruleClass.getAttributeByName("$environ").getDefaultValue(null)));

--- a/src/main/java/com/google/devtools/build/lib/starlarkdocextract/RuleInfoExtractor.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdocextract/RuleInfoExtractor.java
@@ -14,17 +14,32 @@
 
 package com.google.devtools.build.lib.starlarkdocextract;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
 import com.google.devtools.build.lib.packages.StarlarkProviderIdentifier;
 import com.google.devtools.build.lib.packages.Type;
+import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.AttributeInfo;
+import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.AttributeType;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.OriginKey;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.RuleInfo;
 
 /** API documentation extractor for a rule. */
 public final class RuleInfoExtractor {
+
+  @VisibleForTesting
+  public static final ImmutableMap<String, AttributeInfo> IMPLICIT_RULE_ATTRIBUTES =
+      ImmutableMap.of(
+          "name",
+          AttributeInfo.newBuilder()
+              .setName("name")
+              .setType(AttributeType.NAME)
+              .setMandatory(true)
+              .setDocString("A unique name for this target.")
+              .build());
 
   /**
    * Extracts API documentation for a rule in the form of a {@link RuleInfo} proto.
@@ -72,10 +87,11 @@ public final class RuleInfoExtractor {
       ruleInfoBuilder.setExecutable(true);
     }
 
-    ruleInfoBuilder.addAttribute(
-        AttributeInfoExtractor.IMPLICIT_NAME_ATTRIBUTE_INFO); // name comes first
     AttributeInfoExtractor.addDocumentableAttributes(
-        context, ruleClass.getAttributes(), ruleInfoBuilder::addAttribute);
+        context,
+        IMPLICIT_RULE_ATTRIBUTES,
+        ruleClass.getAttributes(),
+        ruleInfoBuilder::addAttribute);
     ImmutableSet<StarlarkProviderIdentifier> advertisedProviders =
         ruleClass.getAdvertisedProviders().getStarlarkProviders();
     if (!advertisedProviders.isEmpty()) {

--- a/src/main/protobuf/stardoc_output.proto
+++ b/src/main/protobuf/stardoc_output.proto
@@ -126,6 +126,9 @@ message MacroInfo {
   // The module where and the name under which the macro was originally
   // declared.
   OriginKey origin_key = 4;
+
+  // True if this macro is a rule finalizer.
+  bool finalizer = 5;
 }
 
 // Representation of a Starlark rule, repository rule, or module extension tag
@@ -161,6 +164,9 @@ message AttributeInfo {
 
   // If true, the attribute is non-configurable.
   bool nonconfigurable = 7;
+
+  // If true, the attribute is defined in Bazel's native code, not in Starlark.
+  bool natively_defined = 8;
 }
 
 // Representation of a set of providers.

--- a/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/BUILD
@@ -31,6 +31,7 @@ java_library(
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/bazel/bzlmod:util",
         "//src/test/java/com/google/devtools/build/lib/testutil",
+        "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
         "@com_google_protobuf//:protobuf_java",

--- a/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/StarlarkDocExtractTest.java
@@ -16,10 +16,11 @@ package com.google.devtools.build.lib.rules.starlarkdocextract;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-import static com.google.devtools.build.lib.starlarkdocextract.AttributeInfoExtractor.IMPLICIT_NAME_ATTRIBUTE_INFO;
+import static com.google.devtools.build.lib.starlarkdocextract.RuleInfoExtractor.IMPLICIT_RULE_ATTRIBUTES;
 import static com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.FunctionParamRole.PARAM_ROLE_ORDINARY;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -355,20 +356,27 @@ public final class StarlarkDocExtractTest extends BuildViewTestCase {
             OriginKey.newBuilder().setName("my_rule").setFile("//:origin.bzl").build());
 
     assertThat(moduleInfo.getRuleInfo(0).getAttributeList())
-        .containsExactly(
-            IMPLICIT_NAME_ATTRIBUTE_INFO,
-            AttributeInfo.newBuilder()
-                .setName("a")
-                .setType(AttributeType.LABEL)
-                .setDefaultValue("None")
-                .addProviderNameGroup(
-                    ProviderNameGroup.newBuilder()
-                        .addProviderName("namespace.RenamedInfo")
-                        .addProviderName("other_namespace.RenamedOtherInfo")
-                        .addOriginKey(
-                            OriginKey.newBuilder().setName("MyInfo").setFile("//:origin.bzl"))
-                        .addOriginKey(
-                            OriginKey.newBuilder().setName("MyOtherInfo").setFile("//:origin.bzl")))
+        .isEqualTo(
+            ImmutableList.builder()
+                .addAll(IMPLICIT_RULE_ATTRIBUTES.values())
+                .add(
+                    AttributeInfo.newBuilder()
+                        .setName("a")
+                        .setType(AttributeType.LABEL)
+                        .setDefaultValue("None")
+                        .addProviderNameGroup(
+                            ProviderNameGroup.newBuilder()
+                                .addProviderName("namespace.RenamedInfo")
+                                .addProviderName("other_namespace.RenamedOtherInfo")
+                                .addOriginKey(
+                                    OriginKey.newBuilder()
+                                        .setName("MyInfo")
+                                        .setFile("//:origin.bzl"))
+                                .addOriginKey(
+                                    OriginKey.newBuilder()
+                                        .setName("MyOtherInfo")
+                                        .setFile("//:origin.bzl")))
+                        .build())
                 .build());
     assertThat(moduleInfo.getRuleInfo(0).getAdvertisedProviders())
         .isEqualTo(
@@ -955,7 +963,7 @@ public final class StarlarkDocExtractTest extends BuildViewTestCase {
                 .setOriginKey(
                     OriginKey.newBuilder().setName("my_repo_rule").setFile("//:dep.bzl").build())
                 .setDocString("My repository rule\n\nWith details")
-                .addAllAttribute(ModuleInfoExtractor.IMPLICIT_REPOSITORY_RULE_ATTRIBUTES)
+                .addAllAttribute(ModuleInfoExtractor.IMPLICIT_REPOSITORY_RULE_ATTRIBUTES.values())
                 .addAttribute(
                     AttributeInfo.newBuilder()
                         .setName("a")

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -17,8 +17,8 @@ package com.google.devtools.build.lib.starlarkdocextract;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static com.google.devtools.build.lib.skyframe.BzlLoadValue.keyForBuild;
-import static com.google.devtools.build.lib.starlarkdocextract.AttributeInfoExtractor.IMPLICIT_MACRO_NAME_ATTRIBUTE_INFO;
-import static com.google.devtools.build.lib.starlarkdocextract.AttributeInfoExtractor.IMPLICIT_NAME_ATTRIBUTE_INFO;
+import static com.google.devtools.build.lib.starlarkdocextract.ModuleInfoExtractor.IMPLICIT_MACRO_ATTRIBUTES;
+import static com.google.devtools.build.lib.starlarkdocextract.RuleInfoExtractor.IMPLICIT_RULE_ATTRIBUTES;
 import static com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.FunctionParamRole.PARAM_ROLE_KWARGS;
 import static com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.FunctionParamRole.PARAM_ROLE_ORDINARY;
 import static com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.FunctionParamRole.PARAM_ROLE_VARARGS;
@@ -45,6 +45,7 @@ import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.Prov
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.ProviderNameGroup;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.RuleInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.StarlarkFunctionInfo;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import net.starlark.java.eval.Module;
@@ -712,55 +713,68 @@ public final class ModuleInfoExtractorTest {
             """);
     ModuleInfo moduleInfo = getExtractor().extractFrom(module);
     assertThat(moduleInfo.getRuleInfoList().get(0).getAttributeList())
-        .containsExactly(
-            IMPLICIT_NAME_ATTRIBUTE_INFO,
-            AttributeInfo.newBuilder()
-                .setName("a")
-                .setType(AttributeType.STRING)
-                .setDocString("My doc")
-                .setDefaultValue("\"foo\"")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("b")
-                .setType(AttributeType.STRING)
-                .setMandatory(true)
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("c")
-                .setType(AttributeType.LABEL)
-                .setDefaultValue("None")
-                .addProviderNameGroup(
-                    ProviderNameGroup.newBuilder()
-                        .addProviderName("MyInfo1")
-                        .addProviderName("MyInfo2")
-                        .addOriginKey(
-                            OriginKey.newBuilder().setName("MyInfo1").setFile(fakeLabelString))
-                        .addOriginKey(
-                            OriginKey.newBuilder().setName("MyInfo2").setFile(fakeLabelString)))
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("d")
-                .setType(AttributeType.LABEL)
-                .setDefaultValue("None")
-                .addProviderNameGroup(
-                    ProviderNameGroup.newBuilder()
-                        .addProviderName("MyInfo1")
-                        .addProviderName("MyInfo2")
-                        .addOriginKey(
-                            OriginKey.newBuilder().setName("MyInfo1").setFile(fakeLabelString))
-                        .addOriginKey(
-                            OriginKey.newBuilder().setName("MyInfo2").setFile(fakeLabelString)))
-                .addProviderNameGroup(
-                    ProviderNameGroup.newBuilder()
-                        .addProviderName("MyInfo3")
-                        .addOriginKey(
-                            OriginKey.newBuilder().setName("MyInfo3").setFile(fakeLabelString)))
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("deprecated_license")
-                .setType(AttributeType.STRING_LIST)
-                .setDefaultValue("[\"none\"]")
-                .setNonconfigurable(true)
+        .containsExactlyElementsIn(
+            ImmutableList.builder()
+                .addAll(IMPLICIT_RULE_ATTRIBUTES.values())
+                .add(
+                    AttributeInfo.newBuilder()
+                        .setName("a")
+                        .setType(AttributeType.STRING)
+                        .setDocString("My doc")
+                        .setDefaultValue("\"foo\"")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("b")
+                        .setType(AttributeType.STRING)
+                        .setMandatory(true)
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("c")
+                        .setType(AttributeType.LABEL)
+                        .setDefaultValue("None")
+                        .addProviderNameGroup(
+                            ProviderNameGroup.newBuilder()
+                                .addProviderName("MyInfo1")
+                                .addProviderName("MyInfo2")
+                                .addOriginKey(
+                                    OriginKey.newBuilder()
+                                        .setName("MyInfo1")
+                                        .setFile(fakeLabelString))
+                                .addOriginKey(
+                                    OriginKey.newBuilder()
+                                        .setName("MyInfo2")
+                                        .setFile(fakeLabelString)))
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("d")
+                        .setType(AttributeType.LABEL)
+                        .setDefaultValue("None")
+                        .addProviderNameGroup(
+                            ProviderNameGroup.newBuilder()
+                                .addProviderName("MyInfo1")
+                                .addProviderName("MyInfo2")
+                                .addOriginKey(
+                                    OriginKey.newBuilder()
+                                        .setName("MyInfo1")
+                                        .setFile(fakeLabelString))
+                                .addOriginKey(
+                                    OriginKey.newBuilder()
+                                        .setName("MyInfo2")
+                                        .setFile(fakeLabelString)))
+                        .addProviderNameGroup(
+                            ProviderNameGroup.newBuilder()
+                                .addProviderName("MyInfo3")
+                                .addOriginKey(
+                                    OriginKey.newBuilder()
+                                        .setName("MyInfo3")
+                                        .setFile(fakeLabelString)))
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("deprecated_license")
+                        .setType(AttributeType.STRING_LIST)
+                        .setDefaultValue("[\"none\"]")
+                        .setNonconfigurable(true)
+                        .build())
                 .build());
   }
 
@@ -817,69 +831,72 @@ public final class ModuleInfoExtractorTest {
             """);
     ModuleInfo moduleInfo = getExtractor().extractFrom(module);
     assertThat(moduleInfo.getRuleInfoList().get(0).getAttributeList())
-        .containsExactly(
-            IMPLICIT_NAME_ATTRIBUTE_INFO,
-            AttributeInfo.newBuilder()
-                .setName("a")
-                .setType(AttributeType.INT)
-                .setDefaultValue("0")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("b")
-                .setType(AttributeType.LABEL)
-                .setDefaultValue("None")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("c")
-                .setType(AttributeType.STRING)
-                .setDefaultValue("\"\"")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("d")
-                .setType(AttributeType.STRING_LIST)
-                .setDefaultValue("[]")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("e")
-                .setType(AttributeType.INT_LIST)
-                .setDefaultValue("[]")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("f")
-                .setType(AttributeType.LABEL_LIST)
-                .setDefaultValue("[]")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("g")
-                .setType(AttributeType.BOOLEAN)
-                .setDefaultValue("False")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("h")
-                .setType(AttributeType.LABEL_STRING_DICT)
-                .setDefaultValue("{}")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("i")
-                .setType(AttributeType.STRING_DICT)
-                .setDefaultValue("{}")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("j")
-                .setType(AttributeType.STRING_LIST_DICT)
-                .setDefaultValue("{}")
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("k")
-                .setType(AttributeType.OUTPUT)
-                .setDefaultValue("None")
-                .setNonconfigurable(true)
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("l")
-                .setType(AttributeType.OUTPUT_LIST)
-                .setDefaultValue("[]")
-                .setNonconfigurable(true)
+        .containsExactlyElementsIn(
+            ImmutableList.builder()
+                .addAll(IMPLICIT_RULE_ATTRIBUTES.values())
+                .add(
+                    AttributeInfo.newBuilder()
+                        .setName("a")
+                        .setType(AttributeType.INT)
+                        .setDefaultValue("0")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("b")
+                        .setType(AttributeType.LABEL)
+                        .setDefaultValue("None")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("c")
+                        .setType(AttributeType.STRING)
+                        .setDefaultValue("\"\"")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("d")
+                        .setType(AttributeType.STRING_LIST)
+                        .setDefaultValue("[]")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("e")
+                        .setType(AttributeType.INT_LIST)
+                        .setDefaultValue("[]")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("f")
+                        .setType(AttributeType.LABEL_LIST)
+                        .setDefaultValue("[]")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("g")
+                        .setType(AttributeType.BOOLEAN)
+                        .setDefaultValue("False")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("h")
+                        .setType(AttributeType.LABEL_STRING_DICT)
+                        .setDefaultValue("{}")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("i")
+                        .setType(AttributeType.STRING_DICT)
+                        .setDefaultValue("{}")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("j")
+                        .setType(AttributeType.STRING_LIST_DICT)
+                        .setDefaultValue("{}")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("k")
+                        .setType(AttributeType.OUTPUT)
+                        .setDefaultValue("None")
+                        .setNonconfigurable(true)
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("l")
+                        .setType(AttributeType.OUTPUT_LIST)
+                        .setDefaultValue("[]")
+                        .setNonconfigurable(true)
+                        .build())
                 .build());
   }
 
@@ -926,13 +943,40 @@ public final class ModuleInfoExtractorTest {
                 .setDocString("My doc")
                 .setOriginKey(
                     OriginKey.newBuilder().setName("documented_macro").setFile(fakeLabelString))
-                .addAttribute(IMPLICIT_MACRO_NAME_ATTRIBUTE_INFO)
+                .addAllAttribute(IMPLICIT_MACRO_ATTRIBUTES.values())
                 .build(),
             MacroInfo.newBuilder()
                 .setMacroName("undocumented_macro")
                 .setOriginKey(
                     OriginKey.newBuilder().setName("undocumented_macro").setFile(fakeLabelString))
-                .addAttribute(IMPLICIT_MACRO_NAME_ATTRIBUTE_INFO)
+                .addAllAttribute(IMPLICIT_MACRO_ATTRIBUTES.values())
+                .build());
+  }
+
+  @Test
+  public void macroFinalizer() throws Exception {
+    Module module =
+        exec(
+            """
+            def _my_impl(name, visibility):
+                pass
+
+            my_finalizer = macro(
+                doc = "My finalizer",
+                implementation = _my_impl,
+                finalizer = True,
+            )
+            """);
+    ModuleInfo moduleInfo = getExtractor().extractFrom(module);
+    assertThat(moduleInfo.getMacroInfoList())
+        .containsExactly(
+            MacroInfo.newBuilder()
+                .setMacroName("my_finalizer")
+                .setDocString("My finalizer")
+                .setOriginKey(
+                    OriginKey.newBuilder().setName("my_finalizer").setFile(fakeLabelString))
+                .addAllAttribute(IMPLICIT_MACRO_ATTRIBUTES.values())
+                .setFinalizer(true)
                 .build());
   }
 
@@ -955,21 +999,22 @@ public final class ModuleInfoExtractorTest {
             """);
     ModuleInfo moduleInfo = getExtractor().extractFrom(module);
     assertThat(moduleInfo.getMacroInfoList().get(0).getAttributeList())
-        .containsExactly(
-            IMPLICIT_MACRO_NAME_ATTRIBUTE_INFO, // name comes first
-            AttributeInfo.newBuilder()
-                .setName("some_attr")
-                .setType(AttributeType.LABEL)
-                .setMandatory(true)
-                .build(),
-            AttributeInfo.newBuilder()
-                .setName("another_attr")
-                .setType(AttributeType.INT)
-                .setDocString("An integer")
-                .setDefaultValue("42")
-                .build()
-            // note that implicit attributes don't get documented
-            );
+        .containsExactlyElementsIn(
+            ImmutableList.builder()
+                .addAll(IMPLICIT_MACRO_ATTRIBUTES.values())
+                .add(
+                    AttributeInfo.newBuilder()
+                        .setName("some_attr")
+                        .setType(AttributeType.LABEL)
+                        .setMandatory(true)
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("another_attr")
+                        .setType(AttributeType.INT)
+                        .setDocString("An integer")
+                        .setDefaultValue("42")
+                        .build())
+                .build());
   }
 
   @Test
@@ -996,20 +1041,29 @@ my_macro = macro(
 )
 """);
     ModuleInfo moduleInfo = getExtractor().extractFrom(module);
-    assertThat(moduleInfo.getMacroInfoList().get(0).getAttributeList())
-        .containsExactly(
-            IMPLICIT_MACRO_NAME_ATTRIBUTE_INFO, // name comes first
-            // TODO(arostovtsev): for macros, we ought to also document the visibility attr
+    List<AttributeInfo> attributes = moduleInfo.getMacroInfoList().get(0).getAttributeList();
+    assertThat(attributes.get(0)).isEqualTo(IMPLICIT_MACRO_ATTRIBUTES.get("name"));
+    assertThat(attributes.get(1)).isEqualTo(IMPLICIT_MACRO_ATTRIBUTES.get("visibility"));
+    // Starlark-defined inherited attribute
+    assertThat(attributes)
+        .contains(
             AttributeInfo.newBuilder()
                 .setName("srcs")
                 .setType(AttributeType.LABEL_LIST)
                 .setDocString("My rule sources")
                 .setDefaultValue("None") // Default value of inherited attributes is always None
-                .build()
-            // TODO(arostovtsev): currently, non-Starlark-defined attributes don't get documented.
-            // This is a reasonable behavior for rules, but we probably ought to document them in
-            // macros with inherited attributes.
-            );
+                .build());
+    // Native inherited attributes may not be documented, so ignore doc string for them.
+    assertThat(attributes)
+        .ignoringFields(AttributeInfo.DOC_STRING_FIELD_NUMBER)
+        .contains(
+            AttributeInfo.newBuilder()
+                .setName("tags")
+                .setType(AttributeType.STRING_LIST)
+                .setDefaultValue("None") // Default value of inherited attributes is always None
+                .setNonconfigurable(true)
+                .setNativelyDefined(true)
+                .build());
   }
 
   @Test
@@ -1098,7 +1152,7 @@ my_macro = macro(
     ModuleInfo moduleInfo = getExtractor(repositoryMapping, "my_repo").extractFrom(module);
     assertThat(
             moduleInfo.getRuleInfoList().get(0).getAttributeList().stream()
-                .filter(attr -> !attr.equals(IMPLICIT_NAME_ATTRIBUTE_INFO))
+                .filter(attr -> !IMPLICIT_RULE_ATTRIBUTES.containsKey(attr.getName()))
                 .map(AttributeInfo::getDefaultValue))
         .containsExactly(
             "\"@my_repo//test:foo\"",
@@ -1160,7 +1214,6 @@ my_macro = macro(
                 .setOriginKey(OriginKey.newBuilder().setName("my_aspect").setFile(fakeLabelString))
                 .addAspectAttribute("deps")
                 .addAspectAttribute("srcs")
-                .addAttribute(IMPLICIT_NAME_ATTRIBUTE_INFO)
                 .addAttribute(
                     AttributeInfo.newBuilder()
                         .setName("a")

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/RuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/RuleInfoExtractorTest.java
@@ -52,7 +52,7 @@ public final class RuleInfoExtractorTest extends PackageLoadingTestCase {
     ExtractorContext extractorContext =
         ExtractorContext.builder()
             .labelRenderer(LabelRenderer.DEFAULT)
-            .extractNonStarlarkAttrs(true)
+            .extractNativelyDefinedAttrs(true)
             .build();
     RuleInfo ruleInfo =
         RuleInfoExtractor.buildRuleInfo(extractorContext, "namespace.test_rule", ruleClass);
@@ -61,13 +61,15 @@ public final class RuleInfoExtractorTest extends PackageLoadingTestCase {
             RuleInfo.newBuilder()
                 .setRuleName("namespace.test_rule")
                 .setOriginKey(OriginKey.newBuilder().setName("test_rule").setFile("<native>"))
-                .addAttribute(AttributeInfoExtractor.IMPLICIT_NAME_ATTRIBUTE_INFO)
+                .addAllAttribute(RuleInfoExtractor.IMPLICIT_RULE_ATTRIBUTES.values())
                 .addAttribute(
                     AttributeInfo.newBuilder()
                         .setName("tags")
                         .setType(AttributeType.STRING_LIST)
                         .setDefaultValue("[]")
-                        .setMandatory(false))
+                        .setMandatory(false)
+                        .setNativelyDefined(true)
+                        .build())
                 .build());
   }
 
@@ -87,7 +89,7 @@ public final class RuleInfoExtractorTest extends PackageLoadingTestCase {
     ExtractorContext extractorContext =
         ExtractorContext.builder()
             .labelRenderer(LabelRenderer.DEFAULT)
-            .extractNonStarlarkAttrs(true)
+            .extractNativelyDefinedAttrs(true)
             .build();
     for (RuleClass ruleClass : ruleClassProvider.getRuleClassMap().values()) {
       RuleInfo ruleInfo =
@@ -99,7 +101,7 @@ public final class RuleInfoExtractorTest extends PackageLoadingTestCase {
           .isEqualTo("<native>");
       assertWithMessage("rule '%s'", ruleClass.getName())
           .that(ruleInfo.getAttributeList().getFirst())
-          .isEqualTo(AttributeInfoExtractor.IMPLICIT_NAME_ATTRIBUTE_INFO);
+          .isEqualTo(RuleInfoExtractor.IMPLICIT_RULE_ATTRIBUTES.get("name"));
       assertWithMessage("rule '%s'", ruleClass.getName())
           .that(ruleInfo.getAttributeList().stream().map(AttributeInfo::getName))
           .containsNoDuplicates();

--- a/tools/ctexplain/analyses/summary.py
+++ b/tools/ctexplain/analyses/summary.py
@@ -18,7 +18,7 @@ from typing import Tuple
 from dataclasses import dataclass
 
 from tools.ctexplain.types import ConfiguredTarget
-# Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.util as util
+import tools.ctexplain.util as util
 
 
 @dataclass(frozen=True)

--- a/tools/ctexplain/analyses/summary_test.py
+++ b/tools/ctexplain/analyses/summary_test.py
@@ -17,7 +17,7 @@ import unittest
 # Do not edit this line. Copybara replaces it with PY2 migration helper.
 from frozendict import frozendict
 
-# Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.analyses.summary as summary
+import tools.ctexplain.analyses.summary as summary
 from tools.ctexplain.types import Configuration
 from tools.ctexplain.types import ConfiguredTarget
 from tools.ctexplain.types import NullConfiguration

--- a/tools/ctexplain/ctexplain.py
+++ b/tools/ctexplain/ctexplain.py
@@ -42,11 +42,11 @@ from absl import app
 from absl import flags
 from dataclasses import dataclass
 
-# Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.analyses.summary as summary
+import tools.ctexplain.analyses.summary as summary
 from tools.ctexplain.bazel_api import BazelApi
-# Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.lib as lib
+import tools.ctexplain.lib as lib
 from tools.ctexplain.types import ConfiguredTarget
-# Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.util as util
+import tools.ctexplain.util as util
 
 FLAGS = flags.FLAGS
 

--- a/tools/ctexplain/lib.py
+++ b/tools/ctexplain/lib.py
@@ -14,7 +14,7 @@
 """General-purpose business logic."""
 from typing import Tuple
 
-# Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.bazel_api as bazel_api
+import tools.ctexplain.bazel_api as bazel_api
 from tools.ctexplain.types import ConfiguredTarget
 
 

--- a/tools/ctexplain/lib_test.py
+++ b/tools/ctexplain/lib_test.py
@@ -14,8 +14,8 @@
 """Tests for lib.py."""
 import unittest
 from src.test.py.bazel import test_base
-# Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.bazel_api as bazel_api
-# Do not edit this line. Copybara replaces it with PY2 migration helper..third_party.bazel.tools.ctexplain.lib as lib
+import tools.ctexplain.bazel_api as bazel_api
+import tools.ctexplain.lib as lib
 from tools.ctexplain.types import Configuration
 from tools.ctexplain.types import HostConfiguration
 from tools.ctexplain.types import NullConfiguration


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/24643

This is a cherry-pick of the following 2 commits, which collectively allow API documentation generation for symbolic macros using Stardoc:

1. Update symbolic macro stardoc protos for visibility, finalizers, and attribute inheritance

Cherry-pick of

https://github.com/bazelbuild/bazel/commit/59e99b67533ebc5375cca98bc95ec0b74c4d4a69
PiperOrigin-RevId: 700811908
Change-Id: I5486919b9e2af98a7d08f952f8075216c3c60bfd

2. In stardoc proto output, mark macro visibility as non-configurable and natively defined.

Cherry-pick of

https://github.com/bazelbuild/bazel/commit/e6a44c873b553b61c8f0feba50acf57694d6a9f8

PiperOrigin-RevId: 703255080
Change-Id: I1055c4c8b7e2e627199bdca9e2daab5654102831