### PR TITLE
[8.0.1] Fix invalid `dict` syntax in macro docs

### DIFF
--- a/site/en/extending/macros.md
+++ b/site/en/extending/macros.md
@@ -83,9 +83,9 @@ my_macro = macro(
     inherit_attrs = native.cc_library,
     attrs = {
         # override native.cc_library's `local_defines` attribute
-        local_defines = attr.string_list(default = ["FOO"]),
+        "local_defines": attr.string_list(default = ["FOO"]),
         # do not inherit native.cc_library's `defines` attribute
-        defines = None,
+        "defines": None,
     },
     ...
 )


### PR DESCRIPTION
Closes #24585.

PiperOrigin-RevId: 704366607
Change-Id: Ibdc89e1ad30ded6f3b69edc2877fcac78c622ea9

Commit https://github.com/bazelbuild/bazel/commit/baa01598cc8e2747d65c0fedcde276e6c9690adf