### PR TITLE
Allow `native.bazel_version` to be overridden for dev builds

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BlazeVersionInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BlazeVersionInfo.java
@@ -35,6 +35,11 @@ public class BlazeVersionInfo {
   /** Key for the release timestamp is seconds. */
   public static final String BUILD_TIMESTAMP = "Build timestamp as int";
 
+  // If the current version is a development version, this environment variable can be used to
+  // override the version string (e.g. to deal with version-based feature detection during a
+  // bisect).
+  public static final String BAZEL_DEV_VERSION_OVERRIDE_ENV_VAR = "BAZEL_DEV_VERSION_OVERRIDE";
+
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private static BlazeVersionInfo instance = null;
@@ -126,7 +131,14 @@ public class BlazeVersionInfo {
    */
   public String getVersion() {
     String buildLabel = buildData.get(BUILD_LABEL);
-    return buildLabel != null ? buildLabel : "";
+    if (buildLabel != null) {
+      return buildLabel;
+    }
+    String override = System.getenv(BAZEL_DEV_VERSION_OVERRIDE_ENV_VAR);
+    if (override != null) {
+      return override;
+    }
+    return "";
   }
 
   /**


### PR DESCRIPTION
This is necessary to allow for accurate bisects of Bazel issues when rules rely on `bazel_features` for feature detection. The variable can be used to force the lowest version relevant to the bisect or, in the future, `bazelisk --bisect` could extrapolate the release version from tags.