### PR TITLE
Introducing Bazel Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ disclosure timeline.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-[![Build status](https://badge.buildkite.com/1fd282f8ad98c3fb10758a821e5313576356709dd7d11e9618.svg?status=master)](https://buildkite.com/bazel/bazel-bazel)
+[![Build status](https://badge.buildkite.com/1fd282f8ad98c3fb10758a821e5313576356709dd7d11e9618.svg?status=master)](https://buildkite.com/bazel/bazel-bazel) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Bazel%20Guru-006BFF)](https://gurubase.io/g/bazel)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Build and test software of any size, quickly and reliably.
   * [Write tests](https://bazel.build/reference/test-encyclopedia)
   * [Roadmap](https://bazel.build/community/roadmaps)
   * [Who is using Bazel?](https://bazel.build/community/users)
+  * [Ask Bazel AI](https://gurubase.io/g/bazel)
 
 ## Reporting a Vulnerability
 
@@ -55,4 +56,4 @@ disclosure timeline.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-[![Build status](https://badge.buildkite.com/1fd282f8ad98c3fb10758a821e5313576356709dd7d11e9618.svg?status=master)](https://buildkite.com/bazel/bazel-bazel) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Bazel%20Guru-006BFF)](https://gurubase.io/g/bazel)
+[![Build status](https://badge.buildkite.com/1fd282f8ad98c3fb10758a821e5313576356709dd7d11e9618.svg?status=master)](https://buildkite.com/bazel/bazel-bazel)


### PR DESCRIPTION
Hello Team,

This PR is a friendly notification that the [Bazel Guru](https://gurubase.io/g/bazel) has been added to Gurubase. The Bazel Guru uses data from this repository and the [documentation](https://bazel.build/) to answer questions by leveraging the LLM.

Gurubase is a centralized, RAG-based learning and troubleshooting assistant platform. Each "Guru" is equipped with custom knowledge to answer user questions based on data collected for that tool. More information can be found in [this repo](https://github.com/getanteon/gurubase).

This PR updates the README to indicate that Bazel users can now ask questions to Bazel Guru. As shown in the [Used By](https://github.com/getanteon/gurubase?tab=readme-ov-file#used-by) section, over 100 open-source repositories currently showcase their Guru in their README.md.

By default, there are three possible actions:
1. If you dislike it, we can immediately disable Bazel Guru in Gurubase and remove this PR.
2. If you like it but don’t want to add it to the README, we can remove this PR or include it in another place you prefer.
3. If you’re happy with it, we can keep it as is and merge the PR.

Although this PR is created by the Gurubase Notifier account, the team monitors it and will answer any questions you may have.

**Note:** If you consider this PR a time-waster, apologize for the inconvenience. Developers often request us to create a Guru for the tools they use. Once we create it, we notify the maintainers to inform them and seek their approval.
