### PR TITLE
Enabling the CircuitBreaker for remote HTTP cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -227,6 +227,17 @@ public final class RemoteModule extends BlazeModule {
         return retry;
       };
 
+  public static final Predicate<? super Exception> HTTP_SUCCESS_CODES =
+      e -> {
+        boolean success = false;
+        if (e instanceof HttpException) {
+          int status = ((HttpException) e).response().status().code();
+          success =
+              status == HttpResponseStatus.NOT_FOUND.code();
+        }
+        return success;
+      };
+
   private void initHttpAndDiskCache(
       CommandEnvironment env,
       Credentials credentials,
@@ -238,6 +249,8 @@ public final class RemoteModule extends BlazeModule {
     Retrier.CircuitBreaker circuitBreaker =
         CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
     try {
+      Retrier.CircuitBreaker circuitBreaker =
+        CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
       combinedCacheClient =
           CombinedCacheClientFactory.create(
               remoteOptions,
@@ -247,7 +260,7 @@ public final class RemoteModule extends BlazeModule {
               digestUtil,
               executorService,
               new RemoteRetrier(
-                  remoteOptions, RETRIABLE_HTTP_ERRORS, retryScheduler, circuitBreaker));
+                  remoteOptions, RETRIABLE_HTTP_ERRORS, retryScheduler, circuitBreaker, HTTP_SUCCESS_CODES));
     } catch (IOException e) {
       handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
       return;
@@ -474,7 +487,7 @@ public final class RemoteModule extends BlazeModule {
         CircuitBreakerFactory.createCircuitBreaker(remoteOptions);
     RemoteRetrier retrier =
         new RemoteRetrier(
-            remoteOptions, RemoteRetrier.RETRIABLE_GRPC_ERRORS, retryScheduler, circuitBreaker);
+            remoteOptions, RemoteRetrier.RETRIABLE_GRPC_ERRORS, retryScheduler, circuitBreaker, RemoteRetrier.GRPC_SUCCESS_CODES);
 
     if (!Strings.isNullOrEmpty(remoteOptions.remoteOutputService)) {
       var bazelOutputServiceChannel =
@@ -648,7 +661,8 @@ public final class RemoteModule extends BlazeModule {
                 remoteOptions,
                 RemoteRetrier.RETRIABLE_GRPC_ERRORS, // Handle NOT_FOUND internally
                 retryScheduler,
-                circuitBreaker);
+                circuitBreaker,
+                RemoteRetrier.GRPC_SUCCESS_CODES);
         remoteExecutor =
             new ExperimentalGrpcRemoteExecutor(
                 remoteOptions, execChannel.retain(), callCredentialsProvider, execRetrier);
@@ -658,7 +672,8 @@ public final class RemoteModule extends BlazeModule {
                 remoteOptions,
                 RemoteRetrier.RETRIABLE_GRPC_EXEC_ERRORS,
                 retryScheduler,
-                circuitBreaker);
+                circuitBreaker,
+                RemoteRetrier.GRPC_SUCCESS_CODES);
         remoteExecutor =
             new GrpcRemoteExecutor(execChannel.retain(), callCredentialsProvider, execRetrier);
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/CircuitBreakerFactory.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.remote.options.RemoteOptions;
 /** Factory for {@link Retrier.CircuitBreaker} */
 public class CircuitBreakerFactory {
   public static final int DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE = 100;
+  public static final int DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE = 12;
 
   private CircuitBreakerFactory() {}
 

--- a/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreaker.java
@@ -35,6 +35,7 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
   private final int failureRateThreshold;
   private final int slidingWindowSize;
   private final int minCallCountToComputeFailureRate;
+  private final int minFailCountToComputeFailureRate;
   private final ScheduledExecutorService scheduledExecutor;
 
   /**
@@ -52,6 +53,8 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
     this.slidingWindowSize = slidingWindowSize;
     this.minCallCountToComputeFailureRate =
         CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE;
+    this.minFailCountToComputeFailureRate =
+        CircuitBreakerFactory.DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE;
     this.state = State.ACCEPT_CALLS;
     this.scheduledExecutor =
         slidingWindowSize > 0 ? Executors.newSingleThreadScheduledExecutor() : null;
@@ -72,7 +75,7 @@ public class FailureCircuitBreaker implements Retrier.CircuitBreaker {
               failures::decrementAndGet, slidingWindowSize, TimeUnit.MILLISECONDS);
     }
 
-    if (totalCallCount < minCallCountToComputeFailureRate) {
+    if (totalCallCount < minCallCountToComputeFailureRate && failureCount < minFailCountToComputeFailureRate) {
       // The remote call count is below the threshold required to calculate the failure rate.
       return;
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/circuitbreaker/FailureCircuitBreakerTest.java
@@ -49,8 +49,8 @@ public class FailureCircuitBreakerTest {
     listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
-    // Sleep for windowInterval + 1ms.
-    Thread.sleep(windowInterval + 1 /*to compensate any delay*/);
+    // Sleep for windowInterval + 5ms.
+    Thread.sleep(windowInterval + 5 /*to compensate any delay*/);
 
     // make calls equals to threshold number of not ignored failure calls in parallel.
     listOfSuccessAndFailureCalls.stream().parallel().forEach(Runnable::run);
@@ -64,21 +64,40 @@ public class FailureCircuitBreakerTest {
 
   @Test
   public void testRecordFailure_minCallCriteriaNotMet() throws InterruptedException {
-    final int failureRateThreshold = 10;
+    final int failureRateThreshold = 0;
     final int windowInterval = 100;
     final int minCallToComputeFailure =
         CircuitBreakerFactory.DEFAULT_MIN_CALL_COUNT_TO_COMPUTE_FAILURE_RATE;
     FailureCircuitBreaker failureCircuitBreaker =
         new FailureCircuitBreaker(failureRateThreshold, windowInterval);
 
-    // make half failure call, half success call and number of total call less than
+    // make success calls, failure call and number of total calls less than
     // minCallToComputeFailure.
-    IntStream.range(0, minCallToComputeFailure >> 1)
-        .parallel()
-        .forEach(i -> failureCircuitBreaker.recordFailure());
-    IntStream.range(0, minCallToComputeFailure >> 1)
+    IntStream.range(0, minCallToComputeFailure - 2)
         .parallel()
         .forEach(i -> failureCircuitBreaker.recordSuccess());
+    failureCircuitBreaker.recordFailure();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
+
+    // Sleep for less than windowInterval.
+    Thread.sleep(windowInterval - 50);
+    failureCircuitBreaker.recordFailure();
+    assertThat(failureCircuitBreaker.state()).isEqualTo(State.REJECT_CALLS);
+  }
+
+  @Test
+  public void testRecordFailure_minFailCriteriaNotMet() throws InterruptedException {
+    final int failureRateThreshold = 10;
+    final int windowInterval = 100;
+    final int minFailToComputeFailure =
+        CircuitBreakerFactory.DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE;
+    FailureCircuitBreaker failureCircuitBreaker =
+        new FailureCircuitBreaker(failureRateThreshold, windowInterval);
+
+    // make number of failure calls less than minFailToComputeFailure.
+    IntStream.range(0, minFailToComputeFailure - 1)
+        .parallel()
+        .forEach(i -> failureCircuitBreaker.recordFailure());
     assertThat(failureCircuitBreaker.state()).isEqualTo(State.ACCEPT_CALLS);
 
     // Sleep for less than windowInterval.


### PR DESCRIPTION
This PR implements the feature to stop using the remote HTTP cache when it became unreachable.

The implementation is based on already existing `CircuitBreaker` logic. It includes the following changes:
- Added the `CircuitBreaker` to HTTP cache client. Currently it is used in grpc clients only
- All non-retriable errors were counted as successful API calls. However, they include not only the cache miss errors (which should be considered as a successful call), but also the different connectivity errors (which should be considered as failures). To distinguish these errors, we have added the `isSuccess` predicate. `HTTP_SUCCESS_CODES` defines success codes for HTTP, and `RemoteRetrier.GRPC_SUCCESS_CODES` defines success codes for grpc.
- Current implementation of `FailureCircuitBreaker` defines the threshold required to calculate the failure rate: `minCallCountToComputeFailureRate=100`. In case of connection timeout errors this requires a very large time interval to reach the threshold, larger that the default `experimental_remote_failure_window_interval=60s`. To solve the problem, we have added one more threshold: `DEFAULT_MIN_FAIL_COUNT_TO_COMPUTE_FAILURE_RATE=12`. The value is chosen to be slightly more than number of failures within window interval with default `experimental_remote_failure_rate_threshold=10`.
