### PR TITLE
[7.5.0] Backport 9b027c8 and be2186f to fix windows CI failures

### DIFF
--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -400,7 +400,7 @@ class BazelOverridesTest(test_base.TestBase):
             'bazel_dep(name = "ss", version = "1.0")',
             'local_path_override(',
             '  module_name = "ss",',
-            '  path = "%s",' % self.Path('aa'),
+            '  path = "%s",' % self.Path('aa').replace('\\', '/'),
             ')',
         ],
     )

--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -28,8 +28,9 @@ class PyTest(test_base.TestBase):
         'a/BUILD',
         [
             'py_binary(name="a", srcs=["a.py"], deps=[":b"])',
-            'py_library(name="b", srcs=["b.py"])',
-        ])
+            'py_library(name="b", srcs=["b.py"], imports=["."])',
+        ],
+    )
 
     self.ScratchFile(
         'a/a.py',

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -577,7 +577,7 @@ class TestBase(absltest.TestCase):
         ]
 
         if not allow_failure:
-          self.AssertExitCode(exit_code, 0, stderr_lines)
+          self.AssertExitCode(exit_code, 0, stderr_lines, stdout_lines)
 
         return exit_code, stdout_lines, stderr_lines
 


### PR DESCRIPTION
python: fix bazel py_test testSmoke for Python 3.11+
The test was failing because the `b.py` file couldn't be imported because, starting with Python 3.11, the `PYTHONSAFEPATH` environment variable (set by the bootstrap startup) is respected. This setting inhibits the default Python behavior of adding the main script's directory to sys.path.

To fix, use `py_library.imports` to explicitly add the necessary directory to `sys.path`.

Fixes https://github.com/bazelbuild/bazel/issues/20660

Closes https://github.com/bazelbuild/bazel/pull/20738.

PiperOrigin-RevId: 595498775
Change-Id: I0c9521b210fe9e2c40692727fc87d41995e0968a

Commit https://github.com/bazelbuild/bazel/commit/9b027c88051797ada7350098ef190191b953014a

No public description
PiperOrigin-RevId: 694487395
Change-Id: I3f3e154ebfa932721d917661d61a878477a8e574

Commit https://github.com/bazelbuild/bazel/commit/be2186fbe76ea52b9c146a5f01780a0171384ac8