### PR TITLE
Detect file reads that are longer than expected

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -844,42 +844,6 @@ public class FileSystemUtils {
   }
 
   /**
-   * Reads at most {@code limit} bytes from {@code inputFile} and returns them as a byte array.
-   *
-   * @throws IOException if there was an error.
-   */
-  public static byte[] readContentWithLimit(Path inputFile, int limit) throws IOException {
-    return readContentWithLimit(inputFile, limit, /* expectEOF= */ false);
-  }
-
-  /**
-   * Reads at most {@code limit} bytes from {@code inputFile} and returns them as a byte array.
-   *
-   * @throws IOException if there was an error or if the file is longer than {@code limit} bytes.
-   */
-  private static byte[] readContentWithLimitExpectingEOF(Path inputFile, int limit)
-      throws IOException {
-    return readContentWithLimit(inputFile, limit, /* expectEOF= */ true);
-  }
-
-  private static byte[] readContentWithLimit(Path inputFile, int limit, boolean expectEOF)
-      throws IOException {
-    Preconditions.checkArgument(limit >= 0, "limit needs to be >=0, but it is %s", limit);
-    ByteSource byteSource = asByteSource(inputFile);
-    byte[] buffer = new byte[limit];
-    try (InputStream inputStream = byteSource.openBufferedStream()) {
-      int read = ByteStreams.read(inputStream, buffer, 0, limit);
-      if (expectEOF) {
-        int eof = inputStream.read();
-        if (eof != -1) {
-          throw new LongReadIOException(inputFile, limit);
-        }
-      }
-      return read == limit ? buffer : Arrays.copyOf(buffer, read);
-    }
-  }
-
-  /**
    * The type of {@link IOException} thrown by {@link #readWithKnownFileSize} when fewer bytes than
    * expected are read.
    */
@@ -898,8 +862,8 @@ public class FileSystemUtils {
   }
 
   /**
-   * The type of {@link IOException} thrown by {@link #readContentWithLimitExpectingEOF} when more
-   * bytes than expected could be read.
+   * The type of {@link IOException} thrown by {@link #readWithKnownFileSize} when more bytes than
+   * expected could be read.
    */
   public static class LongReadIOException extends IOException {
     public final Path path;
@@ -917,19 +881,27 @@ public class FileSystemUtils {
    * the number of bytes read.
    *
    * <p>Use this method when you already know the size of the file. The check is intended to catch
-   * issues where filesystems or external interference results in truncated or concurrently modified
-   * files.
+   * issues where filesystems or external interference results in truncated or concurrent
+   * modifications.
    *
    * @throws IOException if there was an error, or if fewer than {@code fileSize} bytes were read.
    */
   public static byte[] readWithKnownFileSize(Path path, long fileSize) throws IOException {
+    Preconditions.checkArgument(fileSize >= 0, "fileSize needs to be >=0, but it is %s", fileSize);
     if (fileSize > Integer.MAX_VALUE) {
       throw new IOException("Cannot read file with size larger than 2GB");
     }
-    int fileSizeInt = (int) fileSize;
-    byte[] bytes = readContentWithLimitExpectingEOF(path, fileSizeInt);
-    if (fileSizeInt > bytes.length) {
-      throw new ShortReadIOException(path, fileSizeInt, bytes.length);
+    int size = (int) fileSize;
+    byte[] bytes = new byte[size];
+    try (InputStream in = asByteSource(path).openBufferedStream()) {
+      int read = ByteStreams.read(in, bytes, 0, size);
+      if (read != size) {
+        throw new ShortReadIOException(path, size, read);
+      }
+      int eof = in.read();
+      if (eof != -1) {
+        throw new LongReadIOException(path, size);
+      }
     }
     return bytes;
   }

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -881,9 +881,8 @@ public class FileSystemUtils {
    * the number of bytes read.
    *
    * <p>Use this method when you already know the size of the file. The check is intended to catch
-   * issues where filesystems or external interference results in truncated or concurrent
-   * modifications.
-   *
+   * issues where the filesystem incorrectly returns truncated file contents, or where an external
+   * modification has concurrently truncated or appended to the file.
    * @throws IOException if there was an error, or if fewer than {@code fileSize} bytes were read.
    */
   public static byte[] readWithKnownFileSize(Path path, long fileSize) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemUtilsTest.java
@@ -33,7 +33,6 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils.MoveResult;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Before;
@@ -407,27 +406,13 @@ public class FileSystemUtilsTest {
   }
 
   @Test
-  public void testReadContentWithKnownSize() throws IOException {
-    createTestDirectoryTree();
-    String str = "this is a test of readContentWithLimit method";
-    FileSystemUtils.writeContent(file1, StandardCharsets.ISO_8859_1, str);
-    assertThat(readStringFromFile(file1, 0)).isEmpty();
-    assertThat(str.substring(0, 10)).isEqualTo(readStringFromFile(file1, 10));
-    assertThat(str).isEqualTo(readStringFromFile(file1, 1000000));
-  }
-
-  private String readStringFromFile(Path file, int limit) throws IOException {
-    byte[] bytes = FileSystemUtils.readContentWithLimit(file, limit);
-    return new String(bytes, StandardCharsets.ISO_8859_1);
-  }
-
-  @Test
   public void testReadWithKnownFileSize() throws IOException {
     createTestDirectoryTree();
     String str = "this is a test of readContentWithLimit method";
-    FileSystemUtils.writeContent(file1, StandardCharsets.ISO_8859_1, str);
+    FileSystemUtils.writeContent(file1, ISO_8859_1, str);
 
-    assertThat(FileSystemUtils.readWithKnownFileSize(file1, str.length())).hasLength(str.length());
+    assertThat(FileSystemUtils.readWithKnownFileSize(file1, str.length()))
+        .isEqualTo(str.getBytes(ISO_8859_1));
     assertThrows(
         FileSystemUtils.LongReadIOException.class,
         () -> FileSystemUtils.readWithKnownFileSize(file1, str.length() - 1));

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemUtilsTest.java
@@ -407,7 +407,7 @@ public class FileSystemUtilsTest {
   }
 
   @Test
-  public void testReadContentWithLimit() throws IOException {
+  public void testReadContentWithKnownSize() throws IOException {
     createTestDirectoryTree();
     String str = "this is a test of readContentWithLimit method";
     FileSystemUtils.writeContent(file1, StandardCharsets.ISO_8859_1, str);
@@ -419,6 +419,21 @@ public class FileSystemUtilsTest {
   private String readStringFromFile(Path file, int limit) throws IOException {
     byte[] bytes = FileSystemUtils.readContentWithLimit(file, limit);
     return new String(bytes, StandardCharsets.ISO_8859_1);
+  }
+
+  @Test
+  public void testReadWithKnownFileSize() throws IOException {
+    createTestDirectoryTree();
+    String str = "this is a test of readContentWithLimit method";
+    FileSystemUtils.writeContent(file1, StandardCharsets.ISO_8859_1, str);
+
+    assertThat(FileSystemUtils.readWithKnownFileSize(file1, str.length())).hasLength(str.length());
+    assertThrows(
+        FileSystemUtils.LongReadIOException.class,
+        () -> FileSystemUtils.readWithKnownFileSize(file1, str.length() - 1));
+    assertThrows(
+        FileSystemUtils.ShortReadIOException.class,
+        () -> FileSystemUtils.readWithKnownFileSize(file1, str.length() + 1));
   }
 
   @Test


### PR DESCRIPTION
When Bazel knows the size of a file, it can also detect whether it would go past this size while reading the file. This is virtually free due to using a buffered stream and can catch cases of concurrent modifications or even bugs in Bazel.

Work towards #24694