### PR TITLE
[8.0.1] Fix linking objc binaries in the root package

### DIFF
--- a/src/main/starlark/builtins_bzl/common/objc/compilation_support.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/compilation_support.bzl
@@ -24,6 +24,7 @@ load(":common/objc/compilation_artifacts_info.bzl", "CompilationArtifactsInfo")
 load(":common/objc/intermediate_artifacts.bzl", "create_intermediate_artifacts")
 load(":common/objc/objc_common.bzl", "objc_common")
 load(":common/objc/providers.bzl", "J2ObjcEntryClassInfo", "J2ObjcMappingFileInfo")
+load(":common/paths.bzl", "paths")
 load(":common/xcode/providers.bzl", "XcodeVersionInfo")
 
 objc_internal = _builtins.internal.objc_internal
@@ -617,9 +618,13 @@ def _register_j2objc_dead_code_removal_actions(common_variables, deps, build_con
     replace_libs = {}
     for j2objc_archive in common_variables.objc_provider.j2objc_library.to_list():
         pruned_j2objc_archive = ctx.actions.declare_shareable_artifact(
-            ctx.label.package + "/_j2objc_pruned/" + ctx.label.name + "/" +
-            j2objc_archive.short_path[:-len(j2objc_archive.extension)].strip(".") +
-            "_pruned." + j2objc_archive.extension,
+            paths.join(
+                ctx.label.package,
+                "_j2objc_pruned",
+                ctx.label.name,
+                j2objc_archive.short_path[:-len(j2objc_archive.extension)].strip(".") +
+                "_pruned." + j2objc_archive.extension,
+            ),
             build_config.bin_dir,
         )
         replace_libs[j2objc_archive] = pruned_j2objc_archive
@@ -674,7 +679,7 @@ def _register_obj_filelist_action(ctx, build_config, obj_files):
     This File is suitable to signal symbols to archive in a libtool archiving invocation.
     """
     obj_list = ctx.actions.declare_shareable_artifact(
-        ctx.label.package + "/" + ctx.label.name + "-linker.objlist",
+        paths.join(ctx.label.package, ctx.label.name + "-linker.objlist"),
         build_config.bin_dir,
     )
 
@@ -712,7 +717,7 @@ def _register_binary_strip_action(
         strip_safe = True
 
     stripped_binary = ctx.actions.declare_shareable_artifact(
-        ctx.label.package + "/" + name,
+        paths.join(ctx.label.package, name),
         build_config.bin_dir,
     )
     args = ctx.actions.args()
@@ -773,12 +778,12 @@ def _linkstamp_map(ctx, linkstamps, output, build_config):
     # create linkstamps_map - mapping from linkstamps to object files
     linkstamps_map = {}
 
-    stamp_output_dir = ctx.label.package + "/_objs/" + output.basename + "/"
+    stamp_output_dir = paths.join(ctx.label.package, "_objs", output.basename)
     for linkstamp in linkstamps.to_list():
         linkstamp_file = linkstamp.file()
-        stamp_output_path = (
-            stamp_output_dir +
-            linkstamp_file.short_path[:-len(linkstamp_file.extension)].rstrip(".") + ".o"
+        stamp_output_path = paths.join(
+            stamp_output_dir,
+            linkstamp_file.short_path[:-len(linkstamp_file.extension)].rstrip(".") + ".o",
         )
         stamp_output_file = ctx.actions.declare_shareable_artifact(
             stamp_output_path,
@@ -851,12 +856,12 @@ def _register_configuration_specific_link_actions(
     if (ctx.fragments.cpp.objc_enable_binary_stripping() and
         ctx.fragments.cpp.compilation_mode() == "opt"):
         binary = ctx.actions.declare_shareable_artifact(
-            ctx.label.package + "/" + name + "_unstripped",
+            paths.join(ctx.label.package, name + "_unstripped"),
             build_config.bin_dir,
         )
     else:
         binary = ctx.actions.declare_shareable_artifact(
-            ctx.label.package + "/" + name,
+            paths.join(ctx.label.package, name),
             build_config.bin_dir,
         )
 

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkTest.java
@@ -294,6 +294,32 @@ public class ObjcStarlarkTest extends ObjcRuleTestCase {
   }
 
   @Test
+  public void testStarlarkLinkBinaryInRootPackage() throws Exception {
+    scratch.file("a.m");
+    addAppleBinaryStarlarkRule(scratch);
+    scratch.file(
+        "BUILD",
+        """
+        load("//test_starlark:apple_binary_starlark.bzl", "apple_binary_starlark")
+
+        package(default_visibility = ["//visibility:public"])
+
+        objc_library(
+            name = "lib",
+            srcs = ["a.m"],
+        )
+
+        apple_binary_starlark(
+            name = "bin",
+            platform_type = "macos",
+            deps = [":lib"],
+        )
+        """);
+
+    assertThat(getConfiguredTarget("//:bin")).isNotNull();
+  }
+
+  @Test
   public void testObjcRuleCanDependOnArbitraryStarlarkRuleThatProvidesCcInfo() throws Exception {
     scratch.file("test_starlark/rule/BUILD");
     scratch.file(


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/24625

Closes #24698.

PiperOrigin-RevId: 707183228
Change-Id: I369a37e8e652545274ec4949b1c3ac1d2fab38cb

Commit https://github.com/bazelbuild/bazel/commit/2864f2afd948825571761e15dcb5aff517005342