### PR TITLE
[7.5.0] Cherry-pick "Migrate imp to importlib in path_test.py"

### DIFF
--- a/tools/build_defs/pkg/path_test.py
+++ b/tools/build_defs/pkg/path_test.py
@@ -13,12 +13,16 @@
 # limitations under the License.
 """Testing for helper functions."""
 
-import imp
+import importlib.machinery
+import importlib.util
 import unittest
 
-pkg_bzl = imp.load_source(
-    'pkg_bzl',
-    'tools/build_defs/pkg/path.bzl')
+
+loader = importlib.machinery.SourceFileLoader(
+    'pkg_bzl', 'tools/build_defs/pkg/path.bzl')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+pkg_bzl = importlib.util.module_from_spec(spec)
+loader.exec_module(pkg_bzl)
 
 
 class File(object):


### PR DESCRIPTION
No longer works with python 3.12 or later.

PiperOrigin-RevId: 694480477
Change-Id: Ia662c8fb5511e9c551448730800240ab627463be

Commit https://github.com/bazelbuild/bazel/commit/5b54c7412cfb251d9ab83e23b37f06504b893331