### PR TITLE
[8.0.1] Fix parsing cpu.max file in cgroup v2 implementation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/cgroups/controller/v2/UnifiedCpu.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/cgroups/controller/v2/UnifiedCpu.java
@@ -42,7 +42,7 @@ public class UnifiedCpu extends UnifiedController implements Controller.Cpu {
   public void setCpus(double cpus) throws IOException {
     long period;
     try (Scanner scanner = new Scanner(Files.newBufferedReader(path.resolve("cpu.max")))) {
-      period = scanner.skip(".*\\s").nextInt();
+      period = scanner.skip("\\S+\\s").nextInt();
     }
     long quota = Math.round(period * cpus);
     String limit = String.format("%d %d", quota, period);
@@ -52,6 +52,10 @@ public class UnifiedCpu extends UnifiedController implements Controller.Cpu {
   @Override
   public long getCpus() throws IOException {
     try (Scanner scanner = new Scanner(Files.newBufferedReader(path.resolve("cpu.max")))) {
+      if (!scanner.hasNextLong()) {
+        // Not a number, assume no limit and all processors available
+        return Runtime.getRuntime().availableProcessors();
+      }
       long quota = scanner.nextLong();
       long period = scanner.nextLong();
       return quota / period;

--- a/src/test/java/com/google/devtools/build/lib/sandbox/cgroups/CpuTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/cgroups/CpuTest.java
@@ -59,9 +59,31 @@ public class CpuTest {
   }
 
   @Test
+  public void setCpuLimitNewLine_v2() throws IOException {
+    File limit = scratch.file("cgroup/cpu/cpu.max", "-1 100000\n").getPathFile();
+    Cpu cpu = new UnifiedCpu(scratch.path("cgroup/cpu").getPathFile().toPath());
+    cpu.setCpus(5);
+    assertThat(Files.asCharSource(limit, UTF_8).read()).isEqualTo("500000 100000");
+  }
+
+  @Test
   public void getCpuLimit_v2() throws IOException {
     scratch.file("cgroup/cpu/cpu.max", "6000 1000");
-    Cpu memory = new UnifiedCpu(scratch.path("cgroup/cpu").getPathFile().toPath());
-    assertThat(memory.getCpus()).isEqualTo(6);
+    Cpu cpu = new UnifiedCpu(scratch.path("cgroup/cpu").getPathFile().toPath());
+    assertThat(cpu.getCpus()).isEqualTo(6);
+  }
+
+  @Test
+  public void getCpuLimitNewLine_v2() throws IOException {
+    scratch.file("cgroup/cpu/cpu.max", "6000 1000\n");
+    Cpu cpu = new UnifiedCpu(scratch.path("cgroup/cpu").getPathFile().toPath());
+    assertThat(cpu.getCpus()).isEqualTo(6);
+  }
+
+  @Test
+  public void getCpuLimitMax_v2() throws IOException {
+    scratch.file("cgroup/cpu/cpu.max", "max 1000\n");
+    Cpu cpu = new UnifiedCpu(scratch.path("cgroup/cpu").getPathFile().toPath());
+    assertThat(cpu.getCpus()).isEqualTo(Runtime.getRuntime().availableProcessors());
   }
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/24680

Closes #24714.

PiperOrigin-RevId: 707775390
Change-Id: I1a34c0917174aca3bbcfdec8668aef2d7e68ae6e

Commit https://github.com/bazelbuild/bazel/commit/1c6aa500db5c3c8cc554088154be510c78dd7aee