### PR TITLE
Allow `cc_binary` with `dynamic_deps` to be extended

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -1704,7 +1704,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
             checkAttributeName(arg);
             if (arg.startsWith("_")) {
               // allow setting private attributes from initializers in builtins
-              Label definitionLabel = ruleClass.getRuleDefinitionEnvironmentLabel();
+              Label definitionLabel = currentRuleClass.getRuleDefinitionEnvironmentLabel();
               BuiltinRestriction.failIfLabelOutsideAllowlist(
                   definitionLabel,
                   RepositoryMapping.ALWAYS_FALLBACK,

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -2080,4 +2080,45 @@ EOF
   bazel build //pkg:testCodegen &> "$TEST_log" || fail "Build failed"
 }
 
+function test_extend_cc_binary_with_dynamic_deps() {
+  mkdir -p pkg
+  cat >pkg/BUILD <<'EOF'
+load("my_cc_binary.bzl", "my_cc_binary")
+
+constraint_setting(name = "foo")
+constraint_value(name = "never_selected", constraint_setting = ":foo")
+
+my_cc_binary(
+    name = "hello",
+    srcs = ["main.cpp"],
+    # Ensure that the select has no effect but can't be simplified.
+    dynamic_deps = select({":never_selected": ["unused"], "//conditions:default": []}),
+)
+EOF
+
+  cat >pkg/my_cc_binary.bzl << 'EOF'
+def _my_cc_binary_impl(ctx):
+  print("Hello from my_cc_binary")
+  return ctx.super()
+
+my_cc_binary = rule(
+  implementation = _my_cc_binary_impl,
+  parent = native.cc_binary,
+)
+EOF
+
+  cat >pkg/main.cpp <<'EOF'
+#include <iostream>
+
+int main() {
+  std::cout << "Hello from main.cpp" << std::endl;
+  return 0;
+}
+EOF
+
+  bazel run //pkg:hello &> $TEST_log || fail "Expected success"
+  expect_log "Hello from my_cc_binary"
+  expect_log "Hello from main.cpp"
+}
+
 run_suite "cc_integration_test"


### PR DESCRIPTION
`cc_binary` has an initializer that may set a private attribute, which is only permitted for built-in rules. The allowlist check always used the outermost rule class, thus failing if `cc_binary` is extended by a non-built-in rule. This is fixed by checking the rule class that actually declares the initializer.

Work towards https://github.com/bazelbuild/bazel/issues/19507#issuecomment-1933572248