### PR TITLE
Add dwo files depset to DebugPackageInfo provider in cc_binary

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/DebugPackageInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/DebugPackageInfoApi.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.starlarkbuildapi.cpp;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.docgen.annot.StarlarkConstructor;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.core.ProviderApi;
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
@@ -67,6 +68,14 @@ public interface DebugPackageInfoApi<FileT extends FileApi> extends StructApi {
   @Nullable
   FileT getDwpArtifact();
 
+  @StarlarkMethod(
+      name = "dwo_files",
+      doc = "Returns the .dwo files (for fission builds) or empty if --fission=no.",
+      structField = true,
+      allowReturnNones = true)
+  @Nullable
+  Depset getDwoFiles();
+
   /** The provider implementing this can construct DebugPackageInfo objects. */
   @StarlarkBuiltin(name = "Provider", doc = "", documented = false)
   interface Provider<FileT extends FileApi> extends ProviderApi {
@@ -98,12 +107,19 @@ public interface DebugPackageInfoApi<FileT extends FileApi> extends StructApi {
               positional = false,
               named = true,
               defaultValue = "None",
-              allowedTypes = {@ParamType(type = FileApi.class), @ParamType(type = NoneType.class)})
+              allowedTypes = {@ParamType(type = FileApi.class), @ParamType(type = NoneType.class)}),
+          @Param(
+              name = "dwo_files",
+              doc = "The depset of .dwo files (for fission builds) or null if --fission=no.",
+              positional = false,
+              named = true,
+              defaultValue = "None",
+              allowedTypes = {@ParamType(type = Depset.class), @ParamType(type = NoneType.class)})
         },
         selfCall = true)
     @StarlarkConstructor
     DebugPackageInfoApi<FileT> createDebugPackageInfo(
-        Label targetLabel, Object strippedFile, FileT unstrippedFile, Object dwpFile)
+        Label targetLabel, Object strippedFile, FileT unstrippedFile, Object dwpFile, Object dwoFiles)
         throws EvalException;
   }
 }

--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -650,7 +650,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
     stripped_file = ctx.outputs.stripped_binary
     cc_helper.create_strip_action(ctx, cc_toolchain, cpp_config, binary, stripped_file, feature_configuration)
     dwp_file = ctx.outputs.dwp_file
-    create_debug_packager_actions(
+    dwo_files = create_debug_packager_actions(
         ctx,
         cc_toolchain,
         dwp_file,
@@ -749,6 +749,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
         stripped_file = stripped_file,
         unstripped_file = binary,
         dwp_file = explicit_dwp_file,
+        dwo_files = dwo_files,
     )
     binary_info = struct(
         files = files_to_build,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_debug_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_debug_helper.bzl
@@ -82,6 +82,7 @@ def create_debug_packager_actions(
         inputs = packager["inputs"],
         outputs = packager["outputs"],
     )
+    return dwo_files
 
 def _collect_transitive_dwo_artifacts(cc_compilation_outputs, cc_debug_context, linking_mode, use_pic, lto_backend_artifacts):
     dwo_files = []

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -7290,6 +7290,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
                             ctx.file.stripped_file if wrapped_dbginfo.stripped_file else None,
                         unstripped_file = out,
                         dwp_file = ctx.file.dwp_file if wrapped_dbginfo.dwp_file else None,
+                        dwo_files = wrapped_dbginfo.dwo_files
                     ),
                 )
             return result
@@ -7355,6 +7356,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(debugPackageProvider.getStrippedArtifact().getFilename()).isEqualTo("w.stripped");
     assertThat(debugPackageProvider.getUnstrippedArtifact().getFilename()).isEqualTo("w");
     assertThat(debugPackageProvider.getDwpArtifact()).isNull();
+    assertThat(debugPackageProvider.getDwoFiles()).isNull();
   }
 
   @Test
@@ -7367,6 +7369,11 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(debugPackageProvider.getStrippedArtifact().getFilename()).isEqualTo("w.stripped");
     assertThat(debugPackageProvider.getUnstrippedArtifact().getFilename()).isEqualTo("w");
     assertThat(debugPackageProvider.getDwpArtifact().getFilename()).isEqualTo("w.dwp");
+    Depset dwo_files = debugPackageProvider.getDwoFiles();
+    List<Artifact> f = dwo_files.toList(Artifact.class);
+    assertThat(f.size()).isEqualTo(2);
+    assertThat(f.get(0).getFilename()).isEqualTo("linkextra.dwo");
+    assertThat(f.get(1).getFilename()).isEqualTo("main.dwo");
   }
 
   @Test


### PR DESCRIPTION
This change supports several use cases listed in https://github.com/bazelbuild/bazel/issues/19149
