### PR TITLE
[7.5.0] Fix error in dynamic_mode documentation

### DIFF
--- a/site/en/docs/user-manual.md
+++ b/site/en/docs/user-manual.md
@@ -565,8 +565,6 @@ the [linkstatic attribute](/reference/be/c-cpp#cc_binary.linkstatic) on build ru
 
 Modes:
 
-* `auto`: Translates to a platform-dependent mode;
-  `default` for linux and `off` for cygwin.
 * `default`: Allows bazel to choose whether to link dynamically.
   See [linkstatic](/reference/be/c-cpp#cc_binary.linkstatic) for more
   information.


### PR DESCRIPTION
auto does not exist in Bazel 4, 5, 6 or 7. I'm not sure if was there before but in any of these versions when trying it the following error appears

ERROR: While parsing option --dynamic_mode=auto: Not a valid dynamic mode: 'auto' (should be off, default or fully)

Fixes: https://github.com/bazelbuild/bazel/issues/20707

Closes #20705.

PiperOrigin-RevId: 630063050
Change-Id: Ib0b0427268a885d6ffc62c81183b6dd24a6dc517 (cherry picked from commit a70a28f22b18122a52a90e50ecf1360fbd45736c)