### PR TITLE
[7.5.0] Allow `cc_binary` with `dynamic_deps` to be extended

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -1115,7 +1115,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
             checkAttributeName(arg);
             if (arg.startsWith("_")) {
               // allow setting private attributes from initializers in builtins
-              Label definitionLabel = ruleClass.getRuleDefinitionEnvironmentLabel();
+              Label definitionLabel = currentRuleClass.getRuleDefinitionEnvironmentLabel();
               BuiltinRestriction.failIfLabelOutsideAllowlist(
                   definitionLabel,
                   RepositoryMapping.ALWAYS_FALLBACK,


### PR DESCRIPTION
`cc_binary` has an initializer that may set a private attribute, which is only permitted for built-in rules. The allowlist check always used the outermost rule class, thus failing if `cc_binary` is extended by a non-built-in rule. This is fixed by checking the rule class that actually declares the initializer.

Work towards https://github.com/bazelbuild/bazel/issues/19507#issuecomment-1933572248

Closes #24778.

PiperOrigin-RevId: 711361632
Change-Id: I3c0b6e1e6c50fd1af9f1dc635052d0054114ee2d

Commit https://github.com/bazelbuild/bazel/commit/7093088c5427b016e62bed70852b010fc308ad4a