### PR TITLE
[8.0.1] Detect file reads that are longer than expected

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -844,21 +844,6 @@ public class FileSystemUtils {
   }
 
   /**
-   * Reads at most {@code limit} bytes from {@code inputFile} and returns it as a byte array.
-   *
-   * @throws IOException if there was an error.
-   */
-  public static byte[] readContentWithLimit(Path inputFile, int limit) throws IOException {
-    Preconditions.checkArgument(limit >= 0, "limit needs to be >=0, but it is %s", limit);
-    ByteSource byteSource = asByteSource(inputFile);
-    byte[] buffer = new byte[limit];
-    try (InputStream inputStream = byteSource.openBufferedStream()) {
-      int read = ByteStreams.read(inputStream, buffer, 0, limit);
-      return read == limit ? buffer : Arrays.copyOf(buffer, read);
-    }
-  }
-
-  /**
    * The type of {@link IOException} thrown by {@link #readWithKnownFileSize} when fewer bytes than
    * expected are read.
    */
@@ -877,22 +862,46 @@ public class FileSystemUtils {
   }
 
   /**
+   * The type of {@link IOException} thrown by {@link #readWithKnownFileSize} when more bytes than
+   * expected could be read.
+   */
+  public static class LongReadIOException extends IOException {
+    public final Path path;
+    public final int fileSize;
+
+    private LongReadIOException(Path path, int fileSize) {
+      super("File '" + path + "' is unexpectedly longer than " + fileSize + " bytes)");
+      this.path = path;
+      this.fileSize = fileSize;
+    }
+  }
+
+  /**
    * Reads the given file {@code path}, assumed to have size {@code fileSize}, and does a check on
    * the number of bytes read.
    *
    * <p>Use this method when you already know the size of the file. The check is intended to catch
-   * issues where filesystems incorrectly truncate files.
+   * issues where the filesystem incorrectly returns truncated file contents, or where an external
+   * modification has concurrently truncated or appended to the file.
    *
    * @throws IOException if there was an error, or if fewer than {@code fileSize} bytes were read.
    */
   public static byte[] readWithKnownFileSize(Path path, long fileSize) throws IOException {
+    Preconditions.checkArgument(fileSize >= 0, "fileSize needs to be >=0, but it is %s", fileSize);
     if (fileSize > Integer.MAX_VALUE) {
       throw new IOException("Cannot read file with size larger than 2GB");
     }
-    int fileSizeInt = (int) fileSize;
-    byte[] bytes = readContentWithLimit(path, fileSizeInt);
-    if (fileSizeInt > bytes.length) {
-      throw new ShortReadIOException(path, fileSizeInt, bytes.length);
+    int size = (int) fileSize;
+    byte[] bytes = new byte[size];
+    try (InputStream in = asByteSource(path).openBufferedStream()) {
+      int read = ByteStreams.read(in, bytes, 0, size);
+      if (read != size) {
+        throw new ShortReadIOException(path, size, read);
+      }
+      int eof = in.read();
+      if (eof != -1) {
+        throw new LongReadIOException(path, size);
+      }
     }
     return bytes;
   }


### PR DESCRIPTION
When Bazel knows the size of a file, it can also detect whether it would go past this size while reading the file. This is virtually free due to using a buffered stream and can catch cases of concurrent modifications or even bugs in Bazel.

Work towards #24694

Closes #24708.

PiperOrigin-RevId: 711678485
Change-Id: I85093c0d54dd365b1c301b6036f150dae3552c2a

Commit https://github.com/bazelbuild/bazel/commit/57ef120efad58cf5025dfb44c73beb45713a2d91