### PR TITLE
Create parent folder for build event protocol files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -1047,7 +1047,8 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
                   cmdEnv,
                   cmdEnv.getReporter(),
                   /* append= */ null,
-                  /* internal= */ null);
+                  /* internal= */ null,
+                  /* createParent= */ true);
       return new BufferedOutputStream(output.createOutputStream());
     }
   }


### PR DESCRIPTION
Hi!

Some of our CI workflows rely on the `--build_event_*_file` flags to store the BEP events for further postprocessing. Concretely, our `.bazelrc` defines:  

```
build --build_event_json_file=build/events.json
```

The problem is that we output these events files into a `build` folder that is `.gitignore`d, and hence doesn't exist by default on a fresh clone of our repo. This forces any script that invokes bazel to make sure to `mkdir -p build` in advance.

We believe this is something that could be elegantly solved on the bazel side by creating the parent `build` folder if it doesn't exist. And fortunately, there is support for this in the underlying call to `InstrumentationOutput.createInstrumentationOutput` (added a couple of days ago in [c13c669](https://github.com/bazelbuild/bazel/commit/c13c6695b3786b9135fad9f948857f88afe1db12#diff-dc995507b7dd623c94660ab182db3641ad73e0b44fd0681fc05f70bb99edc795R179)).

This PR sets `createParent=true` in the underlying call to `InstrumentationOutput.createInstrumentationOutput` made by `BuildEventServiceModule.create`.

We'll be happy to discuss about whether this should be the default behavior, or if it's worth it adding a new flag to enable it :)