### PR TITLE
Remove hardcoded denylist for struct fields

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkInfoWithMessage.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkInfoWithMessage.java
@@ -74,7 +74,6 @@ public final class StarlarkInfoWithMessage extends StarlarkInfoNoSchema {
   // However, either of these migrations could cause obscure user-visible changes in:
   //   - the type name ("struct" vs something else)
   //   - equality (`==`) semantics
-  //   - the availability of the ".to_proto" and ".to_json" methods
   //   - the availability of the struct concatenation operator (`+`) and the type of its result.
   //     (Today, concatenation of structs with different error messages is allowed, and the result
   //     uses the error message of the left-hand side. But maybe this should be disallowed, or maybe

--- a/src/main/java/com/google/devtools/build/lib/packages/StructImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StructImpl.java
@@ -27,9 +27,8 @@ import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.Structure;
 
 /**
- * An abstract base class for Starlark values that have fields, have to_json and to_proto methods,
- * have an associated provider (type symbol), and may be returned as the result of analysis from one
- * target to another.
+ * An abstract base class for Starlark values that have fields, have an associated provider (type
+ * symbol), and may be returned as the result of analysis from one target to another.
  *
  * <p>StructImpl does not specify how the fields are represented; subclasses must define {@code
  * getValue} and {@code getFieldNames}. For example, {@code NativeInfo} supplies fields from the

--- a/src/main/java/com/google/devtools/build/lib/packages/StructProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StructProvider.java
@@ -17,8 +17,6 @@ package com.google.devtools.build.lib.packages;
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
 import java.util.Map;
 import net.starlark.java.eval.Dict;
-import net.starlark.java.eval.EvalException;
-import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkThread;
 
 /**
@@ -38,14 +36,7 @@ public final class StructProvider extends BuiltinProvider<StarlarkInfo>
 
   /** Implementation of {@code struct(**kwargs)} function exposed to Starlark. */
   @Override
-  public StructImpl createStruct(Dict<String, Object> kwargs, StarlarkThread thread)
-      throws EvalException {
-    if (kwargs.containsKey("to_json")) {
-      throw Starlark.errorf("cannot override built-in struct function 'to_json'");
-    }
-    if (kwargs.containsKey("to_proto")) {
-      throw Starlark.errorf("cannot override built-in struct function 'to_proto'");
-    }
+  public StructImpl createStruct(Dict<String, Object> kwargs, StarlarkThread thread) {
     return StarlarkInfo.create(this, kwargs, thread.getCallerLocation());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -1001,8 +1001,6 @@ public final class BuildLanguageOptions extends OptionsBase {
       "+incompatible_require_linker_input_cc_api";
   public static final String INCOMPATIBLE_RUN_SHELL_COMMAND_STRING =
       "+incompatible_run_shell_command_string";
-  public static final String INCOMPATIBLE_STRUCT_HAS_NO_METHODS =
-      "+incompatible_struct_has_no_methods";
   public static final String INCOMPATIBLE_USE_CC_CONFIGURE_FROM_RULES_CC =
       "-incompatible_use_cc_configure_from_rules";
   public static final String INCOMPATIBLE_UNAMBIGUOUS_LABEL_STRINGIFICATION =

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaInfoRoundtripTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaInfoRoundtripTest.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.rules.java;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.packages.StarlarkInfo;
@@ -141,9 +140,7 @@ public class JavaInfoRoundtripTest extends BuildViewTestCase {
     StarlarkInfo dictInfo = getStarlarkProvider(dictTarget, "Info");
     @SuppressWarnings("unchecked") // deserialization
     Dict<Object, Object> javaInfo = (Dict<Object, Object>) dictInfo.getValue("result");
-    return deepStripAttributes(
-        javaInfo,
-        attr -> attr.startsWith("_") || ImmutableSet.of("to_proto", "to_json").contains(attr));
+    return deepStripAttributes(javaInfo, attr -> attr.startsWith("_"));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
The built-in `to_json` and `to_proto` methods no longer exist, not even with a flag, so there is no longer any reason to block certain struct field names.