### PR TITLE
Reduce retained memory of `UnresolvedSymlinkAction`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
@@ -212,8 +212,7 @@ public class ActionGraphDump {
 
 
     if (action instanceof UnresolvedSymlinkAction) {
-      actionBuilder.setUnresolvedSymlinkTarget(
-          ((UnresolvedSymlinkAction) action).getTarget().toString());
+      actionBuilder.setUnresolvedSymlinkTarget(((UnresolvedSymlinkAction) action).getTarget());
     }
 
     // Include the content of param files in output.


### PR DESCRIPTION
The required conversion to `PathFragment` can be performed during execution, which avoids retaining a new `PathFragment` instance per action.