### PR TITLE
Inject metadata for `UnresolvedSymlinkAction`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkAction.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactExpander;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -79,6 +80,16 @@ public final class UnresolvedSymlinkAction extends AbstractAction {
               getPrimaryOutput().getExecPathString(), target, e.getMessage());
       DetailedExitCode code = createDetailedExitCode(message, Code.LINK_CREATION_IO_EXCEPTION);
       throw new ActionExecutionException(message, e, this, false, code);
+    }
+
+    // Action filesystems are responsible for their own metadata injection.
+    if (actionExecutionContext.getActionFileSystem() == null) {
+      actionExecutionContext
+          .getOutputMetadataStore()
+          .injectFile(
+              getPrimaryOutput(),
+              FileArtifactValue.createForUnresolvedSymlinkWithKnownTarget(
+                  getPrimaryOutput().getPath(), target.getPathString()));
     }
 
     return ActionResult.EMPTY;

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
@@ -196,6 +196,7 @@ java_test(
         "//src/test/java/com/google/devtools/build/lib/exec/util",
         "//third_party:guava",
         "//third_party:junit4",
+        "//third_party:mockito",
         "//third_party:truth",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/UnresolvedSymlinkActionTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.analysis.starlark;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.actions.util.ActionsTestUtil.NULL_ACTION_OWNER;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
@@ -28,6 +29,7 @@ import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.DiscoveredModulesPruner;
 import com.google.devtools.build.lib.actions.Executor;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
+import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -106,7 +108,7 @@ public class UnresolvedSymlinkActionTest extends BuildViewTestCase {
                 /* actionInputFileCache= */ null,
                 ActionInputPrefetcher.NONE,
                 actionKeyContext,
-                /* outputMetadataStore= */ null,
+                mock(OutputMetadataStore.class),
                 /* rewindingEnabled= */ false,
                 LostInputsCheck.NONE,
                 /* fileOutErr= */ null,


### PR DESCRIPTION
The metadata of the output is known and does not require IO to create.