### PR TITLE
[7.5.0] Remove empty coverage environment

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -1104,7 +1104,7 @@ def _get_coverage_environment(ctx, cc_config, cc_toolchain):
     }
     for k in list(env.keys()):
         if env[k] == None:
-            env[k] = ""
+            env.pop(k)
     if cc_config.fdo_instrument():
         env["FDO_DIR"] = cc_config.fdo_instrument()
     return env

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderTest.java
@@ -338,7 +338,7 @@ public class CcToolchainProviderTest extends BuildViewTestCase {
         break;
       }
     }
-    assertThat(gcovPath).isEmpty();
+    assertThat(gcovPath).isNull();
   }
 
   @Test
@@ -471,10 +471,8 @@ public class CcToolchainProviderTest extends BuildViewTestCase {
       }
     }
 
-    assertThat(llvmCov).isNotNull();
-    assertThat(llvmCov).isEmpty();
-    assertThat(llvmProfdata).isNotNull();
-    assertThat(llvmProfdata).isEmpty();
+    assertThat(llvmCov).isNull();
+    assertThat(llvmProfdata).isNull();
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/23247

Closes https://github.com/bazelbuild/bazel/issues/24768

PiperOrigin-RevId: 707176116
Change-Id: I71ef3c630f8130467cc6a0c730c1278ae6b0817f
(cherry picked from commit 03eae37f24dbaaacf8a0fa4299bd452b643014b8)
