### PR TITLE
Use shorthand display form in `Label#debugPrint`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/Label.java
@@ -689,7 +689,7 @@ public final class Label implements Comparable<Label>, StarlarkValue, SkyKey, Co
         // ignore
       }
     }
-    printer.append(getDisplayForm(mainRepoMapping));
+    printer.append(getShorthandDisplayForm(mainRepoMapping));
   }
 
   @Override

--- a/src/test/shell/bazel/workspace_test.sh
+++ b/src/test/shell/bazel/workspace_test.sh
@@ -723,8 +723,8 @@ EOF
   cd main
   bazel build @foo//:bar \
       >& "$TEST_log" || fail "Expected build to succeed"
-  expect_log "@b//blah:blah"
-  expect_not_log "@a//blah:blah"
+  expect_log "@b//blah"
+  expect_not_log "@a//blah"
 }
 
 function test_workspace_addition_change_aspect() {


### PR DESCRIPTION
This makes the output, which is meant to be friendly to humans, more concise. If users want `//foo` to be `print`ed as `//foo:foo`, they can specify `sep = ""` and also print `:foo`, but stripping the name off is not possible without this change.