### PR TITLE
[7.5.0] Don't show fixup warnings during `bazel mod tidy`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -459,6 +459,7 @@ java_library(
     ],
     deps = [
         ":module_extension",
+        "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RootModuleFileFixup.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RootModuleFileFixup.java
@@ -16,6 +16,7 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.vfs.PathFragment;
 
 /**
@@ -29,7 +30,8 @@ import com.google.devtools.build.lib.vfs.PathFragment;
  */
 public record RootModuleFileFixup(
     ImmutableListMultimap<PathFragment, String> moduleFilePathToBuildozerCommands,
-    ModuleExtensionUsage usage) {
+    ModuleExtensionUsage usage,
+    Event warning) {
 
   /** A human-readable message describing the fixup after it has been applied. */
   public String getSuccessMessage() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -470,8 +470,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
                 .get()
                 .generateFixup(
                     usagesValue.getExtensionUsages().get(ModuleKey.ROOT),
-                    generatedRepoSpecs.keySet(),
-                    env.getListener());
+                    generatedRepoSpecs.keySet());
       } catch (EvalException e) {
         env.getListener().handle(Event.error(e.getInnermostLocation(), e.getMessageWithStack()));
         throw new SingleExtensionEvalFunctionException(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionFunction.java
@@ -48,6 +48,10 @@ public class SingleExtensionFunction implements SkyFunction {
       return null;
     }
 
+    // SingleExtensionEvalFunction doesn't handle the fixup warning so that bazel mod tidy doesn't
+    // show it.
+    evalOnlyValue.getFixup().ifPresent(fixup -> env.getListener().handle(fixup.warning()));
+
     // Check that all imported repos have actually been generated.
     for (ModuleExtensionUsage usage : usagesValue.getExtensionUsages().values()) {
       for (ModuleExtensionUsage.Proxy proxy : usage.getProxies()) {

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -682,13 +682,13 @@ class ModCommandTest(test_base.TestBase):
     # The extensions should not be reevaluated by the command.
     self.assertNotIn('ext1 is being evaluated', stderr)
     self.assertNotIn('ext2 is being evaluated', stderr)
-    # The fixup warnings should be shown again due to Skyframe replaying.
-    self.assertIn(
+    # bazel mod tidy doesn't show fixup warnings.
+    self.assertNotIn(
         'Not imported, but reported as direct dependencies by the extension'
         ' (may cause the build to fail):\nmissing_dep',
         stderr,
     )
-    self.assertIn(
+    self.assertNotIn(
         'Imported, but reported as indirect dependencies by the'
         ' extension:\nindirect_dep',
         stderr,
@@ -984,10 +984,6 @@ class ModCommandTest(test_base.TestBase):
     # extension fails after evaluation.
     _, _, stderr = self.RunBazel(['mod', 'tidy'])
     stderr = '\n'.join(stderr)
-    self.assertIn(
-        'ext defined in @//:extension.bzl reported incorrect imports', stderr
-    )
-    self.assertIn('invalid_dep', stderr)
     self.assertIn(
         'INFO: Updated use_repo calls for @//:extension.bzl%ext', stderr
     )


### PR DESCRIPTION
The warnings tell the user to run `bazel mod tidy`, which is very confusing.

Fixes #24495

Closes #24729.

PiperOrigin-RevId: 708007222
Change-Id: I60dc889281a776bbf08a7f9537272d7692cce1d8 
(cherry picked from commit 455ddb74f79a5eb9b47ad212a8d439f56fd58a5f)

Fixes #24740