### PR TITLE
Mark built-in providers as hashable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/BuiltinProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuiltinProvider.java
@@ -66,6 +66,11 @@ public abstract class BuiltinProvider<T extends Info> implements Provider {
   }
 
   @Override
+  public void checkHashable() {
+    // The hash code is based on the class, so it is hashable.
+  }
+
+  @Override
   public boolean isExported() {
     return true;
   }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -78,6 +78,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Mutability;
 import net.starlark.java.eval.Printer;
@@ -4024,5 +4025,12 @@ args.add_all(d, map_each = _map_each, uniquify = True)
     assertThat(a2).isNotNull();
     assertThat(a2.getRoot().getExecPathString())
         .matches(getRelativeOutputPath() + "/[\\w\\-]+\\-exec/bin");
+  }
+
+  @Test
+  public void testHashableProviders() throws Exception {
+    ev.execAndExport("p = provider()");
+    Dict<?, ?> dict = (Dict<?, ?>) ev.eval("{k: None for k in [DefaultInfo, p, DefaultInfo, p]}");
+    assertThat(dict.size()).isEqualTo(2);
   }
 }


### PR DESCRIPTION
Built-in providers always have an immutable `hashCode`. Making them hashable makes it easier to deduplicate a list of providers, which is sometimes required as the list of provider instances returned by a rule must not contain two instances for a given provider. 

Starlark-defined providers are already hashable, so this brings the behavior of built-in providers in line with them.