### PR TITLE
Fix SkyframeExecutior.getStarlarkExecTransition to handle all error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkExecTransitionLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkExecTransitionLoader.java
@@ -37,9 +37,17 @@ public final class StarlarkExecTransitionLoader {
   /** Thrown when the Starlark transition failed to load. */
   public static class StarlarkExecTransitionLoadingException extends Exception {
     public StarlarkExecTransitionLoadingException(String context, String ref, String message) {
-      super(
+      this(
           String.format(
               "Bad Starlark transition reference from %s: %s. %s.", context, ref, message));
+    }
+
+    public StarlarkExecTransitionLoadingException(String message) {
+      super(message);
+    }
+
+    public StarlarkExecTransitionLoadingException(Throwable cause) {
+      super(cause);
     }
   }
 
@@ -49,7 +57,8 @@ public final class StarlarkExecTransitionLoader {
      * Loads the given {@link BzlLoadValue.Key}. Returns null if not all Skyframe deps are ready.
      */
     @Nullable
-    BzlLoadValue getValue(BzlLoadValue.Key key) throws BzlLoadFailedException, InterruptedException;
+    BzlLoadValue getValue(BzlLoadValue.Key key)
+        throws BzlLoadFailedException, InterruptedException, StarlarkExecTransitionLoadingException;
   }
 
   /**

--- a/src/test/shell/integration/info_test.sh
+++ b/src/test/shell/integration/info_test.sh
@@ -98,4 +98,12 @@ function test_multiple_keys_wrong_keys() {
   expect_log "ERROR: unknown key(s): 'foo', 'bar'"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/24671
+function test_invalid_flag_error() {
+  bazel info --registry=foobarbaz &>$TEST_log \
+    && fail "expected ${PRODUCT_NAME} to fail with an invalid registry"
+  expect_not_log "crashed due to an internal error"
+  expect_log "Invalid registry URL: foobarbaz"
+}
+
 run_suite "Integration tests for ${PRODUCT_NAME} info."


### PR DESCRIPTION
types.

Fixes #24671.