### PR TITLE
[8.0.1] Remove autoload warnings, improve errors and fix legacy repo name support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -31,7 +32,6 @@ import com.google.devtools.build.lib.cmdline.Label.RepoContext;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
-import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.lib.skyframe.BzlLoadValue;
@@ -417,7 +417,7 @@ public class AutoloadSymbols {
       throws InterruptedException {
 
     final RepoContext repoContext;
-    ImmutableMap<String, ModuleKey> highestVersions = ImmutableMap.of();
+    ImmutableMap<String, ModuleKey> highestVersionRepo = ImmutableMap.of();
     if (bzlmodEnabled) {
       BazelDepGraphValue bazelDepGraphValue =
           (BazelDepGraphValue) env.getValue(BazelDepGraphValue.KEY);
@@ -425,19 +425,16 @@ public class AutoloadSymbols {
         return null;
       }
 
-      highestVersions =
+      highestVersionRepo =
           bazelDepGraphValue.getCanonicalRepoNameLookup().values().stream()
               .collect(
                   toImmutableMap(
-                      moduleKey ->
-                          moduleKey.name().equals("protobuf")
-                              ? "com_google_protobuf"
-                              : moduleKey.name(),
+                      SymbolRedirect::toRepoName,
                       moduleKey -> moduleKey,
                       (m1, m2) -> m1.version().compareTo(m2.version()) >= 0 ? m1 : m2));
       RepositoryMapping repositoryMapping =
           RepositoryMapping.create(
-              highestVersions.entrySet().stream()
+              highestVersionRepo.entrySet().stream()
                   .collect(
                       toImmutableMap(
                           Map.Entry::getKey,
@@ -464,18 +461,16 @@ public class AutoloadSymbols {
     // Inject loads for rules and symbols removed from Bazel
     ImmutableMap.Builder<String, BzlLoadValue.Key> loadKeysBuilder =
         ImmutableMap.builderWithExpectedSize(autoloadedSymbols.size());
-    ImmutableSet.Builder<String> missingRepositories = ImmutableSet.builder();
     for (String symbol : autoloadedSymbols) {
-      String requiredModule = AUTOLOAD_CONFIG.get(symbol).getModuleName();
+      var redirect = AUTOLOAD_CONFIG.get(symbol);
       // Skip if version doesn't have the rules
-      if (highestVersions.containsKey(requiredModule)
-          && requiredVersions.containsKey(requiredModule)) {
-        if (highestVersions
-                .get(requiredModule)
+      if (highestVersionRepo.containsKey(redirect.getRepoName())
+          && requiredVersionForModules.containsKey(redirect.getModuleName())) {
+        if (highestVersionRepo
+                .get(redirect.getRepoName())
                 .version()
-                .compareTo(requiredVersions.get(requiredModule))
+                .compareTo(requiredVersionForModules.get(redirect.getModuleName()))
             <= 0) {
-          missingRepositories.add(requiredModule);
           continue;
         }
       }
@@ -497,19 +492,7 @@ public class AutoloadSymbols {
       // Only load if the dependency is present
       if (repositoryExists) {
         loadKeysBuilder.put(symbol, BzlLoadValue.keyForBuild(label));
-      } else {
-        missingRepositories.add(label.getRepository().getName());
       }
-    }
-    for (String missingRepository : missingRepositories.build()) {
-      env.getListener()
-          .handle(
-              Event.warn(
-                  String.format(
-                      "Couldn't auto load rules or symbols, because no dependency on"
-                          + " module/repository '%s' found. This will result in a failure if"
-                          + " there's a reference to those rules or symbols.",
-                      missingRepository)));
     }
     return loadKeysBuilder.buildOrThrow();
   }
@@ -569,9 +552,16 @@ public class AutoloadSymbols {
               @Override
               public Object call(StarlarkThread thread, Tuple args, Dict<String, Object> kwargs)
                   throws EvalException {
+                String what =
+                    bzlmodEnabled
+                        ? "a 'bazel_dep(name = \"%s\", ...)' in your MODULE.bazel file"
+                            .formatted(AUTOLOAD_CONFIG.get(symbol).getModuleName())
+                        : "an 'http_archive(name = \"%s\", ...)' in your WORKSPACE file"
+                            .formatted(AUTOLOAD_CONFIG.get(symbol).getRepoName());
                 throw Starlark.errorf(
-                    "Couldn't auto load '%s' from '%s'.",
-                    getName(), AUTOLOAD_CONFIG.get(getName()).loadLabel());
+                    "Couldn't auto load '%s' from '%s'. Ensure that you have %s or add an explicit"
+                        + " load statement to your BUILD file.",
+                    getName(), AUTOLOAD_CONFIG.get(getName()).loadLabel(), what);
               }
             });
       }
@@ -617,7 +607,16 @@ public class AutoloadSymbols {
       requireNonNull(rdeps, "rdeps");
     }
 
-    String getModuleName() throws InterruptedException {
+    private static final ImmutableBiMap<String, String> moduleToRepoName =
+        ImmutableBiMap.of(
+            "apple_support", "build_bazel_apple_support", "protobuf", "com_google_protobuf");
+
+    String getModuleName() {
+      String repoName = getRepoName();
+      return moduleToRepoName.inverse().getOrDefault(repoName, repoName);
+    }
+
+    String getRepoName() {
       return Label.parseCanonicalUnchecked(loadLabel()).getRepository().getName();
     }
 
@@ -627,6 +626,10 @@ public class AutoloadSymbols {
       } catch (LabelSyntaxException e) {
         throw new IllegalStateException(e);
       }
+    }
+
+    static String toRepoName(ModuleKey moduleKey) {
+      return moduleToRepoName.getOrDefault(moduleKey.name(), moduleKey.name());
     }
   }
 
@@ -665,15 +668,16 @@ public class AutoloadSymbols {
           "rules_python_internal",
           "rules_shell",
           "apple_support",
+          "build_bazel_apple_support",
           "bazel_skylib",
           "bazel_tools",
           "bazel_features");
 
-  private static final ImmutableMap<String, Version> requiredVersions;
+  private static final ImmutableMap<String, Version> requiredVersionForModules;
 
   static {
     try {
-      requiredVersions =
+      requiredVersionForModules =
           ImmutableMap.of(
               "protobuf", Version.parse("29.0-rc1"), //
               "rules_android", Version.parse("0.6.0-rc1"));
@@ -850,14 +854,21 @@ public class AutoloadSymbols {
           .put("sh_binary", ruleRedirect("@rules_shell//shell:sh_binary.bzl"))
           .put("sh_library", ruleRedirect("@rules_shell//shell:sh_library.bzl"))
           .put("sh_test", ruleRedirect("@rules_shell//shell:sh_test.bzl"))
-          .put("available_xcodes", ruleRedirect("@apple_support//xcode:available_xcodes.bzl"))
-          .put("xcode_config", ruleRedirect("@apple_support//xcode:xcode_config.bzl"))
-          .put("xcode_config_alias", ruleRedirect("@apple_support//xcode:xcode_config_alias.bzl"))
-          .put("xcode_version", ruleRedirect("@apple_support//xcode:xcode_version.bzl"))
+          .put(
+              "available_xcodes",
+              ruleRedirect("@build_bazel_apple_support//xcode:available_xcodes.bzl"))
+          .put("xcode_config", ruleRedirect("@build_bazel_apple_support//xcode:xcode_config.bzl"))
+          .put(
+              "xcode_config_alias",
+              ruleRedirect("@build_bazel_apple_support//xcode:xcode_config_alias.bzl"))
+          .put("xcode_version", ruleRedirect("@build_bazel_apple_support//xcode:xcode_version.bzl"))
           // this redirect doesn't exists and probably never will, we still need a configuration for
           // it, so that it can be removed from Bazels <= 7 if needed
           .put(
               "apple_common",
-              symbolRedirect("@apple_support//lib:apple_common.bzl", "objc_import", "objc_library"))
+              symbolRedirect(
+                  "@build_bazel_apple_support//lib:apple_common.bzl",
+                  "objc_import",
+                  "objc_library"))
           .buildOrThrow();
 }


### PR DESCRIPTION
This reduces noise while giving users more actionable information when they actually use a symbol that failed to autoload.

Also ensures that modules with legacy repo names (`com_google_protobuf` and `build_bazel_apple_support`) are handled correctly.

Fixes #23929
Fixes #24597

Closes #24601.

PiperOrigin-RevId: 713208045
Change-Id: I81ae8e9e09dd3a935dca2897fe9fc58d52189a07

Commit https://github.com/bazelbuild/bazel/commit/eba205433aedcd55185f105adbf998ce501b84c8