### PR TITLE
[8.1.0] Reduce retained memory of `UnresolvedSymlinkAction`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
@@ -212,8 +212,7 @@ public class ActionGraphDump {
 
 
     if (action instanceof UnresolvedSymlinkAction) {
-      actionBuilder.setUnresolvedSymlinkTarget(
-          ((UnresolvedSymlinkAction) action).getTarget().toString());
+      actionBuilder.setUnresolvedSymlinkTarget(((UnresolvedSymlinkAction) action).getTarget());
     }
 
     // Include the content of param files in output.


### PR DESCRIPTION
The required conversion to `PathFragment` can be performed during execution, which avoids retaining a new `PathFragment` instance per action.

Closes #24831.

PiperOrigin-RevId: 713577830
Change-Id: I2781ea979a3c97abf5a519acd5d3d6a668dd1f77

Commit https://github.com/bazelbuild/bazel/commit/293be8a64f41d2aa5e2d5fc655d0fe0d33c700e0