### PR TITLE
[8.0.1] Add and flip `--incompatible_locations_prefers_executable`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -817,6 +817,18 @@ public final class BuildLanguageOptions extends OptionsBase {
               + " attributes of symbolic macros or attribute default values.")
   public boolean incompatibleSimplifyUnconditionalSelectsInRuleAttrs;
 
+  @Option(
+      name = "incompatible_locations_prefers_executable",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "Whether a target that provides an executable expands to the executable rather than the"
+              + " files in <code>DefaultInfo.files</code> under $(locations ...) expansion if the"
+              + " number of files is not 1.")
+  public boolean incompatibleLocationsPrefersExecutable;
+
   /**
    * An interner to reduce the number of StarlarkSemantics instances. A single Blaze instance should
    * never accumulate a large number of these and being able to shortcut on object identity makes a
@@ -930,6 +942,8 @@ public final class BuildLanguageOptions extends OptionsBase {
             .setBool(
                 INCOMPATIBLE_SIMPLIFY_UNCONDITIONAL_SELECTS_IN_RULE_ATTRS,
                 incompatibleSimplifyUnconditionalSelectsInRuleAttrs)
+            .setBool(
+                INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE, incompatibleLocationsPrefersExecutable)
             .build();
     return INTERNER.intern(semantics);
   }
@@ -1037,6 +1051,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       "+incompatible_disallow_ctx_resolve_tools";
   public static final String INCOMPATIBLE_SIMPLIFY_UNCONDITIONAL_SELECTS_IN_RULE_ATTRS =
       "+incompatible_simplify_unconditional_selects_in_rule_attrs";
+  public static final String INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE =
+      "+incompatible_locations_prefers_executable";
   // non-booleans
   public static final StarlarkSemantics.Key<String> EXPERIMENTAL_BUILTINS_BZL_PATH =
       new StarlarkSemantics.Key<>("experimental_builtins_bzl_path", "%bundled%");

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/BUILD
@@ -34,6 +34,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/packages/semantics",
         "//src/main/java/com/google/devtools/build/lib/rules/apple",
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcStarlarkInternal.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.analysis.Expander;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleContext;
 import com.google.devtools.build.lib.packages.Types;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.rules.apple.AppleConfiguration;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
 import java.util.List;
@@ -128,7 +129,10 @@ public class ObjcStarlarkInternal implements StarlarkValue {
                             starlarkRuleContext.getRuleContext().getPrerequisites("srcs"),
                             starlarkRuleContext.getRuleContext().getPrerequisites("non_arc_srcs"),
                             starlarkRuleContext.getRuleContext().getPrerequisites("hdrs"),
-                            starlarkRuleContext.getRuleContext().getPrerequisites("data")))))
+                            starlarkRuleContext.getRuleContext().getPrerequisites("data"))),
+                    starlarkRuleContext
+                        .getStarlarkSemantics()
+                        .getBool(BuildLanguageOptions.INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE)))
             .withDataExecLocations();
     ImmutableList<String> expandedFlags =
         expander.tokenized(attributeName, Sequence.cast(flags, String.class, attributeName));

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
@@ -448,7 +448,13 @@ public interface StarlarkRuleContextApi<ConstraintValueT extends ConstraintValue
             },
             defaultValue = "[]",
             named = true,
-            doc = "List of targets for additional lookup information."),
+            doc =
+                "List of targets for additional lookup information. These are expanded as follows:"
+                    + " A target with a single file in <code>DefaultInfo.files</code> expands to"
+                    + " that file. Other targets expand to their"
+                    + " <code>DefaultInfo.executable</code> file if set and if"
+                    + " <code>--incompatible_locations_prefers_executable</code> is enabled,"
+                    + " otherwise they expand to <code>DefaultInfo.files</code>."),
         @Param(
             name = "short_paths",
             named = true,

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -143,6 +143,7 @@ public class ConsistencyTest {
         "--incompatible_do_not_split_linking_cmdline=" + rand.nextBoolean(),
         "--incompatible_enable_deprecated_label_apis=" + rand.nextBoolean(),
         "--incompatible_java_common_parameters=" + rand.nextBoolean(),
+        "--incompatible_locations_prefers_executable=" + rand.nextBoolean(),
         "--incompatible_merge_fixed_and_default_shell_env=" + rand.nextBoolean(),
         "--incompatible_no_attr_license=" + rand.nextBoolean(),
         "--incompatible_no_implicit_file_export=" + rand.nextBoolean(),
@@ -195,6 +196,7 @@ public class ConsistencyTest {
         .setBool(BuildLanguageOptions.INCOMPATIBLE_DO_NOT_SPLIT_LINKING_CMDLINE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_ENABLE_DEPRECATED_LABEL_APIS, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_JAVA_COMMON_PARAMETERS, rand.nextBoolean())
+        .setBool(BuildLanguageOptions.INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE, rand.nextBoolean())
         .setBool(
             BuildLanguageOptions.INCOMPATIBLE_MERGE_FIXED_AND_DEFAULT_SHELL_ENV, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_ATTR_LICENSE, rand.nextBoolean())


### PR DESCRIPTION
Work towards #11820
Fixes #20038
Fixes #23200
Fixes #24613

RELNOTES: Extra targets provided to `ctx.expand_location` now expand to their executable (if any) instead of resulting in an error if they provide a number of files different from one.

RELNOTES[INC]: The `--incompatible_locations_prefers_executable` flag has been added and enabled, which makes it so that `ctx.expand_location` expands `$(locations :x)` to the executable of an extra target `:x` if it provides one and the number of files provided by it is not one.

Closes #24690.

PiperOrigin-RevId: 713453768
Change-Id: I0d6e052bc70deea029554ab722feb544f9597a23 
(cherry picked from commit 457d248218540b0ae93d6454fa8a95ccad877063)

Fixes #24646