### PR TITLE
[7.5.0] Mark `--blazerc` as `allows_multiple` in flag docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelStartupOptionsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelStartupOptionsModule.java
@@ -19,6 +19,7 @@ import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionsBase;
+import java.util.List;
 
 /** Provides Bazel startup flags. */
 public class BazelStartupOptionsModule extends BlazeModule {
@@ -26,6 +27,7 @@ public class BazelStartupOptionsModule extends BlazeModule {
   public static final class Options extends OptionsBase {
     @Option(
         name = "bazelrc",
+        allowMultiple = true,
         defaultValue = "null", // NOTE: purely decorative, rc files are read by the client.
         documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
         effectTags = {OptionEffectTag.CHANGES_INPUTS},
@@ -45,7 +47,7 @@ public class BazelStartupOptionsModule extends BlazeModule {
                 + "the following two locations: the workspace directory, then the user's home "
                 + "directory.\n"
                 + "Note: command line options will always supersede any option in bazelrc.")
-    public String blazerc;
+    public List<String> blazerc;
 
     // For the system_rc, it can be /etc/bazel.bazelrc, or a special Windows value, or can be
     // custom-set by the Bazel distributor. We don't list a known path in the help output in order

--- a/src/test/shell/integration/startup_options_test.sh
+++ b/src/test/shell/integration/startup_options_test.sh
@@ -85,7 +85,7 @@ function test_autodetect_server_javabase() {
 # Below are the regression tests for Issue #7489
 function test_multiple_bazelrc_later_overwrites_earlier() {
   # Help message only visible with --help_verbosity=medium
-  help_message_in_description="--${PRODUCT_NAME}rc (a string; default: see description)"
+  help_message_in_description="--${PRODUCT_NAME}rc (a string; may be used multiple times)"
 
   echo "help --help_verbosity=short" > 1.rc
   echo "help --help_verbosity=medium" > 2.rc


### PR DESCRIPTION
Fixes #24730

Closes #24735.

PiperOrigin-RevId: 713606521
Change-Id: If8578fcdfc30dcbfb6af283089614f3364eb30d8

Commit https://github.com/bazelbuild/bazel/commit/e78bab504940ea2abce749cf8654320cc2fbf96f