### PR TITLE
[7.5.0] Explain why a module hasn't been found in any registry

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -100,6 +100,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/cache",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/util:os",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Registry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Registry.java
@@ -28,13 +28,22 @@ public interface Registry extends NotComparableSkyValue {
   /** The URL that uniquely identifies the registry. */
   String getUrl();
 
+  /** Thrown when a file is not found in the registry. */
+  final class NotFoundException extends Exception {
+    public NotFoundException(String message) {
+      super(message);
+    }
+  }
+
   /**
    * Retrieves the contents of the module file of the module identified by {@code key} from the
-   * registry. Returns {@code Optional.empty()} when the module is not found in this registry.
+   * registry.
+   *
+   * @throws NotFoundException if the module file is not found in the registry
    */
-  Optional<ModuleFile> getModuleFile(
+  ModuleFile getModuleFile(
       ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
-      throws IOException, InterruptedException;
+      throws IOException, InterruptedException, NotFoundException;
 
   /**
    * Retrieves the {@link RepoSpec} object that indicates how the contents of the module identified

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/FakeRegistry.java
@@ -66,13 +66,17 @@ public class FakeRegistry implements Registry {
   }
 
   @Override
-  public Optional<ModuleFile> getModuleFile(
-      ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager) {
+  public ModuleFile getModuleFile(
+      ModuleKey key, ExtendedEventHandler eventHandler, DownloadManager downloadManager)
+      throws NotFoundException {
     String uri =
         String.format("%s/modules/%s/%s/MODULE.bazel", url, key.getName(), key.getVersion());
     var maybeContent = Optional.ofNullable(modules.get(key)).map(value -> value.getBytes(UTF_8));
     eventHandler.post(RegistryFileDownloadEvent.create(uri, maybeContent));
-    return maybeContent.map(content -> ModuleFile.create(content, uri));
+    if (maybeContent.isEmpty()) {
+      throw new NotFoundException("module not found: " + key);
+    }
+    return ModuleFile.create(maybeContent.get(), uri);
   }
 
   @Override

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -494,8 +494,8 @@ class BazelOverridesTest(test_base.TestBase):
         allow_failure=True,
     )
     self.assertIn(
-        'ERROR: Error computing the main repository mapping: module not found'
-        ' in registries: ss@1.0',
+        'ERROR: Error computing the main repository mapping: module ss@1.0 not'
+        ' found in registries:',
         stderr,
     )
 


### PR DESCRIPTION
This makes it easier for users to discover that a module hasn't been found because its absence was recorded in the lockfile during a previous build.

Fixes #24803

Closes #24804.

PiperOrigin-RevId: 713142592
Change-Id: Id541f5710481bd947c09d8dba315d683a1666b1c 
(cherry picked from commit 6061e5eab4b0bf1b9424a348c32bdcda69a8280b)

Fixes #24805