### PR TITLE
[8.0.1] Remove BUILD.bazel before symlinking when creating new_local_repository

### DIFF
--- a/tools/build_defs/repo/local.bzl
+++ b/tools/build_defs/repo/local.bzl
@@ -94,6 +94,9 @@ def _new_local_repository_impl(rctx):
             rctx.watch(child)
 
     if rctx.attr.build_file != None:
+        # Remove any existing BUILD.bazel in the repository to ensure
+        # the symlink to the defined build_file doesn't fail.
+        rctx.delete("BUILD.bazel")
         rctx.symlink(rctx.attr.build_file, "BUILD.bazel")
         if rctx.os.name.startswith("windows"):
             rctx.watch(rctx.attr.build_file)  # same reason as above


### PR DESCRIPTION
Fixes #24770

Closes #24887.

PiperOrigin-RevId: 714107497
Change-Id: Ib914aa54b2afa2a90fcce2f2263b9c1b2d2c193c

Commit https://github.com/bazelbuild/bazel/commit/6a141eab3fa5d57eb8b5dadbb6260a120c597fe9