### PR TITLE
[8.0.1] Report options with `BoolOrEnumConverter` as supporting `--no...`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -271,7 +271,7 @@ public final class HelpCommand implements BlazeCommand {
   private static BazelFlagsProto.FlagInfo.Builder createFlagInfo(OptionDefinition option) {
     BazelFlagsProto.FlagInfo.Builder flagBuilder = BazelFlagsProto.FlagInfo.newBuilder();
     flagBuilder.setName(option.getOptionName());
-    flagBuilder.setHasNegativeFlag(option.hasNegativeOption());
+    flagBuilder.setHasNegativeFlag(option.usesBooleanValueSyntax());
     flagBuilder.setDocumentation(option.getHelpText());
     flagBuilder.setAllowsMultiple(option.allowsMultiple());
     flagBuilder.setRequiresValue(option.requiresValue());

--- a/src/main/java/com/google/devtools/common/options/OptionDefinition.java
+++ b/src/main/java/com/google/devtools/common/options/OptionDefinition.java
@@ -124,11 +124,6 @@ public abstract class OptionDefinition implements Comparable<OptionDefinition> {
   /** Returns a warning to use with this option if the old name is specified. */
   public abstract boolean getOldNameWarning();
 
-  /** Returns whether an option --foo has a negative equivalent --nofoo. */
-  public boolean hasNegativeOption() {
-    return getType().equals(boolean.class) || getType().equals(TriState.class);
-  }
-
   /** The type of the optionDefinition. */
   public abstract Class<?> getType();
 


### PR DESCRIPTION
Fixes #24882

Closes #24883.

PiperOrigin-RevId: 714854122
Change-Id: I5e48e84f88606320223a9969e8367924aeeb13dd

Commit https://github.com/bazelbuild/bazel/commit/6423b04c1bf95bc0e9ef99667688b3763c3bce4e