### PR TITLE
[7.5.0] Include invocation ID in compact execution log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -111,7 +111,8 @@ public final class SpawnLogModule extends BlazeModule {
                     .experimentalSiblingRepositoryLayout,
                 env.getOptions().getOptions(RemoteOptions.class),
                 env.getRuntime().getFileSystem().getDigestFunction(),
-                env.getXattrProvider());
+                env.getXattrProvider(),
+                env.getCommandId());
       } catch (InterruptedException e) {
         env.getReporter()
             .handle(Event.error("Error while setting up the execution log: " + e.getMessage()));

--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -65,6 +65,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.ForkJoinPool;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -145,6 +146,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
   @Nullable private final RemoteOptions remoteOptions;
   private final DigestHashFunction digestHashFunction;
   private final XattrProvider xattrProvider;
+  private final UUID invocationId;
 
   // Maps a key identifying an entry into its ID.
   // Each key is either a NestedSet.Node or the String path of a file, directory, symlink or
@@ -168,7 +170,8 @@ public class CompactSpawnLogContext extends SpawnLogContext {
       boolean siblingRepositoryLayout,
       @Nullable RemoteOptions remoteOptions,
       DigestHashFunction digestHashFunction,
-      XattrProvider xattrProvider)
+      XattrProvider xattrProvider,
+      UUID invocationId)
       throws IOException, InterruptedException {
     this.execRoot = execRoot;
     this.workspaceName = workspaceName;
@@ -176,6 +179,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
     this.remoteOptions = remoteOptions;
     this.digestHashFunction = digestHashFunction;
     this.xattrProvider = xattrProvider;
+    this.invocationId = invocationId;
     this.outputStream = getOutputStream(outputPath);
 
     logInvocation();
@@ -196,7 +200,8 @@ public class CompactSpawnLogContext extends SpawnLogContext {
                     ExecLogEntry.Invocation.newBuilder()
                         .setHashFunctionName(digestHashFunction.toString())
                         .setWorkspaceRunfilesDirectory(workspaceName)
-                        .setSiblingRepositoryLayout(siblingRepositoryLayout)));
+                        .setSiblingRepositoryLayout(siblingRepositoryLayout)
+                        .setId(invocationId.toString())));
   }
 
   @Override

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -232,6 +232,9 @@ message ExecLogEntry {
 
     // Whether --experimental_sibling_repository_layout is enabled.
     bool sibling_repository_layout = 3;
+
+    // The ID of the invocation.
+    string id = 4;
   }
 
   // An input or output file.

--- a/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/CompactSpawnLogContextTest.java
@@ -49,6 +49,7 @@ import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.UUID;
 import net.starlark.java.syntax.Location;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -155,7 +156,8 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
                     Protos.ExecLogEntry.Invocation.newBuilder()
                         .setHashFunctionName("SHA-256")
                         .setWorkspaceRunfilesDirectory(TestConstants.WORKSPACE_NAME)
-                        .setSiblingRepositoryLayout(siblingRepositoryLayout))
+                        .setSiblingRepositoryLayout(siblingRepositoryLayout)
+                        .setId("00000000-0000-0000-0000-000000000000"))
                 .build(),
             Protos.ExecLogEntry.newBuilder()
                 .setSymlinkAction(
@@ -265,7 +267,8 @@ public final class CompactSpawnLogContextTest extends SpawnLogContextTestBase {
         siblingRepositoryLayout,
         remoteOptions,
         DigestHashFunction.SHA256,
-        SyscallCache.NO_CACHE);
+        SyscallCache.NO_CACHE,
+        UUID.fromString("00000000-0000-0000-0000-000000000000"));
   }
 
   @Override


### PR DESCRIPTION
This makes it possible to retroactively link an execution log file to a particular build.

Closes #24790.

PiperOrigin-RevId: 715017597
Change-Id: Ia8f6a3677a165a9f428b59ab8a19587a357b8803

Commit https://github.com/bazelbuild/bazel/commit/fd6a9833ba9fe18799193295b82134bc64ab17b3