### PR TITLE
Flip flags for coverage support with remote execution

### DIFF
--- a/site/en/configure/coverage.md
+++ b/site/en/configure/coverage.md
@@ -86,32 +86,6 @@ To view the result, simply open the `index.html` file produced in the
 For further help and information around the `genhtml` tool, or the
 `lcov` coverage format, see [the lcov project][lcov].
 
-## Remote execution {:#remote-execution}
-
-Running with remote test execution currently has a few caveats:
-
-- The report combination action cannot yet run remotely. This is
-  because Bazel does not consider the coverage output files as part of
-  its graph (see [this issue][remote_report_issue]), and can therefore
-  not correctly treat them as inputs to the combination action. To
-  work around this, use `--strategy=CoverageReport=local`.
-  - Note: It may be necessary to specify something like
-    `--strategy=CoverageReport=local,remote` instead, if Bazel is set
-    up to try `local,remote`, due to how Bazel resolves strategies.
-- `--remote_download_minimal` and similar flags can also not be used
-  as a consequence of the former.
-- Bazel will currently fail to create coverage information if tests
-  have been cached previously. To work around this,
-  `--nocache_test_results` can be set specifically for coverage runs,
-  although this of course incurs a heavy cost in terms of test times.
-- `--experimental_split_coverage_postprocessing` and
-  `--experimental_fetch_all_coverage_outputs`
-  - Usually coverage is run as part of the test action, and so by
-    default, we don't get all coverage back as outputs of the remote
-    execution by default. These flags override the default and obtain
-    the coverage data. See [this issue][split_coverage_issue] for more
-    details.
-
 ## Language-specific configuration
 
 ### Java
@@ -127,5 +101,3 @@ for additional steps needed to enable coverage support in Python.
 
 [lcov]: https://github.com/linux-test-project/lcov
 [bazel_toolchains]: https://github.com/bazelbuild/bazel-toolchains
-[remote_report_issue]: https://github.com/bazelbuild/bazel/issues/4685
-[split_coverage_issue]: https://github.com/bazelbuild/bazel/issues/4685

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -279,7 +279,7 @@ public class TestConfiguration extends Fragment {
 
     @Option(
         name = "experimental_fetch_all_coverage_outputs",
-        defaultValue = "false",
+        defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
         effectTags = {OptionEffectTag.AFFECTS_OUTPUTS, OptionEffectTag.LOADING_AND_ANALYSIS},
         metadataTags = {OptionMetadataTag.EXPERIMENTAL},
@@ -301,7 +301,7 @@ public class TestConfiguration extends Fragment {
 
     @Option(
         name = "experimental_split_coverage_postprocessing",
-        defaultValue = "false",
+        defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
         effectTags = {OptionEffectTag.EXECUTION},
         metadataTags = {OptionMetadataTag.EXPERIMENTAL},

--- a/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
@@ -906,7 +906,7 @@ int main() {
   return 0;
 }
 EOF
-  bazel coverage --test_output=all --experimental_split_coverage_postprocessing //:hello-test \
+  bazel coverage --test_output=all --experimental_split_coverage_postprocessing --noexperimental_fetch_all_coverage_outputs //:hello-test \
                 &>$TEST_log && fail "Expected test failure" || :
 
   assert_contains '--experimental_split_coverage_postprocessing depends on --experimental_fetch_all_coverage_outputs being enabled' $TEST_log
@@ -932,7 +932,6 @@ EOF
      bazel coverage  --test_output=all \
         //empty_cov:empty-cov-test  &>"$TEST_log" \
      || fail "Coverage for //empty_cov:empty-cov-test failed"
-     expect_log "WARNING: There was no coverage found."
 }
 
 function setup_external_cc_target() {

--- a/src/test/shell/bazel/bazel_coverage_sh_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_sh_test.sh
@@ -505,7 +505,7 @@ exit 0
 EOF
   chmod +x pull-test.sh
 
-  bazel coverage --test_output=all --experimental_fetch_all_coverage_outputs //:pull &>$TEST_log \
+  bazel coverage --test_output=all --experimental_fetch_all_coverage_outputs --noexperimental_split_coverage_postprocessing //:pull &>$TEST_log \
       || fail "Coverage failed"
 
   local coverage_file_path="$(dirname $( get_coverage_file_path_from_test_log ))/_coverage/foo.txt"

--- a/src/test/shell/bazel/bazel_execlog_test.sh
+++ b/src/test/shell/bazel/bazel_execlog_test.sh
@@ -219,7 +219,7 @@ EOF
   [[ -e output.compact ]] || fail "no compact log produced"
 
   rm output.compact
-  bazel coverage //:test --experimental_split_coverage_postprocessing --experimental_fetch_all_coverage_outputs \
+  bazel coverage //:test --noexperimental_split_coverage_postprocessing --noexperimental_fetch_all_coverage_outputs \
     --execution_log_compact_file=output.compact >> $TEST_log 2>&1 || fail "coverage failed"
   [[ -e output.compact ]] || fail "no compact log produced"
 }

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -1915,8 +1915,6 @@ EOF
 
   bazel coverage \
     --test_output=all \
-    --experimental_fetch_all_coverage_outputs \
-    --experimental_split_coverage_postprocessing \
     --remote_download_minimal \
     --combined_report=lcov \
     --spawn_strategy=remote \

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -2178,8 +2178,6 @@ EOF
 
   bazel coverage \
     --test_output=all \
-    --experimental_fetch_all_coverage_outputs \
-    --experimental_split_coverage_postprocessing \
     --spawn_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
     --instrumentation_filter=//java/factorial \
@@ -2507,8 +2505,6 @@ EOF
 
   bazel coverage \
       --test_output=all \
-      --experimental_fetch_all_coverage_outputs \
-      --experimental_split_coverage_postprocessing \
       --spawn_strategy=remote \
       --remote_executor=grpc://localhost:${worker_port} \
       //"$test_dir":hello-test >& $TEST_log \
@@ -2643,9 +2639,7 @@ EOF
   BAZEL_USE_LLVM_NATIVE_COVERAGE=1 GCOV=llvm-profdata BAZEL_LLVM_COV=llvm-cov CC=clang \
     bazel coverage \
       --test_output=all \
-      --experimental_fetch_all_coverage_outputs \
       --experimental_generate_llvm_lcov \
-      --experimental_split_coverage_postprocessing \
       --spawn_strategy=remote \
       --remote_executor=grpc://localhost:${worker_port} \
       //"$test_dir":hello-test >& $TEST_log \


### PR DESCRIPTION
With BwoB enabled by default, these flags are already relevant with a disk cache. They are not easily discovered and make for a bad onboarding experience for coverage.

Also remove the outdated "RE caveats" section from the coverage docs as all issues have been resolved.

RELNOTES: `--experimental_split_coverage_postprocessing` and `--experimental_fetch_all_coverage_outputs` are now enabled by default.