### PR TITLE
Handle large numeric segments in Bazel module versions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Version.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Version.java
@@ -91,14 +91,18 @@ public record Version(
    * compared differently based on whether it's digits-only or not.
    */
   @AutoCodec
-  record Identifier(boolean isDigitsOnly, int asNumber, String asString)
+  record Identifier(boolean isDigitsOnly, long asNumber, String asString)
       implements Comparable<Identifier> {
     static Identifier from(String string) throws ParseException {
       if (Strings.isNullOrEmpty(string)) {
         throw new ParseException("identifier is empty");
       }
       if (string.chars().allMatch(Character::isDigit)) {
-        return new Identifier(true, Integer.parseInt(string), string);
+        try {
+          return new Identifier(true, Long.parseUnsignedLong(string), string);
+        } catch (NumberFormatException e) {
+          throw new ParseException("numeric version segment is too large: " + string);
+        }
       } else {
         return new Identifier(false, 0, string);
       }
@@ -106,7 +110,7 @@ public record Version(
 
     private static final Comparator<Identifier> COMPARATOR =
         comparing(Identifier::isDigitsOnly, trueFirst())
-            .thenComparingInt(Identifier::asNumber)
+            .thenComparing((a, b) -> Long.compareUnsigned(a.asNumber, b.asNumber))
             .thenComparing(Identifier::asString);
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Version.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Version.java
@@ -101,7 +101,7 @@ public record Version(
         try {
           return new Identifier(true, Long.parseUnsignedLong(string), string);
         } catch (NumberFormatException e) {
-          throw new ParseException("numeric version segment is too large: " + string);
+          throw new ParseException("numeric version segment is too large: " + string, e);
         }
       } else {
         return new Identifier(false, 0, string);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/VersionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/VersionTest.java
@@ -77,14 +77,18 @@ public class VersionTest {
     assertThat(Version.parse("1.0-pre.99")).isLessThan(Version.parse("1.0-pre.2a"));
     assertThat(Version.parse("1.0-pre.patch.3")).isLessThan(Version.parse("1.0-pre.patch.4"));
     assertThat(Version.parse("1.0--")).isLessThan(Version.parse("1.0----"));
+    assertThat(Version.parse("2.1.1-develop.bcr.20250113215904"))
+        .isGreaterThan(Version.parse("2.1.1-develop.bcr.20250113215903"));
   }
 
   @Test
-  public void testParseException() throws Exception {
+  public void testParseException() {
     assertThrows(ParseException.class, () -> Version.parse("-abc"));
     assertThrows(ParseException.class, () -> Version.parse("1_2"));
     assertThrows(ParseException.class, () -> Version.parse("ßážëł"));
     assertThrows(ParseException.class, () -> Version.parse("1.0-pre?"));
+    assertThrows(
+        ParseException.class, () -> Version.parse("1.0-11111111111111111111111111111111111111111"));
     assertThrows(ParseException.class, () -> Version.parse("1.0-pre///"));
     assertThrows(ParseException.class, () -> Version.parse("1..0"));
     assertThrows(ParseException.class, () -> Version.parse("1.0-pre..erp"));


### PR DESCRIPTION
Numeric segments can now be unsigned longs rather than just signed integers. Segments that exceed this (large) range now result in an error rather than a crash.

Work towards #23461