### PR TITLE
Support --output=commands flag for aquery

### DIFF
--- a/site/en/query/aquery.md
+++ b/site/en/query/aquery.md
@@ -111,11 +111,17 @@ available during a build.
 
 ### Aquery options {:#aquery-options}
 
-#### `--output=(text|summary|proto|jsonproto|textproto), default=text` {:#output}
+#### `--output=(text|summary|commands|proto|jsonproto|textproto), default=text` {:#output}
 
 The default output format (`text`) is human-readable,
 use `proto`, `textproto`, or `jsonproto` for machine-readable format.
 The proto message is `analysis.ActionGraphContainer`.
+
+The `commands` output format prints a list of build commands with
+one command per line.
+
+In general, do not depend on the order of output. For more information,
+see the [core query ordering contract](/query/language#graph-order).
 
 #### `--include_commandline, default=true` {:#include-commandline}
 

--- a/src/main/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/BUILD
@@ -116,6 +116,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:command",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
+        "//src/main/java/com/google/devtools/build/lib/util:script_util",
         "//src/main/java/com/google/devtools/build/lib/util:shell_escaper",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
@@ -183,7 +183,21 @@ public class ActionGraphQueryEnvironment
             AqueryOutputHandler.OutputType.JSON,
             actionFilters),
         new ActionGraphTextOutputFormatterCallback(
-            eventHandler, aqueryOptions, out, accessor, actionFilters, getLabelPrinter()),
+            eventHandler,
+            aqueryOptions,
+            out,
+            accessor,
+            ActionGraphTextOutputFormatterCallback.OutputType.TEXT,
+            actionFilters,
+            getLabelPrinter()),
+        new ActionGraphTextOutputFormatterCallback(
+            eventHandler,
+            aqueryOptions,
+            out,
+            accessor,
+            ActionGraphTextOutputFormatterCallback.OutputType.COMMANDS,
+            actionFilters,
+            getLabelPrinter()),
         new ActionGraphSummaryOutputFormatterCallback(
             eventHandler, aqueryOptions, out, accessor, actionFilters));
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -46,6 +46,7 @@ import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccess
 import com.google.devtools.build.lib.skyframe.RuleConfiguredTargetValue;
 import com.google.devtools.build.lib.util.CommandDescriptionForm;
 import com.google.devtools.build.lib.util.CommandFailureUtils;
+import com.google.devtools.build.lib.util.ScriptUtil;
 import com.google.devtools.build.lib.util.ShellEscaper;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -58,8 +59,19 @@ import net.starlark.java.eval.EvalException;
 
 /** Output callback for aquery, prints human readable output. */
 class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
+  public enum OutputType {
+    TEXT("text"),
+    COMMANDS("commands");
+
+    final String formatName;
+
+    OutputType(String formatName) {
+      this.formatName = formatName;
+    }
+  }
 
   private final ActionKeyContext actionKeyContext = new ActionKeyContext();
+  private final OutputType outputType;
   private final AqueryActionFilter actionFilters;
   private final LabelPrinter labelPrinter;
   private Map<String, String> paramFileNameToContentMap;
@@ -69,16 +81,18 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
       AqueryOptions options,
       OutputStream out,
       TargetAccessor<ConfiguredTargetValue> accessor,
+      OutputType outputType,
       AqueryActionFilter actionFilters,
       LabelPrinter labelPrinter) {
     super(eventHandler, options, out, accessor);
+    this.outputType = outputType;
     this.actionFilters = actionFilters;
     this.labelPrinter = labelPrinter;
   }
 
   @Override
   public String getName() {
-    return "text";
+    return outputType.formatName;
   }
 
   @Override
@@ -128,8 +142,17 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
       return;
     }
 
-    ActionOwner actionOwner = action.getOwner();
     StringBuilder stringBuilder = new StringBuilder();
+    switch (outputType) {
+      case TEXT -> writeText(action, stringBuilder);
+      case COMMANDS -> writeCommand(action, stringBuilder);
+    }
+    printStream.write(stringBuilder.toString().getBytes(UTF_8));
+  }
+
+  private void writeText(ActionAnalysisMetadata action, StringBuilder stringBuilder)
+      throws IOException, CommandLineExpansionException, InterruptedException, EvalException {
+    ActionOwner actionOwner = action.getOwner();
     stringBuilder
         .append(action.prettyPrint())
         .append('\n')
@@ -338,8 +361,28 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
     }
 
     stringBuilder.append('\n');
+  }
 
-    printStream.write(stringBuilder.toString().getBytes(UTF_8));
+  private void writeCommand(ActionAnalysisMetadata action, StringBuilder stringBuilder)
+      throws IOException, CommandLineExpansionException, InterruptedException, EvalException {
+    if (!(action instanceof CommandAction)) {
+      return;
+    }
+
+    boolean first = true;
+    for (String arg :
+        ((CommandAction) action)
+            .getArguments().stream()
+                .map(a -> internalToEscapedUnicode(a))
+                .collect(toImmutableList())) {
+      if (!first) {
+        stringBuilder.append(' ');
+      }
+      ScriptUtil.emitCommandElement(
+          /* message= */ stringBuilder, /* commandElement= */ arg, /* isBinary= */ first);
+      first = false;
+    }
+    stringBuilder.append('\n');
   }
 
   /** Lazy initialization of paramFileNameToContentMap. */

--- a/src/test/shell/integration/aquery_test.sh
+++ b/src/test/shell/integration/aquery_test.sh
@@ -148,6 +148,25 @@ EOF
   assert_not_contains "echo unused" output
 }
 
+function test_basic_aquery_commands() {
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
+  cat > "$pkg/BUILD" <<'EOF'
+genrule(
+    name = "bar",
+    srcs = ["dummy.txt"],
+    outs = ["bar_out.txt"],
+    cmd = "echo unused > $(OUTS)",
+)
+EOF
+  echo "hello aquery" > "$pkg/in.txt"
+
+  bazel aquery --output=commands "//$pkg:bar" > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+  assert_contains "echo unused" output
+}
+
 function test_basic_aquery_proto() {
   local pkg="${FUNCNAME[0]}"
   mkdir -p "$pkg" || fail "mkdir -p $pkg"


### PR DESCRIPTION
This output format prints a list of build commands with one command per line, similar to `ninja -t commands`. This is frequently useful when debugging build issues.

Fixes #22389.