### PR TITLE
[8.1.0] Make `RunUnder` a sealed interface

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -2053,7 +2053,11 @@ java_library(
 java_library(
     name = "config/run_under",
     srcs = ["config/RunUnder.java"],
-    deps = ["//src/main/java/com/google/devtools/build/lib/cmdline"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
+        "//third_party:guava",
+    ],
 )
 
 java_library(
@@ -2066,7 +2070,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:guava",
-        "//third_party:jsr305",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
+import com.google.devtools.build.lib.analysis.config.RunUnder.LabelRunUnder;
 import com.google.devtools.build.lib.analysis.config.transitions.NoConfigTransition;
 import com.google.devtools.build.lib.analysis.constraints.ConstraintConstants;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
@@ -181,7 +182,7 @@ public class BaseRuleClasses {
                 || config.getRunUnder() == null) {
               return null;
             }
-            return config.getRunUnder().getLabel();
+            return config.getRunUnder() instanceof LabelRunUnder runUnder ? runUnder.label() : null;
           });
 
   // TODO(b/65746853): provide a way to do this without passing the entire configuration
@@ -203,7 +204,7 @@ public class BaseRuleClasses {
                 || config.getRunUnder() == null) {
               return null;
             }
-            return config.getRunUnder().getLabel();
+            return config.getRunUnder() instanceof LabelRunUnder runUnder ? runUnder.label() : null;
           });
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.analysis.actions.SymlinkTreeAction;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.RunfileSymlinksMode;
 import com.google.devtools.build.lib.analysis.config.RunUnder;
+import com.google.devtools.build.lib.analysis.config.RunUnder.LabelRunUnder;
 import com.google.devtools.build.lib.analysis.test.TestActionBuilder;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -285,9 +286,7 @@ public final class RunfilesSupport {
     // Adding run_under target to the runfiles manifest so it would become part
     // of runfiles tree and would be executable everywhere.
     RunUnder runUnder = ruleContext.getConfiguration().getRunUnder();
-    if (runUnder != null
-        && runUnder.getLabel() != null
-        && TargetUtils.isTestRule(ruleContext.getRule())) {
+    if (runUnder instanceof LabelRunUnder && TargetUtils.isTestRule(ruleContext.getRule())) {
       TransitiveInfoCollection runUnderTarget = ruleContext.getRunUnderPrerequisite();
       runfiles =
           new Runfiles.Builder(

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnder.java
@@ -13,36 +13,37 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis.config;
 
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.Label;
-import java.util.List;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 
 /** Components of the {@code --run_under} option. */
-public interface RunUnder {
+public sealed interface RunUnder {
   /**
    * @return the whole value passed to --run_under option.
    */
-  String getValue();
+  String value();
 
   /**
-   * Returns label corresponding to the first word (according to shell
-   * tokenization) passed to --run_under.
-   *
-   * @return if the first word (according to shell tokenization) passed to
-   *         --run_under starts with {@code "//"} returns the label
-   *         corresponding to that word otherwise {@code null}
+   * Returns everything except the first word (according to shell tokenization) passed to {@code
+   * --run_under}.
    */
-  Label getLabel();
+  ImmutableList<String> options();
 
   /**
-   * @return if the first word (according to shell tokenization) passed to
-   *         --run_under starts with {@code "//"} returns {@code null}
-   *         otherwise the first word
+   * Represents a value of {@code --run_under} whose first word (according to shell tokenization)
+   * starts with {@code "//"} or {@code "@"}. It is treated as a label referencing a target that
+   * should be used as the {@code --run_under} executable.
    */
-  String getCommand();
+  @AutoCodec
+  record LabelRunUnder(String value, ImmutableList<String> options, Label label)
+      implements RunUnder {}
 
   /**
-   * @return everything except the first word (according to shell
-   *         tokenization) passed to --run_under.
+   * Represents a value of {@code --run_under} whose first word (according to shell tokenization)
+   * does not start with {@code "//"} or {@code "@"}. It is treated as a shell command.
    */
-  List<String> getOptions();
+  @AutoCodec
+  record CommandRunUnder(String value, ImmutableList<String> options, String command)
+      implements RunUnder {}
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnderConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnderConverter.java
@@ -15,6 +15,8 @@ package com.google.devtools.build.lib.analysis.config;
 
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.LabelConverter;
+import com.google.devtools.build.lib.analysis.config.RunUnder.CommandRunUnder;
+import com.google.devtools.build.lib.analysis.config.RunUnder.LabelRunUnder;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.shell.ShellUtils;
 import com.google.devtools.build.lib.shell.ShellUtils.TokenizationException;
@@ -22,8 +24,6 @@ import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import javax.annotation.Nullable;
 
 /** --run_under options converter. */
 public class RunUnderConverter implements Converter<RunUnder> {
@@ -47,126 +47,15 @@ public class RunUnderConverter implements Converter<RunUnder> {
     if (runUnderCommand.startsWith("//") || runUnderCommand.startsWith("@")) {
       try {
         final Label runUnderLabel = LABEL_CONVERTER.convert(runUnderCommand, conversionContext);
-        return new RunUnderLabel(input, runUnderLabel, runUnderSuffix);
+        return new LabelRunUnder(input, runUnderSuffix, runUnderLabel);
       } catch (OptionsParsingException e) {
         throw new OptionsParsingException("Not a valid label " + e.getMessage());
       }
     } else {
-      return new RunUnderCommand(input, runUnderCommand, runUnderSuffix);
+      return new CommandRunUnder(input, runUnderSuffix, runUnderCommand);
     }
   }
 
-  private static final class RunUnderLabel implements RunUnder {
-    private final String input;
-    private final Label runUnderLabel;
-    private final ImmutableList<String> runUnderList;
-
-    RunUnderLabel(String input, Label runUnderLabel, ImmutableList<String> runUnderList) {
-      this.input = input;
-      this.runUnderLabel = runUnderLabel;
-      this.runUnderList = runUnderList;
-    }
-
-    @Override
-    public String getValue() {
-      return input;
-    }
-
-    @Override
-    public Label getLabel() {
-      return runUnderLabel;
-    }
-
-    @Override
-    @Nullable
-    public String getCommand() {
-      return null;
-    }
-
-    @Override
-    public ImmutableList<String> getOptions() {
-      return runUnderList;
-    }
-
-    @Override
-    public String toString() {
-      return input;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (this == other) {
-        return true;
-      } else if (other instanceof RunUnderLabel otherRunUnderLabel) {
-        return Objects.equals(input, otherRunUnderLabel.input)
-            && Objects.equals(runUnderLabel, otherRunUnderLabel.runUnderLabel)
-            && Objects.equals(runUnderList, otherRunUnderLabel.runUnderList);
-      } else {
-        return false;
-      }
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(input, runUnderLabel, runUnderList);
-    }
-  }
-
-  private static final class RunUnderCommand implements RunUnder {
-    private final String input;
-    private final String runUnderCommand;
-    private final ImmutableList<String> runUnderList;
-
-    RunUnderCommand(String input, String runUnderCommand, ImmutableList<String> runUnderList) {
-      this.input = input;
-      this.runUnderCommand = runUnderCommand;
-      this.runUnderList = runUnderList;
-    }
-
-    @Override
-    public String getValue() {
-      return input;
-    }
-
-    @Override
-    @Nullable
-    public Label getLabel() {
-      return null;
-    }
-
-    @Override
-    public String getCommand() {
-      return runUnderCommand;
-    }
-
-    @Override
-    public ImmutableList<String> getOptions() {
-      return runUnderList;
-    }
-
-    @Override
-    public String toString() {
-      return input;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (this == other) {
-        return true;
-      } else if (other instanceof RunUnderCommand otherRunUnderCommand) {
-        return Objects.equals(input, otherRunUnderCommand.input)
-            && Objects.equals(runUnderCommand, otherRunUnderCommand.runUnderCommand)
-            && Objects.equals(runUnderList, otherRunUnderCommand.runUnderList);
-      } else {
-        return false;
-      }
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(input, runUnderCommand, runUnderList);
-    }
-  }
   @Override
   public String getTypeDescription() {
     return "a prefix in front of command";

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -507,7 +507,7 @@ public class TestRunnerAction extends AbstractAction
     fp.addString(Strings.nullToEmpty(executionSettings.getTestFilter()));
     fp.addBoolean(executionSettings.getTestRunnerFailFast());
     RunUnder runUnder = executionSettings.getRunUnder();
-    fp.addString(runUnder == null ? "" : runUnder.getValue());
+    fp.addString(runUnder == null ? "" : runUnder.value());
     extraTestEnv.addTo(fp);
     // TODO(ulfjack): It might be better for performance to hash the action and test envs in config,
     // and only add a hash here.

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
@@ -29,6 +29,9 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.PerLabelOptions;
+import com.google.devtools.build.lib.analysis.config.RunUnder;
+import com.google.devtools.build.lib.analysis.config.RunUnder.CommandRunUnder;
+import com.google.devtools.build.lib.analysis.config.RunUnder.LabelRunUnder;
 import com.google.devtools.build.lib.analysis.test.TestRunnerAction.ResolvedPaths;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.Event;
@@ -242,27 +245,31 @@ public abstract class TestStrategy implements TestActionContext {
   private static void addRunUnderArgs(TestRunnerAction testAction, List<String> args) {
     TestTargetExecutionSettings execSettings = testAction.getExecutionSettings();
     OS executionOs = execSettings.getExecutionOs();
-    if (execSettings.getRunUnderExecutable() != null) {
-      args.add(
-          execSettings
-              .getRunUnderExecutable()
-              .getRunfilesPath()
-              .getCallablePathStringForOs(executionOs));
-    } else {
-      if (execSettings.needsShell()) {
-        // TestActionBuilder constructs TestRunnerAction with a 'null' shell only when none is
-        // required. Something clearly went wrong.
-        Preconditions.checkNotNull(testAction.getShExecutableMaybe(), "%s", testAction);
-        String shellExecutable =
-            testAction.getShExecutableMaybe().getCallablePathStringForOs(executionOs);
-        args.add(shellExecutable);
-        args.add("-c");
-        args.add("\"$@\"");
-        args.add(shellExecutable); // Sets $0.
+    RunUnder runUnder = execSettings.getRunUnder();
+    switch (runUnder) {
+      case LabelRunUnder ignored -> {
+        args.add(
+            execSettings
+                .getRunUnderExecutable()
+                .getRunfilesPath()
+                .getCallablePathStringForOs(executionOs));
       }
-      args.add(execSettings.getRunUnder().getCommand());
+      case CommandRunUnder commandRunUnder -> {
+        if (execSettings.needsShell()) {
+          // TestActionBuilder constructs TestRunnerAction with a 'null' shell only when none is
+          // required. Something clearly went wrong.
+          Preconditions.checkNotNull(testAction.getShExecutableMaybe(), "%s", testAction);
+          String shellExecutable =
+              testAction.getShExecutableMaybe().getCallablePathStringForOs(executionOs);
+          args.add(shellExecutable);
+          args.add("-c");
+          args.add("\"$@\"");
+          args.add(shellExecutable); // Sets $0.
+        }
+        args.add(commandRunUnder.command());
+      }
     }
-    args.addAll(testAction.getExecutionSettings().getRunUnder().getOptions());
+    args.addAll(runUnder.options());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.analysis.ShToolchain;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.RunUnder;
+import com.google.devtools.build.lib.analysis.config.RunUnder.LabelRunUnder;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration;
 import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.analysis.test.TestRunnerAction;
@@ -350,8 +351,8 @@ public class RunCommand implements BlazeCommand {
       @Nullable RunUnder runUnder)
       throws RunCommandException {
     ImmutableList<String> targetsToBuild =
-        (runUnder != null) && (runUnder.getLabel() != null)
-            ? ImmutableList.of(targetString, runUnder.getLabel().toString())
+        runUnder instanceof LabelRunUnder runUnderLabel
+            ? ImmutableList.of(targetString, runUnderLabel.label().toString())
             : ImmutableList.of(targetString);
     BuildRequest request =
         BuildRequest.builder()
@@ -394,7 +395,7 @@ public class RunCommand implements BlazeCommand {
       // Make sure that we have exactly 1 built target (excluding --run_under) and that it is
       // executable. These checks should only fail if keepGoing is true, because we already did
       // validation before the build began in validateTargets().
-      int maxTargets = runUnder != null && runUnder.getLabel() != null ? 2 : 1;
+      int maxTargets = runUnder instanceof LabelRunUnder ? 2 : 1;
       if (topLevelTargets.size() > maxTargets) {
         throw new RunCommandException(
             reportAndCreateFailureResult(
@@ -411,7 +412,8 @@ public class RunCommand implements BlazeCommand {
         if (!targetValidationResult.isSuccess()) {
           throw new RunCommandException(targetValidationResult, result.getStopTime());
         }
-        if (runUnder != null && target.getOriginalLabel().equals(runUnder.getLabel())) {
+        if (runUnder instanceof LabelRunUnder labelRunUnder
+            && target.getOriginalLabel().equals(labelRunUnder.label())) {
           if (runUnderTarget != null) {
             throw new RunCommandException(
                 reportAndCreateFailureResult(
@@ -826,9 +828,9 @@ public class RunCommand implements BlazeCommand {
                 .getProvider(FilesToRunProvider.class)
                 .getExecutable()
                 .getPath();
-        runCommandLine.setRunUnderTarget(runUnderPath, runUnder.getOptions(), prettyPrinter);
+        runCommandLine.setRunUnderTarget(runUnderPath, runUnder.options(), prettyPrinter);
       } else {
-        runCommandLine.setRunUnderPrefix(runUnder.getValue());
+        runCommandLine.setRunUnderPrefix(runUnder.value());
       }
     }
 
@@ -988,7 +990,7 @@ public class RunCommand implements BlazeCommand {
     Target runUnderTarget = null;
 
     boolean singleTargetWarningWasOutput = false;
-    int maxTargets = runUnder != null && runUnder.getLabel() != null ? 2 : 1;
+    int maxTargets = runUnder instanceof LabelRunUnder ? 2 : 1;
     if (targets.size() > maxTargets) {
       warningOrException(
           reporter,
@@ -1005,7 +1007,8 @@ public class RunCommand implements BlazeCommand {
             reporter, notExecutableError(target), keepGoing, Code.TARGET_NOT_EXECUTABLE);
       }
 
-      if (runUnder != null && target.getLabel().equals(runUnder.getLabel())) {
+      if (runUnder instanceof LabelRunUnder labelRunUnder
+          && target.getLabel().equals(labelRunUnder.label())) {
         // It's impossible to have two targets with the same label.
         Preconditions.checkState(runUnderTarget == null);
         runUnderTarget = target;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -253,6 +253,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:config/core_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/invalid_configuration_exception",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/options_diff",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/run_under",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/starlark_exec_transition_loader",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/starlark_transition_cache",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/toolchain_type_requirement",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
 import com.google.devtools.build.lib.analysis.ToolchainCollection;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.ConfigConditions;
+import com.google.devtools.build.lib.analysis.config.RunUnder.LabelRunUnder;
 import com.google.devtools.build.lib.analysis.config.StarlarkExecTransitionLoader.StarlarkExecTransitionLoadingException;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.analysis.constraints.IncompatibleTargetChecker;
@@ -329,19 +330,17 @@ public final class ConfiguredTargetFunction implements SkyFunction {
       // the parent: --run_under targets are configured in the exec configuration, but the
       // --run_under build option doesn't pass to the exec config.
       BuildConfigurationValue config = prereqs.getTargetAndConfiguration().getConfiguration();
-      if (config != null
-          && config.getRunUnder() != null
-          && config.getRunUnder().getLabel() != null) {
+      if (config != null && config.getRunUnder() instanceof LabelRunUnder runUnder) {
         Optional<ConfiguredTarget> runUnderTarget =
             prereqs.getDepValueMap().values().stream()
                 .map(ConfiguredTargetAndData::getConfiguredTarget)
-                .filter(d -> d.getLabel().equals(config.getRunUnder().getLabel()))
+                .filter(d -> d.getLabel().equals(runUnder.label()))
                 .findAny();
         if (runUnderTarget.isPresent()
             && runUnderTarget.get().getProvider(FilesToRunProvider.class).getExecutable() == null) {
           throw new ConfiguredValueCreationException(
               prereqs.getTargetAndConfiguration().getTarget(),
-              "run_under target " + config.getRunUnder().getLabel() + " is not executable");
+              "run_under target " + runUnder.label() + " is not executable");
         }
       }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/RunUnderConverterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/RunUnderConverterTest.java
@@ -17,8 +17,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.analysis.config.RunUnder.CommandRunUnder;
+import com.google.devtools.build.lib.analysis.config.RunUnder.LabelRunUnder;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.common.options.OptionsParsingException;
-import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -41,13 +43,15 @@ public class RunUnderConverterTest {
     assertRunUnderFails("", "Empty command");
   }
 
-  private void assertEqualsRunUnder(String input, String label, String command,
-      List<String> options) throws Exception {
+  private void assertEqualsRunUnder(
+      String input, String label, String command, ImmutableList<String> options) throws Exception {
     RunUnder runUnder = new RunUnderConverter().convert(input, /*conversionContext=*/ null);
-    assertThat(runUnder.getLabel() == null ? null : runUnder.getLabel().toString())
-        .isEqualTo(label);
-    assertThat(runUnder.getCommand()).isEqualTo(command);
-    assertThat(runUnder.getOptions()).isEqualTo(options);
+    if (label == null) {
+      assertThat(runUnder).isEqualTo(new CommandRunUnder(input, options, command));
+    } else {
+      assertThat(runUnder)
+          .isEqualTo(new LabelRunUnder(input, options, Label.parseCanonicalUnchecked(label)));
+    }
   }
 
   private void assertRunUnderFails(String input, String expectedError) {


### PR DESCRIPTION
Closes #24318.

PiperOrigin-RevId: 696635274
Change-Id: Ib98b01132c535ce72002c5acfcadf846f9166119

Commit https://github.com/bazelbuild/bazel/commit/fccfaa170590383d93a654d16cad230ad6e09f7d