### PR TITLE
[8.1.0] Make Bazel not crash with an absolute path in .bazelignore.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredSubdirectoriesValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/IgnoredSubdirectoriesValue.java
@@ -112,4 +112,11 @@ public class IgnoredSubdirectoriesValue implements SkyValue {
       return interner;
     }
   }
+
+  /** Exception thrown when an ignore path is wrong for some reason. */
+  public static final class InvalidIgnorePathException extends Exception {
+    public InvalidIgnorePathException(String path, String message) {
+      super("Invalid path in " + path + ": " + message);
+    }
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.PackageLoading;
 import com.google.devtools.build.lib.server.FailureDetails.PackageLoading.Code;
+import com.google.devtools.build.lib.skyframe.IgnoredSubdirectoriesValue.InvalidIgnorePathException;
 import com.google.devtools.build.lib.skyframe.PackageFunctionWithMultipleGlobDeps.SkyframeGlobbingIOException;
 import com.google.devtools.build.lib.skyframe.RepoFileFunction.BadRepoFileException;
 import com.google.devtools.build.lib.skyframe.RepoPackageArgsFunction.RepoPackageArgsValue;
@@ -411,8 +412,18 @@ public abstract class PackageFunction implements SkyFunction {
               env.getValueOrThrow(
                   packageLookupKey,
                   BadRepoFileException.class,
+                  InvalidIgnorePathException.class,
                   BuildFileNotFoundException.class,
                   InconsistentFilesystemException.class);
+    } catch (InvalidIgnorePathException e) {
+      throw PackageFunctionException.builder()
+          .setType(PackageFunctionException.Type.NO_SUCH_PACKAGE)
+          .setTransience(Transience.PERSISTENT)
+          .setPackageIdentifier(packageId)
+          .setMessage(e.getMessage())
+          .setException(e)
+          .setPackageLoadingCode(PackageLoading.Code.BAD_IGNORED_DIRECTORIES)
+          .build();
     } catch (BadRepoFileException e) {
       throw badRepoFileException(e, packageId);
     } catch (BuildFileNotFoundException e) {

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -1303,6 +1303,7 @@ message PackageLoading {
     SYMLINK_CYCLE_OR_INFINITE_EXPANSION = 30 [(metadata) = { exit_code: 1 }];
     OTHER_IO_EXCEPTION = 31 [(metadata) = { exit_code: 36 }];
     BAD_REPO_FILE = 32 [(metadata) = { exit_code: 1 }];
+    BAD_IGNORED_DIRECTORIES = 33 [(metadata) = { exit_code: 1 }];
   }
 
   Code code = 1;


### PR DESCRIPTION
Fixes #24611.

RELNOTES: None.
PiperOrigin-RevId: 704618999
Change-Id: I4b82df8829cd8f4d98dd52934d4fa075d0414e23

Commit https://github.com/bazelbuild/bazel/commit/7879fac3ad3680114e8a988d4ae00522953e58fa