### PR TITLE
[8.1.0] Also apply --experimental_repository_downloader_retries to a SocketException

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -357,17 +358,21 @@ public class DownloadManager {
       return false;
     }
 
-    if (e instanceof ContentLengthMismatchException) {
+    if (isRetryableException(e)) {
       return true;
     }
 
     for (var suppressed : e.getSuppressed()) {
-      if (suppressed instanceof ContentLengthMismatchException) {
+      if (isRetryableException(suppressed)) {
         return true;
       }
     }
 
     return false;
+  }
+
+  private boolean isRetryableException(Throwable e) {
+    return e instanceof ContentLengthMismatchException || e instanceof SocketException;
   }
 
   /**


### PR DESCRIPTION
Fix for #24530

--experimental_repository_downloader_retries will now retry on `SocketException` in addition to `ContentLengthMismatchException`

Closes #24608.

PiperOrigin-RevId: 704633572
Change-Id: Idd1fcbb768c9dabed596fe15d8ae9260ef3e895d

Commit https://github.com/bazelbuild/bazel/commit/459bb5736c5af6fc7a70e1cd9dceb40abb0ad71d