### PR TITLE
[8.1.0] Don't fall back to `help` command when command is empty

### DIFF
--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -151,6 +151,14 @@ std::unique_ptr<CommandLine> OptionProcessor::SplitCommandLine(
         std::move(path_to_binary), std::move(startup_args), "", {}));
   }
   string& command = args[i];
+  // Distinguish an empty command from the case of no command above.
+  if (command.empty()) {
+    blaze_util::StringPrintf(error,
+                             "Command cannot be the empty string.\n"
+                             "  For more info, run '%s help'.",
+                             lowercase_product_name.c_str());
+    return nullptr;
+  }
 
   // The rest are the command arguments.
   vector<string> command_args(std::make_move_iterator(args.begin() + i + 1),

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -222,6 +222,11 @@ function test_no_arguments() {
   expect_log "Usage: b\\(laze\\|azel\\)"
 }
 
+function test_empty_command() {
+  bazel '' >&$TEST_log && fail "Expected non-zero exit"
+  expect_log "Command cannot be the empty string."
+}
+
 function test_local_startup_timeout() {
   local output_base=$(bazel info output_base 2>"$TEST_log") ||
     fail "bazel info failed"


### PR DESCRIPTION
This masked issues in Bazel wrappers in a very confusing way.

Fixes #24577

Closes #24579.

PiperOrigin-RevId: 704193424
Change-Id: Iaf486b9eb5764073439be9968f449eaf172667ca

Commit https://github.com/bazelbuild/bazel/commit/40c942ac484e8a5a5834a2c7686991a4f3e42746