### PR TITLE
[8.1.0] java_launcher: Fix non-portable ofstream usage

### DIFF
--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -249,7 +249,11 @@ wstring JavaBinaryLauncher::CreateClasspathJar(const wstring& classpath) {
   wstring jar_manifest_file_path =
       binary_base_path + rand_id + L".jar_manifest";
   blaze_util::AddUncPrefixMaybe(&jar_manifest_file_path);
+#if (__cplusplus >= 201703L)
+  wofstream jar_manifest_file(std::filesystem::path(jar_manifest_file_path));
+#else
   wofstream jar_manifest_file(jar_manifest_file_path);
+#endif
   jar_manifest_file << L"Manifest-Version: 1.0\n";
   // No line in the MANIFEST.MF file may be longer than 72 bytes.
   // A space prefix indicates the line is still the content of the last


### PR DESCRIPTION
wofstream cannot be constructed from wstring according to the standard https://en.cppreference.com/w/cpp/io/basic_ofstream/basic_ofstream.

Closes #24703.

PiperOrigin-RevId: 707172911
Change-Id: I973f9560c5b20748e4635cd757f53fff9c8ef0c5

Commit https://github.com/bazelbuild/bazel/commit/5b35276f57271bf1d81edade231abd667f1d034b