### PR TITLE
[8.1.0] Remove the unused concept of exec group inheritance

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ExecGroupCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ExecGroupCollection.java
@@ -15,7 +15,6 @@ package com.google.devtools.build.lib.analysis;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.devtools.build.lib.packages.ExecGroup.DEFAULT_EXEC_GROUP_NAME;
-import static java.util.stream.Collectors.joining;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.HashBasedTable;
@@ -48,8 +47,7 @@ public abstract class ExecGroupCollection {
   /**
    * Prepares the input exec groups to serve as {@link Builder#execGroups}.
    *
-   * <p>Applies any inheritance specified via {@link ExecGroup#copyFrom} and adds auto exec groups
-   * when {@code useAutoExecGroups} is true.
+   * <p>Adds auto exec groups when {@code useAutoExecGroups} is true.
    */
   public static ImmutableMap<String, ExecGroup> process(
       ImmutableMap<String, ExecGroup> execGroups,
@@ -65,16 +63,12 @@ public abstract class ExecGroupCollection {
       String name = entry.getKey();
       ExecGroup execGroup = entry.getValue();
 
-      if (execGroup.copyFrom() != null) {
-        if (execGroup.copyFrom().equals(DEFAULT_EXEC_GROUP_NAME)) {
+      if (execGroup.copyFromDefault()) {
           execGroup =
               ExecGroup.builder()
                   .execCompatibleWith(defaultExecWith)
                   .toolchainTypes(defaultToolchainTypes)
                   .build();
-        } else {
-          execGroup = execGroup.inheritFrom(execGroups.get(execGroup.copyFrom()));
-        }
       }
 
       processedGroups.put(name, execGroup);
@@ -87,7 +81,6 @@ public abstract class ExecGroupCollection {
             toolchainType.toolchainType().toString(),
             ExecGroup.builder()
                 .addToolchainType(toolchainType)
-                .copyFrom(null)
                 .execCompatibleWith(defaultExecWith)
                 .build());
       }
@@ -268,7 +261,7 @@ public abstract class ExecGroupCollection {
       super(
           String.format(
               "Tried to set properties for non-existent exec groups: %s.",
-              invalidNames.stream().collect(joining(","))));
+              String.join(",", invalidNames)));
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -600,9 +600,10 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
   /**
    * Returns a new callable representing a Starlark-defined rule.
    *
-   * <p>This is public for the benefit of {@link StarlarkTestingModule}, which has the unusual use
-   * case of creating new rule types to house analysis-time test assertions ({@code analysis_test}).
-   * It's probably not a good idea to add new callers of this method.
+   * <p>This is public for the benefit of {@link
+   * com.google.devtools.build.lib.rules.test.StarlarkTestingModule}, which has the unusual use case
+   * of creating new rule types to house analysis-time test assertions ({@code analysis_test}). It's
+   * probably not a good idea to add new callers of this method.
    *
    * <p>Note that the bzlFile and transitiveDigest params correspond to the outermost .bzl file
    * being evaluated, not the one in which rule() is called.
@@ -1980,7 +1981,6 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     return ExecGroup.builder()
         .toolchainTypes(toolchainTypes)
         .execCompatibleWith(constraints)
-        .copyFrom(null)
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -1624,7 +1624,7 @@ public class RuleClass implements RuleClassData {
 
     /** Adds an exec group that copies its toolchains and constraints from the rule. */
     public Builder addExecGroup(String name) {
-      return addExecGroups(ImmutableMap.of(name, ExecGroup.copyFromDefault()));
+      return addExecGroups(ImmutableMap.of(name, ExecGroup.COPY_FROM_DEFAULT));
     }
 
     /** An error to help report {@link ExecGroup}s with the same name */

--- a/src/test/java/com/google/devtools/build/lib/analysis/testing/ExecGroupSubject.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/testing/ExecGroupSubject.java
@@ -17,7 +17,6 @@ import static com.google.common.truth.Truth.assertAbout;
 
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.IterableSubject;
-import com.google.common.truth.StringSubject;
 import com.google.common.truth.Subject;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.ExecGroup;
@@ -72,11 +71,7 @@ public class ExecGroupSubject extends Subject {
     execCompatibleWith().contains(constraintLabel);
   }
 
-  public StringSubject copiesFrom() {
-    return check("copyFrom()").that(actual.copyFrom());
-  }
-
   public void copiesFromDefault() {
-    copiesFrom().isEqualTo(ExecGroup.DEFAULT_EXEC_GROUP_NAME);
+    check("copyFromDefault()").that(actual.copyFromDefault()).isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassBuilderTest.java
@@ -205,13 +205,11 @@ public class RuleClassBuilderTest extends PackageLoadingTestCase {
         ExecGroup.builder()
             .addToolchainType(ToolchainTypeRequirement.create(mockToolchainType))
             .execCompatibleWith(ImmutableSet.of(mockConstraint))
-            .copyFrom(null)
             .build();
     ExecGroup childGroup =
         ExecGroup.builder()
             .toolchainTypes(ImmutableSet.of())
             .execCompatibleWith(ImmutableSet.of())
-            .copyFrom(null)
             .build();
     RuleClass parent =
         new RuleClass.Builder("$parent", RuleClassType.ABSTRACT, false)
@@ -233,7 +231,7 @@ public class RuleClassBuilderTest extends PackageLoadingTestCase {
     RuleClass a =
         new RuleClass.Builder("ruleA", RuleClassType.NORMAL, false)
             .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .addExecGroups(ImmutableMap.of("blueberry", ExecGroup.copyFromDefault()))
+            .addExecGroups(ImmutableMap.of("blueberry", ExecGroup.COPY_FROM_DEFAULT))
             .add(attr("tags", STRING_LIST))
             .addToolchainTypes(
                 ToolchainTypeRequirement.create(Label.parseCanonicalUnchecked("//some/toolchain")))
@@ -241,7 +239,7 @@ public class RuleClassBuilderTest extends PackageLoadingTestCase {
     RuleClass b =
         new RuleClass.Builder("ruleB", RuleClassType.NORMAL, false)
             .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .addExecGroups(ImmutableMap.of("blueberry", ExecGroup.copyFromDefault()))
+            .addExecGroups(ImmutableMap.of("blueberry", ExecGroup.COPY_FROM_DEFAULT))
             .add(attr("tags", STRING_LIST))
             .addToolchainTypes(
                 ToolchainTypeRequirement.create(
@@ -271,7 +269,6 @@ public class RuleClassBuilderTest extends PackageLoadingTestCase {
                             ToolchainTypeRequirement.create(
                                 Label.parseCanonicalUnchecked("//some/toolchain")))
                         .execCompatibleWith(ImmutableSet.of())
-                        .copyFrom(null)
                         .build()))
             .add(attr("tags", STRING_LIST))
             .build();
@@ -284,7 +281,6 @@ public class RuleClassBuilderTest extends PackageLoadingTestCase {
                     ExecGroup.builder()
                         .toolchainTypes(ImmutableSet.of())
                         .execCompatibleWith(ImmutableSet.of())
-                        .copyFrom(null)
                         .build()))
             .add(attr("tags", STRING_LIST))
             .build();

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -1206,7 +1206,6 @@ public final class RuleClassTest extends PackageLoadingTestCase {
             ExecGroup.builder()
                 .addToolchainType(ToolchainTypeRequirement.create(toolchain))
                 .execCompatibleWith(ImmutableSet.of(constraint))
-                .copyFrom(null)
                 .build()));
 
     RuleClass ruleClass = ruleClassBuilder.build();


### PR DESCRIPTION
Work towards #23802

Closes #24704.

PiperOrigin-RevId: 708006518
Change-Id: Ibe2294750d7238dc20c8c39dba9e63a987a46b14

Commit https://github.com/bazelbuild/bazel/commit/51a6c387459b42360faf64e94626bdd9716f6075