### PR TITLE
[8.1.0] Remove empty coverage environment

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -1100,7 +1100,7 @@ def _get_coverage_environment(ctx, cc_config, cc_toolchain):
     }
     for k in list(env.keys()):
         if env[k] == None:
-            env[k] = ""
+            env.pop(k)
     if cc_config.fdo_instrument():
         env["FDO_DIR"] = cc_config.fdo_instrument()
     return env

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderTest.java
@@ -356,7 +356,7 @@ public class CcToolchainProviderTest extends BuildViewTestCase {
         getConfiguredTarget("//a:lib").get(InstrumentedFilesInfo.STARLARK_CONSTRUCTOR);
 
     assertThat(instrumentedFilesInfo.getCoverageEnvironment())
-        .containsEntry("COVERAGE_GCOV_PATH", "");
+        .doesNotContainKey("COVERAGE_GCOV_PATH");
   }
 
   // regression test for b/319501294
@@ -503,7 +503,8 @@ public class CcToolchainProviderTest extends BuildViewTestCase {
             .get(InstrumentedFilesInfo.STARLARK_CONSTRUCTOR)
             .getCoverageEnvironment();
 
-    assertThat(coverageEnv).containsAtLeast("LLVM_COV", "", "LLVM_PROFDATA", "");
+    assertThat(coverageEnv).doesNotContainKey("LLVM_COV");
+    assertThat(coverageEnv).doesNotContainKey("LLVM_PROFDATA");
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/23247

Closes #24670.

PiperOrigin-RevId: 707176116
Change-Id: I71ef3c630f8130467cc6a0c730c1278ae6b0817f

Commit https://github.com/bazelbuild/bazel/commit/03eae37f24dbaaacf8a0fa4299bd452b643014b8