### PR TITLE
 Forward `exec_properties` to main test spawn's execution info 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -112,8 +112,7 @@ public class StandaloneTestStrategy extends TestStrategy {
         createEnvironment(
             actionExecutionContext, action, tmpDirRoot, executionOptions.splitXmlGeneration);
 
-    Map<String, String> executionInfo =
-        new TreeMap<>(action.getTestProperties().getExecutionInfo());
+    Map<String, String> executionInfo = new TreeMap<>(action.getExecutionInfo());
     if (!action.shouldAcceptCachedResult()) {
       // TODO(tjgq): We want to reject a previously cached result, but not prevent the result of the
       // current execution from being uploaded. We should introduce a separate execution requirement

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkExecGroupTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkExecGroupTest.java
@@ -863,6 +863,7 @@ public class StarlarkExecGroupTest extends BuildViewTestCase {
     // the exec_compatible_with constraint and thus select the target platform.
     // TODO: Change this as soon as exec_group_compatible_with is available, which provides an
     // explicit way to specify additional constraints for the test exec group.
+    // https://github.com/bazelbuild/bazel/issues/23802
     assertThat(testAction.getExecutionPlatform().label())
         .isEqualTo(Label.parseCanonicalUnchecked("//platform:fast_cpu_platform"));
     assertThat(testAction.getExecProperties())

--- a/src/test/shell/bazel/remote/BUILD
+++ b/src/test/shell/bazel/remote/BUILD
@@ -28,6 +28,7 @@ sh_test(
         "//src/test/shell/bazel:test-deps",
         "//src/tools/remote:worker",
         "@bazel_tools//tools/bash/runfiles",
+        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
     ],
     shard_count = 5,
     tags = [

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3508,6 +3508,7 @@ my_test(
     # forced by this constraint for both the build and the test action. Instead,
     # use exec_group_compatible_with = {"test": [":has_foo"]} once it is
     # implemented.
+    # https://github.com/bazelbuild/bazel/issues/23802
     exec_compatible_with = [":has_foo"],
 )
 


### PR DESCRIPTION
This makes `exec_properties` such as `no-remote-exec` effective for the main test spawn, where they previously only affected post-processing spawns such as test XML generation.

Pros:
* relatively simple (and more precise than `tags`) way to affect test execution using existing API
* provides consistency between test spawns
* provides consistency between test spawns and spawns produced by Starlark actions

Cons:
* similar to Starlark actions, execution info is "polluted" with `exec_properties` such as `OSFamily` and `container-image`, which shows up in `aquery` and may increase memory usage
* the fact that `exec_properties` end up in execution info appears to have been an unintentional side effect of https://github.com/bazelbuild/bazel/commit/adb56ccd811b60db5dc05c5434cd7c436a6cb81b rather than a conscious design decision
* provides functionality may be better addressed by [Execution Platform Scoped Spawn Strategies](https://github.com/bazelbuild/proposals/blob/main/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md)