### PR TITLE
Add execution info to `--subcommands` output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -492,7 +492,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
             /* environmentVariablesToClear= */ null,
             getExecRoot().getPathString(),
             spawn.getConfigurationChecksum(),
-            spawn.getExecutionPlatformLabel());
+            spawn.getExecutionPlatformLabel(),
+            spawn.getExecutionInfo());
     getEventHandler().handle(Event.of(EventKind.SUBCOMMAND, null, "# " + reason + "\n" + message));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -257,7 +257,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
                   /* prettyPrintArgs= */ true,
                   ((CommandAction) action)
                       .getArguments().stream()
-                          .map(a -> internalToEscapedUnicode(a))
+                          .map(ActionGraphTextOutputFormatterCallback::internalToEscapedUnicode)
                           .collect(toImmutableList()),
                   /* environment= */ null,
                   /* environmentVariablesToClear= */ null,
@@ -265,7 +265,8 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
                   action.getOwner().getConfigurationChecksum(),
                   action.getExecutionPlatform() != null
                       ? action.getExecutionPlatform().label()
-                      : null))
+                      : null,
+                  action.getExecutionInfo()))
           .append("\n");
     }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -152,6 +152,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
                 /* environmentVariablesToClear= */ null,
                 /* cwd= */ null,
                 /* configurationChecksum= */ null,
-                /* executionPlatformLabel= */ null));
+                /* executionPlatformLabel= */ null,
+                /* executionInfo= */ null));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
@@ -49,7 +49,8 @@ public class CommandFailureUtils {
       @Nullable List<String> environmentVariablesToClear,
       @Nullable String cwd,
       @Nullable String configurationChecksum,
-      @Nullable Label executionPlatformLabel) {
+      @Nullable Label executionPlatformLabel,
+      @Nullable Map<String, String> executionInfo) {
 
     Preconditions.checkNotNull(form);
     StringBuilder message = new StringBuilder();
@@ -134,6 +135,19 @@ public class CommandFailureUtils {
         message.append("\n");
         message.append("# Execution platform: ").append(executionPlatformLabel);
       }
+
+      if (executionInfo != null && !executionInfo.isEmpty()) {
+        message.append("\n");
+        message.append("# Execution info: ");
+        boolean first = true;
+        for (Map.Entry<String, String> entry : executionInfo.entrySet()) {
+          if (!first) {
+            message.append(", ");
+          }
+          message.append(entry.getKey()).append(": ").append(entry.getValue());
+          first = false;
+        }
+      }
     }
 
     return message.toString();
@@ -152,7 +166,8 @@ public class CommandFailureUtils {
       @Nullable String cwd,
       @Nullable String configurationChecksum,
       @Nullable String targetDescription,
-      @Nullable Label executionPlatformLabel) {
+      @Nullable Label executionPlatformLabel,
+      @Nullable Map<String, String> executionInfo) {
 
     String commandName = commandLineElements.iterator().next();
     // Extract the part of the command name after the last "/", if any.
@@ -181,7 +196,8 @@ public class CommandFailureUtils {
             null,
             cwd,
             configurationChecksum,
-            executionPlatformLabel));
+            executionPlatformLabel,
+            executionInfo));
     return shortCommandName + " failed: " + output;
   }
 
@@ -195,6 +211,7 @@ public class CommandFailureUtils {
         cwd,
         command.getConfigurationChecksum(),
         command.getTargetDescription(),
-        command.getExecutionPlatformLabel());
+        command.getExecutionPlatformLabel(),
+        command.getExecutionInfo());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/util/DescribableExecutionUnit.java
+++ b/src/main/java/com/google/devtools/build/lib/util/DescribableExecutionUnit.java
@@ -49,5 +49,11 @@ public interface DescribableExecutionUnit {
     return null;
   }
 
+  /** Returns the execution info for this command, if any. */
+  @Nullable
+  default ImmutableMap<String, String> getExecutionInfo() {
+    return null;
+  }
+
   String getMnemonic();
 }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
@@ -234,6 +234,7 @@ public final class WorkerKey {
         /* environmentVariablesToClear= */ null,
         execRoot.getPathString(),
         /* configurationChecksum= */ null,
-        /* executionPlatformLabel= */ null);
+        /* executionPlatformLabel= */ null,
+        /* executionInfo= */ null);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/util/CommandFailureUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/CommandFailureUtilsTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.util;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import java.util.Arrays;
@@ -51,7 +52,8 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            ImmutableMap.of("remote-cache", "false", "timeout", "7"));
     assertThat(message)
         .isEqualTo(
             "sh failed: error executing Mnemonic command (from target //foo:bar) "
@@ -80,16 +82,19 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            ImmutableMap.of("remote-cache", "false", "timeout", "7"));
     assertThat(message)
         .isEqualTo(
-            "sh failed: error executing Mnemonic command (from target //foo:bar) \n"
-                + "  (exec env - \\\n"
-                + "    FOO=foo \\\n"
-                + "    PATH=/usr/bin:/bin:/sbin \\\n"
-                + "  /bin/sh -c 'echo Some errors 1>&2; echo Some output; exit 42')\n"
-                + "# Configuration: cfg12345\n"
-                + "# Execution platform: //platform:exec");
+            """
+                sh failed: error executing Mnemonic command (from target //foo:bar)\s
+                  (exec env - \\
+                    FOO=foo \\
+                    PATH=/usr/bin:/bin:/sbin \\
+                  /bin/sh -c 'echo Some errors 1>&2; echo Some output; exit 42')
+                # Configuration: cfg12345
+                # Execution platform: //platform:exec
+                # Execution info: remote-cache: false, timeout: 7""");
   }
 
   @Test
@@ -117,7 +122,8 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            ImmutableMap.of("remote-cache", "false", "timeout", "7"));
     assertThat(message)
         .isEqualTo(
             "some_command failed: error executing Mnemonic command (from target //foo:bar) "
@@ -153,21 +159,24 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            ImmutableMap.of("remote-cache", "false", "timeout", "7"));
     assertThat(message)
         .isEqualTo(
-            "some_command failed: error executing Mnemonic command (from target //foo:bar) \n"
-                + "  (cd /my/working/directory && \\\n"
-                + "  exec env - \\\n"
-                + "    FOO=foo \\\n"
-                + "    PATH=/usr/bin:/bin:/sbin \\\n"
-                + "  some_command arg1 arg2 arg3 arg4 arg5 arg6 'with spaces' arg8 '*' arg10 "
-                + "arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 "
-                + "arg19 arg20 arg21 arg22 arg23 arg24 arg25 arg26 "
-                + "arg27 arg28 arg29 arg30 arg31 arg32 arg33 arg34 "
-                + "arg35 arg36 arg37 arg38 arg39)\n"
-                + "# Configuration: cfg12345\n"
-                + "# Execution platform: //platform:exec");
+            """
+                some_command failed: error executing Mnemonic command (from target //foo:bar)\s
+                  (cd /my/working/directory && \\
+                  exec env - \\
+                    FOO=foo \\
+                    PATH=/usr/bin:/bin:/sbin \\
+                  some_command arg1 arg2 arg3 arg4 arg5 arg6 'with spaces' arg8 '*' arg10 \
+                arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 \
+                arg19 arg20 arg21 arg22 arg23 arg24 arg25 arg26 \
+                arg27 arg28 arg29 arg30 arg31 arg32 arg33 arg34 \
+                arg35 arg36 arg37 arg38 arg39)
+                # Configuration: cfg12345
+                # Execution platform: //platform:exec
+                # Execution info: remote-cache: false, timeout: 7""");
   }
 
   @Test
@@ -191,7 +200,8 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            ImmutableMap.of("remote-cache", "false", "timeout", "7"));
     assertThat(message)
         .isEqualTo(
             "some_command failed: error executing Mnemonic command (from target //foo:bar)"
@@ -230,23 +240,26 @@ public class CommandFailureUtilsTest {
             envToClear,
             cwd,
             "cfg12345",
-            executionPlatform.label());
+            executionPlatform.label(),
+            ImmutableMap.of("remote-cache", "false", "timeout", "7"));
 
     assertThat(message)
         .isEqualTo(
-            "(cd /my/working/directory && \\\n"
-                + "  exec env - \\\n"
-                + "    -u CLEAR \\\n"
-                + "    -u THIS \\\n"
-                + "    FOO=foo \\\n"
-                + "    PATH=/usr/bin:/bin:/sbin \\\n"
-                + "  some_command \\\n"
-                + "    arg1 \\\n"
-                + "    arg2 \\\n"
-                + "    'with spaces' \\\n"
-                + "    '*' \\\n"
-                + "    arg5)\n"
-                + "# Configuration: cfg12345\n"
-                + "# Execution platform: //platform:exec");
+            """
+                (cd /my/working/directory && \\
+                  exec env - \\
+                    -u CLEAR \\
+                    -u THIS \\
+                    FOO=foo \\
+                    PATH=/usr/bin:/bin:/sbin \\
+                  some_command \\
+                    arg1 \\
+                    arg2 \\
+                    'with spaces' \\
+                    '*' \\
+                    arg5)
+                # Configuration: cfg12345
+                # Execution platform: //platform:exec
+                # Execution info: remote-cache: false, timeout: 7""");
   }
 }


### PR DESCRIPTION
Makes it easier to debug where spawns (of which there may be multiple per action) are actually executed (remote vs local, with caching, ...).

Work towards #23802