### PR TITLE
Unify implementations of `Spawn#getCombinedExecProperties`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionAnalysisMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionAnalysisMetadata.java
@@ -224,7 +224,13 @@ public interface ActionAnalysisMetadata {
    */
   NestedSet<Artifact> getMandatoryInputs();
 
-  /** Returns a String to String map containing the execution properties of this action. */
+  /**
+   * Returns a String to String map containing the execution properties of this action.
+   *
+   * <p>These properties are typically inherited from {@link #getOwner()} and contain the
+   * exec_properties provided on the target or execution platform level. Subclasses representing
+   * actions that are internal only can override this to return an empty map.
+   */
   ImmutableMap<String, String> getExecProperties();
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionOwner.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionOwner.java
@@ -178,7 +178,12 @@ public abstract class ActionOwner {
 
   public abstract ImmutableList<AspectDescriptor> getAspectDescriptors();
 
-  /** Returns a String to String map containing the execution properties of this action. */
+  /**
+   * Returns a String to String map containing the execution properties available at the target
+   * level, e.g. via the exec_properties attribute of the rule or the execution platform for the
+   * exec group that the action is assigned to. This does <em>not</em> include any action-specific
+   * properties.
+   */
   @VisibleForTesting
   public abstract ImmutableMap<String, String> getExecProperties();
 

--- a/src/main/java/com/google/devtools/build/lib/actions/BaseSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/BaseSpawn.java
@@ -107,11 +107,6 @@ public class BaseSpawn implements Spawn {
   }
 
   @Override
-  public ImmutableMap<String, String> getCombinedExecProperties() {
-    return action.getOwner().getExecProperties();
-  }
-
-  @Override
   @Nullable
   public PlatformInfo getExecutionPlatform() {
     return action.getExecutionPlatform();

--- a/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
@@ -296,11 +296,6 @@ public final class SimpleSpawn implements Spawn {
   }
 
   @Override
-  public ImmutableMap<String, String> getCombinedExecProperties() {
-    return owner.getExecProperties();
-  }
-
-  @Override
   @Nullable
   public PlatformInfo getExecutionPlatform() {
     return owner.getExecutionPlatform();

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawn.java
@@ -158,7 +158,9 @@ public interface Spawn extends DescribableExecutionUnit {
    * #getExecutionInfo()} can be set by multiple sources while this data is set via the {@code
    * exec_properties} attribute on targets and platforms.
    */
-  ImmutableMap<String, String> getCombinedExecProperties();
+  default ImmutableMap<String, String> getCombinedExecProperties() {
+    return getResourceOwner().getOwner().getExecProperties();
+  }
 
   @Nullable
   PlatformInfo getExecutionPlatform();

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformUtilsTest.java
@@ -86,7 +86,7 @@ public final class PlatformUtilsTest {
   public void testParsePlatformSortsProperties_execProperties() throws Exception {
     // execProperties are chosen even if there are remoteOptions
     ImmutableMap<String, String> map = ImmutableMap.of("aa", "99", "zz", "66", "dd", "11");
-    Spawn s = new SpawnBuilder("dummy").withExecProperties(map).build();
+    Spawn s = new SpawnBuilder("dummy").withCombinedExecProperties(map).build();
 
     Platform expected =
         Platform.newBuilder()
@@ -100,7 +100,7 @@ public final class PlatformUtilsTest {
 
   @Test
   public void getPlatformProto_mergeTargetExecPropertiesWithPlatform() throws Exception {
-    Spawn spawn = new SpawnBuilder("dummy").withExecProperties(ImmutableMap.of("c", "3")).build();
+    Spawn spawn = new SpawnBuilder("dummy").withCombinedExecProperties(ImmutableMap.of("c", "3")).build();
     Platform expected =
         Platform.newBuilder()
             .addProperties(Platform.Property.newBuilder().setName("a").setValue("1"))
@@ -113,7 +113,7 @@ public final class PlatformUtilsTest {
   @Test
   public void getPlatformProto_targetExecPropertiesConflictWithPlatform_override()
       throws Exception {
-    Spawn spawn = new SpawnBuilder("dummy").withExecProperties(ImmutableMap.of("b", "3")).build();
+    Spawn spawn = new SpawnBuilder("dummy").withCombinedExecProperties(ImmutableMap.of("b", "3")).build();
     Platform expected =
         Platform.newBuilder()
             .addProperties(Platform.Property.newBuilder().setName("a").setValue("1"))

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -2066,7 +2066,9 @@ public abstract class SpawnLogContextTestBase {
   @Test
   public void testSpawnPlatformProperties() throws Exception {
     Spawn spawn =
-        defaultSpawnBuilder().withExecProperties(ImmutableMap.of("a", "3", "c", "4")).build();
+        defaultSpawnBuilder()
+            .withCombinedExecProperties(ImmutableMap.of("a", "3", "c", "4"))
+            .build();
 
     SpawnLogContext context = createSpawnLogContext(ImmutableMap.of("a", "1", "b", "2"));
 

--- a/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
@@ -44,7 +44,7 @@ public class FakeOwner implements ActionExecutionMetadata {
   private final String ownerRuleKind;
   @Nullable private final Artifact primaryOutput;
   @Nullable private final PlatformInfo platform;
-  private final ImmutableMap<String, String> execProperties;
+  private final ImmutableMap<String, String> combinedExecProperties;
   private final boolean isBuiltForToolConfiguration;
 
   FakeOwner(
@@ -54,7 +54,7 @@ public class FakeOwner implements ActionExecutionMetadata {
       String ownerRuleKind,
       @Nullable Artifact primaryOutput,
       @Nullable PlatformInfo platform,
-      ImmutableMap<String, String> execProperties,
+      ImmutableMap<String, String> combinedExecProperties,
       boolean isBuiltForToolConfiguration) {
     this.mnemonic = mnemonic;
     this.progressMessage = progressMessage;
@@ -62,7 +62,7 @@ public class FakeOwner implements ActionExecutionMetadata {
     this.ownerRuleKind = checkNotNull(ownerRuleKind);
     this.primaryOutput = primaryOutput;
     this.platform = platform;
-    this.execProperties = execProperties;
+    this.combinedExecProperties = combinedExecProperties;
     this.isBuiltForToolConfiguration = isBuiltForToolConfiguration;
   }
 
@@ -97,7 +97,7 @@ public class FakeOwner implements ActionExecutionMetadata {
         /* isToolConfiguration= */ isBuiltForToolConfiguration,
         /* executionPlatform= */ null,
         /* aspectDescriptors= */ ImmutableList.of(),
-        /* execProperties= */ ImmutableMap.of());
+        /* execProperties= */ combinedExecProperties);
   }
 
   @Override
@@ -205,7 +205,7 @@ public class FakeOwner implements ActionExecutionMetadata {
 
   @Override
   public ImmutableMap<String, String> getExecProperties() {
-    return execProperties;
+    return ImmutableMap.of();
   }
 
   @Nullable

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -139,7 +139,7 @@ public final class SpawnBuilder {
   }
 
   @CanIgnoreReturnValue
-  public SpawnBuilder withExecProperties(ImmutableMap<String, String> execProperties) {
+  public SpawnBuilder withCombinedExecProperties(ImmutableMap<String, String> execProperties) {
     this.execProperties = execProperties;
     return this;
   }


### PR DESCRIPTION
`SimpleSpawn` returned the exec properties of the action owning the spawn, while `BaseSpawn` returned the exec properties of the exec group owning the action that owns the spawn. The latter contains the `exec_properties` set on the target or exec platform, whereas the former is entirely specified by the action.