### PR TITLE
Fix potential race in `Spawn#getLocalResources()`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/BaseSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/BaseSpawn.java
@@ -33,7 +33,7 @@ public class BaseSpawn implements Spawn {
   private final ImmutableMap<String, String> executionInfo;
   private final ActionExecutionMetadata action;
   private final ResourceSetOrBuilder localResources;
-  private ResourceSet localResourcesCached = null;
+  @Nullable private ResourceSet localResourcesCached;
 
   public BaseSpawn(
       List<String> arguments,
@@ -92,13 +92,15 @@ public class BaseSpawn implements Spawn {
 
   @Override
   public ResourceSet getLocalResources() throws ExecException {
-    if (localResourcesCached == null) {
+    ResourceSet result = localResourcesCached;
+    if (result == null) {
       // Not expected to be called concurrently, and an idempotent computation if it is.
-      localResourcesCached =
+      result =
           localResources.buildResourceSet(
               OS.getCurrent(), action.getInputs().memoizedFlattenAndGetSize());
+      localResourcesCached = result;
     }
-    return localResourcesCached;
+    return result;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
@@ -43,7 +43,7 @@ public final class SimpleSpawn implements Spawn {
   @Nullable private final Set<? extends ActionInput> mandatoryOutputs;
   private final PathMapper pathMapper;
   private final LocalResourcesSupplier localResourcesSupplier;
-  private ResourceSet localResourcesCached;
+  @Nullable private ResourceSet localResourcesCached;
 
   private SimpleSpawn(
       ActionExecutionMetadata owner,
@@ -278,11 +278,13 @@ public final class SimpleSpawn implements Spawn {
 
   @Override
   public ResourceSet getLocalResources() throws ExecException {
-    if (localResourcesCached == null) {
+    ResourceSet result = localResourcesCached;
+    if (result == null) {
       // Not expected to be called concurrently, and an idempotent computation if it is.
-      localResourcesCached = localResourcesSupplier.get();
+      result = localResourcesSupplier.get();
+      localResourcesCached = result;
     }
-    return localResourcesCached;
+    return result;
   }
 
   @Override


### PR DESCRIPTION
Both implementations performed two reads of the nullable instance variable, which could be reordered so that the first read returns a non-null value and the second read returns null.