### PR TITLE
Emit spawn runner with `--subcommands`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -455,7 +455,7 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
    * Report a subcommand event to this Executor's Reporter and, if action
    * logging is enabled, post it on its EventBus.
    */
-  public void maybeReportSubcommand(Spawn spawn) {
+  public void maybeReportSubcommand(Spawn spawn, @Nullable String spawnRunner) {
     ShowSubcommands showSubcommands = executor.reportsSubcommands();
     if (!showSubcommands.shouldShowSubcommands) {
       return;
@@ -492,7 +492,8 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
             /* environmentVariablesToClear= */ null,
             getExecRoot().getPathString(),
             spawn.getConfigurationChecksum(),
-            spawn.getExecutionPlatformLabel());
+            spawn.getExecutionPlatformLabel(),
+            spawnRunner);
     getEventHandler().handle(Event.of(EventKind.SUBCOMMAND, null, "# " + reason + "\n" + message));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -124,7 +124,7 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
       ActionExecutionContext actionExecutionContext,
       @Nullable SandboxedSpawnStrategy.StopConcurrentSpawns stopConcurrentSpawns)
       throws ExecException, InterruptedException {
-    actionExecutionContext.maybeReportSubcommand(spawn);
+    actionExecutionContext.maybeReportSubcommand(spawn, spawnRunner.getName());
 
     final Duration timeout = Spawns.getTimeout(spawn);
     SpawnExecutionContext context =

--- a/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
@@ -386,7 +386,7 @@ public class SpawnIncludeScanner {
             outputs,
             LOCAL_RESOURCES);
 
-    actionExecutionContext.maybeReportSubcommand(spawn);
+    actionExecutionContext.maybeReportSubcommand(spawn, /* spawnRunner= */ null);
 
     // Don't share the originalOutErr across spawnGrep calls. Doing so would not be thread-safe.
     FileOutErr originalOutErr = actionExecutionContext.getFileOutErr();

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -265,7 +265,8 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
                   action.getOwner().getConfigurationChecksum(),
                   action.getExecutionPlatform() != null
                       ? action.getExecutionPlatform().label()
-                      : null))
+                      : null,
+                  /* spawnRunner= */ null))
           .append("\n");
     }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -152,6 +152,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
                 /* environmentVariablesToClear= */ null,
                 /* cwd= */ null,
                 /* configurationChecksum= */ null,
-                /* executionPlatformLabel= */ null));
+                /* executionPlatformLabel= */ null,
+                /* spawnRunner= */ null));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
@@ -49,7 +49,8 @@ public class CommandFailureUtils {
       @Nullable List<String> environmentVariablesToClear,
       @Nullable String cwd,
       @Nullable String configurationChecksum,
-      @Nullable Label executionPlatformLabel) {
+      @Nullable Label executionPlatformLabel,
+      @Nullable String spawnRunner) {
 
     Preconditions.checkNotNull(form);
     StringBuilder message = new StringBuilder();
@@ -134,6 +135,11 @@ public class CommandFailureUtils {
         message.append("\n");
         message.append("# Execution platform: ").append(executionPlatformLabel);
       }
+
+      if (spawnRunner != null) {
+        message.append("\n");
+        message.append("# Runner: ").append(spawnRunner);
+      }
     }
 
     return message.toString();
@@ -152,7 +158,8 @@ public class CommandFailureUtils {
       @Nullable String cwd,
       @Nullable String configurationChecksum,
       @Nullable String targetDescription,
-      @Nullable Label executionPlatformLabel) {
+      @Nullable Label executionPlatformLabel,
+      @Nullable String spawnRunner) {
 
     String commandName = commandLineElements.iterator().next();
     // Extract the part of the command name after the last "/", if any.
@@ -181,7 +188,8 @@ public class CommandFailureUtils {
             null,
             cwd,
             configurationChecksum,
-            executionPlatformLabel));
+            executionPlatformLabel,
+            spawnRunner));
     return shortCommandName + " failed: " + output;
   }
 
@@ -195,6 +203,7 @@ public class CommandFailureUtils {
         cwd,
         command.getConfigurationChecksum(),
         command.getTargetDescription(),
-        command.getExecutionPlatformLabel());
+        command.getExecutionPlatformLabel(),
+        /* spawnRunner= */ null);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
@@ -234,6 +234,7 @@ public final class WorkerKey {
         /* environmentVariablesToClear= */ null,
         execRoot.getPathString(),
         /* configurationChecksum= */ null,
-        /* executionPlatformLabel= */ null);
+        /* executionPlatformLabel= */ null,
+        /* spawnRunner= */ getWorkerTypeName());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/util/CommandFailureUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/CommandFailureUtilsTest.java
@@ -51,7 +51,8 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            "local");
     assertThat(message)
         .isEqualTo(
             "sh failed: error executing Mnemonic command (from target //foo:bar) "
@@ -80,16 +81,19 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            "local");
     assertThat(message)
         .isEqualTo(
-            "sh failed: error executing Mnemonic command (from target //foo:bar) \n"
-                + "  (exec env - \\\n"
-                + "    FOO=foo \\\n"
-                + "    PATH=/usr/bin:/bin:/sbin \\\n"
-                + "  /bin/sh -c 'echo Some errors 1>&2; echo Some output; exit 42')\n"
-                + "# Configuration: cfg12345\n"
-                + "# Execution platform: //platform:exec");
+            """
+                sh failed: error executing Mnemonic command (from target //foo:bar)\s
+                  (exec env - \\
+                    FOO=foo \\
+                    PATH=/usr/bin:/bin:/sbin \\
+                  /bin/sh -c 'echo Some errors 1>&2; echo Some output; exit 42')
+                # Configuration: cfg12345
+                # Execution platform: //platform:exec
+                # Runner: local""");
   }
 
   @Test
@@ -117,7 +121,8 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            "local");
     assertThat(message)
         .isEqualTo(
             "some_command failed: error executing Mnemonic command (from target //foo:bar) "
@@ -153,21 +158,24 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            "local");
     assertThat(message)
         .isEqualTo(
-            "some_command failed: error executing Mnemonic command (from target //foo:bar) \n"
-                + "  (cd /my/working/directory && \\\n"
-                + "  exec env - \\\n"
-                + "    FOO=foo \\\n"
-                + "    PATH=/usr/bin:/bin:/sbin \\\n"
-                + "  some_command arg1 arg2 arg3 arg4 arg5 arg6 'with spaces' arg8 '*' arg10 "
-                + "arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 "
-                + "arg19 arg20 arg21 arg22 arg23 arg24 arg25 arg26 "
-                + "arg27 arg28 arg29 arg30 arg31 arg32 arg33 arg34 "
-                + "arg35 arg36 arg37 arg38 arg39)\n"
-                + "# Configuration: cfg12345\n"
-                + "# Execution platform: //platform:exec");
+            """
+                some_command failed: error executing Mnemonic command (from target //foo:bar)\s
+                  (cd /my/working/directory && \\
+                  exec env - \\
+                    FOO=foo \\
+                    PATH=/usr/bin:/bin:/sbin \\
+                  some_command arg1 arg2 arg3 arg4 arg5 arg6 'with spaces' arg8 '*' arg10 \
+                arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 \
+                arg19 arg20 arg21 arg22 arg23 arg24 arg25 arg26 \
+                arg27 arg28 arg29 arg30 arg31 arg32 arg33 arg34 \
+                arg35 arg36 arg37 arg38 arg39)
+                # Configuration: cfg12345
+                # Execution platform: //platform:exec
+                # Runner: local""");
   }
 
   @Test
@@ -191,7 +199,8 @@ public class CommandFailureUtilsTest {
             cwd,
             "cfg12345",
             "target " + target,
-            executionPlatform.label());
+            executionPlatform.label(),
+            "local");
     assertThat(message)
         .isEqualTo(
             "some_command failed: error executing Mnemonic command (from target //foo:bar)"
@@ -230,23 +239,26 @@ public class CommandFailureUtilsTest {
             envToClear,
             cwd,
             "cfg12345",
-            executionPlatform.label());
+            executionPlatform.label(),
+            "remote");
 
     assertThat(message)
         .isEqualTo(
-            "(cd /my/working/directory && \\\n"
-                + "  exec env - \\\n"
-                + "    -u CLEAR \\\n"
-                + "    -u THIS \\\n"
-                + "    FOO=foo \\\n"
-                + "    PATH=/usr/bin:/bin:/sbin \\\n"
-                + "  some_command \\\n"
-                + "    arg1 \\\n"
-                + "    arg2 \\\n"
-                + "    'with spaces' \\\n"
-                + "    '*' \\\n"
-                + "    arg5)\n"
-                + "# Configuration: cfg12345\n"
-                + "# Execution platform: //platform:exec");
+            """
+                (cd /my/working/directory && \\
+                  exec env - \\
+                    -u CLEAR \\
+                    -u THIS \\
+                    FOO=foo \\
+                    PATH=/usr/bin:/bin:/sbin \\
+                  some_command \\
+                    arg1 \\
+                    arg2 \\
+                    'with spaces' \\
+                    '*' \\
+                    arg5)
+                # Configuration: cfg12345
+                # Execution platform: //platform:exec
+                # Runner: remote""");
   }
 }


### PR DESCRIPTION
This makes it easier to tell whether a given spawn ran remotely or sandboxed, which is especially important for test actions (which run multiple spawns).