### PR TITLE
[8.1.0] Do not fall back to interpreting a %workspace% placeholder literally if resolution fails, even for try-import.

### DIFF
--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -13,21 +13,22 @@
 // limitations under the License.
 
 #include "src/main/cpp/option_processor.h"
-#include "src/main/cpp/option_processor-internal.h"
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+
 #include <algorithm>
 #include <cassert>
 #include <iterator>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <utility>
 
 #include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/blaze_util_platform.h"
-#include "src/main/cpp/util/file.h"
+#include "src/main/cpp/option_processor-internal.h"
+#include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/logging.h"
 #include "src/main/cpp/util/path.h"
 #include "src/main/cpp/util/path_platform.h"
@@ -51,7 +52,6 @@ using std::set;
 using std::string;
 using std::vector;
 
-constexpr char WorkspaceLayout::WorkspacePrefix[];
 static constexpr const char* kRcBasename = ".bazelrc";
 
 OptionProcessor::OptionProcessor(

--- a/src/main/cpp/workspace_layout.cc
+++ b/src/main/cpp/workspace_layout.cc
@@ -16,20 +16,22 @@
 
 #include <assert.h>
 
+#include <optional>
+#include <string>
+#include <vector>
+
 #include "src/main/cpp/blaze_util_platform.h"
-#include "src/main/cpp/util/file.h"
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/path.h"
 #include "src/main/cpp/util/path_platform.h"
+#include "absl/strings/match.h"
 
 namespace blaze {
 
 using std::string;
 using std::vector;
 
-string WorkspaceLayout::GetOutputRoot() const {
-  return blaze::GetOutputRoot();
-}
+string WorkspaceLayout::GetOutputRoot() const { return blaze::GetOutputRoot(); }
 
 bool WorkspaceLayout::InWorkspace(const string &workspace) const {
   for (auto boundaryFileName :
@@ -56,7 +58,7 @@ string WorkspaceLayout::GetWorkspace(const string &cwd) const {
 }
 
 string WorkspaceLayout::GetPrettyWorkspaceName(
-    const std::string& workspace) const {
+    const std::string &workspace) const {
   // e.g. A Bazel server process running in ~/src/myproject (where there's a
   // ~/src/myproject/WORKSPACE file) will appear in ps(1) as "bazel(myproject)".
   return blaze_util::Basename(workspace);
@@ -71,15 +73,17 @@ std::string WorkspaceLayout::GetWorkspaceRcPath(
   return blaze_util::JoinPath(workspace, "tools/bazel.rc");
 }
 
-bool WorkspaceLayout::WorkspaceRelativizeRcFilePath(const string &workspace,
-                                                    string *path_fragment)
-    const {
+std::optional<std::string> WorkspaceLayout::ResolveWorkspaceRelativeRcFilePath(
+    const string &workspace, const string &import_path) const {
   // Strip off the "%workspace%/" prefix and prepend the true workspace path.
   // In theory this could use alternate search paths for blazerc files.
-  path_fragment->assign(
-      blaze_util::JoinPath(workspace,
-                           path_fragment->substr(WorkspacePrefixLength)));
-  return true;
+  assert(absl::StartsWith(import_path, kWorkspacePrefix));
+  string resolved_path = blaze_util::JoinPath(
+      workspace, import_path.substr(kWorkspacePrefixLength));
+  if (blaze_util::PathExists(resolved_path)) {
+    return resolved_path;
+  }
+  return std::nullopt;
 }
 
 }  // namespace blaze

--- a/src/main/cpp/workspace_layout.h
+++ b/src/main/cpp/workspace_layout.h
@@ -15,6 +15,7 @@
 #ifndef BAZEL_SRC_MAIN_CPP_WORKSPACE_LAYOUT_H_
 #define BAZEL_SRC_MAIN_CPP_WORKSPACE_LAYOUT_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -54,15 +55,13 @@ class WorkspaceLayout {
       const std::string& workspace,
       const std::vector<std::string>& startup_args) const;
 
-  // Turn a %workspace%-relative import into its true name in the filesystem.
-  // path_fragment is modified in place.
-  // Unlike FindCandidateBlazercPaths, it is an error if no import file
-  // exists.
-  virtual bool WorkspaceRelativizeRcFilePath(const std::string& workspace,
-                                             std::string* path_fragment) const;
+  // Resolves a %workspace%-relative import into an actual path.
+  // Returns nullopt if it could not be resolved into an existing file.
+  virtual std::optional<std::string> ResolveWorkspaceRelativeRcFilePath(
+      const std::string& workspace, const std::string& import_path) const;
 
-  static constexpr const char WorkspacePrefix[] = "%workspace%/";
-  static const int WorkspacePrefixLength = sizeof WorkspacePrefix - 1;
+  static constexpr const char kWorkspacePrefix[] = "%workspace%/";
+  static constexpr int kWorkspacePrefixLength = sizeof kWorkspacePrefix - 1;
 };
 
 }  // namespace blaze

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -19,15 +19,15 @@
 #include <windows.h>
 #endif
 
-#include "src/main/cpp/rc_file.h"
-
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "src/main/cpp/bazel_startup_options.h"
-#include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/blaze_util_platform.h"
 #include "src/main/cpp/option_processor-internal.h"
 #include "src/main/cpp/option_processor.h"
+#include "src/main/cpp/rc_file.h"
 #include "src/main/cpp/util/file.h"
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/path.h"
@@ -817,10 +817,51 @@ TEST_F(BlazercImportTest, BazelRcTryImportDoesNotFailForUnreadableFile) {
   const std::string unreadable_rc_path =
       blaze_util::JoinPath(workspace_, "tryimported.bazelrc");
   ASSERT_TRUE(blaze_util::WriteFile("startup --max_idle_secs=123",
-                                    unreadable_rc_path, 222));
+                                    unreadable_rc_path, 0222));
   std::string workspace_rc;
   ASSERT_TRUE(
       SetUpWorkspaceRcFile("try-import " + unreadable_rc_path, &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
+}
+
+TEST_F(BlazercImportTest, BazelRcImportDoesNotFallBackToLiteralPlaceholder) {
+  // Check that we don't fall back to interpreting the %workspace% placeholder
+  // literally if an import statement cannot be resolved against it.
+
+  const std::string literal_placeholder_rc_path =
+      blaze_util::JoinPath(cwd_, "%workspace%/tryimported.bazelrc");
+  ASSERT_TRUE(blaze_util::MakeDirectories(
+      blaze_util::Dirname(literal_placeholder_rc_path), 0755));
+  ASSERT_TRUE(blaze_util::WriteFile("import syntax error",
+                                    literal_placeholder_rc_path, 0755));
+
+  std::string workspace_rc;
+  ASSERT_TRUE(SetUpWorkspaceRcFile("import %workspace%/tryimported.bazelrc",
+                                   &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::BAD_ARGV,
+                             "Nonexistent path in import declaration in config "
+                             "file.*'import %workspace%/tryimported.bazelrc'",
+                             "");
+}
+
+TEST_F(BlazercImportTest, BazelRcTryImportDoesNotFallBackToLiteralPlaceholder) {
+  // Check that we don't fall back to interpreting the %workspace% placeholder
+  // literally if a try-import statement cannot be resolved against it.
+
+  const std::string literal_placeholder_rc_path =
+      blaze_util::JoinPath(cwd_, "%workspace%/tryimported.bazelrc");
+  ASSERT_TRUE(blaze_util::MakeDirectories(
+      blaze_util::Dirname(literal_placeholder_rc_path), 0755));
+  ASSERT_TRUE(blaze_util::WriteFile("import syntax error",
+                                    literal_placeholder_rc_path, 0755));
+
+  std::string workspace_rc;
+  ASSERT_TRUE(SetUpWorkspaceRcFile("try-import %workspace%/tryimported.bazelrc",
+                                   &workspace_rc));
 
   const std::vector<std::string> args = {"bazel", "build"};
   ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");


### PR DESCRIPTION
PiperOrigin-RevId: 699910973
Change-Id: I12072b521fcbee6f7f9aa0274ecaf10eb769f715