### PR TITLE
[8.1.0] Remove no-op `--block_for_lock` command option

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -458,17 +458,6 @@ public class CommonCommandOptions extends OptionsBase {
       help = "Enable processing of +<file> parameters.")
   public boolean allowProjectFiles;
 
-  @Option(
-      name = "block_for_lock",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
-      metadataTags = {OptionMetadataTag.HIDDEN},
-      help =
-          "If set (the default), a command will block if there is another one running. If "
-              + "unset, these commands will immediately return with an error.")
-  public boolean blockForLock;
-
   // We could accept multiple of these, in the event where there's a chain of tools that led to a
   // Bazel invocation. We would not want to expect anything from the order of these, and would need
   // to guarantee that the "label" for each command line is unique. Unless a need is demonstrated,


### PR DESCRIPTION
This option, which is different from the startup option of the same name, has no effect and doesn't even show a warning, which can be confusing.

Closes #24953.

PiperOrigin-RevId: 717853503
Change-Id: I8d7d1229f692007c4350b6c15526b7a95bbed5ef

Commit https://github.com/bazelbuild/bazel/commit/79508becbb9195dc59e24b9aa3dbaf880c209e2e