### PR TITLE
[8.1.0] sh_toolchain: Fix broken alias

### DIFF
--- a/tools/sh/sh_toolchain.bzl
+++ b/tools/sh/sh_toolchain.bzl
@@ -13,6 +13,6 @@
 # limitations under the License.
 """Deprecated forwarders to rules_shell."""
 
-load("@rules_shell//shell:sh_toolchain.bzl", _sh_toolchain = "sh_toolchain")
+load("@rules_shell//shell/toolchains:sh_toolchain.bzl", _sh_toolchain = "sh_toolchain")
 
 sh_toolchain = _sh_toolchain


### PR DESCRIPTION
Closes #24961.

PiperOrigin-RevId: 717997981
Change-Id: I1b80bb9cb483a1c2e2ad53f983ebae050b1c5fd4

Commit https://github.com/bazelbuild/bazel/commit/aa2e431415ff513f148b27a006ec7068d596681e