### PR TITLE
[8.1.0] Fix File.is_symlink doc to correctly say it tells if it's a symlink.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/FileApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/FileApi.java
@@ -100,9 +100,9 @@ public interface FileApi extends StarlarkValue {
       name = "is_symlink",
       structField = true,
       doc =
-          "Returns true if this is a directory. This reflects the type the file was declared as"
-              + " (i.e. ctx.actions.declare_symlink), not its type on the filesystem, which might"
-              + " differ.")
+          "Returns true if this was declared as a symlink. This reflects the type the file was"
+              + " declared as (i.e. ctx.actions.declare_symlink), not its type on the filesystem,"
+              + " which might differ.")
   boolean isSymlink();
 
   @StarlarkMethod(


### PR DESCRIPTION
The previous doc say it told if it was a directory; probably a copy/paste mistake.

PiperOrigin-RevId: 714089602
Change-Id: Ib6f6bee762afdd41f7249f120f4f95a088a3ccef

Commit https://github.com/bazelbuild/bazel/commit/b69cba6807f5753435a7ccf61695ca371b1a790c