### PR TITLE
[8.1.0] Update coverage output generator to coverage_output_generator-v2.7.

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_starlark_test.sh
@@ -380,10 +380,7 @@ DA:1,1
 DA:2,0
 LH:1
 LF:2
-end_of_record"
-    # TODO: Remove this check after the next release of the coverage generator.
-    if [[ "${COVERAGE_GENERATOR_WORKSPACE_FILE}" != "released" ]]; then
-      expected_coverage="$expected_coverage
+end_of_record
 SF:test/untested_1.txt
 FNF:0
 FNH:0
@@ -396,7 +393,7 @@ FNH:0
 LH:0
 LF:0
 end_of_record"
-    fi
+
     assert_coverage_result "$expected_coverage" bazel-out/_coverage/_coverage_report.dat
 }
 

--- a/tools/test/extensions.bzl
+++ b/tools/test/extensions.bzl
@@ -19,9 +19,9 @@ load("//tools/build_defs/repo:http.bzl", "http_archive")
 def _remote_coverage_tools_extension_impl(ctx):
     http_archive(
         name = "remote_coverage_tools",
-        sha256 = "7006375f6756819b7013ca875eab70a541cf7d89142d9c511ed78ea4fefa38af",
+        sha256 = "69fa4fdd887295e5a45e592352ad00ef6afa6a435d13e3f38f6ed338ded85dfd",
         urls = [
-            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip",
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.7.zip",
         ],
     )
     return ctx.extension_metadata(reproducible = True)

--- a/workspace_deps.bzl
+++ b/workspace_deps.bzl
@@ -69,9 +69,9 @@ WORKSPACE_REPOS = {
         "urls": ["https://github.com/bazelbuild/rules_testing/releases/download/v0.6.0/rules_testing-v0.6.0.tar.gz"],
     },
     "remote_coverage_tools": {
-        "archive": "coverage_output_generator-v2.6.zip",
-        "sha256": "7006375f6756819b7013ca875eab70a541cf7d89142d9c511ed78ea4fefa38af",
-        "urls": ["https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"],
+        "archive": "coverage_output_generator-v2.7.zip",
+        "sha256": "69fa4fdd887295e5a45e592352ad00ef6afa6a435d13e3f38f6ed338ded85dfd",
+        "urls": ["https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.7.zip"],
     },
 }
 


### PR DESCRIPTION
Built at commit 82c1ff79.

Relevant changes:
 * Log level for many messages changed from INFO to FINE (#22257).
 * IOExceptions are no longer ignored (#21987).
 * Baseline coverage files are not ignored (#24563).

RELNOTES: Baseline coverage files are no longer ignored.

Closes #24593.

PiperOrigin-RevId: 705492845
Change-Id: I6f7b99ec0f040f93cc148c9c8448d4395729adac

Commit https://github.com/bazelbuild/bazel/commit/6cd487048a69fc6a90707d5cce15b47e00d230a8