### PR TITLE
[8.1.0] Remove the comments indicating which symbols make each include necessary.

### DIFF
--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -25,13 +25,13 @@
 # define DEFAULT_SYSTEM_JAVABASE STANDARD_JAVABASE
 #endif
 
-#include <errno.h>  // errno, ENAMETOOLONG
+#include <errno.h>
 #include <limits.h>
 #include <pwd.h>
 #include <signal.h>
 #include <spawn.h>
 #include <stdlib.h>
-#include <string.h>  // strerror
+#include <string.h>
 #include <sys/mount.h>
 #include <sys/param.h>
 #include <sys/queue.h>

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <errno.h>  // errno, ENAMETOOLONG
+#include <errno.h>
 #include <limits.h>
 #include <linux/magic.h>
 #include <pwd.h>
@@ -20,7 +20,7 @@
 #include <spawn.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>  // strerror
+#include <string.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 #define _WITH_DPRINTF
-#include "src/main/cpp/blaze_util_platform.h"
-
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <limits.h>  // PATH_MAX
+#include <limits.h>
 #include <poll.h>
 #include <pwd.h>
 #include <signal.h>
@@ -38,7 +36,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cinttypes>
 #include <cstdlib>
 #include <fstream>
 #include <iterator>
@@ -50,6 +47,7 @@
 #include <vector>
 
 #include "src/main/cpp/blaze_util.h"
+#include "src/main/cpp/blaze_util_platform.h"
 #include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/util/errors.h"
 #include "src/main/cpp/util/exit_code.h"

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -18,12 +18,12 @@
 // clang-format on
 
 #include <fcntl.h>
-#include <io.h>            // _open
-#include <knownfolders.h>  // FOLDERID_Profile
-#include <lmcons.h>        // UNLEN
-#include <objbase.h>       // CoTaskMemFree
-#include <shlobj.h>        // SHGetKnownFolderPath
-#include <stdarg.h>        // va_start, va_end, va_list
+#include <io.h>
+#include <knownfolders.h>
+#include <lmcons.h>
+#include <objbase.h>
+#include <shlobj.h>
+#include <stdarg.h>
 
 #include <algorithm>
 #include <cstdio>

--- a/src/main/cpp/util/errors_posix.cc
+++ b/src/main/cpp/util/errors_posix.cc
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include <errno.h>
-#include <string.h>  // strerror
+#include <string.h>
+
 #include <sstream>
 #include <string>
+
 #include "src/main/cpp/util/errors.h"
 
 namespace blaze_util {

--- a/src/main/cpp/util/file.cc
+++ b/src/main/cpp/util/file.cc
@@ -14,7 +14,7 @@
 
 #include "src/main/cpp/util/file.h"
 
-#include <limits.h>  // PATH_MAX
+#include <limits.h>
 
 #include <algorithm>
 #include <cstdlib>

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <dirent.h>  // DIR, dirent, opendir, closedir
+#include <dirent.h>
 #include <errno.h>
-#include <fcntl.h>   // O_RDONLY
-#include <limits.h>  // PATH_MAX
-#include <stdlib.h>  // getenv
-#include <string.h>  // strncmp
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <time.h>
-#include <unistd.h>  // access, open, close, fsync
-#include <utime.h>   // utime
+#include <unistd.h>
+#include <utime.h>
 
 #include <string>
 

--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -14,11 +14,11 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <wchar.h>   // wcslen
-#include <wctype.h>  // iswalpha
+#include <wchar.h>
+#include <wctype.h>
 #include <windows.h>
 
-#include <memory>  // unique_ptr
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/main/cpp/util/md5.cc
+++ b/src/main/cpp/util/md5.cc
@@ -39,10 +39,9 @@
 
 #include "src/main/cpp/util/md5.h"
 
-#include <stddef.h>  // for offsetof
-#include <string.h>  // for memcpy
-
-#include <cinttypes>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 #if !_STRING_ARCH_unaligned
 #if defined(_LP64) || defined(_WIN64)

--- a/src/main/cpp/util/numbers.cc
+++ b/src/main/cpp/util/numbers.cc
@@ -13,10 +13,11 @@
 // limitations under the License.
 #include "src/main/cpp/util/numbers.h"
 
-#include <errno.h>  // errno, ERANGE
+#include <errno.h>
 #include <limits.h>
+#include <stdint.h>
+
 #include <cassert>
-#include <cinttypes>
 #include <cstdlib>
 #include <limits>
 

--- a/src/main/cpp/util/path_posix.cc
+++ b/src/main/cpp/util/path_posix.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <limits.h>  // PATH_MAX
-#include <stdlib.h>  // getenv
-#include <string.h>  // strncmp
-#include <unistd.h>  // access, open, close, fsync
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include <vector>
 

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -16,14 +16,12 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
-#include "src/main/cpp/util/path_platform.h"
-
 #include <assert.h>
-#include <wchar.h>  // wcslen
+#include <wchar.h>
 #include <windows.h>
 
 #include <algorithm>
-#include <memory>  // unique_ptr
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -31,6 +29,7 @@
 #include "src/main/cpp/util/exit_code.h"
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/logging.h"
+#include "src/main/cpp/util/path_platform.h"
 #include "src/main/cpp/util/strings.h"
 #include "src/main/native/windows/file.h"
 

--- a/src/main/cpp/util/strings.cc
+++ b/src/main/cpp/util/strings.cc
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 
 #include <cassert>
-#include <memory>  // unique_ptr
+#include <memory>
 
 #include "src/main/cpp/util/exit_code.h"
 

--- a/src/main/cpp/util/strings.h
+++ b/src/main/cpp/util/strings.h
@@ -14,7 +14,6 @@
 #ifndef BAZEL_SRC_MAIN_CPP_UTIL_STRINGS_H_
 #define BAZEL_SRC_MAIN_CPP_UTIL_STRINGS_H_
 
-#include <memory>  // unique_ptr
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
We don't do this consistently, and where we do it, the comments tend to get out of sync with the code over time, anyway.

PiperOrigin-RevId: 691793914
Change-Id: I48fedb727ab27a9c95c1972bf3fb6bac593337c8