### PR TITLE
[8.1.0] Use blaze_util::Path instead of std::string in more places.

### DIFF
--- a/src/main/cpp/archive_utils.cc
+++ b/src/main/cpp/archive_utils.cc
@@ -29,7 +29,7 @@
 #include "src/main/cpp/util/file.h"
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/logging.h"
-#include "src/main/cpp/util/path.h"
+#include "src/main/cpp/util/path_platform.h"
 #include "third_party/ijar/zip.h"
 
 namespace blaze {
@@ -116,12 +116,13 @@ std::optional<DurationMillis> ExtractData(
     const string &self_path, const vector<string> &archive_contents,
     const string &expected_install_md5, const StartupOptions &startup_options,
     LoggingInfo *logging_info) {
-  const string &install_base = startup_options.install_base;
+  const blaze_util::Path &install_base = startup_options.install_base;
   // If the install dir doesn't exist, create it, if it does, we know it's good.
   if (!blaze_util::PathExists(install_base)) {
     uint64_t st = GetMillisecondsMonotonic();
-    // Work in a temp dir to avoid races.
-    string tmp_install = blaze_util::CreateTempDir(install_base + ".tmp.");
+    // Work in a sibling temporary directory to avoid races.
+    blaze_util::Path tmp_install =
+        blaze_util::CreateSiblingTempDir(install_base);
     ExtractArchiveOrDie(self_path, startup_options.product_name,
                         expected_install_md5, tmp_install);
     BlessFiles(tmp_install);
@@ -144,7 +145,8 @@ std::optional<DurationMillis> ExtractData(
         // (in case we're running on Windows) so we need to wait for that to
         // finish and try renaming again.
         ++attempts;
-        BAZEL_LOG(USER) << "install base directory '" << tmp_install
+        BAZEL_LOG(USER) << "install base directory '"
+                        << tmp_install.AsPrintablePath()
                         << "' could not be renamed into place after "
                         << attempts << " second(s), trying again\r";
         std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -155,7 +157,7 @@ std::optional<DurationMillis> ExtractData(
     if (attempts == 120) {
       blaze_util::RemoveRecursively(tmp_install);
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-          << "install base directory '" << tmp_install
+          << "install base directory '" << tmp_install.AsPrintablePath()
           << "' could not be renamed into place: "
           << blaze_util::GetLastErrorString();
     }
@@ -165,7 +167,7 @@ std::optional<DurationMillis> ExtractData(
     // us give a better error message.
     if (!blaze_util::IsDirectory(install_base)) {
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-          << "install base directory '" << install_base
+          << "install base directory '" << install_base.AsPrintablePath()
           << "' could not be created. It exists but is not a directory.";
     }
     blaze_util::Path install_dir(install_base);
@@ -175,8 +177,8 @@ std::optional<DurationMillis> ExtractData(
       if (!IsUntampered(path)) {
         BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
             << "corrupt installation: file '" << path.AsPrintablePath()
-            << "' is missing or modified.  Please remove '" << install_base
-            << "' and try again.";
+            << "' is missing or modified.  Please remove '"
+            << install_base.AsPrintablePath() << "' and try again.";
       }
     }
     // Also check that the installed files claim to match this binary.
@@ -191,7 +193,7 @@ std::optional<DurationMillis> ExtractData(
     }
     if (on_disk_key != expected_install_md5) {
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-          << "The install_base directory '" << install_base
+          << "The install_base directory '" << install_base.AsPrintablePath()
           << "' contains a different " << startup_options.product_name
           << " version (found " << on_disk_key << " but this binary is "
           << expected_install_md5
@@ -209,7 +211,7 @@ void DetermineArchiveContents(const string &archive_path, vector<string> *files,
 
 void ExtractArchiveOrDie(const string &archive_path, const string &product_name,
                          const string &expected_install_md5,
-                         const string &output_dir) {
+                         const blaze_util::Path &output_dir) {
   string error;
   std::unique_ptr<blaze::embedded_binaries::Dumper> dumper(
       blaze::embedded_binaries::Create(&error));
@@ -219,17 +221,18 @@ void ExtractArchiveOrDie(const string &archive_path, const string &product_name,
 
   if (!blaze_util::PathExists(output_dir)) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
-        << "Archive output directory didn't exist: " << output_dir;
+        << "Archive output directory didn't exist: "
+        << output_dir.AsPrintablePath();
   }
 
   BAZEL_LOG(USER) << "Extracting " << product_name << " installation...";
 
   PartialZipExtractor pze;
-  string install_md5 = pze.UnzipUntil(
-      archive_path, "install_base_key", nullptr,
-      [&](const char *name, const char *data, size_t size) {
-        dumper->Dump(data, size, blaze_util::JoinPath(output_dir, name));
-      });
+  string install_md5 =
+      pze.UnzipUntil(archive_path, "install_base_key", nullptr,
+                     [&](const char *name, const char *data, size_t size) {
+                       dumper->Dump(data, size, output_dir.GetRelative(name));
+                     });
 
   if (!dumper->Finish(&error)) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
@@ -248,22 +251,17 @@ void ExtractArchiveOrDie(const string &archive_path, const string &product_name,
   }
 }
 
-void BlessFiles(const string &embedded_binaries) {
-  blaze_util::Path embedded_binaries_(embedded_binaries);
-
+void BlessFiles(const blaze_util::Path &embedded_binaries) {
   // Set the timestamps of the extracted files to the future and make sure (or
   // at least as sure as we can...) that the files we have written are actually
   // on the disk.
-
-  vector<string> extracted_files;
+  vector<blaze_util::Path> extracted_files;
 
   // Walks the temporary directory recursively and collects full file paths.
   blaze_util::GetAllFilesUnder(embedded_binaries, &extracted_files);
 
   set<blaze_util::Path> synced_directories;
-  for (const auto &f : extracted_files) {
-    blaze_util::Path it(f);
-
+  for (const auto &file : extracted_files) {
     // Set the time to a distantly futuristic value so we can observe tampering.
     // Note that keeping a static, deterministic timestamp, such as the default
     // timestamp set by unzip (1970-01-01) and using that to detect tampering is
@@ -271,16 +269,16 @@ void BlessFiles(const string &embedded_binaries) {
     // releases so that the metadata cache knows that the files may have
     // changed. This is essential for the correctness of actions that use
     // embedded binaries as artifacts.
-    if (!SetMtimeToDistantFuture(it)) {
+    if (!SetMtimeToDistantFuture(file)) {
       string err = blaze_util::GetLastErrorString();
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-          << "failed to set timestamp on '" << it.AsPrintablePath()
+          << "failed to set timestamp on '" << file.AsPrintablePath()
           << "': " << err;
     }
 
-    blaze_util::SyncFile(it);
+    blaze_util::SyncFile(file);
 
-    blaze_util::Path directory = it.GetParent();
+    blaze_util::Path directory = file.GetParent();
 
     // Now walk up until embedded_binaries and sync every directory in between.
     // synced_directories is used to avoid syncing the same directory twice.
@@ -288,7 +286,7 @@ void BlessFiles(const string &embedded_binaries) {
     // conditions are not strictly needed, but it makes this loop more robust,
     // because otherwise, if due to some glitch, directory was not under
     // embedded_binaries, it would get into an infinite loop.
-    while (directory != embedded_binaries_ && !directory.IsEmpty() &&
+    while (directory != embedded_binaries && !directory.IsEmpty() &&
            !blaze_util::IsRootDirectory(directory) &&
            synced_directories.insert(directory).second) {
       blaze_util::SyncFile(directory);
@@ -296,7 +294,7 @@ void BlessFiles(const string &embedded_binaries) {
     }
   }
 
-  blaze_util::SyncFile(embedded_binaries_);
+  blaze_util::SyncFile(embedded_binaries);
 }
 
 void ExtractBuildLabel(const string &archive_path, string *build_label) {

--- a/src/main/cpp/archive_utils.h
+++ b/src/main/cpp/archive_utils.h
@@ -87,14 +87,14 @@ std::optional<DurationMillis> ExtractData(
 void ExtractArchiveOrDie(const std::string &archive_path,
                          const std::string &product_name,
                          const std::string &expected_install_md5,
-                         const std::string &output_dir);
+                         const blaze_util::Path &output_dir);
 
 // Sets the timestamps of the extracted files to the future via
 // blaze_util::IFileMtime::SetToDistanceFuture and ensures that the files we
 // have written are actually on the disk. Later, the blaze client calls
 // blaze_util::IFileMtime::IsUntampered to ensure the files were "blessed" with
 // these distant mtimes.
-void BlessFiles(const std::string &embedded_binaries);
+void BlessFiles(const blaze_util::Path &embedded_binaries);
 
 // Retrieves the build label (version string) from `archive_path` into
 // `build_label`.

--- a/src/main/cpp/bazel_startup_options.cc
+++ b/src/main/cpp/bazel_startup_options.cc
@@ -77,11 +77,9 @@ void BazelStartupOptions::MaybeLogStartupOptionWarnings() const {
                             "ignored, since --ignore_all_rc_files is on.";
     }
   }
-  bool output_user_root_has_space =
-      output_user_root.find_first_of(' ') != std::string::npos;
-  if (output_user_root_has_space) {
+  if (output_user_root.Contains(' ')) {
     BAZEL_LOG(WARNING)
-        << "Output user root \"" << output_user_root
+        << "Output user root \"" << output_user_root.AsPrintablePath()
         << "\" contains a space. This will probably break the build. "
            "You should set a different --output_user_root.";
   } else if (output_base.Contains(' ')) {

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -431,9 +431,9 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
                    blaze_util::ToString(startup_options.connect_timeout_secs));
 
   result.push_back("--output_user_root=" +
-                   blaze_util::ConvertPath(startup_options.output_user_root));
+                   startup_options.output_user_root.AsCommandLineArgument());
   result.push_back("--install_base=" +
-                   blaze_util::ConvertPath(startup_options.install_base));
+                   startup_options.install_base.AsCommandLineArgument());
   result.push_back("--install_md5=" + install_md5);
   result.push_back("--output_base=" +
                    startup_options.output_base.AsCommandLineArgument());
@@ -1017,13 +1017,13 @@ static void EnsureCorrectRunningVersion(const StartupOptions &startup_options,
   // target dirs don't match, or if the symlink was not present, then kill any
   // running servers. Lastly, symlink to our installation so others know which
   // installation is running.
-  const blaze_util::Path installation_path =
+  const blaze_util::Path install_base_symlink =
       startup_options.output_base.GetRelative("install");
-  string prev_installation;
-  bool ok =
-      blaze_util::ReadDirectorySymlink(installation_path, &prev_installation);
-  if (!ok || !blaze_util::CompareAbsolutePaths(prev_installation,
-                                               startup_options.install_base)) {
+  blaze_util::Path prev_install_base;
+  if (!blaze_util::ReadDirectorySymlink(install_base_symlink,
+                                        &prev_install_base) ||
+      !blaze_util::ArePathsEquivalent(prev_install_base,
+                                      startup_options.install_base)) {
     if (server->Connected()) {
       BAZEL_LOG(INFO)
           << "Killing running server because it is using another version of "
@@ -1032,12 +1032,13 @@ static void EnsureCorrectRunningVersion(const StartupOptions &startup_options,
       logging_info->restart_reason = NEW_VERSION;
     }
 
-    blaze_util::UnlinkPath(installation_path);
-    if (!SymlinkDirectories(startup_options.install_base, installation_path)) {
-      string err = GetLastErrorString();
+    blaze_util::UnlinkPath(install_base_symlink);
+    if (!SymlinkDirectories(startup_options.install_base,
+                            install_base_symlink)) {
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
           << "failed to create installation symlink '"
-          << installation_path.AsPrintablePath() << "': " << err;
+          << install_base_symlink.AsPrintablePath()
+          << "': " << GetLastErrorString();
     }
 
     // Update the mtime of the install base so that cleanup tools can
@@ -1045,10 +1046,10 @@ static void EnsureCorrectRunningVersion(const StartupOptions &startup_options,
     // Ignore permissions errors (i.e. if the install base is not writable).
     if (!SetMtimeToNowIfPossible(
             blaze_util::Path(startup_options.install_base))) {
-      string err = GetLastErrorString();
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-          << "failed to set timestamp on '" << startup_options.install_base
-          << "': " << err;
+          << "failed to set timestamp on '"
+          << startup_options.install_base.AsPrintablePath()
+          << "': " << GetLastErrorString();
     }
   }
 }
@@ -1153,15 +1154,14 @@ static void UpdateConfiguration(const string &install_md5,
   // The default install_base is <output_user_root>/install/<md5(blaze)>
   // but if an install_base is specified on the command line, we use that as
   // the base instead.
-  if (startup_options->install_base.empty()) {
+  if (startup_options->install_base.IsEmpty()) {
     if (server_mode) {
       BAZEL_DIE(blaze_exit_code::BAD_ARGV)
           << "exec-server requires --install_base";
     }
-    string install_user_root =
-        blaze_util::JoinPath(startup_options->output_user_root, "install");
-    startup_options->install_base =
-        blaze_util::JoinPath(install_user_root, install_md5);
+    blaze_util::Path install_user_root =
+        startup_options->output_user_root.GetRelative("install");
+    startup_options->install_base = install_user_root.GetRelative(install_md5);
   }
 
   if (startup_options->output_base.IsEmpty()) {
@@ -1169,8 +1169,8 @@ static void UpdateConfiguration(const string &install_md5,
       BAZEL_DIE(blaze_exit_code::BAD_ARGV)
           << "exec-server requires --output_base";
     }
-    startup_options->output_base = blaze_util::Path(
-        blaze::GetHashedBaseDir(startup_options->output_user_root, workspace));
+    startup_options->output_base =
+        blaze::GetHashedBaseDir(startup_options->output_user_root, workspace);
   }
 
   if (!blaze_util::PathExists(startup_options->output_base)) {

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -1,3 +1,4 @@
+#include "src/main/cpp/util/path_platform.h"
 // Copyright 2014 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +48,7 @@ class Dumper {
   // If writing fails, this method sets a flag in the `Dumper`, and `Finish`
   // will return false. Subsequent `Dump` calls will have no effect.
   virtual void Dump(const void* data, const size_t size,
-                    const std::string& path) = 0;
+                    const blaze_util::Path& path) = 0;
 
   // Finishes dumping data.
   //
@@ -187,16 +188,16 @@ int ExecuteDaemon(
     const blaze_util::Path& exe, const std::vector<std::string>& args_vector,
     const std::map<std::string, EnvVarValue>& env,
     const blaze_util::Path& daemon_output, const bool daemon_output_append,
-    const std::string& binaries_dir, const blaze_util::Path& server_dir,
+    const blaze_util::Path& binaries_dir, const blaze_util::Path& server_dir,
     const StartupOptions& options, BlazeServerStartup** server_startup);
 
 // A character used to separate paths in a list.
 extern const char kListSeparator;
 
 // Create a symlink to directory ``target`` at location ``link``.
-// Returns true on success, false on failure. The target must be absolute.
+// Returns true on success, false on failure.
 // Implemented via junctions on Windows.
-bool SymlinkDirectories(const std::string& target,
+bool SymlinkDirectories(const blaze_util::Path& target,
                         const blaze_util::Path& link);
 
 typedef uintptr_t LockHandle;
@@ -237,8 +238,8 @@ void ExcludePathFromBackup(const blaze_util::Path& path);
 
 // Returns the canonical form of the base dir given a root and a hashable
 // string. The resulting dir is composed of the root + md5(hashable)
-std::string GetHashedBaseDir(const std::string& root,
-                             const std::string& hashable);
+blaze_util::Path GetHashedBaseDir(const blaze_util::Path& root,
+                                  const std::string& hashable);
 
 // Create a safe installation directory where we keep state, installations etc.
 // This method ensures that the directory is created, is owned by the current

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -144,16 +144,16 @@ class StartupOptions {
   blaze_util::Path output_base;
 
   // Installation base for a specific release installation.
-  std::string install_base;
+  blaze_util::Path install_base;
 
   // The toplevel directory containing Blaze's output.  When Blaze is
   // run by a test, we use TEST_TMPDIR, simplifying the correct
   // hermetic invocation of Blaze from tests.
-  std::string output_root;
+  blaze_util::Path output_root;
 
   // Blaze's output_user_root. Used only for computing install_base and
   // output_base.
-  std::string output_user_root;
+  blaze_util::Path output_user_root;
 
   // Override more finegrained rc file flags and ignore them all.
   bool ignore_all_rc_files;

--- a/src/main/cpp/util/file.cc
+++ b/src/main/cpp/util/file.cc
@@ -15,15 +15,14 @@
 #include "src/main/cpp/util/file.h"
 
 #include <limits.h>
+#include <stdlib.h>
 
 #include <algorithm>
-#include <cstdlib>
+#include <string>
 #include <vector>
 
-#include "src/main/cpp/util/errors.h"
-#include "src/main/cpp/util/exit_code.h"
-#include "src/main/cpp/util/path.h"
-#include "src/main/cpp/util/strings.h"
+#include "src/main/cpp/util/file_platform.h"
+#include "src/main/cpp/util/path_platform.h"
 
 namespace blaze_util {
 
@@ -95,33 +94,24 @@ bool WriteFile(const std::string &content, const Path &path,
 
 class DirectoryTreeWalker : public DirectoryEntryConsumer {
  public:
-  DirectoryTreeWalker(vector<string> *files,
-                      _ForEachDirectoryEntry walk_entries)
-      : _files(files), _walk_entries(walk_entries) {}
+  explicit DirectoryTreeWalker(vector<Path> *files) : files(files) {}
 
-  void Consume(const string &path, bool follow_directory) override {
-    if (follow_directory) {
+  void Consume(const Path &path, bool is_directory) override {
+    if (is_directory) {
       Walk(path);
     } else {
-      _files->push_back(path);
+      files->push_back(path);
     }
   }
 
-  void Walk(const string &path) { _walk_entries(path, this); }
+  void Walk(const Path &path) { ForEachDirectoryEntry(path, this); }
 
  private:
-  vector<string> *_files;
-  _ForEachDirectoryEntry _walk_entries;
+  vector<Path> *files;
 };
 
-void GetAllFilesUnder(const string &path, vector<string> *result) {
-  _GetAllFilesUnder(path, result, &ForEachDirectoryEntry);
-}
-
-void _GetAllFilesUnder(const string &path,
-                       vector<string> *result,
-                       _ForEachDirectoryEntry walk_entries) {
-  DirectoryTreeWalker(result, walk_entries).Walk(path);
+void GetAllFilesUnder(const Path &path, vector<Path> *result) {
+  DirectoryTreeWalker(result).Walk(path);
 }
 
 }  // namespace blaze_util

--- a/src/main/cpp/util/file.h
+++ b/src/main/cpp/util/file.h
@@ -73,19 +73,7 @@ bool WriteFile(const std::string &content, const Path &path,
 // Populates `result` with the full paths of the files. Every entry will have
 // `path` as its prefix. If `path` is a file, `result` contains just this
 // file.
-void GetAllFilesUnder(const std::string &path,
-                      std::vector<std::string> *result);
-
-class DirectoryEntryConsumer;
-
-// Visible for testing only.
-typedef void (*_ForEachDirectoryEntry)(const std::string &path,
-                                       DirectoryEntryConsumer *consume);
-
-// Visible for testing only.
-void _GetAllFilesUnder(const std::string &path,
-                       std::vector<std::string> *result,
-                       _ForEachDirectoryEntry walk_entries);
+void GetAllFilesUnder(const Path &path, std::vector<Path> *result);
 
 }  // namespace blaze_util
 

--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -42,6 +42,8 @@ class Path {
 
   Path GetParent() const;
 
+  std::string GetBaseName() const;
+
   // Returns a printable string representing this path.
   // Only use when printing user messages, do not pass to filesystem API
   // functions.
@@ -84,11 +86,11 @@ std::string ConvertPath(const std::string &path);
 // See https://github.com/bazelbuild/bazel/issues/2576
 std::string PathAsJvmFlag(const std::string &path);
 
-// Compares two absolute paths. Necessary because the same path can have
-// multiple different names under msys2: "C:\foo\bar" or "C:/foo/bar"
-// (Windows-style) and "/c/foo/bar" (msys2 style). Returns if the paths are
-// equal.
-bool CompareAbsolutePaths(const std::string &a, const std::string &b);
+// Returns whether two paths are equivalent.
+// On Windows, there are multiple ways to represent the same path, e.g.
+// "C:\foo\bar" or "C:/foo/bar" or "/c/foo/bar" (msys2 style).
+// On Unix, this is a simple string comparison.
+bool ArePathsEquivalent(const blaze_util::Path &a, const blaze_util::Path &b);
 
 // Split a path to dirname and basename parts.
 std::pair<std::string, std::string> SplitPath(const std::string &path);

--- a/src/main/cpp/util/path_posix.cc
+++ b/src/main/cpp/util/path_posix.cc
@@ -31,7 +31,7 @@ std::string ConvertPath(const std::string &path) { return path; }
 
 std::string PathAsJvmFlag(const std::string &path) { return path; }
 
-bool CompareAbsolutePaths(const std::string &a, const std::string &b) {
+bool ArePathsEquivalent(const blaze_util::Path &a, const blaze_util::Path &b) {
   return a == b;
 }
 
@@ -159,6 +159,8 @@ Path Path::GetRelative(const std::string &r) const {
 }
 
 Path Path::Canonicalize() const { return Path(MakeCanonical(path_.c_str())); }
+
+std::string Path::GetBaseName() const { return SplitPath(path_).second; }
 
 Path Path::GetParent() const { return Path(SplitPath(path_).first); }
 

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -116,8 +116,9 @@ std::string MakeAbsoluteAndResolveEnvvars(const std::string& path) {
   return MakeAbsolute(std::string(resolved.get()));
 }
 
-bool CompareAbsolutePaths(const std::string& a, const std::string& b) {
-  return ConvertPath(a) == ConvertPath(b);
+bool ArePathsEquivalent(const blaze_util::Path& a, const blaze_util::Path& b) {
+  return ConvertPath(WstringToCstring(a.AsNativePath())) ==
+         ConvertPath(WstringToCstring(b.AsNativePath()));
 }
 
 std::string PathAsJvmFlag(const std::string& path) {
@@ -512,6 +513,10 @@ Path Path::Canonicalize() const {
 }
 
 Path Path::GetParent() const { return Path(SplitPathW(path_).first); }
+
+std::string Path::GetBaseName() const {
+  return WstringToCstring(SplitPathW(path_).second);
+}
 
 bool Path::IsNull() const { return path_ == L"NUL"; }
 

--- a/src/test/cpp/option_processor_test.cc
+++ b/src/test/cpp/option_processor_test.cc
@@ -47,15 +47,7 @@ class OptionProcessorTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    // TODO(bazel-team): The code below deletes all the files in the workspace
-    // but it intentionally skips directories. As a consequence, there may be
-    // empty directories from test to test. Remove this once
-    // blaze_util::DeleteDirectories(path) exists.
-    std::vector<std::string> files_in_workspace;
-    blaze_util::GetAllFilesUnder(workspace_, &files_in_workspace);
-    for (const std::string& file : files_in_workspace) {
-      blaze_util::UnlinkPath(file);
-    }
+    blaze_util::RemoveRecursively(blaze_util::Path(workspace_));
   }
 
   void FailedSplitCommandLineTest(const std::vector<std::string>& args,

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -98,27 +98,10 @@ class RcFileTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    // TODO(bazel-team): The code below deletes all the files in the workspace
-    // and other rc-related directories, but it intentionally skips directories.
-    // As a consequence, there may be empty directories from test to test.
-    // Remove this once blaze_util::DeleteDirectories(path) exists.
-    std::vector<std::string> files;
-    blaze_util::GetAllFilesUnder(workspace_, &files);
-    for (const std::string& file : files) {
-      blaze_util::UnlinkPath(file);
-    }
-    blaze_util::GetAllFilesUnder(cwd_, &files);
-    for (const std::string& file : files) {
-      blaze_util::UnlinkPath(file);
-    }
-    blaze_util::GetAllFilesUnder(home_, &files);
-    for (const std::string& file : files) {
-      blaze_util::UnlinkPath(file);
-    }
-    blaze_util::GetAllFilesUnder(binary_dir_, &files);
-    for (const std::string& file : files) {
-      blaze_util::UnlinkPath(file);
-    }
+    blaze_util::RemoveRecursively(blaze_util::Path(workspace_));
+    blaze_util::RemoveRecursively(blaze_util::Path(cwd_));
+    blaze_util::RemoveRecursively(blaze_util::Path(home_));
+    blaze_util::RemoveRecursively(blaze_util::Path(binary_dir_));
   }
 
   bool SetUpSystemRcFile(const std::string& contents,

--- a/src/test/cpp/util/BUILD
+++ b/src/test/cpp/util/BUILD
@@ -31,6 +31,7 @@ cc_test(
     deps = [
         ":test_util",
         "//src/main/cpp/util:filesystem",
+        "@abseil-cpp//absl/strings",
         "@com_google_googletest//:gtest_main",
     ] + select({
         "//src/conditions:windows": [

--- a/src/test/cpp/util/file_posix_test.cc
+++ b/src/test/cpp/util/file_posix_test.cc
@@ -13,9 +13,12 @@
 // limitations under the License.
 #include <fcntl.h>
 #include <limits.h>
+#include <stdlib.h>
 #include <unistd.h>
 
-#include <algorithm>
+#include <map>
+#include <string>
+#include <vector>
 
 #include "src/main/cpp/util/file.h"
 #include "src/main/cpp/util/file_platform.h"
@@ -23,15 +26,20 @@
 #include "src/main/cpp/util/path_platform.h"
 #include "src/test/cpp/util/test_util.h"
 #include "googletest/include/gtest/gtest.h"
+#include "absl/strings/match.h"
 
 namespace blaze_util {
 
-using std::pair;
+using std::map;
 using std::string;
 using std::vector;
 
 static bool Symlink(const string& old_path, const string& new_path) {
   return symlink(old_path.c_str(), new_path.c_str()) == 0;
+}
+
+static bool Symlink(const Path& old_path, const Path& new_path) {
+  return Symlink(old_path.AsNativePath(), new_path.AsNativePath());
 }
 
 static bool CreateEmptyFile(const string& path) {
@@ -46,37 +54,6 @@ static bool CreateEmptyFile(const string& path) {
     return false;
   }
   return close(fd) == 0;
-}
-
-void MockDirectoryListingFunction(const string& path,
-                                  DirectoryEntryConsumer* consume) {
-  if (path == "root") {
-    consume->Consume("root/file1", false);
-    consume->Consume("root/dir2", true);
-    consume->Consume("root/dir1", true);
-  } else if (path == "root/dir1") {
-    consume->Consume("root/dir1/dir3", true);
-    consume->Consume("root/dir1/file2", false);
-  } else if (path == "root/dir2") {
-    consume->Consume("root/dir2/file3", false);
-  } else if (path == "root/dir1/dir3") {
-    consume->Consume("root/dir1/dir3/file4", false);
-    consume->Consume("root/dir1/dir3/file5", false);
-  } else {
-    // Unexpected path
-    GTEST_FAIL();
-  }
-}
-
-TEST(FilePosixTest, GetAllFilesUnder) {
-  vector<string> result;
-  _GetAllFilesUnder("root", &result, &MockDirectoryListingFunction);
-  std::sort(result.begin(), result.end());
-
-  vector<string> expected({"root/dir1/dir3/file4", "root/dir1/dir3/file5",
-                           "root/dir1/file2", "root/dir2/file3",
-                           "root/file1"});
-  ASSERT_EQ(expected, result);
 }
 
 TEST(FilePosixTest, MakeDirectories) {
@@ -227,136 +204,102 @@ TEST(FilePosixTest, ChangeDirectory) {
 
 class MockDirectoryEntryConsumer : public DirectoryEntryConsumer {
  public:
-  void Consume(const std::string& name, bool is_directory) override {
-    entries.push_back(pair<string, bool>(name, is_directory));
+  void Consume(const Path& path, bool is_directory) override {
+    entries[path] = is_directory;
   }
 
-  vector<pair<string, bool> > entries;
+  map<Path, bool> entries;
 };
 
 TEST(FilePosixTest, ForEachDirectoryEntry) {
   // Get the test's temp dir.
   char* tmpdir_cstr = getenv("TEST_TMPDIR");
-  ASSERT_FALSE(tmpdir_cstr == nullptr);
-  string tempdir(tmpdir_cstr);
-  ASSERT_FALSE(tempdir.empty());
-  if (tempdir.back() == '/') {
-    tempdir = tempdir.substr(0, tempdir.size() - 1);
-  }
-
-  // Create the root directory for the mock directory tree.
-  string root = tempdir + "/FilePosixTest.ForEachDirectoryEntry.root";
-  ASSERT_EQ(0, mkdir(root.c_str(), 0700));
+  ASSERT_NE(tmpdir_cstr, nullptr);
+  Path tmpdir(tmpdir_cstr);
+  ASSERT_TRUE(PathExists(tmpdir));
 
   // Names of mock files and directories.
-  string dir = root + "/dir";
-  string file = root + "/file";
-  string dir_sym = root + "/dir_sym";
-  string file_sym = root + "/file_sym";
-  string subfile = dir + "/subfile";
-  string subfile_through_sym = dir_sym + "/subfile";
+  Path root = tmpdir.GetRelative("FilePosixTest.ForEachDirectoryEntry.root");
+  Path dir = root.GetRelative("dir");
+  Path file = root.GetRelative("file");
+  Path dir_sym = root.GetRelative("dir_sym");
+  Path file_sym = root.GetRelative("file_sym");
+  Path subfile = dir.GetRelative("subfile");
+  Path subfile_through_sym = dir_sym.GetRelative("subfile");
 
   // Create mock directory, file, and symlinks.
-  AutoFd fd(open(file.c_str(), O_CREAT, 0700));
-  ASSERT_TRUE(fd.IsOpen());
-  fd.Close();
-  ASSERT_EQ(0, mkdir(dir.c_str(), 0700));
-  ASSERT_EQ(0, symlink("dir", dir_sym.c_str()));
-  ASSERT_EQ(0, symlink("file", file_sym.c_str()));
-  fd = open(subfile.c_str(), O_CREAT, 0700);
-  ASSERT_TRUE(fd.IsOpen());
-  fd.Close();
-
-  // Assert that stat'ing the symlinks (with following them) point to the
-  // right filesystem entry types.
-  struct stat stat_buf;
-  ASSERT_EQ(0, stat(dir_sym.c_str(), &stat_buf));
-  ASSERT_TRUE(S_ISDIR(stat_buf.st_mode));
-  ASSERT_EQ(0, stat(file_sym.c_str(), &stat_buf));
-  ASSERT_FALSE(S_ISDIR(stat_buf.st_mode));
+  ASSERT_TRUE(MakeDirectories(root, 0700));
+  ASSERT_TRUE(WriteFile("", file));
+  ASSERT_TRUE(MakeDirectories(dir, 0700));
+  ASSERT_TRUE(Symlink(dir, dir_sym));
+  ASSERT_TRUE(Symlink(file, file_sym));
+  ASSERT_TRUE(WriteFile("", subfile));
 
   // Actual test: list the directory.
-  MockDirectoryEntryConsumer consumer;
-  ForEachDirectoryEntry(root, &consumer);
-  ASSERT_EQ(size_t(4), consumer.entries.size());
-
-  // Sort the collected directory entries.
-  struct {
-    bool operator()(const pair<string, bool>& a,
-                    const pair<string, bool>& b) {
-      return a.first < b.first;
-    }
-  } sort_pairs;
-
-  std::sort(consumer.entries.begin(), consumer.entries.end(), sort_pairs);
-
-  // Assert that the directory entries have the right name and type.
-  pair<string, bool> expected;
-  expected = pair<string, bool>(dir, true);
-  ASSERT_EQ(expected, consumer.entries[0]);
-  expected = pair<string, bool>(dir_sym, false);
-  ASSERT_EQ(expected, consumer.entries[1]);
-  expected = pair<string, bool>(file, false);
-  ASSERT_EQ(expected, consumer.entries[2]);
-  expected = pair<string, bool>(file_sym, false);
-  ASSERT_EQ(expected, consumer.entries[3]);
+  MockDirectoryEntryConsumer consumer1;
+  ForEachDirectoryEntry(root, &consumer1);
+  map<Path, bool> expected1;
+  expected1[dir] = true;
+  expected1[dir_sym] = false;
+  expected1[file] = false;
+  expected1[file_sym] = false;
+  EXPECT_EQ(expected1, consumer1.entries);
 
   // Actual test: list a directory symlink.
-  consumer.entries.clear();
-  ForEachDirectoryEntry(dir_sym, &consumer);
-  ASSERT_EQ(size_t(1), consumer.entries.size());
-  expected = pair<string, bool>(subfile_through_sym, false);
-  ASSERT_EQ(expected, consumer.entries[0]);
+  MockDirectoryEntryConsumer consumer2;
+  ForEachDirectoryEntry(dir_sym, &consumer2);
+  map<Path, bool> expected2;
+  expected2[subfile_through_sym] = false;
+  EXPECT_EQ(expected2, consumer2.entries);
 
   // Actual test: list a path that's actually a file, not a directory.
-  consumer.entries.clear();
-  ForEachDirectoryEntry(file, &consumer);
-  ASSERT_TRUE(consumer.entries.empty());
+  MockDirectoryEntryConsumer consumer3;
+  ForEachDirectoryEntry(file, &consumer3);
+  EXPECT_TRUE(consumer3.entries.empty());
 
   // Cleanup: delete mock directory tree.
-  rmdir(subfile.c_str());
-  rmdir(dir.c_str());
-  unlink(dir_sym.c_str());
-  unlink(file.c_str());
-  unlink(file_sym.c_str());
-  rmdir(root.c_str());
+  EXPECT_TRUE(blaze_util::RemoveRecursively(root));
 }
 
 TEST(FileTest, TestRemoveRecursivelyPosix) {
   const char* tempdir_cstr = getenv("TEST_TMPDIR");
   ASSERT_NE(tempdir_cstr, nullptr);
-  string tempdir(tempdir_cstr);
+  Path tempdir(tempdir_cstr);
   ASSERT_TRUE(PathExists(tempdir));
 
-  string unwritable_dir(JoinPath(tempdir, "test_rmr_unwritable"));
+  Path unwritable_dir = tempdir.GetRelative("test_rmr_unwritable");
   EXPECT_TRUE(MakeDirectories(unwritable_dir, 0700));
-  EXPECT_TRUE(WriteFile("junkdata", 8, JoinPath(unwritable_dir, "file")));
-  ASSERT_EQ(0, chmod(unwritable_dir.c_str(), 0500));
+  EXPECT_TRUE(WriteFile("junkdata", 8, unwritable_dir.GetRelative("file")));
+  ASSERT_EQ(0, chmod(unwritable_dir.AsNativePath().c_str(), 0500));
   EXPECT_FALSE(RemoveRecursively(unwritable_dir));
 
-  string symlink_target_dir(JoinPath(tempdir, "test_rmr_symlink_target_dir"));
+  Path symlink_target_dir = tempdir.GetRelative("test_rmr_symlink_target_dir");
   EXPECT_TRUE(MakeDirectories(symlink_target_dir, 0700));
-  string symlink_target_dir_file(JoinPath(symlink_target_dir, "file"));
+  Path symlink_target_dir_file = symlink_target_dir.GetRelative("file");
   EXPECT_TRUE(WriteFile("junkdata", 8, symlink_target_dir_file));
-  string symlink_dir(JoinPath(tempdir, "test_rmr_symlink_dir"));
-  EXPECT_EQ(0, symlink(symlink_target_dir.c_str(), symlink_dir.c_str()));
+  Path symlink_dir = tempdir.GetRelative("test_rmr_symlink_dir");
+  EXPECT_EQ(0, symlink(symlink_target_dir.AsNativePath().c_str(),
+                       symlink_dir.AsNativePath().c_str()));
   EXPECT_TRUE(RemoveRecursively(symlink_dir));
   EXPECT_FALSE(PathExists(symlink_dir));
   EXPECT_TRUE(PathExists(symlink_target_dir));
   EXPECT_TRUE(PathExists(symlink_target_dir_file));
 
-  string dir_with_symlinks(JoinPath(tempdir, "test_rmr_dir_w_symlinks"));
+  Path dir_with_symlinks = tempdir.GetRelative("test_rmr_dir_w_symlinks");
   EXPECT_TRUE(MakeDirectories(dir_with_symlinks, 0700));
-  string file_symlink_target(JoinPath(tempdir, "test_rmr_dir_w_symlinks_file"));
+  Path file_symlink_target =
+      tempdir.GetRelative("test_rmr_dir_w_symlinks_file");
   EXPECT_TRUE(WriteFile("junkdata", 8, file_symlink_target));
-  EXPECT_EQ(0, symlink(file_symlink_target.c_str(),
-                       JoinPath(dir_with_symlinks, "file").c_str()));
-  string dir_symlink_target(JoinPath(tempdir, "test_rmr_dir_w_symlinks_dir"));
+  EXPECT_EQ(
+      0, symlink(file_symlink_target.AsNativePath().c_str(),
+                 dir_with_symlinks.GetRelative("file").AsNativePath().c_str()));
+  Path dir_symlink_target = tempdir.GetRelative("test_rmr_dir_w_symlinks_dir");
   EXPECT_TRUE(MakeDirectories(dir_symlink_target, 0700));
-  string dir_symlink_target_file(JoinPath(dir_symlink_target, "file"));
+  Path dir_symlink_target_file = dir_symlink_target.GetRelative("file");
   EXPECT_TRUE(WriteFile("junkdata", 8, dir_symlink_target_file));
-  EXPECT_EQ(0, symlink(dir_symlink_target.c_str(),
-                       JoinPath(dir_with_symlinks, "dir").c_str()));
+  EXPECT_EQ(
+      0, symlink(dir_symlink_target.AsNativePath().c_str(),
+                 dir_with_symlinks.GetRelative("dir").AsNativePath().c_str()));
   EXPECT_TRUE(RemoveRecursively(dir_with_symlinks));
   EXPECT_FALSE(PathExists(dir_with_symlinks));
   EXPECT_TRUE(PathExists(dir_symlink_target));
@@ -364,20 +307,22 @@ TEST(FileTest, TestRemoveRecursivelyPosix) {
   EXPECT_TRUE(PathExists(file_symlink_target));
 }
 
-TEST(FileTest, TestCreateTempDirDoesntClobberParentPerms) {
+TEST(FileTest, TestCreatSiblingTempDirDoesntClobberParentPerms) {
   const char* tempdir_cstr = getenv("TEST_TMPDIR");
   ASSERT_NE(tempdir_cstr, nullptr);
-  string tempdir(tempdir_cstr);
+  Path tempdir(tempdir_cstr);
   ASSERT_TRUE(PathExists(tempdir));
 
-  string existing_parent_dir(JoinPath(tempdir, "existing"));
+  Path existing_parent_dir = tempdir.GetRelative("existing");
   ASSERT_TRUE(MakeDirectories(existing_parent_dir, 0700));
-  string prefix(JoinPath(existing_parent_dir, "mytmp"));
-  string result(CreateTempDir(prefix));
-  ASSERT_EQ(0, result.find(prefix));
-  EXPECT_TRUE(PathExists(result));
+  Path other_dir = existing_parent_dir.GetRelative("other");
+  Path temp_dir = CreateSiblingTempDir(other_dir);
+  ASSERT_EQ(other_dir.GetParent(), temp_dir.GetParent());
+  ASSERT_TRUE(absl::StartsWith(temp_dir.GetBaseName(),
+                               other_dir.GetBaseName() + ".tmp."));
+  EXPECT_TRUE(PathExists(temp_dir));
   struct stat filestat = {};
-  ASSERT_EQ(0, stat(existing_parent_dir.c_str(), &filestat));
+  ASSERT_EQ(0, stat(existing_parent_dir.AsNativePath().c_str(), &filestat));
   ASSERT_EQ(mode_t(0700), filestat.st_mode & 0777);
 }
 

--- a/src/test/cpp/util/file_test.cc
+++ b/src/test/cpp/util/file_test.cc
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 // Copyright 2014 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,21 +12,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "src/main/cpp/util/file.h"
-
 #include <stdio.h>
 #include <string.h>
 
 #include <algorithm>
 #include <map>
-#include <memory>  // unique_ptr
+#include <memory>
 #include <thread>  // NOLINT (to silence Google-internal linter)
+#include <vector>
 
+#include "src/main/cpp/util/file.h"
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/path.h"
 #include "src/main/cpp/util/path_platform.h"
 #include "src/test/cpp/util/test_util.h"
 #include "googletest/include/gtest/gtest.h"
+#include "absl/strings/match.h"
 
 namespace blaze_util {
 
@@ -184,38 +186,41 @@ TEST(FileTest, TestMtimeHandling) {
   ASSERT_FALSE(IsUntampered(file));
 }
 
-TEST(FileTest, TestCreateTempDir) {
+TEST(FileTest, TestCreateSiblingTempDir) {
   const char* tempdir_cstr = getenv("TEST_TMPDIR");
   EXPECT_NE(tempdir_cstr, nullptr);
   EXPECT_NE(tempdir_cstr[0], 0);
-  string tempdir(tempdir_cstr);
-  string tmpdir(tempdir_cstr);
+  Path tempdir(tempdir_cstr);
 
-  string prefix_in_existing_dir(JoinPath(tempdir, "foo."));
-  string result_in_existing_dir(CreateTempDir(prefix_in_existing_dir));
-  ASSERT_NE(result_in_existing_dir, prefix_in_existing_dir);
-  ASSERT_EQ(0, result_in_existing_dir.find(prefix_in_existing_dir));
-  EXPECT_TRUE(PathExists(result_in_existing_dir));
+  Path input_in_existing = tempdir.GetRelative("other");
+  Path output_in_existing = CreateSiblingTempDir(input_in_existing);
+  ASSERT_NE(input_in_existing, output_in_existing);
+  ASSERT_EQ(input_in_existing.GetParent(), output_in_existing.GetParent());
+  ASSERT_TRUE(absl::StartsWith(output_in_existing.GetBaseName(),
+                               input_in_existing.GetBaseName() + ".tmp."));
+  EXPECT_TRUE(PathExists(output_in_existing));
 
-  string base_dir(JoinPath(tempdir, "doesntexistyet"));
-  ASSERT_FALSE(PathExists(base_dir));
-  string prefix_in_new_dir(JoinPath(base_dir, "foo."));
-  string result_in_new_dir(CreateTempDir(prefix_in_new_dir));
-  ASSERT_NE(result_in_new_dir, prefix_in_new_dir);
-  ASSERT_EQ(0, result_in_new_dir.find(prefix_in_new_dir));
-  EXPECT_TRUE(PathExists(result_in_new_dir));
+  Path missing_dir = tempdir.GetRelative("doesntexistyet");
+  ASSERT_FALSE(PathExists(missing_dir));
+  Path input_in_missing = missing_dir.GetRelative("other");
+  Path output_in_missing = CreateSiblingTempDir(input_in_missing);
+  ASSERT_NE(input_in_missing, output_in_missing);
+  ASSERT_EQ(input_in_missing.GetParent(), output_in_missing.GetParent());
+  ASSERT_TRUE(absl::StartsWith(output_in_missing.GetBaseName(),
+                               input_in_missing.GetBaseName() + ".tmp."));
+  EXPECT_TRUE(PathExists(output_in_missing));
 }
 
 TEST(FileTest, TestRenameDirectory) {
   const char* tempdir_cstr = getenv("TEST_TMPDIR");
   EXPECT_NE(tempdir_cstr, nullptr);
   EXPECT_NE(tempdir_cstr[0], 0);
-  string tempdir(tempdir_cstr);
+  Path tempdir(tempdir_cstr);
 
-  string dir1(JoinPath(tempdir, "test_rename_dir/dir1"));
-  string dir2(JoinPath(tempdir, "test_rename_dir/dir2"));
+  Path dir1 = tempdir.GetRelative("test_rename_dir/dir1");
+  Path dir2 = tempdir.GetRelative("test_rename_dir/dir2");
   EXPECT_TRUE(MakeDirectories(dir1, 0700));
-  string file1(JoinPath(dir1, "file1.txt"));
+  Path file1 = dir1.GetRelative("file1.txt");
   EXPECT_TRUE(WriteFile("hello", 5, file1));
 
   ASSERT_EQ(RenameDirectory(dir1, dir2), kRenameDirectorySuccess);
@@ -225,54 +230,81 @@ TEST(FileTest, TestRenameDirectory) {
   ASSERT_EQ(RenameDirectory(dir2, dir1), kRenameDirectoryFailureNotEmpty);
 }
 
-class CollectingDirectoryEntryConsumer : public DirectoryEntryConsumer {
+class MockDirectoryEntryConsumer : public DirectoryEntryConsumer {
  public:
-  CollectingDirectoryEntryConsumer(const string& _rootname)
-      : rootname(_rootname) {}
-
-  void Consume(const string& name, bool is_directory) override {
-    // Strip the path prefix up to the `rootname` to ease testing on all
-    // platforms.
-    size_t index = name.rfind(rootname);
-    string key = (index == string::npos) ? name : name.substr(index);
-    // Replace backslashes with forward slashes (necessary on Windows only).
-    std::replace(key.begin(), key.end(), '\\', '/');
-    entries[key] = is_directory;
+  void Consume(const Path& path, bool is_directory) override {
+    entries[path] = is_directory;
   }
 
-  const string rootname;
-  std::map<string, bool> entries;
+  std::map<Path, bool> entries;
 };
 
 TEST(FileTest, ForEachDirectoryEntryTest) {
-  string tmpdir(getenv("TEST_TMPDIR"));
-  EXPECT_FALSE(tmpdir.empty());
-  // Create a directory structure:
+  const char* tmpdir_cstr = getenv("TEST_TMPDIR");
+  ASSERT_NE(tmpdir_cstr, nullptr);
+  Path tmpdir(tmpdir_cstr);
+  ASSERT_TRUE(PathExists(tmpdir));
   //   $TEST_TMPDIR/
   //      foo/
   //        bar/
   //          file3.txt
   //        file1.txt
   //        file2.txt
-  string rootdir(JoinPath(tmpdir, "foo"));
-  string file1(JoinPath(rootdir, "file1.txt"));
-  string file2(JoinPath(rootdir, "file2.txt"));
-  string subdir(JoinPath(rootdir, "bar"));
-  string file3(JoinPath(subdir, "file3.txt"));
+  Path rootdir = tmpdir.GetRelative("foo");
+  Path file1 = rootdir.GetRelative("file1.txt");
+  Path file2 = rootdir.GetRelative("file2.txt");
+  Path subdir = rootdir.GetRelative("bar");
+  Path file3 = subdir.GetRelative("file3.txt");
 
-  EXPECT_TRUE(MakeDirectories(subdir, 0700));
-  EXPECT_TRUE(WriteFile("hello", 5, file1));
-  EXPECT_TRUE(WriteFile("hello", 5, file2));
-  EXPECT_TRUE(WriteFile("hello", 5, file3));
+  ASSERT_TRUE(MakeDirectories(subdir, 0700));
+  ASSERT_TRUE(WriteFile("hello", 5, file1));
+  ASSERT_TRUE(WriteFile("hello", 5, file2));
+  ASSERT_TRUE(WriteFile("hello", 5, file3));
 
-  std::map<string, bool> expected;
-  expected["foo/file1.txt"] = false;
-  expected["foo/file2.txt"] = false;
-  expected["foo/bar"] = true;
+  std::map<Path, bool> expected;
+  expected[file1] = false;
+  expected[file2] = false;
+  expected[subdir] = true;
 
-  CollectingDirectoryEntryConsumer consumer("foo");
+  MockDirectoryEntryConsumer consumer;
   ForEachDirectoryEntry(rootdir, &consumer);
-  ASSERT_EQ(consumer.entries, expected);
+  EXPECT_EQ(consumer.entries, expected);
+}
+
+TEST(FilePosixTest, GetAllFilesUnder) {
+  const char* tmpdir_cstr = getenv("TEST_TMPDIR");
+  ASSERT_NE(tmpdir_cstr, nullptr);
+  Path tmpdir(tmpdir_cstr);
+  ASSERT_TRUE(PathExists(tmpdir));
+
+  Path root = tmpdir.GetRelative("FilePosixTest.GetAllFilesUnder.root");
+  Path file1 = root.GetRelative("file1");
+  Path dir1 = root.GetRelative("dir1");
+  Path dir2 = root.GetRelative("dir2");
+  Path dir3 = dir1.GetRelative("dir3");
+  Path file2 = dir1.GetRelative("file2");
+  Path file3 = dir2.GetRelative("file3");
+  Path file4 = dir3.GetRelative("file4");
+  Path file5 = dir3.GetRelative("file5");
+
+  ASSERT_TRUE(MakeDirectories(root, 0700));
+  ASSERT_TRUE(MakeDirectories(dir1, 0700));
+  ASSERT_TRUE(MakeDirectories(dir2, 0700));
+  ASSERT_TRUE(MakeDirectories(dir3, 0700));
+  ASSERT_TRUE(WriteFile("", file1));
+  ASSERT_TRUE(WriteFile("", file2));
+  ASSERT_TRUE(WriteFile("", file3));
+  ASSERT_TRUE(WriteFile("", file4));
+  ASSERT_TRUE(WriteFile("", file5));
+
+  std::vector<Path> result;
+  GetAllFilesUnder(root, &result);
+  std::sort(result.begin(), result.end());
+
+  std::vector<Path> expected({file4, file5, file2, file3, file1});
+  EXPECT_EQ(expected, result);
+
+  EXPECT_TRUE(RemoveRecursively(root));
 }
 
 TEST(FileTest, IsDevNullTest) {
@@ -287,30 +319,30 @@ TEST(FileTest, IsDevNullTest) {
 TEST(FileTest, TestRemoveRecursively) {
   const char* tempdir_cstr = getenv("TEST_TMPDIR");
   ASSERT_NE(tempdir_cstr, nullptr);
-  string tempdir(tempdir_cstr);
+  Path tempdir(tempdir_cstr);
   ASSERT_TRUE(PathExists(tempdir));
 
-  string non_existent_dir(JoinPath(tempdir, "test_rmr_non_existent"));
+  Path non_existent_dir = tempdir.GetRelative("test_rmr_non_existent");
   EXPECT_TRUE(RemoveRecursively(non_existent_dir));
   EXPECT_FALSE(PathExists(non_existent_dir));
 
-  string empty_dir(JoinPath(tempdir, "test_rmr_empty_dir"));
+  Path empty_dir = tempdir.GetRelative("test_rmr_empty_dir");
   EXPECT_TRUE(MakeDirectories(empty_dir, 0700));
   EXPECT_TRUE(RemoveRecursively(empty_dir));
   EXPECT_FALSE(PathExists(empty_dir));
 
-  string dir_with_content(JoinPath(tempdir, "test_rmr_dir_w_content"));
+  Path dir_with_content = tempdir.GetRelative("test_rmr_dir_w_content");
   EXPECT_TRUE(MakeDirectories(dir_with_content, 0700));
-  EXPECT_TRUE(WriteFile("junkdata", 8, JoinPath(dir_with_content, "file")));
-  string subdir = JoinPath(dir_with_content, "dir");
+  EXPECT_TRUE(WriteFile("junkdata", 8, dir_with_content.GetRelative("file")));
+  Path subdir = dir_with_content.GetRelative("dir");
   EXPECT_TRUE(MakeDirectories(subdir, 0700));
-  string subsubdir = JoinPath(subdir, "dir");
+  Path subsubdir = subdir.GetRelative("dir");
   EXPECT_TRUE(MakeDirectories(subsubdir, 0700));
-  EXPECT_TRUE(WriteFile("junkdata", 8, JoinPath(subsubdir, "deep_file")));
+  EXPECT_TRUE(WriteFile("junkdata", 8, subsubdir.GetRelative("deep_file")));
   EXPECT_TRUE(RemoveRecursively(dir_with_content));
   EXPECT_FALSE(PathExists(dir_with_content));
 
-  string regular_file(JoinPath(tempdir, "test_rmr_regular_file"));
+  Path regular_file = tempdir.GetRelative("test_rmr_regular_file");
   EXPECT_TRUE(WriteFile("junkdata", 8, regular_file));
   EXPECT_TRUE(RemoveRecursively(regular_file));
   EXPECT_FALSE(PathExists(regular_file));

--- a/src/test/cpp/workspace_layout_test.cc
+++ b/src/test/cpp/workspace_layout_test.cc
@@ -38,15 +38,7 @@ class WorkspaceLayoutTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    // TODO(bazel-team): The code below deletes all the files in the workspace
-    // but it intentionally skips directories. As a consequence, there may be
-    // empty directories from test to test. Remove this once
-    // blaze_util::DeleteDirectories(path) exists.
-    std::vector<std::string> files_in_workspace;
-    blaze_util::GetAllFilesUnder(build_root_, &files_in_workspace);
-    for (const std::string& file : files_in_workspace) {
-      blaze_util::UnlinkPath(file);
-    }
+    blaze_util::RemoveRecursively(blaze_util::Path(build_root_));
   }
 
   const std::string build_root_;


### PR DESCRIPTION
PiperOrigin-RevId: 698818638
Change-Id: Iea02eb6d3524ecc98970a63aa554927c701efe28