### PR TITLE
[8.1.0] Fix docs link rewriting for rules_android

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/bazel_link_map.json
+++ b/src/main/java/com/google/devtools/build/docgen/bazel_link_map.json
@@ -26,6 +26,7 @@
   "repoPathRewrites": {
     "@//": "https://github.com/bazelbuild/bazel/blob/master/",
     "@_builtins//": "https://github.com/bazelbuild/bazel/blob/master/src/main/starlark/builtins_bzl/",
+    "@rules_android//": "https://github.com/bazelbuild/rules_android/blob/main/",
     "@rules_python//": "https://github.com/bazelbuild/rules_python/tree/0.40.0/",
     "@rules_shell//": "https://github.com/bazelbuild/rules_shell/tree/v0.2.0/",
     "@com_google_protobuf//": "https://github.com/protocolbuffers/protobuf/tree/v29.0-rc2/"


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/24905

RELNOTES: None
PiperOrigin-RevId: 717532897
Change-Id: I620d8492689297f7c85824ea261b12bdfae2221b

Commit https://github.com/bazelbuild/bazel/commit/04a44fde9120ff11ab604b3ef7f0874eeddf78df