### PR TITLE
[8.1.0] windows launcher: Make the launcher compile under mingw

### DIFF
--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -18,11 +18,11 @@
 
 #include "src/main/native/windows/file.h"
 
-#include <WinIoCtl.h>
 #include <stdint.h>  // uint8_t
 #include <versionhelpers.h>
 #include <winbase.h>
 #include <windows.h>
+#include <winioctl.h>
 
 #include <memory>
 #include <sstream>

--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -18,8 +18,8 @@
 
 #include "src/main/native/windows/process.h"
 
+#include <versionhelpers.h>
 #include <windows.h>
-#include <VersionHelpers.h>
 
 #include <memory>
 #include <sstream>

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -250,7 +250,7 @@ wstring JavaBinaryLauncher::CreateClasspathJar(const wstring& classpath) {
       binary_base_path + rand_id + L".jar_manifest";
   blaze_util::AddUncPrefixMaybe(&jar_manifest_file_path);
 #if (__cplusplus >= 201703L)
-  wofstream jar_manifest_file(std::filesystem::path(jar_manifest_file_path));
+  wofstream jar_manifest_file{std::filesystem::path(jar_manifest_file_path)};
 #else
   wofstream jar_manifest_file(jar_manifest_file_path);
 #endif


### PR DESCRIPTION
TEST: bazel build --platforms=//:windows_x86_64  --extra_toolchains=@llvm_mingw_linux_x86_64//:cc-toolchain-linux_x86_64-windows_x86_64 //src/tools/launcher:launcher

Closes #24752.

PiperOrigin-RevId: 711358608
Change-Id: Iedacad9b959427ed5d4598e0ea594cb25b8845c8

Commit https://github.com/bazelbuild/bazel/commit/a4bb2543bd2e796b472a5c33c1b68b4b9866d977