### PR TITLE
[8.1.0] Automated rollback of commit 650142fbe290d97e39b702d1dbcdbe126614b927.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1714,6 +1714,8 @@ java_library(
         ":config/run_under",
         ":config/starlark_defined_config_transition",
         ":platform_options",
+        ":test/test_configuration",
+        ":test/test_trimming_logic",
         "//src/main/java/com/google/devtools/build/lib/actions:action_environment",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:build_configuration_event",
@@ -2057,6 +2059,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//third_party:guava",
+        "//third_party:jsr305",
     ],
 )
 
@@ -2821,9 +2824,11 @@ java_library(
     deps = [
         ":config/build_options",
         ":config/core_option_converters",
+        ":config/core_options",
         ":config/fragment",
         ":config/fragment_options",
         ":config/per_label_options",
+        ":config/run_under",
         ":options_diff_predicate",
         ":test/coverage_configuration",
         ":test/test_sharding_strategy",
@@ -2855,17 +2860,30 @@ java_library(
     deps = [
         ":analysis_cluster",
         ":config/build_options",
-        ":config/build_options_cache",
-        ":config/core_options",
         ":config/fragment_options",
         ":config/transitions/no_transition",
         ":config/transitions/patch_transition",
         ":config/transitions/transition_factory",
         ":test/test_configuration",
+        ":test/test_trimming_logic",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/common/options",
+        "//third_party:guava",
+    ],
+)
+
+java_library(
+    name = "test/test_trimming_logic",
+    srcs = ["test/TestTrimmingLogic.java"],
+    deps = [
+        ":config/build_options",
+        ":config/build_options_cache",
+        ":config/core_options",
+        ":config/fragment_options",
+        ":config/run_under",
+        ":test/test_configuration",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.analysis.PlatformOptions;
+import com.google.devtools.build.lib.analysis.test.TestConfiguration;
+import com.google.devtools.build.lib.analysis.test.TestTrimmingLogic;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.server.FailureDetails.BuildConfiguration.Code;
 import com.google.devtools.build.lib.util.Fingerprint;
@@ -298,6 +300,10 @@ public final class OutputPathMnemonicComputer {
       return "";
     }
 
+    if (!toOptions.contains(TestConfiguration.TestOptions.class)) {
+      baselineOptions = TestTrimmingLogic.trim(baselineOptions);
+    }
+
     // TODO(blaze-configurability-team): As a mild performance update, getFirst already includes
     //   details of the corresponding option. Could incorporate this instead of hashChosenOptions
     //   regenerating the OptionDefinitions and values.
@@ -307,8 +313,8 @@ public final class OutputPathMnemonicComputer {
     //   trimmings. See longform note in {@link ConfiguredTargetKey} for details.
     ImmutableSet<String> chosenNativeOptions =
         diff.getFirst().keySet().stream()
-            .filter(optionDef -> !explicitInOutputPathOptions.contains(optionDef.getOptionName()))
             .map(OptionDefinition::getOptionName)
+            .filter(optionName -> !explicitInOutputPathOptions.contains(optionName))
             .collect(toImmutableSet());
     // Note: getChangedStarlarkOptions includes all changed options, added options and removed
     //   options between baselineOptions and toOptions. This is necessary since there is no current

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnder.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.analysis.config;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
+import javax.annotation.Nullable;
 
 /** Components of the {@code --run_under} option. */
 public sealed interface RunUnder {
@@ -29,6 +30,19 @@ public sealed interface RunUnder {
    * --run_under}.
    */
   ImmutableList<String> options();
+
+  /**
+   * Returns a new instance that only retains the information that is relevant for the analysis of
+   * non-test targets.
+   */
+  @Nullable
+  static RunUnder trimForNonTestConfiguration(@Nullable RunUnder runUnder) {
+    return switch (runUnder) {
+      case LabelRunUnder labelRunUnder ->
+          new LabelRunUnder("", ImmutableList.of(), labelRunUnder.label());
+      case null, default -> null;
+    };
+  }
 
   /**
    * Represents a value of {@code --run_under} whose first word (according to shell tokenization)

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTrimmingLogic.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTrimmingLogic.java
@@ -1,0 +1,76 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.analysis.test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.analysis.config.BuildOptionsCache;
+import com.google.devtools.build.lib.analysis.config.BuildOptionsView;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
+import com.google.devtools.build.lib.analysis.config.FragmentOptions;
+import com.google.devtools.build.lib.analysis.config.RunUnder;
+import com.google.devtools.build.lib.analysis.test.TestConfiguration.TestOptions;
+
+/**
+ * Contains the pure logic for trimming test configuration from non-test targets that backs {@link
+ * com.google.devtools.build.lib.analysis.test.TestTrimmingTransitionFactory}.
+ */
+public final class TestTrimmingLogic {
+
+  static final ImmutableSet<Class<? extends FragmentOptions>> REQUIRED_FRAGMENTS =
+      ImmutableSet.of(CoreOptions.class, TestOptions.class);
+
+  // This cache is to prevent major slowdowns when using --trim_test_configuration. This
+  // transition is always invoked on every target in the top-level invocation. Thus, a wide
+  // invocation, like //..., will cause the transition to be invoked on a large number of targets
+  // leading to significant performance degradation. (Notably, the transition itself is somewhat
+  // fast; however, the post-processing of the BuildOptions into the actual BuildConfigurationValue
+  // takes a significant amount of time).
+  //
+  // Test any caching changes for performance impact in a longwide scenario with
+  // --trim_test_configuration on versus off.
+  // LINT.IfChange
+  private static final BuildOptionsCache<Boolean> CACHE =
+      new BuildOptionsCache<>(
+          (options, unused, unusedNonEventHandler) -> {
+            BuildOptions.Builder builder = options.underlying().toBuilder();
+            builder.removeFragmentOptions(TestOptions.class);
+            // Only the label of the --run_under target (if any) needs to be part of the
+            // configuration for non-test targets, all other information is directly obtained
+            // from the options in RunCommand.
+            CoreOptions coreOptions = builder.getFragmentOptions(CoreOptions.class);
+            coreOptions.runUnder = RunUnder.trimForNonTestConfiguration(coreOptions.runUnder);
+            return builder.build();
+          });
+
+  // LINT.ThenChange(TestConfiguration.java)
+
+  /** Returns a new {@link BuildOptions} instance with test configuration removed. */
+  public static BuildOptions trim(BuildOptions buildOptions) {
+    return trim(new BuildOptionsView(buildOptions, REQUIRED_FRAGMENTS));
+  }
+
+  /** Returns a new {@link BuildOptions} instance with test configuration removed. */
+  static BuildOptions trim(BuildOptionsView buildOptions) {
+    try {
+      return CACHE.applyTransition(buildOptions, Boolean.TRUE, /* eventHandler= */ null);
+    } catch (InterruptedException e) {
+      // The transition logic doesn't throw InterruptedException.
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private TestTrimmingLogic() {}
+}

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -678,6 +678,46 @@ EOF
   fi
 }
 
+function test_run_under_command_change_preserves_cache() {
+  if $is_windows; then
+    echo "This test requires --run_under to be able to run echo."
+    return
+  fi
+
+  local -r pkg="pkg${LINENO}"
+  mkdir -p "${pkg}"
+  cat > "$pkg/BUILD" <<'EOF'
+load(":defs.bzl", "my_rule")
+my_rule(
+  name = "my_rule",
+)
+EOF
+  cat > "$pkg/defs.bzl" <<'EOF'
+def _my_rule_impl(ctx):
+  print("my_rule is being analyzed")
+  out = ctx.actions.declare_file(ctx.label.name)
+  ctx.actions.write(out, "echo -n world", is_executable = True)
+  return [DefaultInfo(executable = out)]
+
+my_rule = rule(
+  implementation = _my_rule_impl,
+  executable = True,
+)
+EOF
+
+  bazel run "${pkg}:my_rule" >$TEST_log 2>&1 \
+   || fail "expected run to pass"
+  expect_log "my_rule is being analyzed"
+  expect_not_log "hello"
+  expect_log "world"
+
+  bazel run --run_under="echo -n hello &&" "${pkg}:my_rule" >$TEST_log 2>&1 \
+   || fail "expected run to pass"
+  expect_not_log "my_rule is being analyzed"
+  expect_log "hello"
+  expect_log "world"
+}
+
 function test_run_env() {
   local -r pkg="pkg${LINENO}"
   mkdir -p "${pkg}"


### PR DESCRIPTION
*** Reason for rollback ***

Rollforward with fixes

Preserve analysis cache through `--run_under` command changes

Work towards https://github.com/bazelbuild/bazel/issues/3325 Fixes https://github.com/bazelbuild/bazel/issues/10782

RELNOTES: Changing any part of --run_under that isn't the label (such as the shell command) no longer invalidates the analysis cache.

Closes #24411.

PiperOrigin-RevId: 703516108
Change-Id: Ief9bd2547fe87b4c09b132ada87aed369753e550

Commit https://github.com/bazelbuild/bazel/commit/45d4cff7ff0ce0a6a3159ff537b0b0c65ddfbb76