### PR TITLE
[8.1.0] Ensure that the lock file still exists when AcquireLock returns.

### DIFF
--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -207,12 +207,16 @@ enum class LockMode {
   kExclusive,
 };
 
-// Acquires a `mode` lock on `path`, busy-waiting until it becomes available if
-// `block` is true, and releasing it on exec if `batch_mode` is false.
-// Crashes if the lock cannot be acquired. Returns a handle that can be
-// subsequently passed to ReleaseLock as well as the time spent waiting for the
-// lock, if any. The `name` argument is used to distinguish it from other locks
-// in human-readable error messages.
+// Acquires a `mode` lock on `path`, creating it if doesn't yet exist.
+// If `block` is true, busy-wait until the lock becomes available.
+// If `batch_mode` is false, release the lock on exec.
+// The `path` is guaranteed to exist when this function returns; if it is
+// deleted concurrently with obtaining the lock, we recreate it and try again.
+// This makes it safe to delete the file under an exclusive lock.
+// The `name` argument is used in human-readable error messages.
+// Returns a handle that can be subsequently passed to ReleaseLock as well as
+// the time spent waiting for the lock, if any.
+// Crashes if an error occurs while attempting to obtain the lock.
 std::pair<LockHandle, std::optional<DurationMillis>> AcquireLock(
     const std::string& name, const blaze_util::Path& path, LockMode mode,
     bool batch_mode, bool block);


### PR DESCRIPTION
This makes it possible to use an exclusive lock to guard against concurrent deletion: otherwise, process 1 might delete the file and release the exclusive lock in between process 2 opening the file and acquiring a shared lock.

In practice, process 1 will be garbage-collecting an old install base while process 2 will be attempting to start itself on the same install base. (Note that install base locking is yet to be implemented.)

Also remove an ancient workaround for old glibcs: OFD locks have been available under _GNU_SOURCE on Linux since 2014.

PiperOrigin-RevId: 699142575
Change-Id: Ifc931c1f2952d97c449aaeee17e6ea43cb4c637e