### PR TITLE
Upgrade asm paths in BUILD.java_tools.

### DIFF
--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -104,21 +104,21 @@ java_import(
 
 java_import(
     name = "asm",
-    jars = ["java_tools/third_party/java/jacoco/asm-9.6.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/asm-9.6-sources.jar",
+    jars = ["java_tools/third_party/java/jacoco/asm-9.7.1.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/asm-9.7.1-sources.jar",
 )
 
 java_import(
     name = "asm-commons",
-    jars = ["java_tools/third_party/java/jacoco/asm-commons-9.6.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/asm-commons-9.6-sources.jar",
+    jars = ["java_tools/third_party/java/jacoco/asm-commons-9.7.1.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/asm-commons-9.7.1-sources.jar",
     runtime_deps = [":asm-tree"],
 )
 
 java_import(
     name = "asm-tree",
-    jars = ["java_tools/third_party/java/jacoco/asm-tree-9.6.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/asm-tree-9.6-sources.jar",
+    jars = ["java_tools/third_party/java/jacoco/asm-tree-9.7.1.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/asm-tree-9.7.1-sources.jar",
     runtime_deps = [":asm"],
 )
 


### PR DESCRIPTION
This allows some java_tools (e.g., coverage) to work with the absolute latest JDK.