### PR TITLE
[8.1.0] Print the client pid when --client_debug is set, which is useful for testing.

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1551,6 +1551,8 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
   BAZEL_LOG(INFO) << "Debug logging requested, sending all client log "
                      "statements to stderr";
 
+  BAZEL_LOG(INFO) << "Running (pid=" << GetProcessIdAsString() << ")";
+
   if (startup_options->unlimit_coredumps) {
     UnlimitCoredumps();
   }


### PR DESCRIPTION
PiperOrigin-RevId: 700351720
Change-Id: Ia30e7f217411cce329c053742f3262b70d386800

PiperOrigin-RevId: 704385156
Change-Id: I41b777e3e3b910175dfad8425d4e7913b7df0327