### PR TITLE
Support `--incompatible_allow_tags_propagation` in native `JavaResourceJar` actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Map;
@@ -116,6 +117,15 @@ public class ResourceJarActionBuilder {
       command.addExecPaths("--classpath_resources", classpathResources);
     }
 
+    ImmutableMap<String, String> executionInfo = EXECUTION_INFO;
+    if (ruleContext.isAllowTagsPropagation()) {
+      ImmutableMap.Builder<String, String> executionInfoBuilder = ImmutableMap.builder();
+      executionInfoBuilder.putAll(EXECUTION_INFO);
+      executionInfoBuilder.putAll(
+          TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()));
+      executionInfo = executionInfoBuilder.build();
+    }
+
     ruleContext.registerAction(
         builder
             .setExecutable(javaToolchain.getSingleJar())
@@ -129,7 +139,7 @@ public class ResourceJarActionBuilder {
             .addCommandLine(command.build(), PARAM_FILE_INFO)
             .setProgressMessage("Building Java resource jar")
             .setMnemonic(MNEMONIC)
-            .setExecutionInfo(EXECUTION_INFO)
+            .setExecutionInfo(executionInfo)
             .setExecGroup(execGroup)
             .build(ruleContext));
   }

--- a/src/test/shell/bazel/tags_propagation_native_test.sh
+++ b/src/test/shell/bazel/tags_propagation_native_test.sh
@@ -162,6 +162,33 @@ EOF
   assert_contains_n "no-remote:" 4 output1
 }
 
+function test_java_test_tags_propagated() {
+  add_rules_java "MODULE.bazel"
+  mkdir -p test
+  cat > test/BUILD <<EOF
+load("@rules_java//java:java_test.bzl", "java_test")
+
+package(default_visibility = ["//visibility:public"])
+java_test(
+  name = "test",
+  srcs = [ "Tests.java" ],
+  test_class = "Tests",
+  tags = ["no-cache", "no-remote", "local"],
+  resources = ["resource.txt"],
+)
+EOF
+  touch test/Tests.java
+  touch test/resource.txt
+
+  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+  assert_contains_n "Command Line:" 6 output1
+  assert_contains_n "local:" 6 output1
+  assert_contains_n "no-cache:" 6 output1
+  assert_contains_n "no-remote:" 6 output1
+}
+
 function write_hello_library_files() {
   add_rules_java "MODULE.bazel"
   local -r pkg="$1"


### PR DESCRIPTION
This fixes a bug where tags were not being propagated to `JavaResourceJar` actions (e.g. `java_test(.., resources = ["foo"], ...)` like with other native rule actions when `--incompatible_allow_tags_propagation` is provided.

Relates to #8004

A test case has been added (building on changes in #25050).

Before:
```
action 'Building Java resource jar'
  Mnemonic: JavaResourceJar
  Target: //test:test
  Configuration: k8-fastbuild
  Execution platform: @@platforms//host:host
  ActionKey: 3b749c8811bd0c61168241c1eefd8db5808251fb8c16c45a663c3154d451485a
  Inputs: [bazel-out/k8-fastbuild/bin/test/test-class.jar, external/rules_java++toolchains+remote_java_tools_linux/java_tools/src/tools/singlejar/singlejar_local, test/HelloTests.java]
  Outputs: [bazel-out/k8-fastbuild/bin/test/test.jar]
  Command Line: (exec external/rules_java++toolchains+remote_java_tools_linux/java_tools/src/tools/singlejar/singlejar_local \
    --normalize \
    --dont_change_compression \
    --exclude_build_data \
    --output \
    bazel-out/k8-fastbuild/bin/test/test.jar \
    --sources \
    bazel-out/k8-fastbuild/bin/test/test-class.jar \
    --resources \
    test/HelloTests.java)
# Configuration: a5841cb06d135209cf0f6770d4ead3790474db9531abbac3a35bd81172c0e7ad
# Execution platform: @@platforms//host:host
  ExecutionInfo: {supports-path-mapping: 1}
```


After:
```
action 'Building Java resource jar'
  Mnemonic: JavaResourceJar
  Target: //test:test
  Configuration: k8-fastbuild
  Execution platform: @@platforms//host:host
  ActionKey: 684d899f9fe3fd972719c0b7ddcd7bd752265b2d746fbbe89c4b35092f2a7073
  Inputs: [bazel-out/k8-fastbuild/bin/test/test-class.jar, external/rules_java++toolchains+remote_java_tools_linux/java_tools/src/tools/singlejar/singlejar_local, test/HelloTests.java]
  Outputs: [bazel-out/k8-fastbuild/bin/test/test.jar]
  Command Line: (exec external/rules_java++toolchains+remote_java_tools_linux/java_tools/src/tools/singlejar/singlejar_local \
    --normalize \
    --dont_change_compression \
    --exclude_build_data \
    --output \
    bazel-out/k8-fastbuild/bin/test/test.jar \
    --sources \
    bazel-out/k8-fastbuild/bin/test/test-class.jar \
    --resources \
    test/HelloTests.java)
# Configuration: a5841cb06d135209cf0f6770d4ead3790474db9531abbac3a35bd81172c0e7ad
# Execution platform: @@platforms//host:host
  ExecutionInfo: {local: '', no-cache: '', no-remote: '', supports-path-mapping: 1}
```