### PR TITLE
[8.1.0] Avoid an unnecessary std::optional by allowing a zero DurationMillis.

### DIFF
--- a/src/main/cpp/blaze_util.h
+++ b/src/main/cpp/blaze_util.h
@@ -133,7 +133,9 @@ class WithEnvVars {
 
 struct DurationMillis {
  public:
-  const uint64_t millis;
+  uint64_t millis;
+
+  DurationMillis() : millis(0) {}
 
   DurationMillis(const uint64_t start, const uint64_t end)
       : millis(ComputeDuration(start, end)) {}

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -217,9 +217,10 @@ enum class LockMode {
 // Returns a handle that can be subsequently passed to ReleaseLock as well as
 // the time spent waiting for the lock, if any.
 // Crashes if an error occurs while attempting to obtain the lock.
-std::pair<LockHandle, std::optional<DurationMillis>> AcquireLock(
-    const std::string& name, const blaze_util::Path& path, LockMode mode,
-    bool batch_mode, bool block);
+std::pair<LockHandle, DurationMillis> AcquireLock(const std::string& name,
+                                                  const blaze_util::Path& path,
+                                                  LockMode mode,
+                                                  bool batch_mode, bool block);
 
 // Releases a lock previously obtained from AcquireLock.
 void ReleaseLock(LockHandle lock_handle);

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -45,7 +45,6 @@
 #include <fstream>
 #include <iterator>
 #include <map>
-#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -684,9 +683,10 @@ static void WriteOwnerInformation(int fd) {
   }
 }
 
-std::pair<LockHandle, std::optional<DurationMillis>> AcquireLock(
-    const std::string& name, const blaze_util::Path& path, LockMode mode,
-    bool batch_mode, bool block) {
+std::pair<LockHandle, DurationMillis> AcquireLock(const std::string& name,
+                                                  const blaze_util::Path& path,
+                                                  LockMode mode,
+                                                  bool batch_mode, bool block) {
   const uint64_t start_time = GetMillisecondsMonotonic();
   bool multiple_attempts = false;
   string owner;
@@ -718,10 +718,9 @@ std::pair<LockHandle, std::optional<DurationMillis>> AcquireLock(
         // unnecessary noise in the logs. We are interested in how long it took
         // for other commands to complete, not how fast acquiring a lock is.
         const uint64_t end_time = GetMillisecondsMonotonic();
-        const auto wait_time =
-            multiple_attempts
-                ? std::make_optional(DurationMillis(start_time, end_time))
-                : std::nullopt;
+        const auto wait_time = multiple_attempts
+                                   ? DurationMillis(start_time, end_time)
+                                   : DurationMillis();
         return std::make_pair(static_cast<LockHandle>(fd), wait_time);
       }
     }

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -31,7 +31,6 @@
 #include <algorithm>
 #include <memory>
 #include <mutex>  // NOLINT
-#include <optional>
 #include <set>
 #include <sstream>
 #include <thread>       // NOLINT (to silence Google-internal linter)
@@ -1127,9 +1126,10 @@ static bool StillExists(HANDLE handle, const string& name) {
   return !info.DeletePending;
 }
 
-std::pair<LockHandle, std::optional<DurationMillis>> AcquireLock(
-    const std::string& name, const blaze_util::Path& path, LockMode mode,
-    bool batch_mode, bool block) {
+std::pair<LockHandle, DurationMillis> AcquireLock(const std::string& name,
+                                                  const blaze_util::Path& path,
+                                                  LockMode mode,
+                                                  bool batch_mode, bool block) {
   const uint64_t start_time = GetMillisecondsMonotonic();
   bool multiple_attempts = false;
 
@@ -1166,10 +1166,9 @@ std::pair<LockHandle, std::optional<DurationMillis>> AcquireLock(
         // unnecessary noise in the logs. We are interested in how long it took
         // for other commands to complete, not how fast acquiring a lock is.
         const uint64_t end_time = GetMillisecondsMonotonic();
-        const auto wait_time =
-            multiple_attempts
-                ? std::make_optional(DurationMillis(start_time, end_time))
-                : std::nullopt;
+        const auto wait_time = multiple_attempts
+                                   ? DurationMillis(start_time, end_time)
+                                   : DurationMillis();
         return std::make_pair(reinterpret_cast<LockHandle>(handle), wait_time);
       }
     }


### PR DESCRIPTION
PiperOrigin-RevId: 701232106
Change-Id: If85963b4a4806b019119fd127f4d0dc0579e66a4