### PR TITLE
[8.1.0] Rename CreateSecureOutputRoot as CreateSecureDirectory.

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1557,7 +1557,7 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
     UnlimitCoredumps();
   }
 
-  blaze::CreateSecureOutputRoot(
+  blaze::CreateSecureDirectory(
       blaze_util::Path(startup_options->output_user_root));
 
   // Only start a server when in a workspace because otherwise we won't do more

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -245,10 +245,9 @@ void ExcludePathFromBackup(const blaze_util::Path& path);
 blaze_util::Path GetHashedBaseDir(const blaze_util::Path& root,
                                   const std::string& hashable);
 
-// Create a safe installation directory where we keep state, installations etc.
-// This method ensures that the directory is created, is owned by the current
-// user, and not accessible to anyone else.
-void CreateSecureOutputRoot(const blaze_util::Path& path);
+// Creates a directory while making sure it is owned by the current user and
+// not accessible to anyone else.
+void CreateSecureDirectory(const blaze_util::Path& path);
 
 std::string GetEnv(const std::string& name);
 

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -509,7 +509,7 @@ blaze_util::Path GetHashedBaseDir(const blaze_util::Path& root,
   return root.GetRelative(digest.String());
 }
 
-void CreateSecureOutputRoot(const blaze_util::Path& path) {
+void CreateSecureDirectory(const blaze_util::Path& path) {
   struct stat fileinfo = {};
 
   if (!blaze_util::MakeDirectories(path, 0755)) {

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -917,7 +917,7 @@ blaze_util::Path GetHashedBaseDir(const blaze_util::Path& root,
   return root.GetRelative(string(coded_name));
 }
 
-void CreateSecureOutputRoot(const blaze_util::Path& path) {
+void CreateSecureDirectory(const blaze_util::Path& path) {
   // TODO(bazel-team): implement this properly, by mimicing whatever the POSIX
   // implementation does.
   if (!blaze_util::MakeDirectories(path, 0755)) {


### PR DESCRIPTION
The current name is confusing because the method is used to create the output *user* root, not the output root. Use a name that reflects the behavior, not the presumed use.

PiperOrigin-RevId: 701287357
Change-Id: If9f5b95c96f1d0a5b7f080226daa8b5aa7b86ea2