### PR TITLE
Distinguish between input and output prefetching in request metadata

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionInputPrefetcher.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 /** Prefetches files to local disk. */
 public interface ActionInputPrefetcher {
   public static final ActionInputPrefetcher NONE =
-      (action, inputs, metadataProvider, priority) ->
+      (action, inputs, metadataProvider, priority, reason) ->
           // Do nothing.
           immediateVoidFuture();
 
@@ -49,6 +49,15 @@ public interface ActionInputPrefetcher {
     LOW,
   }
 
+  /** The reason for prefetching. */
+  enum Reason {
+    /** The requested files are needed as inputs to the given action. */
+    INPUTS,
+
+    /** The requested files are requested as outputs of the given action. */
+    OUTPUTS,
+  }
+
   /**
    * Initiates best-effort prefetching of all given inputs.
    *
@@ -60,5 +69,6 @@ public interface ActionInputPrefetcher {
       ActionExecutionMetadata action,
       Iterable<? extends ActionInput> inputs,
       InputMetadataProvider metadataProvider,
-      Priority priority);
+      Priority priority,
+      Reason reason);
 }

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
+import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Reason;
 import com.google.devtools.build.lib.actions.ArtifactExpander;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
@@ -296,7 +297,8 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
                     getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true)
                         .values(),
                     getInputMetadataProvider(),
-                    Priority.MEDIUM),
+                    Priority.MEDIUM,
+                    Reason.INPUTS),
             BulkTransferException.class,
             (BulkTransferException e) -> {
               if (executionOptions.useNewExitCodeForLostInputs

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -255,14 +255,14 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       Path tempPath,
       PathFragment execPath,
       FileArtifactValue metadata,
-      Priority priority)
+      Priority priority,
+      Reason reason)
       throws IOException;
 
   protected void prefetchVirtualActionInput(VirtualActionInput input) throws IOException {}
 
   /**
-   * Fetches remotely stored action outputs, that are inputs to this spawn, and stores them under
-   * their path in the output base.
+   * Fetches remotely stored action outputs and stores them under their path in the output base.
    *
    * <p>The {@code inputs} may not contain any unexpanded directories.
    *
@@ -276,13 +276,14 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       ActionExecutionMetadata action,
       Iterable<? extends ActionInput> inputs,
       InputMetadataProvider metadataProvider,
-      Priority priority) {
-    return prefetchFilesInterruptibly(action, inputs, metadataProvider::getInputMetadata, priority);
+      Priority priority,
+      Reason reason) {
+    return prefetchFilesInterruptibly(
+        action, inputs, metadataProvider::getInputMetadata, priority, reason);
   }
 
   /**
-   * Fetches remotely stored action outputs, that are inputs to this spawn, and stores them under
-   * their path in the output base.
+   * Fetches remotely stored action outputs and stores them under their path in the output base.
    *
    * <p>The {@code inputs} may not contain any unexpanded directories.
    *
@@ -300,7 +301,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       ActionExecutionMetadata action,
       Iterable<? extends ActionInput> inputs,
       MetadataSupplier metadataSupplier,
-      Priority priority) {
+      Priority priority,
+      Reason reason) {
     List<ActionInput> files = new ArrayList<>();
 
     for (ActionInput input : inputs) {
@@ -334,7 +336,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     try (var s = Profiler.instance().profile("compose prefetches")) {
       for (var file : files) {
         transfers.add(
-            prefetchFile(action, dirsWithOutputPermissions, metadataSupplier, file, priority));
+            prefetchFile(
+                action, dirsWithOutputPermissions, metadataSupplier, file, priority, reason));
       }
     }
 
@@ -365,7 +368,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       Set<Path> dirsWithOutputPermissions,
       MetadataSupplier metadataSupplier,
       ActionInput input,
-      Priority priority) {
+      Priority priority,
+      Reason reason) {
     try {
       if (input instanceof VirtualActionInput virtualActionInput) {
         prefetchVirtualActionInput(virtualActionInput);
@@ -397,7 +401,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
               dirsWithOutputPermissions,
               input,
               metadata,
-              priority);
+              priority,
+              reason);
 
       if (symlink != null) {
         result = result.andThen(plantSymlink(symlink));
@@ -516,7 +521,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       Set<Path> dirsWithOutputPermissions,
       ActionInput actionInput,
       FileArtifactValue metadata,
-      Priority priority) {
+      Priority priority,
+      Reason reason) {
     // If the path to be prefetched is a non-dangling symlink, prefetch its target path instead.
     // Note that this only applies to symlinks created by spawns (or, currently, with the internal
     // version of BwoB); symlinks created in-process through an ActionFileSystem should have already
@@ -561,7 +567,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                                 tempPath,
                                 finalPath.relativeTo(execRoot),
                                 metadata,
-                                priority),
+                                priority,
+                                reason),
                         directExecutor())
                     .doOnComplete(
                         () -> {
@@ -729,7 +736,11 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       try (var s = Profiler.instance().profile(ProfilerTask.REMOTE_DOWNLOAD, "Download outputs")) {
         getFromFuture(
             prefetchFilesInterruptibly(
-                action, outputsToDownload, outputMetadataStore::getOutputMetadata, Priority.HIGH));
+                action,
+                outputsToDownload,
+                outputMetadataStore::getOutputMetadata,
+                Priority.HIGH,
+                Reason.OUTPUTS));
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ActionInputMap;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
+import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Reason;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
@@ -758,7 +759,11 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat
       }
       getFromFuture(
           inputFetcher.prefetchFiles(
-              action, ImmutableList.of(input), inputArtifactData, Priority.CRITICAL));
+              action,
+              ImmutableList.of(input),
+              inputArtifactData,
+              Priority.CRITICAL,
+              Reason.INPUTS));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException(String.format("Received interrupt while fetching file '%s'", path), e);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -84,11 +84,19 @@ public class RemoteActionInputFetcher extends AbstractActionInputPrefetcher {
       Path tempPath,
       PathFragment execPath,
       FileArtifactValue metadata,
-      Priority priority)
+      Priority priority,
+      Reason reason)
       throws IOException {
     checkArgument(metadata.isRemote(), "Cannot download file that is not a remote file.");
     RequestMetadata requestMetadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "prefetcher", action);
+        TracingMetadataUtils.buildMetadata(
+            buildRequestId,
+            commandId,
+            switch (reason) {
+              case INPUTS -> "prefetcher";
+              case OUTPUTS -> "requested";
+            },
+            action);
     RemoteActionExecutionContext context = RemoteActionExecutionContext.create(requestMetadata);
 
     Digest digest = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());

--- a/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputMap;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
+import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Reason;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.CompletionContext;
@@ -468,7 +469,8 @@ public final class CompletionFunction<
         var action =
             ActionUtils.getActionForLookupData(env, derivedArtifact.getGeneratingActionKey());
         var future =
-            actionInputPrefetcher.prefetchFiles(action, filesToDownload, inputMap, Priority.LOW);
+            actionInputPrefetcher.prefetchFiles(
+                action, filesToDownload, inputMap, Priority.LOW, Reason.OUTPUTS);
         futures.add(future);
       }
     } else {
@@ -484,7 +486,7 @@ public final class CompletionFunction<
             ActionUtils.getActionForLookupData(env, derivedArtifact.getGeneratingActionKey());
         var future =
             actionInputPrefetcher.prefetchFiles(
-                action, ImmutableList.of(artifact), inputMap, Priority.LOW);
+                action, ImmutableList.of(artifact), inputMap, Priority.LOW, Reason.OUTPUTS);
         futures.add(future);
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -46,6 +46,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
+import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Reason;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
@@ -299,9 +300,10 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, metadata.keySet(), metadata::get, Priority.MEDIUM));
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
-    verify(prefetcher, never()).doDownloadFile(eq(action), any(), any(), any(), any(), any());
+    verify(prefetcher, never())
+        .doDownloadFile(eq(action), any(), any(), any(), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
   }
@@ -317,9 +319,10 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, metadata.keySet(), metadata::get, Priority.MEDIUM));
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
-    verify(prefetcher).doDownloadFile(eq(action), any(), any(), eq(a.getExecPath()), any(), any());
+    verify(prefetcher)
+        .doDownloadFile(eq(action), any(), any(), eq(a.getExecPath()), any(), any(), any());
     assertThat(prefetcher.downloadedFiles()).containsExactly(a.getPath());
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
     assertThat(FileSystemUtils.readContent(a.getPath(), UTF_8)).isEqualTo("hello world remote");
@@ -335,7 +338,7 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, metadata.keySet(), metadata::get, Priority.MEDIUM));
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     assertThat(FileSystemUtils.readContent(a1.getPath(), UTF_8)).isEqualTo("hello world");
     assertReadableNonWritableAndExecutable(a1.getPath());
@@ -355,7 +358,7 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, metadata.keySet(), metadata::get, Priority.MEDIUM));
+            action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     assertThat(a.getPath().isSymbolicLink()).isTrue();
     assertThat(a.getPath().readSymbolicLink())
@@ -385,7 +388,9 @@ public abstract class ActionInputPrefetcherTestBase {
 
     AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
 
-    wait(prefetcher.prefetchFilesInterruptibly(action, children, metadata::get, Priority.MEDIUM));
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action, children, metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     assertThat(FileSystemUtils.readContent(firstChild.getPath(), UTF_8)).isEqualTo("content1");
     assertThat(FileSystemUtils.readContent(secondChild.getPath(), UTF_8)).isEqualTo("content2");
@@ -417,7 +422,11 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, ImmutableList.of(firstChild, secondChild), metadata::get, Priority.MEDIUM));
+            action,
+            ImmutableList.of(firstChild, secondChild),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS));
 
     assertThat(firstChild.getPath().exists()).isFalse();
     assertThat(FileSystemUtils.readContent(secondChild.getPath(), UTF_8)).isEqualTo("content2");
@@ -446,7 +455,9 @@ public abstract class ActionInputPrefetcherTestBase {
 
     AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
 
-    wait(prefetcher.prefetchFilesInterruptibly(action, children, metadata::get, Priority.MEDIUM));
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action, children, metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     assertThat(tree.getPath().isSymbolicLink()).isTrue();
     assertThat(tree.getPath().readSymbolicLink())
@@ -485,13 +496,13 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, ImmutableList.of(firstChild), metadata::get, Priority.MEDIUM));
+            action, ImmutableList.of(firstChild), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     assertTreeReadableWritableAndExecutable(tree.getPath());
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, ImmutableList.of(secondChild), metadata::get, Priority.MEDIUM));
+            action, ImmutableList.of(secondChild), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     assertTreeReadableWritableAndExecutable(tree.getPath());
   }
@@ -507,7 +518,7 @@ public abstract class ActionInputPrefetcherTestBase {
         () ->
             wait(
                 prefetcher.prefetchFilesInterruptibly(
-                    action, ImmutableList.of(a), metadata::get, Priority.MEDIUM)));
+                    action, ImmutableList.of(a), metadata::get, Priority.MEDIUM, Reason.INPUTS)));
 
     assertThat(prefetcher.downloadedFiles()).isEmpty();
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
@@ -526,7 +537,7 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, ImmutableList.of(a), metadata::get, Priority.MEDIUM));
+            action, ImmutableList.of(a), metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     assertThat(prefetcher.downloadedFiles()).isEmpty();
     assertThat(prefetcher.downloadsInProgress()).isEmpty();
@@ -552,7 +563,9 @@ public abstract class ActionInputPrefetcherTestBase {
 
     AbstractActionInputPrefetcher prefetcher = createPrefetcher(cas);
 
-    wait(prefetcher.prefetchFilesInterruptibly(action, children, metadata::get, Priority.MEDIUM));
+    wait(
+        prefetcher.prefetchFilesInterruptibly(
+            action, children, metadata::get, Priority.MEDIUM, Reason.INPUTS));
 
     assertThat(firstChild.getPath().exists()).isFalse();
     assertThat(FileSystemUtils.readContent(secondChild.getPath(), UTF_8)).isEqualTo("content2");
@@ -585,7 +598,11 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, ImmutableList.of(firstChild, secondChild), metadata::get, Priority.MEDIUM));
+            action,
+            ImmutableList.of(firstChild, secondChild),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS));
 
     verify(fs).createWritableDirectory(root);
     verify(fs).createWritableDirectory(subdir);
@@ -596,7 +613,11 @@ public abstract class ActionInputPrefetcherTestBase {
 
     wait(
         prefetcher.prefetchFilesInterruptibly(
-            action, ImmutableList.of(firstChild, secondChild), metadata::get, Priority.MEDIUM));
+            action,
+            ImmutableList.of(firstChild, secondChild),
+            metadata::get,
+            Priority.MEDIUM,
+            Reason.INPUTS));
 
     verify(fs, never()).createWritableDirectory(root);
     verify(fs, never()).createWritableDirectory(subdir);
@@ -635,7 +656,7 @@ public abstract class ActionInputPrefetcherTestBase {
         () -> {
           wait(
               prefetcher.prefetchFilesInterruptibly(
-                  action, ImmutableList.of(child), metadata::get, Priority.MEDIUM));
+                  action, ImmutableList.of(child), metadata::get, Priority.MEDIUM, Reason.INPUTS));
           assertTreeReadableNonWritableAndExecutable(tree.getPath());
           return null;
         };
@@ -669,7 +690,11 @@ public abstract class ActionInputPrefetcherTestBase {
               try {
                 wait(
                     prefetcher.prefetchFilesInterruptibly(
-                        action, ImmutableList.of(artifact), metadata::get, Priority.MEDIUM));
+                        action,
+                        ImmutableList.of(artifact),
+                        metadata::get,
+                        Priority.MEDIUM,
+                        Reason.INPUTS));
               } catch (IOException | ExecException | InterruptedException ignored) {
                 // do nothing
               }
@@ -681,7 +706,11 @@ public abstract class ActionInputPrefetcherTestBase {
               try {
                 wait(
                     prefetcher.prefetchFilesInterruptibly(
-                        action, ImmutableList.of(artifact), metadata::get, Priority.MEDIUM));
+                        action,
+                        ImmutableList.of(artifact),
+                        metadata::get,
+                        Priority.MEDIUM,
+                        Reason.INPUTS));
               } catch (IOException | ExecException | InterruptedException ignored) {
                 // do nothing
               }
@@ -719,7 +748,11 @@ public abstract class ActionInputPrefetcherTestBase {
               try {
                 wait(
                     prefetcher.prefetchFilesInterruptibly(
-                        action, ImmutableList.of(artifact), metadata::get, Priority.MEDIUM));
+                        action,
+                        ImmutableList.of(artifact),
+                        metadata::get,
+                        Priority.MEDIUM,
+                        Reason.INPUTS));
               } catch (IOException | ExecException | InterruptedException ignored) {
                 // do nothing
               }
@@ -732,7 +765,11 @@ public abstract class ActionInputPrefetcherTestBase {
               try {
                 wait(
                     prefetcher.prefetchFilesInterruptibly(
-                        action, ImmutableList.of(artifact), metadata::get, Priority.MEDIUM));
+                        action,
+                        ImmutableList.of(artifact),
+                        metadata::get,
+                        Priority.MEDIUM,
+                        Reason.INPUTS));
                 successful.set(true);
               } catch (IOException | ExecException | InterruptedException ignored) {
                 // do nothing
@@ -776,7 +813,11 @@ public abstract class ActionInputPrefetcherTestBase {
 
     ListenableFuture<Void> future =
         prefetcher.prefetchFilesInterruptibly(
-            action, ImmutableList.of(a1), interruptedMetadataSupplier, Priority.MEDIUM);
+            action,
+            ImmutableList.of(a1),
+            interruptedMetadataSupplier,
+            Priority.MEDIUM,
+            Reason.INPUTS);
 
     assertThrows(InterruptedException.class, () -> getFromFuture(future));
   }
@@ -804,7 +845,11 @@ public abstract class ActionInputPrefetcherTestBase {
               try {
                 getFromFuture(
                     prefetcher.prefetchFilesInterruptibly(
-                        action, ImmutableList.of(a1), metadata::get, Priority.MEDIUM));
+                        action,
+                        ImmutableList.of(a1),
+                        metadata::get,
+                        Priority.MEDIUM,
+                        Reason.INPUTS));
               } catch (IOException ignored) {
                 // Intentionally left empty
               } catch (InterruptedException e) {
@@ -843,7 +888,7 @@ public abstract class ActionInputPrefetcherTestBase {
         () ->
             wait(
                 prefetcher.prefetchFilesInterruptibly(
-                    action, metadata.keySet(), metadata::get, Priority.MEDIUM)));
+                    action, metadata.keySet(), metadata::get, Priority.MEDIUM, Reason.INPUTS)));
 
     assertThat(lostInputsEvents).hasSize(1);
   }
@@ -884,7 +929,7 @@ public abstract class ActionInputPrefetcherTestBase {
               return resultSupplier.get();
             })
         .when(prefetcher)
-        .doDownloadFile(any(), any(), any(), any(), any(), any());
+        .doDownloadFile(any(), any(), any(), any(), any(), any(), any());
   }
 
   private void assertReadableNonWritableAndExecutable(Path path) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -178,7 +178,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     doAnswer(mockPrefetchFile(artifact.getPath(), "remote contents"))
         .when(inputFetcher)
         .prefetchFiles(
-            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
+            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), eq(Reason.INPUTS));
 
     // act
     Path actionFsPath = actionFs.getPath(artifact.getPath().asFragment());
@@ -189,7 +189,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     assertThat(contents).isEqualTo("remote contents");
     verify(inputFetcher)
         .prefetchFiles(
-            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
+            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), eq(Reason.INPUTS));
     verifyNoMoreInteractions(inputFetcher);
   }
 
@@ -202,7 +202,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     doAnswer(mockPrefetchFile(artifact.getPath(), "remote contents"))
         .when(inputFetcher)
         .prefetchFiles(
-            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
+            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), eq(Reason.INPUTS));
 
     // act
     Path actionFsPath = actionFs.getPath(artifact.getPath().asFragment());
@@ -213,7 +213,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     assertThat(contents).isEqualTo("remote contents");
     verify(inputFetcher)
         .prefetchFiles(
-            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
+            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), eq(Reason.INPUTS));
     verifyNoMoreInteractions(inputFetcher);
   }
 
@@ -227,7 +227,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     doAnswer(mockPrefetchFile(path, "remote contents"))
         .when(inputFetcher)
         .prefetchFiles(
-            any(), eq(ImmutableList.of(input)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
+            any(), eq(ImmutableList.of(input)), any(), eq(Priority.CRITICAL), eq(Reason.INPUTS));
 
     // act
     Path actionFsPath = actionFs.getPath(path.asFragment());
@@ -238,7 +238,7 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     assertThat(contents).isEqualTo("remote contents");
     verify(inputFetcher)
         .prefetchFiles(
-            any(), eq(ImmutableList.of(input)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
+            any(), eq(ImmutableList.of(input)), any(), eq(Priority.CRITICAL), eq(Reason.INPUTS));
     verifyNoMoreInteractions(inputFetcher);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ActionInputMap;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
+import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Reason;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
@@ -176,7 +177,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     FileSystem actionFs = createActionFileSystem(inputs);
     doAnswer(mockPrefetchFile(artifact.getPath(), "remote contents"))
         .when(inputFetcher)
-        .prefetchFiles(any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL));
+        .prefetchFiles(
+            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
 
     // act
     Path actionFsPath = actionFs.getPath(artifact.getPath().asFragment());
@@ -186,7 +188,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     assertThat(actionFsPath.getFileSystem()).isSameInstanceAs(actionFs);
     assertThat(contents).isEqualTo("remote contents");
     verify(inputFetcher)
-        .prefetchFiles(any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL));
+        .prefetchFiles(
+            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
     verifyNoMoreInteractions(inputFetcher);
   }
 
@@ -198,7 +201,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     injectRemoteFile(actionFs, artifact.getPath().asFragment(), "remote contents");
     doAnswer(mockPrefetchFile(artifact.getPath(), "remote contents"))
         .when(inputFetcher)
-        .prefetchFiles(any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL));
+        .prefetchFiles(
+            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
 
     // act
     Path actionFsPath = actionFs.getPath(artifact.getPath().asFragment());
@@ -208,7 +212,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     assertThat(actionFsPath.getFileSystem()).isSameInstanceAs(actionFs);
     assertThat(contents).isEqualTo("remote contents");
     verify(inputFetcher)
-        .prefetchFiles(any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL));
+        .prefetchFiles(
+            any(), eq(ImmutableList.of(artifact)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
     verifyNoMoreInteractions(inputFetcher);
   }
 
@@ -221,7 +226,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     injectRemoteFile(actionFs, path.asFragment(), "remote contents");
     doAnswer(mockPrefetchFile(path, "remote contents"))
         .when(inputFetcher)
-        .prefetchFiles(any(), eq(ImmutableList.of(input)), any(), eq(Priority.CRITICAL));
+        .prefetchFiles(
+            any(), eq(ImmutableList.of(input)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
 
     // act
     Path actionFsPath = actionFs.getPath(path.asFragment());
@@ -231,7 +237,8 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     assertThat(actionFsPath.getFileSystem()).isSameInstanceAs(actionFs);
     assertThat(contents).isEqualTo("remote contents");
     verify(inputFetcher)
-        .prefetchFiles(any(), eq(ImmutableList.of(input)), any(), eq(Priority.CRITICAL));
+        .prefetchFiles(
+            any(), eq(ImmutableList.of(input)), any(), eq(Priority.CRITICAL), Reason.INPUTS);
     verifyNoMoreInteractions(inputFetcher);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -23,6 +23,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.hash.HashCode;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Priority;
+import com.google.devtools.build.lib.actions.ActionInputPrefetcher.Reason;
 import com.google.devtools.build.lib.actions.ActionOutputDirectoryHelper;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
@@ -103,7 +104,11 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
     // act
     wait(
         actionInputFetcher.prefetchFilesInterruptibly(
-            action, ImmutableList.of(a), (ActionInput unused) -> null, Priority.MEDIUM));
+            action,
+            ImmutableList.of(a),
+            (ActionInput unused) -> null,
+            Priority.MEDIUM,
+            Reason.INPUTS));
 
     // assert
     Path p = execRoot.getRelative(a.getExecPath());
@@ -135,7 +140,8 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
             action,
             ImmutableList.of(VirtualActionInput.EMPTY_MARKER),
             (ActionInput unused) -> null,
-            Priority.MEDIUM));
+            Priority.MEDIUM,
+            Reason.INPUTS));
 
     // assert that nothing happened
     assertThat(actionInputFetcher.downloadedFiles()).isEmpty();
@@ -154,7 +160,11 @@ public class RemoteActionInputFetcherTest extends ActionInputPrefetcherTestBase 
             () ->
                 wait(
                     prefetcher.prefetchFilesInterruptibly(
-                        action, ImmutableList.of(a), metadata::get, Priority.MEDIUM)));
+                        action,
+                        ImmutableList.of(a),
+                        metadata::get,
+                        Priority.MEDIUM,
+                        Reason.INPUTS)));
 
     assertThat(prefetcher.downloadedFiles()).isEmpty();
     assertThat(prefetcher.downloadsInProgress()).isEmpty();


### PR DESCRIPTION
ea4ad30d4e49b83b62df0e10b5abe2faadea7582 added an action as context for prefetches with BwoB, but assumed that all callers would use the prefetcher for inputs to locally executed actions. However, since then, it has also been used to download outputs of completed actions that have been explicitly requested (e.g. as outputs of top-level targets or those matching the regex path patterns). This resulted in downloads with a `prefetcher` action ID and action details for the action that produced the file, rather than consumed it, resulting in confusing situations for observability tools.

This is fixed by separately tracking the reason for the fetch and using an action ID of `requested` when the action has the requested file as an output.