### PR TITLE
[8.1.0] Improve the encapsulation of StartupOptions.

### DIFF
--- a/src/main/cpp/bazel_startup_options.cc
+++ b/src/main/cpp/bazel_startup_options.cc
@@ -13,17 +13,21 @@
 // limitations under the License.
 #include "src/main/cpp/bazel_startup_options.h"
 
-#include <cassert>
+#include <assert.h>
+
+#include <string>
+#include <vector>
 
 #include "src/main/cpp/blaze_util.h"
+#include "src/main/cpp/blaze_util_platform.h"
+#include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/util/logging.h"
-#include "src/main/cpp/workspace_layout.h"
+#include "src/main/cpp/util/path_platform.h"
 
 namespace blaze {
 
-BazelStartupOptions::BazelStartupOptions(
-    const WorkspaceLayout *workspace_layout)
-    : StartupOptions("Bazel", workspace_layout),
+BazelStartupOptions::BazelStartupOptions()
+    : StartupOptions("Bazel"),
       user_bazelrc_(""),
       use_system_rc(true),
       use_workspace_rc(true),
@@ -32,6 +36,10 @@ BazelStartupOptions::BazelStartupOptions(
   RegisterNullaryStartupFlagNoRc("system_rc", &use_system_rc);
   RegisterNullaryStartupFlagNoRc("workspace_rc", &use_workspace_rc);
   RegisterUnaryStartupFlag("bazelrc");
+}
+
+blaze_util::Path BazelStartupOptions::GetDefaultOutputRoot() const {
+  return blaze_util::Path(blaze::GetCacheDir());
 }
 
 blaze_exit_code::ExitCode BazelStartupOptions::ProcessArgExtra(

--- a/src/main/cpp/bazel_startup_options.h
+++ b/src/main/cpp/bazel_startup_options.h
@@ -18,13 +18,14 @@
 
 #include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/util/exit_code.h"
+#include "src/main/cpp/util/path_platform.h"
 
 namespace blaze {
 
 // BazelStartupOptions contains the startup options that are Bazel-specific.
 class BazelStartupOptions : public StartupOptions {
  public:
-  explicit BazelStartupOptions(const WorkspaceLayout *workspace_layout);
+  BazelStartupOptions();
 
   void AddExtraOptions(std::vector<std::string> *result) const override;
 
@@ -35,6 +36,8 @@ class BazelStartupOptions : public StartupOptions {
   void MaybeLogStartupOptionWarnings() const override;
 
  protected:
+  blaze_util::Path GetDefaultOutputRoot() const override;
+
   std::string GetRcFileBaseName() const override { return ".bazelrc"; }
 
  private:

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1146,39 +1146,16 @@ static string GetCanonicalCwd() {
   return result;
 }
 
-// Updates the parsed startup options and global config to fill in defaults.
-static void UpdateConfiguration(const string &install_md5,
-                                const string &workspace, const bool server_mode,
-                                StartupOptions *startup_options) {
-  // The default install_base is <output_user_root>/install/<md5(blaze)>
-  // but if an install_base is specified on the command line, we use that as
-  // the base instead.
-  if (startup_options->install_base.IsEmpty()) {
-    if (server_mode) {
-      BAZEL_DIE(blaze_exit_code::BAD_ARGV)
-          << "exec-server requires --install_base";
-    }
-    blaze_util::Path install_user_root =
-        startup_options->output_user_root.GetRelative("install");
-    startup_options->install_base = install_user_root.GetRelative(install_md5);
-  }
-
-  if (startup_options->output_base.IsEmpty()) {
-    if (server_mode) {
-      BAZEL_DIE(blaze_exit_code::BAD_ARGV)
-          << "exec-server requires --output_base";
-    }
-    startup_options->output_base =
-        blaze::GetHashedBaseDir(startup_options->output_user_root, workspace);
-  }
+static void PrepareDirectories(StartupOptions *startup_options) {
+  blaze::CreateSecureDirectory(
+      blaze_util::Path(startup_options->output_user_root));
 
   if (!blaze_util::PathExists(startup_options->output_base)) {
     if (!blaze_util::MakeDirectories(startup_options->output_base, 0777)) {
-      string err = GetLastErrorString();
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
           << "Output base directory '"
           << startup_options->output_base.AsPrintablePath()
-          << "' could not be created: " << err;
+          << "' could not be created: " << GetLastErrorString();
     }
   } else {
     if (!blaze_util::IsDirectory(startup_options->output_base)) {
@@ -1194,20 +1171,14 @@ static void UpdateConfiguration(const string &install_md5,
         << startup_options->output_base.AsPrintablePath()
         << "' must be readable and writable.";
   }
+
   ExcludePathFromBackup(startup_options->output_base);
 
   startup_options->output_base = startup_options->output_base.Canonicalize();
   if (startup_options->output_base.IsEmpty()) {
-    string err = GetLastErrorString();
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "blaze_util::MakeCanonical('"
-        << startup_options->output_base.AsPrintablePath()
-        << "') failed: " << err;
-  }
-
-  if (startup_options->failure_detail_out.IsEmpty()) {
-    startup_options->failure_detail_out =
-        startup_options->output_base.GetRelative("failure_detail.rawproto");
+        << "Output base directory could not be canonicalized: "
+        << GetLastErrorString();
   }
 }
 
@@ -1530,6 +1501,10 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
   (void)DetectBashAndExportBazelSh();
 #endif  // if defined(_WIN32) || defined(__CYGWIN__)
 
+  if (blaze::IsRunningWithinTest()) {
+    BAZEL_LOG(USER) << "$TEST_TMPDIR defined, some defaults will be overridden";
+  }
+
   const string workspace = workspace_layout->GetWorkspace(cwd);
   ParseOptionsOrDie(cwd, workspace, *option_processor, argc, argv);
   StartupOptions *startup_options = option_processor->GetParsedStartupOptions();
@@ -1553,9 +1528,6 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
     UnlimitCoredumps();
   }
 
-  blaze::CreateSecureDirectory(
-      blaze_util::Path(startup_options->output_user_root));
-
   // Only start a server when in a workspace because otherwise we won't do more
   // than emit a help message.
   if (!workspace_layout->InWorkspace(workspace)) {
@@ -1570,9 +1542,10 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
   string install_md5;
   DetermineArchiveContents(self_path, &archive_contents, &install_md5);
 
-  UpdateConfiguration(install_md5, workspace,
-                      IsServerMode(option_processor->GetCommand()),
-                      startup_options);
+  startup_options->UpdateConfiguration(
+      install_md5, workspace, IsServerMode(option_processor->GetCommand()));
+
+  PrepareDirectories(startup_options);
 
   RunLauncher(self_path, archive_contents, install_md5, *startup_options,
               *option_processor, *workspace_layout, workspace, &logging_info);

--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -62,7 +62,7 @@ using std::string;
 
 // ${XDG_CACHE_HOME}/bazel, a.k.a. ~/.cache/bazel by default (which is the
 // fallback when XDG_CACHE_HOME is not set)
-string GetOutputRoot() {
+string GetCacheDir() {
   string xdg_cache_home = GetPathEnv("XDG_CACHE_HOME");
   if (xdg_cache_home.empty()) {
     char buf[2048];

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -96,9 +96,7 @@ static string DescriptionFromCFError(CFErrorRef cf_err) {
   return UTF8StringFromCFStringRef(cf_err_string);
 }
 
-string GetOutputRoot() {
-  return "/var/tmp";
-}
+string GetCacheDir() { return "/var/tmp"; }
 
 void WarnFilesystemType(const blaze_util::Path &output_base) {
   // Check to see if we are on a non-local drive.

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -44,7 +44,7 @@ using std::vector;
 
 // ${XDG_CACHE_HOME}/bazel, a.k.a. ~/.cache/bazel by default (which is the
 // fallback when XDG_CACHE_HOME is not set)
-string GetOutputRoot() {
+string GetCacheDir() {
   string xdg_cache_home = GetPathEnv("XDG_CACHE_HOME");
   if (xdg_cache_home.empty()) {
     string home = GetHomeDir();  // via $HOME env variable

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -118,8 +118,8 @@ std::string Which(const std::string& executable);
 // readable.
 std::string GetSelfPath(const char* argv0);
 
-// Returns the directory Bazel can use to store output.
-std::string GetOutputRoot();
+// Returns a directory suitable for storing cached files.
+std::string GetCacheDir();
 
 // Returns the current user's home directory, or the empty string if unknown.
 // On Linux/macOS, this is $HOME. On Windows this is %USERPROFILE%.

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -399,7 +399,7 @@ string GetSelfPath(const char* argv0) {
   return blaze_util::WstringToCstring(buffer);
 }
 
-string GetOutputRoot() {
+string GetCacheDir() {
   string home = GetHomeDir();
   if (home.empty()) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)

--- a/src/main/cpp/main.cc
+++ b/src/main/cpp/main.cc
@@ -24,10 +24,10 @@
 
 int main_impl(int argc, char **argv) {
   uint64_t start_time = blaze::GetMillisecondsMonotonic();
-  std::unique_ptr<blaze::WorkspaceLayout> workspace_layout(
-      new blaze::WorkspaceLayout());
+  std::unique_ptr<blaze::WorkspaceLayout> workspace_layout =
+      std::make_unique<blaze::WorkspaceLayout>();
   std::unique_ptr<blaze::StartupOptions> startup_options(
-      new blaze::BazelStartupOptions(workspace_layout.get()));
+      std::make_unique<blaze::BazelStartupOptions>());
   return blaze::Main(argc, argv, workspace_layout.get(),
                      new blaze::OptionProcessor(workspace_layout.get(),
                                                 std::move(startup_options)),

--- a/src/main/cpp/util/strings.cc
+++ b/src/main/cpp/util/strings.cc
@@ -271,12 +271,7 @@ void StringPrintf(string *str, const char *format, ...) {
   delete[] buf;
 }
 
-void ToLower(string *str) {
-  assert(str);
-  *str = AsLower(*str);
-}
-
-string AsLower(const string &str) {
+string ToLower(const string &str) {
   if (str.empty()) {
     return "";
   }

--- a/src/main/cpp/util/strings.h
+++ b/src/main/cpp/util/strings.h
@@ -116,9 +116,7 @@ void Tokenize(const std::string &str, const char &comment,
 void StringPrintf(std::string *str, const char *format, ...);
 
 // Convert str to lower case. No locale handling, this is just for ASCII.
-void ToLower(std::string *str);
-
-std::string AsLower(const std::string &str);
+std::string ToLower(const std::string &str);
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 // Convert UTF-16 string to ASCII (using the Active Code Page).

--- a/src/main/cpp/workspace_layout.cc
+++ b/src/main/cpp/workspace_layout.cc
@@ -31,8 +31,6 @@ namespace blaze {
 using std::string;
 using std::vector;
 
-string WorkspaceLayout::GetOutputRoot() const { return blaze::GetOutputRoot(); }
-
 bool WorkspaceLayout::InWorkspace(const string &workspace) const {
   for (auto boundaryFileName :
        {"MODULE.bazel", "REPO.bazel", "WORKSPACE.bazel", "WORKSPACE"}) {

--- a/src/main/cpp/workspace_layout.h
+++ b/src/main/cpp/workspace_layout.h
@@ -26,9 +26,6 @@ class WorkspaceLayout {
  public:
   virtual ~WorkspaceLayout() = default;
 
-  // Returns the directory to use for storing outputs.
-  virtual std::string GetOutputRoot() const;
-
   // Given the working directory, returns the nearest enclosing directory with a
   // workspace boundary file in it.  If there is no such enclosing directory,
   // returns "".

--- a/src/test/cpp/bazel_startup_options_test.cc
+++ b/src/test/cpp/bazel_startup_options_test.cc
@@ -19,7 +19,7 @@
 #include <memory>
 
 #include "src/main/cpp/blaze_util_platform.h"
-#include "src/main/cpp/workspace_layout.h"
+#include "src/main/cpp/util/file_platform.h"
 #include "src/test/cpp/test_util.h"
 #include "googletest/include/gtest/gtest.h"
 
@@ -27,9 +27,6 @@ namespace blaze {
 
 class BazelStartupOptionsTest : public ::testing::Test {
  protected:
-  BazelStartupOptionsTest() : workspace_layout_(new WorkspaceLayout()) {}
-  ~BazelStartupOptionsTest() = default;
-
   void SetUp() override {
     // This knowingly ignores the possibility of these environment variables
     // being unset because we expect our test runner to set them in all cases.
@@ -43,11 +40,13 @@ class BazelStartupOptionsTest : public ::testing::Test {
 
   // Recreates startup_options_ after changes to the environment.
   void ReinitStartupOptions() {
-    startup_options_.reset(new BazelStartupOptions(workspace_layout_.get()));
+    startup_options_ = std::make_unique<BazelStartupOptions>();
   }
 
- private:
-  std::unique_ptr<WorkspaceLayout> workspace_layout_;
+  // Calls UpdateConfiguration with some default values.
+  void UpdateConfiguration() {
+    startup_options_->UpdateConfiguration("deadbeef", "workspace", false);
+  }
 
  protected:
   std::unique_ptr<BazelStartupOptions> startup_options_;
@@ -84,6 +83,145 @@ TEST_F(BazelStartupOptionsTest, EmptyFlagsAreInvalid) {
   EXPECT_FALSE(startup_options_->IsUnary(""));
   EXPECT_FALSE(startup_options_->IsUnary("--"));
 }
+
+#ifdef __linux
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithTestTmpdir) {
+  SetEnv("USER", "gandalf");
+  SetEnv("HOME", "/nonexistent/home");
+  SetEnv("XDG_CACHE_HOME", "/nonexistent/cache");
+  SetEnv("TEST_TMPDIR", "/nonexistent/tmpdir");
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path("/nonexistent/tmpdir/_bazel_gandalf"),
+            startup_options_->output_user_root);
+  ASSERT_EQ(
+      blaze_util::Path("/nonexistent/tmpdir/_bazel_gandalf/install/deadbeef"),
+      startup_options_->install_base);
+  ASSERT_EQ(blaze_util::Path("/nonexistent/tmpdir/_bazel_gandalf/"
+                             "1629dee48cc4e53161f9b2be8614e062"),
+            startup_options_->output_base);
+}
+
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithXdgCacheHome) {
+  SetEnv("USER", "gandalf");
+  SetEnv("HOME", "/nonexistent/home");
+  SetEnv("XDG_CACHE_HOME", "/nonexistent/cache");
+  UnsetEnv("TEST_TMPDIR");
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path("/nonexistent/cache/bazel/_bazel_gandalf"),
+            startup_options_->output_user_root);
+  ASSERT_EQ(blaze_util::Path(
+                "/nonexistent/cache/bazel/_bazel_gandalf/install/deadbeef"),
+            startup_options_->install_base);
+  ASSERT_EQ(blaze_util::Path("/nonexistent/cache/bazel/_bazel_gandalf/"
+                             "1629dee48cc4e53161f9b2be8614e062"),
+            startup_options_->output_base);
+}
+
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithHome) {
+  SetEnv("USER", "gandalf");
+  SetEnv("HOME", "/nonexistent/home");
+  UnsetEnv("TEST_TMPDIR");
+  UnsetEnv("XDG_CACHE_HOME");
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path("/nonexistent/home/.cache/bazel/_bazel_gandalf"),
+            startup_options_->output_user_root);
+  ASSERT_EQ(
+      blaze_util::Path(
+          "/nonexistent/home/.cache/bazel/_bazel_gandalf/install/deadbeef"),
+      startup_options_->install_base);
+  ASSERT_EQ(blaze_util::Path("/nonexistent/home/.cache/bazel/_bazel_gandalf/"
+                             "1629dee48cc4e53161f9b2be8614e062"),
+            startup_options_->output_base);
+}
+
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxNoShellExpansion) {
+  SetEnv("USER", "gandalf");
+  SetEnv("TEST_TMPDIR", "~/\"$foo/test\"");
+  SetEnv("XDG_CACHE_HOME", "~/cache${bar}");
+  SetEnv("HOME", "~/home$(echo baz)");
+
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() + "/~/\"$foo/test\"" +
+                             "/_bazel_gandalf"),
+            startup_options_->output_user_root);
+
+  UnsetEnv("TEST_TMPDIR");
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() +
+                             "/~/cache${bar}/bazel/_bazel_gandalf"),
+            startup_options_->output_user_root);
+
+  UnsetEnv("XDG_CACHE_HOME");
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() +
+                             "/~/home$(echo baz)/.cache/bazel/_bazel_gandalf"),
+            startup_options_->output_user_root);
+}
+#endif  // __linux
+
+#ifdef __APPLE__
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwin) {
+  SetEnv("USER", "gandalf");
+  SetEnv("HOME", "/nonexistent/home");
+  UnsetEnv("TEST_TMPDIR");
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path("/var/tmp/_bazel_gandalf"),
+            startup_options_->output_user_root);
+  ASSERT_EQ(blaze_util::Path("/var/tmp/_bazel_gandalf/install/deadbeef"),
+            startup_options_->install_base);
+  ASSERT_EQ(blaze_util::Path("/var/tmp/_bazel_gandalf/"
+                             "1629dee48cc4e53161f9b2be8614e062"),
+            startup_options_->output_base);
+}
+#endif  // __APPLE__
+
+#if defined(__WIN32__) || defined(__CYGWIN__)
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnWindowsWithHome) {
+  SetEnv("USER", "gandalf");
+  SetEnv("HOME", "C:\\Users\\gandalf");
+  UnsetEnv("TEST_TMPDIR");
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path("C:/Users/gandalf/_bazel_gandalf"),
+            startup_options_->output_user_root);
+  ASSERT_EQ(blaze_util::Path("C:/Users/gandalf/install/deadbeef"),
+            startup_options_->install_base);
+  ASSERT_EQ(blaze_util::Path("C:/Users/gandalf/_bazel_gandalf/"
+                             "1629dee48cc4e53161f9b2be8614e062"),
+            startup_options_->output_base);
+}
+
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnWindowsWithUserProfile) {
+  UnsetEnv("HOME");
+  SetEnv("USERPROFILE", "C:\\Users\\gandalf");
+  UnsetEnv("TEST_TMPDIR");
+  ReinitStartupOptions();
+  UpdateConfiguration();
+
+  ASSERT_EQ(blaze_util::Path("C:/Users/gandalf/_bazel_gandalf"),
+            startup_options_->output_user_root);
+  ASSERT_EQ(blaze_util::Path("C:/Users/gandalf/install/deadbeef"),
+            startup_options_->install_base);
+  ASSERT_EQ(blaze_util::Path("C:/Users/gandalf/_bazel_gandalf/"
+                             "1629dee48cc4e53161f9b2be8614e062"),
+            startup_options_->output_base);
+}
+#endif  // __WIN32__ || __CYGWIN__
 
 // TODO(#4502 related cleanup) This test serves as a catalog of the valid
 // options - make this test check that the list is complete, that no options are

--- a/src/test/cpp/blaze_archive_test.cc
+++ b/src/test/cpp/blaze_archive_test.cc
@@ -33,7 +33,6 @@
 #include "src/main/cpp/blaze_util_platform.h"
 #include "src/main/cpp/util/exit_code.h"
 #include "src/main/cpp/util/file_platform.h"
-#include "src/main/cpp/workspace_layout.h"
 #include "util/task/status_macros.h"
 
 using ::testing::Gt;
@@ -124,9 +123,7 @@ class BlazeArchiveTest : public ::testing::Test {
 };
 
 TEST_F(BlazeArchiveTest, TestZipExtractionAndFarOutMTimes) {
-  std::unique_ptr<blaze::WorkspaceLayout> workspace_layout(
-      new blaze::WorkspaceLayout());
-  BazelStartupOptions startup_options(workspace_layout.get());
+  BazelStartupOptions startup_options;
   set_startup_options(startup_options, blaze_path, output_dir);
   LoggingInfo logging_info(blaze_path, blaze::GetMillisecondsMonotonic());
 
@@ -161,9 +158,7 @@ has_value()
 }
 
 TEST_F(BlazeArchiveTest, TestNoDataExtractionIfInstallBaseExists) {
-  std::unique_ptr<blaze::WorkspaceLayout> workspace_layout(
-      new blaze::WorkspaceLayout());
-  BazelStartupOptions startup_options(workspace_layout.get());
+  BazelStartupOptions startup_options;
   set_startup_options(startup_options, blaze_path, output_dir);
   LoggingInfo logging_info(blaze_path, blaze::GetMillisecondsMonotonic());
 

--- a/src/test/cpp/blaze_util_windows_test.cc
+++ b/src/test/cpp/blaze_util_windows_test.cc
@@ -42,7 +42,7 @@ using std::wstring;
 #define ASSERT_ENVVAR_UNSET(/* const char* */ key)                          \
   {                                                                         \
     ASSERT_EQ(::GetEnvironmentVariableA(key, nullptr, 0), (DWORD)0);        \
-    ASSERT_EQ(::GetEnvironmentVariableA(blaze_util::AsLower(key).c_str(),   \
+    ASSERT_EQ(::GetEnvironmentVariableA(blaze_util::ToLower(key).c_str(),   \
                                         nullptr, 0),                        \
               (DWORD)0);                                                    \
     ASSERT_EQ(::GetEnvironmentVariableW(                                    \
@@ -50,7 +50,7 @@ using std::wstring;
               (DWORD)0);                                                    \
     ASSERT_EQ(                                                              \
         ::GetEnvironmentVariableW(                                          \
-            blaze_util::CstringToWstring(blaze_util::AsLower(key)).c_str(), \
+            blaze_util::CstringToWstring(blaze_util::ToLower(key)).c_str(), \
             nullptr, 0),                                                    \
         (DWORD)0);                                                          \
   }
@@ -76,7 +76,7 @@ using std::wstring;
     ASSERT_EQ(string(buf.get()), expected);                               \
                                                                           \
     /* Assert that envvar keys are case-insensitive. */                   \
-    string lkey(blaze_util::AsLower(key));                                \
+    string lkey(blaze_util::ToLower(key));                                \
     ASSERT_EQ(::GetEnvironmentVariableA(lkey.c_str(), buf.get(), size),   \
               size - 1);                                                  \
     ASSERT_EQ(string(buf.get()), expected);                               \

--- a/src/test/cpp/option_processor_test.cc
+++ b/src/test/cpp/option_processor_test.cc
@@ -41,9 +41,7 @@ class OptionProcessorTest : public ::testing::Test {
   void SetUp() override {
     ASSERT_TRUE(blaze_util::MakeDirectories(workspace_, 0755));
     option_processor_.reset(new OptionProcessor(
-        workspace_layout_.get(),
-        std::unique_ptr<StartupOptions>(
-            new BazelStartupOptions(workspace_layout_.get()))));
+        workspace_layout_.get(), std::make_unique<BazelStartupOptions>()));
   }
 
   void TearDown() override {

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -91,9 +91,7 @@ class RcFileTest : public ::testing::Test {
 
     ASSERT_TRUE(blaze_util::MakeDirectories(binary_dir_, 0755));
     option_processor_.reset(new OptionProcessor(
-        workspace_layout_.get(),
-        std::unique_ptr<StartupOptions>(
-            new BazelStartupOptions(workspace_layout_.get())),
+        workspace_layout_.get(), std::make_unique<BazelStartupOptions>(),
         "bazel.bazelrc"));
   }
 

--- a/src/test/cpp/startup_options_test.cc
+++ b/src/test/cpp/startup_options_test.cc
@@ -31,8 +31,7 @@ namespace blaze {
 // Minimal StartupOptions class for testing.
 class FakeStartupOptions : public StartupOptions {
  public:
-  FakeStartupOptions(const WorkspaceLayout *workspace_layout)
-      : StartupOptions("Bazel", workspace_layout) {}
+  FakeStartupOptions() : StartupOptions("Bazel") {}
   blaze_exit_code::ExitCode ProcessArgExtra(
       const char *arg, const char *next_arg, const std::string &rcfile,
       const char **value, bool *is_processed, std::string *error) override {
@@ -42,14 +41,15 @@ class FakeStartupOptions : public StartupOptions {
   void MaybeLogStartupOptionWarnings() const override {}
 
  protected:
+  blaze_util::Path GetDefaultOutputRoot() const override {
+    return blaze_util::Path("/output_root");
+  }
+
   std::string GetRcFileBaseName() const override { return ".bazelrc"; }
 };
 
 class StartupOptionsTest : public ::testing::Test {
  protected:
-  StartupOptionsTest() : workspace_layout_(new WorkspaceLayout()) {}
-  ~StartupOptionsTest() = default;
-
   void SetUp() override {
     // This knowingly ignores the possibility of these environment variables
     // being unset because we expect our test runner to set them in all cases.
@@ -67,7 +67,7 @@ class StartupOptionsTest : public ::testing::Test {
 
   // Recreates startup_options_ after changes to the environment.
   void ReinitStartupOptions() {
-    startup_options_.reset(new FakeStartupOptions(workspace_layout_.get()));
+    startup_options_ = std::make_unique<FakeStartupOptions>();
   }
 
  private:
@@ -89,62 +89,6 @@ TEST_F(StartupOptionsTest, JavaLoggingOptions) {
   ASSERT_EQ("com.google.devtools.build.lib.util.SingleLineFormatter",
             startup_options_->java_logging_formatter);
 }
-
-// TODO(bazel-team): remove the ifdef guard once the implementation of
-// GetOutputRoot is stable among the different platforms.
-#ifdef __linux
-TEST_F(StartupOptionsTest, OutputRootPreferTestTmpdirIfSet) {
-  SetEnv("HOME", "/nonexistent/home");
-  SetEnv("XDG_CACHE_HOME", "/nonexistent/cache");
-  SetEnv("TEST_TMPDIR", "/nonexistent/tmpdir");
-  ReinitStartupOptions();
-
-  ASSERT_EQ(blaze_util::Path("/nonexistent/tmpdir"),
-            startup_options_->output_root);
-}
-
-TEST_F(StartupOptionsTest,
-       OutputRootPreferXdgCacheHomeIfSetAndTestTmpdirUnset) {
-  SetEnv("HOME", "/nonexistent/home");
-  SetEnv("XDG_CACHE_HOME", "/nonexistent/cache");
-  UnsetEnv("TEST_TMPDIR");
-  ReinitStartupOptions();
-
-  ASSERT_EQ(blaze_util::Path("/nonexistent/cache/bazel"),
-            startup_options_->output_root);
-}
-
-TEST_F(StartupOptionsTest, OutputRootUseHomeDirectory) {
-  SetEnv("HOME", "/nonexistent/home");
-  UnsetEnv("TEST_TMPDIR");
-  UnsetEnv("XDG_CACHE_HOME");
-  ReinitStartupOptions();
-
-  ASSERT_EQ(blaze_util::Path("/nonexistent/home/.cache/bazel"),
-            startup_options_->output_root);
-}
-
-TEST_F(StartupOptionsTest, OutputRootIsAbsoluteAndNotShellExpanded) {
-  SetEnv("TEST_TMPDIR", "~/\"$foo/test\"");
-  SetEnv("XDG_CACHE_HOME", "~/cache${bar}");
-  SetEnv("HOME", "~/home$(echo baz)");
-
-  ReinitStartupOptions();
-  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() + "/~/\"$foo/test\""),
-            startup_options_->output_root);
-
-  UnsetEnv("TEST_TMPDIR");
-  ReinitStartupOptions();
-  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() + "/~/cache${bar}/bazel"),
-            startup_options_->output_root);
-
-  UnsetEnv("XDG_CACHE_HOME");
-  ReinitStartupOptions();
-  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() +
-                             "/~/home$(echo baz)/.cache/bazel"),
-            startup_options_->output_root);
-}
-#endif  // __linux
 
 TEST_F(StartupOptionsTest, OutputUserRootTildeExpansion) {
 #if defined(_WIN32)

--- a/src/test/cpp/util/path_windows_test.cc
+++ b/src/test/cpp/util/path_windows_test.cc
@@ -301,7 +301,7 @@ TEST(PathWindowsTest, MakeAbsolute) {
   EXPECT_EQ("c:\\foo\\bar", MakeAbsolute("C:/foo/bar"));
   EXPECT_EQ("c:\\foo\\bar", MakeAbsolute("C:\\foo\\bar\\"));
   EXPECT_EQ("c:\\foo\\bar", MakeAbsolute("C:/foo/bar/"));
-  EXPECT_EQ(blaze_util::AsLower(blaze_util::GetCwd()) + "\\foo",
+  EXPECT_EQ(blaze_util::ToLower(blaze_util::GetCwd()) + "\\foo",
             MakeAbsolute("foo"));
 
   EXPECT_EQ("nul", MakeAbsolute("NUL"));

--- a/src/test/shell/integration/bazel_command_log_test.sh
+++ b/src/test/shell/integration/bazel_command_log_test.sh
@@ -36,7 +36,7 @@ function strip_lines_from_bazel_cc() {
   clean_log=$(\
     sed \
     -e "/^INFO: Reading 'startup' options from /d" \
-    -e '/^\$TEST_TMPDIR defined: output root default is/d' \
+    -e '/^\$TEST_TMPDIR defined, some defaults will be overridden/d' \
     -e '/^OpenJDK 64-Bit Server VM warning: ignoring option UseSeparateVSpacesInYoungGen; support was removed in 8.0/d' \
     -e '/^Starting local B[azel]* server (.*) and connecting to it\.\.\.\.*$/d' \
     -e '/^\.\.\. still trying to connect to local B[azel]* server ([1-9][0-9]*) after [1-9][0-9]* seconds \.\.\.\.*$/d' \

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -786,7 +786,7 @@ function test_client_is_quiet_by_default() {
   strip_lines_from_bazel_cc
 
   assert_equals 2 $(cat $TEST_log | wc -l)
-  expect_log "^\$TEST_TMPDIR defined: output root default"
+  expect_log "^\$TEST_TMPDIR defined, some defaults will be overridden"
   expect_log "^Starting local $capitalized_product_name server (.*) and connecting to it...$"
   cp stdout $TEST_log || fail "cp failed"
 
@@ -802,7 +802,7 @@ function test_client_is_quiet_by_default() {
   strip_lines_from_bazel_cc
 
   assert_equals 1 $(cat $TEST_log | wc -l)
-  expect_log "^\$TEST_TMPDIR defined: output root default"
+  expect_log "^\$TEST_TMPDIR defined, some defaults will be overridden"
   cp stdout $TEST_log || fail "cp failed"
 
   strip_lines_from_bazel_cc


### PR DESCRIPTION
By refactoring the client code in the following manner:

* Make GetOutputRoot (now GetDefaultOutputRoot) a member of StartupOptions rather than WorkspaceLayout, as it doesn't have anything to do with a workspace.

* Remove output_root from StartupOptions as it's not an actual startup option, only an input into the computation of other option defaults.

* Move most of the late initialization in UpdateConfiguration() into a StartupOptions method.

* Move the tests for late initialization into the StartupOption subclasses, as they now depend on the GetDefaultOutputRoot implementation; also add missing test coverage.

PiperOrigin-RevId: 701980022
Change-Id: Ie1dfadc1555a237dd0c88318a2c143088baa43ce