### PR TITLE
Optimize memory usage of write actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1517,6 +1517,7 @@ java_library(
         ":actions/deterministic_writer",
         ":config/core_options",
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/actions:arg_chunk",
         "//src/main/java/com/google/devtools/build/lib/actions:artifact_expander",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/FileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/FileWriteAction.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.analysis.actions;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
@@ -225,7 +224,7 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
 
     @Override
     public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
-      return out -> out.write(getFileContents().getBytes(ISO_8859_1));
+      return out -> out.write(StringUnsafe.getInstance().getInternalStringBytes(getFileContents()));
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
@@ -23,6 +23,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
+import com.google.devtools.build.lib.actions.ArgChunk;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactExpander;
 import com.google.devtools.build.lib.actions.CommandLine;
@@ -138,10 +139,10 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
   @Override
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx)
       throws ExecException, InterruptedException {
-    final Iterable<String> arguments;
+    final ArgChunk arguments;
     try {
       ArtifactExpander artifactExpander = Preconditions.checkNotNull(ctx.getArtifactExpander());
-      arguments = commandLine.arguments(artifactExpander, PathMapper.NOOP);
+      arguments = commandLine.expand(artifactExpander, PathMapper.NOOP);
     } catch (CommandLineExpansionException e) {
       throw new UserExecException(
           e,
@@ -154,17 +155,17 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
   }
 
   private static class ParamFileWriter implements DeterministicWriter {
-    private final Iterable<String> arguments;
+    private final ArgChunk arguments;
     private final ParameterFileType type;
 
-    ParamFileWriter(Iterable<String> arguments, ParameterFileType type) {
+    ParamFileWriter(ArgChunk arguments, ParameterFileType type) {
       this.arguments = arguments;
       this.type = type;
     }
 
     @Override
     public void writeOutputFile(OutputStream out) throws IOException {
-      ParameterFile.writeParameterFile(out, arguments, type);
+      ParameterFile.writeParameterFile(out, arguments.arguments(), type);
     }
   }
 


### PR DESCRIPTION
Reduces peak memory and retained memory of `DeterministicWriter` implementations, which may be retained when Bazel gains the ability to lazily execute file write actions.

Work towards #24808