### PR TITLE
Feature/additional link outputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1135,12 +1135,17 @@ public abstract class CcModule
       Sequence<?> toolPaths, // <StarlarkInfo> expected
       Sequence<?> makeVariables, // <StarlarkInfo> expected
       Object builtinSysroot,
+      Sequence<?> additionalLinkOutputsUnchecked,
       StarlarkThread thread)
       throws EvalException {
     isCalledFromStarlarkCcCommon(thread);
     List<String> cxxBuiltInIncludeDirectories =
         Sequence.cast(
             cxxBuiltInIncludeDirectoriesUnchecked, String.class, "cxx_builtin_include_directories");
+
+    List<String> additionalLinkOutputs =
+        Sequence.cast(
+            additionalLinkOutputsUnchecked, String.class, "additional_link_outputs");
 
     ImmutableList.Builder<Feature> featureBuilder = ImmutableList.builder();
     for (Object feature : features) {
@@ -1296,7 +1301,8 @@ public abstract class CcModule
         convertFromNoneable(abiLibcVersion, /* defaultValue= */ ""),
         toolPathList,
         makeVariablePairs.build(),
-        convertFromNoneable(builtinSysroot, /* defaultValue= */ ""));
+        convertFromNoneable(builtinSysroot, /* defaultValue= */ ""),
+        ImmutableList.copyOf(additionalLinkOutputs));
   }
 
   private static void checkRightStarlarkInfoProvider(

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainConfigInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainConfigInfo.java
@@ -69,6 +69,7 @@ public class CcToolchainConfigInfo extends NativeInfo implements CcToolchainConf
   private final ImmutableList<Pair<String, String>> toolPaths;
   private final ImmutableList<Pair<String, String>> makeVariables;
   private final String builtinSysroot;
+  private final ImmutableList<String> additionalLinkOutputs;
 
   CcToolchainConfigInfo(
       ImmutableList<ActionConfig> actionConfigs,
@@ -85,7 +86,8 @@ public class CcToolchainConfigInfo extends NativeInfo implements CcToolchainConf
       String abiLibcVersion,
       ImmutableList<Pair<String, String>> toolPaths,
       ImmutableList<Pair<String, String>> makeVariables,
-      String builtinSysroot) {
+      String builtinSysroot,
+      ImmutableList<String> additionalLinkOutputs) {
     this.actionConfigs = actionConfigs;
     this.features = features;
     this.artifactNamePatterns = artifactNamePatterns;
@@ -101,6 +103,7 @@ public class CcToolchainConfigInfo extends NativeInfo implements CcToolchainConf
     this.toolPaths = toolPaths;
     this.makeVariables = makeVariables;
     this.builtinSysroot = builtinSysroot;
+    this.additionalLinkOutputs = additionalLinkOutputs;
   }
 
   @Override
@@ -162,7 +165,8 @@ public class CcToolchainConfigInfo extends NativeInfo implements CcToolchainConf
         toolchain.getMakeVariableList().stream()
             .map(makeVariable -> Pair.of(makeVariable.getName(), makeVariable.getValue()))
             .collect(ImmutableList.toImmutableList()),
-        toolchain.getBuiltinSysroot());
+        toolchain.getBuiltinSysroot(),
+        ImmutableList.copyOf(toolchain.getAdditionalLinkOutputsList()));
   }
 
   public ImmutableList<ActionConfig> getActionConfigs() {
@@ -296,6 +300,17 @@ public class CcToolchainConfigInfo extends NativeInfo implements CcToolchainConf
 
   public String getBuiltinSysroot() {
     return builtinSysroot;
+  }
+
+  @StarlarkMethod(name = "additional_link_outputs", documented = false, useStarlarkThread = true)
+  public List<String> getAdditionalLinkOutputsForStarlark(StarlarkThread thread)
+      throws EvalException {
+    CcModule.checkPrivateStarlarkificationAllowlist(thread);
+    return getAdditionalLinkOutputs();
+  }
+
+  public ImmutableList<String> getAdditionalLinkOutputs() {
+    return additionalLinkOutputs;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
@@ -1994,6 +1994,15 @@ public interface CcModuleApi<
             doc =
                 "The built-in sysroot. If this attribute is not present, Bazel does not "
                     + "allow using a different sysroot, i.e. through the --grte_top option."),
+        @Param(
+            name = "additional_link_outputs",
+            positional = false,
+            named = true,
+            defaultValue = "[]",
+            doc = "List of suffixes for additional files created by the link action. "
+                    + "The suffixes will be concatenated to the binary name. f.e. for a "
+                    + "binary `out` with additional link outputs `[.a, .b]`, the following "
+                    + "output files are expected: `[out, out.a, out.b]."),
       })
   CcToolchainConfigInfoT ccToolchainConfigInfoFromStarlark(
       StarlarkRuleContextT starlarkRuleContext,
@@ -2012,6 +2021,7 @@ public interface CcModuleApi<
       Sequence<?> toolPaths, // <StructApi> expected
       Sequence<?> makeVariables, // <StructApi> expected
       Object builtinSysroot,
+      Sequence<?> additionalLinkOutputs,
       StarlarkThread thread)
       throws EvalException;
 

--- a/src/main/protobuf/crosstool_config.proto
+++ b/src/main/protobuf/crosstool_config.proto
@@ -485,7 +485,11 @@ message CToolchain {
   // things internal to Google.
   optional string cc_target_os = 55;
 
-  // Next free id: 56
+  // List of suffixes for additional files created by the link action.
+  // The suffixes will be concatenated to the binary name.
+  repeated string additional_link_outputs = 56;
+
+  // Next free id: 57
 }
 
 message ToolPath {

--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -41,11 +41,6 @@ _TVOS_DEVICE_TARGET_CPUS = ["tvos_arm64"]
 _CATALYST_TARGET_CPUS = ["catalyst_x86_64"]
 _MACOS_TARGET_CPUS = ["darwin_x86_64", "darwin_arm64", "darwin_arm64e"]
 
-def _strip_extension(file):
-    if file.extension == "":
-        return file.basename
-    return file.basename[:-(1 + len(file.extension))]
-
 def _get_non_data_deps(ctx):
     return ctx.attr.srcs + ctx.attr.deps
 
@@ -594,7 +589,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
     # then a pdb file will be built along with the executable.
     pdb_file = None
     if cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "generate_pdb_file"):
-        pdb_file = ctx.actions.declare_file(_strip_extension(binary) + ".pdb", sibling = binary)
+        pdb_file = ctx.actions.declare_file(binary.basename + ".pdb", sibling = binary)
         additional_linker_outputs.append(pdb_file)
 
     linkmap = None

--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -603,6 +603,10 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
     if extra_link_time_libraries != None:
         linker_inputs_extra, runtime_libraries_extra = extra_link_time_libraries.build_libraries(ctx = ctx, static_mode = linking_mode != linker_mode.LINKING_DYNAMIC, for_dynamic_library = _is_link_shared(ctx))
 
+    for suffix in cc_toolchain.additional_link_outputs:
+        outfile = ctx.actions.declare_file(binary.basename + suffix, sibling = binary)
+        additional_linker_outputs.append(outfile)
+
     cc_linking_outputs_binary, cc_launcher_info, deps_cc_linking_context = _create_transitive_linking_actions(
         ctx,
         cc_toolchain,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_common.bzl
@@ -520,6 +520,7 @@ def _create_cc_toolchain_config_info(
         tool_paths = [],
         make_variables = [],
         builtin_sysroot = None,
+        additional_link_outputs = [],
         cc_target_os = None):
     return cc_common_internal.create_cc_toolchain_config_info(
         ctx = ctx,
@@ -538,6 +539,7 @@ def _create_cc_toolchain_config_info(
         tool_paths = tool_paths,
         make_variables = make_variables,
         builtin_sysroot = builtin_sysroot,
+        additional_link_outputs = additional_link_outputs,
     )
 
 def _create_linking_context_from_compilation_outputs(

--- a/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_info.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_info.bzl
@@ -120,6 +120,7 @@ def _create_cc_toolchain_info(
         strip_executable = strip_executable,
         ld_executable = ld_executable,
         gcov_executable = gcov_executable,
+        additional_link_outputs = toolchain_config_info.additional_link_outputs(),
         _runtime_sysroot = runtime_sysroot,
         _as_files = as_files,
         _ar_files = ar_files,
@@ -205,6 +206,7 @@ CcToolchainInfo, _ = provider(
         "strip_executable": "The path to the strip binary.",
         "ld_executable": "The path to the ld binary.",
         "gcov_executable": "The path to the gcov binary.",
+        "additional_link_outputs": "List of additional suffixes to output",
         "_runtime_sysroot": """
             INTERNAL API, DO NOT USE!
             Returns the runtime sysroot, where the dynamic linker and system libraries are found at


### PR DESCRIPTION
Solves #24990.

Implement `additional_link_outputs` feature.

The feature allows for retrieving additional files created by the link
command.

The additional filenames are determined by the `cc_toolchain_config`
attribute `additional_link_outputs` which lists the suffixes that will
be added to the binary name.

For binary `out` where `additional_link_outputs = [".a", ".b"]`, we'll
expect the following files to be created by the link action:
- `out`
- `out.a`
- `out.b`

A link to a `rules_cc` pull request which tests this feature will be added soon.