### PR TITLE
[7.5.0] Backport support for all attribute types in Starlark documentation extraction

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -664,6 +664,7 @@ public final class ModuleInfoExtractorTest {
             "        'j': attr.string_list_dict(),",
             "        'k': attr.output(),",
             "        'l': attr.output_list(),",
+            "        'm': attr.string_keyed_label_dict(),",
             "    }",
             ")");
     ModuleInfo moduleInfo = getExtractor().extractFrom(module);
@@ -731,6 +732,11 @@ public final class ModuleInfoExtractorTest {
                 .setType(AttributeType.OUTPUT_LIST)
                 .setDefaultValue("[]")
                 .setNonconfigurable(true)
+                .build(),
+            AttributeInfo.newBuilder()
+                .setName("m")
+                .setType(AttributeType.LABEL_DICT_UNARY)
+                .setDefaultValue("{}")
                 .build());
   }
 


### PR DESCRIPTION
Previously, we only supported attribute types which could be defined for Starlark rules, with the result that a cherry-pick in the 7.x branch exposing a formerly native-only attribute type to Starlark broke Stardoc: https://github.com/bazelbuild/stardoc/issues/277

Instead of picking and choosing, let's support all attribute types, same as we already do in Bazel 8 and newer.

Cherry-pick of a subset of changes in commit
https://github.com/bazelbuild/bazel/commit/1ce4ab15fab18063d8291132ea84e71fa02d27c4

PiperOrigin-RevId: 675169119
Change-Id: I6541a5eb99d6257339032850d360d2da4bd5aeb4