### PR TITLE
[8.1.0] Fix forward for breakage caused by https://github.com/bazelbuild/bazel/commit/3dcb585fb2f24c75d472df286ccd2891ff7f39b0.

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -479,6 +479,10 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
                    startup_options.install_base.AsCommandLineArgument());
   result.push_back("--install_md5=" + install_md5);
   if (startup_options.lock_install_base) {
+    // This flag is not user-settable. Its sole purpose is to alter the behavior
+    // for Blaze and Bazel. Do *not* explicitly set it to disabled, because at
+    // Google we rely on the ability to run the client code against a server
+    // built before the flag was added.
     result.push_back("--lock_install_base");
   }
   result.push_back("--output_base=" +

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -155,7 +155,8 @@ class StartupOptions {
   blaze_util::Path install_base;
 
   // Whether the install base should be locked before use.
-  // This is always true for Bazel, but overridden for Blaze at Google.
+  // Not user-settable, only used for client/server communication.
+  // Hardcoded to true for Bazel, false for Blaze.
   bool lock_install_base;
 
   // Override more finegrained rc file flags and ignore them all.

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -107,7 +107,7 @@ public class BlazeServerStartupOptions extends OptionsBase {
 
   @Option(
       name = "lock_install_base",
-      defaultValue = "true", // NOTE: only for documentation, value is always passed by the client.
+      defaultValue = "false", // NOTE: only for documentation, value is always passed by the client.
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
       metadataTags = {OptionMetadataTag.HIDDEN},


### PR DESCRIPTION
The --lock_install_base startup flag must default to false, so that the client can obtain the desired behavior by either explicitly enabling or omitting it (explicitly disabling is problematic).

PiperOrigin-RevId: 704347325
Change-Id: I55b9b324c2c16035356673291c254e6629105d8e