### PR TITLE
[8.1.0] Flip the default value of flag `--experimental_use_new_worker_pool` to true.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
@@ -76,7 +76,7 @@ public class WorkerOptions extends OptionsBase {
 
   @Option(
       name = "experimental_use_new_worker_pool",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.EXECUTION},
       help =


### PR DESCRIPTION
Before we completely deprecate the old worker pool, we should flip this to `true` and wait for a grace period.

PiperOrigin-RevId: 694418770
Change-Id: I5d6eb2159f3028aa17cf56fd9dfe85ecf63bc775

Commit https://github.com/bazelbuild/bazel/commit/b8e96e565ba1ff9b640ae2b152d6034af1db0bf2