### PR TITLE
[8.1.0] Explain why vendored repositories are considered out-of-date

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -430,11 +430,12 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       BlazeDirectories directories,
       Map<? extends RepoRecordedInput, String> recordedInputs)
       throws InterruptedException, NeedsSkyframeRestartException {
-    boolean upToDate = RepoRecordedInput.areAllValuesUpToDate(env, directories, recordedInputs);
+    Optional<String> outdated =
+        RepoRecordedInput.isAnyValueOutdated(env, directories, recordedInputs);
     if (env.valuesMissing()) {
       throw new NeedsSkyframeRestartException();
     }
-    return !upToDate;
+    return outdated.isPresent();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepoRecordedInput.java
@@ -66,7 +66,7 @@ import javax.annotation.Nullable;
  * input is stored as a string, with a prefix denoting its type, followed by a colon, and then the
  * information identifying that specific input.
  */
-public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput> {
+public abstract sealed class RepoRecordedInput implements Comparable<RepoRecordedInput> {
   /** Represents a parser for a specific type of recorded inputs. */
   public abstract static class Parser {
     /**
@@ -95,13 +95,13 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
    * Parses a recorded input from its string representation.
    *
    * @param s the string representation
-   * @return The parsed recorded input object, or {@link #NEVER_UP_TO_DATE} if the string
-   *     representation is invalid
+   * @return The parsed recorded input object, or {@link
+   *     NeverUpToDateRepoRecordedInput#PARSE_FAILURE} if the string representation is invalid
    */
   public static RepoRecordedInput parse(String s) {
     List<String> parts = Splitter.on(':').limit(2).splitToList(s);
     if (parts.size() < 2) {
-      return NEVER_UP_TO_DATE;
+      return NeverUpToDateRepoRecordedInput.PARSE_FAILURE;
     }
     for (Parser parser :
         new Parser[] {
@@ -111,7 +111,7 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
         return parser.parse(parts.get(1));
       }
     }
-    return NEVER_UP_TO_DATE;
+    return NeverUpToDateRepoRecordedInput.PARSE_FAILURE;
   }
 
   /**
@@ -119,7 +119,7 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
    * missing, the return value should be ignored; callers are responsible for checking {@code
    * env.valuesMissing()} and triggering a Skyframe restart if needed.
    */
-  public static boolean areAllValuesUpToDate(
+  public static Optional<String> isAnyValueOutdated(
       Environment env,
       BlazeDirectories directories,
       Map<? extends RepoRecordedInput, String> recordedInputValues)
@@ -129,17 +129,17 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
             .map(rri -> rri.getSkyKey(directories))
             .collect(toImmutableSet()));
     if (env.valuesMissing()) {
-      return false;
+      return UNDECIDED;
     }
     for (Map.Entry<? extends RepoRecordedInput, String> recordedInputValue :
         recordedInputValues.entrySet()) {
-      if (!recordedInputValue
-          .getKey()
-          .isUpToDate(env, directories, recordedInputValue.getValue())) {
-        return false;
+      Optional<String> reason =
+          recordedInputValue.getKey().isOutdated(env, directories, recordedInputValue.getValue());
+      if (reason.isPresent()) {
+        return reason;
       }
     }
-    return true;
+    return Optional.empty();
   }
 
   @Override
@@ -167,54 +167,22 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
   /** Returns the parser object for this type of recorded inputs. */
   public abstract Parser getParser();
 
-  /** Returns the {@link SkyKey} that is necessary to determine {@link #isUpToDate}. */
+  /** Returns the {@link SkyKey} that is necessary to determine {@link #isOutdated}. */
   public abstract SkyKey getSkyKey(BlazeDirectories directories);
 
   /**
-   * Returns whether the given {@code oldValue} is still up-to-date for this recorded input. This
-   * method can assume that {@link #getSkyKey(BlazeDirectories)} is already evaluated; it can
-   * request further Skyframe evaluations, and if any values are missing, this method can return any
-   * value (doesn't matter what) and will be reinvoked after a Skyframe restart.
+   * Returns a human-readable reason for why the given {@code oldValue} is no longer up-to-date for
+   * this recorded input, or an empty Optional if it is still up-to-date. This method can assume
+   * that {@link #getSkyKey(BlazeDirectories)} is already evaluated; it can request further Skyframe
+   * evaluations, and if any values are missing, this method can return any value (doesn't matter
+   * what, although {@link #UNDECIDED} is recommended for clarity) and will be reinvoked after a
+   * Skyframe restart.
    */
-  public abstract boolean isUpToDate(
+  public abstract Optional<String> isOutdated(
       Environment env, BlazeDirectories directories, @Nullable String oldValue)
       throws InterruptedException;
 
-  /** A sentinel "input" that's always out-of-date to signify parse failure. */
-  public static final RepoRecordedInput NEVER_UP_TO_DATE =
-      new RepoRecordedInput() {
-        @Override
-        public boolean equals(Object obj) {
-          return this == obj;
-        }
-
-        @Override
-        public int hashCode() {
-          return 12345678;
-        }
-
-        @Override
-        public String toStringInternal() {
-          throw new UnsupportedOperationException("this sentinel input should never be serialized");
-        }
-
-        @Override
-        public Parser getParser() {
-          throw new UnsupportedOperationException("this sentinel input should never be parsed");
-        }
-
-        @Override
-        public SkyKey getSkyKey(BlazeDirectories directories) {
-          // Return a random SkyKey to satisfy the contract.
-          return PrecomputedValue.STARLARK_SEMANTICS.getKey();
-        }
-
-        @Override
-        public boolean isUpToDate(
-            Environment env, BlazeDirectories directories, @Nullable String oldValue) {
-          return false;
-        }
-      };
+  private static final Optional<String> UNDECIDED = Optional.of("values missing");
 
   /**
    * Represents a filesystem path stored in a way that is repo-cache-friendly. That is, if the path
@@ -312,7 +280,7 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
               return new File(RepoCacheFriendlyPath.parse(s));
             } catch (LabelSyntaxException e) {
               // malformed inputs cause refetch
-              return NEVER_UP_TO_DATE;
+              return NeverUpToDateRepoRecordedInput.PARSE_FAILURE;
             }
           }
         };
@@ -372,24 +340,26 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
     }
 
     @Override
-    @Nullable
     public SkyKey getSkyKey(BlazeDirectories directories) {
       return FileValue.key(path.getRootedPath(directories));
     }
 
     @Override
-    public boolean isUpToDate(
+    public Optional<String> isOutdated(
         Environment env, BlazeDirectories directories, @Nullable String oldValue)
         throws InterruptedException {
       var skyKey = getSkyKey(directories);
       try {
         FileValue fileValue = (FileValue) env.getValueOrThrow(skyKey, IOException.class);
         if (fileValue == null) {
-          return false;
+          return UNDECIDED;
         }
-        return oldValue.equals(fileValueToMarkerValue((RootedPath) skyKey.argument(), fileValue));
+        if (!oldValue.equals(fileValueToMarkerValue((RootedPath) skyKey.argument(), fileValue))) {
+          return Optional.of("file info or contents of %s changed".formatted(path));
+        }
+        return Optional.empty();
       } catch (IOException e) {
-        return false;
+        return Optional.of("failed to stat %s: %s".formatted(path, e.getMessage()));
       }
     }
   }
@@ -409,7 +379,7 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
               return new Dirents(RepoCacheFriendlyPath.parse(s));
             } catch (LabelSyntaxException e) {
               // malformed inputs cause refetch
-              return NEVER_UP_TO_DATE;
+              return NeverUpToDateRepoRecordedInput.PARSE_FAILURE;
             }
           }
         };
@@ -452,18 +422,21 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
     }
 
     @Override
-    public boolean isUpToDate(
+    public Optional<String> isOutdated(
         Environment env, BlazeDirectories directories, @Nullable String oldValue)
         throws InterruptedException {
       SkyKey skyKey = getSkyKey(directories);
       if (env.getValue(skyKey) == null) {
-        return false;
+        return UNDECIDED;
       }
       try {
-        return oldValue.equals(
-            getDirentsMarkerValue(((DirectoryListingValue.Key) skyKey).argument().asPath()));
+        if (!oldValue.equals(
+            getDirentsMarkerValue(((DirectoryListingValue.Key) skyKey).argument().asPath()))) {
+          return Optional.of("directory entries of %s changed".formatted(path));
+        }
+        return Optional.empty();
       } catch (IOException e) {
-        return false;
+        return Optional.of("failed to readdir %s: %s".formatted(path, e.getMessage()));
       }
     }
 
@@ -497,7 +470,7 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
               return new DirTree(RepoCacheFriendlyPath.parse(s));
             } catch (LabelSyntaxException e) {
               // malformed inputs cause refetch
-              return NEVER_UP_TO_DATE;
+              return NeverUpToDateRepoRecordedInput.PARSE_FAILURE;
             }
           }
         };
@@ -540,15 +513,18 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
     }
 
     @Override
-    public boolean isUpToDate(
+    public Optional<String> isOutdated(
         Environment env, BlazeDirectories directories, @Nullable String oldValue)
         throws InterruptedException {
       DirectoryTreeDigestValue value =
           (DirectoryTreeDigestValue) env.getValue(getSkyKey(directories));
       if (value == null) {
-        return false;
+        return UNDECIDED;
       }
-      return oldValue.equals(value.hexDigest());
+      if (!oldValue.equals(value.hexDigest())) {
+        return Optional.of("directory tree at %s changed".formatted(path));
+      }
+      return Optional.empty();
     }
   }
 
@@ -611,7 +587,7 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
     }
 
     @Override
-    public boolean isUpToDate(
+    public Optional<String> isOutdated(
         Environment env, BlazeDirectories directories, @Nullable String oldValue)
         throws InterruptedException {
       String v = PrecomputedValue.REPO_ENV.get(env).get(name);
@@ -619,7 +595,15 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
         v = ((ClientEnvironmentValue) env.getValue(getSkyKey(directories))).getValue();
       }
       // Note that `oldValue` can be null if the env var was not set.
-      return Objects.equals(oldValue, v);
+      if (!Objects.equals(oldValue, v)) {
+        return Optional.of(
+            "value of %s changed: %s -> %s"
+                .formatted(
+                    name,
+                    oldValue == null ? "" : "'%s'".formatted(oldValue),
+                    v == null ? "" : "'%s'".formatted(v)));
+      }
+      return Optional.empty();
     }
   }
 
@@ -639,7 +623,7 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
               return new RecordedRepoMapping(RepositoryName.create(parts.get(0)), parts.get(1));
             } catch (LabelSyntaxException | IndexOutOfBoundsException e) {
               // malformed inputs cause refetch
-              return NEVER_UP_TO_DATE;
+              return NeverUpToDateRepoRecordedInput.PARSE_FAILURE;
             }
           }
         };
@@ -690,19 +674,77 @@ public abstract class RepoRecordedInput implements Comparable<RepoRecordedInput>
     }
 
     @Override
-    public boolean isUpToDate(
+    public Optional<String> isOutdated(
         Environment env, BlazeDirectories directories, @Nullable String oldValue)
         throws InterruptedException {
       RepositoryMappingValue repoMappingValue =
           (RepositoryMappingValue) env.getValue(getSkyKey(directories));
+      if (Objects.equals(repoMappingValue, RepositoryMappingValue.NOT_FOUND_VALUE)) {
+        return Optional.of("source repo %s doesn't exist anymore".formatted(sourceRepo));
+      }
+      RepositoryName oldCanonicalName;
       try {
-        return repoMappingValue != RepositoryMappingValue.NOT_FOUND_VALUE
-            && RepositoryName.create(oldValue)
-                .equals(repoMappingValue.repositoryMapping().get(apparentName));
+        oldCanonicalName = RepositoryName.create(oldValue);
       } catch (LabelSyntaxException e) {
         // malformed old value causes refetch
-        return false;
+        return Optional.of("invalid recorded repo name: %s".formatted(e.getMessage()));
       }
+      RepositoryName newCanonicalName = repoMappingValue.repositoryMapping().get(apparentName);
+      if (!oldCanonicalName.equals(newCanonicalName)) {
+        return Optional.of(
+            "canonical name for @%s in %s changed: %s -> %s"
+                .formatted(
+                    apparentName,
+                    sourceRepo,
+                    oldCanonicalName,
+                    newCanonicalName == null ? "<doesn't exist>" : newCanonicalName));
+      }
+      return Optional.empty();
+    }
+  }
+
+  /** A sentinel "input" that's always out-of-date for a given reason. */
+  public static final class NeverUpToDateRepoRecordedInput extends RepoRecordedInput {
+    /** A sentinel "input" that's always out-of-date to signify parse failure. */
+    public static final RepoRecordedInput PARSE_FAILURE =
+        new NeverUpToDateRepoRecordedInput("malformed marker file entry encountered");
+
+    private final String reason;
+
+    public NeverUpToDateRepoRecordedInput(String reason) {
+      this.reason = reason;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return this == obj;
+    }
+
+    @Override
+    public int hashCode() {
+      return 12345678;
+    }
+
+    @Override
+    public String toStringInternal() {
+      throw new UnsupportedOperationException("this sentinel input should never be serialized");
+    }
+
+    @Override
+    public Parser getParser() {
+      throw new UnsupportedOperationException("this sentinel input should never be parsed");
+    }
+
+    @Override
+    public SkyKey getSkyKey(BlazeDirectories directories) {
+      // Return a random SkyKey to satisfy the contract.
+      return PrecomputedValue.STARLARK_SEMANTICS.getKey();
+    }
+
+    @Override
+    public Optional<String> isOutdated(
+        Environment env, BlazeDirectories directories, @Nullable String oldValue) {
+      return Optional.of(reason);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.repository.ExternalPackageHelper;
 import com.google.devtools.build.lib.repository.ExternalRuleNotFoundException;
 import com.google.devtools.build.lib.repository.RepositoryFailedEvent;
 import com.google.devtools.build.lib.repository.RepositoryFetchProgress;
+import com.google.devtools.build.lib.rules.repository.RepoRecordedInput.NeverUpToDateRepoRecordedInput;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue.NoRepositoryDirectoryValue;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.AlreadyReportedRepositoryAccessException;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
@@ -204,14 +205,14 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
 
       if (shouldUseCachedRepos(env, handler, repoRoot, rule)) {
         // Make sure marker file is up-to-date; correctly describes the current repository state
-        byte[] markerHash = digestWriter.areRepositoryAndMarkerFileConsistent(handler, env);
-        if (env.valuesMissing()) {
+        var repoState = digestWriter.areRepositoryAndMarkerFileConsistent(handler, env);
+        if (repoState == null) {
           return null;
         }
-        if (markerHash != null) { // repo exist & up-to-date
+        if (repoState instanceof DigestWriter.RepoDirectoryState.UpToDate(byte[] markerDigest)) {
           return RepositoryDirectoryValue.builder()
               .setPath(repoRoot)
-              .setDigest(markerHash)
+              .setDigest(markerDigest)
               .setExcludeFromVendoring(excludeRepoFromVendoring)
               .build();
         }
@@ -298,24 +299,25 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
         return setupOverride(vendorRepoPath.asFragment(), env, repoRoot, repositoryName);
       }
 
-      boolean isVendorRepoUpToDate =
-          digestWriter.areRepositoryAndMarkerFileConsistent(handler, env, vendorMarker) != null;
-      if (env.valuesMissing()) {
+      DigestWriter.RepoDirectoryState vendoredRepoState =
+          digestWriter.areRepositoryAndMarkerFileConsistent(handler, env, vendorMarker);
+      if (vendoredRepoState == null) {
         return null;
       }
       // If our repo is up-to-date, or this is an offline build (--nofetch), then the vendored repo
       // is used.
-      if (isVendorRepoUpToDate || (!IS_VENDOR_COMMAND.get(env).booleanValue() && !isFetch.get())) {
-        if (!isVendorRepoUpToDate) { // If the repo is out-of-date, show a warning
+      if (vendoredRepoState instanceof DigestWriter.RepoDirectoryState.UpToDate
+          || (!IS_VENDOR_COMMAND.get(env).booleanValue() && !isFetch.get())) {
+        if (vendoredRepoState instanceof DigestWriter.RepoDirectoryState.OutOfDate(String reason)) {
           env.getListener()
               .handle(
                   Event.warn(
                       rule.getLocation(),
                       String.format(
-                          "Vendored repository '%s' is out-of-date and fetching is disabled."
+                          "Vendored repository '%s' is out-of-date (%s) and fetching is disabled."
                               + " Run build without the '--nofetch' option or run"
                               + " the bazel vendor command to update it",
-                          rule.getName())));
+                          rule.getName(), reason)));
         }
         return setupOverride(vendorRepoPath.asFragment(), env, repoRoot, repositoryName);
       } else if (!IS_VENDOR_COMMAND.get(env).booleanValue()) { // build command & fetch enabled
@@ -325,10 +327,11 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
                 Event.warn(
                     rule.getLocation(),
                     String.format(
-                        "Vendored repository '%s' is out-of-date. The up-to-date version will"
+                        "Vendored repository '%s' is out-of-date (%s). The up-to-date version will"
                             + " be fetched into the external cache and used. To update the repo"
                             + " in the vendor directory, run the bazel vendor command",
-                        rule.getName())));
+                        rule.getName(),
+                        ((DigestWriter.RepoDirectoryState.OutOfDate) vendoredRepoState).reason())));
       }
     } else if (vendorFile.pinnedRepos().contains(repositoryName)) {
       throw new RepositoryFunctionException(
@@ -619,13 +622,12 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
   }
 
   private static class DigestWriter {
-    // Input value map to force repo invalidation.
-    private static final ImmutableMap<RepoRecordedInput, String> NOT_UP_TO_DATE =
-        ImmutableMap.of(RepoRecordedInput.NEVER_UP_TO_DATE, "");
+    // Input value map to force repo invalidation upon an invalid marker file.
+    private static final ImmutableMap<RepoRecordedInput, String> PARSE_FAILURE =
+        ImmutableMap.of(NeverUpToDateRepoRecordedInput.PARSE_FAILURE, "");
 
     private final BlazeDirectories directories;
     private final Path markerPath;
-    private final Rule rule;
     private final String ruleKey;
 
     DigestWriter(
@@ -636,7 +638,6 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       this.directories = directories;
       ruleKey = computeRuleKey(rule, starlarkSemantics);
       markerPath = getMarkerPath(directories, repositoryName);
-      this.rule = rule;
     }
 
     byte[] writeMarkerFile(Map<? extends RepoRecordedInput, String> recordedInputValues)
@@ -658,8 +659,15 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       return new Fingerprint().addString(content).digestAndReset();
     }
 
-    @Nullable
-    byte[] areRepositoryAndMarkerFileConsistent(RepositoryFunction handler, Environment env)
+    private sealed interface RepoDirectoryState {
+      @SuppressWarnings("ArrayRecordComponent")
+      record UpToDate(byte[] markerDigest) implements RepoDirectoryState {}
+
+      record OutOfDate(String reason) implements RepoDirectoryState {}
+    }
+
+    RepoDirectoryState areRepositoryAndMarkerFileConsistent(
+        RepositoryFunction handler, Environment env)
         throws InterruptedException, RepositoryFunctionException {
       return areRepositoryAndMarkerFileConsistent(handler, env, markerPath);
     }
@@ -668,38 +676,39 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
      * Checks if the state of the repository in the file system is consistent with the rule in the
      * WORKSPACE file.
      *
-     * <p>Returns null if the file system is not up to date and a hash of the marker file if the
-     * file system is up to date.
+     * <p>Returns null if a Skyframe status is needed.
      *
      * <p>We check the repository root for existence here, but we can't depend on the FileValue,
      * because it's possible that we eventually create that directory in which case the FileValue
      * and the state of the file system would be inconsistent.
      */
     @Nullable
-    byte[] areRepositoryAndMarkerFileConsistent(
+    RepoDirectoryState areRepositoryAndMarkerFileConsistent(
         RepositoryFunction handler, Environment env, Path markerPath)
         throws RepositoryFunctionException, InterruptedException {
       if (!markerPath.exists()) {
-        return null;
+        return new RepoDirectoryState.OutOfDate("repo hasn't been fetched yet");
       }
 
       try {
         String content = FileSystemUtils.readContent(markerPath, UTF_8);
         Map<RepoRecordedInput, String> recordedInputValues =
             readMarkerFile(content, Preconditions.checkNotNull(ruleKey));
-        if (!handler.verifyRecordedInputs(rule, directories, recordedInputValues, env)) {
-          return null;
-        }
+        Optional<String> outdatedReason =
+            handler.isAnyRecordedInputOutdated(directories, recordedInputValues, env);
         if (env.valuesMissing()) {
           return null;
         }
-        return new Fingerprint().addString(content).digestAndReset();
+        if (outdatedReason.isPresent()) {
+          return new RepoDirectoryState.OutOfDate(outdatedReason.get());
+        }
+        return new RepoDirectoryState.UpToDate(
+            new Fingerprint().addString(content).digestAndReset());
       } catch (IOException e) {
         throw new RepositoryFunctionException(e, Transience.TRANSIENT);
       }
     }
 
-    @Nullable
     private static Map<RepoRecordedInput, String> readMarkerFile(
         String content, String expectedRuleKey) {
       Iterable<String> lines = Splitter.on('\n').split(content);
@@ -714,7 +723,10 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
           if (!line.equals(expectedRuleKey)) {
             // Break early, need to reload anyway. This also detects marker file version changes
             // so that unknown formats are not parsed.
-            return NOT_UP_TO_DATE;
+            return ImmutableMap.of(
+                new NeverUpToDateRepoRecordedInput(
+                    "Bazel version, flags, repo rule definition or attributes changed"),
+                "");
           }
           firstLineVerified = true;
           recordedInputValues = new TreeMap<>();
@@ -722,17 +734,17 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
           int sChar = line.indexOf(' ');
           if (sChar > 0) {
             RepoRecordedInput input = RepoRecordedInput.parse(unescape(line.substring(0, sChar)));
-            if (!input.equals(RepoRecordedInput.NEVER_UP_TO_DATE)) {
+            if (!input.equals(NeverUpToDateRepoRecordedInput.PARSE_FAILURE)) {
               recordedInputValues.put(input, unescape(line.substring(sChar + 1)));
               continue;
             }
           }
           // On parse failure, just forget everything else and mark the whole input out of date.
-          return NOT_UP_TO_DATE;
+          return PARSE_FAILURE;
         }
       }
       if (!firstLineVerified) {
-        return NOT_UP_TO_DATE;
+        return PARSE_FAILURE;
       }
       return Preconditions.checkNotNull(recordedInputValues);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -185,8 +185,8 @@ public abstract class RepositoryFunction {
    *     fields set.
    * @param recordedInputValues Any recorded inputs (and their values) encountered during the fetch
    *     of the repo. Changes to these inputs will result in the repo being refetched in the future.
-   *     The {@link #verifyRecordedInputs} method is responsible for checking the value added to
-   *     that map when checking the content of a marker file. Not an ImmutableMap, because
+   *     The {@link #isAnyRecordedInputOutdated} method is responsible for checking the value added
+   *     to that map when checking the content of a marker file. Not an ImmutableMap, because
    *     regrettably the values can be null sometimes.
    */
   public record FetchResult(
@@ -215,17 +215,16 @@ public abstract class RepositoryFunction {
   }
 
   /**
-   * Verify the data provided by the marker file to check if a refetch is needed. Returns true if
-   * the data is up to date and no refetch is needed and false if the data is obsolete and a refetch
-   * is needed.
+   * Verify the data provided by the marker file to check if a refetch is needed. Returns an empty
+   * Optional if the data is up to date and no refetch is needed and an Optional with a
+   * human-readable reason if the data is obsolete and a refetch is needed.
    */
-  public boolean verifyRecordedInputs(
-      Rule rule,
+  public Optional<String> isAnyRecordedInputOutdated(
       BlazeDirectories directories,
       Map<RepoRecordedInput, String> recordedInputValues,
       Environment env)
       throws InterruptedException {
-    return RepoRecordedInput.areAllValuesUpToDate(env, directories, recordedInputValues);
+    return RepoRecordedInput.isAnyValueOutdated(env, directories, recordedInputValues);
   }
 
   public static RootedPath getRootedPathFromLabel(Label label, Environment env)

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -427,7 +427,8 @@ class BazelVendorTest(test_base.TestBase):
         stderr,
     )
     self.assertIn(
-        "Vendored repository '+ext+venRepo' is out-of-date.",
+        "Vendored repository '+ext+venRepo' is out-of-date (repo hasn't been"
+        ' fetched yet).',
         '\n'.join(stderr),
     )
 
@@ -437,7 +438,7 @@ class BazelVendorTest(test_base.TestBase):
         ['build', '@venRepo//:all', '--vendor_dir=vendor'],
     )
     self.assertNotIn(
-        "Vendored repository '+ext+venRepo' is out-of-date.",
+        "Vendored repository '+ext+venRepo' is out-of-date",
         '\n'.join(stderr),
     )
 
@@ -470,13 +471,8 @@ class BazelVendorTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(
         ['build', '@justRepo//:all', '--vendor_dir=vendor']
     )
-    self.assertNotIn(
-        "WARNING: <builtin>: Vendored repository '+ext+justRepo' is"
-        ' out-of-date. The up-to-date version will be fetched into the external'
-        ' cache and used. To update the repo in the vendor directory, run'
-        ' the bazel vendor command',
-        stderr,
-    )
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('out-of-date', stderr)
 
     # Make updates in repo definition
     self.ScratchFile(
@@ -501,10 +497,11 @@ class BazelVendorTest(test_base.TestBase):
     # Assert repo in vendor is out-of-date, and the new one is fetched into
     # external and not a symlink
     self.assertIn(
-        "WARNING: <builtin>: Vendored repository '+ext+justRepo' is"
-        ' out-of-date. The up-to-date version will be fetched into the external'
-        ' cache and used. To update the repo in the vendor directory, run'
-        ' the bazel vendor command',
+        "WARNING: <builtin>: Vendored repository '+ext+justRepo' is out-of-date"
+        ' (Bazel version, flags, repo rule definition or attributes changed).'
+        ' The up-to-date version will be fetched into the external cache and'
+        ' used. To update the repo in the vendor directory, run the bazel'
+        ' vendor command',
         stderr,
     )
     _, stdout, _ = self.RunBazel(['info', 'output_base'])
@@ -516,13 +513,8 @@ class BazelVendorTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(
         ['build', '@justRepo//:all', '--vendor_dir=vendor']
     )
-    self.assertNotIn(
-        "WARNING: <builtin>: Vendored repository '+ext+justRepo' is"
-        ' out-of-date. The up-to-date version will be fetched into the external'
-        ' cache and used. To update the repo in the vendor directory, run'
-        ' the bazel vendor command',
-        stderr,
-    )
+    stderr = '\n'.join(stderr)
+    self.assertNotIn('out-of-date', stderr)
 
   def testBuildingVendoredRepoWithNoFetch(self):
     self.ScratchFile(
@@ -593,9 +585,10 @@ class BazelVendorTest(test_base.TestBase):
         ['build', '@venRepo//:all', '--vendor_dir=vendor', '--nofetch'],
     )
     self.assertIn(
-        "WARNING: <builtin>: Vendored repository '+ext+venRepo' is"
-        ' out-of-date and fetching is disabled. Run build without the'
-        " '--nofetch' option or run the bazel vendor command to update it",
+        "WARNING: <builtin>: Vendored repository '+ext+venRepo' is out-of-date"
+        ' (Bazel version, flags, repo rule definition or attributes changed)'
+        " and fetching is disabled. Run build without the '--nofetch' option or"
+        ' run the bazel vendor command to update it',
         stderr,
     )
     # Assert the out-dated repo is the one built with


### PR DESCRIPTION
Work towards #23243

Closes #24857.

PiperOrigin-RevId: 719146087
Change-Id: I03b1bfa4770fceca4c6eef1675094d39d7fee02e

(cherry picked from commit 1b4106310701c7db10e951eb13ddbe0f4d9da4f9)

Fixes #24862