### PR TITLE
Report the `toolchain` rather than `<lang>_toolchain` label in debug log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
@@ -35,7 +35,9 @@ import javax.annotation.Nullable;
  * @param execConstraints The constraints describing the execution environment.
  * @param targetConstraints The constraints describing the target environment.
  * @param targetSettings The setting, that target build configuration needs to satisfy.
- * @param toolchainLabel The label of the toolchain to resolve for use in toolchain-aware rules.
+ * @param targetLabel The label of the {@code toolchain} target itself.
+ * @param resolvedToolchainLabel The label of the toolchain to resolve for use in toolchain-aware
+ *     rules.
  */
 @AutoCodec
 public record DeclaredToolchainInfo(
@@ -43,24 +45,27 @@ public record DeclaredToolchainInfo(
     ConstraintCollection execConstraints,
     ConstraintCollection targetConstraints,
     ImmutableList<ConfigMatchingProvider> targetSettings,
-    Label toolchainLabel)
+    Label targetLabel,
+    Label resolvedToolchainLabel)
     implements TransitiveInfoProvider {
   public DeclaredToolchainInfo {
     requireNonNull(toolchainType, "toolchainType");
     requireNonNull(execConstraints, "execConstraints");
     requireNonNull(targetConstraints, "targetConstraints");
     requireNonNull(targetSettings, "targetSettings");
-    requireNonNull(toolchainLabel, "toolchainLabel");
+    requireNonNull(targetLabel, "targetLabel");
+    requireNonNull(resolvedToolchainLabel, "resolvedToolchainLabel");
   }
 
   /** Builder class to assist in creating {@link DeclaredToolchainInfo} instances. */
   public static class Builder {
     private ToolchainTypeInfo toolchainType;
-    private ConstraintCollection.Builder execConstraints = ConstraintCollection.builder();
-    private ConstraintCollection.Builder targetConstraints = ConstraintCollection.builder();
-    private ImmutableList.Builder<ConfigMatchingProvider> targetSettings =
+    private final ConstraintCollection.Builder execConstraints = ConstraintCollection.builder();
+    private final ConstraintCollection.Builder targetConstraints = ConstraintCollection.builder();
+    private final ImmutableList.Builder<ConfigMatchingProvider> targetSettings =
         new ImmutableList.Builder<>();
-    private Label toolchainLabel;
+    private Label targetLabel;
+    private Label resolvedToolchainLabel;
 
     /** Sets the type of the toolchain being declared. */
     @CanIgnoreReturnValue
@@ -77,6 +82,7 @@ public record DeclaredToolchainInfo(
     }
 
     /** Adds constraints describing the execution environment. */
+    @CanIgnoreReturnValue
     public Builder addExecConstraints(ConstraintValueInfo... constraints) {
       return addExecConstraints(ImmutableList.copyOf(constraints));
     }
@@ -89,6 +95,7 @@ public record DeclaredToolchainInfo(
     }
 
     /** Adds constraints describing the target environment. */
+    @CanIgnoreReturnValue
     public Builder addTargetConstraints(ConstraintValueInfo... constraints) {
       return addTargetConstraints(ImmutableList.copyOf(constraints));
     }
@@ -99,10 +106,17 @@ public record DeclaredToolchainInfo(
       return this;
     }
 
+    /** Sets the label of the {@code toolchain} target itself. */
+    @CanIgnoreReturnValue
+    public Builder targetLabel(Label targetLabel) {
+      this.targetLabel = targetLabel;
+      return this;
+    }
+
     /** Sets the label of the toolchain to resolve for use in toolchain-aware rules. */
     @CanIgnoreReturnValue
-    public Builder toolchainLabel(Label toolchainLabel) {
-      this.toolchainLabel = toolchainLabel;
+    public Builder resolvedToolchainLabel(Label resolvedToolchainLabel) {
+      this.resolvedToolchainLabel = resolvedToolchainLabel;
       return this;
     }
 
@@ -134,7 +148,8 @@ public record DeclaredToolchainInfo(
           execConstraints,
           targetConstraints,
           targetSettings.build(),
-          toolchainLabel);
+          targetLabel,
+          resolvedToolchainLabel);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Toolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Toolchain.java
@@ -55,7 +55,7 @@ public class Toolchain implements RuleConfiguredTargetFactory {
         ruleContext.getPrerequisites(ToolchainRule.TARGET_SETTING_ATTR).stream()
             .map(target -> target.getProvider(ConfigMatchingProvider.class))
             .collect(toImmutableList());
-    Label toolchainLabel =
+    Label resolvedToolchainLabel =
         ruleContext.attributes().get(ToolchainRule.TOOLCHAIN_ATTR, BuildType.NODEP_LABEL);
 
     DeclaredToolchainInfo registeredToolchain;
@@ -66,7 +66,8 @@ public class Toolchain implements RuleConfiguredTargetFactory {
               .addExecConstraints(execConstraints)
               .addTargetConstraints(targetConstraints)
               .addTargetSettings(targetSettings)
-              .toolchainLabel(toolchainLabel)
+              .resolvedToolchainLabel(resolvedToolchainLabel)
+              .targetLabel(ruleContext.getLabel())
               .build();
     } catch (DeclaredToolchainInfo.DuplicateConstraintException e) {
       if (e.execConstraintsException() != null) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunction.java
@@ -162,15 +162,17 @@ public class RegisteredToolchainsFunction implements SkyFunction {
             key.debug()
                 ? message ->
                     rejectedToolchains.put(
-                        toolchain.toolchainType().typeLabel(), toolchain.toolchainLabel(), message)
+                        toolchain.toolchainType().typeLabel(),
+                        toolchain.targetLabel(),
+                        message)
                 : null;
         if (ConfigMatchingUtil.validate(
-            toolchain.toolchainLabel(), toolchain.targetSettings(), errorHandler)) {
+            toolchain.targetLabel(), toolchain.targetSettings(), errorHandler)) {
           validToolchains.add(toolchain);
         }
       } catch (InvalidConfigurationException e) {
         throw new RegisteredToolchainsFunctionException(
-            new InvalidToolchainLabelException(toolchain.toolchainLabel(), e),
+            new InvalidToolchainLabelException(toolchain.targetLabel(), e),
             Transience.PERSISTENT);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsValue.java
@@ -34,8 +34,9 @@ import javax.annotation.Nullable;
  * A value which represents every toolchain known to Bazel and available for toolchain resolution.
  *
  * @param rejectedToolchains Any toolchains that were rejected, along with a reason. The row keys
- *     are the toolchain type labels, column keys are toolchain implementation labels, and cells are
- *     the reason. Only non-null if {@link RegisteredToolchainsValue.Key#debug} is {@code true}.
+ *     are the toolchain type labels, column keys are toolchain target (not implementation) labels,
+ *     and cells are the reason. Only non-null if {@link RegisteredToolchainsValue.Key#debug} is
+ *     {@code true}.
  */
 @AutoCodec
 public record RegisteredToolchainsValue(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionDebugPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionDebugPrinter.java
@@ -46,7 +46,7 @@ public sealed interface SingleToolchainResolutionDebugPrinter {
 
   void startToolchainResolution(Label toolchainType, Label targetPlatform);
 
-  void reportCompatibleTargetPlatform(Label toolchainLabel);
+  void reportCompatibleTargetPlatform(Label targetLabel, Label resolvedToolchainLabel);
 
   void reportSkippedExecutionPlatformSeen(Label executionPlatform);
 
@@ -63,7 +63,8 @@ public sealed interface SingleToolchainResolutionDebugPrinter {
       ConstraintCollection toolchainConstraints,
       boolean isTargetPlatform,
       PlatformInfo platform,
-      Label toolchainLabel,
+      Label targetLabel,
+      Label resolvedToolchainLabel,
       ImmutableSet<ConstraintSettingInfo> mismatchSettingsWithDefault);
 
   void reportDone(Label toolchainType);
@@ -83,7 +84,7 @@ public sealed interface SingleToolchainResolutionDebugPrinter {
     public void startToolchainResolution(Label toolchainType, Label targetPlatform) {}
 
     @Override
-    public void reportCompatibleTargetPlatform(Label toolchainLabel) {}
+    public void reportCompatibleTargetPlatform(Label targetLabel, Label resolvedToolchainLabel) {}
 
     @Override
     public void reportSkippedExecutionPlatformSeen(Label executionPlatform) {}
@@ -106,7 +107,8 @@ public sealed interface SingleToolchainResolutionDebugPrinter {
         ConstraintCollection toolchainConstraints,
         boolean isTargetPlatform,
         PlatformInfo platform,
-        Label toolchainLabel,
+        Label targetLabel,
+        Label resolvedToolchainLabel,
         ImmutableSet<ConstraintSettingInfo> mismatchSettingsWithDefault) {}
 
     @Override
@@ -173,11 +175,12 @@ public sealed interface SingleToolchainResolutionDebugPrinter {
     }
 
     @Override
-    public void reportCompatibleTargetPlatform(Label toolchainLabel) {
+    public void reportCompatibleTargetPlatform(Label targetLabel, Label resolvedToolchainLabel) {
       debugMessage(
           IndentLevel.TOOLCHAIN_LEVEL,
-          "Toolchain %s is compatible with target platform, searching for execution platforms:",
-          toolchainLabel);
+          "Toolchain %s (resolves to %s) is compatible with target platform, searching for execution platforms:",
+          targetLabel,
+          resolvedToolchainLabel);
     }
 
     @Override
@@ -225,11 +228,11 @@ public sealed interface SingleToolchainResolutionDebugPrinter {
             toolchainType,
             targetPlatform);
         resolvedToolchains.forEach(
-            (executionPlatformKey, toolchainLabel) ->
+            (executionPlatformKey, resolvedToolchainLabel) ->
                 debugMessage(
                     IndentLevel.TOOLCHAIN_LEVEL,
                     "Selected %s to run on execution platform %s",
-                    toolchainLabel,
+                    resolvedToolchainLabel,
                     executionPlatformKey.getLabel()));
       }
     }
@@ -239,7 +242,8 @@ public sealed interface SingleToolchainResolutionDebugPrinter {
         ConstraintCollection toolchainConstraints,
         boolean isTargetPlatform,
         PlatformInfo platform,
-        Label toolchainLabel,
+        Label targetLabel,
+        Label resolvedToolchainLabel,
         ImmutableSet<ConstraintSettingInfo> mismatchSettingsWithDefault) {
       if (!mismatchSettingsWithDefault.isEmpty()) {
         String mismatchValues =
@@ -262,8 +266,9 @@ public sealed interface SingleToolchainResolutionDebugPrinter {
         if (isTargetPlatform) {
           debugMessage(
               IndentLevel.TOOLCHAIN_LEVEL,
-              "Rejected toolchain %s%s",
-              toolchainLabel,
+              "Rejected toolchain %s (resolves to %s) %s",
+              targetLabel,
+              resolvedToolchainLabel,
               mismatchValues + missingSettings);
         } else {
           debugMessage(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionFunction.java
@@ -166,11 +166,13 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
           toolchain.targetConstraints(),
           /* isTargetPlatform= */ true,
           targetPlatform,
-          toolchain.toolchainLabel())) {
+          toolchain.targetLabel(),
+          toolchain.resolvedToolchainLabel())) {
         continue;
       }
 
-      debugPrinter.reportCompatibleTargetPlatform(toolchain.toolchainLabel());
+      debugPrinter.reportCompatibleTargetPlatform(
+          toolchain.targetLabel(), toolchain.resolvedToolchainLabel());
 
       boolean done = true;
 
@@ -201,14 +203,15 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
             toolchain.execConstraints(),
             /* isTargetPlatform= */ false,
             executionPlatform,
-            toolchain.toolchainLabel())) {
+            toolchain.targetLabel(),
+            toolchain.resolvedToolchainLabel())) {
           // Keep looking for a valid toolchain for this exec platform
           done = false;
           continue;
         }
 
         debugPrinter.reportCompatibleExecutionPlatform(executionPlatformKey.getLabel());
-        builder.put(executionPlatformKey, toolchain.toolchainLabel());
+        builder.put(executionPlatformKey, toolchain.resolvedToolchainLabel());
         platformKeysSeen.add(executionPlatformKey);
       }
 
@@ -234,7 +237,8 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
       ConstraintCollection toolchainConstraints,
       boolean isTargetPlatform,
       PlatformInfo platform,
-      Label toolchainLabel) {
+      Label targetLabel,
+      Label resolvedToolchainLabel) {
 
     // Check every constraint_setting in either the toolchain or the platform.
     ImmutableSet<ConstraintSettingInfo> mismatchSettings =
@@ -257,7 +261,8 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
         toolchainConstraints,
         isTargetPlatform,
         platform,
-        toolchainLabel,
+        targetLabel,
+        resolvedToolchainLabel,
         mismatchSettingsWithDefault);
 
     return mismatchSettingsWithDefault.isEmpty();

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfoTest.java
@@ -51,8 +51,7 @@ public class DeclaredToolchainInfoTest extends BuildViewTestCase {
         ConstraintValueInfo.create(setting2, Label.parseCanonicalUnchecked("//constraint:value5")));
 
     DeclaredToolchainInfo.DuplicateConstraintException exception =
-        assertThrows(
-            DeclaredToolchainInfo.DuplicateConstraintException.class, () -> builder.build());
+        assertThrows(DeclaredToolchainInfo.DuplicateConstraintException.class, builder::build);
     assertThat(exception.execConstraintsException()).isNotNull();
     assertThat(exception.execConstraintsException())
         .hasMessageThat()
@@ -86,14 +85,16 @@ public class DeclaredToolchainInfoTest extends BuildViewTestCase {
                     ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//toolchain:tc1")))
                 .addExecConstraints(ImmutableList.of(constraint1))
                 .addTargetConstraints(ImmutableList.of(constraint2))
-                .toolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
+                .resolvedToolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"))
+                .targetLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
                 .build(),
             DeclaredToolchainInfo.builder()
                 .toolchainType(
                     ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//toolchain:tc1")))
                 .addExecConstraints(ImmutableList.of(constraint1))
                 .addTargetConstraints(ImmutableList.of(constraint2))
-                .toolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
+                .resolvedToolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"))
+                .targetLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
                 .build())
         .addEqualityGroup(
             // Different type.
@@ -102,7 +103,8 @@ public class DeclaredToolchainInfoTest extends BuildViewTestCase {
                     ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//toolchain:tc2")))
                 .addExecConstraints(ImmutableList.of(constraint1))
                 .addTargetConstraints(ImmutableList.of(constraint2))
-                .toolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
+                .resolvedToolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"))
+                .targetLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
                 .build())
         .addEqualityGroup(
             // Different constraints.
@@ -111,7 +113,8 @@ public class DeclaredToolchainInfoTest extends BuildViewTestCase {
                     ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//toolchain:tc1")))
                 .addExecConstraints(ImmutableList.of(constraint2))
                 .addTargetConstraints(ImmutableList.of(constraint1))
-                .toolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
+                .resolvedToolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"))
+                .targetLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
                 .build())
         .addEqualityGroup(
             // Different toolchain label.
@@ -120,7 +123,18 @@ public class DeclaredToolchainInfoTest extends BuildViewTestCase {
                     ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//toolchain:tc1")))
                 .addExecConstraints(ImmutableList.of(constraint1))
                 .addTargetConstraints(ImmutableList.of(constraint2))
-                .toolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain2"))
+                .resolvedToolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain_def2"))
+                .targetLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain1"))
+                .build())
+        .addEqualityGroup(
+            // Different target label.
+            DeclaredToolchainInfo.builder()
+                .toolchainType(
+                    ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//toolchain:tc1")))
+                .addExecConstraints(ImmutableList.of(constraint1))
+                .addTargetConstraints(ImmutableList.of(constraint2))
+                .resolvedToolchainLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"))
+                .targetLabel(Label.parseCanonicalUnchecked("//toolchain:toolchain2"))
                 .build())
         .testEquals();
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ApplePlatformsToolchainSelectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ApplePlatformsToolchainSelectionTest.java
@@ -51,7 +51,7 @@ public class ApplePlatformsToolchainSelectionTest extends ObjcRuleTestCase {
     DeclaredToolchainInfo darwinToolchainInfo =
         PlatformProviderUtils.declaredToolchainInfo(darwinToolchain);
     assertThat(darwinToolchainInfo).isNotNull();
-    assertThat(darwinToolchainInfo.toolchainLabel())
+    assertThat(darwinToolchainInfo.resolvedToolchainLabel())
         .isEqualTo(
             Label.parseCanonicalUnchecked(
                 "//" + MockObjcSupport.DEFAULT_OSX_CROSSTOOL_DIR + ":cc-compiler-darwin_x86_64"));
@@ -73,7 +73,7 @@ public class ApplePlatformsToolchainSelectionTest extends ObjcRuleTestCase {
     DeclaredToolchainInfo iosDeviceToolchainInfo =
         PlatformProviderUtils.declaredToolchainInfo(iosDeviceToolchain);
     assertThat(iosDeviceToolchainInfo).isNotNull();
-    assertThat(iosDeviceToolchainInfo.toolchainLabel())
+    assertThat(iosDeviceToolchainInfo.resolvedToolchainLabel())
         .isEqualTo(
             Label.parseCanonicalUnchecked(
                 "//" + MockObjcSupport.DEFAULT_OSX_CROSSTOOL_DIR + ":cc-compiler-ios_arm64"));

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTest.java
@@ -112,8 +112,10 @@ public class ToolchainTest extends BuildViewTestCase {
             ConstraintValueInfo.create(
                 basicConstraintSetting, Label.parseCanonicalUnchecked("//constraint:bar")));
 
-    assertThat(provider.toolchainLabel())
+    assertThat(provider.resolvedToolchainLabel())
         .isEqualTo(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"));
+    assertThat(provider.targetLabel())
+        .isEqualTo(Label.parseCanonicalUnchecked("//toolchain:toolchain1"));
   }
 
   @Test
@@ -178,8 +180,10 @@ public class ToolchainTest extends BuildViewTestCase {
             provider.targetSettings().stream()
                 .anyMatch(x -> x.result() instanceof ConfigMatchingProvider.MatchResult.InError))
         .isFalse();
-    assertThat(provider.toolchainLabel())
+    assertThat(provider.resolvedToolchainLabel())
         .isEqualTo(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"));
+    assertThat(provider.targetLabel())
+        .isEqualTo(Label.parseCanonicalUnchecked("//toolchain:toolchain1"));
   }
 
   @Test
@@ -238,8 +242,10 @@ public class ToolchainTest extends BuildViewTestCase {
             provider.targetSettings().stream()
                 .anyMatch(x -> x.result().equals(ConfigMatchingProvider.MatchResult.MATCH)))
         .isFalse();
-    assertThat(provider.toolchainLabel())
+    assertThat(provider.resolvedToolchainLabel())
         .isEqualTo(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"));
+    assertThat(provider.targetLabel())
+        .isEqualTo(Label.parseCanonicalUnchecked("//toolchain:toolchain1"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTestCase.java
@@ -76,7 +76,7 @@ public abstract class ToolchainTestCase extends BuildViewTestCase {
   protected static List<Label> collectToolchainLabels(
       List<DeclaredToolchainInfo> toolchains, @Nullable PackageIdentifier packageRoot) {
     return toolchains.stream()
-        .map(toolchain -> toolchain.toolchainLabel())
+        .map(DeclaredToolchainInfo::resolvedToolchainLabel)
         .filter(label -> filterLabel(packageRoot, label))
         .collect(Collectors.toList());
   }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
@@ -63,7 +63,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
                             && toolchain.execConstraints().get(setting).equals(linuxConstraint)
                             && toolchain.targetConstraints().get(setting).equals(macConstraint)
                             && toolchain
-                                .toolchainLabel()
+                                .resolvedToolchainLabel()
                                 .equals(
                                     Label.parseCanonicalUnchecked("//toolchain:toolchain_1_impl"))))
         .isTrue();
@@ -76,7 +76,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
                             && toolchain.execConstraints().get(setting).equals(macConstraint)
                             && toolchain.targetConstraints().get(setting).equals(linuxConstraint)
                             && toolchain
-                                .toolchainLabel()
+                                .resolvedToolchainLabel()
                                 .equals(
                                     Label.parseCanonicalUnchecked("//toolchain:toolchain_2_impl"))))
         .isTrue();
@@ -654,7 +654,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
     assertThat(registeredToolchainsValue.rejectedToolchains())
         .containsCell(
             testToolchainTypeLabel,
-            Label.parseCanonicalUnchecked("//extra:extra_toolchain_impl"),
+            Label.parseCanonicalUnchecked("//extra:extra_toolchain"),
             "mismatching config settings: optimized");
   }
 
@@ -715,7 +715,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
         .hasMessageThat()
         .contains(
             "Unrecoverable errors resolving config_setting associated with"
-                + " //extra:extra_toolchain_impl: For config_setting flagged, Feature flag"
+                + " //extra:extra_toolchain: For config_setting flagged, Feature flag"
                 + " //extra:flag was accessed in a configuration it is not present in.");
   }
 
@@ -727,7 +727,8 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
                 ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//test:toolchain")))
             .addExecConstraints(ImmutableList.of())
             .addTargetConstraints(ImmutableList.of())
-            .toolchainLabel(Label.parseCanonicalUnchecked("//test/toolchain_impl_1"))
+            .resolvedToolchainLabel(Label.parseCanonicalUnchecked("//test/toolchain_impl_1"))
+            .targetLabel(Label.parseCanonicalUnchecked("//test/toolchain_1"))
             .build();
     DeclaredToolchainInfo toolchain2 =
         DeclaredToolchainInfo.builder()
@@ -735,7 +736,8 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
                 ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//test:toolchain")))
             .addExecConstraints(ImmutableList.of())
             .addTargetConstraints(ImmutableList.of())
-            .toolchainLabel(Label.parseCanonicalUnchecked("//test/toolchain_impl_2"))
+            .resolvedToolchainLabel(Label.parseCanonicalUnchecked("//test/toolchain_impl_2"))
+            .targetLabel(Label.parseCanonicalUnchecked("//test/toolchain_2"))
             .build();
 
     new EqualsTester()

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
@@ -1297,7 +1297,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     assertThat(getConfiguredTarget("//rule:me")).isNull();
     assertContainsEvent(
         "Unrecoverable errors resolving config_setting associated with"
-            + " //strange:strange_test_toolchain: For config_setting flagged, Feature flag"
+            + " //strange:strange_toolchain: For config_setting flagged, Feature flag"
             + " //strange:flag was accessed in a configuration it is not present in.");
   }
 

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -706,8 +706,8 @@ EOF
     --platform_mappings= \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
   expect_log "Performing resolution of //${pkg}/toolchain:test_toolchain for target platform ${default_host_platform}"
-  expect_log "Rejected toolchain //${pkg}/demo:toolchain_impl_invalid; mismatching config settings: optimized"
-  expect_log "Toolchain //register/${pkg}:test_toolchain_impl_1 is compatible with target platform, searching for execution platforms:"
+  expect_log "Rejected toolchain //${pkg}/demo:toolchain_invalid; mismatching config settings: optimized"
+  expect_log "Toolchain //register/${pkg}:test_toolchain_1 (resolves to //register/${pkg}:test_toolchain_impl_1) is compatible with target platform, searching for execution platforms:"
   expect_log "Compatible execution platform ${default_host_platform}"
   expect_log "Recap of selected //${pkg}/toolchain:test_toolchain toolchains for target platform ${default_host_platform}:"
   expect_log "Selected //register/${pkg}:test_toolchain_impl_1 to run on execution platform ${default_host_platform}"
@@ -738,7 +738,7 @@ EOF
     --platform_mappings= \
     "//${pkg}/demo:use" &> $TEST_log || fail "Build failed"
   expect_log "Performing resolution of //${pkg}/toolchain:test_toolchain for target platform ${default_host_platform}"
-  expect_log "Toolchain //register/${pkg}:test_toolchain_impl_1 is compatible with target platform, searching for execution platforms:"
+  expect_log "Toolchain //register/${pkg}:test_toolchain_1 (resolves to //register/${pkg}:test_toolchain_impl_1) is compatible with target platform, searching for execution platforms:"
   expect_log "Compatible execution platform ${default_host_platform}"
   expect_log "Recap of selected //${pkg}/toolchain:test_toolchain toolchains for target platform ${default_host_platform}:"
   expect_log "Selected //register/${pkg}:test_toolchain_impl_1 to run on execution platform ${default_host_platform}"


### PR DESCRIPTION
When debugging toolchain resolution, there is an important difference between a `toolchain` target (more relevant, as it specifies the constraints checked during resolution) and the `<lang>_toolchain` target it resolves to if selected (less relevant during resolution and also potentially shared between multiple `toolchain` targets with different constraints).

This change starts tracking both labels and emits them in the debug logs where it makes sense.