### PR TITLE
[7.5.0] Record repo mapping entries for labels in module extension tags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -36,7 +36,7 @@ public abstract class BazelLockFileValue implements SkyValue {
 
   // NOTE: See "HACK" note in BazelLockFileModule. While this hack exists, normal increments of the
   // lockfile version need to be done by 2 at a time (i.e. keep LOCK_FILE_VERSION an odd number).
-  public static final int LOCK_FILE_VERSION = 11;
+  public static final int LOCK_FILE_VERSION = 13;
 
   @SerializationConstant public static final SkyKey KEY = () -> SkyFunctions.BAZEL_LOCK_FILE;
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/RegularRunnableExtension.java
@@ -272,7 +272,7 @@ final class RegularRunnableExtension implements RunnableExtension {
     try (Mutability mu =
             Mutability.create("module extension", usagesValue.getExtensionUniqueName());
         ModuleExtensionContext moduleContext =
-            createContext(env, usagesValue, starlarkSemantics, extensionId)) {
+            createContext(env, usagesValue, starlarkSemantics, extensionId, repoMappingRecorder)) {
       StarlarkThread thread = new StarlarkThread(mu, starlarkSemantics);
       thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
       threadContext.storeInThread(thread);
@@ -339,7 +339,8 @@ final class RegularRunnableExtension implements RunnableExtension {
       Environment env,
       SingleExtensionUsagesValue usagesValue,
       StarlarkSemantics starlarkSemantics,
-      ModuleExtensionId extensionId)
+      ModuleExtensionId extensionId,
+      Label.RepoMappingRecorder repoMappingRecorder)
       throws ExternalDepsException {
     Path workingDirectory =
         directories
@@ -354,7 +355,8 @@ final class RegularRunnableExtension implements RunnableExtension {
               abridgedModule,
               extension,
               usagesValue.getRepoMappings().get(moduleKey),
-              usagesValue.getExtensionUsages().get(moduleKey)));
+              usagesValue.getExtensionUsages().get(moduleKey),
+              repoMappingRecorder));
     }
     ModuleExtensionUsage rootUsage = usagesValue.getExtensionUsages().get(ModuleKey.ROOT);
     boolean rootModuleHasNonDevDependency =

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.docgen.annot.DocCategory;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.packages.LabelConverter;
@@ -107,12 +108,14 @@ public class StarlarkBazelModule implements StarlarkValue {
       AbridgedModule module,
       ModuleExtension extension,
       RepositoryMapping repoMapping,
-      @Nullable ModuleExtensionUsage usage)
+      @Nullable ModuleExtensionUsage usage,
+      Label.RepoMappingRecorder repoMappingRecorder)
       throws ExternalDepsException {
     LabelConverter labelConverter =
         new LabelConverter(
             PackageIdentifier.create(repoMapping.ownerRepo(), PathFragment.EMPTY_FRAGMENT),
-            repoMapping);
+            repoMapping,
+            repoMappingRecorder);
     ImmutableList<Tag> tags = usage == null ? ImmutableList.of() : usage.getTags();
     HashMap<String, ArrayList<TypeCheckedTag>> typeCheckedTags = new HashMap<>();
     for (String tagClassName : extension.getTagClasses().keySet()) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -894,6 +894,24 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     }
     assertThat(result.get(skyKey).getModule().getGlobal("data"))
         .isEqualTo("get up at 6am. go to bed at 11pm.");
+
+    SkyKey extensionSkyKey =
+        SingleExtensionValue.key(
+            ModuleExtensionId.create(
+                Label.parseCanonicalUnchecked("@@ext+//:defs.bzl"), "ext", Optional.empty()));
+    EvaluationResult<SingleExtensionValue> extensionResult =
+        evaluator.evaluate(ImmutableList.of(extensionSkyKey), evaluationContext);
+    if (extensionResult.hasError()) {
+      throw extensionResult.getError().getException();
+    }
+    assertThat(
+            extensionResult
+                .get(extensionSkyKey)
+                .getLockFileInfo()
+                .get()
+                .moduleExtension()
+                .getRecordedRepoMappingEntries())
+        .containsCell(RepositoryName.create("foo+"), "bar", RepositoryName.create("bar+"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -898,7 +898,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
     SkyKey extensionSkyKey =
         SingleExtensionValue.key(
             ModuleExtensionId.create(
-                Label.parseCanonicalUnchecked("@@ext+//:defs.bzl"), "ext", Optional.empty()));
+                Label.parseCanonicalUnchecked("@@ext~//:defs.bzl"), "ext", Optional.empty()));
     EvaluationResult<SingleExtensionValue> extensionResult =
         evaluator.evaluate(ImmutableList.of(extensionSkyKey), evaluationContext);
     if (extensionResult.hasError()) {
@@ -911,7 +911,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
                 .get()
                 .moduleExtension()
                 .getRecordedRepoMappingEntries())
-        .containsCell(RepositoryName.create("foo+"), "bar", RepositoryName.create("bar+"));
+        .containsCell(RepositoryName.create("foo~"), "bar", RepositoryName.create("bar~"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModuleTest.java
@@ -129,7 +129,7 @@ public class StarlarkBazelModuleTest {
                 Label.parseCanonical("@@bar~//:pom.xml")));
 
     assertThat(repoMappingRecorder.recordedEntries())
-        .containsCell(RepositoryName.create("foo+"), "bar", RepositoryName.create("bar+"));
+        .containsCell(RepositoryName.create("foo~"), "bar", RepositoryName.create("bar~"));
   }
 
   @Test

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -1925,7 +1925,7 @@ class BazelLockfileTest(test_base.TestBase):
     )
 
     _, _, stderr = self.RunBazel(['build', ':lol'])
-    self.assertIn('STR=@@foo+//:lib_foo', '\n'.join(stderr))
+    self.assertIn('STR=@@foo~//:lib_foo', '\n'.join(stderr))
 
     # Shutdown bazel to make sure we rely on the lockfile and not skyframe
     self.RunBazel(['shutdown'])
@@ -1950,7 +1950,7 @@ class BazelLockfileTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(['build', ':lol'])
     stderr = '\n'.join(stderr)
     self.assertIn('ran the extension!', stderr)
-    self.assertIn('STR=@@bar+//:lib_foo', stderr)
+    self.assertIn('STR=@@bar~//:lib_foo', stderr)
 
     # Shutdown bazel to make sure we rely on the lockfile and not skyframe
     self.RunBazel(['shutdown'])
@@ -1970,7 +1970,7 @@ class BazelLockfileTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(['build', ':lol'])
     stderr = '\n'.join(stderr)
     self.assertNotIn('ran the extension!', stderr)
-    self.assertIn('STR=@@bar+//:lib_foo', stderr)
+    self.assertIn('STR=@@bar~//:lib_foo', stderr)
 
   def testExtensionRepoMappingChange_loadsAndRepoRelativeLabels(self):
     # Regression test for #20721; same test as above, except that the call to

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 11,
+  "lockFileVersion": 13,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",


### PR DESCRIPTION
The mapping of an apparent name in a module extension tag's `attr.label` attribute to the corresponding canonical name has to be recorded in the lockfile so that instantiated repo rules don't reference the stale repos.

Fixes #25063

Closes #25067.

PiperOrigin-RevId: 720592796
Change-Id: Ia202ca4a8482a81da8085ee18ecaca5fe233bddb