### PR TITLE
Add `repository_ctx.original_name`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.StructImpl;
 import com.google.devtools.build.lib.packages.StructProvider;
+import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.repository.RepositoryFetchProgress;
 import com.google.devtools.build.lib.rules.repository.NeedsSkyframeRestartException;
@@ -143,9 +144,24 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
   @StarlarkMethod(
       name = "name",
       structField = true,
-      doc = "The name of the external repository created by this rule.")
+      doc =
+          "The canonical name of the external repository created by this rule. This name is guaranteed to be unique among all external repositories, but its exact format is not specified.")
   public String getName() {
     return rule.getName();
+  }
+
+  @StarlarkMethod(
+      name = "original_name",
+      structField = true,
+      doc =
+          "The name that was originally specified as the 'name' attribute when this repository rule was instantiated. This name is not necessarily unique among external repositories (see 'name').")
+  public String getOriginalName() {
+    String originalName = (String) rule.getAttr("$original_name", Type.STRING);
+    // The original name isn't set for WORKSPACE-defined repositories as well as repositories
+    // backing Bazel modules. In case of the former, the original name is the same as the name, in
+    // the latter the original name doesn't matter as the restricted set of rules that can back
+    // Bazel modules do not use the name.
+    return originalName != null ? originalName : rule.getName();
   }
 
   @StarlarkMethod(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -145,7 +145,11 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       name = "name",
       structField = true,
       doc =
-          "The canonical name of the external repository created by this rule. This name is guaranteed to be unique among all external repositories, but its exact format is not specified.")
+          "The canonical name of the external repository created by this rule. This name is"
+              + " guaranteed to be unique among all external repositories, but its exact format is"
+              + " not specified. Use <a href='#original_name'><code>original_name</code></a>"
+              + " instead to get the name that was originally specified as the <code>name</code>"
+              + " when this repository rule was instantiated.")
   public String getName() {
     return rule.getName();
   }
@@ -154,7 +158,10 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       name = "original_name",
       structField = true,
       doc =
-          "The name that was originally specified as the 'name' attribute when this repository rule was instantiated. This name is not necessarily unique among external repositories (see 'name').")
+          "The name that was originally specified as the <code>name</code> attribute when this"
+              + " repository rule was instantiated. This name is not necessarily unique among"
+              + " external repositories. Use <a href='#name'><code>name</code></a> instead to get"
+              + " the canonical name of the external repository.")
   public String getOriginalName() {
     String originalName = (String) rule.getAttr("$original_name", Type.STRING);
     // The original name isn't set for WORKSPACE-defined repositories as well as repositories

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -81,6 +81,7 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
     builder.setCallStack(
         callstack.subList(0, callstack.size() - 1)); // pop 'repository_rule' itself
 
+    builder.addAttribute(attr("$original_name", STRING).defaultValue("").build());
     builder.addAttribute(attr("$local", BOOLEAN).defaultValue(local).build());
     builder.addAttribute(attr("$configure", BOOLEAN).defaultValue(configure).build());
     if (thread.getSemantics().getBool(BuildLanguageOptions.EXPERIMENTAL_REPO_REMOTE_EXEC)) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -61,6 +61,13 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
         "def _data_repo_impl(ctx):",
         "  ctx.file('BUILD')",
         "  ctx.file('data.bzl', 'data = '+json.encode(ctx.attr.data))",
+        "  ctx.file(",
+        "    'names.bzl',",
+        "    'names='+json.encode({",
+        "      'name': ctx.name,",
+        "      'original_name': ctx.original_name,",
+        "    })",
+        "  )",
         "data_repo = repository_rule(",
         "  implementation=_data_repo_impl,",
         "  attrs={'data':attr.string()})");
@@ -89,8 +96,12 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     scratch.file(
         "data.bzl",
         "load('@foo//:data.bzl', foo_data='data')",
+        "load('@foo//:names.bzl', foo_names='names')",
         "load('@bar//:data.bzl', bar_data='data')",
-        "data = 'foo:'+foo_data+' bar:'+bar_data");
+        "load('@bar//:names.bzl', bar_names='names')",
+        "data = 'foo:'+foo_data+' bar:'+bar_data",
+        "names = 'foo:'+foo_names['name']+' bar:'+bar_names['name']",
+        "original_names = 'foo:'+foo_names['original_name']+' bar:'+bar_names['original_name']");
     invalidatePackages(false);
 
     SkyKey skyKey = BzlLoadValue.keyForBuild(Label.parseCanonical("//:data.bzl"));
@@ -100,6 +111,10 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
       throw result.getError().getException();
     }
     assertThat(result.get(skyKey).getModule().getGlobal("data")).isEqualTo("foo:fu bar:ba");
+    assertThat(result.get(skyKey).getModule().getGlobal("names"))
+        .isEqualTo("foo:+ext+foo bar:+ext+bar");
+    assertThat(result.get(skyKey).getModule().getGlobal("original_names"))
+        .isEqualTo("foo:foo bar:bar");
   }
 
   @Test
@@ -2625,30 +2640,45 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
         "MODULE.bazel",
         "bazel_dep(name='foo',version='1.0')",
         "data_repo = use_repo_rule('@foo//:repo.bzl', 'data_repo')",
-        "data_repo(name='data', data='get up at 6am.')");
+        "data_repo(name='data1', data='get up at 6am.')");
     scratch.overwriteFile("BUILD");
     scratch.file(
         "data.bzl",
-        "load('@data//:data.bzl', self_data='data')",
+        "load('@data1//:data.bzl', self_data='data')",
+        "load('@data1//:names.bzl', self_names='names')",
         "load('@foo//:data.bzl', foo_data='data')",
-        "data=self_data+' '+foo_data");
+        "load('@foo//:names.bzl', foo_names='names')",
+        "data=self_data+' '+foo_data",
+        "names=self_names['name']+' '+foo_names['name']",
+        "original_names=self_names['original_name']+' '+foo_names['original_name']");
 
     registry.addModule(
         createModuleKey("foo", "1.0"),
         "module(name='foo',version='1.0')",
         "data_repo = use_repo_rule('//:repo.bzl', 'data_repo')",
-        "data_repo(name='data', data='go to bed at 11pm.')");
+        "data_repo(name='data2', data='go to bed at 11pm.')");
     scratch.file(moduleRoot.getRelative("foo+1.0/REPO.bazel").getPathString());
     scratch.file(moduleRoot.getRelative("foo+1.0/BUILD").getPathString());
     scratch.file(
         moduleRoot.getRelative("foo+1.0/data.bzl").getPathString(),
-        "load('@data//:data.bzl',repo_data='data')",
+        "load('@data2//:data.bzl',repo_data='data')",
         "data=repo_data");
+    scratch.file(
+        modulesRoot.getRelative("foo+1.0/names.bzl").getPathString(),
+        "load('@data2//:names.bzl',repo_names='names')",
+        "names=repo_names");
     scratch.file(
         moduleRoot.getRelative("foo+1.0/repo.bzl").getPathString(),
         "def _data_repo_impl(ctx):",
         "  ctx.file('BUILD.bazel')",
         "  ctx.file('data.bzl', 'data='+json.encode(ctx.attr.data))",
+        "  ctx.file(",
+        "    'names.bzl',",
+        "    'names='+json.encode({",
+        "      'name': ctx.name,",
+        "      'original_name': ctx.original_name,",
+        "    })",
+        "  )",
         "data_repo = repository_rule(",
         "  implementation=_data_repo_impl, attrs={'data':attr.string()})");
     invalidatePackages(false);
@@ -2661,6 +2691,9 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     }
     assertThat(result.get(skyKey).getModule().getGlobal("data"))
         .isEqualTo("get up at 6am. go to bed at 11pm.");
+    assertThat(result.get(skyKey).getModule().getGlobal("names"))
+        .isEqualTo("+_repo_rules+data1 foo++_repo_rules+data2");
+    assertThat(result.get(skyKey).getModule().getGlobal("original_names")).isEqualTo("data1 data2");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2664,7 +2664,7 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
         "load('@data2//:data.bzl',repo_data='data')",
         "data=repo_data");
     scratch.file(
-        modulesRoot.getRelative("foo+1.0/names.bzl").getPathString(),
+        moduleRoot.getRelative("foo+1.0/names.bzl").getPathString(),
         "load('@data2//:names.bzl',repo_names='names')",
         "names=repo_names");
     scratch.file(

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -452,7 +452,6 @@ class ModCommandTest(test_base.TestBase):
         ],
         rstrip=True,
     )
-    print("\n".join(stdout))
     self.assertRegex(stdout.pop(4), r'^  urls = \[".*"\],$')
     self.assertRegex(stdout.pop(4), r'^  integrity = ".*",$')
     self.assertRegex(stdout.pop(19), r'^  path = ".*",$')
@@ -461,11 +460,11 @@ class ModCommandTest(test_base.TestBase):
     # lines after '# Rule data_repo defined at (most recent call last):'
     stdout.pop(34)
     stdout.pop(45)
-    self.assertRegex(stdout.pop(49), r'^  urls = \[".*"\],$')
-    self.assertRegex(stdout.pop(49), r'^  integrity = ".*",$')
+    self.assertRegex(stdout.pop(50), r'^  urls = \[".*"\],$')
+    self.assertRegex(stdout.pop(50), r'^  integrity = ".*",$')
     # lines after '# Rule http_archive defined at (most recent call last):'
     stdout.pop(13)
-    stdout.pop(57)
+    stdout.pop(58)
     self.assertListEqual(
         stdout,
         [
@@ -507,7 +506,7 @@ class ModCommandTest(test_base.TestBase):
             '# Rule ext++ext+repo3 instantiated at (most recent call last):',
             '#   <builtin> in <toplevel>',
             '# Rule data_repo defined at (most recent call last):',
-            # pop(33)
+            # pop(34)
             '',
             '## @my_repo4:',
             '# <builtin>',
@@ -519,14 +518,14 @@ class ModCommandTest(test_base.TestBase):
             '# Rule ext++ext+repo4 instantiated at (most recent call last):',
             '#   <builtin> in <toplevel>',
             '# Rule data_repo defined at (most recent call last):',
-            # pop(44)
+            # pop(45)
             '',
             '## bar@2.0:',
             '# <builtin>',
             'http_archive(',
             '  name = "bar+",',
-            # pop(49) -- urls=[...]
-            # pop(49) -- integrity=...
+            # pop(50) -- urls=[...]
+            # pop(50) -- integrity=...
             '  strip_prefix = "",',
             '  remote_file_urls = {},',
             '  remote_file_integrity = {},',
@@ -536,7 +535,7 @@ class ModCommandTest(test_base.TestBase):
             '# Rule bar+ instantiated at (most recent call last):',
             '#   <builtin> in <toplevel>',
             '# Rule http_archive defined at (most recent call last):',
-            # pop(57)
+            # pop(58)
             '',
         ],
         'wrong output in the show query for module and extension-generated'

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -452,19 +452,20 @@ class ModCommandTest(test_base.TestBase):
         ],
         rstrip=True,
     )
+    print("\n".join(stdout))
     self.assertRegex(stdout.pop(4), r'^  urls = \[".*"\],$')
     self.assertRegex(stdout.pop(4), r'^  integrity = ".*",$')
     self.assertRegex(stdout.pop(19), r'^  path = ".*",$')
     # lines after '# Rule local_repository defined at (most recent call last):'
     stdout.pop(23)
     # lines after '# Rule data_repo defined at (most recent call last):'
-    stdout.pop(33)
-    stdout.pop(43)
-    self.assertRegex(stdout.pop(48), r'^  urls = \[".*"\],$')
-    self.assertRegex(stdout.pop(48), r'^  integrity = ".*",$')
+    stdout.pop(34)
+    stdout.pop(45)
+    self.assertRegex(stdout.pop(49), r'^  urls = \[".*"\],$')
+    self.assertRegex(stdout.pop(49), r'^  integrity = ".*",$')
     # lines after '# Rule http_archive defined at (most recent call last):'
     stdout.pop(13)
-    stdout.pop(56)
+    stdout.pop(57)
     self.assertListEqual(
         stdout,
         [
@@ -500,6 +501,7 @@ class ModCommandTest(test_base.TestBase):
             '# <builtin>',
             'data_repo(',
             '  name = "ext++ext+repo3",',
+            '  _original_name = "repo3",',
             '  data = "requested repo",',
             ')',
             '# Rule ext++ext+repo3 instantiated at (most recent call last):',
@@ -511,19 +513,20 @@ class ModCommandTest(test_base.TestBase):
             '# <builtin>',
             'data_repo(',
             '  name = "ext++ext+repo4",',
+            '  _original_name = "repo4",',
             '  data = "requested repo",',
             ')',
             '# Rule ext++ext+repo4 instantiated at (most recent call last):',
             '#   <builtin> in <toplevel>',
             '# Rule data_repo defined at (most recent call last):',
-            # pop(43)
+            # pop(44)
             '',
             '## bar@2.0:',
             '# <builtin>',
             'http_archive(',
             '  name = "bar+",',
-            # pop(48) -- urls=[...]
-            # pop(48) -- integrity=...
+            # pop(49) -- urls=[...]
+            # pop(49) -- integrity=...
             '  strip_prefix = "",',
             '  remote_file_urls = {},',
             '  remote_file_integrity = {},',
@@ -533,7 +536,7 @@ class ModCommandTest(test_base.TestBase):
             '# Rule bar+ instantiated at (most recent call last):',
             '#   <builtin> in <toplevel>',
             '# Rule http_archive defined at (most recent call last):',
-            # pop(56)
+            # pop(57)
             '',
         ],
         'wrong output in the show query for module and extension-generated'


### PR DESCRIPTION
This new attribute contains the original value of the `name` attribute at the instantiation site of the repo rule (e.g., `rctx.original_name` would be `foo` if `rctx.name` is `+ext+foo`).

Fixes #24467