### PR TITLE
Add `--@bazel_tools//tools/test:incompatible_use_default_test_toolchain`

### DIFF
--- a/site/en/extending/exec-groups.md
+++ b/site/en/extending/exec-groups.md
@@ -104,7 +104,8 @@ problem.
 
 The following execution groups are predefined:
 
-* `test`: Test runner actions, available on all test rules.
+* `test`: Test runner actions (for more details, see
+  the [execution platform section of the Test Encylopedia](/reference/test-encyclopedia#execution-platform)).
 * `cpp_link`: C++ linking actions.
 
 ## Using execution groups to set execution properties {:#using-exec-groups-for-exec-properties}
@@ -162,12 +163,12 @@ platform(
 )
 
 my_test(
-    name = "my_test",
-    exec_compatible_with = ["//constraints:high_cpu"],
-    exec_group_compatible_with = {
-        "test": ["@platforms//os:linux"],
-    },
-    ...
+  name = "my_test",
+  exec_compatible_with = ["//constraints:high_cpu"],
+  exec_group_compatible_with = {
+    "test": ["@platforms//os:linux"],
+  },
+  ...
 )
 ```
 

--- a/site/en/reference/test-encyclopedia.md
+++ b/site/en/reference/test-encyclopedia.md
@@ -699,6 +699,39 @@ In order to catch early exit, a test may create a file at the path specified by
 file when the test finishes, it will assume that the test exited prematurely and
 mark it as having failed.
 
+## Execution platform {:#execution-platform}
+
+The [execution platform](/extending/platforms) for a test action is determined
+via [toolchain resolution](/extending/toolchains#toolchain-resolution), just
+like for any other action. Each test rule has an implicitly defined [
+`test` exec group](/extending/exec-groups#exec-groups-for-native-rules) that,
+unless overridden, has a mandatory toolchain requirement on
+`@bazel_tools//tools/test:default_test_toolchain_type`. Toolchains of this type
+do not carry any data in the form of providers, but can be used to influence the
+execution platform of the test action. By default, Bazel registers two such
+toolchains:
+
+* If `--@bazel_tools//tools/test:incompatible_use_default_test_toolchain` is
+  disabled (the current default), the active test toolchain is
+  `@bazel_tools//tools/test:legacy_test_toolchain`. This toolchain does not
+  impose any constraints and thus test actions without manually specified exec
+  constraints are configured for the first registered execution platform. This
+  is often not the intended behavior in multi-platform builds as it can result
+  in e.g. a test binary built for Linux on a Windows machine to be executed on
+  Windows.
+* If `--@bazel_tools//tools/test:incompatible_use_default_test_toolchain` is
+  enabled, the active test toolchain is
+  `@bazel_tools//tools/test:default_test_toolchain`. This toolchain requires an
+  execution platform to match all the constraints of the test rule's target
+  platform. In particular, the target platform is compatible with this toolchain
+  if it is also registered as an execution platform. If no such platform is
+  found, the test rule fails with a toolchain resolution error.
+
+Users can register additional toolchains for this type to influence this
+behavior and their toolchains will take precedence over the default ones.
+Test rule authors can define their own test toolchain type and also register
+a default toolchain for it.
+
 ## Tag conventions {:#tag-conventions}
 
 Some tags in the test rules have a special meaning. See also the

--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -44,3 +44,5 @@ bazel_dep(name = "rules_python", version = "0.40.0")
 bazel_dep(name = "rules_shell", version = "0.3.0")
 # add rules_android
 # add apple_support
+
+register_toolchains("//tools/test:all")

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionOwner.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionOwner.java
@@ -42,7 +42,7 @@ public abstract class ActionOwner {
   @SerializationConstant
   public static final ActionOwner SYSTEM_ACTION_OWNER =
       createDummy(
-          /* label= */ Label.parseCanonicalUnchecked(PlatformConstants.INTERNAL_PLATFORM),
+          /* label= */ PlatformConstants.INTERNAL_PLATFORM,
           Location.BUILTIN,
           /* targetKind= */ "empty target kind",
           /* buildConfigurationMnemonic= */ "system",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -936,6 +936,19 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       help = "Whether to throttle the check whether an action is cached.")
   public boolean throttleActionCacheCheck;
 
+  // This cannot be in TestOptions since the default test toolchain needs to be enabled
+  // conditionally based on its value and test trimming would drop it when evaluating the toolchain
+  // target.
+  @Option(
+      name = "use_target_platform_for_tests",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "If true, then Bazel will use the target platform for running tests rather than "
+              + "the test exec group.")
+  public boolean useTargetPlatformForTests;
+
   /** Ways configured targets may provide the {@link Fragment}s they require. */
   public enum IncludeConfigFragmentsEnum {
     /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -944,9 +944,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
-      help =
-          "If true, then Bazel will use the target platform for running tests rather than "
-              + "the test exec group.")
+      help = "If true, use the target platform for running tests rather than the test exec group.")
   public boolean useTargetPlatformForTests;
 
   /** Ways configured targets may provide the {@link Fragment}s they require. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
@@ -14,6 +14,9 @@ filegroup(
 java_library(
     name = "constants",
     srcs = ["PlatformConstants.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+    ],
 )
 
 # Description:

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
@@ -57,6 +57,21 @@ public record DeclaredToolchainInfo(
     requireNonNull(resolvedToolchainLabel, "resolvedToolchainLabel");
   }
 
+  public boolean hasTargetToExecConstraints() {
+    return execConstraints == USE_TARGET_PLATFORM_CONSTRAINTS
+        && targetConstraints == USE_TARGET_PLATFORM_CONSTRAINTS;
+  }
+
+  private static final ConstraintCollection USE_TARGET_PLATFORM_CONSTRAINTS;
+
+  static {
+    try {
+      USE_TARGET_PLATFORM_CONSTRAINTS = ConstraintCollection.builder().build();
+    } catch (ConstraintCollection.DuplicateConstraintException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   /** Builder class to assist in creating {@link DeclaredToolchainInfo} instances. */
   public static class Builder {
     private ToolchainTypeInfo toolchainType;
@@ -147,6 +162,16 @@ public record DeclaredToolchainInfo(
           toolchainType,
           execConstraints,
           targetConstraints,
+          targetSettings.build(),
+          targetLabel,
+          resolvedToolchainLabel);
+    }
+
+    public DeclaredToolchainInfo buildWithTargetToExecConstraints() {
+      return new DeclaredToolchainInfo(
+          toolchainType,
+          USE_TARGET_PLATFORM_CONSTRAINTS,
+          USE_TARGET_PLATFORM_CONSTRAINTS,
           targetSettings.build(),
           targetLabel,
           resolvedToolchainLabel);

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
@@ -58,6 +58,8 @@ public record DeclaredToolchainInfo(
   }
 
   public boolean hasTargetToExecConstraints() {
+    // This needs to check identity as the special ConstraintCollection is otherwise equal to the
+    // empty one. This avoids adding a new field or making ConstraintCollection more complex.
     return execConstraints == USE_TARGET_PLATFORM_CONSTRAINTS
         && targetConstraints == USE_TARGET_PLATFORM_CONSTRAINTS;
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformConstants.java
@@ -13,11 +13,17 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis.platform;
 
+import com.google.devtools.build.lib.cmdline.Label;
+
 /** This file holds hardcoded constants used by the platforms system. */
 public final class PlatformConstants {
 
   private PlatformConstants() {}
 
-  public static final String INTERNAL_PLATFORM = "@bazel_tools//tools:internal_platform";
-}
+  public static final Label INTERNAL_PLATFORM =
+      Label.parseCanonicalUnchecked("@bazel_tools//tools:internal_platform");
 
+  // The label of the toolchain type to add to the default "test" exec group.
+  public static final Label DEFAULT_TEST_TOOLCHAIN_TYPE =
+      Label.parseCanonicalUnchecked("@bazel_tools//tools/test:default_test_toolchain_type");
+}

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
@@ -60,9 +60,7 @@ public class PlatformInfo extends NativeInfo
   static {
     try {
       EMPTY_PLATFORM_INFO =
-          PlatformInfo.builder()
-              .setLabel(Label.parseCanonicalUnchecked(PlatformConstants.INTERNAL_PLATFORM))
-              .build();
+          PlatformInfo.builder().setLabel(PlatformConstants.INTERNAL_PLATFORM).build();
     } catch (DuplicateConstraintException | ExecPropertiesException e) {
       // This can never happen since we're not passing any values to the builder.
       throw new VerifyException(e);

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.analysis.ShToolchain;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.actions.LazyWriteNestedSetOfTupleAction;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -363,7 +364,8 @@ public final class TestActionBuilder {
     ImmutableList.Builder<Artifact> coverageArtifacts = ImmutableList.builder();
     ImmutableList.Builder<ActionInput> testOutputs = ImmutableList.builder();
 
-    ActionOwner actionOwner = getTestActionOwner(testConfiguration.useTargetPlatformForTests());
+    ActionOwner actionOwner =
+        getTestActionOwner(config.getOptions().get(CoreOptions.class).useTargetPlatformForTests);
 
     // Use 1-based indices for user friendliness.
     for (int shard = 0; shard < shardRuns; shard++) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -333,16 +333,6 @@ public class TestConfiguration extends Fragment {
     public boolean zipUndeclaredTestOutputs;
 
     @Option(
-        name = "use_target_platform_for_tests",
-        defaultValue = "false",
-        documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
-        effectTags = {OptionEffectTag.EXECUTION},
-        help =
-            "If true, then Bazel will use the target platform for running tests rather than "
-                + "the test exec group.")
-    public boolean useTargetPlatformForTests;
-
-    @Option(
         name = "incompatible_check_sharding_support",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
@@ -472,10 +462,6 @@ public class TestConfiguration extends Fragment {
 
   public boolean getZipUndeclaredTestOutputs() {
     return options.zipUndeclaredTestOutputs;
-  }
-
-  public boolean useTargetPlatformForTests() {
-    return options.useTargetPlatformForTests;
   }
 
   public boolean checkShardingSupport() {

--- a/src/main/java/com/google/devtools/build/lib/packages/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/packages/BUILD
@@ -77,6 +77,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/transition_factory",
         "//src/main/java/com/google/devtools/build/lib/analysis:rule_definition_environment",
         "//src/main/java/com/google/devtools/build/lib/analysis:transitive_info_provider",
+        "//src/main/java/com/google/devtools/build/lib/analysis/platform:constants",
         "//src/main/java/com/google/devtools/build/lib/bugreport",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/cmdline:LabelValidator",

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory.TransitionType;
+import com.google.devtools.build.lib.analysis.platform.PlatformConstants;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -160,10 +161,11 @@ public class RuleClass implements RuleClassData {
   public static final String APPLICABLE_METADATA_ATTR_ALT = "applicable_licenses";
 
   public static final String DEFAULT_TEST_RUNNER_EXEC_GROUP_NAME = "test";
-  // The test exec group should not inherit any exec constraints or toolchains from the default exec
-  // group since the execution platform for a test is generally independent (and often different)
-  // from the execution platform of the actions that produce the test executable.
-  public static final ExecGroup DEFAULT_TEST_RUNNER_EXEC_GROUP = ExecGroup.builder().build();
+  public static final ExecGroup DEFAULT_TEST_RUNNER_EXEC_GROUP =
+      ExecGroup.builder()
+          .addToolchainType(
+              ToolchainTypeRequirement.create(PlatformConstants.DEFAULT_TEST_TOOLCHAIN_TYPE))
+          .build();
 
   /** Interface for determining whether a rule needs toolchain resolution or not. */
   @FunctionalInterface

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Toolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Toolchain.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.BuildType;
+import com.google.devtools.build.lib.packages.Type;
 import javax.annotation.Nullable;
 
 /** Defines a toolchain that can be used by rules. */
@@ -57,18 +58,33 @@ public class Toolchain implements RuleConfiguredTargetFactory {
             .collect(toImmutableList());
     Label resolvedToolchainLabel =
         ruleContext.attributes().get(ToolchainRule.TOOLCHAIN_ATTR, BuildType.NODEP_LABEL);
+    boolean targetToExecConstraints =
+        ruleContext.attributes().get(ToolchainRule.USE_TARGET_PLATFORM_CONSTRAINTS_ATTR, Type.BOOLEAN);
+    if (targetToExecConstraints && !(execConstraints.isEmpty() && targetConstraints.isEmpty())) {
+      ruleContext.attributeError(
+          ToolchainRule.USE_TARGET_PLATFORM_CONSTRAINTS_ATTR,
+          "Cannot set use_target_platform_constraints to True and also set exec_compatible_with or "
+              + "target_compatible_with");
+      return null;
+    }
 
     DeclaredToolchainInfo registeredToolchain;
     try {
-      registeredToolchain =
+      var registeredToolchainBuilder =
           DeclaredToolchainInfo.builder()
               .toolchainType(toolchainType)
-              .addExecConstraints(execConstraints)
-              .addTargetConstraints(targetConstraints)
               .addTargetSettings(targetSettings)
               .resolvedToolchainLabel(resolvedToolchainLabel)
-              .targetLabel(ruleContext.getLabel())
-              .build();
+              .targetLabel(ruleContext.getLabel());
+      if (targetToExecConstraints) {
+        registeredToolchain = registeredToolchainBuilder.buildWithTargetToExecConstraints();
+      } else {
+        registeredToolchain =
+            registeredToolchainBuilder
+                .addExecConstraints(execConstraints)
+                .addTargetConstraints(targetConstraints)
+                .build();
+      }
     } catch (DeclaredToolchainInfo.DuplicateConstraintException e) {
       if (e.execConstraintsException() != null) {
         ruleContext.attributeError(

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/ToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/ToolchainRule.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.ToolchainResolutionMode;
+import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.packages.Types;
 import com.google.devtools.build.lib.util.FileTypeSet;
 
@@ -37,6 +38,7 @@ public class ToolchainRule implements RuleDefinition {
   public static final String TARGET_COMPATIBLE_WITH_ATTR = "target_compatible_with";
   public static final String TARGET_SETTING_ATTR = "target_settings";
   public static final String TOOLCHAIN_ATTR = "toolchain";
+  public static final String USE_TARGET_PLATFORM_CONSTRAINTS_ATTR = "use_target_platform_constraints";
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -79,6 +81,16 @@ public class ToolchainRule implements RuleDefinition {
             attr(TARGET_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST)
                 .mandatoryProviders(ConstraintValueInfo.PROVIDER.id())
                 .allowedFileTypes(FileTypeSet.NO_FILE)
+                .nonconfigurable("part of toolchain configuration"))
+        /* <!-- #BLAZE_RULE(toolchain).ATTRIBUTE(use_target_platform_constraints) -->
+        If <code>True</code>, this toolchain behaves as if its <code>exec_compatible_with</code> and
+        <code>target_compatible_with</code> constraints are set to those of the current target
+        platform. <code>exec_compatible_with</code> and <code>target_compatible_with</code> must not
+        be set in that case.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(USE_TARGET_PLATFORM_CONSTRAINTS_ATTR, Type.BOOLEAN)
+                .value(false)
                 .nonconfigurable("part of toolchain configuration"))
         /* <!-- #BLAZE_RULE(toolchain).ATTRIBUTE(target_settings) -->
         A list of <code>config_setting</code>s that must be satisfied by the target configuration

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionFunction.java
@@ -160,14 +160,16 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
             .collect(toImmutableList());
 
     for (DeclaredToolchainInfo toolchain : filteredToolchains) {
-      // Make sure the target platform matches.
-      if (!checkConstraints(
-          debugPrinter,
-          toolchain.targetConstraints(),
-          /* isTargetPlatform= */ true,
-          targetPlatform,
-          toolchain.targetLabel(),
-          toolchain.resolvedToolchainLabel())) {
+      // Make sure the target platform matches. A toolchain with use_target_platform_constraints matches
+      // any target platform.
+      if (!toolchain.hasTargetToExecConstraints()
+          && !checkConstraints(
+              debugPrinter,
+              toolchain.targetConstraints(),
+              /* isTargetPlatform= */ true,
+              targetPlatform,
+              toolchain.targetLabel(),
+              toolchain.resolvedToolchainLabel())) {
         continue;
       }
 
@@ -200,7 +202,9 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
         // Check if the execution constraints match.
         if (!checkConstraints(
             debugPrinter,
-            toolchain.execConstraints(),
+            toolchain.hasTargetToExecConstraints()
+                ? targetPlatform.constraints()
+                : toolchain.execConstraints(),
             /* isTargetPlatform= */ false,
             executionPlatform,
             toolchain.targetLabel(),

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -302,30 +302,18 @@ launcher_flag_alias(
     config.create(
         "embedded_tools/tools/BUILD",
         "alias(name='host_platform',actual='" + TestConstants.PLATFORM_LABEL + "')");
+    // Contains a stripped down version of @bazel_tools//tools/test.
     config.create(
         "embedded_tools/tools/test/BUILD",
         """
         load(":default_test_toolchain.bzl", "bool_flag", "empty_toolchain")
 
-        # The mandatory toolchain requirement of the default "test" exec group defined
-        # on every test rule.
-        # Register a toolchain for this type to influence the selection of the
-        # execution platform based on the target platform. ToolchainInfo provided by
-        # toolchain implementations is generally ignored, but test rules are free to
-        # define their own test toolchain types and specify different behavior.
         toolchain_type(
             name = "default_test_toolchain_type",
         )
 
-        # A target that provides an empty platform_common.ToolchainInfo for use
-        # in test toolchains that do not need to carry any data, just
-        # constraints.
         empty_toolchain(name = "empty_toolchain")
 
-        # Whether to register a default test toolchain for all test rules without
-        # an explicitly defined "test" exec group. This toolchain forces the
-        # execution platform to satisfy all constraints specified by the target
-        # platform.
         bool_flag(
             name = "incompatible_use_default_test_toolchain",
             build_setting_default = False,
@@ -359,8 +347,6 @@ launcher_flag_alias(
             visibility = ["//visibility:private"],
         )
 
-        # A toolchain that forces the execution platform to satisfy all constraints
-        # specified by the target platform.
         toolchain(
             name = "default_test_toolchain",
             toolchain_type = ":default_test_toolchain_type",
@@ -370,9 +356,6 @@ launcher_flag_alias(
             visibility = ["//visibility:private"],
         )
 
-        # A toolchain that allows a test action to run on any execution platform, which
-        # matches the behavior of Bazel before the introduction of the default test
-        # toolchain.
         toolchain(
             name = "legacy_test_toolchain",
             toolchain_type = ":default_test_toolchain_type",

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -41,6 +41,8 @@ import com.google.devtools.build.lib.packages.StructImpl;
 import com.google.devtools.build.lib.packages.TestTimeout;
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -51,10 +53,9 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** {@link com.google.devtools.build.lib.analysis.test.TestActionBuilder} tests. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public class TestActionBuilderTest extends BuildViewTestCase {
 
   @Before
@@ -574,6 +575,222 @@ public class TestActionBuilderTest extends BuildViewTestCase {
         "        srcs = ['illegal.sh'],",
         "        timeout = 'unreasonable')",
         "test_suite(name = 'everything')");
+  }
+
+  /**
+   * With the legacy test toolchain, a test action will run on the first execution platform,
+   * regardless of its constraints.
+   */
+  @Test
+  public void testFirstExecPlatformWithLegacyTestToolchain(
+      @TestParameter({"linux", "macos"}) String targetOs,
+      @TestParameter({"x86_64", "aarch64"}) String targetCpu)
+      throws Exception {
+    scratch.file(
+        "some_test.bzl",
+        """
+        def _some_test_impl(ctx):
+            script = ctx.actions.declare_file(ctx.attr.name + ".sh")
+            ctx.actions.write(script, "shell script goes here", is_executable = True)
+            return [
+                DefaultInfo(executable = script),
+            ]
+
+        some_test = rule(
+            implementation = _some_test_impl,
+            test = True,
+        )
+        """);
+    scratch.file(
+        "BUILD",
+        "load(':some_test.bzl', 'some_test')",
+        """
+        constraint_setting(name = "exec")
+        constraint_value(
+            name = "is_exec",
+            constraint_setting = ":exec",
+        )
+
+        [
+            platform(
+                name = "{}_{}_target".format(os, cpu),
+                constraint_values = [
+                    "%1$sos:" + os,
+                    "%1$scpu:" + cpu,
+                ],
+            )
+            for os in ["linux", "macos"]
+            for cpu in ["x86_64", "aarch64"]
+        ]
+
+        [
+            platform(
+                name = "{}_{}_exec".format(os, cpu),
+                constraint_values = [
+                    "%1$sos:" + os,
+                    "%1$scpu:" + cpu,
+                    ":is_exec",
+                ],
+                exec_properties = {
+                    "os": os,
+                    "cpu": cpu,
+                },
+            )
+            for os in ["linux", "macos"]
+            for cpu in ["x86_64", "aarch64"]
+        ]
+
+        some_test(name = "some_test")
+        """
+            .formatted(TestConstants.CONSTRAINTS_PACKAGE_ROOT));
+    useConfiguration(
+        "--no@bazel_tools//tools/test:incompatible_use_default_test_toolchain",
+        "--platforms=//:%s_%s_target".formatted(targetOs, targetCpu),
+        "--extra_execution_platforms=//:linux_x86_64_exec,//:linux_aarch64_exec,//:macos_x86_64_exec,//:macos_aarch64_exec");
+    ImmutableList<Artifact.DerivedArtifact> testStatusList = getTestStatusArtifacts("//:some_test");
+    TestRunnerAction testAction = (TestRunnerAction) getGeneratingAction(testStatusList.get(0));
+    assertThat(testAction.getExecutionPlatform().label())
+        .isEqualTo(Label.parseCanonicalUnchecked("//:linux_x86_64_exec"));
+    assertThat(testAction.getExecProperties()).containsExactly("os", "linux", "cpu", "x86_64");
+  }
+
+  /**
+   * With the default test toolchain, a test action should run on a platform that matches all
+   * constraints of the target platform.
+   */
+  @Test
+  public void testExecPlatformMatchesTargetConstraintsWithDefaultTestToolchain(
+      @TestParameter({"linux", "macos"}) String targetOs,
+      @TestParameter({"x86_64", "aarch64"}) String targetCpu)
+      throws Exception {
+    scratch.file(
+        "some_test.bzl",
+        """
+        def _some_test_impl(ctx):
+            script = ctx.actions.declare_file(ctx.attr.name + ".sh")
+            ctx.actions.write(script, "shell script goes here", is_executable = True)
+            return [
+                DefaultInfo(executable = script),
+            ]
+
+        some_test = rule(
+            implementation = _some_test_impl,
+            test = True,
+        )
+        """);
+    scratch.file(
+        "BUILD",
+        "load(':some_test.bzl', 'some_test')",
+        """
+        constraint_setting(name = "exec")
+        constraint_value(
+            name = "is_exec",
+            constraint_setting = ":exec",
+        )
+
+        [
+            platform(
+                name = "{}_{}_target".format(os, cpu),
+                constraint_values = [
+                    "%1$sos:" + os,
+                    "%1$scpu:" + cpu,
+                ],
+            )
+            for os in ["linux", "macos"]
+            for cpu in ["x86_64", "aarch64"]
+        ]
+
+        [
+            platform(
+                name = "{}_{}_exec".format(os, cpu),
+                constraint_values = [
+                    "%1$sos:" + os,
+                    "%1$scpu:" + cpu,
+                    ":is_exec",
+                ],
+                exec_properties = {
+                    "os": os,
+                    "cpu": cpu,
+                },
+            )
+            for os in ["linux", "macos"]
+            for cpu in ["x86_64", "aarch64"]
+        ]
+
+        some_test(name = "some_test")
+        """
+            .formatted(TestConstants.CONSTRAINTS_PACKAGE_ROOT));
+    useConfiguration(
+        "--@bazel_tools//tools/test:incompatible_use_default_test_toolchain",
+        "--platforms=//:%s_%s_target".formatted(targetOs, targetCpu),
+        "--extra_execution_platforms=//:linux_x86_64_exec,//:linux_aarch64_exec,//:macos_x86_64_exec,//:macos_aarch64_exec");
+    ImmutableList<Artifact.DerivedArtifact> testStatusList = getTestStatusArtifacts("//:some_test");
+    TestRunnerAction testAction = (TestRunnerAction) getGeneratingAction(testStatusList.get(0));
+    assertThat(testAction.getExecutionPlatform().label())
+        .isEqualTo(Label.parseCanonicalUnchecked("//:%s_%s_exec".formatted(targetOs, targetCpu)));
+    assertThat(testAction.getExecProperties()).containsExactly("os", targetOs, "cpu", targetCpu);
+  }
+
+  /**
+   * With the default test toolchain, a failure to find a suitable execution platform will result in
+   * a toolchain resolution error.
+   */
+  @Test
+  public void testNoMatchingExecPlatformWithDefaultTestToolchain() throws Exception {
+    scratch.file(
+        "some_test.bzl",
+        """
+        def _some_test_impl(ctx):
+            script = ctx.actions.declare_file(ctx.attr.name + ".sh")
+            ctx.actions.write(script, "shell script goes here", is_executable = True)
+            return [
+                DefaultInfo(executable = script),
+            ]
+
+        some_test = rule(
+            implementation = _some_test_impl,
+            test = True,
+        )
+        """);
+    scratch.file(
+        "BUILD",
+        "load(':some_test.bzl', 'some_test')",
+        """
+        constraint_setting(name = "exec")
+        constraint_value(
+            name = "is_exec",
+            constraint_setting = ":exec",
+        )
+
+        platform(
+            name = "linux_x86_64_target",
+            constraint_values = [
+                "%1$sos:linux",
+                "%1$scpu:x86_64",
+            ],
+        )
+
+        platform(
+            name = "macos_aarch64_exec",
+            constraint_values = [
+                "%1$sos:macos",
+                "%1$scpu:aarch64",
+                ":is_exec",
+            ],
+        )
+
+        some_test(name = "some_test")
+        """
+            .formatted(TestConstants.CONSTRAINTS_PACKAGE_ROOT));
+    useConfiguration(
+        "--@bazel_tools//tools/test:incompatible_use_default_test_toolchain",
+        "--platforms=//:linux_x86_64_target",
+        "--host_platform=//:macos_aarch64_exec",
+        "--extra_execution_platforms=//:macos_aarch64_exec");
+    reporter.removeHandler(failFastHandler);
+    assertThat(getConfiguredTarget("//:some_test")).isNull();
+    assertContainsEvent(
+        "While resolving toolchains for target //:some_test: No matching toolchains found for types:\n  @@bazel_tools//tools/test:default_test_toolchain_type");
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
@@ -100,7 +100,12 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
     setupTargetPlatform();
     super.useConfiguration(
         ObjectArrays.concat(
-            args, "--platforms=//" + PLATFORMS_PACKAGE_PATH + ":" + targetPlatform));
+            args,
+            new String[] {
+              "--platforms=//" + PLATFORMS_PACKAGE_PATH + ":" + targetPlatform,
+              "--extra_execution_platforms=//" + PLATFORMS_PACKAGE_PATH + ":" + targetPlatform
+            },
+            String.class));
   }
 
   private StructImpl getMyInfoFromTarget(ConfiguredTarget configuredTarget) throws Exception {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3482,11 +3482,14 @@ constraint_value(
 
 platform(
     name = "host",
-    constraint_values = [":has_foo"],
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        ":has_foo",
+    ],
     exec_properties = {
         "test.no-remote-exec": "1",
     },
-    parents = ["@bazel_tools//tools:host_platform"],
     visibility = ["//visibility:public"],
 )
 
@@ -3528,10 +3531,6 @@ EOF
     //a:test >& $TEST_log || fail "Failed to test //a:test"
   expect_log "2 local, 1 remote"
 
-  # Note: While the test spawns are executed locally, they still select the
-  # remote platform as it is the first registered execution platform and there
-  # are no constraints to force a different one. This is not desired behavior,
-  # but it isn't covered by this test.
   bazel test \
     --extra_execution_platforms=//a:remote,//a:host \
     --platforms=//a:host \

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -113,6 +113,7 @@ filegroup(
         "BUILD.tools",
         "collect_cc_coverage.sh",
         "collect_coverage.sh",
+        "default_test_toolchain.bzl",
         "extensions.bzl",
         "generate-xml.sh",
         "test-setup.sh",
@@ -130,5 +131,8 @@ filegroup(
 
 filegroup(
     name = "bzl_srcs",
-    srcs = ["extensions.bzl"],
+    srcs = [
+        "default_test_toolchain.bzl",
+        "extensions.bzl",
+    ],
 )

--- a/tools/test/BUILD.tools
+++ b/tools/test/BUILD.tools
@@ -1,4 +1,94 @@
+load(":default_test_toolchain.bzl", "bool_flag", "empty_toolchain")
+
 package(default_visibility = ["//visibility:public"])
+
+# The mandatory toolchain requirement of the default "test" exec group defined
+# on every test rule.
+# Register a toolchain for this type to influence the selection of the
+# execution platform based on the target platform. ToolchainInfo provided by
+# toolchain implementations is generally ignored, but test rules are free to
+# define their own test toolchain types and specify different behavior.
+toolchain_type(
+    name = "default_test_toolchain_type",
+    no_match_error = """By default, tests are executed on the first execution platform that \
+matches all constraints specified by the target platform. Either register the target platform (or \
+a platform with at least the same constraints) as an execution platform, or override the default \
+behavior by registering a custom toolchain for \
+@bazel_tools//tools/test:default_test_toolchain_type.""",
+)
+
+
+# A target that provides an empty platform_common.ToolchainInfo for use
+# in test toolchains that do not need to carry any data, just
+# constraints.
+empty_toolchain(name = "empty_toolchain")
+
+# Whether to register a default test toolchain for all test rules without
+# an explicitly defined "test" exec group. This toolchain forces the
+# execution platform to satisfy all constraints specified by the target
+# platform.
+bool_flag(
+    name = "incompatible_use_default_test_toolchain",
+    build_setting_default = False,
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "use_default_test_toolchain",
+    values = {
+        "use_target_platform_for_tests": "false",
+    },
+    flag_values = {
+        ":incompatible_use_default_test_toolchain": "true",
+    },
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "use_legacy_test_toolchain_due_to_use_target_platform_for_tests",
+    values = {
+        "use_target_platform_for_tests": "true",
+    },
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "use_legacy_test_toolchain_due_to_incompatible_flag",
+    flag_values = {
+        ":incompatible_use_default_test_toolchain": "false",
+    },
+    visibility = ["//visibility:private"],
+)
+
+# A toolchain that forces the execution platform to satisfy all constraints
+# specified by the target platform.
+toolchain(
+    name = "default_test_toolchain",
+    toolchain_type = ":default_test_toolchain_type",
+    use_target_platform_constraints = True,
+    target_settings = [":use_default_test_toolchain"],
+    toolchain = ":empty_toolchain",
+    visibility = ["//visibility:private"],
+)
+
+# A toolchain that allows a test action to run on any execution platform, which
+# matches the behavior of Bazel before the introduction of the default test
+# toolchain.
+toolchain(
+    name = "legacy_test_toolchain",
+    toolchain_type = ":default_test_toolchain_type",
+    target_settings = [":use_legacy_test_toolchain_due_to_incompatible_flag"],
+    toolchain = ":empty_toolchain",
+    visibility = ["//visibility:private"],
+)
+
+toolchain(
+    name = "legacy_test_toolchain_use_target_platform_for_tests",
+    toolchain_type = ":default_test_toolchain_type",
+    target_settings = [":use_legacy_test_toolchain_due_to_use_target_platform_for_tests"],
+    toolchain = ":empty_toolchain",
+    visibility = ["//visibility:private"],
+)
 
 # Members of this filegroup shouldn't have duplicate basenames, otherwise
 # TestRunnerAction#getRuntimeArtifact() will get confused.
@@ -68,5 +158,8 @@ filegroup(
 
 filegroup(
     name = "bzl_srcs",
-    srcs = ["extensions.bzl"],
+    srcs = [
+        "default_test_toolchain.bzl",
+        "extensions.bzl",
+    ],
 )

--- a/tools/test/default_test_toolchain.bzl
+++ b/tools/test/default_test_toolchain.bzl
@@ -1,0 +1,27 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A bool-typed build setting that can be set on the command line.
+
+visibility("private")
+
+bool_flag = rule(
+    implementation = lambda _: None,
+    build_setting = config.bool(flag = True),
+    doc = "A bool-typed build setting that can be set on the command line",
+)
+
+empty_toolchain = rule(
+    implementation = lambda ctx: platform_common.ToolchainInfo(),
+)


### PR DESCRIPTION
Work towards #25160 

RELNOTES: The new `--@bazel_tools//tools/test:incompatible_use_default_test_toolchain` flag can be used to have test actions select an execution platform that has all the constraints provided by the target platform instead of always selecting the first available execution platform. This supersedes the `--use_target_platform_for_tests` flag.