### PR TITLE
[8.1.0] Do not invalidate remote metadata during action dirtiness check

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -519,11 +519,17 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
 
     @Override
     protected boolean couldBeModifiedByMetadata(FileArtifactValue o) {
-      if (!(o instanceof RegularFileArtifactValue lastKnown)) {
-        return true;
+      switch (o) {
+        case RegularFileArtifactValue lastKnown -> {
+          return size != lastKnown.size || !Objects.equals(proxy, lastKnown.proxy);
+        }
+        case RemoteFileArtifactValueWithMaterializationData lastKnown -> {
+          return size != lastKnown.getSize() || !Objects.equals(proxy, lastKnown.proxy);
+        }
+        default -> {
+          return true;
+        }
       }
-
-      return size != lastKnown.size || !Objects.equals(proxy, lastKnown.proxy);
     }
   }
 
@@ -532,36 +538,25 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     private final byte[] digest;
     private final long size;
     private final int locationIndex;
-    @Nullable private final PathFragment materializationExecPath;
 
-    private RemoteFileArtifactValue(
-        byte[] digest,
-        long size,
-        int locationIndex,
-        @Nullable PathFragment materializationExecPath) {
+    private RemoteFileArtifactValue(byte[] digest, long size, int locationIndex) {
       this.digest = Preconditions.checkNotNull(digest);
       this.size = size;
       this.locationIndex = locationIndex;
-      this.materializationExecPath = materializationExecPath;
     }
 
-    public static RemoteFileArtifactValue create(
-        byte[] digest, long size, int locationIndex, long expireAtEpochMilli) {
-      return create(
-          digest, size, locationIndex, expireAtEpochMilli, /* materializationExecPath= */ null);
+    public static RemoteFileArtifactValue create(byte[] digest, long size, int locationIndex) {
+      return new RemoteFileArtifactValue(digest, size, locationIndex);
     }
 
-    @VisibleForTesting
-    public static RemoteFileArtifactValue create(
+    public static RemoteFileArtifactValueWithMaterializationData createWithMaterializationData(
         byte[] digest,
         long size,
         int locationIndex,
         long expireAtEpochMilli,
         @Nullable PathFragment materializationExecPath) {
-      return expireAtEpochMilli < 0
-          ? new RemoteFileArtifactValue(digest, size, locationIndex, materializationExecPath)
-          : new RemoteFileArtifactValueWithExpiration(
-              digest, size, locationIndex, materializationExecPath, expireAtEpochMilli);
+      return new RemoteFileArtifactValueWithMaterializationData(
+          digest, size, locationIndex, materializationExecPath, expireAtEpochMilli);
     }
 
     /**
@@ -571,10 +566,10 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     public static RemoteFileArtifactValue createFromExistingWithMaterializationPath(
         RemoteFileArtifactValue metadata, PathFragment materializationExecPath) {
       checkNotNull(materializationExecPath);
-      if (metadata.materializationExecPath != null) {
+      if (metadata.getMaterializationExecPath().isPresent()) {
         return metadata;
       }
-      return create(
+      return createWithMaterializationData(
           metadata.getDigest(),
           metadata.getSize(),
           metadata.getLocationIndex(),
@@ -593,13 +588,12 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
 
       return Arrays.equals(digest, that.digest)
           && size == that.size
-          && locationIndex == that.locationIndex
-          && Objects.equals(materializationExecPath, that.materializationExecPath);
+          && locationIndex == that.locationIndex;
     }
 
     @Override
-    public final int hashCode() {
-      return Objects.hash(Arrays.hashCode(digest), size, locationIndex, materializationExecPath);
+    public int hashCode() {
+      return Objects.hash(Arrays.hashCode(digest), size, locationIndex);
     }
 
     @Override
@@ -613,7 +607,7 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     }
 
     @Override
-    public final FileContentsProxy getContentsProxy() {
+    public FileContentsProxy getContentsProxy() {
       throw new UnsupportedOperationException();
     }
 
@@ -631,11 +625,6 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     @Override
     public final int getLocationIndex() {
       return locationIndex;
-    }
-
-    @Override
-    public final Optional<PathFragment> getMaterializationExecPath() {
-      return Optional.ofNullable(materializationExecPath);
     }
 
     /**
@@ -669,28 +658,33 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     }
 
     @Override
-    public final String toString() {
+    public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("digest", bytesToString(digest))
           .add("size", size)
           .add("locationIndex", locationIndex)
-          .add("materializationExecPath", materializationExecPath)
-          .add("expireAtEpochMilli", getExpireAtEpochMilli())
           .toString();
     }
   }
 
-  /** A remote artifact that expires at a particular time. */
-  private static final class RemoteFileArtifactValueWithExpiration extends RemoteFileArtifactValue {
+  /**
+   * A remote artifact that contains additional data for materialization. This is used when the
+   * output mode allows Bazel to materialize remote output to local filesystem.
+   */
+  public static final class RemoteFileArtifactValueWithMaterializationData
+      extends RemoteFileArtifactValue {
+    @Nullable private final PathFragment materializationExecPath;
     private long expireAtEpochMilli;
+    @Nullable private FileContentsProxy proxy;
 
-    private RemoteFileArtifactValueWithExpiration(
+    private RemoteFileArtifactValueWithMaterializationData(
         byte[] digest,
         long size,
         int locationIndex,
         PathFragment materializationExecPath,
         long expireAtEpochMilli) {
-      super(digest, size, locationIndex, materializationExecPath);
+      super(digest, size, locationIndex);
+      this.materializationExecPath = materializationExecPath;
       this.expireAtEpochMilli = expireAtEpochMilli;
     }
 
@@ -701,13 +695,74 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
 
     @Override
     public void extendExpireAtEpochMilli(long expireAtEpochMilli) {
+      if (expireAtEpochMilli < 0) {
+        return;
+      }
       Preconditions.checkState(expireAtEpochMilli > this.expireAtEpochMilli);
       this.expireAtEpochMilli = expireAtEpochMilli;
     }
 
+    /**
+     * Returns a non-null {@link FileContentsProxy} if this remote metadata is backed by a local
+     * file, e.g. the file is materialized after action execution.
+     */
+    @Override
+    public FileContentsProxy getContentsProxy() {
+      return proxy;
+    }
+
+    /**
+     * Sets the {@link FileContentsProxy} if the output backed by this remote metadata is
+     * materialized later.
+     */
+    public void setContentsProxy(FileContentsProxy proxy) {
+      this.proxy = proxy;
+    }
+
     @Override
     public boolean isAlive(Instant now) {
+      if (expireAtEpochMilli < 0) {
+        return true;
+      }
       return now.toEpochMilli() < expireAtEpochMilli;
+    }
+
+    @Override
+    public Optional<PathFragment> getMaterializationExecPath() {
+      return Optional.ofNullable(materializationExecPath);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof RemoteFileArtifactValueWithMaterializationData that)) {
+        return false;
+      }
+
+      return Arrays.equals(getDigest(), that.getDigest())
+          && getSize() == that.getSize()
+          && getLocationIndex() == that.getLocationIndex()
+          && Objects.equals(materializationExecPath, that.materializationExecPath);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          Arrays.hashCode(getDigest()), getSize(), getLocationIndex(), materializationExecPath);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("digest", bytesToString(getDigest()))
+          .add("size", getSize())
+          .add("locationIndex", getLocationIndex())
+          .add("materializationExecPath", materializationExecPath)
+          .add("expireAtEpochMilli", expireAtEpochMilli)
+          .add("proxy", proxy)
+          .toString();
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -541,7 +541,11 @@ public class CompactPersistentActionCache implements ActionCache {
           PathFragment.create(getStringForIndex(indexer, VarInt.getVarInt(source)));
     }
 
-    return RemoteFileArtifactValue.create(
+    if (expireAtEpochMilli < 0 && materializationExecPath == null) {
+      return RemoteFileArtifactValue.create(digest, size, locationIndex);
+    }
+
+    return RemoteFileArtifactValue.createWithMaterializationData(
         digest, size, locationIndex, expireAtEpochMilli, materializationExecPath);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -40,6 +40,8 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValueWithMaterializationData;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.events.Reporter;
@@ -534,7 +536,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
                         directExecutor())
                     .doOnComplete(
                         () -> {
-                          finalizeDownload(tempPath, finalPath, dirsWithOutputPermissions);
+                          finalizeDownload(
+                              metadata, tempPath, finalPath, dirsWithOutputPermissions);
                           alreadyDeleted.set(true);
                         })
                     .doOnError(
@@ -556,7 +559,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
             }));
   }
 
-  private void finalizeDownload(Path tmpPath, Path finalPath, Set<Path> dirsWithOutputPermissions)
+  private void finalizeDownload(
+      FileArtifactValue metadata, Path tmpPath, Path finalPath, Set<Path> dirsWithOutputPermissions)
       throws IOException {
     Path parentDir = checkNotNull(finalPath.getParentDirectory());
 
@@ -586,6 +590,9 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     // for artifacts produced by local actions.
     tmpPath.chmod(outputPermissions.getPermissionsMode());
     FileSystemUtils.moveFile(tmpPath, finalPath);
+    if (metadata instanceof RemoteFileArtifactValueWithMaterializationData remote) {
+      remote.setContentsProxy(FileContentsProxy.create(finalPath.stat()));
+    }
   }
 
   private interface TaskWithTempPath {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -306,7 +306,12 @@ public class RemoteActionFileSystem extends AbstractFileSystemWithCustomStat
       return;
     }
     var metadata =
-        RemoteFileArtifactValue.create(digest, size, /* locationIndex= */ 1, expireAtEpochMilli);
+        RemoteFileArtifactValue.createWithMaterializationData(
+            digest,
+            size,
+            /* locationIndex= */ 1,
+            expireAtEpochMilli,
+            /* materializationExecPath= */ null);
     remoteOutputTree.injectFile(path, metadata);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.skyframe;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.groupingByConcurrent;
 
@@ -32,6 +33,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValueWithMaterializationData;
 import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.actions.RemoteArtifactChecker;
 import com.google.devtools.build.lib.concurrent.ExecutorUtil;
@@ -478,21 +480,39 @@ public class FilesystemValueChecker {
 
     // This could be improved by short-circuiting as soon as we see a child that is not present in
     // the TreeArtifactValue, but it doesn't seem to be a major source of overhead.
-    // visitTree() is called from multiple threads in parallel so this need to be a hash set
-    Set<PathFragment> currentChildren = Sets.newConcurrentHashSet();
+    // visitTree() is called from multiple threads in parallel so this need to be a concurrent set
+    Set<PathFragment> currentLocalChildren = Sets.newConcurrentHashSet();
     try {
       TreeArtifactValue.visitTree(
           path,
           (child, type, traversedSymlink) -> {
             if (type != Dirent.Type.DIRECTORY) {
-              currentChildren.add(child);
+              currentLocalChildren.add(child);
             }
           });
     } catch (IOException e) {
       return true;
     }
-    return !(currentChildren.isEmpty() && value.isEntirelyRemote())
-        && !currentChildren.equals(value.getChildPaths());
+
+    if (currentLocalChildren.isEmpty() && value.isEntirelyRemote()) {
+      return false;
+    }
+
+    var lastKnownLocalChildren =
+        value.getChildValues().entrySet().stream()
+            .filter(
+                entry -> {
+                  var metadata = entry.getValue();
+                  if (!(metadata
+                      instanceof RemoteFileArtifactValueWithMaterializationData remote)) {
+                    return true;
+                  }
+                  return remote.getContentsProxy() != null;
+                })
+            .map(entry -> entry.getKey().getParentRelativePath())
+            .collect(toImmutableSet());
+
+    return !currentLocalChildren.equals(lastKnownLocalChildren);
   }
 
   private boolean artifactIsDirtyWithDirectSystemCalls(

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -519,14 +519,14 @@ public class ActionCacheCheckerTest {
   private RemoteFileArtifactValue createRemoteFileMetadata(
       String content, @Nullable PathFragment materializationExecPath) {
     byte[] bytes = content.getBytes(UTF_8);
-    return RemoteFileArtifactValue.create(
+    return RemoteFileArtifactValue.createWithMaterializationData(
         digest(bytes), bytes.length, 1, /* expireAtEpochMilli= */ -1, materializationExecPath);
   }
 
   private RemoteFileArtifactValue createRemoteFileMetadata(
       String content, long expireAtEpochMilli, @Nullable PathFragment materializationExecPath) {
     byte[] bytes = content.getBytes(UTF_8);
-    return RemoteFileArtifactValue.create(
+    return RemoteFileArtifactValue.createWithMaterializationData(
         digest(bytes), bytes.length, 1, expireAtEpochMilli, materializationExecPath);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/actions/CompletionContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/CompletionContextTest.java
@@ -48,10 +48,7 @@ import org.mockito.InOrder;
 public final class CompletionContextTest {
   private static final FileArtifactValue DUMMY_METADATA =
       RemoteFileArtifactValue.create(
-          /* digest= */ new byte[0],
-          /* size= */ 0,
-          /* locationIndex= */ 0,
-          /* expireAtEpochMilli= */ -1);
+          /* digest= */ new byte[0], /* size= */ 0, /* locationIndex= */ 0);
 
   private final ActionInputMap inputMap = new ActionInputMap(BugReporter.defaultInstance(), 0);
   private final Map<Artifact, TreeArtifactValue> treeExpansions = new HashMap<>();

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -230,7 +230,7 @@ public class CompactPersistentActionCacheTest {
             .getHashFunction()
             .hashBytes(bytes)
             .asBytes();
-    return RemoteFileArtifactValue.create(
+    return RemoteFileArtifactValue.createWithMaterializationData(
         digest, bytes.length, 1, expireAtEpochMilli, materializationExecPath);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ActionInputPrefetcherTestBase.java
@@ -156,7 +156,7 @@ public abstract class ActionInputPrefetcherTestBase {
     byte[] contentsBytes = contents.getBytes(UTF_8);
     HashCode hashCode = HASH_FUNCTION.getHashFunction().hashBytes(contentsBytes);
     RemoteFileArtifactValue f =
-        RemoteFileArtifactValue.create(
+        RemoteFileArtifactValue.createWithMaterializationData(
             hashCode.asBytes(),
             contentsBytes.length,
             /* locationIndex= */ 1,
@@ -214,11 +214,12 @@ public abstract class ActionInputPrefetcherTestBase {
       byte[] contents = entry.getValue().getBytes(UTF_8);
       HashCode hashCode = HASH_FUNCTION.getHashFunction().hashBytes(contents);
       RemoteFileArtifactValue childValue =
-          RemoteFileArtifactValue.create(
+          RemoteFileArtifactValue.createWithMaterializationData(
               hashCode.asBytes(),
               contents.length,
               /* locationIndex= */ 1,
-              /* expireAtEpochMilli= */ -1);
+              /* expireAtEpochMilli= */ -1,
+              /* materializationExecPath= */ null);
       treeBuilder.putChild(child, childValue);
       metadata.put(child, childValue);
       cas.put(hashCode, contents);

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -1329,8 +1329,7 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
-  public void incrementalBuild_remoteFileMetadataIsReplacedWithLocalFileMetadata()
-      throws Exception {
+  public void incrementalBuild_fileOutputIsPrefetched_noRuns() throws Exception {
     // We need to download the intermediate output
     if (!hasAccessToRemoteOutputs()) {
       return;
@@ -1363,13 +1362,58 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     getRuntimeWrapper().registerSubscriber(actionEventCollector);
     buildTarget("//:foobar");
 
-    // Assert: remote file metadata is replaced with local file metadata
+    // Assert: remote file metadata has contents proxy and action node is not marked as dirty.
     assertValidOutputFile("out/foo.txt", "foo\n");
     assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
     assertThat(actionEventCollector.getActionExecutedEvents()).isEmpty();
-    // Two actions are invalidated but were able to hit the action cache
-    assertThat(actionEventCollector.getCachedActionEvents()).hasSize(2);
-    assertThat(getOnlyElement(getMetadata("//:foo").values()).isRemote()).isFalse();
+    assertThat(actionEventCollector.getCachedActionEvents()).isEmpty();
+    var metadata = getOnlyElement(getMetadata("//:foo").values());
+    assertThat(metadata.isRemote()).isTrue();
+    assertThat(metadata.getContentsProxy()).isNotNull();
+  }
+
+  @Test
+  public void incrementalBuild_treeOutputIsPrefetched_noRuns() throws Exception {
+    // We need to download the intermediate output
+    if (!hasAccessToRemoteOutputs()) {
+      return;
+    }
+
+    // Arrange: Prepare workspace and run a clean build
+    writeOutputDirRule();
+    write(
+        "BUILD",
+        "load(':output_dir.bzl', 'output_dir')",
+        "output_dir(",
+        "  name = 'foo',",
+        "  content_map = {'file-1': '1', 'file-2': '2', 'file-3': '3'},",
+        ")",
+        "genrule(",
+        "  name = 'foobar',",
+        "  srcs = [':foo'],",
+        "  outs = ['out/foobar.txt'],",
+        "  cmd = 'echo bar >> $@',",
+        "  tags = ['no-remote'],",
+        ")");
+
+    buildTarget("//:foobar");
+    assertValidOutputFile("foo/file-1", "1");
+    assertValidOutputFile("foo/file-2", "2");
+    assertValidOutputFile("foo/file-3", "3");
+    assertValidOutputFile("out/foobar.txt", "bar\n");
+    assertThat(getOnlyElement(getTreeMetadata("//:foo").values()).isEntirelyRemote()).isTrue();
+
+    // Act: Do an incremental build without any modifications
+    ActionEventCollector actionEventCollector = new ActionEventCollector();
+    getRuntimeWrapper().registerSubscriber(actionEventCollector);
+    buildTarget("//:foobar");
+
+    // Assert: action node is not marked as dirty.
+    assertValidOutputFile("foo/file-1", "1");
+    assertValidOutputFile("foo/file-2", "2");
+    assertValidOutputFile("foo/file-3", "3");
+    assertThat(actionEventCollector.getActionExecutedEvents()).isEmpty();
+    assertThat(actionEventCollector.getCachedActionEvents()).isEmpty();
   }
 
   protected ImmutableMap<Artifact, FileArtifactValue> getMetadata(String target) throws Exception {
@@ -1381,6 +1425,21 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
         result.putAll(actionExecutionValue.getAllFileValues());
       } else if (value instanceof TreeArtifactValue treeArtifactValue) {
         result.putAll(treeArtifactValue.getChildValues());
+      }
+    }
+    return result.buildOrThrow();
+  }
+
+  protected ImmutableMap<Artifact, TreeArtifactValue> getTreeMetadata(String target)
+      throws Exception {
+    var result = ImmutableMap.<Artifact, TreeArtifactValue>builder();
+    var evaluator = getRuntimeWrapper().getSkyframeExecutor().getEvaluator();
+    for (var artifact : getArtifacts(target)) {
+      var value = evaluator.getExistingValue(Artifact.key(artifact));
+      if (value instanceof ActionExecutionValue actionExecutionValue) {
+        result.putAll(actionExecutionValue.getAllTreeArtifactValues());
+      } else if (value instanceof TreeArtifactValue treeArtifactValue) {
+        result.put(artifact, treeArtifactValue);
       }
     }
     return result.buildOrThrow();

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -530,8 +530,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     byte[] b = contents.getBytes(StandardCharsets.UTF_8);
     HashCode h = HashCode.fromString(DIGEST_UTIL.compute(b).getHash());
     FileArtifactValue f =
-        RemoteFileArtifactValue.create(
-            h.asBytes(), b.length, /* locationIndex= */ 1, /* expireAtEpochMilli= */ -1);
+        RemoteFileArtifactValue.create(h.asBytes(), b.length, /* locationIndex= */ 1);
     inputs.putWithNoDepOwner(a, f);
     return a;
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -1332,8 +1332,12 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
     int size = Utf8.encodedLength(content);
     ((RemoteActionFileSystem) actionFs)
         .injectRemoteFile(path, digest, size, /* expireAtEpochMilli= */ -1);
-    return RemoteFileArtifactValue.create(
-        digest, size, /* locationIndex= */ 1, /* expireAtEpochMilli= */ -1);
+    return RemoteFileArtifactValue.createWithMaterializationData(
+        digest,
+        size,
+        /* locationIndex= */ 1,
+        /* expireAtEpochMilli= */ -1,
+        /* materializationExecPath= */ null);
   }
 
   @Override
@@ -1349,11 +1353,12 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
       String pathFragment, String content, ActionInputMap inputs) {
     Artifact a = ActionsTestUtil.createArtifact(outputRoot, pathFragment);
     RemoteFileArtifactValue f =
-        RemoteFileArtifactValue.create(
+        RemoteFileArtifactValue.createWithMaterializationData(
             getDigest(content),
             Utf8.encodedLength(content),
             /* locationIndex= */ 1,
-            /* expireAtEpochMilli= */ -1);
+            /* expireAtEpochMilli= */ -1,
+            /* materializationExecPath= */ null);
     inputs.putWithNoDepOwner(a, f);
     return a;
   }
@@ -1374,11 +1379,12 @@ public final class RemoteActionFileSystemTest extends RemoteActionFileSystemTest
       TreeFileArtifact child = TreeFileArtifact.createTreeOutput(a, entry.getKey());
       String content = entry.getValue();
       RemoteFileArtifactValue childMeta =
-          RemoteFileArtifactValue.create(
+          RemoteFileArtifactValue.createWithMaterializationData(
               getDigest(content),
               Utf8.encodedLength(content),
               /* locationIndex= */ 0,
-              /* expireAtEpochMilli= */ -1);
+              /* expireAtEpochMilli= */ -1,
+              /* materializationExecPath= */ null);
       builder.putChild(child, childMeta);
     }
     return builder.build();

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionExecutionValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionExecutionValueTest.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.skyframe;
 
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
@@ -48,16 +47,10 @@ import org.junit.runners.JUnit4;
 public final class ActionExecutionValueTest {
   private static final FileArtifactValue VALUE_1_REMOTE =
       RemoteFileArtifactValue.create(
-          /* digest= */ new byte[0],
-          /* size= */ 0,
-          /* locationIndex= */ 1,
-          /* expireAtEpochMilli= */ -1);
+          /* digest= */ new byte[0], /* size= */ 0, /* locationIndex= */ 1);
   private static final FileArtifactValue VALUE_2_REMOTE =
       RemoteFileArtifactValue.create(
-          /* digest= */ new byte[0],
-          /* size= */ 0,
-          /* locationIndex= */ 2,
-          /* expireAtEpochMilli= */ -1);
+          /* digest= */ new byte[0], /* size= */ 0, /* locationIndex= */ 2);
 
   private static final ActionLookupKey KEY = ActionsTestUtil.NULL_ARTIFACT_OWNER;
   private static final ActionLookupData ACTION_LOOKUP_DATA_1 = ActionLookupData.create(KEY, 1);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStoreTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionOutputMetadataStoreTest.java
@@ -291,9 +291,7 @@ public final class ActionOutputMetadataStoreTest {
     assertThat(chmodCalls).containsExactly(outputPath, 0555);
 
     // Inject a remote file of size 42.
-    store.injectFile(
-        artifact,
-        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 42, 0, /* expireAtEpochMilli= */ -1));
+    store.injectFile(artifact, RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 42, 0));
     assertThat(store.getOutputMetadata(artifact).getSize()).isEqualTo(42);
 
     // Reset this output, which will make the store stat the file again.
@@ -314,9 +312,7 @@ public final class ActionOutputMetadataStoreTest {
     byte[] digest = new byte[] {1, 2, 3};
     int size = 10;
     store.injectFile(
-        artifact,
-        RemoteFileArtifactValue.create(
-            digest, size, /* locationIndex= */ 1, /* expireAtEpochMilli= */ -1));
+        artifact, RemoteFileArtifactValue.create(digest, size, /* locationIndex= */ 1));
 
     FileArtifactValue v = store.getOutputMetadata(artifact);
     assertThat(v).isNotNull();
@@ -334,8 +330,7 @@ public final class ActionOutputMetadataStoreTest {
     ActionOutputMetadataStore store = createStore(/* outputs= */ ImmutableSet.of(treeArtifact));
     store.prepareForActionExecution();
 
-    RemoteFileArtifactValue childValue =
-        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1, /* expireAtEpochMilli= */ -1);
+    RemoteFileArtifactValue childValue = RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1);
 
     assertThrows(IllegalArgumentException.class, () -> store.injectFile(child, childValue));
     assertThat(store.getAllArtifactData()).isEmpty();
@@ -354,8 +349,7 @@ public final class ActionOutputMetadataStoreTest {
     ActionOutputMetadataStore store = createStore(/* outputs= */ ImmutableSet.of(treeArtifact));
     store.prepareForActionExecution();
 
-    RemoteFileArtifactValue value =
-        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1, /* expireAtEpochMilli= */ -1);
+    RemoteFileArtifactValue value = RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1);
     store.injectFile(output, value);
 
     assertThat(store.getAllArtifactData()).containsExactly(output, value);
@@ -374,12 +368,10 @@ public final class ActionOutputMetadataStoreTest {
         TreeArtifactValue.newBuilder(treeArtifact)
             .putChild(
                 TreeFileArtifact.createTreeOutput(treeArtifact, "foo"),
-                RemoteFileArtifactValue.create(
-                    new byte[] {1, 2, 3}, 5, 1, /* expireAtEpochMilli= */ -1))
+                RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 5, 1))
             .putChild(
                 TreeFileArtifact.createTreeOutput(treeArtifact, "bar"),
-                RemoteFileArtifactValue.create(
-                    new byte[] {4, 5, 6}, 10, 1, /* expireAtEpochMilli= */ -1))
+                RemoteFileArtifactValue.create(new byte[] {4, 5, 6}, 10, 1))
             .build();
 
     store.injectTree(treeArtifact, tree);
@@ -453,7 +445,7 @@ public final class ActionOutputMetadataStoreTest {
       case LOCAL:
         return FileArtifactValue.createForNormalFile(new byte[] {1, 2, 3}, /* proxy= */ null, 10);
       case REMOTE:
-        return RemoteFileArtifactValue.create(
+        return RemoteFileArtifactValue.createWithMaterializationData(
             new byte[] {1, 2, 3}, 10, 1, -1, materializationExecPath);
     }
     throw new AssertionError();
@@ -523,9 +515,9 @@ public final class ActionOutputMetadataStoreTest {
         FileArtifactValue.createForNormalFile(new byte[] {1, 2, 3}, /* proxy= */ null, 20);
 
     RemoteFileArtifactValue remoteMetadata1 =
-        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 10, 1, -1);
+        RemoteFileArtifactValue.create(new byte[] {1, 2, 3}, 10, 1);
     RemoteFileArtifactValue remoteMetadata2 =
-        RemoteFileArtifactValue.create(new byte[] {4, 5, 6}, 20, 1, -1);
+        RemoteFileArtifactValue.create(new byte[] {4, 5, 6}, 20, 1);
 
     switch (composition) {
       case EMPTY:

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
@@ -89,9 +89,18 @@ public final class FileArtifactValueTest {
             FileArtifactValue.createForDirectoryWithMtime(2))
         .addEqualityGroup(
             // expireAtEpochMilli doesn't contribute to the equality
-            RemoteFileArtifactValue.create(toBytes("00112233445566778899AABBCCDDEEFF"), 1, 1, 1),
-            RemoteFileArtifactValue.create(toBytes("00112233445566778899AABBCCDDEEFF"), 1, 1, 2))
-        .addEqualityGroup(FileArtifactValue.OMITTED_FILE_MARKER)
+            RemoteFileArtifactValue.createWithMaterializationData(
+                toBytes("00112233445566778899AABBCCDDEEFF"),
+                1,
+                1,
+                1,
+                /* materializationExecPath= */ null),
+            RemoteFileArtifactValue.createWithMaterializationData(
+                toBytes("00112233445566778899AABBCCDDEEFF"),
+                1,
+                1,
+                2,
+                /* materializationExecPath= */ null))
         .addEqualityGroup(FileArtifactValue.MISSING_FILE_MARKER)
         .addEqualityGroup(FileArtifactValue.DEFAULT_MIDDLEMAN)
         .addEqualityGroup("a string")
@@ -152,7 +161,7 @@ public final class FileArtifactValueTest {
 
   @Test
   public void testDirectory() throws Exception {
-    Path path = scratchDir("/dir", /*mtime=*/ 1L);
+    Path path = scratchDir("/dir", /* mtime= */ 1L);
     FileArtifactValue value = createForTesting(path);
     assertThat(value.getDigest()).isNull();
     assertThat(value.getModifiedTime()).isEqualTo(1L);
@@ -274,9 +283,9 @@ public final class FileArtifactValueTest {
   @Test
   public void addToFingerprint_equalByDigest() throws Exception {
     FileArtifactValue value1 =
-        FileArtifactValue.createForTesting(scratchFile("/dir/file1", /*mtime=*/ 1, "content"));
+        FileArtifactValue.createForTesting(scratchFile("/dir/file1", /* mtime= */ 1, "content"));
     FileArtifactValue value2 =
-        FileArtifactValue.createForTesting(scratchFile("/dir/file2", /*mtime=*/ 2, "content"));
+        FileArtifactValue.createForTesting(scratchFile("/dir/file2", /* mtime= */ 2, "content"));
     Fingerprint fingerprint1 = new Fingerprint();
     Fingerprint fingerprint2 = new Fingerprint();
 
@@ -291,9 +300,9 @@ public final class FileArtifactValueTest {
   @Test
   public void addToFingerprint_notEqualByDigest() throws Exception {
     FileArtifactValue value1 =
-        FileArtifactValue.createForTesting(scratchFile("/dir/file1", /*mtime=*/ 1, "content1"));
+        FileArtifactValue.createForTesting(scratchFile("/dir/file1", /* mtime= */ 1, "content1"));
     FileArtifactValue value2 =
-        FileArtifactValue.createForTesting(scratchFile("/dir/file2", /*mtime=*/ 1, "content2"));
+        FileArtifactValue.createForTesting(scratchFile("/dir/file2", /* mtime= */ 1, "content2"));
     Fingerprint fingerprint1 = new Fingerprint();
     Fingerprint fingerprint2 = new Fingerprint();
 
@@ -308,9 +317,9 @@ public final class FileArtifactValueTest {
   @Test
   public void addToFingerprint_equalByMtime() throws Exception {
     FileArtifactValue value1 =
-        FileArtifactValue.createForTesting(scratchDir("/dir1", /*mtime=*/ 1));
+        FileArtifactValue.createForTesting(scratchDir("/dir1", /* mtime= */ 1));
     FileArtifactValue value2 =
-        FileArtifactValue.createForTesting(scratchDir("/dir2", /*mtime=*/ 1));
+        FileArtifactValue.createForTesting(scratchDir("/dir2", /* mtime= */ 1));
     Fingerprint fingerprint1 = new Fingerprint();
     Fingerprint fingerprint2 = new Fingerprint();
 
@@ -325,9 +334,9 @@ public final class FileArtifactValueTest {
   @Test
   public void addToFingerprint_notEqualByMtime() throws Exception {
     FileArtifactValue value1 =
-        FileArtifactValue.createForTesting(scratchDir("/dir1", /*mtime=*/ 1));
+        FileArtifactValue.createForTesting(scratchDir("/dir1", /* mtime= */ 1));
     FileArtifactValue value2 =
-        FileArtifactValue.createForTesting(scratchDir("/dir2", /*mtime=*/ 2));
+        FileArtifactValue.createForTesting(scratchDir("/dir2", /* mtime= */ 2));
     Fingerprint fingerprint1 = new Fingerprint();
     Fingerprint fingerprint2 = new Fingerprint();
 
@@ -341,9 +350,10 @@ public final class FileArtifactValueTest {
 
   @Test
   public void addToFingerprint_fileWithDigestNotEqualToFileWithOnlyMtime() throws Exception {
-    FileArtifactValue value1 = FileArtifactValue.createForTesting(scratchDir("/dir", /*mtime=*/ 1));
+    FileArtifactValue value1 =
+        FileArtifactValue.createForTesting(scratchDir("/dir", /* mtime= */ 1));
     FileArtifactValue value2 =
-        FileArtifactValue.createForTesting(scratchFile("/dir/file", /*mtime=*/ 1, "contents"));
+        FileArtifactValue.createForTesting(scratchFile("/dir/file", /* mtime= */ 1, "contents"));
     Fingerprint fingerprint1 = new Fingerprint();
     Fingerprint fingerprint2 = new Fingerprint();
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -38,6 +38,8 @@ import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValueWithMaterializationData;
+import com.google.devtools.build.lib.actions.FileContentsProxy;
 import com.google.devtools.build.lib.actions.FileStateValue;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.actions.RemoteArtifactChecker;
@@ -1391,32 +1393,34 @@ public final class FilesystemValueCheckerTest {
         ActionsTestUtil.createActionExecutionValue(ImmutableMap.of(output, value)));
   }
 
-  private RemoteFileArtifactValue createRemoteFileArtifactValue(String contents) {
+  private RemoteFileArtifactValueWithMaterializationData createRemoteFileArtifactValue(
+      String contents) {
     return createRemoteFileArtifactValue(contents, /* expireAtEpochMilli= */ -1);
   }
 
-  private RemoteFileArtifactValue createRemoteFileArtifactValue(
+  private RemoteFileArtifactValueWithMaterializationData createRemoteFileArtifactValue(
       String contents, long expireAtEpochMilli) {
     byte[] data = contents.getBytes();
     DigestHashFunction hashFn = fs.getDigestFunction();
     HashCode hash = hashFn.getHashFunction().hashBytes(data);
-    return RemoteFileArtifactValue.create(hash.asBytes(), data.length, -1, expireAtEpochMilli);
+    return RemoteFileArtifactValue.createWithMaterializationData(
+        hash.asBytes(), data.length, -1, expireAtEpochMilli, /* materializationExecPath= */ null);
   }
 
   @Test
-  public void testRemoteAndLocalArtifacts() throws Exception {
-    // Test that injected remote artifacts are trusted by the FileSystemValueChecker
-    // if it is configured to trust remote artifacts, and that local files always take precedence
-    // over remote files.
+  public void testRemoteAndLocalArtifacts(@TestParameter boolean setContentsProxy)
+      throws Exception {
+    // Test that injected remote artifacts are trusted by the FileSystemValueChecker if it is
+    // configured to trust remote artifacts, and that local files always take precedence over remote
+    // files if they are different.
     SkyKey actionKey1 = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);
     SkyKey actionKey2 = ActionLookupData.create(ACTION_LOOKUP_KEY, 1);
 
     Artifact out1 = createDerivedArtifact("foo");
     Artifact out2 = createDerivedArtifact("bar");
     Map<SkyKey, Delta> metadataToInject = new HashMap<>();
-    metadataToInject.put(
-        actionKey1,
-        actionValueWithRemoteArtifact(out1, createRemoteFileArtifactValue("foo-content")));
+    var out1Metadata = createRemoteFileArtifactValue("foo-content");
+    metadataToInject.put(actionKey1, actionValueWithRemoteArtifact(out1, out1Metadata));
     metadataToInject.put(
         actionKey2,
         actionValueWithRemoteArtifact(out2, createRemoteFileArtifactValue("bar-content")));
@@ -1446,6 +1450,11 @@ public final class FilesystemValueCheckerTest {
                     RemoteArtifactChecker.TRUST_ALL,
                     (ignored, ignored2) -> {}))
         .isEmpty();
+
+    if (setContentsProxy) {
+      FileSystemUtils.writeContentAsLatin1(out1.getPath(), "foo-content");
+      out1Metadata.setContentsProxy(FileContentsProxy.create(out1.getPath().stat()));
+    }
 
     // Create the "out1" artifact on the filesystem and test that it invalidates the generating
     // action's SkyKey.
@@ -1466,18 +1475,18 @@ public final class FilesystemValueCheckerTest {
   }
 
   @Test
-  public void testRemoteAndLocalArtifacts_identicalContent() throws Exception {
-    // Test that even if injected remote artifacts and local files are NO_OVERRIDE, the generating
-    // actions are marked as dirty.
+  public void testRemoteAndLocalArtifacts_identicalContent(@TestParameter boolean setContentsProxy)
+      throws Exception {
+    // Test that if injected remote artifacts and local files are identical, the generating actions
+    // are not marked as dirty if it has contents proxy.
     SkyKey actionKey1 = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);
     SkyKey actionKey2 = ActionLookupData.create(ACTION_LOOKUP_KEY, 1);
 
     Artifact out1 = createDerivedArtifact("foo");
     Artifact out2 = createDerivedArtifact("bar");
     Map<SkyKey, Delta> metadataToInject = new HashMap<>();
-    metadataToInject.put(
-        actionKey1,
-        actionValueWithRemoteArtifact(out1, createRemoteFileArtifactValue("foo-content")));
+    var out1Metadata = createRemoteFileArtifactValue("foo-content");
+    metadataToInject.put(actionKey1, actionValueWithRemoteArtifact(out1, out1Metadata));
     metadataToInject.put(
         actionKey2,
         actionValueWithRemoteArtifact(out2, createRemoteFileArtifactValue("bar-content")));
@@ -1508,22 +1517,29 @@ public final class FilesystemValueCheckerTest {
                     (ignored, ignored2) -> {}))
         .isEmpty();
 
-    // Create NO_OVERRIDE "out1" artifact on the filesystem and test that it invalidates the
-    // generating action's SkyKey.
+    // Create identical "out1" artifact on the filesystem and test that it doesn't invalidate the
+    // generating action's SkyKey if contents proxy is set.
     FileSystemUtils.writeContentAsLatin1(out1.getPath(), "foo-content");
-    assertThat(
-            new FilesystemValueChecker(
-                    /* tsgm= */ null,
-                    SyscallCache.NO_CACHE,
-                    XattrProviderOverrider.NO_OVERRIDE,
-                    FSVC_THREADS_FOR_TEST)
-                .getDirtyActionValues(
-                    evaluator.getValues(),
-                    /* batchStatter= */ null,
-                    ModifiedFileSet.EVERYTHING_MODIFIED,
-                    RemoteArtifactChecker.TRUST_ALL,
-                    (ignored, ignored2) -> {}))
-        .containsExactly(actionKey1);
+    if (setContentsProxy) {
+      out1Metadata.setContentsProxy(FileContentsProxy.create(out1.getPath().stat()));
+    }
+    var dirtyActionKeys =
+        new FilesystemValueChecker(
+                /* tsgm= */ null,
+                SyscallCache.NO_CACHE,
+                XattrProviderOverrider.NO_OVERRIDE,
+                FSVC_THREADS_FOR_TEST)
+            .getDirtyActionValues(
+                evaluator.getValues(),
+                /* batchStatter= */ null,
+                ModifiedFileSet.EVERYTHING_MODIFIED,
+                RemoteArtifactChecker.TRUST_ALL,
+                (ignored, ignored2) -> {});
+    if (setContentsProxy) {
+      assertThat(dirtyActionKeys).isEmpty();
+    } else {
+      assertThat(dirtyActionKeys).containsExactly(actionKey1);
+    }
   }
 
   @Test
@@ -1572,8 +1588,7 @@ public final class FilesystemValueCheckerTest {
 
   @Test
   public void testRemoteAndLocalTreeArtifacts() throws Exception {
-    // Test that injected remote tree artifacts are trusted by the FileSystemValueChecker
-    // and that local files always takes preference over remote files.
+    // Test that change to local tree files invalidates generating action.
     SkyKey actionKey = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);
 
     SpecialArtifact treeArtifact = createTreeArtifact("dir");
@@ -1631,18 +1646,18 @@ public final class FilesystemValueCheckerTest {
   }
 
   @Test
-  public void testRemoteAndLocalTreeArtifacts_identicalContent() throws Exception {
-    // Test that even if injected remote tree artifacts and local files are NO_OVERRIDE, the
-    // generating actions are marked as dirty.
+  public void testRemoteAndLocalTreeArtifacts_partiallyDownloaded(
+      @TestParameter boolean setContentsProxy) throws Exception {
+    // Test that if injected remote tree artifacts and local files are identical, but the tree is
+    // partially downloaded, the generating action is not marked as dirty.
     SkyKey actionKey = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);
 
     SpecialArtifact treeArtifact = createTreeArtifact("dir");
     treeArtifact.getPath().createDirectoryAndParents();
+    var fooMetadata = createRemoteFileArtifactValue("foo-content");
     TreeArtifactValue tree =
         TreeArtifactValue.newBuilder(treeArtifact)
-            .putChild(
-                TreeFileArtifact.createTreeOutput(treeArtifact, "foo"),
-                createRemoteFileArtifactValue("foo-content"))
+            .putChild(TreeFileArtifact.createTreeOutput(treeArtifact, "foo"), fooMetadata)
             .putChild(
                 TreeFileArtifact.createTreeOutput(treeArtifact, "bar"),
                 createRemoteFileArtifactValue("bar-content"))
@@ -1672,10 +1687,59 @@ public final class FilesystemValueCheckerTest {
                     (ignored, ignored2) -> {}))
         .isEmpty();
 
-    // Create NO_OVERRIDE dir/foo on the local disk and test that it invalidates the associated sky
-    // key.
+    // Create identical dir/foo on the local disk and test that it doesn't invalidate the associated
+    // sky key.
     TreeFileArtifact fooArtifact = TreeFileArtifact.createTreeOutput(treeArtifact, "foo");
     FileSystemUtils.writeContentAsLatin1(fooArtifact.getPath(), "foo-content");
+    if (setContentsProxy) {
+      fooMetadata.setContentsProxy(FileContentsProxy.create(fooArtifact.getPath().stat()));
+    }
+    var dirtyActionKeys =
+        new FilesystemValueChecker(
+                /* tsgm= */ null,
+                SyscallCache.NO_CACHE,
+                XattrProviderOverrider.NO_OVERRIDE,
+                FSVC_THREADS_FOR_TEST)
+            .getDirtyActionValues(
+                evaluator.getValues(),
+                /* batchStatter= */ null,
+                ModifiedFileSet.EVERYTHING_MODIFIED,
+                RemoteArtifactChecker.TRUST_ALL,
+                (ignored, ignored2) -> {});
+    if (setContentsProxy) {
+      assertThat(dirtyActionKeys).isEmpty();
+    } else {
+      assertThat(dirtyActionKeys).containsExactly(actionKey);
+    }
+  }
+
+  @Test
+  public void testRemoteAndLocalTreeArtifacts_identicalContent(
+      @TestParameter boolean setContentsProxy) throws Exception {
+    // Test that if injected remote tree artifacts and local files are identical, the generating
+    // actions are not marked as dirty if contents proxy is set.
+    SkyKey actionKey = ActionLookupData.create(ACTION_LOOKUP_KEY, 0);
+
+    SpecialArtifact treeArtifact = createTreeArtifact("dir");
+    treeArtifact.getPath().createDirectoryAndParents();
+    var fooMetadata = createRemoteFileArtifactValue("foo-content");
+    var barMetadata = createRemoteFileArtifactValue("bar-content");
+    TreeArtifactValue tree =
+        TreeArtifactValue.newBuilder(treeArtifact)
+            .putChild(TreeFileArtifact.createTreeOutput(treeArtifact, "foo"), fooMetadata)
+            .putChild(TreeFileArtifact.createTreeOutput(treeArtifact, "bar"), barMetadata)
+            .build();
+
+    differencer.inject(ImmutableMap.of(actionKey, actionValueWithTreeArtifact(treeArtifact, tree)));
+
+    EvaluationContext evaluationContext =
+        EvaluationContext.newBuilder()
+            .setKeepGoing(false)
+            .setParallelism(1)
+            .setEventHandler(NullEventHandler.INSTANCE)
+            .build();
+    assertThat(evaluator.evaluate(ImmutableList.of(actionKey), evaluationContext).hasError())
+        .isFalse();
     assertThat(
             new FilesystemValueChecker(
                     /* tsgm= */ null,
@@ -1688,7 +1752,35 @@ public final class FilesystemValueCheckerTest {
                     ModifiedFileSet.EVERYTHING_MODIFIED,
                     RemoteArtifactChecker.TRUST_ALL,
                     (ignored, ignored2) -> {}))
-        .containsExactly(actionKey);
+        .isEmpty();
+
+    // Create identical dir/foo and dir/bar on the local disk and test that it doesn't invalidate
+    // the associated sky key.
+    TreeFileArtifact fooArtifact = TreeFileArtifact.createTreeOutput(treeArtifact, "foo");
+    FileSystemUtils.writeContentAsLatin1(fooArtifact.getPath(), "foo-content");
+    TreeFileArtifact barArtifact = TreeFileArtifact.createTreeOutput(treeArtifact, "bar");
+    FileSystemUtils.writeContentAsLatin1(barArtifact.getPath(), "bar-content");
+    if (setContentsProxy) {
+      fooMetadata.setContentsProxy(FileContentsProxy.create(fooArtifact.getPath().stat()));
+      barMetadata.setContentsProxy(FileContentsProxy.create(barArtifact.getPath().stat()));
+    }
+    var dirtyActionKeys =
+        new FilesystemValueChecker(
+                /* tsgm= */ null,
+                SyscallCache.NO_CACHE,
+                XattrProviderOverrider.NO_OVERRIDE,
+                FSVC_THREADS_FOR_TEST)
+            .getDirtyActionValues(
+                evaluator.getValues(),
+                /* batchStatter= */ null,
+                ModifiedFileSet.EVERYTHING_MODIFIED,
+                RemoteArtifactChecker.TRUST_ALL,
+                (ignored, ignored2) -> {});
+    if (setContentsProxy) {
+      assertThat(dirtyActionKeys).isEmpty();
+    } else {
+      assertThat(dirtyActionKeys).containsExactly(actionKey);
+    }
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactBuildTest.java
@@ -657,14 +657,12 @@ public final class TreeArtifactBuildTest extends TimestampBuilderTestCase {
         RemoteFileArtifactValue.create(
             Hashing.sha256().hashString("one", UTF_8).asBytes(),
             /* size= */ 3,
-            /* locationIndex= */ 1,
-            /* expireAtEpochMilli= */ -1);
+            /* locationIndex= */ 1);
     RemoteFileArtifactValue remoteFile2 =
         RemoteFileArtifactValue.create(
             Hashing.sha256().hashString("two", UTF_8).asBytes(),
             /* size= */ 3,
-            /* locationIndex= */ 2,
-            /* expireAtEpochMilli= */ -1);
+            /* locationIndex= */ 2);
 
     Action action =
         new SimpleTestAction(out) {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactValueTest.java
@@ -857,8 +857,7 @@ public final class TreeArtifactValueTest {
   }
 
   private static FileArtifactValue metadataWithId(int id) {
-    return RemoteFileArtifactValue.create(
-        new byte[] {(byte) id}, id, id, /* expireAtEpochMilli= */ -1);
+    return RemoteFileArtifactValue.create(new byte[] {(byte) id}, id, id);
   }
 
   private static FileArtifactValue metadataWithIdNoDigest(int id) {


### PR DESCRIPTION
... if the corresponding output is materialized afterwards and hasn't been changed.

Failing to do so will cause an incremental build to re-check the action cache for actions whose outputs were materialized during last build. This can be very slow if the size of the outputs are large.

We achieved this by storing `FileContentsProxy` in the remote metadata after materialization. During dirtiness check, we compare remote metadata and the corresponding local metadata with their `digest`, or `proxy` if `digest` is not available for local metadata,

A user reported back the wall time of their very first increment build is improved by this change from `14s` to less than `1s` in common case, and from `115s` to less than `1s` in worst case. https://github.com/bazelbuild/bazel/issues/24763

PiperOrigin-RevId: 715734718
Change-Id: Id1a1a59d8b5f3e91a7ae05a73663ff37eee6d163

Fixes #24940.