### PR TITLE
[8.1.0] Garbage collect install bases older than 30 days by default.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -108,7 +108,7 @@ public class CommonCommandOptions extends OptionsBase {
 
   @Option(
       name = "experimental_install_base_gc_max_age",
-      defaultValue = "0",
+      defaultValue = "30d",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       converter = DurationConverter.class,


### PR DESCRIPTION
PiperOrigin-RevId: 720535693
Change-Id: I2467ab2d2426b44382904d50b58edc7602ee457e