### PR TITLE
Add `no_match_error` attribute to `toolchain_type`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
@@ -39,6 +39,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:hash_codes",
         "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/net/starlark/java/eval",

--- a/src/main/java/com/google/devtools/build/lib/rules/ToolchainType.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/ToolchainType.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.rules;
 
+import static com.google.devtools.build.lib.packages.Attribute.attr;
+
 import com.google.devtools.build.lib.actions.ActionConflictException;
 import com.google.devtools.build.lib.analysis.BaseRuleClasses;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -27,6 +29,7 @@ import com.google.devtools.build.lib.analysis.RunfilesProvider;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.ToolchainResolutionMode;
+import com.google.devtools.build.lib.packages.Type;
 import javax.annotation.Nullable;
 
 /**
@@ -39,7 +42,10 @@ public class ToolchainType implements RuleConfiguredTargetFactory {
   public ConfiguredTarget create(RuleContext ruleContext)
       throws ActionConflictException, InterruptedException {
 
-    ToolchainTypeInfo toolchainTypeInfo = ToolchainTypeInfo.create(ruleContext.getLabel());
+    String noMatchError = ruleContext.attributes().get("no_match_error", Type.STRING);
+    ToolchainTypeInfo toolchainTypeInfo =
+        ToolchainTypeInfo.create(
+            ruleContext.getLabel(), noMatchError.isEmpty() ? null : noMatchError);
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
@@ -58,6 +64,12 @@ public class ToolchainType implements RuleConfiguredTargetFactory {
           .removeAttribute("licenses")
           .removeAttribute("distribs")
           .removeAttribute(":action_listener")
+          /*<!-- #BLAZE_RULE(toolchain_type).ATTRIBUTE(no_match_error) -->
+          A custom error message to display when no matching toolchain is found for this type.
+          <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+          .add(
+              attr("no_match_error", Type.STRING)
+                  .nonconfigurable("low-level attribute, used in platform configuration"))
           .build();
     }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
@@ -387,7 +387,12 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
         .hasErrorEntryForKeyThat(key)
         .hasExceptionThat()
         .hasMessageThat()
-        .contains("No matching toolchains found for types //toolchain:test_toolchain");
+        .isEqualTo(
+            """
+            No matching toolchains found for types:
+              //toolchain:test_toolchain
+            To debug, rerun with --toolchain_resolution_debug='//toolchain:test_toolchain'
+            For more information on platforms or toolchains see https://bazel.build/concepts/platforms-intro.""");
   }
 
   @Test

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -427,11 +427,13 @@ EOF
 
   bazel build --platforms=//pkg:exotic_platform --java_runtime_version=local_jdk \
     //pkg:foo &>"$TEST_log" && fail "Build should fail"
-  expect_log "While resolving toolchains for target //pkg:foo ([0-9a-f]*): No matching toolchains found for types @@bazel_tools//tools/jdk:runtime_toolchain_type"
+  expect_log "While resolving toolchains for target //pkg:foo ([0-9a-f]*): No matching toolchains found for types:$"
+  expect_log "^  @@bazel_tools//tools/jdk:runtime_toolchain_type$"
 
   bazel build --platforms=//pkg:exotic_platform --java_runtime_version=local_jdk \
     //pkg:foo_deploy.jar &>"$TEST_log" && fail "Build should fail"
-  expect_log "While resolving toolchains for target //pkg:foo_deploy.jar ([0-9a-f]*): No matching toolchains found for types @@bazel_tools//tools/jdk:runtime_toolchain_type"
+  expect_log "While resolving toolchains for target //pkg:foo_deploy.jar ([0-9a-f]*): No matching toolchains found for types:$"
+  expect_log "^  @@bazel_tools//tools/jdk:runtime_toolchain_type$"
 }
 
 function test_executable_java_binary_fails_without_runtime_with_remote_jdk() {
@@ -456,11 +458,13 @@ EOF
 
   bazel build --platforms=//pkg:exotic_platform --java_runtime_version=remotejdk_11 \
     //pkg:foo &>"$TEST_log" && fail "Build should fail"
-  expect_log "While resolving toolchains for target //pkg:foo ([0-9a-f]*): No matching toolchains found for types @@bazel_tools//tools/jdk:runtime_toolchain_type"
+  expect_log "While resolving toolchains for target //pkg:foo ([0-9a-f]*): No matching toolchains found for types:$"
+  expect_log "^  @@bazel_tools//tools/jdk:runtime_toolchain_type$"
 
   bazel build --platforms=//pkg:exotic_platform --java_runtime_version=remotejdk_11 \
     //pkg:foo_deploy.jar &>"$TEST_log" && fail "Build should fail"
-  expect_log "While resolving toolchains for target //pkg:foo_deploy.jar ([0-9a-f]*): No matching toolchains found for types @@bazel_tools//tools/jdk:runtime_toolchain_type"
+  expect_log "While resolving toolchains for target //pkg:foo_deploy.jar ([0-9a-f]*): No matching toolchains found for types:$"
+  expect_log "^  @@bazel_tools//tools/jdk:runtime_toolchain_type$"
 }
 
 run_suite "Java toolchains tests, configured using flags or the default_java_toolchain macro."


### PR DESCRIPTION
Fixes #12318

RELNOTES: The new `no_match_error` attribute on `toolchain_type` can be used to show a custom message when no matching toolchain is found for that type, but one is required.