### PR TITLE
[8.1.0] Improve incompatible platform skipping + config_setting + label_flag …

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/IncompatibleTargetChecker.java
@@ -200,6 +200,10 @@ public class IncompatibleTargetChecker {
     }
   }
 
+  /** Rules where it doesn't make sense to check for platform compatibility. */
+  private static final ImmutableList<String> NO_COMPATIBILITY_CHECK_RULES =
+      ImmutableList.of("toolchain", "config_setting", "label_flag");
+
   /**
    * Creates an incompatible target if it is "indirectly incompatible".
    *
@@ -226,7 +230,7 @@ public class IncompatibleTargetChecker {
     Target target = targetAndConfiguration.getTarget();
     Rule rule = target.getAssociatedRule();
 
-    if (rule == null || rule.getRuleClass().equals("toolchain")) {
+    if (rule == null || NO_COMPATIBILITY_CHECK_RULES.contains(rule.getRuleClass())) {
       return Optional.empty();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
@@ -146,7 +146,7 @@ public class TopLevelConstraintSemantics {
     String targetIncompatibleMessage =
         String.format(
             TARGET_INCOMPATIBLE_ERROR_TEMPLATE,
-            configuredTarget.getLabel(),
+            configuredTarget.getOriginalLabel(),
             // We need access to the provider so we pass in the underlying target here that is
             // responsible for the incompatibility.
             reportOnIncompatibility(underlyingTarget));
@@ -247,7 +247,7 @@ public class TopLevelConstraintSemantics {
                 target,
                 eventHandler,
                 /* eagerlyThrowError= */ !keepGoing,
-                explicitTargetPatterns.contains(target.getLabel()),
+                explicitTargetPatterns.contains(target.getOriginalLabel()),
                 skipIncompatibleExplicitTargets);
         if (PlatformCompatibility.INCOMPATIBLE_EXPLICIT.equals(platformCompatibility)) {
           incompatibleButRequestedTargets.add(target);

--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
@@ -278,7 +278,7 @@ public final class AnalysisPhaseRunner {
       BuildConfigurationValue config =
           env.getSkyframeExecutor()
               .getConfiguration(env.getReporter(), target.getConfigurationKey());
-      Label label = target.getLabel();
+      Label label = target.getOriginalLabel();
       env.getEventBus()
           .post(
               new AbortedEvent(

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildResultPrinter.java
@@ -274,7 +274,7 @@ class BuildResultPrinter {
       ArrayList<ConfiguredTarget> skipped,
       boolean omitNothingToBuild) {
     for (ConfiguredTarget target : skipped) {
-      outErr.printErr("Target " + target.getLabel() + " was skipped\n");
+      outErr.printErr("Target " + target.getOriginalLabel() + " was skipped\n");
     }
     for (int i = 0; i < succeeded.size(); ++i) {
       ConfiguredTarget target = succeeded.get(i);

--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -2653,8 +2653,46 @@ public class ConfigSettingTest extends BuildViewTestCase {
         )
         """);
 
+    // Expect config_setting on an alias to pass completely through the alias to the underlying
+    // flag it references. This means aliases model which flags trigger config_setting matches. This
+    // keeps config_seting in sync with actual builds: if someone builds with --//foo:alias=1,
+    // both the user and config_setting interpret it the same way even when the underlying flag
+    // changes.
     useConfiguration("--//test:flag=specified");
     assertThat(getConfigMatchingProviderResultAsBoolean("//test:alias_setting")).isTrue();
+  }
+
+  @Test
+  public void labelStarlarkFlag() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        """
+
+        label_flag(
+            name = "my_flag",
+            build_setting_default = "other_target",
+        )
+
+        genrule(
+            name = "other_target",
+            srcs = [],
+            outs = ["other_target"],
+            cmd = "echo other_target",
+        )
+
+        config_setting(
+            name = "my_setting",
+            flag_values = {":my_flag": "//test:other_target"},
+        )
+        """);
+
+    // While label_flag is technically an alias, we can't treat it the same way as a normal alias:
+    // label_flag is by definition a flag, and therefore a valid config_setting input. But the
+    // target it refers to isn't necessarily a flag (and for most practical uses won't be a flag).
+    // So it doesn't make sense to treat it like an alias(), where config_setting setting matches
+    // against the reference's value. So config_setting treats a label_flag's value like any
+    // normal flag value and compares against it directly.
+    assertThat(getConfigMatchingProviderResultAsBoolean("//test:my_setting")).isTrue();
   }
 
   @Test

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -1643,4 +1643,240 @@ EOF
   expect_log "Target //missing_toolchain:my_rule was skipped"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/23003.
+function test_config_setting_on_label_flag_works_when_actual_is_incompatible() {
+  # Not using 'EOF' because injecting default_host_platform
+  cat > target_skipping/BUILD <<EOF
+constraint_setting(name = "foo_version")
+constraint_value(
+    name = "foo1",
+    constraint_setting = ":foo_version",
+)
+constraint_value(
+    name = "foo2",
+    constraint_setting = ":foo_version",
+)
+# The label_flag defaults to a target that's incompatible with this build.
+label_flag(
+    name = "my_label_flag",
+    build_setting_default = ":foo1_target",
+)
+sh_library(
+    name = "foo1_target",
+    srcs = ["incompatible.sh"],
+    target_compatible_with = [":foo1"],
+)
+config_setting(
+    name = "mylabel_flag_points_to_foo1",
+    flag_values = {
+        ":my_label_flag": ":foo1_target",
+    },
+)
+genrule(
+    name = "mytarget",
+    srcs = [],
+    outs = ["mytarget.txt"],
+    cmd = "echo " + select({
+        ":mylabel_flag_points_to_foo1": "label flag matches",
+    }) + " > \$(OUTS)",
+)
+platform(
+    name = "platform_foo2",
+    parents = ["${default_host_platform}"],
+    constraint_values = [
+        ":foo2",
+    ],
+)
+EOF
+
+  cd target_skipping || fail "couldn't cd into workspace"
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:platform_foo2 \
+    --platforms=@//target_skipping:platform_foo2 \
+    //target_skipping:mytarget &> "${TEST_log}" || fail "Bazel failed unexpectedly."
+  expect_log " ${PRODUCT_NAME}-bin/target_skipping/mytarget.txt$"
+  expect_log 'Build completed successfully'
+}
+
+# Regression test for https://github.com/bazelbuild/bazel/issues/23003.
+function test_dep_on_label_flag_is_incompatible_when_reference_is_incompatible() {
+  # Not using 'EOF' because injecting default_host_platform
+  cat > target_skipping/BUILD <<EOF
+constraint_setting(name = "foo_version")
+constraint_value(
+    name = "foo1",
+    constraint_setting = ":foo_version",
+)
+constraint_value(
+    name = "foo2",
+    constraint_setting = ":foo_version",
+)
+label_flag(
+    name = "my_label_flag",
+    build_setting_default = ":foo1_target",
+)
+sh_library(
+    name = "foo1_target",
+    srcs = ["incompatible.sh"],
+    target_compatible_with = [":foo1"],
+)
+sh_binary(
+    name = "mytarget",
+    srcs = ["mytarget.sh"],
+    deps = [":my_label_flag"]
+)
+platform(
+    name = "platform_foo2",
+    parents = ["${default_host_platform}"],
+    constraint_values = [
+        ":foo2",
+    ],
+)
+EOF
+
+  cd target_skipping || fail "couldn't cd into workspace"
+  bazel build --nobuild \
+    --show_result=10 \
+    --host_platform=@//target_skipping:platform_foo2 \
+    --platforms=@//target_skipping:platform_foo2 \
+    //target_skipping:mytarget &> "${TEST_log}" && fail "Bazel succeeded unexpectedly."
+    expect_log 'Target //target_skipping:mytarget is incompatible and cannot be built'
+    expect_log '^ERROR: Build did NOT complete successfully'
+}
+
+# Regression test for https://github.com/bazelbuild/bazel/issues/23003.
+function test_building_label_flag_with_incompatible_ref_fails_as_incompatible() {
+  # Not using 'EOF' because injecting default_host_platform
+  cat > target_skipping/BUILD <<EOF
+constraint_setting(name = "foo_version")
+constraint_value(
+    name = "foo1",
+    constraint_setting = ":foo_version",
+)
+constraint_value(
+    name = "foo2",
+    constraint_setting = ":foo_version",
+)
+label_flag(
+    name = "my_label_flag",
+    build_setting_default = ":foo1_target",
+)
+sh_library(
+    name = "foo1_target",
+    srcs = ["incompatible.sh"],
+    target_compatible_with = [":foo1"],
+)
+platform(
+    name = "platform_foo2",
+    parents = ["${default_host_platform}"],
+    constraint_values = [
+        ":foo2",
+    ],
+)
+EOF
+
+  cd target_skipping || fail "couldn't cd into workspace"
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:platform_foo2 \
+    --platforms=@//target_skipping:platform_foo2 \
+    //target_skipping:my_label_flag &> "${TEST_log}" && fail "Bazel succeeded unexpectedly."
+    expect_log 'Target //target_skipping:my_label_flag is incompatible and cannot be built'
+    expect_log '^ERROR: Build did NOT complete successfully'
+}
+
+# Regression test for https://github.com/bazelbuild/bazel/issues/23003.
+function test_building_label_flag_with_compatible_ref_succeeds() {
+  touch target_skipping/incompatible.sh
+  # Not using 'EOF' because injecting default_host_platform
+  cat > target_skipping/BUILD <<EOF
+constraint_setting(name = "foo_version")
+constraint_value(
+    name = "foo1",
+    constraint_setting = ":foo_version",
+)
+constraint_value(
+    name = "foo2",
+    constraint_setting = ":foo_version",
+)
+label_flag(
+    name = "my_label_flag",
+    build_setting_default = ":foo1_target",
+)
+sh_library(
+    name = "foo1_target",
+    srcs = ["incompatible.sh"],
+    target_compatible_with = [":foo1"],
+)
+platform(
+    name = "platform_foo1",
+    parents = ["${default_host_platform}"],
+    constraint_values = [
+        ":foo1",
+    ],
+)
+EOF
+
+  cd target_skipping || fail "couldn't cd into workspace"
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:platform_foo1 \
+    --platforms=@//target_skipping:platform_foo1 \
+    //target_skipping:my_label_flag &> "${TEST_log}" || fail "Bazel failed unexpectedly."
+  expect_log 'Build completed successfully, '
+}
+
+# Regression test for https://github.com/bazelbuild/bazel/issues/23003.
+function test_building_label_flag_with_incompatible_ref_implicity_is_skipped() {
+  touch target_skipping/incompatible.sh
+  touch target_skipping/mytarget.sh
+  chmod u+x target_skipping/mytarget.sh
+
+  # Not using 'EOF' because injecting default_host_platform
+  cat > target_skipping/BUILD <<EOF
+constraint_setting(name = "foo_version")
+constraint_value(
+    name = "foo1",
+    constraint_setting = ":foo_version",
+)
+constraint_value(
+    name = "foo2",
+    constraint_setting = ":foo_version",
+)
+label_flag(
+    name = "my_label_flag",
+    build_setting_default = ":foo1_target",
+)
+sh_library(
+    name = "foo1_target",
+    srcs = ["incompatible.sh"],
+    target_compatible_with = [":foo1"],
+)
+sh_binary(
+    name = "mytarget",
+    srcs = ["mytarget.sh"],
+)
+platform(
+    name = "platform_foo2",
+    parents = ["${default_host_platform}"],
+    constraint_values = [
+        ":foo2",
+    ],
+)
+EOF
+
+  cd target_skipping || fail "couldn't cd into workspace"
+  bazel build \
+    --show_result=10 \
+    --host_platform=@//target_skipping:platform_foo2 \
+    --platforms=@//target_skipping:platform_foo2 \
+    //target_skipping:all &> "${TEST_log}" || fail "Bazel failed unexpectedly."
+  expect_log 'Target //target_skipping:my_label_flag was skipped'
+  expect_log 'Target //target_skipping:foo1_target was skipped'
+  expect_log 'Target //target_skipping:mytarget up-to-date'
+  expect_log 'Build completed successfully, '
+
+}
+
 run_suite "target_compatible_with tests"


### PR DESCRIPTION
…behavior.

Context: https://github.com/bazelbuild/bazel/issues/23003

Technical notes:

This involves a lot of subtle interactions between the concepts of platform skipping, `config_setting`, `label_flag`, and aliases.

This fixes the problem where a `config_setting` keyed on a `label_flag` that references an incompatible target gave the error "not a valid key for the `config_setting"`. The reason is that `config_setting` expects all `flag_values` keys to expose `BuildSettingProvider`. But an incompatible target (whether directly or because one of its deps is incompatible) is a `RuleConfiguredTarget` that only exposes `IncompatiblePlatformProvider`.

I fixed this by exempting `label_flag` from being marked incompatible due to incompatible deps. It therefore returns its normal value, which is a specially created `AliasConfiguredTarget` that adds the right `BuildSettingProvider` via `AliasConfiguredTarget.overrides`.

All well and good. But if you build such a `label_flag directly`, Bazel still returns an error that it's incompatible due to incompatible deps. That's great, and accurate. But why does it do that if we exempted it from being incompatible in that situation?

The reason is that, as an `AliasConfiguredTarget`, it forwards its dependencies' provider. Since its dependency has `IncompatiblePlatformProvider`, that gets forwarded implicitly, so the routine "is the top-level target incompatible?" check still triggers on the `label_flag` the build requested.

That's a bit odd: the `label_flag` both is and isn't indirectly incompatible depending on which logic is checking. But there's no easy way around this: `ConfigSetting` *has* to consider it compatible to avoid it being a special `RuleConfiguredTarget` with `IncompatiblePlatformProvider`. But since i's normal form is an alias that auto-triggers the "forward my incompatible deps" logic

Point is this is all a bit subtle. I vetted reasonable behavior as best I can, but I'm not 100% confident we capture every corner case correctly or intuitively. There's just too much subtle interplay between various delicate parts of the build API.

You could just as well argue, for example, that `$ bazel build //my:label_flag` should *never* produce an incompatibility error since label flags are dependency aliases, and not meant to build anything directly. If you wanted that behavior just use a plain `alias`. But I don't want to scope-creep this fix so I'll just note these API ambiguities and leave this PR's ambition as-is.

Relatedly you'll see I updated a few pieces of "foo was skipped" reporting messages to reflect that `label_flag` is an alias. Note that change *cannot* kick in for requested builds incompatible `alias` targets. Those are properly considered incompatible, which means they get replaced with `RuleConfiguredTarget` with an `IncompatiblePlatformProvider`. So those essentially cease to be aliases for top-level "foo was skipped"-style reporting.

See the test methods I added for specific expectations I encoded.

We should also update the `config_setting` documentation on `label_flag` and `alias` interaction.

Fixes https://github.com/bazelbuild/bazel/issues/23003.

PiperOrigin-RevId: 702118583
Change-Id: Ia6e80af57cc3b4e6d2574bf28a1d8fe0dbff0852

Closes #24542.

Change-Id: Ia6e80af57cc3b4e6d2574bf28a1d8fe0dbff0852
PiperOrigin-RevId: 702478496

Commit https://github.com/bazelbuild/bazel/commit/916e8581bb2861838fbec0cb6e9228caac7efddc