### PR TITLE
[8.1.0] Respect comprehension variable shadowing in Starlark debugger output

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import net.starlark.java.syntax.Location;
+import net.starlark.java.syntax.Resolver.Binding;
+import net.starlark.java.syntax.Resolver.ComprehensionBinding;
 
 /**
  * An StarlarkThread represents a Starlark thread.
@@ -136,7 +138,7 @@ public final class StarlarkThread {
     private Location loc;
 
     // Indicates that setErrorLocation has been called already and the error
-    // location (loc) should not be overrwritten.
+    // location (loc) should not be overwritten.
     private boolean errorLocationSet;
 
     // The locals of this frame, if fn is a StarlarkFunction, otherwise null.
@@ -191,11 +193,26 @@ public final class StarlarkThread {
             local = ((StarlarkFunction.Cell) local).x;
           }
           if (local != null) {
-            env.put(((StarlarkFunction) fn).rfn.getLocals().get(i).getName(), local);
+            Binding binding = ((StarlarkFunction) fn).rfn.getLocals().get(i);
+            if (binding instanceof ComprehensionBinding comprehensionBinding
+                && !comprehensionBinding.inScope(loc)) {
+              // Ignore comprehension variables when outside their comprehension's lexical scope.
+              continue;
+            }
+            env.put(binding.getName(), local);
           }
         }
       }
-      return env.buildOrThrow();
+      // TODO(https://github.com/bazelbuild/bazel/issues/24931): comprehension variables are stored
+      // in their enclosing function's locals, and can shadow the function's proper local variables
+      // (as well as variables of their enclosing comprehension, since comprehensions can nest).
+      // When this happens, we emit only the last comprehension binding which has the frame's `loc`
+      // within its lexical scope (relying on the fact that when comprehensions are nested, the
+      // resolver places inner comprehensions' variables after outer comprehensions' variables in
+      // the function's locals list). However, this makes it impossible to examine the shadowed
+      // variables' values in the debugger. The real fix would be to push a new debugger frame when
+      // in a comprehension.
+      return env.buildKeepingLast();
     }
 
     @Override

--- a/src/main/java/net/starlark/java/syntax/Resolver.java
+++ b/src/main/java/net/starlark/java/syntax/Resolver.java
@@ -76,7 +76,7 @@ public final class Resolver extends NodeVisitor {
    * A Binding is a static abstraction of a variable. The Resolver maps each Identifier to a
    * Binding.
    */
-  public static final class Binding {
+  public static sealed class Binding permits ComprehensionBinding {
     private Scope scope;
     private final int index; // index within frame (LOCAL/CELL), freevars (FREE), or module (GLOBAL)
     @Nullable private final Identifier first; // first binding use, if syntactic
@@ -112,6 +112,39 @@ public final class Resolver extends NodeVisitor {
           ? scope.toString()
           : String.format(
               "%s[%d] %s @ %s", scope, index, first.getName(), first.getStartLocation());
+    }
+  }
+
+  /** A {@link Binding} for a variable of a list or dict comprehension. */
+  public static final class ComprehensionBinding extends Binding {
+    // Used only for determining the range of locations encompassing the comprehension's lexical
+    // scope. Can be replaced with {start0, end0, start1, end1} positions if we switch to a
+    // non-AST-based evaluation model.
+    private final Comprehension node;
+
+    private ComprehensionBinding(Scope scope, int index, Identifier first, Comprehension node) {
+      super(scope, index, first);
+      this.node = node;
+    }
+
+    /** Returns true if the given location falls within the scope of the comprehension. */
+    public boolean inScope(Location loc) {
+      if (!loc.file().equals(node.getStartLocation().file())) {
+        return false;
+      }
+      // Following Python3, the first for clause of a comprehension is resolved outside the
+      // comprehension block. All the other loops are resolved in the scope of their own bindings,
+      // permitting forward references.
+      Comprehension.For for0 = (Comprehension.For) node.getClauses().get(0);
+      Expression iterable0 = for0.getIterable();
+      if (loc.compareTo(iterable0.getStartLocation()) >= 0
+          && loc.compareTo(iterable0.getEndLocation()) < 0) {
+        return false;
+      }
+      if (loc.compareTo(node.getStartLocation()) >= 0 && loc.compareTo(node.getEndLocation()) < 0) {
+        return true;
+      }
+      return false;
     }
   }
 
@@ -931,7 +964,13 @@ public final class Resolver extends NodeVisitor {
         // New local binding: add to current block's bindings map, current function's frame.
         // (These are distinct entities in the case where the current block is a comprehension.)
         isNew = true;
-        bind = new Binding(Scope.LOCAL, locals.frame.size(), id);
+        if (locals.syntax instanceof Comprehension comprehension) {
+          // Assumption: any block nested in a comprehension is either another comprehension or has
+          // its own frame (e.g. a lambda).
+          bind = new ComprehensionBinding(Scope.LOCAL, locals.frame.size(), id, comprehension);
+        } else {
+          bind = new Binding(Scope.LOCAL, locals.frame.size(), id);
+        }
         locals.bindings.put(name, bind);
         locals.frame.add(bind);
       }


### PR DESCRIPTION
The Starlark interpreter, for optimization reasons, stores the bindings of comprehension variables in their enclosing function's locals array. This means we cannot naively transform the locals array into a name -> value map for debugger output: there may be multiple initialized variables having the same name.

And since we have been building this map using buildOrThrow(), attempting to debug a function with a comprehension variable having the same name as a parameter or other local variable would crash Bazel.

The immediate fix would be to track comprehension bindings' lexical scope (by saving a pointer to the comprehension AST node; note that a comprehension's scope has a non-trivial shape - it has a "hole" punched out for the first `for` clause), so we can ignore comprehension variables outside their comprehension, and emit only the innermost one when inside a comprehension (relying on the fact that the resolver places inner comprehensions' variable bindings after the outer ones).

However, while this fixes the crash and the most obvious correctness problem, it does not allow the user of the debugger to examine the value of the shadowed variables.

The proper fix - to be implemented later - would be to push a new debugger frame when debugging inside a comprehension.

See https://github.com/bazelbuild/bazel/issues/24931 and discussion with @fmeum in https://github.com/bazelbuild/bazel/pull/24919

PiperOrigin-RevId: 715908968
Change-Id: I3066e89f2e92d0fd0e483851a767b7c7d70ab555

Cherry pick of
https://github.com/bazelbuild/bazel/commit/29bdfa392bf8a551d0fad5cee4e425e042194bf0