### PR TITLE
[8.1.0] See and use more than 64 CPUs on Windows

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -432,6 +432,14 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
   // https://github.com/openjdk/jdk/blob/2faf8b8d582183275b1fdc92313a1c63c1753e80/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java#L40
   result.push_back("-Djdk.nio.file.WatchService.maxEventsPerPoll=10000");
 
+#if defined(_WIN32)
+  // See and use more than 64 CPUs on Windows.
+  // https://bugs.openjdk.org/browse/JDK-6942632
+  result.push_back("-XX:+IgnoreUnrecognizedVMOptions");
+  result.push_back("-XX:+UseAllWindowsProcessorGroups");
+  result.push_back("-XX:-IgnoreUnrecognizedVMOptions");
+#endif
+
   if (startup_options.host_jvm_debug) {
     BAZEL_LOG(USER)
         << "Running host JVM under debugger (listening on TCP port 5005).";


### PR DESCRIPTION
Fixes #24827

Closes #25087.

PiperOrigin-RevId: 721285704
Change-Id: Id5c1a8b699f7c5bca1995dba7a8c871805b1a598

Commit https://github.com/bazelbuild/bazel/commit/f64f3605226e380d322f8cf503b014c05747f990