### PR TITLE
Revert "Revert https://github.com/bazelbuild/bazel/commit/7f6e6496726aad4038368979c772e944bc323b7f"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractCommandLine.java
@@ -53,10 +53,12 @@ public abstract class AbstractCommandLine extends CommandLine {
   public void addToFingerprint(
       ActionKeyContext actionKeyContext,
       @Nullable ArtifactExpander artifactExpander,
-      CoreOptions.OutputPathsMode outputPathsMode,
+      CoreOptions.OutputPathsMode effectiveOutputPathsMode,
       Fingerprint fingerprint)
       throws CommandLineExpansionException, InterruptedException {
-    for (String s : arguments()) {
+    for (String s :
+        arguments(
+            /* artifactExpander= */ null, PathMapper.forActionKey(effectiveOutputPathsMode))) {
       fingerprint.addString(s);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -311,6 +311,7 @@ java_library(
         "ArtifactRoot.java",
         "Artifacts.java",
         "PathMapper.java",
+        "PathMapperConstants.java",
     ],
     deps = [
         ":action_lookup_data",
@@ -320,6 +321,7 @@ java_library(
         ":commandline_item",
         ":package_roots",
         "//src/main/java/com/google/devtools/build/docgen/annot",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/core_options",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset:fingerprint_cache",

--- a/src/main/java/com/google/devtools/build/lib/actions/CommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CommandLine.java
@@ -99,7 +99,7 @@ public abstract class CommandLine {
   public abstract void addToFingerprint(
       ActionKeyContext actionKeyContext,
       @Nullable ArtifactExpander artifactExpander,
-      CoreOptions.OutputPathsMode outputPathsMode,
+      CoreOptions.OutputPathsMode effectiveOutputPathsMode,
       Fingerprint fingerprint)
       throws CommandLineExpansionException, InterruptedException;
 

--- a/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
@@ -172,7 +172,7 @@ public abstract sealed class CommandLines {
   public void addToFingerprint(
       ActionKeyContext actionKeyContext,
       @Nullable ArtifactExpander artifactExpander,
-      CoreOptions.OutputPathsMode outputPathsMode,
+      CoreOptions.OutputPathsMode effectiveOutputPathsMode,
       Fingerprint fingerprint)
       throws CommandLineExpansionException, InterruptedException {
     ImmutableList<CommandLineAndParamFileInfo> commandLines = unpack();
@@ -180,7 +180,7 @@ public abstract sealed class CommandLines {
       CommandLine commandLine = pair.commandLine;
       ParamFileInfo paramFileInfo = pair.paramFileInfo;
       commandLine.addToFingerprint(
-          actionKeyContext, artifactExpander, outputPathsMode, fingerprint);
+          actionKeyContext, artifactExpander, effectiveOutputPathsMode, fingerprint);
       if (paramFileInfo != null) {
         addParamFileInfoToFingerprint(paramFileInfo, fingerprint);
       }

--- a/src/main/java/com/google/devtools/build/lib/actions/PathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathMapper.java
@@ -14,11 +14,10 @@
 
 package com.google.devtools.build.lib.actions;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.actions.CommandLineItem.ExceptionlessMapFn;
 import com.google.devtools.build.lib.actions.CommandLineItem.MapFn;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.starlarkbuildapi.FileRootApi;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CheckReturnValue;
@@ -45,7 +44,7 @@ public interface PathMapper {
    * {@link #storeIn(StarlarkSemantics)}.
    */
   static PathMapper loadFrom(StarlarkSemantics semantics) {
-    return semantics.get(SEMANTICS_KEY);
+    return semantics.get(PathMapperConstants.SEMANTICS_KEY);
   }
 
   /**
@@ -65,10 +64,11 @@ public interface PathMapper {
   default StarlarkSemantics storeIn(StarlarkSemantics semantics) {
     // This in particular covers the case where the semantics do not have a path mapper yet and this
     // is NOOP.
-    if (semantics.get(SEMANTICS_KEY) == this) {
+    if (semantics.get(PathMapperConstants.SEMANTICS_KEY) == this) {
       return semantics;
     }
-    return new StarlarkSemantics(semantics.toBuilder().set(SEMANTICS_KEY, this).build()) {
+    return new StarlarkSemantics(
+        semantics.toBuilder().set(PathMapperConstants.SEMANTICS_KEY, this).build()) {
       // The path mapper doesn't affect which fields or methods are available on any given Starlark
       // object; it just affects the behavior of certain methods on Artifact. We thus preserve the
       // original semantics as a cache key. Otherwise, even if PathMapper#equals returned true for
@@ -80,6 +80,13 @@ public interface PathMapper {
         return semantics;
       }
     };
+  }
+
+  /** Returns the instance to use during action key computation. */
+  static PathMapper forActionKey(CoreOptions.OutputPathsMode effectiveOutputPathsMode) {
+    return effectiveOutputPathsMode == CoreOptions.OutputPathsMode.OFF
+        ? NOOP
+        : PathMapperConstants.FOR_FINGERPRINTING;
   }
 
   /**
@@ -142,7 +149,7 @@ public interface PathMapper {
     if (root.isSourceRoot()) {
       // Source roots' paths are never mapped, but we still need to wrap them in a
       // MappedArtifactRoot to ensure correct Starlark comparison behavior.
-      return mappedSourceRoots.get(root);
+      return PathMapperConstants.mappedSourceRoots.get(root);
     }
     // It would *not* be correct to just apply #map to the exec path of the root: The root part of
     // the mapped exec path of this artifact may depend on its complete exec path as well as on e.g.
@@ -191,15 +198,6 @@ public interface PathMapper {
           return artifact.getRoot();
         }
       };
-
-  StarlarkSemantics.Key<PathMapper> SEMANTICS_KEY =
-      new StarlarkSemantics.Key<>("path_mapper", PathMapper.NOOP);
-
-  // Not meant for use outside this interface.
-  LoadingCache<ArtifactRoot, MappedArtifactRoot> mappedSourceRoots =
-      Caffeine.newBuilder()
-          .weakKeys()
-          .build(sourceRoot -> new MappedArtifactRoot(sourceRoot.getExecPath()));
 
   /** A {@link FileRootApi} returned by {@link PathMapper#mapRoot(Artifact)}. */
   @StarlarkBuiltin(

--- a/src/main/java/com/google/devtools/build/lib/actions/PathMapperConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathMapperConstants.java
@@ -1,0 +1,81 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.actions;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import net.starlark.java.eval.StarlarkSemantics;
+
+/** Holder class for symbols used by the PathMapper interface that shouldn't be public. */
+final class PathMapperConstants {
+
+  public static final StarlarkSemantics.Key<PathMapper> SEMANTICS_KEY =
+      new StarlarkSemantics.Key<>("path_mapper", PathMapper.NOOP);
+  public static final LoadingCache<ArtifactRoot, PathMapper.MappedArtifactRoot> mappedSourceRoots =
+      Caffeine.newBuilder()
+          .weakKeys()
+          .build(sourceRoot -> new PathMapper.MappedArtifactRoot(sourceRoot.getExecPath()));
+
+  private static final PathFragment BAZEL_OUT = PathFragment.create("bazel-out");
+  private static final PathFragment BLAZE_OUT = PathFragment.create("blaze-out");
+
+  /**
+   * A special instance for use in {@link AbstractAction#computeKey} when path mapping is generally
+   * enabled for an action.
+   *
+   * <p>When computing an action key, the following approaches to taking path mapping into account
+   * do <b>not</b> work:
+   *
+   * <ul>
+   *   <li>Using the actual path mapper is prohibitive since constructing it requires checking for
+   *       collisions among the action input's paths when computing the action key, which flattens
+   *       the input depsets of all actions that opt into path mapping and also increases CPU usage.
+   *   <li>Unconditionally using {@link
+   *       com.google.devtools.build.lib.analysis.actions.StrippingPathMapper} can result in stale
+   *       action keys when an action is opted out of path mapping at execution time due to input
+   *       path collisions after stripping. See path_mapping_test for an example.
+   *   <li>Using {@link PathMapper#NOOP} does not distinguish between map_each results built from
+   *       strings and those built from {@link
+   *       com.google.devtools.build.lib.starlarkbuildapi.FileApi#getExecPathStringForStarlark}.
+   *       While the latter will be mapped at execution time, the former won't, resulting in the
+   *       same digest for actions that behave differently at execution time. This is covered by
+   *       tests in StarlarkRuleImplementationFunctionsTest.
+   * </ul>
+   *
+   * <p>Instead, we use a special path mapping instance that preserves the equality relations
+   * between the original config segments, but prepends a fixed string to distinguish hard-coded
+   * path strings from mapped paths. This relies on actions using path mapping to be "root
+   * agnostic": they must not contain logic that depends on any particular (output) root path.
+   */
+  static final PathMapper FOR_FINGERPRINTING =
+      execPath -> {
+        if (!execPath.startsWith(BAZEL_OUT) && !execPath.startsWith(BLAZE_OUT)) {
+          // This is not an output path.
+          return execPath;
+        }
+        String execPathString = execPath.getPathString();
+        int startOfConfigSegment = execPathString.indexOf('/') + 1;
+        if (startOfConfigSegment == 0) {
+          return execPath;
+        }
+        return PathFragment.createAlreadyNormalized(
+            execPathString.substring(0, startOfConfigSegment)
+                + "pm-"
+                + execPathString.substring(startOfConfigSegment));
+      };
+
+  private PathMapperConstants() {}
+}

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
@@ -1360,7 +1360,7 @@ public class CustomCommandLine extends AbstractCommandLine {
   public void addToFingerprint(
       ActionKeyContext actionKeyContext,
       @Nullable ArtifactExpander artifactExpander,
-      CoreOptions.OutputPathsMode outputPathsMode,
+      CoreOptions.OutputPathsMode effectiveOutputPathsMode,
       Fingerprint fingerprint)
       throws CommandLineExpansionException, InterruptedException {
     List<Object> arguments = rawArgsAsList();

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/PathMappers.java
@@ -40,49 +40,6 @@ import javax.annotation.Nullable;
  * PathMapper}).
  */
 public final class PathMappers {
-  private static final PathFragment BAZEL_OUT = PathFragment.create("bazel-out");
-  private static final PathFragment BLAZE_OUT = PathFragment.create("blaze-out");
-
-  /**
-   * A special instance for use in {@link AbstractAction#computeKey} when path mapping is generally
-   * enabled for an action.
-   *
-   * <p>When computing an action key, the following approaches to taking path mapping into account
-   * do <b>not</b> work:
-   *
-   * <ul>
-   *   <li>Using the actual path mapper is prohibitive since constructing it requires checking for
-   *       collisions among the action input's paths when computing the action key, which flattens
-   *       the input depsets of all actions that opt into path mapping and also increases CPU usage.
-   *   <li>Unconditionally using {@link StrippingPathMapper} can result in stale action keys when an
-   *       action is opted out of path mapping at execution time due to input path collisions after
-   *       stripping. See path_mapping_test for an example.
-   *   <li>Using {@link PathMapper#NOOP} does not distinguish between map_each results built from
-   *       strings and those built from {@link
-   *       com.google.devtools.build.lib.starlarkbuildapi.FileApi#getExecPathStringForStarlark}.
-   *       While the latter will be mapped at execution time, the former won't, resulting in the
-   *       same digest for actions that behave differently at execution time. This is covered by
-   *       tests in StarlarkRuleImplementationFunctionsTest.
-   * </ul>
-   *
-   * <p>Instead, we use a special path mapping instance that preserves the equality relations
-   * between the original config segments, but prepends a fixed string to distinguish hard-coded
-   * path strings from mapped paths. This relies on actions using path mapping to be "root
-   * agnostic": they must not contain logic that depends on any particular (output) root path.
-   */
-  private static final PathMapper FOR_FINGERPRINTING =
-      execPath -> {
-        if (!execPath.startsWith(BAZEL_OUT) && !execPath.startsWith(BLAZE_OUT)) {
-          // This is not an output path.
-          return execPath;
-        }
-        String execPathString = execPath.getPathString();
-        int startOfConfigSegment = execPathString.indexOf('/') + 1;
-        return PathFragment.createAlreadyNormalized(
-            execPathString.substring(0, startOfConfigSegment)
-                + "pm-"
-                + execPathString.substring(startOfConfigSegment));
-      };
 
   // TODO: Remove actions from this list by adding ExecutionRequirements.SUPPORTS_PATH_MAPPING to
   //  their execution info instead.
@@ -136,13 +93,6 @@ public final class PathMappers {
     }
   }
 
-  /** Returns the instance to use during action key computation. */
-  public static PathMapper forActionKey(OutputPathsMode outputPathsMode) {
-    return outputPathsMode == OutputPathsMode.OFF
-        ? PathMapper.NOOP
-        : PathMappers.FOR_FINGERPRINTING;
-  }
-
   /**
    * Actions that support path mapping should call this method when creating their {@link Spawn}.
    *
@@ -190,7 +140,12 @@ public final class PathMappers {
     return configuration.getOptions().get(CoreOptions.class).outputPathsMode;
   }
 
-  private static OutputPathsMode getEffectiveOutputPathsMode(
+  /**
+   * Returns the effective {@link OutputPathsMode} for an action based on the action's mnemonic and
+   * execution info. This may return a mode other than {@link OutputPathsMode#OFF} even though path
+   * mapping will be disabled during execution due to path collisions.
+   */
+  public static OutputPathsMode getEffectiveOutputPathsMode(
       OutputPathsMode outputPathsMode, String mnemonic, Map<String, String> executionInfo) {
     if (executionInfo.containsKey(ExecutionRequirements.LOCAL)
         || (executionInfo.containsKey(ExecutionRequirements.NO_SANDBOX)

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -373,7 +373,11 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       Fingerprint fp)
       throws CommandLineExpansionException, InterruptedException {
     fp.addString(GUID);
-    commandLines.addToFingerprint(actionKeyContext, artifactExpander, outputPathsMode, fp);
+    commandLines.addToFingerprint(
+        actionKeyContext,
+        artifactExpander,
+        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, getMnemonic(), getExecutionInfo()),
+        fp);
     fp.addString(mnemonic);
     env.addTo(fp);
     fp.addStringMap(getExecutionInfo());

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -41,7 +41,6 @@ import com.google.devtools.build.lib.actions.FilesetOutputTree;
 import com.google.devtools.build.lib.actions.FilesetOutputTree.RelativeSymlinkBehaviorWithoutError;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.SingleStringArgFormatter;
-import com.google.devtools.build.lib.analysis.actions.PathMappers;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
@@ -575,7 +574,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
             maybeExpandDirectories(
                 artifactExpander,
                 arguments.subList(argi, argi + count),
-                PathMappers.forActionKey(outputPathsMode));
+                PathMapper.forActionKey(outputPathsMode));
         argi += count;
         if (mapEach != null) {
           // TODO(b/160181927): If artifactExpander == null (which happens in the analysis phase)
@@ -590,7 +589,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
               fingerprint::addString,
               location,
               artifactExpander,
-              PathMappers.forActionKey(outputPathsMode),
+              PathMapper.forActionKey(outputPathsMode),
               starlarkSemantics);
         } else {
           for (Object value : maybeExpandedValues) {
@@ -1034,7 +1033,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
   public void addToFingerprint(
       ActionKeyContext actionKeyContext,
       @Nullable ArtifactExpander artifactExpander,
-      CoreOptions.OutputPathsMode outputPathsMode,
+      CoreOptions.OutputPathsMode effectiveOutputPathsMode,
       Fingerprint fingerprint)
       throws CommandLineExpansionException, InterruptedException {
     List<Object> arguments = rawArgsAsList();
@@ -1057,7 +1056,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
                     actionKeyContext,
                     fingerprint,
                     artifactExpander,
-                    outputPathsMode);
+                    effectiveOutputPathsMode);
       } else if (arg == SingleFormattedArg.MARKER) {
         argi = SingleFormattedArg.addToFingerprint(arguments, argi, fingerprint);
       } else {
@@ -1205,7 +1204,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
           args,
           location,
           artifactExpander,
-          PathMappers.forActionKey(outputPathsMode),
+          PathMapper.forActionKey(outputPathsMode),
           starlarkSemantics);
     }
 
@@ -1215,7 +1214,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
       }
 
       return VectorArg.expandDirectories(
-          artifactExpander, ImmutableList.of(object), PathMappers.forActionKey(outputPathsMode));
+          artifactExpander, ImmutableList.of(object), PathMapper.forActionKey(outputPathsMode));
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcStarlarkInternal.java
@@ -111,24 +111,41 @@ public class CcStarlarkInternal implements StarlarkValue {
 
     CcToolchainVariables.Builder ccToolchainVariables = CcToolchainVariables.builder();
     for (var entry : buildVariables.entrySet()) {
-      if (entry.getValue() instanceof String) {
-        ccToolchainVariables.addStringVariable((String) entry.getKey(), (String) entry.getValue());
-      } else if (entry.getValue() instanceof Boolean) {
-        ccToolchainVariables.addBooleanValue((String) entry.getKey(), (Boolean) entry.getValue());
-      } else if (entry.getValue() instanceof Iterable<?>) {
-        if (entry.getKey().equals("libraries_to_link")) {
-          SequenceBuilder sb = new SequenceBuilder();
-          for (var value : (Iterable<?>) entry.getValue()) {
-            sb.addValue((VariableValue) value);
+      String key = (String) entry.getKey();
+      Object value = entry.getValue();
+      switch (value) {
+        case String s -> ccToolchainVariables.addStringVariable(key, s);
+        case Artifact a -> ccToolchainVariables.addArtifactVariable(key, a);
+        case Boolean b -> ccToolchainVariables.addBooleanValue(key, b);
+        case Iterable<?> values -> {
+          if (key.equals("libraries_to_link")) {
+            SequenceBuilder sb = new SequenceBuilder();
+            for (var v : (Iterable<VariableValue>) values) {
+              sb.addValue(v);
+            }
+            ccToolchainVariables.addCustomBuiltVariable(key, sb);
+          } else {
+            ccToolchainVariables.addStringSequenceVariable(key, (Iterable<String>) values);
           }
-          ccToolchainVariables.addCustomBuiltVariable((String) entry.getKey(), sb);
-        } else {
-          ccToolchainVariables.addStringSequenceVariable(
-              (String) entry.getKey(), (Iterable<String>) entry.getValue());
         }
-      } else if (entry.getValue() instanceof Depset) {
-        ccToolchainVariables.addStringSequenceVariable(
-            (String) entry.getKey(), ((Depset) entry.getValue()).getSet(String.class));
+        case Depset depset -> {
+          Class<?> type = depset.getElementClass();
+          // Type doesn't matter for empty depsets.
+          if (type == String.class || type == null) {
+            ccToolchainVariables.addStringSequenceVariable(key, depset.getSet(String.class));
+          } else if (type == Artifact.class) {
+            ccToolchainVariables.addArtifactSequenceVariable(key, depset.getSet(Artifact.class));
+          } else if (type == PathFragment.class) {
+            ccToolchainVariables.addPathFragmentSequenceVariable(
+                key, depset.getSet(PathFragment.class));
+          } else {
+            throw new IllegalStateException("Unexpected depset element type: %s".formatted(type));
+          }
+        }
+        case NoneType ignored -> {}
+        default ->
+            throw new IllegalStateException(
+                "Unexpected value: %s (%s)".formatted(value, value.getClass()));
       }
     }
     return ccToolchainVariables.build();

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
@@ -412,18 +412,18 @@ public class CcToolchainFeatures implements StarlarkValue {
       }
       if (expandIfTrue != null
           && (!variables.isAvailable(expandIfTrue, expander)
-              || !variables.getVariable(expandIfTrue).isTruthy())) {
+              || !variables.getVariable(expandIfTrue, pathMapper).isTruthy())) {
         return false;
       }
       if (expandIfFalse != null
           && (!variables.isAvailable(expandIfFalse, expander)
-              || variables.getVariable(expandIfFalse).isTruthy())) {
+              || variables.getVariable(expandIfFalse, pathMapper).isTruthy())) {
         return false;
       }
       if (expandIfEqual != null
           && (!variables.isAvailable(expandIfEqual.variable, expander)
               || !variables
-                  .getVariable(expandIfEqual.variable)
+                  .getVariable(expandIfEqual.variable, pathMapper)
                   .getStringValue(expandIfEqual.variable, pathMapper)
                   .equals(expandIfEqual.value))) {
         return false;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.rules.cpp;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
@@ -178,7 +179,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
       parse();
     }
 
-    /** @return the parsed chunks for this string. */
+    /** Returns the parsed chunks for this string. */
     public ImmutableList<StringChunk> getChunks() {
       return chunks.build();
     }
@@ -312,13 +313,15 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
    * @throws ExpansionException when no such variable or no such field are present, or when
    *     accessing a field of non-structured variable
    */
-  VariableValue getVariable(String name) throws ExpansionException {
-    return lookupVariable(name, /* throwOnMissingVariable= */ true, /* expander= */ null);
+  VariableValue getVariable(String name, PathMapper pathMapper) throws ExpansionException {
+    return lookupVariable(
+        name, /* throwOnMissingVariable= */ true, /* expander= */ null, pathMapper);
   }
 
-  private VariableValue getVariable(String name, @Nullable ArtifactExpander expander)
+  private VariableValue getVariable(
+      String name, @Nullable ArtifactExpander expander, PathMapper pathMapper)
       throws ExpansionException {
-    return lookupVariable(name, /* throwOnMissingVariable= */ true, expander);
+    return lookupVariable(name, /* throwOnMissingVariable= */ true, expander, pathMapper);
   }
 
   /**
@@ -327,7 +330,10 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
    */
   @Nullable
   private VariableValue lookupVariable(
-      String name, boolean throwOnMissingVariable, @Nullable ArtifactExpander expander)
+      String name,
+      boolean throwOnMissingVariable,
+      @Nullable ArtifactExpander expander,
+      PathMapper pathMapper)
       throws ExpansionException {
     VariableValue var = getNonStructuredVariable(name);
     if (var != null) {
@@ -354,7 +360,8 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     Object variableOrError = structuredVariableCache.get(name);
     if (variableOrError == null) {
       try {
-        VariableValue variable = getStructureVariable(name, throwOnMissingVariable, expander);
+        VariableValue variable =
+            getStructureVariable(name, throwOnMissingVariable, expander, pathMapper);
         variableOrError = variable != null ? variable : NULL_MARKER;
       } catch (ExpansionException e) {
         if (throwOnMissingVariable) {
@@ -382,7 +389,10 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
 
   @Nullable
   private VariableValue getStructureVariable(
-      String name, boolean throwOnMissingVariable, @Nullable ArtifactExpander expander)
+      String name,
+      boolean throwOnMissingVariable,
+      @Nullable ArtifactExpander expander,
+      PathMapper pathMapper)
       throws ExpansionException {
     if (!name.contains(".")) {
       return null;
@@ -404,7 +414,8 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
 
     while (!fieldsToAccess.empty()) {
       String field = fieldsToAccess.pop();
-      variable = variable.getFieldValue(structPath, field, expander, throwOnMissingVariable);
+      variable =
+          variable.getFieldValue(structPath, field, expander, pathMapper, throwOnMissingVariable);
       if (variable == null) {
         if (throwOnMissingVariable) {
           throw new ExpansionException(
@@ -422,19 +433,21 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
 
   public String getStringVariable(String variableName, PathMapper pathMapper)
       throws ExpansionException {
-    return getVariable(variableName, /* expander= */ null).getStringValue(variableName, pathMapper);
+    return getVariable(variableName, /* expander= */ null, pathMapper)
+        .getStringValue(variableName, pathMapper);
   }
 
   public Iterable<? extends VariableValue> getSequenceVariable(
       String variableName, PathMapper pathMapper) throws ExpansionException {
-    return getVariable(variableName, /* expander= */ null)
+    return getVariable(variableName, /* expander= */ null, pathMapper)
         .getSequenceValue(variableName, pathMapper);
   }
 
   public Iterable<? extends VariableValue> getSequenceVariable(
       String variableName, @Nullable ArtifactExpander expander, PathMapper pathMapper)
       throws ExpansionException {
-    return getVariable(variableName, expander).getSequenceValue(variableName, pathMapper);
+    return getVariable(variableName, expander, pathMapper)
+        .getSequenceValue(variableName, pathMapper);
   }
 
   /** Returns whether {@code variable} is set. */
@@ -444,7 +457,10 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
 
   boolean isAvailable(String variable, @Nullable ArtifactExpander expander) {
     try {
-      return lookupVariable(variable, /* throwOnMissingVariable= */ false, expander) != null;
+      // Availability doesn't depend on the path mapper.
+      return lookupVariable(
+              variable, /* throwOnMissingVariable= */ false, expander, PathMapper.NOOP)
+          != null;
     } catch (ExpansionException e) {
       throw new IllegalStateException(
           "Should not happen - call to lookupVariable threw when asked not to.", e);
@@ -474,7 +490,6 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
      * StringValue), or throw exception if it cannot (e.g. Sequence).
      *
      * @param variableName name of the variable value at hand, for better exception message.
-     * @param pathMapper
      */
     String getStringValue(String variableName, PathMapper pathMapper) throws ExpansionException;
 
@@ -483,7 +498,6 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
      * (e.g. Sequence), or throw exception if it cannot (e.g. StringValue).
      *
      * @param variableName name of the variable value at hand, for better exception message.
-     * @param pathMapper
      */
     Iterable<? extends VariableValue> getSequenceValue(String variableName, PathMapper pathMapper)
         throws ExpansionException;
@@ -494,14 +508,24 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
      *
      * @param variableName name of the variable value at hand, for better exception message.
      */
-    VariableValue getFieldValue(String variableName, String field) throws ExpansionException;
-
     VariableValue getFieldValue(
         String variableName,
         String field,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         boolean throwOnMissingVariable)
         throws ExpansionException;
+
+    @VisibleForTesting
+    default VariableValue getFieldValue(String variableName, String field)
+        throws ExpansionException {
+      return getFieldValue(
+          variableName,
+          field,
+          /* expander= */ null,
+          PathMapper.NOOP,
+          /* throwOnMissingVariable= */ true);
+    }
 
     /** Returns true if the variable is truthy */
     boolean isTruthy();
@@ -522,19 +546,13 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
     @Override
     public abstract boolean isTruthy();
 
-    @Override
-    public VariableValue getFieldValue(String variableName, String field)
-        throws ExpansionException {
-      return getFieldValue(
-          variableName, field, /* expander= */ null, /* throwOnMissingVariable= */ true);
-    }
-
     @Nullable
     @Override
     public VariableValue getFieldValue(
         String variableName,
         String field,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         boolean throwOnMissingVariable)
         throws ExpansionException {
       if (throwOnMissingVariable) {
@@ -730,6 +748,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
         String variableName,
         String field,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         boolean throwOnMissingVariable) {
       if (TYPE_FIELD_NAME.equals(field)) {
         return new StringValue(getTypeName());
@@ -784,11 +803,17 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
           String variableName,
           String field,
           @Nullable ArtifactExpander expander,
+          PathMapper pathMapper,
           boolean throwOnMissingVariable) {
         if (NAME_FIELD_NAME.equals(field)) {
-          return new StringValue(name);
+          if (pathMapper.isNoop()) {
+            return new StringValue(name);
+          }
+          return new StringValue(
+              pathMapper.map(PathFragment.createAlreadyNormalized(name)).getPathString());
         }
-        return super.getFieldValue(variableName, field, expander, throwOnMissingVariable);
+        return super.getFieldValue(
+            variableName, field, expander, pathMapper, throwOnMissingVariable);
       }
 
       @Override
@@ -832,11 +857,13 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
           String variableName,
           String field,
           @Nullable ArtifactExpander expander,
+          PathMapper pathMapper,
           boolean throwOnMissingVariable) {
         if (PATH_FIELD_NAME.equals(field)) {
           return new StringValue(path);
         }
-        return super.getFieldValue(variableName, field, expander, throwOnMissingVariable);
+        return super.getFieldValue(
+            variableName, field, expander, pathMapper, throwOnMissingVariable);
       }
 
       @Override
@@ -929,6 +956,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
           String variableName,
           String field,
           @Nullable ArtifactExpander expander,
+          PathMapper pathMapper,
           boolean throwOnMissingVariable) {
         if (NAME_FIELD_NAME.equals(field)) {
           return null;
@@ -940,15 +968,17 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
             if (objectFile.isTreeArtifact() && expander != null) {
               expandedObjectFiles.addAll(
                   Collections2.transform(
-                      expander.tryExpandTreeArtifact(objectFile), Artifact::getExecPathString));
+                      expander.tryExpandTreeArtifact(objectFile),
+                      pathMapper::getMappedExecPathString));
             } else {
-              expandedObjectFiles.add(objectFile.getExecPathString());
+              expandedObjectFiles.add(pathMapper.getMappedExecPathString(objectFile));
             }
           }
           return StringSequence.of(expandedObjectFiles.build());
         }
 
-        return super.getFieldValue(variableName, field, expander, throwOnMissingVariable);
+        return super.getFieldValue(
+            variableName, field, expander, pathMapper, throwOnMissingVariable);
       }
 
       @Override
@@ -1267,6 +1297,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
         String variableName,
         String field,
         @Nullable ArtifactExpander expander,
+        PathMapper pathMapper,
         boolean throwOnMissingVariable) {
       return value.getOrDefault(field, null);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
@@ -66,7 +66,8 @@ public final class CppLinkAction extends SpawnAction {
       LinkCommandLine linkCommandLine,
       ActionEnvironment env,
       ImmutableMap<String, String> toolchainEnv,
-      ImmutableMap<String, String> executionRequirements)
+      ImmutableMap<String, String> executionRequirements,
+      OutputPathsMode outputPathsMode)
       throws EvalException {
     super(
         owner,
@@ -79,7 +80,7 @@ public final class CppLinkAction extends SpawnAction {
         /* executionInfo= */ executionRequirements,
         /* progressMessage= */ progressMessage,
         /* mnemonic= */ mnemonic,
-        /* outputPathsMode= */ OutputPathsMode.OFF);
+        /* outputPathsMode= */ outputPathsMode);
 
     this.toolchainEnv = toolchainEnv;
   }
@@ -90,6 +91,7 @@ public final class CppLinkAction extends SpawnAction {
         Maps.newLinkedHashMapWithExpectedSize(getEnvironment().estimatedSize());
     getEnvironment().resolve(result, clientEnv);
 
+    // TODO(fmeum): The environment is not path mapped.
     result.putAll(toolchainEnv);
 
     if (!getExecutionInfo().containsKey(ExecutionRequirements.REQUIRES_DARWIN)) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ParameterFile;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.ActionConstructionContext;
+import com.google.devtools.build.lib.analysis.actions.PathMappers;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.PerLabelOptions;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -849,16 +850,16 @@ public class CppLinkActionBuilder {
 
     CcToolchainVariables.Builder buildVariables =
         LinkBuildVariables.setupLinkingVariables(
-            output.getExecPathString(),
+            output,
             SolibSymlinkAction.getDynamicLibrarySoname(
                 output.getRootRelativePath(),
                 /* preserveName= */ linkType != LinkTargetType.NODEPS_DYNAMIC_LIBRARY,
                 linkActionConstruction.getContext().getConfiguration().getMnemonic()),
-            thinltoParamFile != null ? thinltoParamFile.getExecPathString() : null,
+            thinltoParamFile,
             toolchain,
             featureConfiguration,
-            toolchain.getInterfaceSoBuilder().getExecPathString(),
-            interfaceOutput != null ? interfaceOutput.getExecPathString() : null,
+            toolchain.getInterfaceSoBuilder(),
+            interfaceOutput,
             fdoContext);
 
     ImmutableList<String> userLinkFlags =
@@ -1122,7 +1123,8 @@ public class CppLinkActionBuilder {
         linkCommandLine,
         linkActionConstruction.getConfig().getActionEnvironment(),
         toolchainEnv,
-        ImmutableMap.copyOf(executionInfo));
+        ImmutableMap.copyOf(executionInfo),
+        PathMappers.getOutputPathsMode(linkActionConstruction.getConfig()));
   }
 
   /** Returns the output of this action as a {@link LibraryInput} or null if it is an executable. */

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariables.java
@@ -17,6 +17,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.FeatureConfiguration;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.SequenceBuilder;
@@ -158,24 +159,24 @@ public enum LinkBuildVariables {
   }
 
   public static CcToolchainVariables.Builder setupLinkingVariables(
-      String outputFile,
+      Artifact outputFile,
       String runtimeSolibName,
-      String thinltoParamFile,
+      Artifact thinltoParamFile,
       CcToolchainProvider ccToolchainProvider,
       FeatureConfiguration featureConfiguration,
-      String interfaceLibraryBuilder,
-      String interfaceLibraryOutput,
+      Artifact interfaceLibraryBuilder,
+      Artifact interfaceLibraryOutput,
       FdoContext fdoContext)
       throws EvalException {
     CcToolchainVariables.Builder buildVariables = CcToolchainVariables.builder();
     if (thinltoParamFile != null) {
       // This is a normal link action and we need to use param file created by lto-indexing.
-      buildVariables.addStringVariable(
+      buildVariables.addArtifactVariable(
           LinkBuildVariables.THINLTO_PARAM_FILE.getVariableName(), thinltoParamFile);
     }
 
     // output exec path
-    buildVariables.addStringVariable(
+    buildVariables.addArtifactVariable(
         LinkBuildVariables.OUTPUT_EXECPATH.getVariableName(), outputFile);
 
     buildVariables.addStringVariable(
@@ -186,25 +187,26 @@ public enum LinkBuildVariables {
         && featureConfiguration.isEnabled(CppRuleClasses.PROPELLER_OPTIMIZE)
         && fdoContext.getPropellerOptimizeInputFile() != null
         && fdoContext.getPropellerOptimizeInputFile().getLdArtifact() != null) {
-      buildVariables.addStringVariable(
+      buildVariables.addArtifactVariable(
           LinkBuildVariables.PROPELLER_OPTIMIZE_LD_PATH.getVariableName(),
-          fdoContext.getPropellerOptimizeInputFile().getLdArtifact().getExecPathString());
+          fdoContext.getPropellerOptimizeInputFile().getLdArtifact());
     }
 
     boolean shouldGenerateInterfaceLibrary =
         outputFile != null && interfaceLibraryBuilder != null && interfaceLibraryOutput != null;
-    buildVariables.addStringVariable(
-        GENERATE_INTERFACE_LIBRARY.getVariableName(),
-        shouldGenerateInterfaceLibrary ? "yes" : "no");
-    buildVariables.addStringVariable(
-        INTERFACE_LIBRARY_BUILDER.getVariableName(),
-        shouldGenerateInterfaceLibrary ? interfaceLibraryBuilder : "ignored");
-    buildVariables.addStringVariable(
-        INTERFACE_LIBRARY_INPUT.getVariableName(),
-        shouldGenerateInterfaceLibrary ? outputFile : "ignored");
-    buildVariables.addStringVariable(
-        INTERFACE_LIBRARY_OUTPUT.getVariableName(),
-        shouldGenerateInterfaceLibrary ? interfaceLibraryOutput : "ignored");
+    if (shouldGenerateInterfaceLibrary) {
+      buildVariables.addStringVariable(GENERATE_INTERFACE_LIBRARY.getVariableName(), "yes");
+      buildVariables.addArtifactVariable(
+          INTERFACE_LIBRARY_BUILDER.getVariableName(), interfaceLibraryBuilder);
+      buildVariables.addArtifactVariable(INTERFACE_LIBRARY_INPUT.getVariableName(), outputFile);
+      buildVariables.addArtifactVariable(
+          INTERFACE_LIBRARY_OUTPUT.getVariableName(), interfaceLibraryOutput);
+    } else {
+      buildVariables.addStringVariable(GENERATE_INTERFACE_LIBRARY.getVariableName(), "no");
+      buildVariables.addStringVariable(INTERFACE_LIBRARY_BUILDER.getVariableName(), "ignored");
+      buildVariables.addStringVariable(INTERFACE_LIBRARY_INPUT.getVariableName(), "ignored");
+      buildVariables.addStringVariable(INTERFACE_LIBRARY_OUTPUT.getVariableName(), "ignored");
+    }
 
     return buildVariables;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java
@@ -89,7 +89,8 @@ public final class LinkCommandLine extends AbstractCommandLine {
     return this.variables;
   }
 
-  public ImmutableList<String> getParamCommandLine(@Nullable ArtifactExpander expander)
+  public ImmutableList<String> getParamCommandLine(
+      @Nullable ArtifactExpander expander, PathMapper pathMapper)
       throws CommandLineExpansionException {
     ImmutableList.Builder<String> argv = ImmutableList.builder();
     try {
@@ -97,17 +98,17 @@ public final class LinkCommandLine extends AbstractCommandLine {
         // Filter out linker_param_file
         String linkerParamFile =
             variables
-                .getVariable(LINKER_PARAM_FILE.getVariableName())
-                .getStringValue(LINKER_PARAM_FILE.getVariableName(), PathMapper.NOOP);
+                .getVariable(LINKER_PARAM_FILE.getVariableName(), pathMapper)
+                .getStringValue(LINKER_PARAM_FILE.getVariableName(), pathMapper);
         argv.addAll(
             featureConfiguration
-                .getCommandLine(actionName, variables, expander, PathMapper.NOOP)
+                .getCommandLine(actionName, variables, expander, pathMapper)
                 .stream()
                 .filter(s -> !s.contains(linkerParamFile))
                 .collect(toImmutableList()));
       } else {
         argv.addAll(
-            featureConfiguration.getCommandLine(actionName, variables, expander, PathMapper.NOOP));
+            featureConfiguration.getCommandLine(actionName, variables, expander, pathMapper));
       }
     } catch (ExpansionException e) {
       throw new CommandLineExpansionException(e.getMessage());
@@ -153,13 +154,13 @@ public final class LinkCommandLine extends AbstractCommandLine {
 
   @Override
   public List<String> arguments() throws CommandLineExpansionException {
-    return arguments(null, null);
+    return arguments(null, PathMapper.NOOP);
   }
 
   @Override
   public List<String> arguments(ArtifactExpander artifactExpander, PathMapper pathMapper)
       throws CommandLineExpansionException {
-    return getParamCommandLine(artifactExpander);
+    return getParamCommandLine(artifactExpander, pathMapper);
   }
 
   /** A builder for a {@link LinkCommandLine}. */

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -228,8 +228,11 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     fp.addUUID(GUID);
     fp.addInt(classpathMode.ordinal());
     CoreOptions.OutputPathsMode outputPathsMode = PathMappers.getOutputPathsMode(configuration);
-    executableLine.addToFingerprint(actionKeyContext, artifactExpander, outputPathsMode, fp);
-    flagLine.addToFingerprint(actionKeyContext, artifactExpander, outputPathsMode, fp);
+    CoreOptions.OutputPathsMode effectiveOutputPathsMode =
+        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, getMnemonic(), getExecutionInfo());
+    executableLine.addToFingerprint(
+        actionKeyContext, artifactExpander, effectiveOutputPathsMode, fp);
+    flagLine.addToFingerprint(actionKeyContext, artifactExpander, effectiveOutputPathsMode, fp);
     // As the classpath is no longer part of commandLines implicitly, we need to explicitly add
     // the transitive inputs to the key here.
     actionKeyContext.addNestedSetToFingerprint(fp, transitiveInputs);

--- a/src/main/starlark/builtins_bzl/common/cc/link/cpp_link_action.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/link/cpp_link_action.bzl
@@ -196,14 +196,14 @@ def link_action(
     build_variables = variables_extensions | setup_linking_variables(
         cc_toolchain,
         feature_configuration,
-        output.path,
+        output,
         cc_internal.dynamic_library_soname(
             actions,
             output.short_path,
             link_type != LINK_TARGET_TYPE.NODEPS_DYNAMIC_LIBRARY,
         ),
-        interface_output.path if interface_output else None,
-        thinlto_param_file.path if thinlto_param_file else None,
+        interface_output,
+        thinlto_param_file,
     )
 
     user_link_flags = linkopts + cc_toolchain._cpp_configuration.linkopts

--- a/src/main/starlark/builtins_bzl/common/cc/link/link_build_variables.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/link/link_build_variables.bzl
@@ -283,10 +283,10 @@ def setup_linking_variables(
     Args:
       cc_toolchain: cc_toolchain for which we are creating build variables.
       feature_configuration: Feature configuration to be queried.
-      output_file: (str) Optional output file path. Used also as an input to interface_library builder.
+      output_file: (File) Optional output file. Used also as an input to interface_library builder.
       runtime_solib_name: (str) The name of the runtime solib symlink of the shared library.
-      interface_library_output: (str) Path where to generate interface library using the ifso builder tool.
-      thinlto_param_file: (str) Thinlto param file consumed by the final link action. (Produced
+      interface_library_output: (File) Optional interface library to generate using the ifso builder tool.
+      thinlto_param_file: (File) Optional Thinlto param file consumed by the final link action. (Produced
         by thin-lto indexing action)
     Returns:
         (dict[str, ?]) linking build variables
@@ -308,13 +308,13 @@ def setup_linking_variables(
         feature_configuration.is_enabled("propeller_optimize") and
         fdo_context.propeller_optimize_info and
         fdo_context.propeller_optimize_info.ld_profile):
-        vars[LINK_BUILD_VARIABLES.PROPELLER_OPTIMIZE_LD_PATH] = fdo_context.propeller_optimize_info.ld_profile.path
+        vars[LINK_BUILD_VARIABLES.PROPELLER_OPTIMIZE_LD_PATH] = fdo_context.propeller_optimize_info.ld_profile
 
     # ifso variables
-    should_generate_interface_library = output_file and cc_toolchain._if_so_builder.path and interface_library_output
+    should_generate_interface_library = output_file and cc_toolchain._if_so_builder and interface_library_output
     if should_generate_interface_library:
         vars[LINK_BUILD_VARIABLES.GENERATE_INTERFACE_LIBRARY] = "yes"
-        vars[LINK_BUILD_VARIABLES.INTERFACE_LIBRARY_BUILDER] = cc_toolchain._if_so_builder.path
+        vars[LINK_BUILD_VARIABLES.INTERFACE_LIBRARY_BUILDER] = cc_toolchain._if_so_builder
         vars[LINK_BUILD_VARIABLES.INTERFACE_LIBRARY_INPUT] = output_file
         vars[LINK_BUILD_VARIABLES.INTERFACE_LIBRARY_OUTPUT] = interface_library_output
     else:

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.lang.String.format;
 
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FileProvider;
@@ -298,7 +299,7 @@ public class PathMappersTest extends BuildViewTestCase {
 
   @Test
   public void forActionKey() {
-    var pathMapper = PathMappers.forActionKey(CoreOptions.OutputPathsMode.STRIP);
+    var pathMapper = PathMapper.forActionKey(CoreOptions.OutputPathsMode.STRIP);
     assertThat(pathMapper.isNoop()).isFalse();
     assertThat(pathMapper.map(PathFragment.create("pkg/file")))
         .isEqualTo(PathFragment.create("pkg/file"));

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeaturesTest.java
@@ -780,7 +780,10 @@ public final class CcToolchainFeaturesTest extends BuildViewTestCase {
   }
 
   private static VariableValue booleanValue(boolean val) throws ExpansionException {
-    return CcToolchainVariables.builder().addBooleanValue("name", val).build().getVariable("name");
+    return CcToolchainVariables.builder()
+        .addBooleanValue("name", val)
+        .build()
+        .getVariable("name", PathMapper.NOOP);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryToLinkValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryToLinkValueTest.java
@@ -109,6 +109,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("dynamic_library");
@@ -118,6 +119,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
@@ -127,6 +129,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "name",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
@@ -135,6 +138,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "object_files",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
   }
@@ -149,6 +153,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("versioned_dynamic_library");
@@ -158,6 +163,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "path",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo/bar.so");
@@ -167,6 +173,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
@@ -176,6 +183,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "name",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
@@ -184,6 +192,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "object_files",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
   }
@@ -197,6 +206,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("interface_library");
@@ -206,6 +216,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
@@ -215,6 +226,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "name",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
@@ -223,6 +235,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "object_files",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
   }
@@ -237,6 +250,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("static_library");
@@ -246,6 +260,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
@@ -255,6 +270,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "name",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
@@ -263,6 +279,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "object_files",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
   }
@@ -277,6 +294,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("static_library");
@@ -286,6 +304,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("1");
@@ -295,6 +314,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "name",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
@@ -303,6 +323,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "object_files",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
   }
@@ -317,6 +338,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("object_file");
@@ -326,6 +348,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
@@ -335,6 +358,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "name",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
@@ -343,6 +367,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "object_files",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
   }
@@ -357,6 +382,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("object_file");
@@ -366,6 +392,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("1");
@@ -375,6 +402,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "name",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("foo");
@@ -383,6 +411,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "object_files",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
   }
@@ -405,6 +434,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("object_file_group");
@@ -414,6 +444,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("0");
@@ -422,6 +453,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "name",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
     assertThat(
@@ -431,6 +463,7 @@ public class LibraryToLinkValueTest {
                             /* variableName= */ "variable name doesn't matter",
                             /* field= */ "object_files",
                             /* expander= */ null,
+                            PathMapper.NOOP,
                             /* throwOnMissingVariable= */ false)
                         .getSequenceValue("variable name doesn't matter", PathMapper.NOOP))
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
@@ -455,6 +488,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "type",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("object_file_group");
@@ -464,6 +498,7 @@ public class LibraryToLinkValueTest {
                     /* variableName= */ "variable name doesn't matter",
                     /* field= */ "is_whole_archive",
                     /* expander= */ null,
+                    PathMapper.NOOP,
                     /* throwOnMissingVariable= */ false)
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))
         .isEqualTo("1");
@@ -472,6 +507,7 @@ public class LibraryToLinkValueTest {
                 /* variableName= */ "variable name doesn't matter",
                 /* field= */ "name",
                 /* expander= */ null,
+                PathMapper.NOOP,
                 /* throwOnMissingVariable= */ false))
         .isNull();
     assertThat(
@@ -481,6 +517,7 @@ public class LibraryToLinkValueTest {
                             /* variableName= */ "variable name doesn't matter",
                             /* field= */ "object_files",
                             /* expander= */ null,
+                            PathMapper.NOOP,
                             /* throwOnMissingVariable= */ false)
                         .getSequenceValue("variable name doesn't matter", PathMapper.NOOP))
                 .getStringValue("variable name doesn't matter", PathMapper.NOOP))

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariablesTest.java
@@ -90,7 +90,8 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
     CcToolchainVariables variables =
         getLinkBuildVariables(target, LinkTargetType.NODEPS_DYNAMIC_LIBRARY);
     VariableValue librariesToLinkSequence =
-        variables.getVariable(LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+        variables.getVariable(
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     assertThat(librariesToLinkSequence).isNotNull();
     Iterable<? extends VariableValue> librariesToLink =
         librariesToLinkSequence.getSequenceValue(
@@ -136,7 +137,8 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
 
     CcToolchainVariables variables = getLinkBuildVariables(target, LinkTargetType.EXECUTABLE);
     VariableValue librariesToLinkSequence =
-        variables.getVariable(LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+        variables.getVariable(
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     Iterable<? extends VariableValue> librariestoLink =
         librariesToLinkSequence.getSequenceValue(
             LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
@@ -163,7 +165,8 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
 
     CcToolchainVariables variables = getLinkBuildVariables(target, LinkTargetType.EXECUTABLE);
     VariableValue librariesToLinkSequence =
-        variables.getVariable(LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+        variables.getVariable(
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     Iterable<? extends VariableValue> librariestoLink =
         librariesToLinkSequence.getSequenceValue(
             LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
@@ -190,7 +193,8 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
 
     CcToolchainVariables variables = getLinkBuildVariables(target, LinkTargetType.EXECUTABLE);
     VariableValue librariesToLinkSequence =
-        variables.getVariable(LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+        variables.getVariable(
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     Iterable<? extends VariableValue> librariestoLink =
         librariesToLinkSequence.getSequenceValue(
             LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
@@ -464,7 +468,9 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
         getLinkBuildVariables(testTarget, LinkTargetType.EXECUTABLE);
 
     assertThat(
-            testVariables.getVariable(LinkBuildVariables.IS_CC_TEST.getVariableName()).isTruthy())
+            testVariables
+                .getVariable(LinkBuildVariables.IS_CC_TEST.getVariableName(), PathMapper.NOOP)
+                .isTruthy())
         .isTrue();
 
     ConfiguredTarget binaryTarget = getConfiguredTarget("//x:foo");
@@ -472,7 +478,9 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
         getLinkBuildVariables(binaryTarget, LinkTargetType.EXECUTABLE);
 
     assertThat(
-            binaryVariables.getVariable(LinkBuildVariables.IS_CC_TEST.getVariableName()).isTruthy())
+            binaryVariables
+                .getVariable(LinkBuildVariables.IS_CC_TEST.getVariableName(), PathMapper.NOOP)
+                .isTruthy())
         .isFalse();
   }
 
@@ -617,7 +625,8 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
         getLinkBuildVariables(testTarget, LinkTargetType.DYNAMIC_LIBRARY);
 
     VariableValue librariesToLinkSequence =
-        testVariables.getVariable(LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName());
+        testVariables.getVariable(
+            LinkBuildVariables.LIBRARIES_TO_LINK.getVariableName(), PathMapper.NOOP);
     assertThat(librariesToLinkSequence).isNotNull();
     Iterable<? extends VariableValue> librariesToLink =
         librariesToLinkSequence.getSequenceValue(

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLineTest.java
@@ -272,7 +272,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
     assertThat(linkConfig.getCommandLines().unpack().get(0).commandLine.arguments())
         .containsExactly("foo/bar/ar");
     assertThat(linkConfig.getCommandLines().unpack().get(1).paramFileInfo.always()).isTrue();
-    assertThat(linkConfig.getParamCommandLine(null))
+    assertThat(linkConfig.getParamCommandLine(null, PathMapper.NOOP))
         .containsExactly("rcsD", "a/FakeOutput")
         .inOrder();
   }
@@ -295,7 +295,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
             .build();
     assertThat(linkConfig.getCommandLines().unpack().get(0).commandLine.arguments())
         .containsExactly("foo/bar/linker");
-    assertThat(linkConfig.getParamCommandLine(null))
+    assertThat(linkConfig.getParamCommandLine(null, PathMapper.NOOP))
         .containsExactly("-shared", "-o", "a/FakeOutput", "")
         .inOrder();
   }
@@ -339,7 +339,7 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
 
     assertThat(linkConfig.getCommandLines().unpack().get(0).commandLine.arguments())
         .containsExactly("foo/bar/ar");
-    assertThat(linkConfig.getParamCommandLine(null))
+    assertThat(linkConfig.getParamCommandLine(null, PathMapper.NOOP))
         .containsExactly("rcsD", "a/FakeOutput", "foo.o", "bar.o")
         .inOrder();
   }
@@ -398,7 +398,9 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
         linkConfig.arguments(null, PathMapper.NOOP), treeArtifactsPaths, treeFileArtifactsPaths);
     verifyArguments(linkConfig.arguments(), treeArtifactsPaths, treeFileArtifactsPaths);
     verifyArguments(
-        linkConfig.getParamCommandLine(null), treeArtifactsPaths, treeFileArtifactsPaths);
+        linkConfig.getParamCommandLine(null, PathMapper.NOOP),
+        treeArtifactsPaths,
+        treeFileArtifactsPaths);
 
     // Should only reference tree file artifacts.
     verifyArguments(
@@ -406,8 +408,12 @@ public final class LinkCommandLineTest extends BuildViewTestCase {
         treeFileArtifactsPaths,
         treeArtifactsPaths);
     verifyArguments(
-        linkConfig.arguments(expander, null), treeFileArtifactsPaths, treeArtifactsPaths);
+        linkConfig.arguments(expander, PathMapper.NOOP),
+        treeFileArtifactsPaths,
+        treeArtifactsPaths);
     verifyArguments(
-        linkConfig.getParamCommandLine(expander), treeFileArtifactsPaths, treeArtifactsPaths);
+        linkConfig.getParamCommandLine(expander, PathMapper.NOOP),
+        treeFileArtifactsPaths,
+        treeArtifactsPaths);
   }
 }

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1333,6 +1333,7 @@ sh_test(
     data = [
         ":test-deps",
         "//src/tools/remote:worker",
+        "@local_jdk//:jdk",  # for remote_helpers
     ],
     tags = [
         "no_windows",

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -736,7 +736,7 @@ EOF
   bazel run \
     --verbose_failures \
     --experimental_output_paths=strip \
-    --modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping \
+    --modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping,CppArchive=+supports-path-mapping \
     --remote_executor=grpc://localhost:${worker_port} \
     --features=layering_check \
     "//$pkg:main" &>"$TEST_log" || fail "Expected success"
@@ -750,9 +750,10 @@ EOF
   bazel run \
     --verbose_failures \
     --experimental_output_paths=strip \
-    --modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping \
+    --modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping,CppArchive=+supports-path-mapping \
     --remote_executor=grpc://localhost:${worker_port} \
     --features=layering_check \
+    -s \
     "//$pkg:transitioned_main" &>"$TEST_log" || fail "Expected success"
 
   expect_log 'Hi there, lib1!'
@@ -760,8 +761,22 @@ EOF
   expect_log 'Hello, TreeArtifact!'
   expect_log '42 43'
   # Compilation actions for lib1, lib2 and main should result in cache hits due
-  # to path stripping, utils is legitimately different and should not.
-  expect_log ' 4 remote cache hit'
+  # to path stripping, utils is legitimately different and should not (4 cached
+  # out of 5 total).
+  # Likewise, link actions for lib1 and lib2 should result in cache hits, but
+  # the one for utils does not and the linking action for main doesn't support
+  # path mapping (2 cached out of 4 in total). In CI, the C++ toolchain on Linux
+  # uses --start-lib/--end-lib linker support to avoid the CppArchive actions
+  # entirely (0 cached out of 1 in total).
+  # The two custom actions and the four genrule actions are not path-mapped
+  # (0 cached out of 6 in total).
+  if is_darwin; then
+    expect_log ' 6 remote cache hit'
+    expect_log ' 9 remote'
+  else
+    expect_log ' 4 remote cache hit'
+    expect_log ' 8 remote'
+  fi
 }
 
 function test_path_stripping_action_key_not_stale_for_path_collision() {


### PR DESCRIPTION
This reverts commit d165140a50729a55abbad01fe50501d21bc622d8.

Fixes:
* Allow toolchain variables to be `None` and skip them in that case, matching the previous behavior.
* Use the effective output paths mode for fingerprinting to preserve action cache entries for non-path mapped actions even when path mapping is generally enabled.