### PR TITLE
[8.1.0] Check the OS version before we initialize the cgroup factory.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/worker/BUILD
@@ -117,6 +117,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/sandbox:sandbox_options",
         "//src/main/java/com/google/devtools/build/lib/sandbox:tree_deleter",
         "//src/main/java/com/google/devtools/build/lib/sandbox/cgroups",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers;
 import com.google.devtools.build.lib.sandbox.SandboxOptions;
 import com.google.devtools.build.lib.sandbox.cgroups.VirtualCgroup;
 import com.google.devtools.build.lib.sandbox.cgroups.VirtualCgroupFactory;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.worker.SandboxedWorker.WorkerSandboxOptions;
 import com.google.devtools.common.options.OptionsBase;
@@ -124,7 +125,9 @@ public class WorkerModule extends BlazeModule {
       }
     }
     VirtualCgroupFactory cgroupFactory =
-        sandboxOptions == null || !sandboxOptions.useNewCgroupImplementation
+        OS.getCurrent() != OS.LINUX
+                || sandboxOptions == null
+                || !sandboxOptions.useNewCgroupImplementation
             ? null
             : new VirtualCgroupFactory(
                 "worker_",
@@ -197,7 +200,8 @@ public class WorkerModule extends BlazeModule {
 
     // Override the flag value if we can't actually use cgroups so that we at least fallback to ps.
     boolean useCgroupsOnLinux =
-        options.useCgroupsOnLinux
+        OS.getCurrent() == OS.LINUX
+            && options.useCgroupsOnLinux
             && ((sandboxOptions == null || !sandboxOptions.useNewCgroupImplementation)
                 ? CgroupsInfo.isSupported()
                 : VirtualCgroup.getInstance().memory() != null);


### PR DESCRIPTION
This is a bug fix for the FileNotFoundException introduced by flipping the default value of `incompatible_use_new_cgroup_implementation`.

PiperOrigin-RevId: 718390659
Change-Id: Ibad1e7361c9d69b791df9cc058153e942c92f915

Commit https://github.com/bazelbuild/bazel/commit/a87ca4fc42d60b0cc8dd816176ed2b44b8476f53