### PR TITLE
[8.1.0] Implement `debugPrint` for built-in file providers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -795,6 +795,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi",
+        "//src/main/java/net/starlark/java/eval",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/FileProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/FileProvider.java
@@ -21,6 +21,8 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.starlarkbuildapi.FileProviderApi;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkThread;
 
 /**
  * A representation of the concept "this transitive info provider builds these files".
@@ -51,6 +53,13 @@ public final class FileProvider implements TransitiveInfoProvider, FileProviderA
   @Override
   public Depset /*<Artifact>*/ getFilesToBuildForStarlark() {
     return Depset.of(Artifact.class, filesToBuild);
+  }
+
+  @Override
+  public void debugPrint(Printer printer, StarlarkThread thread) {
+    printer.append("FileProvider(files_to_build = ");
+    printer.debugPrint(getFilesToBuildForStarlark(), thread);
+    printer.append(")");
   }
 
   public NestedSet<Artifact> getFilesToBuild() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/FilesToRunProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/FilesToRunProvider.java
@@ -23,6 +23,8 @@ import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.starlarkbuildapi.FilesToRunProviderApi;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkThread;
 
 /** Returns information about executables produced by a target and the files needed to run it. */
 @Immutable
@@ -104,6 +106,17 @@ public class FilesToRunProvider implements TransitiveInfoProvider, FilesToRunPro
   public Artifact getRepoMappingManifest() {
     var runfilesSupport = getRunfilesSupport();
     return runfilesSupport != null ? runfilesSupport.getRepoMappingManifest() : null;
+  }
+
+  @Override
+  public void debugPrint(Printer printer, StarlarkThread thread) {
+    printer.append("FilesToRunProvider(executable = ");
+    printer.debugPrint(getExecutable(), thread);
+    printer.append(", repo_mapping_manifest = ");
+    printer.debugPrint(getRepoMappingManifest(), thread);
+    printer.append(", runfiles_manifest = ");
+    printer.debugPrint(getRunfilesManifest(), thread);
+    printer.append(")");
   }
 
   /** A single executable. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
@@ -55,6 +55,7 @@ import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -1103,5 +1104,18 @@ public final class Runfiles implements RunfilesApi {
                     : RUNFILES_AND_EXEC_PATH_MAP_FN,
                 artifacts))
         + String.format("emptyFilesSupplier: %s\n", emptyFilesSupplier.getClass().getName());
+  }
+
+  @Override
+  public void debugPrint(Printer printer, StarlarkThread thread) {
+    printer.append("Runfiles(empty_files = ");
+    printer.debugPrint(getEmptyFilenamesForStarlark(), thread);
+    printer.append(", files = ");
+    printer.debugPrint(getArtifactsForStarlark(), thread);
+    printer.append(", root_symlinks = ");
+    printer.debugPrint(getRootSymlinksForStarlark(), thread);
+    printer.append(", symlinks = ");
+    printer.debugPrint(getSymlinksForStarlark(), thread);
+    printer.append(")");
   }
 }


### PR DESCRIPTION
Simplifies `print` style debugging.

Closes #24156.

PiperOrigin-RevId: 721850583
Change-Id: I8b3c3a1063f1dbfa3c0c1556e1112c1885a5c6a9

Commit https://github.com/bazelbuild/bazel/commit/fe7b4abe4d9f20a1c5d4807f7bb737fbbe7fb14d