### PR TITLE
[8.1.0] Return back to working directory after installing Bazel version

### DIFF
--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -206,11 +206,11 @@ if [[ ! -x $BAZEL_REAL ]]; then
     if [[ -x $(command -v curl) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && curl -fLO https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  (cd \"${wrapper_dir}\" && curl -fLO https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name} && cd - )") 2>&1
     elif [[ -x $(command -v wget) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && wget https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  (cd \"${wrapper_dir}\" && wget https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name} && cd - )") 2>&1
     else
       (echo ""
       echo "Please put the downloaded Bazel binary into this location:"


### PR DESCRIPTION
Nit: Add `cd -`  to return back to `$OLDPWD` after following the suggestion to install the required Bazel version. That way developers don't have to cd back to their project

Closes #24995.

PiperOrigin-RevId: 718263777
Change-Id: I5133db65dc2b9032a9e631c62966314f3cfb4593

Commit https://github.com/bazelbuild/bazel/commit/d6501217c3418e62198250ccb25a1d450dff3ced