### PR TITLE
Configure `--run_under` target for the test exec platform

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -306,7 +306,7 @@ public class BaseRuleClasses {
           // RunCommand.java to self-transition --run_under to the exec configuration.
           .add(
               attr(":run_under_exec_config", LABEL)
-                  .cfg(ExecutionTransitionFactory.createFactory())
+                  .cfg(ExecutionTransitionFactory.createFactory("test"))
                   .value(RUN_UNDER_EXEC_CONFIG)
                   .skipPrereqValidatorCheck())
           .add(

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -312,7 +312,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
             // See similar definitions in BaseRuleClasses for context.
             .add(
                 attr(":run_under_exec_config", LABEL)
-                    .cfg(ExecutionTransitionFactory.createFactory())
+                    .cfg(ExecutionTransitionFactory.createFactory("test"))
                     .value(RUN_UNDER_EXEC_CONFIG)
                     .skipPrereqValidatorCheck())
             .add(


### PR DESCRIPTION
With `--incompatible_bazel_test_exec_run_under`, the `--run_under` target should be configured for the execution platform of the test action, not the default execution platform of the test rule.

This is still not fully correct if `testing.ExecutionInfo` is used to specify an alternative test exec group, but that's a far more difficult change: it would potentially involve a split transition with one configuration for each exec group.

Work towards #23179 