### PR TITLE
[8.1.0] Add `no_match_error` attribute to `toolchain_type`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
@@ -39,6 +39,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:hash_codes",
         "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/java/net/starlark/java/eval",

--- a/src/main/java/com/google/devtools/build/lib/rules/ToolchainType.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/ToolchainType.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.rules;
 
+import static com.google.devtools.build.lib.packages.Attribute.attr;
+
 import com.google.devtools.build.lib.actions.ActionConflictException;
 import com.google.devtools.build.lib.analysis.BaseRuleClasses;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -27,6 +29,7 @@ import com.google.devtools.build.lib.analysis.RunfilesProvider;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.ToolchainResolutionMode;
+import com.google.devtools.build.lib.packages.Type;
 import javax.annotation.Nullable;
 
 /**
@@ -39,7 +42,10 @@ public class ToolchainType implements RuleConfiguredTargetFactory {
   public ConfiguredTarget create(RuleContext ruleContext)
       throws ActionConflictException, InterruptedException {
 
-    ToolchainTypeInfo toolchainTypeInfo = ToolchainTypeInfo.create(ruleContext.getLabel());
+    String noMatchError = ruleContext.attributes().get("no_match_error", Type.STRING);
+    ToolchainTypeInfo toolchainTypeInfo =
+        ToolchainTypeInfo.create(
+            ruleContext.getLabel(), noMatchError.isEmpty() ? null : noMatchError);
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
@@ -58,6 +64,12 @@ public class ToolchainType implements RuleConfiguredTargetFactory {
           .removeAttribute("licenses")
           .removeAttribute("distribs")
           .removeAttribute(":action_listener")
+          /*<!-- #BLAZE_RULE(toolchain_type).ATTRIBUTE(no_match_error) -->
+          A custom error message to display when no matching toolchain is found for this type.
+          <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+          .add(
+              attr("no_match_error", Type.STRING)
+                  .nonconfigurable("low-level attribute, used in platform configuration"))
           .build();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
@@ -45,9 +45,11 @@ import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyframeLookupResult;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -230,7 +232,7 @@ public class ToolchainResolutionFunction implements SkyFunction {
     // Determine the potential set of toolchains.
     Table<ConfiguredTargetKey, ToolchainTypeInfo, Label> resolvedToolchains =
         HashBasedTable.create();
-    List<Label> missingMandatoryToolchains = new ArrayList<>();
+    SequencedSet<ToolchainTypeInfo> missingMandatoryToolchains = new LinkedHashSet<>();
     for (SingleToolchainResolutionKey key : registeredToolchainKeys) {
       SingleToolchainResolutionValue singleToolchainResolutionValue =
           (SingleToolchainResolutionValue)
@@ -249,7 +251,7 @@ public class ToolchainResolutionFunction implements SkyFunction {
             findPlatformsAndLabels(requiredToolchainType, singleToolchainResolutionValue));
       } else if (key.toolchainType().mandatory()) {
         // Save the missing type and continue looping to check for more.
-        missingMandatoryToolchains.add(key.toolchainType().toolchainType());
+        missingMandatoryToolchains.add(key.toolchainTypeInfo());
       }
       // TODO(katre): track missing optional toolchains?
     }
@@ -395,7 +397,7 @@ public class ToolchainResolutionFunction implements SkyFunction {
 
   /** Exception used when a toolchain type is required but no matching toolchain is found. */
   static final class UnresolvedToolchainsException extends ToolchainException {
-    UnresolvedToolchainsException(List<Label> missingToolchainTypes) {
+    UnresolvedToolchainsException(SequencedSet<ToolchainTypeInfo> missingToolchainTypes) {
       super(getMessage(missingToolchainTypes));
     }
 
@@ -404,15 +406,29 @@ public class ToolchainResolutionFunction implements SkyFunction {
       return Code.NO_MATCHING_TOOLCHAIN;
     }
 
-    private static String getMessage(List<Label> missingToolchainTypes) {
+    private static String getMessage(SequencedSet<ToolchainTypeInfo> missingToolchainTypes) {
       ImmutableList<String> labelStrings =
-          missingToolchainTypes.stream().map(Label::toString).collect(toImmutableList());
+          missingToolchainTypes.stream()
+              .map(ToolchainTypeInfo::typeLabel)
+              .map(Label::toString)
+              .collect(toImmutableList());
+      ImmutableList<String> missingToolchainRows =
+          missingToolchainTypes.stream()
+              .map(
+                  type ->
+                      String.format(
+                          "  %s%s",
+                          type.typeLabel(),
+                          type.noneFoundError() != null ? ": " + type.noneFoundError() : ""))
+              .collect(toImmutableList());
       return String.format(
-          "No matching toolchains found for types %s."
-              + "\nTo debug, rerun with --toolchain_resolution_debug='%s'"
-              + "\nFor more information on platforms or toolchains see "
-              + "https://bazel.build/concepts/platforms-intro.",
-          String.join(", ", labelStrings), String.join("|", labelStrings));
+          """
+No matching toolchains found for types:
+%s
+To debug, rerun with --toolchain_resolution_debug='%s'
+For more information on platforms or toolchains see https://bazel.build/concepts/platforms-intro.\
+""",
+          String.join("\n", missingToolchainRows), String.join("|", labelStrings));
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
@@ -370,7 +370,13 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
         .hasErrorEntryForKeyThat(key)
         .hasExceptionThat()
         .hasMessageThat()
-        .contains("No matching toolchains found for types //toolchain:test_toolchain");
+        .isEqualTo(
+            """
+No matching toolchains found for types:
+  //toolchain:test_toolchain
+To debug, rerun with --toolchain_resolution_debug='//toolchain:test_toolchain'
+For more information on platforms or toolchains see https://bazel.build/concepts/platforms-intro.\
+""");
   }
 
   @Test

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -427,11 +427,13 @@ EOF
 
   bazel build --platforms=//pkg:exotic_platform --java_runtime_version=local_jdk \
     //pkg:foo &>"$TEST_log" && fail "Build should fail"
-  expect_log "While resolving toolchains for target //pkg:foo ([0-9a-f]*): No matching toolchains found for types @@bazel_tools//tools/jdk:runtime_toolchain_type"
+  expect_log "While resolving toolchains for target //pkg:foo ([0-9a-f]*): No matching toolchains found for types:$"
+  expect_log "^  @@bazel_tools//tools/jdk:runtime_toolchain_type$"
 
   bazel build --platforms=//pkg:exotic_platform --java_runtime_version=local_jdk \
     //pkg:foo_deploy.jar &>"$TEST_log" && fail "Build should fail"
-  expect_log "While resolving toolchains for target //pkg:foo_deploy.jar ([0-9a-f]*): No matching toolchains found for types @@bazel_tools//tools/jdk:runtime_toolchain_type"
+  expect_log "While resolving toolchains for target //pkg:foo_deploy.jar ([0-9a-f]*): No matching toolchains found for types:$"
+  expect_log "^  @@bazel_tools//tools/jdk:runtime_toolchain_type$"
 }
 
 function test_executable_java_binary_fails_without_runtime_with_remote_jdk() {
@@ -456,11 +458,13 @@ EOF
 
   bazel build --platforms=//pkg:exotic_platform --java_runtime_version=remotejdk_11 \
     //pkg:foo &>"$TEST_log" && fail "Build should fail"
-  expect_log "While resolving toolchains for target //pkg:foo ([0-9a-f]*): No matching toolchains found for types @@bazel_tools//tools/jdk:runtime_toolchain_type"
+  expect_log "While resolving toolchains for target //pkg:foo ([0-9a-f]*): No matching toolchains found for types:$"
+  expect_log "^  @@bazel_tools//tools/jdk:runtime_toolchain_type$"
 
   bazel build --platforms=//pkg:exotic_platform --java_runtime_version=remotejdk_11 \
     //pkg:foo_deploy.jar &>"$TEST_log" && fail "Build should fail"
-  expect_log "While resolving toolchains for target //pkg:foo_deploy.jar ([0-9a-f]*): No matching toolchains found for types @@bazel_tools//tools/jdk:runtime_toolchain_type"
+  expect_log "While resolving toolchains for target //pkg:foo_deploy.jar ([0-9a-f]*): No matching toolchains found for types:$"
+  expect_log "^  @@bazel_tools//tools/jdk:runtime_toolchain_type$"
 }
 
 run_suite "Java toolchains tests, configured using flags or the default_java_toolchain macro."


### PR DESCRIPTION
Fixes #12318

RELNOTES: The new `no_match_error` attribute on `toolchain_type` can be used to show a custom message when no matching toolchain is found for that type, but one is required.

Closes #25134.

PiperOrigin-RevId: 722733008
Change-Id: I2ff51f7524325be1b70314bb2db24c829602f5fc

Commit https://github.com/bazelbuild/bazel/commit/d514705c1de20b9b6af74d20008e5fc062a18073