### PR TITLE
[8.1.0] Preserve order of exec groups, toolchain types and exec constraints

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -118,7 +118,7 @@ import com.google.devtools.build.lib.util.Pair;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.Keep;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -2040,7 +2040,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
 
   private static ImmutableSet<ToolchainTypeRequirement> parseToolchainTypes(
       Sequence<?> rawToolchains, LabelConverter labelConverter) throws EvalException {
-    Map<Label, ToolchainTypeRequirement> toolchainTypes = new HashMap<>();
+    Map<Label, ToolchainTypeRequirement> toolchainTypes = new LinkedHashMap<>();
 
     for (Object rawToolchain : rawToolchains) {
       ToolchainTypeRequirement toolchainType = parseToolchainType(rawToolchain, labelConverter);

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -68,8 +68,6 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -749,11 +747,11 @@ public class RuleClass implements RuleClassData {
     private boolean supportsConstraintChecking = true;
 
     private final Map<String, Attribute> attributes = new LinkedHashMap<>();
-    private final Set<ToolchainTypeRequirement> toolchainTypes = new HashSet<>();
+    private final Set<ToolchainTypeRequirement> toolchainTypes = new LinkedHashSet<>();
     private ToolchainResolutionMode toolchainResolutionMode = ToolchainResolutionMode.ENABLED;
-    private final Set<Label> executionPlatformConstraints = new HashSet<>();
+    private final Set<Label> executionPlatformConstraints = new LinkedHashSet<>();
     private OutputFile.Kind outputFileKind = OutputFile.Kind.FILE;
-    private final Map<String, ExecGroup> execGroups = new HashMap<>();
+    private final Map<String, ExecGroup> execGroups = new LinkedHashMap<>();
     private AutoExecGroupsMode autoExecGroupsMode = AutoExecGroupsMode.DYNAMIC;
 
     /**

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -3174,6 +3174,89 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testRuleOrderedRequirements() throws Exception {
+    registerDummyStarlarkFunction();
+    evalAndExport(
+        ev,
+        "plum = rule(",
+        "  implementation = impl,",
+        "  exec_compatible_with = [",
+        "    '//constraint:cv5',",
+        "    '//constraint:cv4',",
+        "    '//constraint:cv3',",
+        "    '//constraint:cv2',",
+        "    '//constraint:cv1',",
+        "  ],",
+        "  toolchains = [",
+        "    '//test:my_toolchain_type5',",
+        "    '//test:my_toolchain_type4',",
+        "    '//test:my_toolchain_type3',",
+        "    '//test:my_toolchain_type2',",
+        "    '//test:my_toolchain_type1',",
+        "  ],",
+        "  exec_groups = {",
+        "    'group5': exec_group(",
+        "      toolchains = [",
+        "        '//test:my_toolchain_type5',",
+        "        '//test:my_toolchain_type4',",
+        "        '//test:my_toolchain_type3',",
+        "        '//test:my_toolchain_type2',",
+        "        '//test:my_toolchain_type1',",
+        "      ],",
+        "    ),",
+        "    'group4': exec_group(",
+        "      exec_compatible_with = [",
+        "        '//constraint:cv5',",
+        "        '//constraint:cv4',",
+        "        '//constraint:cv3',",
+        "        '//constraint:cv2',",
+        "        '//constraint:cv1',",
+        "      ],",
+        "    ),",
+        "    'group3': exec_group(),",
+        "    'group2': exec_group(),",
+        "    'group1': exec_group(),",
+        "  },",
+        ")");
+    RuleClass plum = ((StarlarkRuleFunction) ev.lookup("plum")).getRuleClass();
+    assertThat(plum.getToolchainTypes().stream().map(ToolchainTypeRequirement::toolchainType))
+        .containsExactly(
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type5"),
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type4"),
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type3"),
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type2"),
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type1"))
+        .inOrder();
+    assertThat(plum.getExecutionPlatformConstraints())
+        .containsExactly(
+            Label.parseCanonicalUnchecked("//constraint:cv5"),
+            Label.parseCanonicalUnchecked("//constraint:cv4"),
+            Label.parseCanonicalUnchecked("//constraint:cv3"),
+            Label.parseCanonicalUnchecked("//constraint:cv2"),
+            Label.parseCanonicalUnchecked("//constraint:cv1"))
+        .inOrder();
+    assertThat(plum.getExecGroups().keySet())
+        .containsExactly("group5", "group4", "group3", "group2", "group1")
+        .inOrder();
+    assertThat(plum.getExecGroups().get("group5").toolchainTypesMap().keySet())
+        .containsExactly(
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type5"),
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type4"),
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type3"),
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type2"),
+            Label.parseCanonicalUnchecked("//test:my_toolchain_type1"))
+        .inOrder();
+    assertThat(plum.getExecGroups().get("group4").execCompatibleWith())
+        .containsExactly(
+            Label.parseCanonicalUnchecked("//constraint:cv5"),
+            Label.parseCanonicalUnchecked("//constraint:cv4"),
+            Label.parseCanonicalUnchecked("//constraint:cv3"),
+            Label.parseCanonicalUnchecked("//constraint:cv2"),
+            Label.parseCanonicalUnchecked("//constraint:cv1"))
+        .inOrder();
+  }
+
+  @Test
   public void testRuleFunctionReturnsNone() throws Exception {
     scratch.file(
         "test/rule.bzl",


### PR DESCRIPTION
Using collection types that aren't guaranteed to preserve insertion order risks errors that differ across machines or builds.

Closes #25175.

PiperOrigin-RevId: 722768825
Change-Id: Id84c6b5b4bc9a1e6938de727e07c20ee761cbf3d

Commit https://github.com/bazelbuild/bazel/commit/2ee6f9232283408442f7a18ab566607e29d96e26