### PR TITLE
[8.1.0] Configure `--run_under` target for the test exec platform

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -304,7 +304,7 @@ public class BaseRuleClasses {
           // RunCommand.java to self-transition --run_under to the exec configuration.
           .add(
               attr(":run_under_exec_config", LABEL)
-                  .cfg(ExecutionTransitionFactory.createFactory())
+                  .cfg(ExecutionTransitionFactory.createFactory("test"))
                   .value(RUN_UNDER_EXEC_CONFIG)
                   .skipPrereqValidatorCheck())
           .add(

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -302,7 +302,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
             // See similar definitions in BaseRuleClasses for context.
             .add(
                 attr(":run_under_exec_config", LABEL)
-                    .cfg(ExecutionTransitionFactory.createFactory())
+                    .cfg(ExecutionTransitionFactory.createFactory("test"))
                     .value(RUN_UNDER_EXEC_CONFIG)
                     .skipPrereqValidatorCheck())
             .add(

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -23,13 +23,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.eventbus.EventBus;
+import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.MiddlemanAction;
 import com.google.devtools.build.lib.actions.RunfilesTree;
 import com.google.devtools.build.lib.analysis.AnalysisResult;
 import com.google.devtools.build.lib.analysis.ConfiguredAspect;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.PlatformOptions;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
@@ -755,6 +758,114 @@ public class TestActionBuilderTest extends BuildViewTestCase {
       throws Exception {
     ConfiguredTarget target = getConfiguredTarget(label);
     return target.getProvider(TestProvider.class).getTestParams().getTestStatusArtifacts();
+  }
+
+  @Test
+  public void testRunUnderConfiguredForTestExecPlatform() throws Exception {
+    scratch.file(
+        "some_test.bzl",
+        """
+        def _some_test_impl(ctx):
+            script = ctx.actions.declare_file(ctx.attr.name + ".sh")
+            ctx.actions.run_shell(
+                outputs = [script],
+                inputs = [],
+                command = "echo 'shell script goes here' > $@",
+            )
+            return [
+                DefaultInfo(executable = script),
+                testing.ExecutionInfo(exec_group = "alternative_test"),
+            ]
+
+        some_test = rule(
+            implementation = _some_test_impl,
+            test = True,
+            exec_groups = {
+                "test": exec_group(
+                    exec_compatible_with = [
+                        "%1$sos:linux",
+                    ],
+                ),
+                "alternative_test": exec_group(
+                    exec_compatible_with = [
+                        "%1$sos:android",
+                    ],
+                ),
+            },
+        )
+        """
+            .formatted(TestConstants.CONSTRAINTS_PACKAGE_ROOT));
+    scratch.file(
+        "BUILD",
+        """
+        load(':some_test.bzl', 'some_test')
+        platform(
+            name = "linux",
+            constraint_values = [
+                "%1$sos:linux",
+            ],
+        )
+        platform(
+            name = "windows",
+            constraint_values = [
+                "%1$sos:windows",
+            ],
+        )
+        platform(
+            name = "macos",
+            constraint_values = [
+                "%1$sos:macos",
+            ],
+        )
+        platform(
+            name = "android",
+            constraint_values = [
+                "%1$sos:android",
+            ],
+        )
+        genrule(
+            name = "run_under_tool",
+            outs = ["run_under_tool.sh"],
+            cmd = "echo 'runUnderTool' > $@",
+            executable = True,
+        )
+        some_test(
+            name = "some_test",
+            exec_compatible_with = ["%1$sos:macos"],
+        )
+        """
+            .formatted(TestConstants.CONSTRAINTS_PACKAGE_ROOT));
+    useConfiguration(
+        "--run_under=//:run_under_tool",
+        "--incompatible_bazel_test_exec_run_under",
+        "--platforms=//:windows",
+        "--host_platform=//:windows",
+        "--extra_execution_platforms=//:windows,//:android,//:linux,//:macos");
+
+    Action generateAction = getGeneratingAction(getExecutable("//:some_test"));
+    assertThat(generateAction.getExecutionPlatform().label())
+        .isEqualTo(Label.parseCanonicalUnchecked("//:macos"));
+
+    Action testAction = getGeneratingAction(getTestStatusArtifacts("//:some_test").get(0));
+    assertThat(testAction.getExecutionPlatform().label())
+        .isEqualTo(Label.parseCanonicalUnchecked("//:android"));
+
+    Artifact runUnderTool =
+        testAction.getInputs().toList().stream()
+            .filter(artifact -> artifact.getExecPath().getBaseName().equals("run_under_tool.sh"))
+            .findFirst()
+            .orElseThrow();
+    // TODO: The run_under_tool should be built for the exec platform of the test action, which
+    //  differs from the exec platform of the "test" exec group due to testing.ExecutionInfo.
+    //  Building for the "test" exec group is still preferred over building for the target platform
+    //  or the default exec platform of the test rule.
+    assertThat(
+            ((BuildConfigurationValue)
+                    getGeneratingAction(runUnderTool).getOwner().getBuildConfigurationInfo())
+                .getOptions()
+                .get(PlatformOptions.class)
+                .platforms)
+        .containsExactly(Label.parseCanonicalUnchecked("//:linux"));
   }
 
   private ImmutableList<Artifact.DerivedArtifact> getTestStatusArtifacts(


### PR DESCRIPTION
With `--incompatible_bazel_test_exec_run_under`, the `--run_under` target should be configured for the execution platform of the test action, not the default execution platform of the test rule.

This is still not fully correct if `testing.ExecutionInfo` is used to specify an alternative test exec group, but that's a far more difficult change: it would potentially involve a split transition with one configuration for each exec group.

Work towards #23179

Closes #25177.

PiperOrigin-RevId: 722802891
Change-Id: Ie168bf496d46645f7bd2ad739859504c65286d20

Commit https://github.com/bazelbuild/bazel/commit/e262d021e87727a501ccbdff306d188ed88bcb29