### PR TITLE
Flip `--incompatible_bazel_test_exec_run_under` for Bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -832,7 +832,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
   @Option(
       name = "incompatible_bazel_test_exec_run_under",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
       effectTags = {
         OptionEffectTag.AFFECTS_OUTPUTS,


### PR DESCRIPTION
RELNOTES[inc]: `--incompatible_bazel_test_exec_run_under` is now enabled by default, which means that the `--run_under` target in a `bazel test` invocation will be built for each test's execution platform.

Fixes #23179