### PR TITLE
Update to use coverage_output_generator-v2.8

### DIFF
--- a/tools/test/extensions.bzl
+++ b/tools/test/extensions.bzl
@@ -19,9 +19,9 @@ load("//tools/build_defs/repo:http.bzl", "http_archive")
 def _remote_coverage_tools_extension_impl(ctx):
     http_archive(
         name = "remote_coverage_tools",
-        sha256 = "69fa4fdd887295e5a45e592352ad00ef6afa6a435d13e3f38f6ed338ded85dfd",
+        sha256 = "172be177db06b16632335f27d50cee0786fb1873df344852db71b2171cd6d996",
         urls = [
-            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.7.zip",
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.8.zip",
         ],
     )
     return ctx.extension_metadata(reproducible = True)

--- a/workspace_deps.bzl
+++ b/workspace_deps.bzl
@@ -69,9 +69,9 @@ WORKSPACE_REPOS = {
         "urls": ["https://github.com/bazelbuild/rules_testing/releases/download/v0.6.0/rules_testing-v0.6.0.tar.gz"],
     },
     "remote_coverage_tools": {
-        "archive": "coverage_output_generator-v2.7.zip",
-        "sha256": "69fa4fdd887295e5a45e592352ad00ef6afa6a435d13e3f38f6ed338ded85dfd",
-        "urls": ["https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.7.zip"],
+        "archive": "coverage_output_generator-v2.8.zip",
+        "sha256": "172be177db06b16632335f27d50cee0786fb1873df344852db71b2171cd6d996",
+        "urls": ["https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.8.zip"],
     },
 }
 


### PR DESCRIPTION
Built at commit ee12906c

Relevant changes:

 * Add support for input FN lines that include a function end line (#25118).

RELNOTES:
    LCOV parsing does not break on FN lines including an end line number.