### PR TITLE
Respect XDG directory settings on macOS

### DIFF
--- a/site/en/remote/output-directories.md
+++ b/site/en/remote/output-directories.md
@@ -30,13 +30,14 @@ The solution that's currently implemented:
   subdirectory thereof. In other words, Bazel must be invoked from inside a
   [repository](../external/overview#repository). Otherwise, an error is
   reported.
-* The _outputRoot_ directory defaults to `${XDG_CACHE_HOME}/bazel` (or
-  `~/.cache/bazel`, if the `XDG_CACHE_HOME` environment variable is not set) on
-  Linux, `/private/var/tmp` on macOS, and on Windows it defaults to `%HOME%` if
+* The _outputRoot_ directory defaults to `~/.cache/bazel` on Linux,
+  `/private/var/tmp` on macOS, and on Windows it defaults to `%HOME%` if
   set, else `%USERPROFILE%` if set, else the result of calling
   `SHGetKnownFolderPath()` with the `FOLDERID_Profile` flag set. If the
-  environment variable `$TEST_TMPDIR` is set, as in a test of Bazel itself,
-  then that value overrides the default.
+  environment variable `$XDG_CACHE_HOME` is set on either Linux or
+  macOS, the value `${XDG_CACHE_HOME}/bazel` will override the default.
+  If the environment variable `$TEST_TMPDIR` is set, as in a test of Bazel
+  itself, then that value overrides any defaults.
 * The Bazel user's build state is located beneath `outputRoot/_bazel_$USER`.
   This is called the _outputUserRoot_ directory.
 * Beneath the `outputUserRoot` directory there is an `install` directory, and in

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -96,7 +96,13 @@ static string DescriptionFromCFError(CFErrorRef cf_err) {
   return UTF8StringFromCFStringRef(cf_err_string);
 }
 
-string GetCacheDir() { return "/var/tmp"; }
+string GetCacheDir() {
+  string xdg_cache_home = GetPathEnv("XDG_CACHE_HOME");
+  if (!xdg_cache_home.empty()) {
+    return blaze_util::JoinPath(xdg_cache_home, "bazel");
+  }
+  return "/var/tmp";
+}
 
 void WarnFilesystemType(const blaze_util::Path &output_base) {
   // Check to see if we are on a non-local drive.

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -97,6 +97,15 @@ static string DescriptionFromCFError(CFErrorRef cf_err) {
 }
 
 string GetCacheDir() {
+  // On macOS, the standard location for application caches is $HOME/Library/Caches.
+  // Bazel historically has not used this location, and instead has used /var/tmp,
+  // due to Unix domain socket path length limitations. These limitations are no
+  // longer relevant as we no longer create Unix domain sockets under the output base.
+  //
+  // However, respecting $XDG_CACHE_HOME is still useful as it allows users to easily
+  // override the cache directory, and is respected by many Linux derived tools.
+  //
+  // See also: https://stackoverflow.com/questions/3373948/equivalents-of-xdg-config-home-and-xdg-data-home-on-mac-os-x
   string xdg_cache_home = GetPathEnv("XDG_CACHE_HOME");
   if (!xdg_cache_home.empty()) {
     return blaze_util::JoinPath(xdg_cache_home, "bazel");

--- a/src/test/cpp/bazel_startup_options_test.cc
+++ b/src/test/cpp/bazel_startup_options_test.cc
@@ -85,42 +85,6 @@ TEST_F(BazelStartupOptionsTest, EmptyFlagsAreInvalid) {
 }
 
 #ifdef __linux
-TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithTestTmpdir) {
-  SetEnv("USER", "gandalf");
-  SetEnv("HOME", "/nonexistent/home");
-  SetEnv("XDG_CACHE_HOME", "/nonexistent/cache");
-  SetEnv("TEST_TMPDIR", "/nonexistent/tmpdir");
-  ReinitStartupOptions();
-  UpdateConfiguration();
-
-  ASSERT_EQ(blaze_util::Path("/nonexistent/tmpdir/_bazel_gandalf"),
-            startup_options_->output_user_root);
-  ASSERT_EQ(
-      blaze_util::Path("/nonexistent/tmpdir/_bazel_gandalf/install/deadbeef"),
-      startup_options_->install_base);
-  ASSERT_EQ(blaze_util::Path("/nonexistent/tmpdir/_bazel_gandalf/"
-                             "1629dee48cc4e53161f9b2be8614e062"),
-            startup_options_->output_base);
-}
-
-TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithXdgCacheHome) {
-  SetEnv("USER", "gandalf");
-  SetEnv("HOME", "/nonexistent/home");
-  SetEnv("XDG_CACHE_HOME", "/nonexistent/cache");
-  UnsetEnv("TEST_TMPDIR");
-  ReinitStartupOptions();
-  UpdateConfiguration();
-
-  ASSERT_EQ(blaze_util::Path("/nonexistent/cache/bazel/_bazel_gandalf"),
-            startup_options_->output_user_root);
-  ASSERT_EQ(blaze_util::Path(
-                "/nonexistent/cache/bazel/_bazel_gandalf/install/deadbeef"),
-            startup_options_->install_base);
-  ASSERT_EQ(blaze_util::Path("/nonexistent/cache/bazel/_bazel_gandalf/"
-                             "1629dee48cc4e53161f9b2be8614e062"),
-            startup_options_->output_base);
-}
-
 TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithHome) {
   SetEnv("USER", "gandalf");
   SetEnv("HOME", "/nonexistent/home");
@@ -138,36 +102,6 @@ TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxWithHome) {
   ASSERT_EQ(blaze_util::Path("/nonexistent/home/.cache/bazel/_bazel_gandalf/"
                              "1629dee48cc4e53161f9b2be8614e062"),
             startup_options_->output_base);
-}
-
-TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxNoShellExpansion) {
-  SetEnv("USER", "gandalf");
-  SetEnv("TEST_TMPDIR", "~/\"$foo/test\"");
-  SetEnv("XDG_CACHE_HOME", "~/cache${bar}");
-  SetEnv("HOME", "~/home$(echo baz)");
-
-  ReinitStartupOptions();
-  UpdateConfiguration();
-
-  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() + "/~/\"$foo/test\"" +
-                             "/_bazel_gandalf"),
-            startup_options_->output_user_root);
-
-  UnsetEnv("TEST_TMPDIR");
-  ReinitStartupOptions();
-  UpdateConfiguration();
-
-  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() +
-                             "/~/cache${bar}/bazel/_bazel_gandalf"),
-            startup_options_->output_user_root);
-
-  UnsetEnv("XDG_CACHE_HOME");
-  ReinitStartupOptions();
-  UpdateConfiguration();
-
-  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() +
-                             "/~/home$(echo baz)/.cache/bazel/_bazel_gandalf"),
-            startup_options_->output_user_root);
 }
 #endif  // __linux
 
@@ -187,8 +121,10 @@ TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwin) {
                              "1629dee48cc4e53161f9b2be8614e062"),
             startup_options_->output_base);
 }
+#endif  // __APPLE__
 
-TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwinWithTestTmpdir) {
+#if defined(__linux) || defined(__APPLE__)
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxOrDarwinWithTestTmpdir) {
   SetEnv("USER", "gandalf");
   SetEnv("HOME", "/nonexistent/home");
   SetEnv("XDG_CACHE_HOME", "/nonexistent/cache");
@@ -205,7 +141,7 @@ TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwinWithTestTmpdir) {
             startup_options_->output_base);
 }
 
-TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwinWithXdgCacheHome) {
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxOrDarwinWithXdgCacheHome) {
   SetEnv("USER", "gandalf");
   SetEnv("HOME", "/nonexistent/home");
   SetEnv("XDG_CACHE_HOME", "/nonexistent/cache");
@@ -222,7 +158,7 @@ TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwinWithXdgCacheHome) {
             startup_options_->output_base);
 }
 
-TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwinNoShellExpansion) {
+TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnLinuxOrDarwinNoShellExpansion) {
   SetEnv("USER", "gandalf");
   SetEnv("TEST_TMPDIR", "~/\"$foo/test\"");
   SetEnv("XDG_CACHE_HOME", "~/cache${bar}");
@@ -247,10 +183,16 @@ TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnDarwinNoShellExpansion) {
   ReinitStartupOptions();
   UpdateConfiguration();
 
+#ifdef __linux
+  ASSERT_EQ(blaze_util::Path(blaze_util::GetCwd() +
+                             "/~/home$(echo baz)/.cache/bazel/_bazel_gandalf"),
+            startup_options_->output_user_root);
+#elif defined(__APPLE__)
   ASSERT_EQ(blaze_util::Path("/var/tmp/_bazel_gandalf"),
             startup_options_->output_user_root);
+#endif
 }
-#endif  // __APPLE__
+#endif  // __linux || __APPLE__
 
 #if defined(__WIN32__) || defined(__CYGWIN__)
 TEST_F(BazelStartupOptionsTest, UpdateConfigurationOnWindowsWithHome) {


### PR DESCRIPTION
Fixes #25167

Copies much of the logic over from `blaze_util_linux.cc` and its tests into the Darwin space to implement the feature request.
