### PR TITLE
[8.1.0] Add version selector buttons to repo rule docs

### DIFF
--- a/tools/build_defs/repo/BUILD
+++ b/tools/build_defs/repo/BUILD
@@ -39,6 +39,14 @@ genrule(
     cmd = "touch $@",
 )
 
+# This seemingly useless rule is needed to work around some Google-internal linter issues.
+genrule(
+    name = "index_md",
+    srcs = [":index.md.tmpl"],
+    outs = ["index.md"],
+    cmd = "cat $< > $@",
+)
+
 REPO_BZL_FILES = [
     "cache",
     "git",
@@ -56,7 +64,7 @@ REPO_BZL_FILES = [
 
 [genrule(
     name = "preamb_%s_md" % (name,),
-    srcs = [":preamb.md"],
+    srcs = [":preamb.md.tmpl"],
     outs = ["preamb_%s.md" % (name,)],
     cmd = "sed 's/BZL_FILE_BASE_NAME/%s/g' < $< > $@" % (name,),
 ) for name in REPO_BZL_FILES]

--- a/tools/build_defs/repo/index.md.tmpl
+++ b/tools/build_defs/repo/index.md.tmpl
@@ -1,6 +1,8 @@
 Project: /_project.yaml
 Book: /_book.yaml
 
+{% include "_buttons.html" %}
+
 # Repository Rules
 
 * [Rules related to git](git)

--- a/tools/build_defs/repo/preamb.md.tmpl
+++ b/tools/build_defs/repo/preamb.md.tmpl
@@ -3,5 +3,8 @@ Book: /_book.yaml
 
 # BZL_FILE_BASE_NAME repository rules
 
+{% dynamic setvar source_file "tools/build_defs/repo/BZL_FILE_BASE_NAME.bzl" %}
+{% include "_buttons.html" %}
+
 The following functions can be loaded from
 `@bazel_tools//tools/build_defs/repo:BZL_FILE_BASE_NAME.bzl`.


### PR DESCRIPTION
After https://github.com/bazelbuild/bazel/commit/20c02afe2a7192e8b25dac180451b6ea4fb8c7cf, I _think_ the repo rule docs (e.g. https://bazel.build/versions/7.4.0/rules/lib/repo/http) are the only ones missing the version selectors now. This CL should fix that for nightlies; will send another one to fix the released versions.

PiperOrigin-RevId: 721807046
Change-Id: Ib1e5287a0b2d22993a6014130235f32cf268952c