### PR TITLE
Preserve insertion order in maps that are traversed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
@@ -66,7 +66,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -152,10 +152,10 @@ public /*final*/ class ConfiguredRuleClassProvider
     private final List<Class<? extends Fragment>> configurationFragmentClasses = new ArrayList<>();
     private final List<Class<? extends FragmentOptions>> configurationOptions = new ArrayList<>();
 
-    private final Map<String, RuleClass> ruleClassMap = new HashMap<>();
-    private final Map<String, RuleDefinition> ruleDefinitionMap = new HashMap<>();
-    private final Map<String, NativeAspectClass> nativeAspectClassMap = new HashMap<>();
-    private final Map<Class<? extends RuleDefinition>, RuleClass> ruleMap = new HashMap<>();
+    private final Map<String, RuleClass> ruleClassMap = new LinkedHashMap<>();
+    private final Map<String, RuleDefinition> ruleDefinitionMap = new LinkedHashMap<>();
+    private final Map<String, NativeAspectClass> nativeAspectClassMap = new LinkedHashMap<>();
+    private final Map<Class<? extends RuleDefinition>, RuleClass> ruleMap = new LinkedHashMap<>();
     private final Digraph<Class<? extends RuleDefinition>> dependencyGraph = new Digraph<>();
     private final List<Class<? extends Fragment>> universalFragments = new ArrayList<>();
     @Nullable private TransitionFactory<RuleTransitionData> trimmingTransitionFactory = null;

--- a/src/main/java/com/google/devtools/build/lib/analysis/ExecGroupCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ExecGroupCollection.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
@@ -60,7 +59,7 @@ public abstract class ExecGroupCollection {
       ImmutableSet<ToolchainTypeRequirement> defaultToolchainTypes,
       boolean useAutoExecGroups) {
     var processedGroups =
-        Maps.<String, ExecGroup>newHashMapWithExpectedSize(
+        ImmutableMap.<String, ExecGroup>builderWithExpectedSize(
             useAutoExecGroups
                 ? (execGroups.size() + defaultToolchainTypes.size())
                 : execGroups.size());
@@ -108,7 +107,7 @@ public abstract class ExecGroupCollection {
                 .build());
       }
     }
-    return ImmutableMap.copyOf(processedGroups);
+    return processedGroups.buildOrThrow();
   }
 
   /** Builder class for correctly constructing ExecGroupCollection instances. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/ToolchainCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ToolchainCollection.java
@@ -14,7 +14,7 @@
 package com.google.devtools.build.lib.analysis;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
+import static com.google.common.collect.Maps.newLinkedHashMapWithExpectedSize;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
@@ -25,8 +25,8 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.ExecGroup;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.SequencedMap;
 
 /**
  * A wrapper class for a map of exec_group names to their relevant ToolchainContext.
@@ -88,14 +88,14 @@ public record ToolchainCollection<T extends ToolchainContext>(ImmutableMap<Strin
   /** Builder for ToolchainCollection. */
   public static final class Builder<T extends ToolchainContext> {
     // This is not immutable so that we can check for duplicate keys easily.
-    private final Map<String, T> toolchainContexts;
+    private final SequencedMap<String, T> toolchainContexts;
 
     private Builder() {
-      this.toolchainContexts = new HashMap<>();
+      this.toolchainContexts = new LinkedHashMap<>();
     }
 
     private Builder(int expectedSize) {
-      this.toolchainContexts = newHashMapWithExpectedSize(expectedSize);
+      this.toolchainContexts = newLinkedHashMapWithExpectedSize(expectedSize);
     }
 
     public ToolchainCollection<T> build() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -604,7 +604,7 @@ public class BuildConfigurationValue
     ImmutableMap.Builder<String, String> makeEnvironment = ImmutableMap.builder();
     makeEnvironment.putAll(globalMakeEnv);
     makeEnvironment.putAll(commandLineBuildVariables);
-    return makeEnvironment.build();
+    return makeEnvironment.buildKeepingLast();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -600,11 +600,11 @@ public class BuildConfigurationValue
    * <p>Command-line definitions of make environments override variables defined by {@code
    * Fragment.addGlobalMakeVariables()}.
    */
-  public Map<String, String> getMakeEnvironment() {
-    Map<String, String> makeEnvironment = new HashMap<>();
+  public ImmutableMap<String, String> getMakeEnvironment() {
+    ImmutableMap.Builder<String, String> makeEnvironment = ImmutableMap.builder();
     makeEnvironment.putAll(globalMakeEnv);
     makeEnvironment.putAll(commandLineBuildVariables);
-    return ImmutableMap.copyOf(makeEnvironment);
+    return makeEnvironment.build();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OptionsDiff.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OptionsDiff.java
@@ -29,12 +29,12 @@ import com.google.devtools.build.lib.util.OrderedSetMultimap;
 import com.google.devtools.common.options.OptionDefinition;
 import com.google.devtools.common.options.OptionsParser;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.SequencedMap;
 import java.util.Set;
 
 /**
@@ -138,7 +138,7 @@ public final class OptionsDiff {
   private final Map<Label, Object> starlarkSecond = new LinkedHashMap<>();
 
   private final List<Label> extraStarlarkOptionsFirst = new ArrayList<>();
-  private final Map<Label, Object> extraStarlarkOptionsSecond = new HashMap<>();
+  private final SequencedMap<Label, Object> extraStarlarkOptionsSecond = new LinkedHashMap<>();
 
   private boolean hasStarlarkOptions = false;
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformProperties.java
@@ -17,8 +17,9 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.SequencedMap;
 import javax.annotation.Nullable;
 
 /** Proepeties set on a specific {@link PlatformInfo}. */
@@ -70,8 +71,8 @@ public abstract class PlatformProperties {
         return properties;
       }
 
-      HashMap<String, String> result = new HashMap<>();
-      if (parent != null && !parent.properties().isEmpty()) {
+      SequencedMap<String, String> result = new LinkedHashMap<>();
+      if (!parent.properties().isEmpty()) {
         result.putAll(parent.properties());
       }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
@@ -60,7 +60,7 @@ final class Discovery {
       throws InterruptedException, ExternalDepsException {
     String rootModuleName = root.getModule().getName();
     ImmutableMap<String, ModuleOverride> overrides = root.getOverrides();
-    Map<ModuleKey, InterimModule> depGraph = new HashMap<>();
+    Map<ModuleKey, InterimModule> depGraph = new LinkedHashMap<>();
     depGraph.put(
         ModuleKey.ROOT,
         root.getModule()

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -70,10 +70,11 @@ import com.google.devtools.build.skyframe.SkyframeLookupResult;
 import com.google.errorprone.annotations.FormatMethod;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.SequencedMap;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.Dict;
@@ -138,7 +139,8 @@ public class ModuleFileFunction implements SkyFunction {
     // the `includeLabelToCompiledModuleFile` map for use during actual Starlark execution.
     CompiledModuleFile compiledRootModuleFile;
     ImmutableList<IncludeStatement> horizon;
-    HashMap<String, CompiledModuleFile> includeLabelToCompiledModuleFile = new HashMap<>();
+    SequencedMap<String, CompiledModuleFile> includeLabelToCompiledModuleFile =
+        new LinkedHashMap<>();
   }
 
   @Nullable
@@ -313,7 +315,7 @@ public class ModuleFileFunction implements SkyFunction {
    */
   @Nullable
   private static ImmutableList<IncludeStatement> advanceHorizon(
-      HashMap<String, CompiledModuleFile> includeLabelToCompiledModuleFile,
+      SequencedMap<String, CompiledModuleFile> includeLabelToCompiledModuleFile,
       ImmutableList<IncludeStatement> horizon,
       Environment env,
       StarlarkSemantics starlarkSemantics,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -31,7 +31,6 @@ import java.io.InterruptedIOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -139,17 +138,16 @@ final class HttpConnectorMultiplexer {
     Preconditions.checkNotNull(credentials);
 
     return url -> {
-      Map<String, List<String>> headers = new HashMap<>(baseHeaders);
       try {
-        headers.putAll(credentials.getRequestMetadata(url.toURI()));
+        return ImmutableMap.copyOf(credentials.getRequestMetadata(url.toURI()));
       } catch (URISyntaxException | IOException e) {
         // If we can't convert the URL to a URI (because it is syntactically malformed), or fetching
         // credentials fails for any other reason, still try to do the connection, not adding
         // authentication information as we cannot look it up.
         eventHandler.handle(
             Event.warn("Error retrieving auth headers, continuing without: " + e.getMessage()));
+        return ImmutableMap.of();
       }
-      return ImmutableMap.copyOf(headers);
     };
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -138,16 +138,18 @@ final class HttpConnectorMultiplexer {
     Preconditions.checkNotNull(credentials);
 
     return url -> {
+      ImmutableMap.Builder<String, List<String>> headers = new ImmutableMap.Builder<>();
+      headers.putAll(baseHeaders);
       try {
-        return ImmutableMap.copyOf(credentials.getRequestMetadata(url.toURI()));
+        headers.putAll(credentials.getRequestMetadata(url.toURI()));
       } catch (URISyntaxException | IOException e) {
         // If we can't convert the URL to a URI (because it is syntactically malformed), or fetching
         // credentials fails for any other reason, still try to do the connection, not adding
         // authentication information as we cannot look it up.
         eventHandler.handle(
             Event.warn("Error retrieving auth headers, continuing without: " + e.getMessage()));
-        return ImmutableMap.of();
       }
+      return headers.buildKeepingLast();
     };
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryMapping.java
@@ -88,12 +88,12 @@ public class RepositoryMapping {
   }
 
   public static RepositoryMapping create(
-      Map<String, RepositoryName> entries, RepositoryName ownerRepo) {
+      ImmutableMap<String, RepositoryName> entries, RepositoryName ownerRepo) {
     return new RepositoryMapping(
         Preconditions.checkNotNull(entries), Preconditions.checkNotNull(ownerRepo));
   }
 
-  public static RepositoryMapping createAllowingFallback(Map<String, RepositoryName> entries) {
+  public static RepositoryMapping createAllowingFallback(ImmutableMap<String, RepositoryName> entries) {
     return new RepositoryMapping(Preconditions.checkNotNull(entries), null);
   }
 
@@ -101,10 +101,15 @@ public class RepositoryMapping {
    * Create a new {@link RepositoryMapping} instance based on existing repo mappings and given
    * additional mappings. If there are conflicts, existing mappings will take precedence.
    */
-  public RepositoryMapping withAdditionalMappings(Map<String, RepositoryName> additionalMappings) {
-    HashMap<String, RepositoryName> allMappings = new HashMap<>(additionalMappings);
-    allMappings.putAll(entries());
-    return new RepositoryMapping(allMappings, ownerRepo());
+  public RepositoryMapping withAdditionalMappings(
+      ImmutableMap<String, RepositoryName> additionalMappings) {
+    return new RepositoryMapping(
+        ImmutableMap.<String, RepositoryName>builderWithExpectedSize(
+                entries().size() + additionalMappings.size())
+            .putAll(additionalMappings)
+            .putAll(entries())
+            .buildKeepingLast(),
+        ownerRepo());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/exec/TestPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestPolicy.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.util.UserUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -64,7 +65,7 @@ public class TestPolicy {
       Duration timeout,
       PathFragment relativeRunfilesDir,
       PathFragment tmpDir) {
-    Map<String, String> env = new HashMap<>();
+    Map<String, String> env = new LinkedHashMap<>();
 
     // Add all env variables, allow some string replacements and inheritance.
     String userProp = UserUtils.getUserName();

--- a/src/main/java/com/google/devtools/build/lib/metrics/PostGCMemoryUseRecorder.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/PostGCMemoryUseRecorder.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.bugreport.BugReporter;
@@ -128,7 +129,7 @@ public final class PostGCMemoryUseRecorder implements NotificationListener {
    * Returns the number of bytes garbage collected during this invocation. Broken down by GC space.
    */
   public synchronized ImmutableMap<String, Long> getGarbageStats() {
-    return ImmutableMap.copyOf(garbageStats);
+    return ImmutableSortedMap.copyOf(garbageStats);
   }
 
   public synchronized void reset() {

--- a/src/main/java/com/google/devtools/build/lib/packages/BazelStarlarkEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BazelStarlarkEnvironment.java
@@ -18,8 +18,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedMap;
 import java.util.Set;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.GuardedValue;
@@ -458,11 +460,11 @@ public final class BazelStarlarkEnvironment {
       throws InjectionException {
     Map<String, Boolean> overridesMap = parseInjectionOverridesList(overridesList);
 
-    Map<String, Object> env = new HashMap<>(bzlToplevelsWithoutNative);
+    SequencedMap<String, Object> env = new LinkedHashMap<>(bzlToplevelsWithoutNative);
 
     // Determine "native" bindings.
     // TODO(#11954): See above comment in createUninjectedBuildBzlEnv.
-    Map<String, Object> nativeBindings = new HashMap<>(nativeBase);
+    SequencedMap<String, Object> nativeBindings = new LinkedHashMap<>(nativeBase);
     for (Map.Entry<String, Object> entry : exportedRules.entrySet()) {
       String key = entry.getKey();
       String name = getKeySuffix(key);
@@ -508,7 +510,7 @@ public final class BazelStarlarkEnvironment {
       Map<String, Object> exportedRules, List<String> overridesList) throws InjectionException {
     Map<String, Boolean> overridesMap = parseInjectionOverridesList(overridesList);
 
-    HashMap<String, Object> env = new HashMap<>(uninjectedBuildEnv);
+    SequencedMap<String, Object> env = new LinkedHashMap<>(uninjectedBuildEnv);
     for (Map.Entry<String, Object> entry : exportedRules.entrySet()) {
       String key = entry.getKey();
       String name = getKeySuffix(key);

--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -61,12 +61,14 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.SequencedMap;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import javax.annotation.Nullable;
@@ -1107,7 +1109,7 @@ public class Package {
 
     // The map from each repository to that repository's remappings map.
     // This is only used in the //external package, it is an empty map for all other packages.
-    private final HashMap<RepositoryName, HashMap<String, RepositoryName>>
+    private final HashMap<RepositoryName, LinkedHashMap<String, RepositoryName>>
         externalPackageRepositoryMappings = new HashMap<>();
 
     /** Estimates the package overhead of this package. */
@@ -1357,7 +1359,7 @@ public class Package {
         RepositoryName repoWithin, String localName, RepositoryName mappedName) {
       HashMap<String, RepositoryName> mapping =
           externalPackageRepositoryMappings.computeIfAbsent(
-              repoWithin, (RepositoryName k) -> new HashMap<>());
+              repoWithin, (RepositoryName k) -> new LinkedHashMap<>());
       mapping.put(localName, mappedName);
       return this;
     }
@@ -1387,11 +1389,11 @@ public class Package {
      * the main workspace to the canonical main name '@').
      */
     RepositoryMapping getRepositoryMappingFor(RepositoryName name) {
-      Map<String, RepositoryName> mapping = externalPackageRepositoryMappings.get(name);
+      SequencedMap<String, RepositoryName> mapping = externalPackageRepositoryMappings.get(name);
       if (mapping == null) {
         return RepositoryMapping.ALWAYS_FALLBACK;
       } else {
-        return RepositoryMapping.createAllowingFallback(mapping);
+        return RepositoryMapping.createAllowingFallback(ImmutableMap.copyOf(mapping));
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -40,6 +40,7 @@ import com.google.devtools.common.options.OptionsParsingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -110,13 +111,13 @@ public class StarlarkOptionsParser {
   private final Map<String, String> scopes = new TreeMap<>();
 
   // Map of parsed starlark options to their loaded BuildSetting objects (used for canonicalization)
-  private final Map<String, BuildSetting> parsedBuildSettings = new HashMap<>();
+  private final Map<String, BuildSetting> parsedBuildSettings = new LinkedHashMap<>();
 
   // Local cache of build settings so we don't repeatedly load them.
   private final Map<String, Target> buildSettings = new HashMap<>();
 
   // The default value for each build setting.
-  private final Map<String, Object> buildSettingDefaults = new HashMap<>();
+  private final Map<String, Object> buildSettingDefaults = new LinkedHashMap<>();
 
   // whether options explicitly set to their default values are added to {@code starlarkOptions}
   private final boolean includeDefaultValues;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2468,6 +2468,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//third_party:auto_value",
         "//third_party:error_prone_annotations",
+        "//third_party:guava",
         "//third_party:jsr305",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
@@ -84,6 +84,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1338,7 +1339,7 @@ public abstract class PackageFunction implements SkyFunction {
                 .getUninjectedBuildEnv()
             : starlarkBuiltinsValue.predeclaredForBuild;
     if (preludeBindings != null) {
-      predeclared = new HashMap<>(predeclared);
+      predeclared = new LinkedHashMap<>(predeclared);
       predeclared.putAll(preludeBindings);
     }
     Module module = Module.withPredeclared(semantics, predeclared);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunction.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.skyframe;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
 import com.google.devtools.build.lib.bazel.bzlmod.Module;
@@ -36,7 +38,6 @@ import com.google.devtools.build.skyframe.SkyValue;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkSemantics;
 
@@ -140,7 +141,7 @@ public class RepositoryMappingFunction implements SkyFunction {
         if (env.valuesMissing()) {
           return null;
         }
-        Map<String, RepositoryName> additionalMappings =
+        ImmutableMap<String, RepositoryName> additionalMappings =
             externalPackageValue.getPackage().getTargets().entrySet().stream()
                 // We need to filter out the non repository rule targets in the //external package.
                 .filter(
@@ -148,7 +149,7 @@ public class RepositoryMappingFunction implements SkyFunction {
                         entry.getValue().getAssociatedRule() != null
                             && !entry.getValue().getAssociatedRule().getRuleClass().equals("bind"))
                 .collect(
-                    Collectors.toMap(
+                    toImmutableMap(
                         Entry::getKey, entry -> RepositoryName.createUnvalidated(entry.getKey())));
         return computeForBazelModuleRepo(repositoryName, bazelDepGraphValue)
             .get()

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RepositoryMappingValue.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.skyframe;
 import static java.util.Objects.requireNonNull;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.bzlmod.Version;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -27,7 +28,6 @@ import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
-import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -108,7 +108,8 @@ public record RepositoryMappingValue(
    * Replaces the inner {@link #getRepositoryMapping() repository mapping} with one returned by
    * calling its {@link RepositoryMapping#withAdditionalMappings} method.
    */
-  public final RepositoryMappingValue withAdditionalMappings(Map<String, RepositoryName> mappings) {
+  public final RepositoryMappingValue withAdditionalMappings(
+      ImmutableMap<String, RepositoryName> mappings) {
     return new RepositoryMappingValue(
         repositoryMapping().withAdditionalMappings(mappings),
         associatedModuleName(),

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainTypeLookupUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainTypeLookupUtil.java
@@ -32,9 +32,10 @@ import com.google.devtools.build.lib.skyframe.ConfiguredTargetKey;
 import com.google.devtools.build.lib.skyframe.ConfiguredValueCreationException;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyframeLookupResult;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedMap;
 import javax.annotation.Nullable;
 
 /** Helper class that looks up {@link ToolchainTypeInfo} data. */
@@ -60,7 +61,7 @@ public class ToolchainTypeLookupUtil {
 
     SkyframeLookupResult values = env.getValuesAndExceptions(toolchainTypesByKey.keySet());
     boolean valuesMissing = env.valuesMissing();
-    Map<Label, ToolchainTypeInfo> results = valuesMissing ? null : new HashMap<>();
+    SequencedMap<Label, ToolchainTypeInfo> results = valuesMissing ? null : new LinkedHashMap<>();
     for (Map.Entry<ConfiguredTargetKey, ToolchainTypeRequirement> entry :
         toolchainTypesByKey.entrySet()) {
       ConfiguredTargetKey key = entry.getKey();


### PR DESCRIPTION
Consumers of an `Immutable{List,Map,Set}` cannot know whether it has been created from a source with unspecified iteration order, such as `HashMap`. Since `ImmutableMap` itself prescribes that it preserves insertion order, it's reasonable for consumers to expect a specified, reasonable, deterministic order. While the current implementation of `HashMap` in the OpenJDK still results in a deterministic order, this kind of "sequenced-washing" doesn't cause non-determinism, but it still runs the risk of having the order of elements change between JDK versions or vendors.

The locations changed in this PR have been identified by instrumenting the factory methods of the `Immutable{List,Map,Set}` classes to track whether they 1) have been created from an unsequenced collection and 2) are iterated over. I then manually picked out those cases in which I couldn't rule out that a change in order would be observable to users.

Related to https://github.com/google/guava/issues/6903#issuecomment-2633372142