### PR TITLE
[8.1.0] Use digest function matching the checksum in gRPC remote downloader

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -70,7 +70,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
   private final Optional<CallCredentials> credentials;
   private final RemoteRetrier retrier;
   private final RemoteCacheClient cacheClient;
-  private final DigestFunction.Value digestFunction;
+  private final DigestFunction.Value defaultDigestFunction;
   private final RemoteOptions options;
   private final boolean verboseFailures;
   @Nullable private final Downloader fallbackDownloader;
@@ -100,7 +100,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       Optional<CallCredentials> credentials,
       RemoteRetrier retrier,
       RemoteCacheClient cacheClient,
-      DigestFunction.Value digestFunction,
+      DigestFunction.Value defaultDigestFunction,
       RemoteOptions options,
       boolean verboseFailures,
       @Nullable Downloader fallbackDownloader) {
@@ -110,7 +110,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     this.credentials = credentials;
     this.retrier = retrier;
     this.cacheClient = cacheClient;
-    this.digestFunction = digestFunction;
+    this.defaultDigestFunction = defaultDigestFunction;
     this.options = options;
     this.verboseFailures = verboseFailures;
     this.fallbackDownloader = fallbackDownloader;
@@ -149,7 +149,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
             urls,
             checksum,
             canonicalId,
-            digestFunction,
+            defaultDigestFunction,
             headers,
             credentials);
     try {
@@ -200,14 +200,12 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       List<URL> urls,
       Optional<Checksum> checksum,
       String canonicalId,
-      DigestFunction.Value digestFunction,
+      DigestFunction.Value defaultDigestFunction,
       Map<String, List<String>> headers,
       Credentials credentials)
       throws IOException {
     FetchBlobRequest.Builder requestBuilder =
-        FetchBlobRequest.newBuilder()
-            .setInstanceName(instanceName)
-            .setDigestFunction(digestFunction);
+        FetchBlobRequest.newBuilder().setInstanceName(instanceName);
     for (int i = 0; i < urls.size(); i++) {
       var url = urls.get(i);
       requestBuilder.addUris(url.toString());
@@ -233,12 +231,21 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     }
 
     if (checksum.isPresent()) {
+      requestBuilder.setDigestFunction(
+          switch (checksum.get().getKeyType()) {
+            case SHA1 -> DigestFunction.Value.SHA1;
+            case SHA256 -> DigestFunction.Value.SHA256;
+            case SHA384 -> DigestFunction.Value.SHA384;
+            case SHA512 -> DigestFunction.Value.SHA512;
+            case BLAKE3 -> DigestFunction.Value.BLAKE3;
+          });
       requestBuilder.addQualifiers(
           Qualifier.newBuilder()
               .setName(QUALIFIER_CHECKSUM_SRI)
               .setValue(checksum.get().toSubresourceIntegrity())
               .build());
     } else {
+      requestBuilder.setDigestFunction(defaultDigestFunction);
       // If no checksum is provided, never accept cached content.
       // Timestamp is offset by an hour to account for clock skew.
       requestBuilder.setOldestContentAccepted(


### PR DESCRIPTION
Fixes https://bazelbuild.slack.com/archives/CA31HN1T3/p1738763759125489

Closes #25206.

PiperOrigin-RevId: 724267755
Change-Id: Ia23bdae310231bd0ee5763311b948f3465aa8ed0

Commit https://github.com/bazelbuild/bazel/commit/ef45e02bfb4af1124bb9ad1ef94f36c70c82ce48