### PR TITLE
Replace counter with rule name in innate extension name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -191,7 +191,7 @@ public class BazelDepGraphFunction implements SkyFunction {
     // cannot be part of a valid repo name.
     String extensionName =
         id.isInnate()
-            ? "_repo_rule_" + id.extensionName().substring(id.extensionName().indexOf(' ') + 1)
+            ? id.extensionName().substring(id.extensionName().indexOf(' ') + 1)
             : id.extensionName();
     return id.isolationKey()
         .map(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelDepGraphFunction.java
@@ -187,9 +187,12 @@ public class BazelDepGraphFunction implements SkyFunction {
   private static String makeUniqueNameCandidate(ModuleExtensionId id, int attempt) {
     Preconditions.checkArgument(attempt >= 1);
     String extensionNameDisambiguator = attempt == 1 ? "" : String.valueOf(attempt);
-    // An innate extension name is of the form @repo//path/to/defs.bzl%repo_rule_name, which cannot
-    // be part of a valid repo name.
-    String extensionName = id.isInnate() ? "_repo_rules" : id.extensionName();
+    // An innate extension name is of the form "@repo//path/to/defs.bzl repo_rule_name", which
+    // cannot be part of a valid repo name.
+    String extensionName =
+        id.isInnate()
+            ? "_repo_rule_" + id.extensionName().substring(id.extensionName().indexOf(' ') + 1)
+            : id.extensionName();
     return id.isolationKey()
         .map(
             isolationKey ->

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileValue.java
@@ -38,7 +38,7 @@ public abstract class BazelLockFileValue implements SkyValue {
   // https://cs.opensource.google/bazel/bazel/+/release-7.3.0:src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java;l=120-127;drc=5f5355b75c7c93fba1e15f6658f308953f4baf51
   // While this hack exists on 7.x, lockfile version increments should be done 2 at a time (i.e.
   // keep this number even).
-  public static final int LOCK_FILE_VERSION = 18;
+  public static final int LOCK_FILE_VERSION = 20;
 
   @SerializationConstant public static final SkyKey KEY = () -> SkyFunctions.BAZEL_LOCK_FILE;
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2692,7 +2692,7 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     assertThat(result.get(skyKey).getModule().getGlobal("data"))
         .isEqualTo("get up at 6am. go to bed at 11pm.");
     assertThat(result.get(skyKey).getModule().getGlobal("names"))
-        .isEqualTo("+_repo_rule_data_repo+data1 foo++_repo_rule_data_repo+data2");
+        .isEqualTo("+data_repo+data1 foo++data_repo+data2");
     assertThat(result.get(skyKey).getModule().getGlobal("original_names")).isEqualTo("data1 data2");
   }
 
@@ -2824,7 +2824,7 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     assertThat(result.hasError()).isTrue();
     assertContainsEvent(
         """
-        ERROR /workspace/MODULE.bazel:3:10: //:+_repo_rule_data_repo+data: expected value of type 'string' \
+        ERROR /workspace/MODULE.bazel:3:10: //:+data_repo+data: expected value of type 'string' \
         for attribute 'data' of 'data_repo', but got 5 (int)\
         """);
     assertThat(result.getError().getException())
@@ -3000,10 +3000,10 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     }
     assertThat((List<?>) result.get(skyKey).getModule().getGlobal("bar_list"))
         .containsExactly(
-            "@@+_repo_rule_data_repo+override//:target1",
-            "@@+_repo_rule_data_repo+override//:target2",
-            "@@+_repo_rule_data_repo+override//:target3",
-            "@@+_repo_rule_data_repo+override//:target4")
+            "@@+data_repo+override//:target1",
+            "@@+data_repo+override//:target2",
+            "@@+data_repo+override//:target3",
+            "@@+data_repo+override//:target4")
         .inOrder();
     Object overrideData = result.get(skyKey).getModule().getGlobal("override_data");
     assertThat(overrideData).isInstanceOf(String.class);
@@ -3133,10 +3133,10 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     }
     assertThat((List<?>) result.get(skyKey).getModule().getGlobal("bar_list"))
         .containsExactly(
-            "@@+_repo_rule_data_repo+foo//:target1",
-            "@@+_repo_rule_data_repo+foo//:target2",
-            "@@+_repo_rule_data_repo+foo//:target3",
-            "@@+_repo_rule_data_repo+foo//:target4")
+            "@@+data_repo+foo//:target1",
+            "@@+data_repo+foo//:target2",
+            "@@+data_repo+foo//:target3",
+            "@@+data_repo+foo//:target4")
         .inOrder();
     Object fooData = result.get(skyKey).getModule().getGlobal("foo_data");
     assertThat(fooData).isInstanceOf(String.class);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -2692,7 +2692,7 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     assertThat(result.get(skyKey).getModule().getGlobal("data"))
         .isEqualTo("get up at 6am. go to bed at 11pm.");
     assertThat(result.get(skyKey).getModule().getGlobal("names"))
-        .isEqualTo("+_repo_rules+data1 foo++_repo_rules+data2");
+        .isEqualTo("+_repo_rule_data_repo+data1 foo++_repo_rule_data_repo+data2");
     assertThat(result.get(skyKey).getModule().getGlobal("original_names")).isEqualTo("data1 data2");
   }
 
@@ -2824,7 +2824,7 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     assertThat(result.hasError()).isTrue();
     assertContainsEvent(
         """
-        ERROR /workspace/MODULE.bazel:3:10: //:+_repo_rules+data: expected value of type 'string' \
+        ERROR /workspace/MODULE.bazel:3:10: //:+_repo_rule_data_repo+data: expected value of type 'string' \
         for attribute 'data' of 'data_repo', but got 5 (int)\
         """);
     assertThat(result.getError().getException())
@@ -3000,10 +3000,10 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     }
     assertThat((List<?>) result.get(skyKey).getModule().getGlobal("bar_list"))
         .containsExactly(
-            "@@+_repo_rules+override//:target1",
-            "@@+_repo_rules+override//:target2",
-            "@@+_repo_rules+override//:target3",
-            "@@+_repo_rules+override//:target4")
+            "@@+_repo_rule_data_repo+override//:target1",
+            "@@+_repo_rule_data_repo+override//:target2",
+            "@@+_repo_rule_data_repo+override//:target3",
+            "@@+_repo_rule_data_repo+override//:target4")
         .inOrder();
     Object overrideData = result.get(skyKey).getModule().getGlobal("override_data");
     assertThat(overrideData).isInstanceOf(String.class);
@@ -3133,10 +3133,10 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
     }
     assertThat((List<?>) result.get(skyKey).getModule().getGlobal("bar_list"))
         .containsExactly(
-            "@@+_repo_rules+foo//:target1",
-            "@@+_repo_rules+foo//:target2",
-            "@@+_repo_rules+foo//:target3",
-            "@@+_repo_rules+foo//:target4")
+            "@@+_repo_rule_data_repo+foo//:target1",
+            "@@+_repo_rule_data_repo+foo//:target2",
+            "@@+_repo_rule_data_repo+foo//:target3",
+            "@@+_repo_rule_data_repo+foo//:target4")
         .inOrder();
     Object fooData = result.get(skyKey).getModule().getGlobal("foo_data");
     assertThat(fooData).isInstanceOf(String.class);

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryIntegrationTest.java
@@ -62,7 +62,7 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foo', path='/repo2')");
     invalidatePackages();
-    getConfiguredTargetAndData("@@+_repo_rules+foo//:bar");
+    getConfiguredTargetAndData("@@+_repo_rule_repo+foo//:bar");
   }
 
   @Test
@@ -91,7 +91,7 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foo', path='/repo2')");
     invalidatePackages();
-    getConfiguredTargetAndData("@@+_repo_rules+foo//:bar");
+    getConfiguredTargetAndData("@@+_repo_rule_repo+foo//:bar");
   }
 
   @Test
@@ -120,7 +120,7 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foo')");
     invalidatePackages();
-    getConfiguredTargetAndData("@@+_repo_rules+foo//:bar");
+    getConfiguredTargetAndData("@@+_repo_rule_repo+foo//:bar");
   }
 
   @Test
@@ -146,11 +146,11 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foo')");
     invalidatePackages();
-    ConfiguredTargetAndData target = getConfiguredTargetAndData("@@+_repo_rules+foo//:bar");
+    ConfiguredTargetAndData target = getConfiguredTargetAndData("@@+_repo_rule_repo+foo//:bar");
     @SuppressWarnings("unchecked")
     List<Label> srcs =
         (List<Label>) target.getTargetForTesting().getAssociatedRule().getAttr("srcs", LABEL_LIST);
-    assertThat(srcs).containsExactly(Label.parseCanonical("@@+_repo_rules+foo//:foo"));
+    assertThat(srcs).containsExactly(Label.parseCanonical("@@+_repo_rule_repo+foo//:foo"));
   }
 
   @Test
@@ -177,12 +177,13 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foobar')");
     invalidatePackages();
-    ConfiguredTargetAndData target = getConfiguredTargetAndData("@@+_repo_rules+foobar//:bar");
+    ConfiguredTargetAndData target = getConfiguredTargetAndData("@@+_repo_rule_repo+foobar//:bar");
     @SuppressWarnings("unchecked")
     List<Label> srcs =
         (List<Label>) target.getTargetForTesting().getAssociatedRule().getAttr("srcs", LABEL_LIST);
     assertThat(srcs)
-        .containsExactly(Label.parseCanonical("@@+_repo_rules+foobar//:+_repo_rules+foobar"));
+        .containsExactly(
+            Label.parseCanonical("@@+_repo_rule_repo+foobar//:+_repo_rule_repo+foobar"));
   }
 
   @Test
@@ -206,7 +207,8 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
 
     invalidatePackages();
     AssertionError e =
-        assertThrows(AssertionError.class, () -> getConfiguredTarget("@@+_repo_rules+foo//:bar"));
+        assertThrows(
+            AssertionError.class, () -> getConfiguredTarget("@@+_repo_rule_repo+foo//:bar"));
     assertThat(e)
         .hasMessageThat()
         .contains("There is already a built-in attribute 'name' " + "which cannot be overridden");

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryIntegrationTest.java
@@ -62,7 +62,7 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foo', path='/repo2')");
     invalidatePackages();
-    getConfiguredTargetAndData("@@+_repo_rule_repo+foo//:bar");
+    getConfiguredTargetAndData("@@+repo+foo//:bar");
   }
 
   @Test
@@ -91,7 +91,7 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foo', path='/repo2')");
     invalidatePackages();
-    getConfiguredTargetAndData("@@+_repo_rule_repo+foo//:bar");
+    getConfiguredTargetAndData("@@+repo+foo//:bar");
   }
 
   @Test
@@ -120,7 +120,7 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foo')");
     invalidatePackages();
-    getConfiguredTargetAndData("@@+_repo_rule_repo+foo//:bar");
+    getConfiguredTargetAndData("@@+repo+foo//:bar");
   }
 
   @Test
@@ -146,11 +146,11 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foo')");
     invalidatePackages();
-    ConfiguredTargetAndData target = getConfiguredTargetAndData("@@+_repo_rule_repo+foo//:bar");
+    ConfiguredTargetAndData target = getConfiguredTargetAndData("@@+repo+foo//:bar");
     @SuppressWarnings("unchecked")
     List<Label> srcs =
         (List<Label>) target.getTargetForTesting().getAssociatedRule().getAttr("srcs", LABEL_LIST);
-    assertThat(srcs).containsExactly(Label.parseCanonical("@@+_repo_rule_repo+foo//:foo"));
+    assertThat(srcs).containsExactly(Label.parseCanonical("@@+repo+foo//:foo"));
   }
 
   @Test
@@ -177,13 +177,13 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
         "repo = use_repo_rule('//:def.bzl', 'repo')",
         "repo(name='foobar')");
     invalidatePackages();
-    ConfiguredTargetAndData target = getConfiguredTargetAndData("@@+_repo_rule_repo+foobar//:bar");
+    ConfiguredTargetAndData target = getConfiguredTargetAndData("@@+repo+foobar//:bar");
     @SuppressWarnings("unchecked")
     List<Label> srcs =
         (List<Label>) target.getTargetForTesting().getAssociatedRule().getAttr("srcs", LABEL_LIST);
     assertThat(srcs)
         .containsExactly(
-            Label.parseCanonical("@@+_repo_rule_repo+foobar//:+_repo_rule_repo+foobar"));
+            Label.parseCanonical("@@+repo+foobar//:+repo+foobar"));
   }
 
   @Test
@@ -208,7 +208,7 @@ public class StarlarkRepositoryIntegrationTest extends BuildViewTestCase {
     invalidatePackages();
     AssertionError e =
         assertThrows(
-            AssertionError.class, () -> getConfiguredTarget("@@+_repo_rule_repo+foo//:bar"));
+            AssertionError.class, () -> getConfiguredTarget("@@+repo+foo//:bar"));
     assertThat(e)
         .hasMessageThat()
         .contains("There is already a built-in attribute 'name' " + "which cannot be overridden");

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
@@ -113,13 +113,13 @@ public class BazelEmbeddedStarlarkBlackBoxTest extends AbstractBlackBoxTest {
         context()
             .resolveBinPath(
                 bazel,
-                String.format("external/+_repo_rule_local_repository+ext_local/%s.tar", tarTarget));
+                String.format("external/+local_repository+ext_local/%s.tar", tarTarget));
     Files.copy(packedFile, zipFile);
 
     // now build the target from http_archive
     bazel.build("@ext//:" + RepoWithRuleWritingTextGenerator.TARGET);
 
-    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rule_http_archive+ext/out");
+    Path xPath = context().resolveBinPath(bazel, "external/+http_archive+ext/out");
     WorkspaceTestUtils.assertLinesExactly(xPath, HELLO_FROM_EXTERNAL_REPOSITORY);
 
     // and use the rule from http_archive in the main repository

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
@@ -112,13 +112,14 @@ public class BazelEmbeddedStarlarkBlackBoxTest extends AbstractBlackBoxTest {
     Path packedFile =
         context()
             .resolveBinPath(
-                bazel, String.format("external/+_repo_rules+ext_local/%s.tar", tarTarget));
+                bazel,
+                String.format("external/+_repo_rule_local_repository+ext_local/%s.tar", tarTarget));
     Files.copy(packedFile, zipFile);
 
     // now build the target from http_archive
     bazel.build("@ext//:" + RepoWithRuleWritingTextGenerator.TARGET);
 
-    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rules2+ext/out");
+    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rule_http_archive+ext/out");
     WorkspaceTestUtils.assertLinesExactly(xPath, HELLO_FROM_EXTERNAL_REPOSITORY);
 
     // and use the rule from http_archive in the main repository

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryBlackBoxTest.java
@@ -85,7 +85,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
     Path outPath =
-        context().resolveBinPath(bazel, "external/+_repo_rule_new_git_repository+ext/out.txt");
+        context().resolveBinPath(bazel, "external/+new_git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
@@ -118,7 +118,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
     Path outPath =
-        context().resolveBinPath(bazel, "external/+_repo_rule_new_git_repository+ext/out.txt");
+        context().resolveBinPath(bazel, "external/+new_git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
@@ -151,7 +151,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
     Path outPath =
-        context().resolveBinPath(bazel, "external/+_repo_rule_new_git_repository+ext/out.txt");
+        context().resolveBinPath(bazel, "external/+new_git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
@@ -196,7 +196,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rule_git_repository+ext/out");
+    Path outPath = context().resolveBinPath(bazel, "external/+git_repository+ext/out");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_BRANCH);
   }
 
@@ -247,7 +247,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rule_git_repository+ext/out");
+    Path outPath = context().resolveBinPath(bazel, "external/+git_repository+ext/out");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_BRANCH);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryBlackBoxTest.java
@@ -84,7 +84,8 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rules+ext/out.txt");
+    Path outPath =
+        context().resolveBinPath(bazel, "external/+_repo_rule_new_git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
@@ -116,7 +117,8 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rules+ext/out.txt");
+    Path outPath =
+        context().resolveBinPath(bazel, "external/+_repo_rule_new_git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
@@ -148,7 +150,8 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:call_write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rules+ext/out.txt");
+    Path outPath =
+        context().resolveBinPath(bazel, "external/+_repo_rule_new_git_repository+ext/out.txt");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
   }
 
@@ -193,7 +196,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rules+ext/out");
+    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rule_git_repository+ext/out");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_BRANCH);
   }
 
@@ -244,7 +247,7 @@ public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
     // This creates Bazel without MSYS, see implementation for details.
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@ext//:write_text");
-    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rules+ext/out");
+    Path outPath = context().resolveBinPath(bazel, "external/+_repo_rule_git_repository+ext/out");
     WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_BRANCH);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/PatchApiBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/PatchApiBlackBoxTest.java
@@ -159,7 +159,7 @@ public class PatchApiBlackBoxTest extends AbstractBlackBoxTest {
       // foo.sh.orig should be generated due to "-b" argument.
       Path fooOrig =
           context()
-              .resolveExecRootPath(bazel, "external/+_repo_rule_patched_repo+test/foo.sh.orig");
+              .resolveExecRootPath(bazel, "external/+patched_repo+test/foo.sh.orig");
       assertThat(fooOrig.toFile().exists()).isTrue();
     }
   }
@@ -203,7 +203,7 @@ public class PatchApiBlackBoxTest extends AbstractBlackBoxTest {
 
   private void assertFooIsPatched(BuilderRunner bazel) throws Exception {
     Path foo =
-        context().resolveExecRootPath(bazel, "external/+_repo_rule_patched_repo+test/foo.sh");
+        context().resolveExecRootPath(bazel, "external/+patched_repo+test/foo.sh");
     assertThat(foo.toFile().exists()).isTrue();
     ImmutableList<String> patchedFoo =
         ImmutableList.of(

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/PatchApiBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/PatchApiBlackBoxTest.java
@@ -157,7 +157,9 @@ public class PatchApiBlackBoxTest extends AbstractBlackBoxTest {
     } else {
       assertFooIsPatched(bazel);
       // foo.sh.orig should be generated due to "-b" argument.
-      Path fooOrig = context().resolveExecRootPath(bazel, "external/+_repo_rules+test/foo.sh.orig");
+      Path fooOrig =
+          context()
+              .resolveExecRootPath(bazel, "external/+_repo_rule_patched_repo+test/foo.sh.orig");
       assertThat(fooOrig.toFile().exists()).isTrue();
     }
   }
@@ -200,7 +202,8 @@ public class PatchApiBlackBoxTest extends AbstractBlackBoxTest {
   }
 
   private void assertFooIsPatched(BuilderRunner bazel) throws Exception {
-    Path foo = context().resolveExecRootPath(bazel, "external/+_repo_rules+test/foo.sh");
+    Path foo =
+        context().resolveExecRootPath(bazel, "external/+_repo_rule_patched_repo+test/foo.sh");
     assertThat(foo.toFile().exists()).isTrue();
     ImmutableList<String> patchedFoo =
         ImmutableList.of(

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -138,19 +138,19 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
 
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@relative//:debug_me");
-    Path outFile = context().resolveBinPath(bazel, "external/+_repo_rules+relative/out");
+    Path outFile = context().resolveBinPath(bazel, "external/+_repo_rule_check_wd+relative/out");
     assertThat(outFile.toFile().exists()).isTrue();
     List<String> lines = PathUtils.readFile(outFile);
     assertThat(lines.size()).isEqualTo(1);
     assertThat(
-            Paths.get(lines.get(0)).endsWith(Paths.get("external/+_repo_rules+relative/relative")))
+            Paths.get(lines.get(0)).endsWith(Paths.get("external/+_repo_rule_check_wd+relative/relative")))
         .isTrue();
 
     bazel.build("@relative2//:debug_me");
     bazel.build("@absolute//:debug_me");
 
     bazel.build("@absolute2//:debug_me");
-    Path outFile2 = context().resolveBinPath(bazel, "external/+_repo_rules+absolute2/out");
+    Path outFile2 = context().resolveBinPath(bazel, "external/+_repo_rule_check_wd+absolute2/out");
     assertThat(outFile2.toFile().exists()).isTrue();
     List<String> lines2 = PathUtils.readFile(outFile2);
     assertThat(lines2.size()).isEqualTo(1);
@@ -177,7 +177,7 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@x//:" + RepoWithRuleWritingTextGenerator.TARGET);
 
-    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rules+x/out");
+    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rule_local_repository+x/out");
     WorkspaceTestUtils.assertLinesExactly(xPath, "hi");
 
     context()
@@ -213,7 +213,7 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
             // and Bazel recognizes that there is a terminal, so progress events will be displayed
             .withFlags("--experimental_ui_debug_all_events", "--curses=yes");
 
-    final String progressMessage = "PROGRESS <no location>: Loading package: @@+_repo_rules+ext//";
+    final String progressMessage = "PROGRESS <no location>: Loading package: @@+_repo_rule_local_repository+ext//";
 
     ProcessResult result = bazel.query("@ext//:all");
     assertThat(result.outString()).contains(progressMessage);

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -138,19 +138,19 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
 
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@relative//:debug_me");
-    Path outFile = context().resolveBinPath(bazel, "external/+_repo_rule_check_wd+relative/out");
+    Path outFile = context().resolveBinPath(bazel, "external/+check_wd+relative/out");
     assertThat(outFile.toFile().exists()).isTrue();
     List<String> lines = PathUtils.readFile(outFile);
     assertThat(lines.size()).isEqualTo(1);
     assertThat(
-            Paths.get(lines.get(0)).endsWith(Paths.get("external/+_repo_rule_check_wd+relative/relative")))
+            Paths.get(lines.get(0)).endsWith(Paths.get("external/+check_wd+relative/relative")))
         .isTrue();
 
     bazel.build("@relative2//:debug_me");
     bazel.build("@absolute//:debug_me");
 
     bazel.build("@absolute2//:debug_me");
-    Path outFile2 = context().resolveBinPath(bazel, "external/+_repo_rule_check_wd+absolute2/out");
+    Path outFile2 = context().resolveBinPath(bazel, "external/+check_wd+absolute2/out");
     assertThat(outFile2.toFile().exists()).isTrue();
     List<String> lines2 = PathUtils.readFile(outFile2);
     assertThat(lines2.size()).isEqualTo(1);
@@ -177,7 +177,7 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@x//:" + RepoWithRuleWritingTextGenerator.TARGET);
 
-    Path xPath = context().resolveBinPath(bazel, "external/+_repo_rule_local_repository+x/out");
+    Path xPath = context().resolveBinPath(bazel, "external/+local_repository+x/out");
     WorkspaceTestUtils.assertLinesExactly(xPath, "hi");
 
     context()
@@ -213,7 +213,7 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
             // and Bazel recognizes that there is a terminal, so progress events will be displayed
             .withFlags("--experimental_ui_debug_all_events", "--curses=yes");
 
-    final String progressMessage = "PROGRESS <no location>: Loading package: @@+_repo_rule_local_repository+ext//";
+    final String progressMessage = "PROGRESS <no location>: Loading package: @@+local_repository+ext//";
 
     ProcessResult result = bazel.query("@ext//:all");
     assertThat(result.outString()).contains(progressMessage);

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -364,7 +364,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
 
     StoredEventHandler eventHandler = new StoredEventHandler();
     SkyKey key =
-        RepositoryDirectoryValue.key(RepositoryName.createUnvalidated("+_repo_rules+broken"));
+        RepositoryDirectoryValue.key(RepositoryName.createUnvalidated("+_repo_rule_broken_repo+broken"));
     // Make it be evaluated every time, as we are testing evaluation.
     differencer.invalidate(ImmutableSet.of(key));
     EvaluationContext evaluationContext =

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -364,7 +364,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
 
     StoredEventHandler eventHandler = new StoredEventHandler();
     SkyKey key =
-        RepositoryDirectoryValue.key(RepositoryName.createUnvalidated("+_repo_rule_broken_repo+broken"));
+        RepositoryDirectoryValue.key(RepositoryName.createUnvalidated("+broken_repo+broken"));
     // Make it be evaluated every time, as we are testing evaluation.
     differencer.invalidate(ImmutableSet.of(key));
     EvaluationContext evaluationContext =

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -324,7 +324,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     )
     self.AssertExitCode(exit_code, 1, stderr)
     self.assertIn(
-        "'@@+_repo_rules+other_repo//pkg/ignore' is a subpackage",
+        "'@@+_repo_rule_local_repository+other_repo//pkg/ignore' is a subpackage",
         ''.join(stderr),
     )
 
@@ -333,7 +333,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
             'build',
             '@other_repo//pkg:file',
             # TODO(bzlmod): support apparent repo name for --deleted_packages
-            '--deleted_packages=@@+_repo_rules+other_repo//pkg/ignore',
+            '--deleted_packages=@@+_repo_rule_local_repository+other_repo//pkg/ignore',
         ],
         cwd=work_dir,
     )
@@ -362,7 +362,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     )
     self.AssertExitCode(exit_code, 1, stderr)
     self.assertIn(
-        "'@@+_repo_rules+other_repo//pkg/ignore' is a subpackage",
+        "'@@+_repo_rule_local_repository+other_repo//pkg/ignore' is a subpackage",
         ''.join(stderr),
     )
 
@@ -383,7 +383,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     )
     self.AssertExitCode(exit_code, 1, stderr)
     self.assertIn(
-        "no such package '@@+_repo_rules+other_repo//pkg/ignore'",
+        "no such package '@@+_repo_rule_local_repository+other_repo//pkg/ignore'",
         ''.join(stderr),
     )
 

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -324,7 +324,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     )
     self.AssertExitCode(exit_code, 1, stderr)
     self.assertIn(
-        "'@@+_repo_rule_local_repository+other_repo//pkg/ignore' is a subpackage",
+        "'@@+local_repository+other_repo//pkg/ignore' is a subpackage",
         ''.join(stderr),
     )
 
@@ -333,7 +333,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
             'build',
             '@other_repo//pkg:file',
             # TODO(bzlmod): support apparent repo name for --deleted_packages
-            '--deleted_packages=@@+_repo_rule_local_repository+other_repo//pkg/ignore',
+            '--deleted_packages=@@+local_repository+other_repo//pkg/ignore',
         ],
         cwd=work_dir,
     )
@@ -362,7 +362,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     )
     self.AssertExitCode(exit_code, 1, stderr)
     self.assertIn(
-        "'@@+_repo_rule_local_repository+other_repo//pkg/ignore' is a subpackage",
+        "'@@+local_repository+other_repo//pkg/ignore' is a subpackage",
         ''.join(stderr),
     )
 
@@ -383,7 +383,7 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     )
     self.AssertExitCode(exit_code, 1, stderr)
     self.assertIn(
-        "no such package '@@+_repo_rule_local_repository+other_repo//pkg/ignore'",
+        "no such package '@@+local_repository+other_repo//pkg/ignore'",
         ''.join(stderr),
     )
 

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -384,7 +384,8 @@ class BazelWindowsCppTest(test_base.TestBase):
     # Test if A.dll is copied to the directory of main.exe
     main_bin = os.path.join(bazel_bin, 'main.exe')
     self.assertTrue(os.path.exists(main_bin))
-    self.assertTrue(os.path.exists(os.path.join(bazel_bin, 'A_729d833d.dll')))
+    self.assertEqual(
+      len(glob.glob(os.path.join(bazel_bin, 'A_*.dll'))), 1)
 
     # Run the binary to see if it runs successfully
     _, stdout, _ = self.RunProgram([main_bin])

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -105,9 +105,9 @@ class BazelFetchTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="hello")',
@@ -143,10 +143,10 @@ class BazelFetchTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
-            'repo_rule2 = repository_rule(implementation=_repo_rule_impl, ',
+            'repo_rule = repository_rule(implementation=impl)',
+            'repo_rule2 = repository_rule(implementation=impl, ',
             'configure=True)',
             '',
             'def _ext_impl(ctx):',
@@ -184,7 +184,7 @@ class BazelFetchTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    print("Fetching {}".format(ctx.attr.name))',
             '    if ctx.attr.name.endswith("IamConfig"):',
             (
@@ -192,8 +192,8 @@ class BazelFetchTest(test_base.TestBase):
                 ' ctx.path(Label("@notConfig//:whatever")).dirname.readdir()'
             ),
             '    ctx.file("BUILD")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
-            'repo_rule2 = repository_rule(implementation=_repo_rule_impl, ',
+            'repo_rule = repository_rule(implementation=impl)',
+            'repo_rule2 = repository_rule(implementation=impl, ',
             'configure=True)',
             '',
             'def _ext_impl(ctx):',
@@ -309,11 +309,11 @@ class BazelFetchTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    file_content = ctx.read("' + file_path + '", watch="no")',
             '    print(file_content)',
             '    ctx.file("BUILD")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="hello")',

--- a/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_lockfile_test.py
@@ -363,10 +363,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    print("Hello from the other side!")',
@@ -417,10 +417,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    print("Hello from the other side, %s!" % ctx.is_isolated)',
@@ -464,10 +464,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    print("Hello from the other side, %s!" % ctx.is_isolated)',
@@ -535,9 +535,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             'def _ext_a_impl(ctx):',
             '    repo_rule(name="hello_ext_A")',
             'def _ext_b_impl(ctx):',
@@ -568,9 +568,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
-            'repo_rule = repository_rule(implementation = _repo_rule_impl)',
+            'repo_rule = repository_rule(implementation = impl)',
             'def _mod_ext_impl(ctx):',
             '    print("Hello from the other side!")',
             '    repo_rule(name= "hello")',
@@ -595,9 +595,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
-            'repo_rule = repository_rule(implementation = _repo_rule_impl)',
+            'repo_rule = repository_rule(implementation = impl)',
             'def _mod_ext_impl(ctx):',
             '    print("Hello from the other town!")',
             '    repo_rule(name= "hello")',
@@ -625,9 +625,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
-            'repo_rule = repository_rule(implementation = _repo_rule_impl)',
+            'repo_rule = repository_rule(implementation = impl)',
             'def _mod_ext_impl(ctx):',
             '    print("Hello from the other side!")',
             '    repo_rule(name= "hello")',
@@ -642,9 +642,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\\"lalo\\")")',
-            'repo_rule = repository_rule(implementation = _repo_rule_impl)',
+            'repo_rule = repository_rule(implementation = impl)',
             'def _mod_ext_impl(ctx):',
             '    print("Hello from the other town!")',
             '    repo_rule(name= "hello")',
@@ -681,9 +681,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             'def _ext_impl(ctx):',
             '    repo_rule(name="hello")',
             'ext = module_extension(implementation=_ext_impl)',
@@ -719,10 +719,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    for mod in ctx.modules:',
@@ -778,9 +778,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
-            'repo_rule = repository_rule(implementation = _repo_rule_impl)',
+            'repo_rule = repository_rule(implementation = impl)',
             'def _module_ext_impl(ctx):',
             '    print("Hello from the other side!")',
             '    repo_rule(name= "hello")',
@@ -819,9 +819,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\\"lala\\")")',
-            'repo_rule = repository_rule(implementation = _repo_rule_impl)',
+            'repo_rule = repository_rule(implementation = impl)',
             'def _module_ext_impl(ctx):',
             '    print("Hello from the other side!")',
             '    repo_rule(name= "hello")',
@@ -861,10 +861,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    print("I am running the extension")',
@@ -944,10 +944,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    print("I am being evaluated")',
@@ -1065,10 +1065,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    repo_rule(name="hello")',
@@ -1108,10 +1108,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext1_impl(ctx):',
             '    repo_rule(name="hello1")',
@@ -1162,10 +1162,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext1_impl(ctx):',
             '    repo_rule(name="hello1")',
@@ -1216,10 +1216,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext1_impl(ctx):',
             '    print("Hello from ext1!")',
@@ -1270,9 +1270,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    repo_rule(name="hello")',
@@ -1304,9 +1304,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    repo_rule(name="hello")',
@@ -1336,9 +1336,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    repo_rule(name="hello")',
@@ -1379,13 +1379,13 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "exports_files([\\"data.txt\\"])")',
             '    ctx.file("data.txt", ctx.attr.value)',
             '    print(ctx.attr.value)',
             '',
             'repo_rule = repository_rule(',
-            '    implementation=_repo_rule_impl,',
+            '    implementation=impl,',
             '    attrs = {"value": attr.string()},)',
             '',
             'def _ext_1_impl(ctx):',
@@ -1616,13 +1616,13 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "exports_files([\\"data.txt\\"])")',
             '    ctx.file("data.txt", ctx.attr.value)',
             '    print(ctx.attr.value)',
             '',
             'repo_rule = repository_rule(',
-            '    implementation=_repo_rule_impl,',
+            '    implementation=impl,',
             '    attrs = {"value": attr.string()},)',
             '',
             'def _ext_impl(ctx):',
@@ -2123,9 +2123,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _should_lock_impl(ctx): repo_rule(name="repo1")',
             'def _no_lock_impl(ctx):',
@@ -2150,9 +2150,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _should_lock_impl(ctx): repo_rule(name="repo2")',
             'def _no_lock_impl(ctx):',
@@ -2186,9 +2186,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="repo")',
@@ -2213,9 +2213,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx): repo_rule(name="repo")',
             'ext = module_extension(implementation=_ext_impl)',
@@ -2244,9 +2244,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    ctx.file("hello", "repo")',
@@ -2276,9 +2276,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name=ctx.read(%s, watch="yes"))'
@@ -2307,9 +2307,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'repo\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    print("I see: " + ",".join(sorted([e.basename for e in'
@@ -2348,9 +2348,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'repo\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    print("I see: " + ",".join(sorted([e.basename for e in'
@@ -2385,9 +2385,9 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'repo\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    print("I see: " + ",".join(sorted([e.basename for e in'
@@ -2419,10 +2419,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             '    print("I am running the extension: " + ctx.modules[0].name)',
@@ -2474,10 +2474,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             (
@@ -2529,10 +2529,10 @@ class BazelLockfileTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _module_ext_impl(ctx):',
             (

--- a/src/test/py/bazel/bzlmod/bazel_module_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_module_test.py
@@ -352,9 +352,9 @@ class BazelModuleTest(test_base.TestBase):
     self.ScratchFile(
         'pkg/rules.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    pass',
-            'repo_rule = repository_rule(implementation = _repo_rule_impl)',
+            'repo_rule = repository_rule(implementation = impl)',
         ],
     )
     self.ScratchFile('pkg/extension.bzl', [

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -603,13 +603,13 @@ class BazelOverridesTest(test_base.TestBase):
         '',
     ])
     main_repo_mapping = json.loads('\n'.join(stdout))
-    self.assertEqual(main_repo_mapping['my_repo'], '+_repo_rule_my_repo+my_repo')
+    self.assertEqual(main_repo_mapping['my_repo'], '+_repo_rule_local_repository+my_repo')
 
     _, stdout, _ = self.RunBazel([
         'mod',
         'dump_repo_mapping',
         '--inject_repository=my_repo=%workspace%/other_repo',
-        '+_repo_rule_my_repo+my_repo',
+        '+_repo_rule_local_repository+my_repo',
     ])
     my_repo_mapping = json.loads('\n'.join(stdout))
     self.assertEqual(main_repo_mapping, my_repo_mapping)

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -603,13 +603,13 @@ class BazelOverridesTest(test_base.TestBase):
         '',
     ])
     main_repo_mapping = json.loads('\n'.join(stdout))
-    self.assertEqual(main_repo_mapping['my_repo'], '+_repo_rule_local_repository+my_repo')
+    self.assertEqual(main_repo_mapping['my_repo'], '+local_repository+my_repo')
 
     _, stdout, _ = self.RunBazel([
         'mod',
         'dump_repo_mapping',
         '--inject_repository=my_repo=%workspace%/other_repo',
-        '+_repo_rule_local_repository+my_repo',
+        '+local_repository+my_repo',
     ])
     my_repo_mapping = json.loads('\n'.join(stdout))
     self.assertEqual(main_repo_mapping, my_repo_mapping)

--- a/src/test/py/bazel/bzlmod/bazel_overrides_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_overrides_test.py
@@ -603,13 +603,13 @@ class BazelOverridesTest(test_base.TestBase):
         '',
     ])
     main_repo_mapping = json.loads('\n'.join(stdout))
-    self.assertEqual(main_repo_mapping['my_repo'], '+_repo_rules+my_repo')
+    self.assertEqual(main_repo_mapping['my_repo'], '+_repo_rule_my_repo+my_repo')
 
     _, stdout, _ = self.RunBazel([
         'mod',
         'dump_repo_mapping',
         '--inject_repository=my_repo=%workspace%/other_repo',
-        '+_repo_rules+my_repo',
+        '+_repo_rule_my_repo+my_repo',
     ])
     my_repo_mapping = json.loads('\n'.join(stdout))
     self.assertEqual(main_repo_mapping, my_repo_mapping)

--- a/src/test/py/bazel/bzlmod/bazel_vendor_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_vendor_test.py
@@ -306,14 +306,14 @@ class BazelVendorTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD")',
             '',
-            'repo_rule1 = repository_rule(implementation=_repo_rule_impl)',
-            'repo_rule2 = repository_rule(implementation=_repo_rule_impl, ',
+            'repo_rule1 = repository_rule(implementation=impl)',
+            'repo_rule2 = repository_rule(implementation=impl, ',
             'local=True)',
-            'repo_rule3 = repository_rule(implementation=_repo_rule_impl, ',
+            'repo_rule3 = repository_rule(implementation=impl, ',
             'configure=True)',
             '',
             'def _ext_impl(ctx):',
@@ -356,10 +356,10 @@ class BazelVendorTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="venRepo")',
@@ -373,10 +373,10 @@ class BazelVendorTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'IhaveChanged\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="venRepo")',
@@ -438,10 +438,10 @@ class BazelVendorTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="justRepo")',
@@ -462,10 +462,10 @@ class BazelVendorTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'haha\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="justRepo")',
@@ -511,10 +511,10 @@ class BazelVendorTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="venRepo")',
@@ -539,10 +539,10 @@ class BazelVendorTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'haha\')")',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="venRepo")',

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -662,11 +662,11 @@ class ModCommandTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext1_impl(ctx):',
             '    print("ext1 is being evaluated")',
@@ -816,11 +816,11 @@ class ModCommandTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="dep")',
@@ -860,11 +860,11 @@ class ModCommandTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="dep")',
@@ -1013,11 +1013,11 @@ class ModCommandTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext1_impl(ctx):',
             '    print("ext1 is being evaluated")',
@@ -1152,11 +1152,11 @@ class ModCommandTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="dep")',
@@ -1231,11 +1231,11 @@ class ModCommandTest(test_base.TestBase):
     self.ScratchFile(
         'extension.bzl',
         [
-            'def _repo_rule_impl(ctx):',
+            'def impl(ctx):',
             '    ctx.file("WORKSPACE")',
             '    ctx.file("BUILD", "filegroup(name=\'lala\')")',
             '',
-            'repo_rule = repository_rule(implementation=_repo_rule_impl)',
+            'repo_rule = repository_rule(implementation=impl)',
             '',
             'def _ext_impl(ctx):',
             '    repo_rule(name="dep")',

--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -322,7 +322,7 @@ class PyRunfilesLibraryTest(test_base.TestBase):
 
     _, stdout, _ = self.RunBazel(['run', '@other_repo//other_pkg:binary'])
     self.assertIn(
-        "in external/other_repo/other_pkg/binary.py: '+_repo_rules+other_repo'",
+        "in external/other_repo/other_pkg/binary.py: '+_repo_rule_local_repository+other_repo'",
         stdout,
     )
     self.assertIn('in pkg/library.py: \'\'', stdout)
@@ -331,7 +331,7 @@ class PyRunfilesLibraryTest(test_base.TestBase):
         ['test', '@other_repo//other_pkg:test', '--test_output=streamed']
     )
     self.assertIn(
-        "in external/other_repo/other_pkg/test.py: '+_repo_rules+other_repo'",
+        "in external/other_repo/other_pkg/test.py: '+_repo_rule_local_repository+other_repo'",
         stdout,
     )
     self.assertIn('in pkg/library.py: \'\'', stdout)

--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -322,7 +322,7 @@ class PyRunfilesLibraryTest(test_base.TestBase):
 
     _, stdout, _ = self.RunBazel(['run', '@other_repo//other_pkg:binary'])
     self.assertIn(
-        "in external/other_repo/other_pkg/binary.py: '+_repo_rule_local_repository+other_repo'",
+        "in external/other_repo/other_pkg/binary.py: '+local_repository+other_repo'",
         stdout,
     )
     self.assertIn('in pkg/library.py: \'\'', stdout)
@@ -331,7 +331,7 @@ class PyRunfilesLibraryTest(test_base.TestBase):
         ['test', '@other_repo//other_pkg:test', '--test_output=streamed']
     )
     self.assertIn(
-        "in external/other_repo/other_pkg/test.py: '+_repo_rule_local_repository+other_repo'",
+        "in external/other_repo/other_pkg/test.py: '+local_repository+other_repo'",
         stdout,
     )
     self.assertIn('in pkg/library.py: \'\'', stdout)

--- a/src/test/shell/bazel/bazel_build_event_stream_test.sh
+++ b/src/test/shell/bazel/bazel_build_event_stream_test.sh
@@ -179,9 +179,9 @@ EOF
 
   # TODO: https://github.com/bazelbuild/bazel/issues/23240
   # Create a new event id type that doesn't use "//external"
-  expect_log 'label: "//external:+_repo_rule_failing+remote"'
+  expect_log 'label: "//external:+failing+remote"'
   expect_log 'description:.*This is the error message'
-  expect_not_log 'label.*@+_repo_rule_failing+remote//file'
+  expect_not_log 'label.*@+failing+remote//file'
 }
 
 function test_residue_in_run_bep(){

--- a/src/test/shell/bazel/bazel_build_event_stream_test.sh
+++ b/src/test/shell/bazel/bazel_build_event_stream_test.sh
@@ -179,9 +179,9 @@ EOF
 
   # TODO: https://github.com/bazelbuild/bazel/issues/23240
   # Create a new event id type that doesn't use "//external"
-  expect_log 'label: "//external:+_repo_rules+remote"'
+  expect_log 'label: "//external:+_repo_rule_failing+remote"'
   expect_log 'description:.*This is the error message'
-  expect_not_log 'label.*@+_repo_rules+remote//file'
+  expect_not_log 'label.*@+_repo_rule_failing+remote//file'
 }
 
 function test_residue_in_run_bep(){

--- a/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
@@ -1024,7 +1024,7 @@ function test_external_cc_target_can_collect_coverage() {
       &>"$TEST_log" || fail "Coverage for @other_repo//:t failed"
 
   local coverage_file_path="$(get_coverage_file_path_from_test_log)"
-  local expected_result_a_cc='SF:external/+_repo_rules+other_repo/a.cc
+  local expected_result_a_cc='SF:external/+_repo_rule_local_repository+other_repo/a.cc
 FN:4,_Z1ab
 FNDA:1,_Z1ab
 FNF:1
@@ -1090,7 +1090,7 @@ LF:4
 end_of_record'
 
   assert_cc_coverage_result "$expected_result_b_cc" "$coverage_file_path"
-  assert_not_contains "SF:external/+_repo_rules+other_repo/a.cc" "$coverage_file_path"
+  assert_not_contains "SF:external/+_repo_rule_local_repository+other_repo/a.cc" "$coverage_file_path"
 }
 
 run_suite "test tests"

--- a/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
@@ -1024,7 +1024,7 @@ function test_external_cc_target_can_collect_coverage() {
       &>"$TEST_log" || fail "Coverage for @other_repo//:t failed"
 
   local coverage_file_path="$(get_coverage_file_path_from_test_log)"
-  local expected_result_a_cc='SF:external/+_repo_rule_local_repository+other_repo/a.cc
+  local expected_result_a_cc='SF:external/+local_repository+other_repo/a.cc
 FN:4,_Z1ab
 FNDA:1,_Z1ab
 FNF:1
@@ -1090,7 +1090,7 @@ LF:4
 end_of_record'
 
   assert_cc_coverage_result "$expected_result_b_cc" "$coverage_file_path"
-  assert_not_contains "SF:external/+_repo_rule_local_repository+other_repo/a.cc" "$coverage_file_path"
+  assert_not_contains "SF:external/+local_repository+other_repo/a.cc" "$coverage_file_path"
 }
 
 run_suite "test tests"

--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -363,7 +363,7 @@ LH:5
 LF:7
 end_of_record'
 
-  local expected_a_cc='SF:external/+_repo_rule_local_repository+other_repo/a.cc
+  local expected_a_cc='SF:external/+local_repository+other_repo/a.cc
 FN:4,_Z1ab
 FNDA:1,_Z1ab
 FNF:1

--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -363,7 +363,7 @@ LH:5
 LF:7
 end_of_record'
 
-  local expected_a_cc='SF:external/+_repo_rules+other_repo/a.cc
+  local expected_a_cc='SF:external/+_repo_rule_local_repository+other_repo/a.cc
 FN:4,_Z1ab
 FNDA:1,_Z1ab
 FNF:1

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -1329,7 +1329,7 @@ DA:6,1
 LH:1
 LF:2
 end_of_record'
-  local expected_result_collatz="SF:external/+_repo_rules+other_repo/src/main/com/example/Collatz.java
+  local expected_result_collatz="SF:external/+_repo_rule_local_repository+other_repo/src/main/com/example/Collatz.java
 FN:3,com/example/Collatz::<init> ()V
 FN:6,com/example/Collatz::getCollatzFinal (I)I
 FNDA:0,com/example/Collatz::<init> ()V
@@ -1384,10 +1384,10 @@ LF:2
 end_of_record'
 
   assert_coverage_result "$expected_result_math" "$coverage_file_path"
-  assert_not_contains "SF:external/+_repo_rules+other_repo/" "$coverage_file_path"
+  assert_not_contains "SF:external/+_repo_rule_local_repository+other_repo/" "$coverage_file_path"
 
   assert_coverage_result "$expected_result_math" bazel-out/_coverage/_coverage_report.dat
-  assert_not_contains "SF:external/+_repo_rules+other_repo/" bazel-out/_coverage/_coverage_report.dat
+  assert_not_contains "SF:external/+_repo_rule_local_repository+other_repo/" bazel-out/_coverage/_coverage_report.dat
 }
 
 run_suite "test tests"

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -1329,7 +1329,7 @@ DA:6,1
 LH:1
 LF:2
 end_of_record'
-  local expected_result_collatz="SF:external/+_repo_rule_local_repository+other_repo/src/main/com/example/Collatz.java
+  local expected_result_collatz="SF:external/+local_repository+other_repo/src/main/com/example/Collatz.java
 FN:3,com/example/Collatz::<init> ()V
 FN:6,com/example/Collatz::getCollatzFinal (I)I
 FNDA:0,com/example/Collatz::<init> ()V
@@ -1384,10 +1384,10 @@ LF:2
 end_of_record'
 
   assert_coverage_result "$expected_result_math" "$coverage_file_path"
-  assert_not_contains "SF:external/+_repo_rule_local_repository+other_repo/" "$coverage_file_path"
+  assert_not_contains "SF:external/+local_repository+other_repo/" "$coverage_file_path"
 
   assert_coverage_result "$expected_result_math" bazel-out/_coverage/_coverage_report.dat
-  assert_not_contains "SF:external/+_repo_rule_local_repository+other_repo/" bazel-out/_coverage/_coverage_report.dat
+  assert_not_contains "SF:external/+local_repository+other_repo/" bazel-out/_coverage/_coverage_report.dat
 }
 
 run_suite "test tests"

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1962,14 +1962,14 @@ EOF
   expect_log "in pkg/Library.java: ''"
 
   bazel run @other_repo//pkg:binary &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/other_repo/pkg/Binary.java: '+_repo_rules+other_repo'"
-  expect_log "in external/other_repo/pkg/Library2.java: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/Binary.java: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/Library2.java: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/Library.java: ''"
 
   bazel test --test_output=streamed \
     @other_repo//pkg:test &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/other_repo/pkg/Test.java: '+_repo_rules+other_repo'"
-  expect_log "in external/other_repo/pkg/Library2.java: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/Test.java: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/Library2.java: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/Library.java: ''"
 }
 

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1962,14 +1962,14 @@ EOF
   expect_log "in pkg/Library.java: ''"
 
   bazel run @other_repo//pkg:binary &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/other_repo/pkg/Binary.java: '+_repo_rule_local_repository+other_repo'"
-  expect_log "in external/other_repo/pkg/Library2.java: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/Binary.java: '+local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/Library2.java: '+local_repository+other_repo'"
   expect_log "in pkg/Library.java: ''"
 
   bazel test --test_output=streamed \
     @other_repo//pkg:test &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/other_repo/pkg/Test.java: '+_repo_rule_local_repository+other_repo'"
-  expect_log "in external/other_repo/pkg/Library2.java: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/Test.java: '+local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/Library2.java: '+local_repository+other_repo'"
   expect_log "in pkg/Library.java: ''"
 }
 

--- a/src/test/shell/bazel/bazel_repository_cache_test.sh
+++ b/src/test/shell/bazel/bazel_repository_cache_test.sh
@@ -153,7 +153,7 @@ EOF
 
     cat > zoo/female.sh <<EOF
 #!/bin/sh
-../+_repo_rule_http_archive+endangered/fox/male
+../+http_archive+endangered/fox/male
 EOF
     chmod +x zoo/female.sh
 fi
@@ -163,7 +163,7 @@ fi
   shutdown_server
   expect_log "$what_does_the_fox_say"
 
-  base_external_path=bazel-out/../external/+_repo_rule_http_archive+endangered/fox
+  base_external_path=bazel-out/../external/+http_archive+endangered/fox
   assert_files_same ${base_external_path}/male ${base_external_path}/male_relative
   assert_files_same ${base_external_path}/male ${base_external_path}/male_absolute
 }

--- a/src/test/shell/bazel/bazel_repository_cache_test.sh
+++ b/src/test/shell/bazel/bazel_repository_cache_test.sh
@@ -153,7 +153,7 @@ EOF
 
     cat > zoo/female.sh <<EOF
 #!/bin/sh
-../+_repo_rules+endangered/fox/male
+../+_repo_rule_http_archive+endangered/fox/male
 EOF
     chmod +x zoo/female.sh
 fi
@@ -163,7 +163,7 @@ fi
   shutdown_server
   expect_log "$what_does_the_fox_say"
 
-  base_external_path=bazel-out/../external/+_repo_rules+endangered/fox
+  base_external_path=bazel-out/../external/+_repo_rule_http_archive+endangered/fox
   assert_files_same ${base_external_path}/male ${base_external_path}/male_relative
   assert_files_same ${base_external_path}/male ${base_external_path}/male_absolute
 }

--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -374,8 +374,8 @@ EOF
   cd ..
 
   bazel build @other_repo//package:hi >$TEST_log 2>&1 || fail "Should build"
-  expect_log "bazel-.*bin/external/+_repo_rules+other_repo/package/a/b"
-  expect_log "bazel-.*bin/external/+_repo_rules+other_repo/package/c/d"
+  expect_log "bazel-.*bin/external/+_repo_rule_local_repository+other_repo/package/a/b"
+  expect_log "bazel-.*bin/external/+_repo_rule_local_repository+other_repo/package/c/d"
 }
 
 function test_genrule_toolchain_dependency {
@@ -851,13 +851,13 @@ function test_bash_runfiles_current_repository_binary_enable_runfiles() {
     &>"$TEST_log" || fail "Run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   RUNFILES_LIB_DEBUG=1 bazel run --enable_bzlmod --enable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_enable_runfiles_direct_run() {
@@ -869,15 +869,15 @@ function test_bash_runfiles_current_repository_binary_enable_runfiles_direct_run
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   bazel run --enable_bzlmod --enable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/+_repo_rules+other_repo/pkg/binary$exe_suffix \
+  clean_runfiles_run bazel-bin/external/+_repo_rule_local_repository+other_repo/pkg/binary$exe_suffix \
     &>"$TEST_log" || fail "Direct run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_test_enable_runfiles() {
@@ -887,13 +887,13 @@ function test_bash_runfiles_current_repository_test_enable_runfiles() {
     --test_output=all //pkg:test &>"$TEST_log" || fail "Test should succeed"
   expect_log "in pkg/test.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   bazel test --enable_bzlmod --enable_runfiles --test_env=RUNFILES_LIB_DEBUG=1 \
     --test_output=all @other_repo//pkg:test &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_noenable_runfiles() {
@@ -903,13 +903,13 @@ function test_bash_runfiles_current_repository_binary_noenable_runfiles() {
     &>"$TEST_log" || fail "Run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   RUNFILES_LIB_DEBUG=1 bazel run --enable_bzlmod --noenable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_noenable_runfiles_direct_run() {
@@ -921,15 +921,15 @@ function test_bash_runfiles_current_repository_binary_noenable_runfiles_direct_r
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   bazel run --enable_bzlmod --noenable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/+_repo_rules+other_repo/pkg/binary$exe_suffix \
+  clean_runfiles_run bazel-bin/external/+_repo_rule_local_repository+other_repo/pkg/binary$exe_suffix \
     &>"$TEST_log" || fail "Direct run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_test_noenable_runfiles() {
@@ -939,13 +939,13 @@ function test_bash_runfiles_current_repository_test_noenable_runfiles() {
     --test_output=all //pkg:test &>"$TEST_log" || fail "Test should succeed"
   expect_log "in pkg/test.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   bazel test --enable_bzlmod --noenable_runfiles --test_env=RUNFILES_LIB_DEBUG=1 \
     --test_output=all @other_repo//pkg:test &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_nobuild_runfile_links() {
@@ -955,13 +955,13 @@ function test_bash_runfiles_current_repository_binary_nobuild_runfile_links() {
     &>"$TEST_log" || fail "Run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   RUNFILES_LIB_DEBUG=1 bazel run --enable_bzlmod --nobuild_runfile_links @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_nobuild_runfile_links_direct_run() {
@@ -973,15 +973,15 @@ function test_bash_runfiles_current_repository_binary_nobuild_runfile_links_dire
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   bazel run --enable_bzlmod --nobuild_runfile_links @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/+_repo_rules+other_repo/pkg/binary$exe_suffix \
+  clean_runfiles_run bazel-bin/external/+_repo_rule_local_repository+other_repo/pkg/binary$exe_suffix \
     &>"$TEST_log" || fail "Direct run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_test_nobuild_runfile_links() {
@@ -992,14 +992,14 @@ function test_bash_runfiles_current_repository_test_nobuild_runfile_links() {
     &>"$TEST_log" || fail "Test should succeed"
   expect_log "in pkg/test.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 
   bazel test --enable_bzlmod --noenable_runfiles --nobuild_runfile_links \
     --test_env=RUNFILES_LIB_DEBUG=1 --test_output=all @other_repo//pkg:test \
     &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_action_binary_main_repo() {
@@ -1147,7 +1147,7 @@ EOF
   chmod +x other_repo/pkg/binary.sh
 
   bazel build --enable_bzlmod //pkg:gen &>"$TEST_log" || fail "Build should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_action_generated_binary_external_repo() {
@@ -1209,7 +1209,7 @@ EOF
   chmod +x other_repo/pkg/binary.sh
 
   bazel build --enable_bzlmod //pkg:gen &>"$TEST_log" || fail "Build should succeed"
-  expect_log "in copy of external/other_repo/pkg/binary.sh: '+_repo_rules+other_repo'"
+  expect_log "in copy of external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
 }
 
 run_suite "rules test"

--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -374,8 +374,8 @@ EOF
   cd ..
 
   bazel build @other_repo//package:hi >$TEST_log 2>&1 || fail "Should build"
-  expect_log "bazel-.*bin/external/+_repo_rule_local_repository+other_repo/package/a/b"
-  expect_log "bazel-.*bin/external/+_repo_rule_local_repository+other_repo/package/c/d"
+  expect_log "bazel-.*bin/external/+local_repository+other_repo/package/a/b"
+  expect_log "bazel-.*bin/external/+local_repository+other_repo/package/c/d"
 }
 
 function test_genrule_toolchain_dependency {
@@ -851,13 +851,13 @@ function test_bash_runfiles_current_repository_binary_enable_runfiles() {
     &>"$TEST_log" || fail "Run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   RUNFILES_LIB_DEBUG=1 bazel run --enable_bzlmod --enable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_enable_runfiles_direct_run() {
@@ -869,15 +869,15 @@ function test_bash_runfiles_current_repository_binary_enable_runfiles_direct_run
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   bazel run --enable_bzlmod --enable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/+_repo_rule_local_repository+other_repo/pkg/binary$exe_suffix \
+  clean_runfiles_run bazel-bin/external/+local_repository+other_repo/pkg/binary$exe_suffix \
     &>"$TEST_log" || fail "Direct run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_test_enable_runfiles() {
@@ -887,13 +887,13 @@ function test_bash_runfiles_current_repository_test_enable_runfiles() {
     --test_output=all //pkg:test &>"$TEST_log" || fail "Test should succeed"
   expect_log "in pkg/test.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   bazel test --enable_bzlmod --enable_runfiles --test_env=RUNFILES_LIB_DEBUG=1 \
     --test_output=all @other_repo//pkg:test &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/test.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_noenable_runfiles() {
@@ -903,13 +903,13 @@ function test_bash_runfiles_current_repository_binary_noenable_runfiles() {
     &>"$TEST_log" || fail "Run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   RUNFILES_LIB_DEBUG=1 bazel run --enable_bzlmod --noenable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_noenable_runfiles_direct_run() {
@@ -921,15 +921,15 @@ function test_bash_runfiles_current_repository_binary_noenable_runfiles_direct_r
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   bazel run --enable_bzlmod --noenable_runfiles @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/+_repo_rule_local_repository+other_repo/pkg/binary$exe_suffix \
+  clean_runfiles_run bazel-bin/external/+local_repository+other_repo/pkg/binary$exe_suffix \
     &>"$TEST_log" || fail "Direct run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_test_noenable_runfiles() {
@@ -939,13 +939,13 @@ function test_bash_runfiles_current_repository_test_noenable_runfiles() {
     --test_output=all //pkg:test &>"$TEST_log" || fail "Test should succeed"
   expect_log "in pkg/test.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   bazel test --enable_bzlmod --noenable_runfiles --test_env=RUNFILES_LIB_DEBUG=1 \
     --test_output=all @other_repo//pkg:test &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/test.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_nobuild_runfile_links() {
@@ -955,13 +955,13 @@ function test_bash_runfiles_current_repository_binary_nobuild_runfile_links() {
     &>"$TEST_log" || fail "Run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   RUNFILES_LIB_DEBUG=1 bazel run --enable_bzlmod --nobuild_runfile_links @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_binary_nobuild_runfile_links_direct_run() {
@@ -973,15 +973,15 @@ function test_bash_runfiles_current_repository_binary_nobuild_runfile_links_dire
     || fail "Direct run should succeed"
   expect_log "in pkg/binary.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   bazel run --enable_bzlmod --nobuild_runfile_links @other_repo//pkg:binary \
     &>"$TEST_log" || fail "Run should succeed"
-  clean_runfiles_run bazel-bin/external/+_repo_rule_local_repository+other_repo/pkg/binary$exe_suffix \
+  clean_runfiles_run bazel-bin/external/+local_repository+other_repo/pkg/binary$exe_suffix \
     &>"$TEST_log" || fail "Direct run should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_test_nobuild_runfile_links() {
@@ -992,14 +992,14 @@ function test_bash_runfiles_current_repository_test_nobuild_runfile_links() {
     &>"$TEST_log" || fail "Test should succeed"
   expect_log "in pkg/test.sh: ''"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 
   bazel test --enable_bzlmod --noenable_runfiles --nobuild_runfile_links \
     --test_env=RUNFILES_LIB_DEBUG=1 --test_output=all @other_repo//pkg:test \
     &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/other_repo/pkg/test.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/test.sh: '+local_repository+other_repo'"
   expect_log "in pkg/library.sh: ''"
-  expect_log "in external/other_repo/pkg/library2.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/library2.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_action_binary_main_repo() {
@@ -1147,7 +1147,7 @@ EOF
   chmod +x other_repo/pkg/binary.sh
 
   bazel build --enable_bzlmod //pkg:gen &>"$TEST_log" || fail "Build should succeed"
-  expect_log "in external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/other_repo/pkg/binary.sh: '+local_repository+other_repo'"
 }
 
 function test_bash_runfiles_current_repository_action_generated_binary_external_repo() {
@@ -1209,7 +1209,7 @@ EOF
   chmod +x other_repo/pkg/binary.sh
 
   bazel build --enable_bzlmod //pkg:gen &>"$TEST_log" || fail "Build should succeed"
-  expect_log "in copy of external/other_repo/pkg/binary.sh: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in copy of external/other_repo/pkg/binary.sh: '+local_repository+other_repo'"
 }
 
 run_suite "rules test"

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -733,7 +733,7 @@ genrule(
     "  echo reading $$i",
     "  cat $$i >> $@",
     "done",
-    "for i in a/s a/go b/s b/go ../+_repo_rules+repo/c/s ../+_repo_rules+repo/c/go; do",
+    "for i in a/s a/go b/s b/go ../+_repo_rule_local_repository+repo/c/s ../+_repo_rule_local_repository+repo/c/go; do",
     "  echo reading $$RUNFILES/$$i",
     "  cat $$RUNFILES/$$i >> $@",
     "done",

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -733,7 +733,7 @@ genrule(
     "  echo reading $$i",
     "  cat $$i >> $@",
     "done",
-    "for i in a/s a/go b/s b/go ../+_repo_rule_local_repository+repo/c/s ../+_repo_rule_local_repository+repo/c/go; do",
+    "for i in a/s a/go b/s b/go ../+local_repository+repo/c/s ../+local_repository+repo/c/go; do",
     "  echo reading $$RUNFILES/$$i",
     "  cat $$RUNFILES/$$i >> $@",
     "done",

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -1073,9 +1073,9 @@ EOF
   bazel test --experimental_sibling_repository_layout @a//:x &> $TEST_log \
       || fail "expected success"
 
-  cp $(testlogs_dir +_repo_rules+a)/x/test.xml $TEST_log
-  expect_log "<testsuite name=\"+_repo_rules+a/x\""
-  expect_log "<testcase name=\"+_repo_rules+a/x\""
+  cp $(testlogs_dir +_repo_rule_local_repository+a)/x/test.xml $TEST_log
+  expect_log "<testsuite name=\"+_repo_rule_local_repository+a/x\""
+  expect_log "<testcase name=\"+_repo_rule_local_repository+a/x\""
 }
 
 function test_xml_output_format() {

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -1073,9 +1073,9 @@ EOF
   bazel test --experimental_sibling_repository_layout @a//:x &> $TEST_log \
       || fail "expected success"
 
-  cp $(testlogs_dir +_repo_rule_local_repository+a)/x/test.xml $TEST_log
-  expect_log "<testsuite name=\"+_repo_rule_local_repository+a/x\""
-  expect_log "<testcase name=\"+_repo_rule_local_repository+a/x\""
+  cp $(testlogs_dir +local_repository+a)/x/test.xml $TEST_log
+  expect_log "<testsuite name=\"+local_repository+a/x\""
+  expect_log "<testcase name=\"+local_repository+a/x\""
 }
 
 function test_xml_output_format() {

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1567,12 +1567,12 @@ EOF
   expect_log "in pkg/library.cpp: ''"
 
   bazel run @other_repo//pkg:binary &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/+_repo_rules+other_repo/pkg/binary.cpp: '+_repo_rules+other_repo'"
+  expect_log "in external/+_repo_rule_local_repository+other_repo/pkg/binary.cpp: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.cpp: ''"
 
   bazel test --test_output=streamed \
     @other_repo//pkg:test &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/+_repo_rules+other_repo/pkg/test.cpp: '+_repo_rules+other_repo'"
+  expect_log "in external/+_repo_rule_local_repository+other_repo/pkg/test.cpp: '+_repo_rule_local_repository+other_repo'"
   expect_log "in pkg/library.cpp: ''"
 }
 

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1567,12 +1567,12 @@ EOF
   expect_log "in pkg/library.cpp: ''"
 
   bazel run @other_repo//pkg:binary &>"$TEST_log" || fail "Run should succeed"
-  expect_log "in external/+_repo_rule_local_repository+other_repo/pkg/binary.cpp: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/+local_repository+other_repo/pkg/binary.cpp: '+local_repository+other_repo'"
   expect_log "in pkg/library.cpp: ''"
 
   bazel test --test_output=streamed \
     @other_repo//pkg:test &>"$TEST_log" || fail "Test should succeed"
-  expect_log "in external/+_repo_rule_local_repository+other_repo/pkg/test.cpp: '+_repo_rule_local_repository+other_repo'"
+  expect_log "in external/+local_repository+other_repo/pkg/test.cpp: '+local_repository+other_repo'"
   expect_log "in pkg/library.cpp: ''"
 }
 

--- a/src/test/shell/bazel/check_external_files_test.sh
+++ b/src/test/shell/bazel/check_external_files_test.sh
@@ -109,12 +109,12 @@ test_check_external_files() {
   setup_remote
   bazel build @remote//:g >& "$TEST_log" || fail "Expected build to succeed"
 
-  echo "broken file" > bazel-main/external/+_repo_rules+remote/BUILD
+  echo "broken file" > bazel-main/external/+_repo_rule_http_archive+remote/BUILD
   # The --noexperimental_check_external_repository_files flag doesn't notice the file is broken
   bazel build --noexperimental_check_external_repository_files @remote//:g >& "$TEST_log" || fail "Expected build to succeed"
 
   bazel build @remote//:g >& "$TEST_log" && fail "Expected build to fail" || true
-  expect_log "no such target '@@+_repo_rules+remote//:g'"
+  expect_log "no such target '@@+_repo_rule_http_archive+remote//:g'"
 }
 
 test_check_all_flags_fast() {
@@ -125,7 +125,7 @@ test_check_all_flags_fast() {
   instances=$(grep -c "$msg" "$(bazel info server_log)")
   [[ $instances -eq 1 ]] || fail "Should have only been 1 instance, got $instances"
 
-  echo "broken file" > bazel-main/external/+_repo_rules+remote/BUILD
+  echo "broken file" > bazel-main/external/+_repo_rule_http_archive+remote/BUILD
 
   bazel build \
     --noexperimental_check_external_repository_files \
@@ -151,7 +151,7 @@ run_local_repository_isnt_affected() {
     $extra_args \
     @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
   bazel build --noexperimental_check_external_repository_files @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
-  expect_log "no such target '@@+_repo_rules+local_rep//:g'"
+  expect_log "no such target '@@+_repo_rule_local_repository+local_rep//:g'"
 }
 
 test_local_repository_isnt_affected() {
@@ -178,7 +178,7 @@ EOF
   bazel build @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
   expect_log "but it does not exist or is not a directory"
 
-  argv="--override_repository=+_repo_rules+local_rep=$(pwd)/../local_rep"
+  argv="--override_repository=+_repo_rule_local_repository+local_rep=$(pwd)/../local_rep"
   bazel build "$argv" $extra_args @local_rep//:g >& "$TEST_log" || fail "Expected build to succeed"
 
   echo "broken file" > ../local_rep/BUILD
@@ -188,7 +188,7 @@ EOF
     "$argv" \
     $extra_args \
     @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
-  expect_log "no such target '@@+_repo_rules+local_rep//:g'"
+  expect_log "no such target '@@+_repo_rule_local_repository+local_rep//:g'"
 }
 
 test_override_repository_isnt_affected() {
@@ -223,7 +223,7 @@ test_no_build_doesnt_break_the_cache() {
     --noexperimental_check_output_files \
     --watchfs \
     @remote//:g >& "$TEST_log" || fail "Expected build to pass"
-  [[ ! -f bazel-main/external/+_repo_rules+remote/BUILD ]] || fail "external files shouldn't have been made"
+  [[ ! -f bazel-main/external/+_repo_rule_http_archive+remote/BUILD ]] || fail "external files shouldn't have been made"
   bazel build \
     --noexperimental_check_external_repository_files \
     --noexperimental_check_output_files \

--- a/src/test/shell/bazel/check_external_files_test.sh
+++ b/src/test/shell/bazel/check_external_files_test.sh
@@ -109,12 +109,12 @@ test_check_external_files() {
   setup_remote
   bazel build @remote//:g >& "$TEST_log" || fail "Expected build to succeed"
 
-  echo "broken file" > bazel-main/external/+_repo_rule_http_archive+remote/BUILD
+  echo "broken file" > bazel-main/external/+http_archive+remote/BUILD
   # The --noexperimental_check_external_repository_files flag doesn't notice the file is broken
   bazel build --noexperimental_check_external_repository_files @remote//:g >& "$TEST_log" || fail "Expected build to succeed"
 
   bazel build @remote//:g >& "$TEST_log" && fail "Expected build to fail" || true
-  expect_log "no such target '@@+_repo_rule_http_archive+remote//:g'"
+  expect_log "no such target '@@+http_archive+remote//:g'"
 }
 
 test_check_all_flags_fast() {
@@ -125,7 +125,7 @@ test_check_all_flags_fast() {
   instances=$(grep -c "$msg" "$(bazel info server_log)")
   [[ $instances -eq 1 ]] || fail "Should have only been 1 instance, got $instances"
 
-  echo "broken file" > bazel-main/external/+_repo_rule_http_archive+remote/BUILD
+  echo "broken file" > bazel-main/external/+http_archive+remote/BUILD
 
   bazel build \
     --noexperimental_check_external_repository_files \
@@ -151,7 +151,7 @@ run_local_repository_isnt_affected() {
     $extra_args \
     @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
   bazel build --noexperimental_check_external_repository_files @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
-  expect_log "no such target '@@+_repo_rule_local_repository+local_rep//:g'"
+  expect_log "no such target '@@+local_repository+local_rep//:g'"
 }
 
 test_local_repository_isnt_affected() {
@@ -178,7 +178,7 @@ EOF
   bazel build @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
   expect_log "but it does not exist or is not a directory"
 
-  argv="--override_repository=+_repo_rule_local_repository+local_rep=$(pwd)/../local_rep"
+  argv="--override_repository=+local_repository+local_rep=$(pwd)/../local_rep"
   bazel build "$argv" $extra_args @local_rep//:g >& "$TEST_log" || fail "Expected build to succeed"
 
   echo "broken file" > ../local_rep/BUILD
@@ -188,7 +188,7 @@ EOF
     "$argv" \
     $extra_args \
     @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
-  expect_log "no such target '@@+_repo_rule_local_repository+local_rep//:g'"
+  expect_log "no such target '@@+local_repository+local_rep//:g'"
 }
 
 test_override_repository_isnt_affected() {
@@ -223,7 +223,7 @@ test_no_build_doesnt_break_the_cache() {
     --noexperimental_check_output_files \
     --watchfs \
     @remote//:g >& "$TEST_log" || fail "Expected build to pass"
-  [[ ! -f bazel-main/external/+_repo_rule_http_archive+remote/BUILD ]] || fail "external files shouldn't have been made"
+  [[ ! -f bazel-main/external/+http_archive+remote/BUILD ]] || fail "external files shouldn't have been made"
   bazel build \
     --noexperimental_check_external_repository_files \
     --noexperimental_check_output_files \

--- a/src/test/shell/bazel/external_correctness_test.sh
+++ b/src/test/shell/bazel/external_correctness_test.sh
@@ -143,8 +143,8 @@ genrule(
 )
 EOF
   bazel build @a//b/c:echo-d &> $TEST_log || fail "Build failed"
-  assert_contains "bazel-out/.*-fastbuild/.*/external/+_repo_rules+a/b/c" \
-    "bazel-genfiles/external/+_repo_rules+a/b/c/d"
+  assert_contains "bazel-out/.*-fastbuild/.*/external/+_repo_rule_local_repository+a/b/c" \
+    "bazel-genfiles/external/+_repo_rule_local_repository+a/b/c/d"
 }
 
 function test_package_group_in_external_repos() {
@@ -164,11 +164,11 @@ EOF
   echo "local_repository(name='r', path='$REMOTE')" >> MODULE.bazel
   bazel build @r//v:rv >& $TEST_log || fail "Build failed"
   bazel build @r//a:ra >& $TEST_log && fail "Build succeeded"
-  expect_log "target '@@+_repo_rules+r//:fg' is not visible"
+  expect_log "target '@@+_repo_rule_local_repository+r//:fg' is not visible"
   bazel build //a:ma >& $TEST_log && fail "Build succeeded"
-  expect_log "target '@@+_repo_rules+r//:fg' is not visible"
+  expect_log "target '@@+_repo_rule_local_repository+r//:fg' is not visible"
   bazel build //v:mv >& $TEST_log && fail "Build succeeded"
-  expect_log "target '@@+_repo_rules+r//:fg' is not visible"
+  expect_log "target '@@+_repo_rule_local_repository+r//:fg' is not visible"
 
 }
 
@@ -204,7 +204,7 @@ local_repository(
 EOF
 
   bazel build @remote2//:x &> $TEST_log || fail "Build failed"
-  assert_contains 1.0 bazel-genfiles/external/+_repo_rules+remote2/x.out
+  assert_contains 1.0 bazel-genfiles/external/+_repo_rule_local_repository+remote2/x.out
 }
 
 function test_visibility_attributes_in_external_repos() {
@@ -236,7 +236,7 @@ EOF
 
   bazel build @r//:fg || fail "Build failed"
   bazel build //:fg >& $TEST_log && fail "Build succeeded"
-  expect_log "target '@@+_repo_rules+r//r:fg1' is not visible"
+  expect_log "target '@@+_repo_rule_local_repository+r//r:fg1' is not visible"
 
 }
 
@@ -281,15 +281,15 @@ config_setting(name = "four", values = { "define": "ARG=four" })
 EOF
 
   bazel build @r//a:gr || fail "build failed"
-  assert_contains "default" bazel-genfiles/external/+_repo_rules+r/a/gro
+  assert_contains "default" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
   bazel build @r//a:gr --define=ARG=one|| fail "build failed"
-  assert_contains "one" bazel-genfiles/external/+_repo_rules+r/a/gro
+  assert_contains "one" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
   bazel build @r//a:gr --define=ARG=two || fail "build failed"
-  assert_contains "two" bazel-genfiles/external/+_repo_rules+r/a/gro
+  assert_contains "two" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
   bazel build @r//a:gr --define=ARG=three || fail "build failed"
-  assert_contains "three" bazel-genfiles/external/+_repo_rules+r/a/gro
+  assert_contains "three" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
   bazel build @r//a:gr --define=ARG=four || fail "build failed"
-  assert_contains "four" bazel-genfiles/external/+_repo_rules+r/a/gro
+  assert_contains "four" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
 
 }
 
@@ -319,11 +319,11 @@ EOF
   touch ../r/three
   bazel "$batch_flag" build @r//:fg &> $TEST_log || \
     fail "Expected build to succeed"
-  assert_contains "external/+_repo_rules+r/three" bazel-genfiles/external/+_repo_rules+r/fg.out
+  assert_contains "external/+_repo_rule_local_repository+r/three" bazel-genfiles/external/+_repo_rule_new_local_repository+r/fg.out
   touch ../r/subdir/four
   bazel "$batch_flag" build @r//:fg &> $TEST_log || \
     fail "Expected build to succeed"
-  assert_contains "external/+_repo_rules+r/subdir/four" bazel-genfiles/external/+_repo_rules+r/fg.out
+  assert_contains "external/+_repo_rule_local_repository+r/subdir/four" bazel-genfiles/external/+_repo_rule_new_local_repository+r/fg.out
 }
 
 function test_top_level_dir_changes_batch() {

--- a/src/test/shell/bazel/external_correctness_test.sh
+++ b/src/test/shell/bazel/external_correctness_test.sh
@@ -319,11 +319,11 @@ EOF
   touch ../r/three
   bazel "$batch_flag" build @r//:fg &> $TEST_log || \
     fail "Expected build to succeed"
-  assert_contains "external/+_repo_rule_local_repository+r/three" bazel-genfiles/external/+_repo_rule_new_local_repository+r/fg.out
+  assert_contains "external/+_repo_rule_new_local_repository+r/three" bazel-genfiles/external/+_repo_rule_new_local_repository+r/fg.out
   touch ../r/subdir/four
   bazel "$batch_flag" build @r//:fg &> $TEST_log || \
     fail "Expected build to succeed"
-  assert_contains "external/+_repo_rule_local_repository+r/subdir/four" bazel-genfiles/external/+_repo_rule_new_local_repository+r/fg.out
+  assert_contains "external/+_repo_rule_new_local_repository+r/subdir/four" bazel-genfiles/external/+_repo_rule_new_local_repository+r/fg.out
 }
 
 function test_top_level_dir_changes_batch() {

--- a/src/test/shell/bazel/external_correctness_test.sh
+++ b/src/test/shell/bazel/external_correctness_test.sh
@@ -143,8 +143,8 @@ genrule(
 )
 EOF
   bazel build @a//b/c:echo-d &> $TEST_log || fail "Build failed"
-  assert_contains "bazel-out/.*-fastbuild/.*/external/+_repo_rule_local_repository+a/b/c" \
-    "bazel-genfiles/external/+_repo_rule_local_repository+a/b/c/d"
+  assert_contains "bazel-out/.*-fastbuild/.*/external/+local_repository+a/b/c" \
+    "bazel-genfiles/external/+local_repository+a/b/c/d"
 }
 
 function test_package_group_in_external_repos() {
@@ -164,11 +164,11 @@ EOF
   echo "local_repository(name='r', path='$REMOTE')" >> MODULE.bazel
   bazel build @r//v:rv >& $TEST_log || fail "Build failed"
   bazel build @r//a:ra >& $TEST_log && fail "Build succeeded"
-  expect_log "target '@@+_repo_rule_local_repository+r//:fg' is not visible"
+  expect_log "target '@@+local_repository+r//:fg' is not visible"
   bazel build //a:ma >& $TEST_log && fail "Build succeeded"
-  expect_log "target '@@+_repo_rule_local_repository+r//:fg' is not visible"
+  expect_log "target '@@+local_repository+r//:fg' is not visible"
   bazel build //v:mv >& $TEST_log && fail "Build succeeded"
-  expect_log "target '@@+_repo_rule_local_repository+r//:fg' is not visible"
+  expect_log "target '@@+local_repository+r//:fg' is not visible"
 
 }
 
@@ -204,7 +204,7 @@ local_repository(
 EOF
 
   bazel build @remote2//:x &> $TEST_log || fail "Build failed"
-  assert_contains 1.0 bazel-genfiles/external/+_repo_rule_local_repository+remote2/x.out
+  assert_contains 1.0 bazel-genfiles/external/+local_repository+remote2/x.out
 }
 
 function test_visibility_attributes_in_external_repos() {
@@ -236,7 +236,7 @@ EOF
 
   bazel build @r//:fg || fail "Build failed"
   bazel build //:fg >& $TEST_log && fail "Build succeeded"
-  expect_log "target '@@+_repo_rule_local_repository+r//r:fg1' is not visible"
+  expect_log "target '@@+local_repository+r//r:fg1' is not visible"
 
 }
 
@@ -281,15 +281,15 @@ config_setting(name = "four", values = { "define": "ARG=four" })
 EOF
 
   bazel build @r//a:gr || fail "build failed"
-  assert_contains "default" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
+  assert_contains "default" bazel-genfiles/external/+local_repository+r/a/gro
   bazel build @r//a:gr --define=ARG=one|| fail "build failed"
-  assert_contains "one" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
+  assert_contains "one" bazel-genfiles/external/+local_repository+r/a/gro
   bazel build @r//a:gr --define=ARG=two || fail "build failed"
-  assert_contains "two" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
+  assert_contains "two" bazel-genfiles/external/+local_repository+r/a/gro
   bazel build @r//a:gr --define=ARG=three || fail "build failed"
-  assert_contains "three" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
+  assert_contains "three" bazel-genfiles/external/+local_repository+r/a/gro
   bazel build @r//a:gr --define=ARG=four || fail "build failed"
-  assert_contains "four" bazel-genfiles/external/+_repo_rule_local_repository+r/a/gro
+  assert_contains "four" bazel-genfiles/external/+local_repository+r/a/gro
 
 }
 
@@ -319,11 +319,11 @@ EOF
   touch ../r/three
   bazel "$batch_flag" build @r//:fg &> $TEST_log || \
     fail "Expected build to succeed"
-  assert_contains "external/+_repo_rule_new_local_repository+r/three" bazel-genfiles/external/+_repo_rule_new_local_repository+r/fg.out
+  assert_contains "external/+new_local_repository+r/three" bazel-genfiles/external/+new_local_repository+r/fg.out
   touch ../r/subdir/four
   bazel "$batch_flag" build @r//:fg &> $TEST_log || \
     fail "Expected build to succeed"
-  assert_contains "external/+_repo_rule_new_local_repository+r/subdir/four" bazel-genfiles/external/+_repo_rule_new_local_repository+r/fg.out
+  assert_contains "external/+new_local_repository+r/subdir/four" bazel-genfiles/external/+new_local_repository+r/fg.out
 }
 
 function test_top_level_dir_changes_batch() {

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -144,7 +144,7 @@ EOF
 
     cat > zoo/female.sh <<EOF
 #!/bin/sh
-../+_repo_rules+endangered/fox/male
+../+_repo_rule_http_archive+endangered/fox/male
 EOF
     chmod +x zoo/female.sh
 fi
@@ -154,7 +154,7 @@ fi
   kill_nc
   expect_log $what_does_the_fox_say
 
-  base_external_path=bazel-out/../external/+_repo_rules+endangered/fox
+  base_external_path=bazel-out/../external/+_repo_rule_http_archive+endangered/fox
   assert_files_same ${base_external_path}/male ${base_external_path}/male_relative
   assert_files_same ${base_external_path}/male ${base_external_path}/male_absolute
   case "${PLATFORM}" in
@@ -221,7 +221,7 @@ http_archive(
 EOF
   bazel build @test_zstd_repo//...
 
-  base_external_path=bazel-out/../external/+_repo_rules+test_zstd_repo
+  base_external_path=bazel-out/../external/+_repo_rule_http_archive+test_zstd_repo
   assert_contains "test content" "${base_external_path}/test_dir/test_file"
 }
 
@@ -237,7 +237,7 @@ http_archive(
 EOF
   bazel build @test_zstd_repo//...
 
-  base_external_path=bazel-out/../external/+_repo_rules+test_zstd_repo
+  base_external_path=bazel-out/../external/+_repo_rule_http_archive+test_zstd_repo
   assert_contains "test content" "${base_external_path}/test_dir/test_file"
 }
 
@@ -326,7 +326,7 @@ function test_sha256_caching() {
 
 function test_cached_across_server_restart() {
   http_archive_helper zip_up
-  local marker_file=$(bazel info output_base)/external/\@+_repo_rules+endangered.marker
+  local marker_file=$(bazel info output_base)/external/\@+_repo_rule_http_archive+endangered.marker
   echo "<MARKER>"
   cat "${marker_file}"
   echo "</MARKER>"
@@ -374,7 +374,7 @@ EOF
   kill_nc
   expect_log "Tra-la!"
   output_base=$(bazel info output_base)
-  jar_dir=$output_base/external/+_repo_rules+endangered/jar
+  jar_dir=$output_base/external/+_repo_rule_http_jar+endangered/jar
   [[ -f ${jar_dir}/foo.jar ]] || fail "${jar_dir}/foo.jar not found"
 }
 
@@ -808,7 +808,7 @@ EOF
 
   cat > zoo/female.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rules+endangered/fox/male
+cat ../+_repo_rule_http_archive+endangered/fox/male
 EOF
   chmod +x zoo/female.sh
 
@@ -895,7 +895,7 @@ EOF
   touch BUILD
 
   bazel build @x//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
 }
 
 function test_prefix_stripping_zip() {
@@ -926,7 +926,7 @@ EOF
   touch BUILD
 
   bazel build @x//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
 }
 
 function test_prefix_stripping_existing_repo() {
@@ -956,7 +956,7 @@ http_archive(
 EOF
 
   bazel build @x//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
 }
 
 function test_adding_prefix_zip() {
@@ -987,7 +987,7 @@ EOF
   touch BUILD
 
   bazel build @ws//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rules+ws/catter.out
+  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+ws/catter.out
 }
 
 function test_adding_and_stripping_prefix_zip() {
@@ -1019,7 +1019,7 @@ EOF
   touch BUILD
 
   bazel build @ws//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rules+ws/catter.out
+  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+ws/catter.out
 }
 
 function test_moving_build_file() {
@@ -1048,13 +1048,13 @@ genrule(
 EOF
 
   bazel build @x//:catter &> $TEST_log || fail "Build 1 failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
   mv x.BUILD x.BUILD.new || fail "Moving x.BUILD failed"
   sed 's/x.BUILD/x.BUILD.new/g' MODULE.bazel > MODULE.bazel.tmp || \
     fail "Editing MODULE.bazel failed"
   mv MODULE.bazel.tmp MODULE.bazel
   bazel build @x//:catter &> $TEST_log || fail "Build 2 failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
 }
 
 function test_changing_build_file() {
@@ -1093,12 +1093,12 @@ genrule(
 EOF
 
   bazel build @x//:catter || fail "Build 1 failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rules+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
   sed 's/x.BUILD/x.BUILD.new/g' MODULE.bazel > MODULE.bazel.tmp || \
     fail "Editing MODULE.bazel failed"
   mv MODULE.bazel.tmp MODULE.bazel
   bazel build @x//:catter &> $TEST_log || fail "Build 2 failed"
-  assert_contains "def" bazel-genfiles/external/+_repo_rules+x/catter.out
+  assert_contains "def" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
 }
 
 function test_flip_flopping() {
@@ -1134,12 +1134,12 @@ EOF
   for i in $(seq 1 3); do
     cp local_ws MODULE.bazel
     bazel build @repo//:all &> $TEST_log || fail "Build failed"
-    test -L "$external_dir/+_repo_rules+repo" || fail "creating local symlink failed"
-    test -a "$external_dir/+_repo_rules+repo/bar" || fail "bar not found"
+    test -L "$external_dir/+_repo_rule_local_repository+repo" || fail "creating local symlink failed"
+    test -a "$external_dir/+_repo_rule_local_repository+repo/bar" || fail "bar not found"
     cp remote_ws MODULE.bazel
     bazel build @repo//:all &> $TEST_log || fail "Build failed"
-    test -d "$external_dir/+_repo_rules+repo" || fail "creating remote repo failed"
-    test -a "$external_dir/+_repo_rules+repo/foo" || fail "foo not found"
+    test -d "$external_dir/+_repo_rule_http_archive+repo" || fail "creating remote repo failed"
+    test -a "$external_dir/+_repo_rule_http_archive+repo/foo" || fail "foo not found"
   done
 
   shutdown_server
@@ -2408,7 +2408,7 @@ EOF
 
   bazel build //:it > "${TEST_log}" 2>&1 && fail "Expected failure" || :
 
-  expect_log '@@+_repo_rules+ext.*badargument'
+  expect_log '@@+_repo_rule_http_archive+ext.*badargument'
 }
 
 function test_prefix_suggestions() {
@@ -2835,7 +2835,7 @@ EOF
   bazel build --experimental_merged_skyframe_analysis_execution //:foo \
     || fail 'Expected build to succeed with Skymeld'
 
-  test -h "$execroot/external/+_repo_rules+ext" || fail "Expected symlink to external repo."
+  test -h "$execroot/external/+_repo_rule_http_archive+ext" || fail "Expected symlink to external repo."
 }
 
 function test_default_canonical_id_enabled() {

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -144,7 +144,7 @@ EOF
 
     cat > zoo/female.sh <<EOF
 #!/bin/sh
-../+_repo_rule_http_archive+endangered/fox/male
+../+http_archive+endangered/fox/male
 EOF
     chmod +x zoo/female.sh
 fi
@@ -154,7 +154,7 @@ fi
   kill_nc
   expect_log $what_does_the_fox_say
 
-  base_external_path=bazel-out/../external/+_repo_rule_http_archive+endangered/fox
+  base_external_path=bazel-out/../external/+http_archive+endangered/fox
   assert_files_same ${base_external_path}/male ${base_external_path}/male_relative
   assert_files_same ${base_external_path}/male ${base_external_path}/male_absolute
   case "${PLATFORM}" in
@@ -221,7 +221,7 @@ http_archive(
 EOF
   bazel build @test_zstd_repo//...
 
-  base_external_path=bazel-out/../external/+_repo_rule_http_archive+test_zstd_repo
+  base_external_path=bazel-out/../external/+http_archive+test_zstd_repo
   assert_contains "test content" "${base_external_path}/test_dir/test_file"
 }
 
@@ -237,7 +237,7 @@ http_archive(
 EOF
   bazel build @test_zstd_repo//...
 
-  base_external_path=bazel-out/../external/+_repo_rule_http_archive+test_zstd_repo
+  base_external_path=bazel-out/../external/+http_archive+test_zstd_repo
   assert_contains "test content" "${base_external_path}/test_dir/test_file"
 }
 
@@ -326,7 +326,7 @@ function test_sha256_caching() {
 
 function test_cached_across_server_restart() {
   http_archive_helper zip_up
-  local marker_file=$(bazel info output_base)/external/\@+_repo_rule_http_archive+endangered.marker
+  local marker_file=$(bazel info output_base)/external/\@+http_archive+endangered.marker
   echo "<MARKER>"
   cat "${marker_file}"
   echo "</MARKER>"
@@ -374,7 +374,7 @@ EOF
   kill_nc
   expect_log "Tra-la!"
   output_base=$(bazel info output_base)
-  jar_dir=$output_base/external/+_repo_rule_http_jar+endangered/jar
+  jar_dir=$output_base/external/+http_jar+endangered/jar
   [[ -f ${jar_dir}/foo.jar ]] || fail "${jar_dir}/foo.jar not found"
 }
 
@@ -808,7 +808,7 @@ EOF
 
   cat > zoo/female.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rule_http_archive+endangered/fox/male
+cat ../+http_archive+endangered/fox/male
 EOF
   chmod +x zoo/female.sh
 
@@ -895,7 +895,7 @@ EOF
   touch BUILD
 
   bazel build @x//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+http_archive+x/catter.out
 }
 
 function test_prefix_stripping_zip() {
@@ -926,7 +926,7 @@ EOF
   touch BUILD
 
   bazel build @x//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+http_archive+x/catter.out
 }
 
 function test_prefix_stripping_existing_repo() {
@@ -956,7 +956,7 @@ http_archive(
 EOF
 
   bazel build @x//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+http_archive+x/catter.out
 }
 
 function test_adding_prefix_zip() {
@@ -987,7 +987,7 @@ EOF
   touch BUILD
 
   bazel build @ws//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+ws/catter.out
+  assert_contains "abc" bazel-genfiles/external/+http_archive+ws/catter.out
 }
 
 function test_adding_and_stripping_prefix_zip() {
@@ -1019,7 +1019,7 @@ EOF
   touch BUILD
 
   bazel build @ws//:catter &> $TEST_log || fail "Build failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+ws/catter.out
+  assert_contains "abc" bazel-genfiles/external/+http_archive+ws/catter.out
 }
 
 function test_moving_build_file() {
@@ -1048,13 +1048,13 @@ genrule(
 EOF
 
   bazel build @x//:catter &> $TEST_log || fail "Build 1 failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+http_archive+x/catter.out
   mv x.BUILD x.BUILD.new || fail "Moving x.BUILD failed"
   sed 's/x.BUILD/x.BUILD.new/g' MODULE.bazel > MODULE.bazel.tmp || \
     fail "Editing MODULE.bazel failed"
   mv MODULE.bazel.tmp MODULE.bazel
   bazel build @x//:catter &> $TEST_log || fail "Build 2 failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+http_archive+x/catter.out
 }
 
 function test_changing_build_file() {
@@ -1093,12 +1093,12 @@ genrule(
 EOF
 
   bazel build @x//:catter || fail "Build 1 failed"
-  assert_contains "abc" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
+  assert_contains "abc" bazel-genfiles/external/+http_archive+x/catter.out
   sed 's/x.BUILD/x.BUILD.new/g' MODULE.bazel > MODULE.bazel.tmp || \
     fail "Editing MODULE.bazel failed"
   mv MODULE.bazel.tmp MODULE.bazel
   bazel build @x//:catter &> $TEST_log || fail "Build 2 failed"
-  assert_contains "def" bazel-genfiles/external/+_repo_rule_http_archive+x/catter.out
+  assert_contains "def" bazel-genfiles/external/+http_archive+x/catter.out
 }
 
 function test_flip_flopping() {
@@ -1134,12 +1134,12 @@ EOF
   for i in $(seq 1 3); do
     cp local_ws MODULE.bazel
     bazel build @repo//:all &> $TEST_log || fail "Build failed"
-    test -L "$external_dir/+_repo_rule_local_repository+repo" || fail "creating local symlink failed"
-    test -a "$external_dir/+_repo_rule_local_repository+repo/bar" || fail "bar not found"
+    test -L "$external_dir/+local_repository+repo" || fail "creating local symlink failed"
+    test -a "$external_dir/+local_repository+repo/bar" || fail "bar not found"
     cp remote_ws MODULE.bazel
     bazel build @repo//:all &> $TEST_log || fail "Build failed"
-    test -d "$external_dir/+_repo_rule_http_archive+repo" || fail "creating remote repo failed"
-    test -a "$external_dir/+_repo_rule_http_archive+repo/foo" || fail "foo not found"
+    test -d "$external_dir/+http_archive+repo" || fail "creating remote repo failed"
+    test -a "$external_dir/+http_archive+repo/foo" || fail "foo not found"
   done
 
   shutdown_server
@@ -2408,7 +2408,7 @@ EOF
 
   bazel build //:it > "${TEST_log}" 2>&1 && fail "Expected failure" || :
 
-  expect_log '@@+_repo_rule_http_archive+ext.*badargument'
+  expect_log '@@+http_archive+ext.*badargument'
 }
 
 function test_prefix_suggestions() {
@@ -2835,7 +2835,7 @@ EOF
   bazel build --experimental_merged_skyframe_analysis_execution //:foo \
     || fail 'Expected build to succeed with Skymeld'
 
-  test -h "$execroot/external/+_repo_rule_http_archive+ext" || fail "Expected symlink to external repo."
+  test -h "$execroot/external/+http_archive+ext" || fail "Expected symlink to external repo."
 }
 
 function test_default_canonical_id_enabled() {

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -101,7 +101,7 @@ EOF
 
   cat > zoo/dumper.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rule_local_repository+pandas/red/baby-panda
+cat ../+local_repository+pandas/red/baby-panda
 cat red/day-keeper
 EOF
   chmod +x zoo/dumper.sh
@@ -488,7 +488,7 @@ genrule(
 EOF
   bazel fetch @mutant//:turtle || fail "Fetch failed"
   bazel build @mutant//:turtle &> $TEST_log || fail "First build failed"
-  assert_contains "Leonardo" bazel-genfiles/external/+_repo_rule_new_local_repository+mutant/tmnt
+  assert_contains "Leonardo" bazel-genfiles/external/+new_local_repository+mutant/tmnt
 
   cat > mutant.BUILD <<EOF
 genrule(
@@ -499,7 +499,7 @@ genrule(
 )
 EOF
   bazel build @mutant//:turtle &> $TEST_log || fail "Second build failed"
-  assert_contains "Donatello" bazel-genfiles/external/+_repo_rule_new_local_repository+mutant/tmnt
+  assert_contains "Donatello" bazel-genfiles/external/+new_local_repository+mutant/tmnt
 }
 
 function test_external_deps_in_remote_repo() {
@@ -533,7 +533,7 @@ genrule(
 EOF
 
  bazel build @r//:r || fail "build failed"
- assert_contains "GOLF" bazel-genfiles/external/+_repo_rule_local_repository+r/r.out
+ assert_contains "GOLF" bazel-genfiles/external/+local_repository+r/r.out
 }
 
 function test_local_deps() {
@@ -844,8 +844,8 @@ local_repository(name='r', path='$r')
 EOF
 
   bazel build @r//a:b || fail "build failed"
-  cat bazel-genfiles/external/+_repo_rule_local_repository+r/a/bo > $TEST_log
-  expect_log "@+_repo_rule_local_repository+r a"
+  cat bazel-genfiles/external/+local_repository+r/a/bo > $TEST_log
+  expect_log "@+local_repository+r a"
 }
 
 function test_slash_in_repo_name() {

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -101,7 +101,7 @@ EOF
 
   cat > zoo/dumper.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rules+pandas/red/baby-panda
+cat ../+_repo_rule_local_repository+pandas/red/baby-panda
 cat red/day-keeper
 EOF
   chmod +x zoo/dumper.sh
@@ -488,7 +488,7 @@ genrule(
 EOF
   bazel fetch @mutant//:turtle || fail "Fetch failed"
   bazel build @mutant//:turtle &> $TEST_log || fail "First build failed"
-  assert_contains "Leonardo" bazel-genfiles/external/+_repo_rules+mutant/tmnt
+  assert_contains "Leonardo" bazel-genfiles/external/+_repo_rule_new_local_repository+mutant/tmnt
 
   cat > mutant.BUILD <<EOF
 genrule(
@@ -499,7 +499,7 @@ genrule(
 )
 EOF
   bazel build @mutant//:turtle &> $TEST_log || fail "Second build failed"
-  assert_contains "Donatello" bazel-genfiles/external/+_repo_rules+mutant/tmnt
+  assert_contains "Donatello" bazel-genfiles/external/+_repo_rule_new_local_repository+mutant/tmnt
 }
 
 function test_external_deps_in_remote_repo() {
@@ -533,7 +533,7 @@ genrule(
 EOF
 
  bazel build @r//:r || fail "build failed"
- assert_contains "GOLF" bazel-genfiles/external/+_repo_rules+r/r.out
+ assert_contains "GOLF" bazel-genfiles/external/+_repo_rule_local_repository+r/r.out
 }
 
 function test_local_deps() {
@@ -844,8 +844,8 @@ local_repository(name='r', path='$r')
 EOF
 
   bazel build @r//a:b || fail "build failed"
-  cat bazel-genfiles/external/+_repo_rules+r/a/bo > $TEST_log
-  expect_log "@+_repo_rules+r a"
+  cat bazel-genfiles/external/+_repo_rule_local_repository+r/a/bo > $TEST_log
+  expect_log "@+_repo_rule_local_repository+r a"
 }
 
 function test_slash_in_repo_name() {

--- a/src/test/shell/bazel/new_local_repo_test.sh
+++ b/src/test/shell/bazel/new_local_repo_test.sh
@@ -91,13 +91,13 @@ eof
 
   echo "dummy" >$pkg/B/a.txt
 
-  # Build 1: g.txt should contain external/+_repo_rules+B/a.txt
+  # Build 1: g.txt should contain external/+_repo_rule_new_local_repository+B/a.txt
   ( cd $pkg/A
     bazel build //:G
     cat bazel-genfiles/g.txt >$TEST_log
   )
-  expect_log "external/+_repo_rules+B/a.txt"
-  expect_not_log "external/+_repo_rules+B/b.txt"
+  expect_log "external/+_repo_rule_new_local_repository+B/a.txt"
+  expect_not_log "external/+_repo_rule_new_local_repository+B/b.txt"
 
   # Build 2: add B/b.txt and see if the glob picks it up.
   # Shut down the server afterwards so the test cleanup can remove $pkg/A.
@@ -107,8 +107,8 @@ eof
     cat bazel-genfiles/g.txt >$TEST_log
     bazel shutdown >& /dev/null
   )
-  expect_log "external/+_repo_rules+B/a.txt"
-  expect_log "external/+_repo_rules+B/b.txt"
+  expect_log "external/+_repo_rule_new_local_repository+B/a.txt"
+  expect_log "external/+_repo_rule_new_local_repository+B/b.txt"
 }
 
 # Regression test for https://github.com/bazelbuild/bazel/issues/9176

--- a/src/test/shell/bazel/new_local_repo_test.sh
+++ b/src/test/shell/bazel/new_local_repo_test.sh
@@ -91,13 +91,13 @@ eof
 
   echo "dummy" >$pkg/B/a.txt
 
-  # Build 1: g.txt should contain external/+_repo_rule_new_local_repository+B/a.txt
+  # Build 1: g.txt should contain external/+new_local_repository+B/a.txt
   ( cd $pkg/A
     bazel build //:G
     cat bazel-genfiles/g.txt >$TEST_log
   )
-  expect_log "external/+_repo_rule_new_local_repository+B/a.txt"
-  expect_not_log "external/+_repo_rule_new_local_repository+B/b.txt"
+  expect_log "external/+new_local_repository+B/a.txt"
+  expect_not_log "external/+new_local_repository+B/b.txt"
 
   # Build 2: add B/b.txt and see if the glob picks it up.
   # Shut down the server afterwards so the test cleanup can remove $pkg/A.
@@ -107,8 +107,8 @@ eof
     cat bazel-genfiles/g.txt >$TEST_log
     bazel shutdown >& /dev/null
   )
-  expect_log "external/+_repo_rule_new_local_repository+B/a.txt"
-  expect_log "external/+_repo_rule_new_local_repository+B/b.txt"
+  expect_log "external/+new_local_repository+B/a.txt"
+  expect_log "external/+new_local_repository+B/b.txt"
 }
 
 # Regression test for https://github.com/bazelbuild/bazel/issues/9176

--- a/src/test/shell/bazel/python_version_test.sh
+++ b/src/test/shell/bazel/python_version_test.sh
@@ -460,14 +460,14 @@ EOF
   fi
 
   cp bazel-bin/py/foo$exe.runfiles_manifest runfiles_manifest
-  assert_contains _main/external/+_repo_rule_local_repository+repo2/r2.txt runfiles_manifest \
+  assert_contains _main/external/+local_repository+repo2/r2.txt runfiles_manifest \
     "runfiles manifest didn't have external path mapping"
 
   # By default, Python binaries are put into zip files on Windows and don't
   # have a real runfiles tree.
   if ! "$is_windows"; then
     find bazel-bin/py/foo.runfiles > runfiles_listing
-    assert_contains bazel-bin/py/foo.runfiles/_main/external/+_repo_rule_local_repository+repo2/r2.txt \
+    assert_contains bazel-bin/py/foo.runfiles/_main/external/+local_repository+repo2/r2.txt \
       runfiles_listing \
       "runfiles didn't have external links"
   fi

--- a/src/test/shell/bazel/python_version_test.sh
+++ b/src/test/shell/bazel/python_version_test.sh
@@ -460,14 +460,14 @@ EOF
   fi
 
   cp bazel-bin/py/foo$exe.runfiles_manifest runfiles_manifest
-  assert_contains _main/external/+_repo_rules+repo2/r2.txt runfiles_manifest \
+  assert_contains _main/external/+_repo_rule_local_repository+repo2/r2.txt runfiles_manifest \
     "runfiles manifest didn't have external path mapping"
 
   # By default, Python binaries are put into zip files on Windows and don't
   # have a real runfiles tree.
   if ! "$is_windows"; then
     find bazel-bin/py/foo.runfiles > runfiles_listing
-    assert_contains bazel-bin/py/foo.runfiles/_main/external/+_repo_rules+repo2/r2.txt \
+    assert_contains bazel-bin/py/foo.runfiles/_main/external/+_repo_rule_local_repository+repo2/r2.txt \
       runfiles_listing \
       "runfiles didn't have external links"
   fi

--- a/src/test/shell/bazel/runfiles_test.sh
+++ b/src/test/shell/bazel/runfiles_test.sh
@@ -72,17 +72,17 @@ int main() { return 0; }
 EOF
   bazel build --legacy_external_runfiles //:thing &> $TEST_log \
     || fail "Build failed"
-  [[ -d bazel-bin/thing.runfiles/_main/external/+_repo_rule_new_local_repository+bar ]] \
+  [[ -d bazel-bin/thing.runfiles/_main/external/+new_local_repository+bar ]] \
     || fail "bar not found"
 
   bazel build --nolegacy_external_runfiles //:thing &> $TEST_log \
     || fail "Build failed"
-  [[ ! -d bazel-bin/thing.runfiles/_main/external/+_repo_rule_new_local_repository+bar ]] \
+  [[ ! -d bazel-bin/thing.runfiles/_main/external/+new_local_repository+bar ]] \
     || fail "Old bar still found"
 
   bazel build --legacy_external_runfiles //:thing &> $TEST_log \
     || fail "Build failed"
-  [[ -d bazel-bin/thing.runfiles/_main/external/+_repo_rule_new_local_repository+bar ]] \
+  [[ -d bazel-bin/thing.runfiles/_main/external/+new_local_repository+bar ]] \
     || fail "bar not recreated"
 }
 

--- a/src/test/shell/bazel/runfiles_test.sh
+++ b/src/test/shell/bazel/runfiles_test.sh
@@ -72,17 +72,17 @@ int main() { return 0; }
 EOF
   bazel build --legacy_external_runfiles //:thing &> $TEST_log \
     || fail "Build failed"
-  [[ -d bazel-bin/thing.runfiles/_main/external/+_repo_rules+bar ]] \
+  [[ -d bazel-bin/thing.runfiles/_main/external/+_repo_rule_new_local_repository+bar ]] \
     || fail "bar not found"
 
   bazel build --nolegacy_external_runfiles //:thing &> $TEST_log \
     || fail "Build failed"
-  [[ ! -d bazel-bin/thing.runfiles/_main/external/+_repo_rules+bar ]] \
+  [[ ! -d bazel-bin/thing.runfiles/_main/external/+_repo_rule_new_local_repository+bar ]] \
     || fail "Old bar still found"
 
   bazel build --legacy_external_runfiles //:thing &> $TEST_log \
     || fail "Build failed"
-  [[ -d bazel-bin/thing.runfiles/_main/external/+_repo_rules+bar ]] \
+  [[ -d bazel-bin/thing.runfiles/_main/external/+_repo_rule_new_local_repository+bar ]] \
     || fail "bar not recreated"
 }
 

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -158,7 +158,7 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rule_git_repository+pluto/info
+cat ../+git_repository+pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -166,7 +166,7 @@ EOF
     || echo "Expected build/run to succeed"
   expect_log "Pluto is a dwarf planet"
 
-  git_repos_count=$(find $(bazel info output_base)/external/+_repo_rule_git_repository+pluto -type d -name .git | wc -l)
+  git_repos_count=$(find $(bazel info output_base)/external/+git_repository+pluto -type d -name .git | wc -l)
   assert_equals $git_repos_count 0
 }
 
@@ -284,7 +284,7 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rule_new_git_repository+pluto/info
+cat ../+new_git_repository+pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -296,7 +296,7 @@ EOF
       expect_log "Pluto is a dwarf planet"
   fi
 
-  git_repos_count=$(find $(bazel info output_base)/external/+_repo_rule_new_git_repository+pluto -type d -name .git | wc -l)
+  git_repos_count=$(find $(bazel info output_base)/external/+new_git_repository+pluto -type d -name .git | wc -l)
   assert_equals $git_repos_count 0
 }
 
@@ -369,8 +369,8 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rule_new_git_repository+outer_planets/neptune/info
-cat ../+_repo_rule_new_git_repository+outer_planets/pluto/info
+cat ../+new_git_repository+outer_planets/neptune/info
+cat ../+new_git_repository+outer_planets/pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -426,8 +426,8 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rule_new_git_repository+outer_planets/neptune/info
-cat ../+_repo_rule_new_git_repository+outer_planets/pluto/info
+cat ../+new_git_repository+outer_planets/neptune/info
+cat ../+new_git_repository+outer_planets/pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -449,12 +449,12 @@ EOF
   # Use batch to force server restarts.
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 1" bazel-genfiles/external/+git_repository+g/go
 
   # Without changing anything, restart the server, which should not cause the checkout to be re-cloned.
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_not_log "Cloning"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 1" bazel-genfiles/external/+git_repository+g/go
 
   # Change the commit id, which should cause the checkout to be re-cloned.
   rm MODULE.bazel
@@ -465,7 +465,7 @@ EOF
 
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+git_repository+g/go
 
   # Change the MODULE.bazel but not the commit id, which should not cause the checkout to be re-cloned.
   rm MODULE.bazel
@@ -478,7 +478,7 @@ EOF
 
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_not_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+git_repository+g/go
 }
 
 function test_git_repository_not_refetched_on_server_restart_strip_prefix() {
@@ -491,7 +491,7 @@ git_repository(name='g', remote='$repo_dir', commit='17ea13b242e4cbcc27a6ef74593
 EOF
   bazel --batch build @g//gdir:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/gdir/go
+  assert_contains "GIT 2" bazel-genfiles/external/+git_repository+g/gdir/go
 
   rm MODULE.bazel
   cat >> MODULE.bazel <<EOF
@@ -500,7 +500,7 @@ git_repository(name='g', remote='$repo_dir', commit='17ea13b242e4cbcc27a6ef74593
 EOF
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+git_repository+g/go
 }
 
 
@@ -515,7 +515,7 @@ EOF
 
   bazel build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 1" bazel-genfiles/external/+git_repository+g/go
 
   # Change the commit id, which should cause the checkout to be re-cloned.
   rm MODULE.bazel
@@ -526,7 +526,7 @@ EOF
 
   bazel build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+git_repository+g/go
 }
 
 function test_git_repository_and_nofetch() {
@@ -541,7 +541,7 @@ EOF
   bazel build --nofetch @g//:g >& $TEST_log && fail "Build succeeded"
   expect_log "fetching repositories is disabled"
   bazel build @g//:g >& $TEST_log || fail "Build failed"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 1" bazel-genfiles/external/+git_repository+g/go
 
   rm MODULE.bazel
   cat >> MODULE.bazel <<EOF
@@ -550,10 +550,10 @@ git_repository(name='g', remote='$repo_dir', commit='db134ae9b644d8237954a8e6f1e
 EOF
 
   bazel build --nofetch @g//:g >& $TEST_log || fail "Build failed"
-  expect_log "External repository '+_repo_rule_git_repository+g' is not up-to-date"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  expect_log "External repository '+git_repository+g' is not up-to-date"
+  assert_contains "GIT 1" bazel-genfiles/external/+git_repository+g/go
   bazel build  @g//:g >& $TEST_log || fail "Build failed"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+git_repository+g/go
 
   rm MODULE.bazel
   cat >> MODULE.bazel <<EOF
@@ -562,9 +562,9 @@ git_repository(name='g', remote='$repo_dir', commit='17ea13b242e4cbcc27a6ef74593
 EOF
 
   bazel build --nofetch @g//:g >& $TEST_log || fail "Build failed"
-  expect_log "External repository '+_repo_rule_git_repository+g' is not up-to-date"
+  expect_log "External repository '+git_repository+g' is not up-to-date"
   bazel build  @g//:g >& $TEST_log || fail "Build failed"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+git_repository+g/go
 
 }
 
@@ -579,7 +579,7 @@ function setup_error_test() {
   mkdir -p planets
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat external/+_repo_rule_git_repository+pluto/info
+cat external/+git_repository+pluto/info
 EOF
 
   cat > planets/BUILD <<EOF

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -284,7 +284,7 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rule_git_repository+pluto/info
+cat ../+_repo_rule_new_git_repository+pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -296,7 +296,7 @@ EOF
       expect_log "Pluto is a dwarf planet"
   fi
 
-  git_repos_count=$(find $(bazel info output_base)/external/+_repo_rule_git_repository+pluto -type d -name .git | wc -l)
+  git_repos_count=$(find $(bazel info output_base)/external/+_repo_rule_new_git_repository+pluto -type d -name .git | wc -l)
   assert_equals $git_repos_count 0
 }
 
@@ -465,7 +465,7 @@ EOF
 
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_new_git_repository+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 
   # Change the MODULE.bazel but not the commit id, which should not cause the checkout to be re-cloned.
   rm MODULE.bazel

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -158,7 +158,7 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rules+pluto/info
+cat ../+_repo_rule_git_repository+pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -166,7 +166,7 @@ EOF
     || echo "Expected build/run to succeed"
   expect_log "Pluto is a dwarf planet"
 
-  git_repos_count=$(find $(bazel info output_base)/external/+_repo_rules+pluto -type d -name .git | wc -l)
+  git_repos_count=$(find $(bazel info output_base)/external/+_repo_rule_git_repository+pluto -type d -name .git | wc -l)
   assert_equals $git_repos_count 0
 }
 
@@ -284,7 +284,7 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rules+pluto/info
+cat ../+_repo_rule_git_repository+pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -296,7 +296,7 @@ EOF
       expect_log "Pluto is a dwarf planet"
   fi
 
-  git_repos_count=$(find $(bazel info output_base)/external/+_repo_rules+pluto -type d -name .git | wc -l)
+  git_repos_count=$(find $(bazel info output_base)/external/+_repo_rule_git_repository+pluto -type d -name .git | wc -l)
   assert_equals $git_repos_count 0
 }
 
@@ -369,8 +369,8 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rules+outer_planets/neptune/info
-cat ../+_repo_rules+outer_planets/pluto/info
+cat ../+_repo_rule_new_git_repository+outer_planets/neptune/info
+cat ../+_repo_rule_new_git_repository+outer_planets/pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -426,8 +426,8 @@ EOF
 
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat ../+_repo_rules+outer_planets/neptune/info
-cat ../+_repo_rules+outer_planets/pluto/info
+cat ../+_repo_rule_new_git_repository+outer_planets/neptune/info
+cat ../+_repo_rule_new_git_repository+outer_planets/pluto/info
 EOF
   chmod +x planets/planet_info.sh
 
@@ -449,12 +449,12 @@ EOF
   # Use batch to force server restarts.
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 
   # Without changing anything, restart the server, which should not cause the checkout to be re-cloned.
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_not_log "Cloning"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 
   # Change the commit id, which should cause the checkout to be re-cloned.
   rm MODULE.bazel
@@ -465,7 +465,7 @@ EOF
 
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_new_git_repository+g/go
 
   # Change the MODULE.bazel but not the commit id, which should not cause the checkout to be re-cloned.
   rm MODULE.bazel
@@ -478,7 +478,7 @@ EOF
 
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_not_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 }
 
 function test_git_repository_not_refetched_on_server_restart_strip_prefix() {
@@ -491,7 +491,7 @@ git_repository(name='g', remote='$repo_dir', commit='17ea13b242e4cbcc27a6ef74593
 EOF
   bazel --batch build @g//gdir:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rules+g/gdir/go
+  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/gdir/go
 
   rm MODULE.bazel
   cat >> MODULE.bazel <<EOF
@@ -500,7 +500,7 @@ git_repository(name='g', remote='$repo_dir', commit='17ea13b242e4cbcc27a6ef74593
 EOF
   bazel --batch build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 }
 
 
@@ -515,7 +515,7 @@ EOF
 
   bazel build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 
   # Change the commit id, which should cause the checkout to be re-cloned.
   rm MODULE.bazel
@@ -526,7 +526,7 @@ EOF
 
   bazel build @g//:g >& $TEST_log || fail "Build failed"
   expect_log "Cloning"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 }
 
 function test_git_repository_and_nofetch() {
@@ -541,7 +541,7 @@ EOF
   bazel build --nofetch @g//:g >& $TEST_log && fail "Build succeeded"
   expect_log "fetching repositories is disabled"
   bazel build @g//:g >& $TEST_log || fail "Build failed"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 
   rm MODULE.bazel
   cat >> MODULE.bazel <<EOF
@@ -550,10 +550,10 @@ git_repository(name='g', remote='$repo_dir', commit='db134ae9b644d8237954a8e6f1e
 EOF
 
   bazel build --nofetch @g//:g >& $TEST_log || fail "Build failed"
-  expect_log "External repository '+_repo_rules+g' is not up-to-date"
-  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rules+g/go
+  expect_log "External repository '+_repo_rule_git_repository+g' is not up-to-date"
+  assert_contains "GIT 1" bazel-genfiles/external/+_repo_rule_git_repository+g/go
   bazel build  @g//:g >& $TEST_log || fail "Build failed"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 
   rm MODULE.bazel
   cat >> MODULE.bazel <<EOF
@@ -562,9 +562,9 @@ git_repository(name='g', remote='$repo_dir', commit='17ea13b242e4cbcc27a6ef74593
 EOF
 
   bazel build --nofetch @g//:g >& $TEST_log || fail "Build failed"
-  expect_log "External repository '+_repo_rules+g' is not up-to-date"
+  expect_log "External repository '+_repo_rule_git_repository+g' is not up-to-date"
   bazel build  @g//:g >& $TEST_log || fail "Build failed"
-  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rules+g/go
+  assert_contains "GIT 2" bazel-genfiles/external/+_repo_rule_git_repository+g/go
 
 }
 
@@ -579,7 +579,7 @@ function setup_error_test() {
   mkdir -p planets
   cat > planets/planet_info.sh <<EOF
 #!/bin/sh
-cat external/+_repo_rules+pluto/info
+cat external/+_repo_rule_git_repository+pluto/info
 EOF
 
   cat > planets/BUILD <<EOF

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -185,7 +185,7 @@ EOF
 
   bazel build @foo//:bar >& $TEST_log || fail "Failed to build"
   expect_log "foo"
-  cat bazel-bin/external/+_repo_rules+foo/bar.txt >$TEST_log
+  cat bazel-bin/external/+_repo_rule_foo+foo/bar.txt >$TEST_log
   expect_log "foo"
 }
 
@@ -386,9 +386,9 @@ EOF
   bazel build "--repo_env=INPUT_$unicode=${input_file}" @foo//:bar >& $TEST_log || fail "Failed to build"
   expect_log "UNICODE = $unicode"
   output_base="$(bazel info output_base)"
-  assert_contains "$unicode" "$output_base/external/+_repo_rules+foo/direct${unicode}.txt"
-  assert_contains "$unicode" "$output_base/external/+_repo_rules+foo/indirect${unicode}.txt"
-  assert_contains "${unicode}_replaced_${unicode}" "$output_base/external/+_repo_rules+foo/template${unicode}.txt"
+  assert_contains "$unicode" "$output_base/external/+_repo_rule_repo+foo/direct${unicode}.txt"
+  assert_contains "$unicode" "$output_base/external/+_repo_rule_repo+foo/indirect${unicode}.txt"
+  assert_contains "${unicode}_replaced_${unicode}" "$output_base/external/+_repo_rule_repo+foo/template${unicode}.txt"
 
   # The repo rule should not be re-run on server restart
   bazel shutdown
@@ -995,10 +995,10 @@ EOF
 
   bazel run @foo//:bar >& $TEST_log || fail "Execution of @foo//:bar failed"
   output_base=$(bazel info output_base)
-  test -x "${output_base}/external/+_repo_rules+foo/test.sh" || fail "test.sh is not executable"
-  test -x "${output_base}/external/+_repo_rules+foo/test2.sh" || fail "test2.sh is not executable"
-  test ! -x "${output_base}/external/+_repo_rules+foo/BUILD" || fail "BUILD is executable"
-  test ! -x "${output_base}/external/+_repo_rules+foo/test2" || fail "test2 is executable"
+  test -x "${output_base}/external/+_repo_rule_repo+foo/test.sh" || fail "test.sh is not executable"
+  test -x "${output_base}/external/+_repo_rule_repo+foo/test2.sh" || fail "test2.sh is not executable"
+  test ! -x "${output_base}/external/+_repo_rule_repo+foo/BUILD" || fail "BUILD is executable"
+  test ! -x "${output_base}/external/+_repo_rule_repo+foo/test2" || fail "test2 is executable"
 }
 
 function test_starlark_repository_download() {
@@ -1034,15 +1034,15 @@ EOF
 
   output_base="$(bazel info output_base)"
   # Test download
-  test -e "${output_base}/external/+_repo_rules+foo/download_with_sha256.txt" \
+  test -e "${output_base}/external/+_repo_rule_repo+foo/download_with_sha256.txt" \
     || fail "download_with_sha256.txt is not downloaded"
-  test -e "${output_base}/external/+_repo_rules+foo/download_executable_file.sh" \
+  test -e "${output_base}/external/+_repo_rule_repo+foo/download_executable_file.sh" \
     || fail "download_executable_file.sh is not downloaded"
   # Test download
-  diff "${output_base}/external/+_repo_rules+foo/download_with_sha256.txt" \
+  diff "${output_base}/external/+_repo_rule_repo+foo/download_with_sha256.txt" \
     "${download_with_sha256}" >/dev/null \
     || fail "download_with_sha256.txt is not downloaded successfully"
-  diff "${output_base}/external/+_repo_rules+foo/download_executable_file.sh" \
+  diff "${output_base}/external/+_repo_rule_repo+foo/download_executable_file.sh" \
     "${download_executable_file}" >/dev/null \
     || fail "download_executable_file.sh is not downloaded successfully"
 
@@ -1052,9 +1052,9 @@ EOF
   fi
 
   # Test executable
-  test ! -x "${output_base}/external/+_repo_rules+foo/download_with_sha256.txt" \
+  test ! -x "${output_base}/external/+_repo_rule_repo+foo/download_with_sha256.txt" \
     || fail "download_with_sha256.txt is executable"
-  test -x "${output_base}/external/+_repo_rules+foo/download_executable_file.sh" \
+  test -x "${output_base}/external/+_repo_rule_repo+foo/download_executable_file.sh" \
     || fail "download_executable_file.sh is not executable"
 }
 
@@ -1123,13 +1123,13 @@ EOF
         >& $TEST_log && shutdown_server || fail "Execution of @foo//:all failed"
 
   output_base="$(bazel info output_base)"
-  grep "no_sha_return $not_provided_sha256" $output_base/external/+_repo_rules+foo/returned_shas.txt \
+  grep "no_sha_return $not_provided_sha256" $output_base/external/+_repo_rule_foo+foo/returned_shas.txt \
       || fail "expected calculated sha256 $not_provided_sha256"
-  grep "with_sha_return $provided_sha256" $output_base/external/+_repo_rules+foo/returned_shas.txt \
+  grep "with_sha_return $provided_sha256" $output_base/external/+_repo_rule_foo+foo/returned_shas.txt \
       || fail "expected provided sha256 $provided_sha256"
-  grep "compressed_with_sha_return $compressed_provided_sha256" $output_base/external/+_repo_rules+foo/returned_shas.txt \
+  grep "compressed_with_sha_return $compressed_provided_sha256" $output_base/external/+_repo_rule_foo+foo/returned_shas.txt \
       || fail "expected provided sha256 $compressed_provided_sha256"
-  grep "compressed_no_sha_return $compressed_not_provided_sha256" $output_base/external/+_repo_rules+foo/returned_shas.txt \
+  grep "compressed_no_sha_return $compressed_not_provided_sha256" $output_base/external/+_repo_rule_foo+foo/returned_shas.txt \
       || fail "expected compressed calculated sha256 $compressed_not_provided_sha256"
 }
 
@@ -1189,7 +1189,7 @@ EOF
 
   output_base="$(bazel info output_base)"
   # Test download
-  test -e "${output_base}/external/+_repo_rules+foo/whatever.txt" \
+  test -e "${output_base}/external/+_repo_rule_repo+foo/whatever.txt" \
     || fail "whatever.txt is not downloaded"
 }
 
@@ -1242,26 +1242,26 @@ EOF
 
   output_base="$(bazel info output_base)"
   # Test cleanup
-  test -e "${output_base}/external/+_repo_rules+foo/server_dir/download_and_extract1.tar.gz" \
+  test -e "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract1.tar.gz" \
     && fail "temp file was not deleted successfully" || true
-  test -e "${output_base}/external/+_repo_rules+foo/server_dir/download_and_extract2.zip" \
+  test -e "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract2.zip" \
     && fail "temp file was not deleted successfully" || true
-  test -e "${output_base}/external/+_repo_rules+foo/server_dir/download_and_extract3.zip" \
+  test -e "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract3.zip" \
     && fail "temp file was not deleted successfully" || true
   # Test download_and_extract
-  diff "${output_base}/external/+_repo_rules+foo/server_dir/download_and_extract1.txt" \
+  diff "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract1.txt" \
     "${file_prefix}1.txt" >/dev/null \
     || fail "download_and_extract1.tar.gz was not extracted successfully"
-  diff "${output_base}/external/+_repo_rules+foo/some/path/server_dir/download_and_extract1.txt" \
+  diff "${output_base}/external/+_repo_rule_repo+foo/some/path/server_dir/download_and_extract1.txt" \
     "${file_prefix}1.txt" >/dev/null \
     || fail "download_and_extract1.tar.gz was not extracted successfully in some/path"
-  diff "${output_base}/external/+_repo_rules+foo/server_dir/download_and_extract2.txt" \
+  diff "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract2.txt" \
     "${file_prefix}2.txt" >/dev/null \
     || fail "download_and_extract2.zip was not extracted successfully"
-  diff "${output_base}/external/+_repo_rules+foo/server_dir/download_and_extract3.txt" \
+  diff "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract3.txt" \
     "${file_prefix}3.txt" >/dev/null \
     || fail "download_and_extract3.zip was not extracted successfully"
-  diff "${output_base}/external/+_repo_rules+foo/other/path/server_dir/download_and_extract3.txt" \
+  diff "${output_base}/external/+_repo_rule_repo+foo/other/path/server_dir/download_and_extract3.txt" \
     "${file_prefix}3.txt" >/dev/null \
     || fail "download_and_extract3.tar.gz was not extracted successfully"
 }
@@ -2477,9 +2477,9 @@ EOF
   bazel build @foo >& $TEST_log || fail "expected bazel to succeed"
   expect_log "I see: nothing"
 
-  local marker_file=$(bazel info output_base)/external/@+_repo_rules+foo.marker
-  # the marker file for this repo should contain a reference to "@@+_repo_rules2+bar". Mangle that.
-  sed -i'' -e 's/@@+_repo_rules2+bar/@@LOL@@LOL/g' ${marker_file}
+  local marker_file=$(bazel info output_base)/external/@+_repo_rule_foo+foo.marker
+  # the marker file for this repo should contain a reference to "@@+_repo_rule_bar+bar". Mangle that.
+  sed -i'' -e 's/@@+_repo_rule_bar+bar/@@LOL@@LOL/g' ${marker_file}
 
   # Running Bazel again shouldn't crash, and should result in a refetch.
   bazel shutdown
@@ -2506,7 +2506,7 @@ EOF
 def _foo(rctx):
   rctx.file("BUILD", "filegroup(name='foo')")
   # this repo might not have been defined yet
-  rctx.watch("../+_repo_rules2+bar/BUILD")
+  rctx.watch("../+_repo_rule_bar+bar/BUILD")
   print("I see something!")
 foo=repository_rule(_foo)
 EOF
@@ -2919,8 +2919,8 @@ filegroup(
 EOF
     bazel build //:foo >& $TEST_log || fail "expected bazel to succeed"
     expect_log "main repo: //:foo @@//:foo"
-    expect_log "my_first_repo: @my_first_repo//:foo @@+_repo_rules+my_first_repo//:foo"
-    expect_log "my_second_repo: @my_first_repo//:foo @@+_repo_rules+my_first_repo//:foo"
+    expect_log "my_first_repo: @my_first_repo//:foo @@+_repo_rule_my_repository_rule+my_first_repo//:foo"
+    expect_log "my_second_repo: @my_first_repo//:foo @@+_repo_rule_my_repository_rule+my_first_repo//:foo"
 }
 
 function test_execute_environment_remove_vars() {

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -185,7 +185,7 @@ EOF
 
   bazel build @foo//:bar >& $TEST_log || fail "Failed to build"
   expect_log "foo"
-  cat bazel-bin/external/+_repo_rule_repo+foo/bar.txt >$TEST_log
+  cat bazel-bin/external/+repo+foo/bar.txt >$TEST_log
   expect_log "foo"
 }
 
@@ -386,9 +386,9 @@ EOF
   bazel build "--repo_env=INPUT_$unicode=${input_file}" @foo//:bar >& $TEST_log || fail "Failed to build"
   expect_log "UNICODE = $unicode"
   output_base="$(bazel info output_base)"
-  assert_contains "$unicode" "$output_base/external/+_repo_rule_repo+foo/direct${unicode}.txt"
-  assert_contains "$unicode" "$output_base/external/+_repo_rule_repo+foo/indirect${unicode}.txt"
-  assert_contains "${unicode}_replaced_${unicode}" "$output_base/external/+_repo_rule_repo+foo/template${unicode}.txt"
+  assert_contains "$unicode" "$output_base/external/+repo+foo/direct${unicode}.txt"
+  assert_contains "$unicode" "$output_base/external/+repo+foo/indirect${unicode}.txt"
+  assert_contains "${unicode}_replaced_${unicode}" "$output_base/external/+repo+foo/template${unicode}.txt"
 
   # The repo rule should not be re-run on server restart
   bazel shutdown
@@ -995,10 +995,10 @@ EOF
 
   bazel run @foo//:bar >& $TEST_log || fail "Execution of @foo//:bar failed"
   output_base=$(bazel info output_base)
-  test -x "${output_base}/external/+_repo_rule_repo+foo/test.sh" || fail "test.sh is not executable"
-  test -x "${output_base}/external/+_repo_rule_repo+foo/test2.sh" || fail "test2.sh is not executable"
-  test ! -x "${output_base}/external/+_repo_rule_repo+foo/BUILD" || fail "BUILD is executable"
-  test ! -x "${output_base}/external/+_repo_rule_repo+foo/test2" || fail "test2 is executable"
+  test -x "${output_base}/external/+repo+foo/test.sh" || fail "test.sh is not executable"
+  test -x "${output_base}/external/+repo+foo/test2.sh" || fail "test2.sh is not executable"
+  test ! -x "${output_base}/external/+repo+foo/BUILD" || fail "BUILD is executable"
+  test ! -x "${output_base}/external/+repo+foo/test2" || fail "test2 is executable"
 }
 
 function test_starlark_repository_download() {
@@ -1034,15 +1034,15 @@ EOF
 
   output_base="$(bazel info output_base)"
   # Test download
-  test -e "${output_base}/external/+_repo_rule_repo+foo/download_with_sha256.txt" \
+  test -e "${output_base}/external/+repo+foo/download_with_sha256.txt" \
     || fail "download_with_sha256.txt is not downloaded"
-  test -e "${output_base}/external/+_repo_rule_repo+foo/download_executable_file.sh" \
+  test -e "${output_base}/external/+repo+foo/download_executable_file.sh" \
     || fail "download_executable_file.sh is not downloaded"
   # Test download
-  diff "${output_base}/external/+_repo_rule_repo+foo/download_with_sha256.txt" \
+  diff "${output_base}/external/+repo+foo/download_with_sha256.txt" \
     "${download_with_sha256}" >/dev/null \
     || fail "download_with_sha256.txt is not downloaded successfully"
-  diff "${output_base}/external/+_repo_rule_repo+foo/download_executable_file.sh" \
+  diff "${output_base}/external/+repo+foo/download_executable_file.sh" \
     "${download_executable_file}" >/dev/null \
     || fail "download_executable_file.sh is not downloaded successfully"
 
@@ -1052,9 +1052,9 @@ EOF
   fi
 
   # Test executable
-  test ! -x "${output_base}/external/+_repo_rule_repo+foo/download_with_sha256.txt" \
+  test ! -x "${output_base}/external/+repo+foo/download_with_sha256.txt" \
     || fail "download_with_sha256.txt is executable"
-  test -x "${output_base}/external/+_repo_rule_repo+foo/download_executable_file.sh" \
+  test -x "${output_base}/external/+repo+foo/download_executable_file.sh" \
     || fail "download_executable_file.sh is not executable"
 }
 
@@ -1123,13 +1123,13 @@ EOF
         >& $TEST_log && shutdown_server || fail "Execution of @foo//:all failed"
 
   output_base="$(bazel info output_base)"
-  grep "no_sha_return $not_provided_sha256" $output_base/external/+_repo_rule_repo+foo/returned_shas.txt \
+  grep "no_sha_return $not_provided_sha256" $output_base/external/+repo+foo/returned_shas.txt \
       || fail "expected calculated sha256 $not_provided_sha256"
-  grep "with_sha_return $provided_sha256" $output_base/external/+_repo_rule_repo+foo/returned_shas.txt \
+  grep "with_sha_return $provided_sha256" $output_base/external/+repo+foo/returned_shas.txt \
       || fail "expected provided sha256 $provided_sha256"
-  grep "compressed_with_sha_return $compressed_provided_sha256" $output_base/external/+_repo_rule_repo+foo/returned_shas.txt \
+  grep "compressed_with_sha_return $compressed_provided_sha256" $output_base/external/+repo+foo/returned_shas.txt \
       || fail "expected provided sha256 $compressed_provided_sha256"
-  grep "compressed_no_sha_return $compressed_not_provided_sha256" $output_base/external/+_repo_rule_repo+foo/returned_shas.txt \
+  grep "compressed_no_sha_return $compressed_not_provided_sha256" $output_base/external/+repo+foo/returned_shas.txt \
       || fail "expected compressed calculated sha256 $compressed_not_provided_sha256"
 }
 
@@ -1189,7 +1189,7 @@ EOF
 
   output_base="$(bazel info output_base)"
   # Test download
-  test -e "${output_base}/external/+_repo_rule_repo+foo/whatever.txt" \
+  test -e "${output_base}/external/+repo+foo/whatever.txt" \
     || fail "whatever.txt is not downloaded"
 }
 
@@ -1242,26 +1242,26 @@ EOF
 
   output_base="$(bazel info output_base)"
   # Test cleanup
-  test -e "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract1.tar.gz" \
+  test -e "${output_base}/external/+repo+foo/server_dir/download_and_extract1.tar.gz" \
     && fail "temp file was not deleted successfully" || true
-  test -e "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract2.zip" \
+  test -e "${output_base}/external/+repo+foo/server_dir/download_and_extract2.zip" \
     && fail "temp file was not deleted successfully" || true
-  test -e "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract3.zip" \
+  test -e "${output_base}/external/+repo+foo/server_dir/download_and_extract3.zip" \
     && fail "temp file was not deleted successfully" || true
   # Test download_and_extract
-  diff "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract1.txt" \
+  diff "${output_base}/external/+repo+foo/server_dir/download_and_extract1.txt" \
     "${file_prefix}1.txt" >/dev/null \
     || fail "download_and_extract1.tar.gz was not extracted successfully"
-  diff "${output_base}/external/+_repo_rule_repo+foo/some/path/server_dir/download_and_extract1.txt" \
+  diff "${output_base}/external/+repo+foo/some/path/server_dir/download_and_extract1.txt" \
     "${file_prefix}1.txt" >/dev/null \
     || fail "download_and_extract1.tar.gz was not extracted successfully in some/path"
-  diff "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract2.txt" \
+  diff "${output_base}/external/+repo+foo/server_dir/download_and_extract2.txt" \
     "${file_prefix}2.txt" >/dev/null \
     || fail "download_and_extract2.zip was not extracted successfully"
-  diff "${output_base}/external/+_repo_rule_repo+foo/server_dir/download_and_extract3.txt" \
+  diff "${output_base}/external/+repo+foo/server_dir/download_and_extract3.txt" \
     "${file_prefix}3.txt" >/dev/null \
     || fail "download_and_extract3.zip was not extracted successfully"
-  diff "${output_base}/external/+_repo_rule_repo+foo/other/path/server_dir/download_and_extract3.txt" \
+  diff "${output_base}/external/+repo+foo/other/path/server_dir/download_and_extract3.txt" \
     "${file_prefix}3.txt" >/dev/null \
     || fail "download_and_extract3.tar.gz was not extracted successfully"
 }
@@ -2477,9 +2477,9 @@ EOF
   bazel build @foo >& $TEST_log || fail "expected bazel to succeed"
   expect_log "I see: nothing"
 
-  local marker_file=$(bazel info output_base)/external/@+_repo_rule_foo+foo.marker
-  # the marker file for this repo should contain a reference to "@@+_repo_rule_bar+bar". Mangle that.
-  sed -i'' -e 's/@@+_repo_rule_bar+bar/@@LOL@@LOL/g' ${marker_file}
+  local marker_file=$(bazel info output_base)/external/@+foo+foo.marker
+  # the marker file for this repo should contain a reference to "@@+bar+bar". Mangle that.
+  sed -i'' -e 's/@@+bar+bar/@@LOL@@LOL/g' ${marker_file}
 
   # Running Bazel again shouldn't crash, and should result in a refetch.
   bazel shutdown
@@ -2506,7 +2506,7 @@ EOF
 def _foo(rctx):
   rctx.file("BUILD", "filegroup(name='foo')")
   # this repo might not have been defined yet
-  rctx.watch("../+_repo_rule_bar+bar/BUILD")
+  rctx.watch("../+bar+bar/BUILD")
   print("I see something!")
 foo=repository_rule(_foo)
 EOF
@@ -2919,8 +2919,8 @@ filegroup(
 EOF
     bazel build //:foo >& $TEST_log || fail "expected bazel to succeed"
     expect_log "main repo: //:foo @@//:foo"
-    expect_log "my_first_repo: @my_first_repo//:foo @@+_repo_rule_my_repository_rule+my_first_repo//:foo"
-    expect_log "my_second_repo: @my_first_repo//:foo @@+_repo_rule_my_repository_rule+my_first_repo//:foo"
+    expect_log "my_first_repo: @my_first_repo//:foo @@+my_repository_rule+my_first_repo//:foo"
+    expect_log "my_second_repo: @my_first_repo//:foo @@+my_repository_rule+my_first_repo//:foo"
 }
 
 function test_execute_environment_remove_vars() {

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -185,7 +185,7 @@ EOF
 
   bazel build @foo//:bar >& $TEST_log || fail "Failed to build"
   expect_log "foo"
-  cat bazel-bin/external/+_repo_rule_foo+foo/bar.txt >$TEST_log
+  cat bazel-bin/external/+_repo_rule_repo+foo/bar.txt >$TEST_log
   expect_log "foo"
 }
 
@@ -1123,13 +1123,13 @@ EOF
         >& $TEST_log && shutdown_server || fail "Execution of @foo//:all failed"
 
   output_base="$(bazel info output_base)"
-  grep "no_sha_return $not_provided_sha256" $output_base/external/+_repo_rule_foo+foo/returned_shas.txt \
+  grep "no_sha_return $not_provided_sha256" $output_base/external/+_repo_rule_repo+foo/returned_shas.txt \
       || fail "expected calculated sha256 $not_provided_sha256"
-  grep "with_sha_return $provided_sha256" $output_base/external/+_repo_rule_foo+foo/returned_shas.txt \
+  grep "with_sha_return $provided_sha256" $output_base/external/+_repo_rule_repo+foo/returned_shas.txt \
       || fail "expected provided sha256 $provided_sha256"
-  grep "compressed_with_sha_return $compressed_provided_sha256" $output_base/external/+_repo_rule_foo+foo/returned_shas.txt \
+  grep "compressed_with_sha_return $compressed_provided_sha256" $output_base/external/+_repo_rule_repo+foo/returned_shas.txt \
       || fail "expected provided sha256 $compressed_provided_sha256"
-  grep "compressed_no_sha_return $compressed_not_provided_sha256" $output_base/external/+_repo_rule_foo+foo/returned_shas.txt \
+  grep "compressed_no_sha_return $compressed_not_provided_sha256" $output_base/external/+_repo_rule_repo+foo/returned_shas.txt \
       || fail "expected compressed calculated sha256 $compressed_not_provided_sha256"
 }
 

--- a/src/test/shell/integration/bazel_aquery_test.sh
+++ b/src/test/shell/integration/bazel_aquery_test.sh
@@ -78,7 +78,7 @@ EOF
   bazel aquery --output=textproto --include_file_write_contents \
      "//:foo" >output 2> "$TEST_log" || fail "Expected success"
   cat output >> "$TEST_log"
-  assert_contains "^file_contents:.*pkg2,+_repo_rule_local_repository+pkg2" output
+  assert_contains "^file_contents:.*pkg2,+local_repository+pkg2" output
 
   bazel aquery --output=text --include_file_write_contents "//:foo" | \
     sed -nr '/Mnemonic: RepoMappingManifest/,/^ *$/p' >output \
@@ -88,7 +88,7 @@ EOF
   # Verify file contents if we can decode base64-encoded data.
   if which base64 >/dev/null; then
     sed -nr 's/^ *FileWriteContents: \[(.*)\]/echo \1 | base64 -d/p' output | \
-       sh | tee -a "$TEST_log"  | assert_contains "pkg2,+_repo_rule_local_repository+pkg2" -
+       sh | tee -a "$TEST_log"  | assert_contains "pkg2,+local_repository+pkg2" -
   fi
 }
 

--- a/src/test/shell/integration/bazel_aquery_test.sh
+++ b/src/test/shell/integration/bazel_aquery_test.sh
@@ -78,7 +78,7 @@ EOF
   bazel aquery --output=textproto --include_file_write_contents \
      "//:foo" >output 2> "$TEST_log" || fail "Expected success"
   cat output >> "$TEST_log"
-  assert_contains "^file_contents:.*pkg2,+_repo_rules+pkg2" output
+  assert_contains "^file_contents:.*pkg2,+_repo_rule_local_repository+pkg2" output
 
   bazel aquery --output=text --include_file_write_contents "//:foo" | \
     sed -nr '/Mnemonic: RepoMappingManifest/,/^ *$/p' >output \
@@ -88,7 +88,7 @@ EOF
   # Verify file contents if we can decode base64-encoded data.
   if which base64 >/dev/null; then
     sed -nr 's/^ *FileWriteContents: \[(.*)\]/echo \1 | base64 -d/p' output | \
-       sh | tee -a "$TEST_log"  | assert_contains "pkg2,+_repo_rules+pkg2" -
+       sh | tee -a "$TEST_log"  | assert_contains "pkg2,+_repo_rule_local_repository+pkg2" -
   fi
 }
 

--- a/src/test/shell/integration/prelude_test.sh
+++ b/src/test/shell/integration/prelude_test.sh
@@ -100,7 +100,7 @@ EOF
   output=$(cat bazel-genfiles/gr.out)
   check_eq "outer from test_prelude_external_repository, outer workspace" "$output" "unexpected output in gr.out"
 
-  output=$(cat bazel-genfiles/external/+_repo_rules+imported_workspace/gr_inner.out)
+  output=$(cat bazel-genfiles/external/+_repo_rule_local_repository+imported_workspace/gr_inner.out)
   check_eq "inner from test_prelude_external_repository, inner workspace" "$output" "unexpected output in gr_inner.out"
 }
 

--- a/src/test/shell/integration/prelude_test.sh
+++ b/src/test/shell/integration/prelude_test.sh
@@ -100,7 +100,7 @@ EOF
   output=$(cat bazel-genfiles/gr.out)
   check_eq "outer from test_prelude_external_repository, outer workspace" "$output" "unexpected output in gr.out"
 
-  output=$(cat bazel-genfiles/external/+_repo_rule_local_repository+imported_workspace/gr_inner.out)
+  output=$(cat bazel-genfiles/external/+local_repository+imported_workspace/gr_inner.out)
   check_eq "inner from test_prelude_external_repository, inner workspace" "$output" "unexpected output in gr_inner.out"
 }
 

--- a/src/test/shell/integration/target_compatible_with_test_external_repo.sh
+++ b/src/test/shell/integration/target_compatible_with_test_external_repo.sh
@@ -197,12 +197,12 @@ EOF
     --platforms=@//:foo3_platform \
     --build_event_text_file="${TEST_log}".build.json \
     @test_repo//:bin &> "${TEST_log}" && fail "Bazel passed unexpectedly."
-  expect_log 'ERROR:.*Target @@+_repo_rules+test_repo//:bin is incompatible and cannot be built'
+  expect_log 'ERROR:.*Target @@+_repo_rule_local_repository+test_repo//:bin is incompatible and cannot be built'
   expect_log '^ERROR: Build did NOT complete successfully'
   # Now look at the build event log.
   mv "${TEST_log}".build.json "${TEST_log}"
   expect_log '^    name: "PARSING_FAILURE"$'
-  expect_log 'Target @@+_repo_rules+test_repo//:bin is incompatible and cannot be built.'
+  expect_log 'Target @@+_repo_rule_local_repository+test_repo//:bin is incompatible and cannot be built.'
 }
 
 # Regression test for https://github.com/bazelbuild/bazel/issues/12374

--- a/src/test/shell/integration/target_compatible_with_test_external_repo.sh
+++ b/src/test/shell/integration/target_compatible_with_test_external_repo.sh
@@ -197,22 +197,22 @@ EOF
     --platforms=@//:foo3_platform \
     --build_event_text_file="${TEST_log}".build.json \
     @test_repo//:bin &> "${TEST_log}" && fail "Bazel passed unexpectedly."
-  expect_log 'ERROR:.*Target @@+_repo_rule_local_repository+test_repo//:bin is incompatible and cannot be built'
+  expect_log 'ERROR:.*Target @@+local_repository+test_repo//:bin is incompatible and cannot be built'
   expect_log '^ERROR: Build did NOT complete successfully'
   # Now look at the build event log.
   mv "${TEST_log}".build.json "${TEST_log}"
   expect_log '^    name: "PARSING_FAILURE"$'
-  expect_log 'Target @@+_repo_rule_local_repository+test_repo//:bin is incompatible and cannot be built.'
+  expect_log 'Target @@+local_repository+test_repo//:bin is incompatible and cannot be built.'
 }
 
 # Regression test for https://github.com/bazelbuild/bazel/issues/12374
 function test_repository_defines_target_compatible_with() {
   cat > repo.bzl <<EOF
-def _repo_rule_impl(repo_ctx):
+def impl(repo_ctx):
     pass
 
 repo_rule = repository_rule(
-    implementation = _repo_rule_impl,
+    implementation = impl,
     attrs = {
         "target_compatible_with": attr.label_list(),
     },

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -2697,7 +2697,7 @@ EOF
   # Test the build.
   bazel build \
     "//${pkg}/demo:demo" &> $TEST_log || fail "Build failed"
-  expect_log "foo_tool = <target @@+_repo_rules+rules_foo//foo_tools:foo_tool>"
+  expect_log "foo_tool = <target @@+_repo_rule_local_repository+rules_foo//foo_tools:foo_tool>"
 }
 
 function test_exec_platform_order_with_mandatory_toolchains {

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -2697,7 +2697,7 @@ EOF
   # Test the build.
   bazel build \
     "//${pkg}/demo:demo" &> $TEST_log || fail "Build failed"
-  expect_log "foo_tool = <target @@+_repo_rule_local_repository+rules_foo//foo_tools:foo_tool>"
+  expect_log "foo_tool = <target @@+local_repository+rules_foo//foo_tools:foo_tool>"
 }
 
 function test_exec_platform_order_with_mandatory_toolchains {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 18,
+  "lockFileVersion": 20,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",


### PR DESCRIPTION
This makes canonical repo names more stable and avoids repo thrashing when adding or reordering repo rule usages in `MODULE.bazel`.

RELNOTES[INC]: The canonical names of repos created with `use_repo_rule` have changed, which may require updating command-line flags such as `--override_repository`.