### PR TITLE
Use `Single.using` instead of `onError`/`onSuccess` for async uploads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -129,11 +129,8 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
 import io.grpc.Status.Code;
-import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.core.SingleObserver;
-import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -160,6 +157,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -1795,8 +1793,14 @@ public class RemoteExecutionService {
 
     if (remoteOptions.remoteCacheAsync
         && !action.getSpawn().getResourceOwner().mayModifySpawnOutputsAfterExecution()) {
+      AtomicLong startTime = new AtomicLong();
       Single.using(
-              combinedCache::retain,
+              () -> {
+                backgroundTaskPhaser.register();
+                CombinedCache cache = combinedCache.retain();
+                startTime.set(Profiler.nanoTimeMaybe());
+                return cache;
+              },
               combinedCache ->
                   buildUploadManifestAsync(action, spawnResult)
                       .flatMap(
@@ -1804,36 +1808,18 @@ public class RemoteExecutionService {
                               manifest.uploadAsync(
                                   action.getRemoteActionExecutionContext(),
                                   combinedCache,
-                                  reporter)),
-              CombinedCache::release)
+                                  reporter))
+                      .doOnError(this::reportUploadError),
+              cacheResource -> {
+                Profiler.instance()
+                    .completeTask(startTime.get(), ProfilerTask.UPLOAD_TIME, "upload outputs");
+                backgroundTaskPhaser.arriveAndDeregister();
+                onUploadComplete.run();
+                cacheResource.release();
+              },
+              /* eager= */ false)
           .subscribeOn(scheduler)
-          .subscribe(
-              new SingleObserver<ActionResult>() {
-                long startTime = 0;
-
-                @Override
-                public void onSubscribe(@NonNull Disposable d) {
-                  backgroundTaskPhaser.register();
-                  startTime = Profiler.nanoTimeMaybe();
-                }
-
-                @Override
-                public void onSuccess(@NonNull ActionResult actionResult) {
-                  Profiler.instance()
-                      .completeTask(startTime, ProfilerTask.UPLOAD_TIME, "upload outputs");
-                  backgroundTaskPhaser.arriveAndDeregister();
-                  onUploadComplete.run();
-                }
-
-                @Override
-                public void onError(@NonNull Throwable e) {
-                  Profiler.instance()
-                      .completeTask(startTime, ProfilerTask.UPLOAD_TIME, "upload outputs");
-                  backgroundTaskPhaser.arriveAndDeregister();
-                  reportUploadError(e);
-                  onUploadComplete.run();
-                }
-              });
+          .subscribe(result -> {}, error -> {});
     } else {
       try (SilentCloseable c =
           Profiler.instance().profile(ProfilerTask.UPLOAD_TIME, "upload outputs")) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1808,8 +1808,7 @@ public class RemoteExecutionService {
                               manifest.uploadAsync(
                                   action.getRemoteActionExecutionContext(),
                                   combinedCache,
-                                  reporter))
-                      .doOnError(this::reportUploadError),
+                                  reporter)),
               cacheResource -> {
                 Profiler.instance()
                     .completeTask(startTime.get(), ProfilerTask.UPLOAD_TIME, "upload outputs");
@@ -1819,7 +1818,7 @@ public class RemoteExecutionService {
               },
               /* eager= */ false)
           .subscribeOn(scheduler)
-          .subscribe(result -> {}, error -> {});
+          .subscribe(result -> {}, this::reportUploadError);
     } else {
       try (SilentCloseable c =
           Profiler.instance().profile(ProfilerTask.UPLOAD_TIME, "upload outputs")) {


### PR DESCRIPTION
Users have reported hangs in Bazel's asynchronous remote cache uploads that may be happening because neither `onSuccess` nor `onError` is called on the observer.

Work towards #25232