### PR TITLE
Add `no_toolchain_error` to the `platform` rule.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
@@ -89,7 +89,7 @@ public class PlatformInfo extends NativeInfo
   private final boolean checkToolchainTypes;
   private final ImmutableList<Label> allowedToolchainTypes;
 
-  @Nullable private final String noToolchainErrorMessage;
+  @Nullable private final String missingToolchainErrorMessage;
 
   private PlatformInfo(
       Label label,
@@ -100,7 +100,7 @@ public class PlatformInfo extends NativeInfo
       ImmutableList<ConfigMatchingProvider> requiredSettings,
       boolean checkToolchainTypes,
       ImmutableList<Label> allowedToolchainTypes,
-      String noToolchainErrorMessage,
+      String missingToolchainErrorMessage,
       Location creationLocation) {
     super(creationLocation);
     this.label = label;
@@ -111,7 +111,7 @@ public class PlatformInfo extends NativeInfo
     this.requiredSettings = requiredSettings;
     this.checkToolchainTypes = checkToolchainTypes;
     this.allowedToolchainTypes = allowedToolchainTypes;
-    this.noToolchainErrorMessage = noToolchainErrorMessage;
+    this.missingToolchainErrorMessage = missingToolchainErrorMessage;
   }
 
   @Override
@@ -154,8 +154,8 @@ public class PlatformInfo extends NativeInfo
   }
 
   @Nullable
-  public String getNoToolchainErrorMessage() {
-    return noToolchainErrorMessage;
+  public String getMissingToolchainErrorMessage() {
+    return missingToolchainErrorMessage;
   }
 
   @Override
@@ -177,7 +177,7 @@ public class PlatformInfo extends NativeInfo
             .collect(toImmutableList()));
     fp.addStrings(allowedToolchainTypes.stream().map(Label::toString).collect(toImmutableList()));
     fp.addBoolean(checkToolchainTypes);
-    fp.addNullableString(noToolchainErrorMessage);
+    fp.addNullableString(missingToolchainErrorMessage);
   }
 
   @Override
@@ -193,7 +193,7 @@ public class PlatformInfo extends NativeInfo
         && Objects.equals(requiredSettings, that.requiredSettings)
         && (checkToolchainTypes == that.checkToolchainTypes)
         && Objects.equals(allowedToolchainTypes, that.allowedToolchainTypes)
-        && Objects.equals(noToolchainErrorMessage, that.noToolchainErrorMessage);
+        && Objects.equals(missingToolchainErrorMessage, that.missingToolchainErrorMessage);
   }
 
   @Override
@@ -207,7 +207,7 @@ public class PlatformInfo extends NativeInfo
         requiredSettings,
         checkToolchainTypes,
         allowedToolchainTypes,
-        noToolchainErrorMessage);
+        missingToolchainErrorMessage);
   }
 
   /** Returns a new {@link Builder} for creating a fresh {@link PlatformInfo} instance. */
@@ -229,7 +229,7 @@ public class PlatformInfo extends NativeInfo
     private boolean checkToolchainTypes = false;
     private final ImmutableList.Builder<Label> allowedToolchainTypes =
         new ImmutableList.Builder<>();
-    @Nullable private String noToolchainErrorMessage = null;
+    @Nullable private String missingToolchainErrorMessage = null;
     private Location creationLocation = Location.BUILTIN;
 
     /**
@@ -362,11 +362,11 @@ public class PlatformInfo extends NativeInfo
      * platform.
      */
     @CanIgnoreReturnValue
-    public Builder setNoToolchainErrorMessage(@Nullable String message) {
+    public Builder setMissingToolchainErrorMessage(@Nullable String message) {
       if (message == null || message.isEmpty()) {
-        this.noToolchainErrorMessage = null;
+        this.missingToolchainErrorMessage = null;
       } else {
-        this.noToolchainErrorMessage = message;
+        this.missingToolchainErrorMessage = message;
       }
       return this;
     }
@@ -434,7 +434,7 @@ public class PlatformInfo extends NativeInfo
           settings,
           checkToolchainTypes,
           allowedToolchainTypes.build(),
-          noToolchainErrorMessage,
+          missingToolchainErrorMessage,
           creationLocation);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
@@ -89,6 +89,8 @@ public class PlatformInfo extends NativeInfo
   private final boolean checkToolchainTypes;
   private final ImmutableList<Label> allowedToolchainTypes;
 
+  @Nullable private final String noToolchainErrorMessage;
+
   private PlatformInfo(
       Label label,
       ConstraintCollection constraints,
@@ -98,6 +100,7 @@ public class PlatformInfo extends NativeInfo
       ImmutableList<ConfigMatchingProvider> requiredSettings,
       boolean checkToolchainTypes,
       ImmutableList<Label> allowedToolchainTypes,
+      String noToolchainErrorMessage,
       Location creationLocation) {
     super(creationLocation);
     this.label = label;
@@ -108,6 +111,7 @@ public class PlatformInfo extends NativeInfo
     this.requiredSettings = requiredSettings;
     this.checkToolchainTypes = checkToolchainTypes;
     this.allowedToolchainTypes = allowedToolchainTypes;
+    this.noToolchainErrorMessage = noToolchainErrorMessage;
   }
 
   @Override
@@ -149,6 +153,11 @@ public class PlatformInfo extends NativeInfo
     return allowedToolchainTypes;
   }
 
+  @Nullable
+  public String getNoToolchainErrorMessage() {
+    return noToolchainErrorMessage;
+  }
+
   @Override
   public void repr(Printer printer) {
     printer.append(String.format("PlatformInfo(%s, constraints=%s)", label, constraints));
@@ -168,6 +177,7 @@ public class PlatformInfo extends NativeInfo
             .collect(toImmutableList()));
     fp.addStrings(allowedToolchainTypes.stream().map(Label::toString).collect(toImmutableList()));
     fp.addBoolean(checkToolchainTypes);
+    fp.addNullableString(noToolchainErrorMessage);
   }
 
   @Override
@@ -182,7 +192,8 @@ public class PlatformInfo extends NativeInfo
         && Objects.equals(flags, that.flags)
         && Objects.equals(requiredSettings, that.requiredSettings)
         && (checkToolchainTypes == that.checkToolchainTypes)
-        && Objects.equals(allowedToolchainTypes, that.allowedToolchainTypes);
+        && Objects.equals(allowedToolchainTypes, that.allowedToolchainTypes)
+        && Objects.equals(noToolchainErrorMessage, that.noToolchainErrorMessage);
   }
 
   @Override
@@ -195,7 +206,8 @@ public class PlatformInfo extends NativeInfo
         flags,
         requiredSettings,
         checkToolchainTypes,
-        allowedToolchainTypes);
+        allowedToolchainTypes,
+        noToolchainErrorMessage);
   }
 
   /** Returns a new {@link Builder} for creating a fresh {@link PlatformInfo} instance. */
@@ -217,6 +229,7 @@ public class PlatformInfo extends NativeInfo
     private boolean checkToolchainTypes = false;
     private final ImmutableList.Builder<Label> allowedToolchainTypes =
         new ImmutableList.Builder<>();
+    @Nullable private String noToolchainErrorMessage = null;
     private Location creationLocation = Location.BUILTIN;
 
     /**
@@ -344,6 +357,20 @@ public class PlatformInfo extends NativeInfo
       return this;
     }
 
+    /**
+     * Sets an error message to display when a required toolchain cannot be resolved for this
+     * platform.
+     */
+    @CanIgnoreReturnValue
+    public Builder setNoToolchainErrorMessage(@Nullable String message) {
+      if (message == null || message.isEmpty()) {
+        this.noToolchainErrorMessage = null;
+      } else {
+        this.noToolchainErrorMessage = message;
+      }
+      return this;
+    }
+
     private static void checkRemoteExecutionProperties(
         PlatformInfo parent,
         String remoteExecutionProperties,
@@ -407,6 +434,7 @@ public class PlatformInfo extends NativeInfo
           settings,
           checkToolchainTypes,
           allowedToolchainTypes.build(),
+          noToolchainErrorMessage,
           creationLocation);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
@@ -94,6 +94,10 @@ public class Platform implements RuleConfiguredTargetFactory {
       platformBuilder.checkToolchainTypes(false);
     }
 
+    String noToolchainErrorMessage =
+        ruleContext.attributes().get(PlatformRule.NO_TOOLCHAIN_ERROR_ATTR, Type.STRING);
+    platformBuilder.setNoToolchainErrorMessage(noToolchainErrorMessage);
+
     PlatformInfo platformInfo;
     try {
       platformInfo = platformBuilder.build();

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
@@ -94,9 +94,9 @@ public class Platform implements RuleConfiguredTargetFactory {
       platformBuilder.checkToolchainTypes(false);
     }
 
-    String noToolchainErrorMessage =
-        ruleContext.attributes().get(PlatformRule.NO_TOOLCHAIN_ERROR_ATTR, Type.STRING);
-    platformBuilder.setNoToolchainErrorMessage(noToolchainErrorMessage);
+    String missingToolchainErrorMessage =
+        ruleContext.attributes().get(PlatformRule.MISSING_TOOLCHAIN_ERROR_ATTR, Type.STRING);
+    platformBuilder.setMissingToolchainErrorMessage(missingToolchainErrorMessage);
 
     PlatformInfo platformInfo;
     try {

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
@@ -39,7 +39,7 @@ public class PlatformRule implements RuleDefinition {
   public static final String EXEC_PROPS_ATTR = "exec_properties";
   public static final String FLAGS_ATTR = "flags";
   public static final String REQUIRED_SETTINGS_ATTR = "required_settings";
-  public static final String NO_TOOLCHAIN_ERROR_ATTR = "no_toolchain_error";
+  public static final String MISSING_TOOLCHAIN_ERROR_ATTR = "missing_toolchain_error";
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -131,13 +131,14 @@ public class PlatformRule implements RuleDefinition {
             attr(REQUIRED_SETTINGS_ATTR, BuildType.LABEL_LIST)
                 .allowedRuleClasses("config_setting")
                 .allowedFileTypes(FileTypeSet.NO_FILE))
-        /* <!-- #BLAZE_RULE(platform).ATTRIBUTE(no_toolchain_error) -->
+        /* <!-- #BLAZE_RULE(platform).ATTRIBUTE(missing_toolchain_error) -->
         A custom error message that is displayed when a mandatory toolchain requirement cannot be satisfied for this target platform. Intended to point to relevant documentation users can read to understand why their toolchains are misconfigured.
 
         Not inherited from parent platforms.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
-            attr(NO_TOOLCHAIN_ERROR_ATTR, Type.STRING).nonconfigurable("Part of the configuration"))
+            attr(MISSING_TOOLCHAIN_ERROR_ATTR, Type.STRING)
+                .nonconfigurable("Part of the configuration"))
         // Undocumented, used for exec platform migrations.
         .add(attr("check_toolchain_types", Type.BOOLEAN).value(false))
         .add(attr("allowed_toolchain_types", BuildType.NODEP_LABEL_LIST))

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
@@ -132,7 +132,7 @@ public class PlatformRule implements RuleDefinition {
                 .allowedRuleClasses("config_setting")
                 .allowedFileTypes(FileTypeSet.NO_FILE))
         /* <!-- #BLAZE_RULE(platform).ATTRIBUTE(no_toolchain_error) -->
-        A custom error message that is displayed when a required toolchain type cannot be found for this platform. Intended to point to relevant documentation users can read to understand why their toolchains are misconfigured.
+        A custom error message that is displayed when a mandatory toolchain requirement cannot be satisfied for this target platform. Intended to point to relevant documentation users can read to understand why their toolchains are misconfigured.
 
         Not inherited from parent platforms.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
@@ -32,6 +32,10 @@ import com.google.devtools.build.lib.util.FileTypeSet;
 
 /** Rule definition for {@link Platform}. */
 public class PlatformRule implements RuleDefinition {
+  public static final String DEFAULT_MISSING_TOOLCHAIN_ERROR =
+      "For more information on platforms or toolchains see"
+          + " https://bazel.build/concepts/platforms-intro.";
+
   public static final String RULE_NAME = "platform";
   public static final String CONSTRAINT_VALUES_ATTR = "constraint_values";
   public static final String PARENTS_PLATFORM_ATTR = "parents";
@@ -138,6 +142,7 @@ public class PlatformRule implements RuleDefinition {
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
             attr(MISSING_TOOLCHAIN_ERROR_ATTR, Type.STRING)
+                .value(DEFAULT_MISSING_TOOLCHAIN_ERROR)
                 .nonconfigurable("Part of the configuration"))
         // Undocumented, used for exec platform migrations.
         .add(attr("check_toolchain_types", Type.BOOLEAN).value(false))

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
@@ -39,6 +39,7 @@ public class PlatformRule implements RuleDefinition {
   public static final String EXEC_PROPS_ATTR = "exec_properties";
   public static final String FLAGS_ATTR = "flags";
   public static final String REQUIRED_SETTINGS_ATTR = "required_settings";
+  public static final String NO_TOOLCHAIN_ERROR_ATTR = "no_toolchain_error";
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -130,6 +131,13 @@ public class PlatformRule implements RuleDefinition {
             attr(REQUIRED_SETTINGS_ATTR, BuildType.LABEL_LIST)
                 .allowedRuleClasses("config_setting")
                 .allowedFileTypes(FileTypeSet.NO_FILE))
+        /* <!-- #BLAZE_RULE(platform).ATTRIBUTE(no_toolchain_error) -->
+        A custom error message that is displayed when a required toolchain type cannot be found for this platform. Intended to point to relevant documentation users can read to understand why their toolchains are misconfigured.
+
+        Not inherited from parent platforms.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(NO_TOOLCHAIN_ERROR_ATTR, Type.STRING).nonconfigurable("Part of the configuration"))
         // Undocumented, used for exec platform migrations.
         .add(attr("check_toolchain_types", Type.BOOLEAN).value(false))
         .add(attr("allowed_toolchain_types", BuildType.NODEP_LABEL_LIST))

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/PlatformKeys.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/PlatformKeys.java
@@ -265,6 +265,11 @@ record PlatformKeys(
   }
 
   @Nullable
+  PlatformInfo targetPlatformInfo() {
+    return platformInfo(targetPlatformKey);
+  }
+
+  @Nullable
   PlatformInfo platformInfo(ConfiguredTargetKey configuredTargetKey) {
     return platformInfos.get(configuredTargetKey);
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
@@ -411,8 +411,8 @@ public class ToolchainResolutionFunction implements SkyFunction {
                           type.noneFoundError() != null ? ": " + type.noneFoundError() : ""))
               .collect(toImmutableList());
       String platformSpecificMessage = DEFAULT_PLATFORM_MESSAGE;
-      if (targetPlatformInfo.getNoToolchainErrorMessage() != null) {
-        platformSpecificMessage = targetPlatformInfo.getNoToolchainErrorMessage();
+      if (targetPlatformInfo.getMissingToolchainErrorMessage() != null) {
+        platformSpecificMessage = targetPlatformInfo.getMissingToolchainErrorMessage();
       }
       return String.format(
           """

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
@@ -57,6 +57,9 @@ import javax.annotation.Nullable;
  * selecting the execution platform.
  */
 public class ToolchainResolutionFunction implements SkyFunction {
+  public static final String DEFAULT_PLATFORM_MESSAGE =
+      "For more information on platforms or toolchains see"
+          + " https://bazel.build/concepts/platforms-intro.";
 
   @Nullable
   @Override
@@ -253,7 +256,8 @@ public class ToolchainResolutionFunction implements SkyFunction {
 
     // Verify that all mandatory toolchain types have a toolchain.
     if (!missingMandatoryToolchains.isEmpty()) {
-      throw new UnresolvedToolchainsException(missingMandatoryToolchains);
+      throw new UnresolvedToolchainsException(
+          platformKeys.targetPlatformInfo(), missingMandatoryToolchains);
     }
 
     if (valuesMissing) {
@@ -379,8 +383,10 @@ public class ToolchainResolutionFunction implements SkyFunction {
 
   /** Exception used when a toolchain type is required but no matching toolchain is found. */
   static final class UnresolvedToolchainsException extends ToolchainException {
-    UnresolvedToolchainsException(SequencedSet<ToolchainTypeInfo> missingToolchainTypes) {
-      super(getMessage(missingToolchainTypes));
+
+    UnresolvedToolchainsException(
+        PlatformInfo targetPlatformInfo, SequencedSet<ToolchainTypeInfo> missingToolchainTypes) {
+      super(getMessage(targetPlatformInfo, missingToolchainTypes));
     }
 
     @Override
@@ -388,7 +394,8 @@ public class ToolchainResolutionFunction implements SkyFunction {
       return Code.NO_MATCHING_TOOLCHAIN;
     }
 
-    private static String getMessage(SequencedSet<ToolchainTypeInfo> missingToolchainTypes) {
+    private static String getMessage(
+        PlatformInfo targetPlatformInfo, SequencedSet<ToolchainTypeInfo> missingToolchainTypes) {
       ImmutableList<String> labelStrings =
           missingToolchainTypes.stream()
               .map(ToolchainTypeInfo::typeLabel)
@@ -403,14 +410,20 @@ public class ToolchainResolutionFunction implements SkyFunction {
                           type.typeLabel(),
                           type.noneFoundError() != null ? ": " + type.noneFoundError() : ""))
               .collect(toImmutableList());
+      String platformSpecificMessage = DEFAULT_PLATFORM_MESSAGE;
+      if (targetPlatformInfo.getNoToolchainErrorMessage() != null) {
+        platformSpecificMessage = targetPlatformInfo.getNoToolchainErrorMessage();
+      }
       return String.format(
           """
-No matching toolchains found for types:
-%s
-To debug, rerun with --toolchain_resolution_debug='%s'
-For more information on platforms or toolchains see https://bazel.build/concepts/platforms-intro.\
-""",
-          String.join("\n", missingToolchainRows), String.join("|", labelStrings));
+          No matching toolchains found for types:
+          %s
+          To debug, rerun with --toolchain_resolution_debug='%s'
+          %s\
+          """,
+          String.join("\n", missingToolchainRows),
+          String.join("|", labelStrings),
+          platformSpecificMessage);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
@@ -57,10 +57,6 @@ import javax.annotation.Nullable;
  * selecting the execution platform.
  */
 public class ToolchainResolutionFunction implements SkyFunction {
-  public static final String DEFAULT_PLATFORM_MESSAGE =
-      "For more information on platforms or toolchains see"
-          + " https://bazel.build/concepts/platforms-intro.";
-
   @Nullable
   @Override
   public UnloadedToolchainContext compute(SkyKey skyKey, Environment env)
@@ -410,7 +406,7 @@ public class ToolchainResolutionFunction implements SkyFunction {
                           type.typeLabel(),
                           type.noneFoundError() != null ? ": " + type.noneFoundError() : ""))
               .collect(toImmutableList());
-      String platformSpecificMessage = DEFAULT_PLATFORM_MESSAGE;
+      String platformSpecificMessage = "";
       if (targetPlatformInfo.getMissingToolchainErrorMessage() != null) {
         platformSpecificMessage = targetPlatformInfo.getMissingToolchainErrorMessage();
       }

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
@@ -499,6 +499,14 @@ public class PlatformInfoTest extends BuildViewTestCase {
                 .addConstraint(value2)
                 .setRemoteExecutionProperties("foo")
                 .build())
+        .addEqualityGroup(
+            // Different no toolchain error message.
+            PlatformInfo.builder()
+                .setLabel(Label.parseCanonicalUnchecked("//platform/plat1"))
+                .addConstraint(value1)
+                .addConstraint(value2)
+                .setNoToolchainErrorMessage("Check docs for plat1 at http://example.com/plat1")
+                .build())
         .testEquals();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
@@ -505,7 +505,7 @@ public class PlatformInfoTest extends BuildViewTestCase {
                 .setLabel(Label.parseCanonicalUnchecked("//platform/plat1"))
                 .addConstraint(value1)
                 .addConstraint(value2)
-                .setNoToolchainErrorMessage("Check docs for plat1 at http://example.com/plat1")
+                .setMissingToolchainErrorMessage("Check docs for plat1 at http://example.com/plat1")
                 .build())
         .testEquals();
   }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/PlatformLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/PlatformLookupUtilTest.java
@@ -89,8 +89,10 @@ public class PlatformLookupUtilTest extends ToolchainTestCase {
     assertThatEvaluationResult(result).hasEntryThat(key).isNotNull();
 
     Map<ConfiguredTargetKey, PlatformInfo> platforms = result.get(key).platforms();
-    assertThat(platforms).containsEntry(linuxKey, linuxPlatform);
-    assertThat(platforms).containsEntry(macKey, macPlatform);
+    assertThat(platforms).containsKey(linuxKey);
+    assertThat(platforms.get(linuxKey).label()).isEqualTo(linuxPlatform.label());
+    assertThat(platforms).containsKey(macKey);
+    assertThat(platforms.get(macKey).label()).isEqualTo(macPlatform.label());
     assertThat(platforms).hasSize(2);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
@@ -404,7 +404,7 @@ For more information on platforms or toolchains see https://bazel.build/concepts
         platform(
             name = "linux_custom_message",
             parents = [":linux"],
-            no_toolchain_error = "Check custom docs for setup instructions",
+            missing_toolchain_error = "Check custom docs for setup instructions",
         )
         """);
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
@@ -397,6 +397,35 @@ For more information on platforms or toolchains see https://bazel.build/concepts
   }
 
   @Test
+  public void resolve_mandatory_missing_customPlatformMessage() throws Exception {
+    scratch.appendFile(
+        "platforms/BUILD",
+        """
+        platform(
+            name = "linux_custom_message",
+            parents = [":linux"],
+            no_toolchain_error = "Check custom docs for setup instructions",
+        )
+        """);
+
+    // There is no toolchain for the requested type.
+    useConfiguration("--platforms=//platforms:linux_custom_message");
+    ToolchainContextKey key =
+        ToolchainContextKey.key()
+            .configurationKey(targetConfigKey)
+            .toolchainTypes(testToolchainType)
+            .build();
+
+    EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
+
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .hasMessageThat()
+        .contains("Check custom docs for setup instructions");
+  }
+
+  @Test
   public void resolve_multiple_optional() throws Exception {
     Label secondToolchainTypeLabel = Label.parseCanonicalUnchecked("//second:toolchain_type");
     ToolchainTypeRequirement secondToolchainTypeRequirement =

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
@@ -423,6 +423,11 @@ For more information on platforms or toolchains see https://bazel.build/concepts
         .hasExceptionThat()
         .hasMessageThat()
         .contains("Check custom docs for setup instructions");
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .hasMessageThat()
+        .doesNotContain("see https://bazel.build/concepts/platforms-intro");
   }
 
   @Test

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -523,7 +523,7 @@ function test_toolchain_use_in_rule_missing_with_custom_platform_error {
   cat > "${pkg}/platforms/BUILD" <<EOF
 platform(
     name = "custom_message",
-    no_toolchain_error = "Check custom docs for setup instructions",
+    missing_toolchain_error = "Check custom docs for setup instructions",
 )
 EOF
 

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -482,7 +482,7 @@ EOF
   expect_log "  //${pkg}/toolchain:test_toolchain$"
 }
 
-function test_toolchain_use_in_rule_missing_with_custom_error {
+function test_toolchain_use_in_rule_missing_with_custom_toolchain_type_error {
   local -r pkg="${FUNCNAME[0]}"
   write_test_toolchain "${pkg}" test_toolchain_with_message
   cat > "${pkg}/toolchain/BUILD" <<EOF
@@ -509,6 +509,41 @@ EOF
   bazel build "//${pkg}/demo:use" &> $TEST_log && fail "Build failure expected"
   expect_log "While resolving toolchains for target //${pkg}/demo:use[^:]*: No matching toolchains found for types:$"
   expect_log "^  //${pkg}/toolchain:test_toolchain_with_message: Go register a toolchain!$"
+}
+
+function test_toolchain_use_in_rule_missing_with_custom_platform_error {
+  local -r pkg="${FUNCNAME[0]}"
+  write_test_toolchain "${pkg}"
+  write_test_rule "${pkg}"
+  #rite_register_toolchain
+  # Do not register test_toolchain to trigger the error.
+
+  # Use a custom platform.
+  mkdir -p "${pkg}/platforms"
+  cat > "${pkg}/platforms/BUILD" <<EOF
+platform(
+    name = "custom_message",
+    no_toolchain_error = "Check custom docs for setup instructions",
+)
+EOF
+
+  mkdir -p "${pkg}/demo"
+  cat > "${pkg}/demo/BUILD" <<EOF
+load('//${pkg}/toolchain:rule_use_toolchain.bzl', 'use_toolchain')
+
+package(default_visibility = ["//visibility:public"])
+
+# Use the toolchain.
+use_toolchain(
+    name = 'use',
+    message = 'this is the rule')
+EOF
+
+  bazel build \
+    --platforms="//${pkg}/platforms:custom_message" \
+    "//${pkg}/demo:use" &> $TEST_log && fail "Build failure expected"
+  expect_log "Check custom docs for setup instructions"
+  expect_not_log "see https://bazel.build/concepts/platforms-intro"
 }
 
 function test_multiple_toolchain_use_in_rule {


### PR DESCRIPTION
This allows platforms to provide custom error messages to users when no required toolchain can be found for a specific type (similar to the `toolchain_type.no_match_error` from
b60a0f4b4072567e482419fac48c5da91f102648).

This should point to documentation or directions for users to properly use the platform.

When this is set it replaces the previous message "For more information on platforms or toolchains see
https://bazel.build/concepts/platforms-intro."

RELNOTES: Add `no_toolchain_error` to the `platform` rule, to customize error messages when a required toolchain type cannot be found for that platform.