### PR TITLE
Add support for riscv64 linux

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -296,6 +296,7 @@ use_repo(
     "openjdk_linux_aarch64_vanilla",
     "openjdk_linux_ppc64le_vanilla",
     "openjdk_linux_s390x_vanilla",
+    "openjdk_linux_riscv64_vanilla",
     "openjdk_linux_vanilla",
     "openjdk_macos_aarch64_vanilla",
     "openjdk_macos_x86_64_vanilla",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -233,7 +233,7 @@
   "moduleExtensions": {
     "//:repositories.bzl%async_profiler_repos": {
       "general": {
-        "bzlTransitiveDigest": "sZP+1R6WWs3AtxwigiCKw4QSdhIWK8m+woUU1R+KxKo=",
+        "bzlTransitiveDigest": "C3OTAuPVFLe0XREmrFVkGlypKUxmrumaobzVyFjy2tw=",
         "usagesDigest": "fv/Ru+up/1CLlox7G1yNn9y4JOVK1qeU6uQCAkCcMaM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -101,6 +101,12 @@ def embedded_jdk_repositories():
         url = "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.1%2B11/OpenJDK23U-jdk_ppc64le_linux_hotspot_23.0.1_11.tar.gz",
     )
     http_file(
+        name = "openjdk_linux_riscv64_vanilla",
+        integrity = "sha256-gNe6uflhS9+TTGvEQQMb0f6tOuqF8WdwEjvYprzcUrY=",
+        downloaded_file_path = "adoptopenjdk-riscv64-vanilla.tar.gz",
+        url = "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.1%2B11/OpenJDK23U-jdk_riscv64_linux_hotspot_23.0.1_11.tar.gz",
+    )
+    http_file(
         name = "openjdk_macos_x86_64_vanilla",
         integrity = "sha256-Ha2a94Z+QAc367voEEMXGo8Lw92vcvvu9ilbPR2+cow=",
         downloaded_file_path = "zulu-macos-vanilla.tar.gz",

--- a/src/BUILD
+++ b/src/BUILD
@@ -173,6 +173,9 @@ filegroup(
         "//src/conditions:linux_s390x": [
             "@openjdk_linux_s390x_vanilla//file",
         ],
+        "//src/conditions:linux_riscv64": [
+            "@openjdk_linux_riscv64_vanilla//file",
+        ],
         "//conditions:default": [
             "@openjdk_linux_vanilla//file",
         ],

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -40,8 +40,8 @@ else
 fi
 fulljdk=$1
 out=$3
-ARCH=`uname -p`
-if [[ "${ARCH}" == 'ppc64le'  ]] || [[ "${ARCH}" == 's390x' ]]; then
+ARCH=`uname -m`
+if [[ "${ARCH}" == 'ppc64le'  ]] || [[ "${ARCH}" == 's390x' ]] || [[ "${ARCH}" == 'riscv64' ]]; then
   FULL_JDK_DIR="jdk*"
   DOCS=""
 else


### PR DESCRIPTION
This patch fixes bootstrapping bazel on riscv64 linux

In `src/minimize_jdk.sh`, 

The usage of `uname -p` isn't portable and it returns `unknown` for me on riscv64.
So I changed it to `uname -m`.