### PR TITLE
Add `--incompatible_repo_env_ignores_action_env` option

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -469,7 +469,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
           environment. This option can be used multiple times; for options given for the same \
           variable, the latest wins, options for different variables accumulate.
           <br>
-          Note that unless <code>--incompatible_action_env_no_repo</code> is true, all <code>name=value</code> \
+          Note that unless <code>--incompatible_repo_env_ignores_action_env</code> is true, all <code>name=value</code> \
           pairs will be available to repository rules.
           """)
   public List<Map.Entry<String, String>> actionEnvironment;

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -461,12 +461,17 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
       help =
-          "Specifies the set of environment variables available to actions with target"
-              + " configuration. Variables can be either specified by name, in which case the"
-              + " value will be taken from the invocation environment, or by the name=value pair"
-              + " which sets the value independent of the invocation environment. This option can"
-              + " be used multiple times; for options given for the same variable, the latest"
-              + " wins, options for different variables accumulate.")
+          """
+          Specifies the set of environment variables available to actions with target \
+          configuration. Variables can be either specified by <code>name</code>, in which case
+          the value will be taken from the invocation environment, or by the \
+          <code>name=value</code> pair which sets the value independent of the invocation \
+          environment. This option can be used multiple times; for options given for the same \
+          variable, the latest wins, options for different variables accumulate.
+          <br>
+          Note that unless <code>--incompatible_action_env_no_repo</code> is true, all <code>name=value</code> \
+          pairs will be available to repository rules.
+          """)
   public List<Map.Entry<String, String>> actionEnvironment;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -345,7 +345,9 @@ public class CommandEnvironment {
           visibleActionEnv.add(entry.getKey());
         } else {
           visibleActionEnv.remove(entry.getKey());
-          repoEnv.put(entry.getKey(), entry.getValue());
+          if (!options.getOptions(CommonCommandOptions.class).actionEnvNoRepo) {
+            repoEnv.put(entry.getKey(), entry.getValue());
+          }
         }
       }
     }
@@ -943,7 +945,10 @@ public class CommandEnvironment {
     }
   }
 
-  /** Returns the client environment with all settings from --action_env and --repo_env. */
+  /**
+   * Returns the repository environment created from the client environment, `--repo_env, and
+   * `--action_env=NAME=VALUE` (when `--incompatible_action_env_no_repo=false`).
+   */
   public Map<String, String> getRepoEnv() {
     return Collections.unmodifiableMap(repoEnv);
   }

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -345,7 +345,7 @@ public class CommandEnvironment {
           visibleActionEnv.add(entry.getKey());
         } else {
           visibleActionEnv.remove(entry.getKey());
-          if (!options.getOptions(CommonCommandOptions.class).actionEnvNoRepo) {
+          if (!options.getOptions(CommonCommandOptions.class).repoEnvIgnoresActionEnv) {
             repoEnv.put(entry.getKey(), entry.getValue());
           }
         }
@@ -947,7 +947,7 @@ public class CommandEnvironment {
 
   /**
    * Returns the repository environment created from the client environment, `--repo_env, and
-   * `--action_env=NAME=VALUE` (when `--incompatible_action_env_no_repo=false`).
+   * `--action_env=NAME=VALUE` (when `--incompatible_repo_env_ignores_action_env=false`).
    */
   public Map<String, String> getRepoEnv() {
     return Collections.unmodifiableMap(repoEnv);

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -585,7 +585,7 @@ public class CommonCommandOptions extends OptionsBase {
   public List<Map.Entry<String, String>> repositoryEnvironment;
 
   @Option(
-      name = "incompatible_action_env_no_repo",
+      name = "incompatible_repo_env_ignores_action_env",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
@@ -595,7 +595,7 @@ public class CommonCommandOptions extends OptionsBase {
           If true, <code>--action_env=NAME=VALUE</code> will no longer affect repository rule \
           and module extension environments.
           """)
-    public boolean actionEnvNoRepo;
+    public boolean repoEnvIgnoresActionEnv;
 
   @Option(
       name = "heuristically_drop_nodes",

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -576,11 +576,26 @@ public class CommonCommandOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
       help =
-          "Specifies additional environment variables to be available only for repository rules."
-              + " Note that repository rules see the full environment anyway, but in this way"
-              + " configuration information can be passed to repositories through options without"
-              + " invalidating the action graph.")
+          """
+          Specifies additional environment variables to be available only for repository rules. \
+          Note that repository rules see the full environment anyway, but in this way \
+          configuration information can be passed to repositories through options without \
+          invalidating the action graph.
+          """)
   public List<Map.Entry<String, String>> repositoryEnvironment;
+
+  @Option(
+      name = "incompatible_action_env_no_repo",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          """
+          If true, <code>--action_env=NAME=VALUE</code> will no longer affect repository rule \
+          and module extension environments.
+          """)
+    public boolean actionEnvNoRepo;
 
   @Option(
       name = "heuristically_drop_nodes",

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2975,7 +2975,7 @@ EOF
     @repo//... &> $TEST_log || fail "expected Bazel to succeed"
 }
 
-function test_execute_environment_action_env_no_repo_off() {
+function test_execute_environment_repo_env_ignores_action_env_off() {
   cat >> $(setup_module_dot_bazel)  <<'EOF'
 my_repo = use_repo_rule("//:repo.bzl", "my_repo")
 my_repo(name="repo")
@@ -2996,12 +2996,12 @@ my_repo = repository_rule(_impl)
 EOF
 
   bazel build \
-    --noincompatible_action_env_no_repo \
+    --noincompatible_repo_env_ignores_action_env \
     --action_env=ACTION_ENV_PRESENT=value1 \
     @repo//... &> $TEST_log || fail "expected Bazel to succeed"
 }
 
-function test_execute_environment_action_env_no_repo_on() {
+function test_execute_environment_repo_env_ignores_action_env_on() {
   cat >> $(setup_module_dot_bazel)  <<'EOF'
 my_repo = use_repo_rule("//:repo.bzl", "my_repo")
 my_repo(name="repo")
@@ -3022,7 +3022,7 @@ my_repo = repository_rule(_impl)
 EOF
 
   bazel build \
-    --incompatible_action_env_no_repo \
+    --incompatible_repo_env_ignores_action_env \
     --action_env=ACTION_ENV_REMOVED=value1 \
     @repo//... &> $TEST_log || fail "expected Bazel to succeed"
 }


### PR DESCRIPTION
This adds a new flag `--incompatible_repo_env_ignores_action_env` which when flipped stops `--action_env=NAME=VALUE` from affecting repository rule and module extension environments.

Split from #24404.