### PR TITLE
Replace finalizer of NativeFileOutputStream.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/shell/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/shell/BUILD
@@ -20,6 +20,7 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/jni",
+        "//src/main/java/com/google/devtools/build/lib/util:cleaner",
         "//src/main/java/com/google/devtools/build/lib/util:describable_execution_unit",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",

--- a/src/main/java/com/google/devtools/build/lib/shell/WindowsSubprocess.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/WindowsSubprocess.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.shell;
 
+import static com.google.devtools.build.lib.util.BazelCleaner.CLEANER;
+
 import com.google.common.base.Throwables;
 import com.google.devtools.build.lib.windows.WindowsProcesses;
 import java.io.IOException;
@@ -29,8 +31,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /** A Windows subprocess backed by a native object. */
 public class WindowsSubprocess implements Subprocess {
-  private static final Cleaner cleaner = Cleaner.create();
-
   // For debugging purposes.
   private String commandLine;
 
@@ -200,7 +200,7 @@ public class WindowsSubprocess implements Subprocess {
             stderrRedirected
                 ? null
                 : new ProcessInputStream(WindowsProcesses.getStderr(nativeProcess)));
-    cleanable = cleaner.register(this, nativeState);
+    cleanable = CLEANER.register(this, nativeState);
     // As per the spec of Command, we should only apply timeouts that are > 0.
     this.timeoutMillis = timeoutMillis <= 0 ? -1 : timeoutMillis;
     // Every Windows process we start consumes a thread here. This is suboptimal, but seems to be

--- a/src/main/java/com/google/devtools/build/lib/unix/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/unix/BUILD
@@ -23,6 +23,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/jni",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/util:blocker",
+        "//src/main/java/com/google/devtools/build/lib/util:cleaner",
         "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/main/java/com/google/devtools/build/lib/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/util/BUILD
@@ -462,3 +462,8 @@ java_library(
         "//third_party:jsr305",
     ],
 )
+
+java_library(
+    name = "cleaner",
+    srcs = ["BazelCleaner.java"],
+)

--- a/src/main/java/com/google/devtools/build/lib/util/BazelCleaner.java
+++ b/src/main/java/com/google/devtools/build/lib/util/BazelCleaner.java
@@ -1,0 +1,10 @@
+package com.google.devtools.build.lib.util;
+
+import java.lang.ref.Cleaner;
+
+/** Common {@link Cleaner} for Bazel. */
+public final class BazelCleaner {
+  public static final Cleaner CLEANER = Cleaner.create();
+
+  private BazelCleaner() {}
+}


### PR DESCRIPTION
This removes the last deprecated object finalizer from Bazel.

I created a single java.lang.ref.Cleaner instance for multiple users in Bazel.