### PR TITLE
[8.1.0] Don't fetch empty digest on failure status in `FetchBlobResponse`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/BUILD
@@ -29,6 +29,7 @@ java_library(
         "//third_party:jsr305",
         "//third_party/grpc-java:grpc-jar",
         "@com_google_protobuf//:protobuf_java_util",
+        "@googleapis//google/rpc:rpc_java_proto",
         "@remoteapis//:build_bazel_remote_asset_v1_remote_asset_java_grpc",
         "@remoteapis//:build_bazel_remote_asset_v1_remote_asset_java_proto",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -40,9 +40,11 @@ import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.protobuf.util.Timestamps;
+import com.google.rpc.Code;
 import io.grpc.CallCredentials;
 import io.grpc.Channel;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
@@ -160,6 +162,9 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
                       channel ->
                           fetchBlockingStub(remoteActionExecutionContext, channel)
                               .fetchBlob(request)));
+      if (response.getStatus().getCode() != Code.OK_VALUE) {
+        throw StatusProto.toStatusRuntimeException(response.getStatus());
+      }
       final Digest blobDigest = response.getBlobDigest();
 
       retrier.execute(

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/BUILD
@@ -47,6 +47,7 @@ java_library(
         "//third_party/grpc-java:grpc-jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
+        "@googleapis//google/rpc:rpc_java_proto",
         "@remoteapis//:build_bazel_remote_asset_v1_remote_asset_java_grpc",
         "@remoteapis//:build_bazel_remote_asset_v1_remote_asset_java_proto",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",


### PR DESCRIPTION
When the `GrpcRemoteDownloader` receives a `FetchBlobResponse` with an error status (instead of a connection level status error), it must fail and fall back to the HTTP downloader if configured instead of ignoring the status and attempting to fetch the (usually empty) digest from the cache. The previous behavior could result in errors being masked and resulting in an empty file being downloaded if the remote cache accepts empty `Digest` messages.

Closes #25244.

PiperOrigin-RevId: 725963696
Change-Id: I9f643b944b9fff9264c72f41485564ff1fab71d9

Commit https://github.com/bazelbuild/bazel/commit/e0cd2f245491f93065e5e04106a9b6e7eb029292