### PR TITLE
Fix JacocoInstrumentationProcessor move() failure on some filesystems

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/instrumentation/JacocoInstrumentationProcessor.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/instrumentation/JacocoInstrumentationProcessor.java
@@ -33,6 +33,8 @@ import java.util.List;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+
 /** Instruments compiled java classes using Jacoco instrumentation library. */
 public final class JacocoInstrumentationProcessor {
 
@@ -103,18 +105,21 @@ public final class JacocoInstrumentationProcessor {
             // It's not clear whether there is any advantage in not instrumenting *Test classes,
             // apart from lowering the covered percentage in the aggregate statistics.
 
-            // We first move the original .class file to our metadata directory, then instrument it
-            // and output the instrumented version in the regular classes output directory.
+            // We first copy the original .class file to our metadata directory, then instrument it
+            // and rewrite the instrumented version back into the regular classes output directory.
+
+            // Not moving or unlinking the source .class file is essential to guarantee visiting
+            // it only once during recursive directory traversal while also mutating the directory.
             Path instrumentedCopy = file;
             Path absoluteUninstrumentedCopy = Path.of(file + ".uninstrumented");
             Path uninstrumentedCopy =
                 instrumentedClassesDirectory.resolve(root.relativize(absoluteUninstrumentedCopy));
             Files.createDirectories(uninstrumentedCopy.getParent());
-            Files.move(file, uninstrumentedCopy);
+            Files.copy(file, uninstrumentedCopy);
             try (InputStream input =
                     new BufferedInputStream(Files.newInputStream(uninstrumentedCopy));
                 OutputStream output =
-                    new BufferedOutputStream(Files.newOutputStream(instrumentedCopy))) {
+                    new BufferedOutputStream(Files.newOutputStream(instrumentedCopy, TRUNCATE_EXISTING))) {
               instr.instrument(input, output, file.toString());
             }
             return FileVisitResult.CONTINUE;


### PR DESCRIPTION
Recursive directory traversal has no guarantees around files&directories that are added after the traversal has started, in particular it's unsafe to
- move `.class` away to `.class.uninstrumented`
- create new `.class` with same name
- continue recursive traversal

As it is allowed by POSIX `readdir()` to visit newly-created `.class` again https://pubs.opengroup.org/onlinepubs/007904875/functions/readdir_r.html
> If a file is removed from or added to the directory after the most recent call to opendir() or rewinddir(), whether a subsequent call to readdir_r() returns an entry for that file is unspecified.

And second visit will attempt to instrument already instrumented `.class`, but actually fail on the `move()` step as destination already exists.

This does reliably happen on buildbarn remote FUSE workers when running `bazel coverage` for JVM targets

Fixes #25272