### PR TITLE
[8.2.0] Add `missing_toolchain_error` to the `platform` rule.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
@@ -83,6 +83,8 @@ public class PlatformInfo extends NativeInfo
   private final boolean checkToolchainTypes;
   private final ImmutableList<Label> allowedToolchainTypes;
 
+  @Nullable private final String missingToolchainErrorMessage;
+
   private PlatformInfo(
       Label label,
       ConstraintCollection constraints,
@@ -92,6 +94,7 @@ public class PlatformInfo extends NativeInfo
       ImmutableList<ConfigMatchingProvider> requiredSettings,
       boolean checkToolchainTypes,
       ImmutableList<Label> allowedToolchainTypes,
+      String missingToolchainErrorMessage,
       Location creationLocation) {
     super(creationLocation);
     this.label = label;
@@ -102,6 +105,7 @@ public class PlatformInfo extends NativeInfo
     this.requiredSettings = requiredSettings;
     this.checkToolchainTypes = checkToolchainTypes;
     this.allowedToolchainTypes = allowedToolchainTypes;
+    this.missingToolchainErrorMessage = missingToolchainErrorMessage;
   }
 
   @Override
@@ -143,6 +147,11 @@ public class PlatformInfo extends NativeInfo
     return allowedToolchainTypes;
   }
 
+  @Nullable
+  public String getMissingToolchainErrorMessage() {
+    return missingToolchainErrorMessage;
+  }
+
   @Override
   public void repr(Printer printer) {
     printer.append(String.format("PlatformInfo(%s, constraints=%s)", label, constraints));
@@ -162,6 +171,7 @@ public class PlatformInfo extends NativeInfo
             .collect(toImmutableList()));
     fp.addStrings(allowedToolchainTypes.stream().map(Label::toString).collect(toImmutableList()));
     fp.addBoolean(checkToolchainTypes);
+    fp.addNullableString(missingToolchainErrorMessage);
   }
 
   @Override
@@ -176,7 +186,8 @@ public class PlatformInfo extends NativeInfo
         && Objects.equals(flags, that.flags)
         && Objects.equals(requiredSettings, that.requiredSettings)
         && (checkToolchainTypes == that.checkToolchainTypes)
-        && Objects.equals(allowedToolchainTypes, that.allowedToolchainTypes);
+        && Objects.equals(allowedToolchainTypes, that.allowedToolchainTypes)
+        && Objects.equals(missingToolchainErrorMessage, that.missingToolchainErrorMessage);
   }
 
   @Override
@@ -189,7 +200,8 @@ public class PlatformInfo extends NativeInfo
         flags,
         requiredSettings,
         checkToolchainTypes,
-        allowedToolchainTypes);
+        allowedToolchainTypes,
+        missingToolchainErrorMessage);
   }
 
   /** Returns a new {@link Builder} for creating a fresh {@link PlatformInfo} instance. */
@@ -211,6 +223,7 @@ public class PlatformInfo extends NativeInfo
     private boolean checkToolchainTypes = false;
     private final ImmutableList.Builder<Label> allowedToolchainTypes =
         new ImmutableList.Builder<>();
+    @Nullable private String missingToolchainErrorMessage = null;
     private Location creationLocation = Location.BUILTIN;
 
     /**
@@ -338,6 +351,20 @@ public class PlatformInfo extends NativeInfo
       return this;
     }
 
+    /**
+     * Sets an error message to display when a required toolchain cannot be resolved for this
+     * platform.
+     */
+    @CanIgnoreReturnValue
+    public Builder setMissingToolchainErrorMessage(@Nullable String message) {
+      if (message == null || message.isEmpty()) {
+        this.missingToolchainErrorMessage = null;
+      } else {
+        this.missingToolchainErrorMessage = message;
+      }
+      return this;
+    }
+
     private static void checkRemoteExecutionProperties(
         PlatformInfo parent,
         String remoteExecutionProperties,
@@ -401,6 +428,7 @@ public class PlatformInfo extends NativeInfo
           settings,
           checkToolchainTypes,
           allowedToolchainTypes.build(),
+          missingToolchainErrorMessage,
           creationLocation);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
@@ -94,6 +94,10 @@ public class Platform implements RuleConfiguredTargetFactory {
       platformBuilder.checkToolchainTypes(false);
     }
 
+    String missingToolchainErrorMessage =
+        ruleContext.attributes().get(PlatformRule.MISSING_TOOLCHAIN_ERROR_ATTR, Type.STRING);
+    platformBuilder.setMissingToolchainErrorMessage(missingToolchainErrorMessage);
+
     PlatformInfo platformInfo;
     try {
       platformInfo = platformBuilder.build();

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
@@ -33,6 +33,10 @@ import com.google.devtools.build.lib.util.FileTypeSet;
 
 /** Rule definition for {@link Platform}. */
 public class PlatformRule implements RuleDefinition {
+  public static final String DEFAULT_MISSING_TOOLCHAIN_ERROR =
+      "For more information on platforms or toolchains see"
+          + " https://bazel.build/concepts/platforms-intro.";
+
   public static final String RULE_NAME = "platform";
   public static final String CONSTRAINT_VALUES_ATTR = "constraint_values";
   public static final String PARENTS_PLATFORM_ATTR = "parents";
@@ -40,6 +44,7 @@ public class PlatformRule implements RuleDefinition {
   public static final String EXEC_PROPS_ATTR = "exec_properties";
   public static final String FLAGS_ATTR = "flags";
   public static final String REQUIRED_SETTINGS_ATTR = "required_settings";
+  public static final String MISSING_TOOLCHAIN_ERROR_ATTR = "missing_toolchain_error";
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -132,6 +137,15 @@ public class PlatformRule implements RuleDefinition {
             attr(REQUIRED_SETTINGS_ATTR, BuildType.LABEL_LIST)
                 .allowedRuleClasses("config_setting")
                 .allowedFileTypes(FileTypeSet.NO_FILE))
+        /* <!-- #BLAZE_RULE(platform).ATTRIBUTE(missing_toolchain_error) -->
+        A custom error message that is displayed when a mandatory toolchain requirement cannot be satisfied for this target platform. Intended to point to relevant documentation users can read to understand why their toolchains are misconfigured.
+
+        Not inherited from parent platforms.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(MISSING_TOOLCHAIN_ERROR_ATTR, Type.STRING)
+                .value(DEFAULT_MISSING_TOOLCHAIN_ERROR)
+                .nonconfigurable("Part of the configuration"))
         // Undocumented, used for exec platform migrations.
         .add(attr("check_toolchain_types", Type.BOOLEAN).value(false))
         .add(attr("allowed_toolchain_types", BuildType.NODEP_LABEL_LIST))

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
@@ -499,6 +499,14 @@ public class PlatformInfoTest extends BuildViewTestCase {
                 .addConstraint(value2)
                 .setRemoteExecutionProperties("foo")
                 .build())
+        .addEqualityGroup(
+            // Different no toolchain error message.
+            PlatformInfo.builder()
+                .setLabel(Label.parseCanonicalUnchecked("//platform/plat1"))
+                .addConstraint(value1)
+                .addConstraint(value2)
+                .setMissingToolchainErrorMessage("Check docs for plat1 at http://example.com/plat1")
+                .build())
         .testEquals();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/PlatformLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/PlatformLookupUtilTest.java
@@ -89,8 +89,10 @@ public class PlatformLookupUtilTest extends ToolchainTestCase {
     assertThatEvaluationResult(result).hasEntryThat(key).isNotNull();
 
     Map<ConfiguredTargetKey, PlatformInfo> platforms = result.get(key).platforms();
-    assertThat(platforms).containsEntry(linuxKey, linuxPlatform);
-    assertThat(platforms).containsEntry(macKey, macPlatform);
+    assertThat(platforms).containsKey(linuxKey);
+    assertThat(platforms.get(linuxKey).label()).isEqualTo(linuxPlatform.label());
+    assertThat(platforms).containsKey(macKey);
+    assertThat(platforms.get(macKey).label()).isEqualTo(macPlatform.label());
     assertThat(platforms).hasSize(2);
   }
 


### PR DESCRIPTION
This allows platforms to provide custom error messages to users when no required toolchain can be found for a specific type (similar to the `toolchain_type.no_match_error` from b60a0f4b4072567e482419fac48c5da91f102648).

This should point to documentation or directions for users to properly use the platform.

When this is set it replaces the previous message "For more information on platforms or toolchains see https://bazel.build/concepts/platforms-intro."

RELNOTES: Add `missing_toolchain_error` to the `platform` rule, to customize error messages when a required toolchain type cannot be found for that platform.

Closes #25234.

PiperOrigin-RevId: 725775441
Change-Id: Ica00d215ad4ec8fb0edb714369e1d240d52c08f5