### PR TITLE
Reland "Make Bazel itself build under an output base with Unicode characters"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -479,6 +479,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis:frontier_serializer",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis:frontier_violation_checker",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis:options",
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:TestType",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/ArFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/ArFunction.java
@@ -18,7 +18,6 @@ import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -37,12 +36,6 @@ public class ArFunction implements Decompressor {
   // This is the same value as picked for .tar files, which appears to have worked well.
   private static final int BUFFER_SIZE = 32 * 1024;
 
-  private InputStream getDecompressorStream(DecompressorDescriptor descriptor) throws IOException {
-    return new BufferedInputStream(
-        new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE);
-  }
-  ;
-
   @Override
   public Path decompress(DecompressorDescriptor descriptor)
       throws InterruptedException, IOException {
@@ -52,7 +45,8 @@ public class ArFunction implements Decompressor {
 
     Map<String, String> renameFiles = descriptor.renameFiles();
 
-    try (InputStream decompressorStream = getDecompressorStream(descriptor)) {
+    try (InputStream decompressorStream =
+        new BufferedInputStream(descriptor.archivePath().getInputStream(), BUFFER_SIZE)) {
       ArArchiveInputStream arStream = new ArArchiveInputStream(decompressorStream);
       ArArchiveEntry entry;
       while ((entry = arStream.getNextArEntry()) != null) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarBz2Function.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarBz2Function.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
@@ -26,17 +25,12 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
  */
 public class TarBz2Function extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarBz2Function();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
-  private TarBz2Function() {
-  }
+  private TarBz2Function() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
       throws IOException {
-    return new BZip2CompressorInputStream(
-        new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE),
-        true);
+    return new BZip2CompressorInputStream(compressedInputStream, true);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarFunction.java
@@ -16,21 +16,16 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 /** Creates a repository by unarchiving a plain .tar file. */
 public class TarFunction extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarFunction();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
   private TarFunction() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
-      throws IOException {
-    return new BufferedInputStream(
-        new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE);
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream) {
+    return compressedInputStream;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
@@ -26,17 +25,12 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
  */
 public class TarGzFunction extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarGzFunction();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
-  private TarGzFunction() {
-  }
+  private TarGzFunction() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
       throws IOException {
-    return new GzipCompressorInputStream(
-        new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE),
-        true);
+    return new GzipCompressorInputStream(compressedInputStream, true);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarXzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarXzFunction.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.tukaani.xz.XZInputStream;
@@ -26,16 +25,12 @@ import org.tukaani.xz.XZInputStream;
  */
 class TarXzFunction extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarXzFunction();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
-  private TarXzFunction() {
-  }
+  private TarXzFunction() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
       throws IOException {
-    return new XZInputStream(
-        new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
+    return new XZInputStream(compressedInputStream);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarZstFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarZstFunction.java
@@ -17,22 +17,18 @@ package com.google.devtools.build.lib.bazel.repository;
 import com.github.luben.zstd.ZstdInputStreamNoFinalizer;
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 /** Creates a repository by unarchiving a zstandard-compressed .tar file. */
 final class TarZstFunction extends CompressedTarFunction {
   static final Decompressor INSTANCE = new TarZstFunction();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
   private TarZstFunction() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
       throws IOException {
-    return new ZstdInputStreamNoFinalizer(
-        new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
+    return new ZstdInputStreamNoFinalizer(compressedInputStream);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -78,9 +78,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -1051,10 +1049,7 @@ the same path on case-insensitive filesystems.
     Path downloadDirectory;
     try {
       // Download to temp directory inside the outputDirectory and delete it after extraction
-      java.nio.file.Path tempDirectory =
-          Files.createTempDirectory(Paths.get(outputPath.toString()), "temp");
-      downloadDirectory =
-          workingDirectory.getFileSystem().getPath(tempDirectory.toFile().getAbsolutePath());
+      downloadDirectory = outputPath.getPath().createTempDirectory("temp");
 
       Phaser downloadPhaser = new Phaser();
       Future<Path> pendingDownload =

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -63,7 +63,6 @@ import com.google.errorprone.annotations.FormatString;
 import java.io.File;
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -180,11 +179,7 @@ public class LocalSpawnRunner implements SpawnRunner {
   }
 
   protected Path createActionTemp(Path execRoot) throws IOException {
-    return execRoot.getRelative(
-        Files.createTempDirectory(
-                java.nio.file.Paths.get(execRoot.getPathString()), "local-spawn-runner.")
-            .getFileName()
-            .toString());
+    return execRoot.createTempDirectory("local-spawn-runner.");
   }
 
   private final class SubprocessHandler {

--- a/src/main/java/com/google/devtools/build/lib/runtime/InfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/InfoItem.java
@@ -14,13 +14,11 @@
 
 package com.google.devtools.build.lib.runtime;
 
+
 import com.google.common.base.Supplier;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import com.google.devtools.build.lib.util.AbruptExitException;
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 
 /** An item that is returned by <code>blaze info</code>. */
 public abstract class InfoItem {
@@ -77,11 +75,6 @@ public abstract class InfoItem {
     if (value instanceof byte[]) {
       return (byte[]) value;
     }
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    PrintWriter writer =
-        new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
-    writer.print(value + "\n");
-    writer.flush();
-    return outputStream.toByteArray();
+    return StringUnsafe.getInternalStringBytes(String.valueOf(value));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/InfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/InfoItem.java
@@ -19,6 +19,7 @@ import com.google.common.base.Supplier;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import com.google.devtools.build.lib.util.AbruptExitException;
+import java.util.Arrays;
 
 /** An item that is returned by <code>blaze info</code>. */
 public abstract class InfoItem {
@@ -75,6 +76,9 @@ public abstract class InfoItem {
     if (value instanceof byte[]) {
       return (byte[]) value;
     }
-    return StringUnsafe.getInternalStringBytes(String.valueOf(value));
+    byte[] bytes = StringUnsafe.getInternalStringBytes(String.valueOf(value));
+    bytes = Arrays.copyOf(bytes, bytes.length + 1);
+    bytes[bytes.length - 1] = '\n';
+    return bytes;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BUILD
@@ -30,6 +30,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/runtime/commands:paths_to_replace_utils",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/skyframe:starlark_builtins_value",
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:debug-logger-configurator",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BuildLanguageInfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BuildLanguageInfoItem.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.skyframe.StarlarkBuiltinsValue;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.skyframe.EvaluationResult;
 import com.google.devtools.build.skyframe.SkyValue;
 import java.util.Collection;
@@ -172,7 +173,7 @@ public final class BuildLanguageInfoItem extends InfoItem {
       // TODO(adonovan): need dual function of parseDistributions.
       // Treat as empty list for now.
     } else if (t == Type.STRING) {
-      b.setString((String) v);
+      b.setString(StringEncoding.internalToUnicode((String) v));
     } else if (t == Type.INTEGER) {
       b.setInt(((StarlarkInt) v).toIntUnchecked());
     } else if (t == Type.BOOLEAN) {
@@ -180,7 +181,7 @@ public final class BuildLanguageInfoItem extends InfoItem {
     } else if (t == BuildType.TRISTATE) {
       b.setInt(((TriState) v).toInt());
     } else if (BuildType.isLabelType(t)) { // case order matters!
-      b.setString(v.toString());
+      b.setString(StringEncoding.internalToUnicode(v.toString()));
     } else {
       // No native rule attribute of this type (FilesetEntry?) has a default value.
       throw new IllegalStateException("unexpected type of attribute default value: " + t);

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/StdoutInfoItemHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/StdoutInfoItemHandler.java
@@ -34,7 +34,6 @@ public class StdoutInfoItemHandler implements InfoItemHandler {
       outErr.getOutputStream().write(' ');
     }
     outErr.getOutputStream().write(value);
-    outErr.getOutputStream().write('\n');
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/StdoutInfoItemHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/StdoutInfoItemHandler.java
@@ -13,9 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.runtime.commands.info;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.google.devtools.build.lib.runtime.InfoItem;
+import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import com.google.devtools.build.lib.util.io.OutErr;
 import java.io.IOException;
 
@@ -30,9 +29,12 @@ public class StdoutInfoItemHandler implements InfoItemHandler {
   @Override
   public void addInfoItem(String key, byte[] value, boolean printKeys) throws IOException {
     if (printKeys) {
-      outErr.getOutputStream().write((key + ": ").getBytes(UTF_8));
+      outErr.getOutputStream().write(StringUnsafe.getInternalStringBytes(key));
+      outErr.getOutputStream().write(':');
+      outErr.getOutputStream().write(' ');
     }
     outErr.getOutputStream().write(value);
+    outErr.getOutputStream().write('\n');
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/WorkerMetricsInfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/WorkerMetricsInfoItem.java
@@ -87,9 +87,9 @@ public final class WorkerMetricsInfoItem extends InfoItem {
                 .map(e -> e.toString())
                 .collect(joining(", "));
         if (workerMetrics.getWorkerIdsList().size() == 1) {
-          stringBuilder.append("id ").append(workerIds).append("\n");
+          stringBuilder.append("id ").append(workerIds);
         } else {
-          stringBuilder.append("ids [").append(workerIds).append("]\n");
+          stringBuilder.append("ids [").append(workerIds).append("]");
         }
       }
       return print(stringBuilder.toString());

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
@@ -106,11 +106,7 @@ final class WindowsSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   }
 
   private static Path createActionTemp(Path execRoot) throws IOException {
-    return execRoot.getRelative(
-        java.nio.file.Files.createTempDirectory(
-                java.nio.file.Paths.get(execRoot.getPathString()), "windows-sandbox.")
-            .getFileName()
-            .toString());
+    return execRoot.createTempDirectory("windows-sandbox.");
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/shell/SubprocessBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/SubprocessBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.jni.JniLoader;
 import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.File;
 import java.io.IOException;
@@ -110,7 +111,7 @@ public class SubprocessBuilder {
   public SubprocessBuilder setArgv(ImmutableList<String> argv) {
     this.argv = Preconditions.checkNotNull(argv);
     Preconditions.checkArgument(!this.argv.isEmpty());
-    File argv0 = new File(this.argv.get(0));
+    File argv0 = new File(StringEncoding.internalToPlatform(this.argv.get(0)));
     Preconditions.checkArgument(
         argv0.isAbsolute() || argv0.getParent() == null,
         "argv[0] = '%s'; it should be either absolute or just a single file name"

--- a/src/main/java/com/google/devtools/build/lib/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/util/BUILD
@@ -76,6 +76,7 @@ java_library(
     deps = [
         ":os",
         ":single_line_formatter",
+        ":string_encoding",
         ":util",
         "//third_party:error_prone_annotations",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -31,6 +31,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileAlreadyExistsException;
+import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -841,6 +842,22 @@ public abstract class FileSystem {
   protected java.nio.file.Path getNioPath(PathFragment path) {
     throw new UnsupportedOperationException(
         "getNioPath() not supported for " + getClass().getName());
+  }
+
+  /**
+   * Returns the path of a new temporary directory with the given prefix created under the given
+   * parent path, but <b>not</b> necessarily with secure permissions.
+   */
+  protected PathFragment createTempDirectory(PathFragment parent, String prefix)
+      throws IOException {
+    SecureRandom rand = new SecureRandom();
+    while (true) {
+      PathFragment candidate = parent.getRelative(prefix + Long.toUnsignedString(rand.nextLong()));
+      if (createDirectory(candidate)) {
+        chmod(candidate, 0700);
+        return candidate;
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -22,6 +22,7 @@ import com.google.common.hash.Hasher;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.util.FileType;
+import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.vfs.FileSystem.PathDevirtualizer;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -461,6 +462,14 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   }
 
   /**
+   * Returns the path of a new temporary directory with the given prefix created under the given
+   * parent path, but <b>not</b> necessarily with secure permissions.
+   */
+  public Path createTempDirectory(String prefix) throws IOException {
+    return fileSystem.getPath(fileSystem.createTempDirectory(asFragment(), prefix));
+  }
+
+  /**
    * Creates a symbolic link with the name of the current path, following symbolic links. The
    * referent of the created symlink is is the absolute path "target"; it is not possible to create
    * relative symbolic links via this method.
@@ -779,7 +788,7 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
    * <p>Caveat: the result may be useless if this path's getFileSystem() is not the UNIX filesystem.
    */
   public File getPathFile() {
-    return new File(getPathString());
+    return new File(StringEncoding.internalToPlatform(getPathString()));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
@@ -295,6 +295,12 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
     return delegateFs.getNioPath(toDelegatePath(path));
   }
 
+  @Override
+  protected PathFragment createTempDirectory(PathFragment parent, String prefix)
+      throws IOException {
+    return delegateFs.createTempDirectory(toDelegatePath(parent), prefix);
+  }
+
   /** Transform original path to a different one to be used with the {@code delegateFs}. */
   protected abstract PathFragment toDelegatePath(PathFragment path);
 

--- a/src/main/java/com/google/devtools/build/lib/worker/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/worker/BUILD
@@ -329,6 +329,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/sandbox:cgroups_info",
         "//src/main/java/com/google/devtools/build/lib/sandbox:sandbox_helpers",
         "//src/main/java/com/google/devtools/build/lib/shell",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/protobuf:failure_details_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.shell.Subprocess;
 import com.google.devtools.build.lib.shell.SubprocessBuilder;
 import com.google.devtools.build.lib.shell.SubprocessFactory;
+import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.worker.WorkerProcessStatus.Status;
@@ -200,10 +201,14 @@ public class WorkerMultiplexer {
               });
       Runtime.getRuntime().addShutdownHook(shutdownHook);
       ImmutableList<String> args = workerKey.getArgs();
-      File executable = new File(args.get(0));
+      File executable = new File(StringEncoding.internalToPlatform(args.get(0)));
       if (!executable.isAbsolute() && executable.getParent() != null) {
         List<String> newArgs = new ArrayList<>(args);
-        newArgs.set(0, new File(workDir.getPathFile(), newArgs.get(0)).getAbsolutePath());
+        newArgs.set(
+            0,
+            StringEncoding.platformToInternal(
+                new File(workDir.getPathFile(), StringEncoding.internalToPlatform(newArgs.get(0)))
+                    .getAbsolutePath()));
         args = ImmutableList.copyOf(newArgs);
       }
       SubprocessBuilder processBuilder =

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -29,6 +29,15 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
+# Force a UTF-8 compatible locale for Java tools to operate under paths with
+# Unicode characters.
+if [[ $(locale charmap) != "UTF-8" ]]; then
+  export LC_CTYPE=C.UTF-8
+fi
+if [[ $(locale charmap) != "UTF-8" ]]; then
+  export LC_CTYPE=en_US.UTF-8
+fi
+
 if [ "$1" == "--allmodules" ]; then
   shift
   modules="ALL-MODULE-PATH"

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
@@ -19,7 +19,7 @@ import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescript
 import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 
 import com.google.devtools.build.lib.vfs.Path;
-import java.io.FileInputStream;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -105,9 +105,9 @@ public class CompressedTarFunctionTest {
   private Path decompress(DecompressorDescriptor descriptor) throws Exception {
     return new CompressedTarFunction() {
       @Override
-      protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+      protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
           throws IOException {
-        return new GZIPInputStream(new FileInputStream(descriptor.archivePath().getPathFile()));
+        return new GZIPInputStream(compressedInputStream);
       }
     }.decompress(descriptor);
   }

--- a/src/test/java/com/google/devtools/build/lib/runtime/commands/info/StdoutInfoItemHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/commands/info/StdoutInfoItemHandlerTest.java
@@ -38,7 +38,7 @@ public class StdoutInfoItemHandlerTest {
     RecordingOutErr outErr = new RecordingOutErr();
     try (StdoutInfoItemHandler stdoutInfoItemHandler = new StdoutInfoItemHandler(outErr)) {
       stdoutInfoItemHandler.addInfoItem(
-          "info-1", "value-1\n".getBytes(UTF_8), /* printKeys= */ false);
+          "info-1", "value-1".getBytes(UTF_8), /* printKeys= */ false);
     }
 
     assertThat(outErr.outAsLatin1()).isEqualTo("value-1\n");
@@ -48,10 +48,8 @@ public class StdoutInfoItemHandlerTest {
   public void testStdOutputItemHandler_addTwoItemWithPrintingKey() throws Exception {
     RecordingOutErr outErr = new RecordingOutErr();
     try (StdoutInfoItemHandler stdoutInfoItemHandler = new StdoutInfoItemHandler(outErr)) {
-      stdoutInfoItemHandler.addInfoItem(
-          "foo", "value-foo\n".getBytes(UTF_8), /* printKeys= */ true);
-      stdoutInfoItemHandler.addInfoItem(
-          "bar", "value-bar\n".getBytes(UTF_8), /* printKeys= */ true);
+      stdoutInfoItemHandler.addInfoItem("foo", "value-foo".getBytes(UTF_8), /* printKeys= */ true);
+      stdoutInfoItemHandler.addInfoItem("bar", "value-bar".getBytes(UTF_8), /* printKeys= */ true);
     }
 
     assertThat(outErr.outAsLatin1()).isEqualTo("foo: value-foo\nbar: value-bar\n");

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -50,6 +50,8 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.After;
@@ -2034,5 +2036,19 @@ public abstract class FileSystemTest {
   protected static void assumeUtf8CompatibleEncoding() {
     Charset sunJnuEncoding = Charset.forName(System.getProperty("sun.jnu.encoding"));
     assume().that(ImmutableList.of(UTF_8, ISO_8859_1)).contains(sunJnuEncoding);
+  }
+
+  @Test
+  public void testCreateTempDirectory() throws Exception {
+    Set<Path> tempDirs = new HashSet<>();
+    for (int i = 0; i < 10; i++) {
+      Path tempDir = workingDir.createTempDirectory("prefix" + i);
+      assertThat(tempDir.isDirectory()).isTrue();
+      assertThat(tempDir.isReadable()).isTrue();
+      assertThat(tempDir.isWritable()).isTrue();
+      assertThat(tempDir.getBaseName()).startsWith("prefix" + i);
+      assertThat(tempDirs).doesNotContain(tempDir);
+      tempDirs.add(tempDir);
+    }
   }
 }

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -46,6 +46,15 @@ else
   fail "Could not find sha1sum or shasum on the PATH"
 fi
 
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*|darwin)
+  declare -r is_linux=false
+  ;;
+*)
+  declare -r is_linux=true
+  ;;
+esac
+
 function hash_outputs() {
   # runfiles/MANIFEST & runfiles_manifest contain absolute path, ignore.
   # ar on OS-X is non-deterministic, ignore .a files.
@@ -72,8 +81,20 @@ function test_determinism()  {
     cp derived/maven/BUILD.vendor derived/maven/BUILD
 
     # Build Bazel once.
+    #
+    # Use an output base with spaces and non-ASCII characters to verify that
+    # Bazel supports this. Characters with a 4-byte UTF-8 encoding would cause
+    # Java compilation to fail due to
+    # https://bugs.openjdk.org/browse/JDK-8258246.
+    # On Linux, the host needs to provide the C.UTF-8 locale for this to work,
+    # otherwise the DumpPlatformClasspath action will fail.
+    if [[ $is_linux && "$(LC_CTYPE=C.UTF-8 locale charmap)" != "UTF-8" ]]; then
+      output_base_1="${TEST_TMPDIR}/out 1"
+    else
+      output_base_1="${TEST_TMPDIR}/ouäöü€t 1"
+    fi
     bazel \
-      --output_base="${TEST_TMPDIR}/out 1" \
+      --output_base="${output_base_1}" \
       build \
       --extra_toolchains=@rules_python//python:autodetecting_toolchain \
       --enable_bzlmod \
@@ -81,14 +102,23 @@ function test_determinism()  {
       --lockfile_mode=update \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       --nostamp \
-      //src:bazel
+      //src:bazel &> $TEST_log || fail "First build failed"
+    assert_exists "${output_base_1}/java.log"
+    expect_not_log ERROR
+    expect_not_log "Exception:"
+    expect_not_log "Error:"
     hash_outputs >"${TEST_TMPDIR}/sum1"
 
     # Build Bazel twice.
+    if [[ $is_linux && "$(LC_CTYPE=C.UTF-8 locale charmap)" != "UTF-8" ]]; then
+      output_base_2="${TEST_TMPDIR}/out 2"
+    else
+      output_base_2="${TEST_TMPDIR}/ouäöü€t 2"
+    fi
     bazel-bin/src/bazel \
       --bazelrc="${TEST_TMPDIR}/bazelrc" \
-      --install_base="${TEST_TMPDIR}/install_base2" \
-      --output_base="${TEST_TMPDIR}/out 2" \
+      --install_base="${TEST_TMPDIR}/install_baseäöü€t 2" \
+      --output_base="${output_base_2}" \
       build \
       --extra_toolchains=@rules_python//python:autodetecting_toolchain \
       --enable_bzlmod \
@@ -96,7 +126,11 @@ function test_determinism()  {
       --lockfile_mode=update \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       --nostamp \
-      //src:bazel
+      //src:bazel &> $TEST_log || fail "Second build failed"
+    assert_exists "${output_base_2}/java.log"
+    expect_not_log ERROR
+    expect_not_log "Exception:"
+    expect_not_log "Error:"
     hash_outputs >"${TEST_TMPDIR}/sum2"
 
     if ! diff -U0 "${TEST_TMPDIR}/sum1" "${TEST_TMPDIR}/sum2" >$TEST_log; then

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_import", "java_library", "java_plugin")
+load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library", "java_plugin")
 load("@rules_license//rules:license.bzl", "license")
 load("//src/tools/bzlmod:utils.bzl", "get_repo_root")
 load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup", "distrib_java_import")
@@ -316,13 +316,17 @@ genrule(
         "@rules_java//toolchains:platformclasspath",
     ],
     outs = ["fastutil-stripped.jar"],
+    # ProGuard output is silenced below because it prints
+    # ...
+    # Caused by: java.net.UnknownHostException: bk-docker-3gmr: Temporary failure in name resolution
+    # ...
+    # when running in the Bazel sandbox, which throws off bazel_determinism_test.
     cmd = """
     $(location :proguard) \
         -injars $(execpath @maven//:it_unimi_dsi_fastutil_file) \
         -outjars $@ \
         -libraryjars $(execpath @rules_java//toolchains:platformclasspath) \
-        @$(location //tools:fastutil.proguard) \
-      | tail -n +2 # Skip the "ProGuard, version X" line
+        @$(location //tools:fastutil.proguard) > /dev/null
     # Null out the file times stored in the jar to make the output reproducible.
     TMPDIR=$$(mktemp -d)
     trap 'rm -rf $$TMPDIR' EXIT
@@ -340,6 +344,10 @@ genrule(
 
 java_binary(
     name = "proguard",
+    jvm_flags = [
+        # Prevent ProGuard from calling out to the internet through log4j.
+        "-Dlog4j.rootLogger=OFF",
+    ],
     main_class = "proguard.ProGuard",
     runtime_deps = ["@maven//:com_guardsquare_proguard_base"],
 )


### PR DESCRIPTION
This reverts commit https://github.com/bazelbuild/bazel/commit/5463126ab94e949eeaaa00c73292ebe79b0bbf08, thus relanding https://github.com/bazelbuild/bazel/commit/6982c14667440980665c536b8f1b7b6e57f5a808.

Additional fixes:
* Fix the encoding of rules default values in `bazel info build-language` output.
* Do not append a newline to binary `bazel info` output.

