### PR TITLE
Add support for cache eviction retries with fixed invocation ID

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeWorkspace.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeWorkspace.java
@@ -234,6 +234,7 @@ public final class BlazeWorkspace {
       Consumer<String> shutdownReasonConsumer,
       CommandExtensionReporter commandExtensionReporter,
       int attemptNumber,
+      @Nullable String buildIdOverride,
       ConfigFlagDefinitions configFlagDefinitions) {
     quiescingExecutors.resetParameters(options);
     CommandEnvironment env =
@@ -255,6 +256,7 @@ public final class BlazeWorkspace {
             shutdownReasonConsumer,
             commandExtensionReporter,
             attemptNumber,
+            buildIdOverride,
             configFlagDefinitions);
     skyframeExecutor.setClientEnv(env.getClientEnv());
     BuildRequestOptions buildRequestOptions = options.getOptions(BuildRequestOptions.class);

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeWorkspace.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeWorkspace.java
@@ -234,7 +234,7 @@ public final class BlazeWorkspace {
       Consumer<String> shutdownReasonConsumer,
       CommandExtensionReporter commandExtensionReporter,
       int attemptNumber,
-      @Nullable String buildIdOverride,
+      @Nullable String buildRequestIdOverride,
       ConfigFlagDefinitions configFlagDefinitions) {
     quiescingExecutors.resetParameters(options);
     CommandEnvironment env =
@@ -256,7 +256,7 @@ public final class BlazeWorkspace {
             shutdownReasonConsumer,
             commandExtensionReporter,
             attemptNumber,
-            buildIdOverride,
+            buildRequestIdOverride,
             configFlagDefinitions);
     skyframeExecutor.setClientEnv(env.getClientEnv());
     BuildRequestOptions buildRequestOptions = options.getOptions(BuildRequestOptions.class);

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -230,7 +230,7 @@ public class CommandEnvironment {
       Consumer<String> shutdownReasonConsumer,
       CommandExtensionReporter commandExtensionReporter,
       int attemptNumber,
-      @Nullable String buildIdOverride,
+      @Nullable String buildRequestIdOverride,
       ConfigFlagDefinitions configFlagDefinitions) {
     checkArgument(attemptNumber >= 1);
 
@@ -318,11 +318,12 @@ public class CommandEnvironment {
 
     this.clientEnv = makeMapFromMapEntries(clientOptions.clientEnv);
     this.commandId = computeCommandId(commandOptions.invocationId, warnings, attemptNumber);
-    // Use a fixed ID across cache eviction retries.
     this.buildRequestId =
         commandOptions.buildRequestId != null
             ? commandOptions.buildRequestId
-            : buildIdOverride != null ? buildIdOverride : UUID.randomUUID().toString();
+            : buildRequestIdOverride != null
+                ? buildRequestIdOverride
+                : UUID.randomUUID().toString();
 
     this.repoEnv.putAll(clientEnv);
     if (command.buildPhase().analyzes() || command.name().equals("info")) {

--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
@@ -206,7 +206,7 @@ public class BlazeRuntimeWrapper {
                 this.crashMessages::add,
                 NO_OP_COMMAND_EXTENSION_REPORTER,
                 /* attemptNumber= */ 1,
-                /* buildIdOverride= */ null,
+                /* buildRequestIdOverride= */ null,
                 ConfigFlagDefinitions.NONE);
     return env;
   }

--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
@@ -206,6 +206,7 @@ public class BlazeRuntimeWrapper {
                 this.crashMessages::add,
                 NO_OP_COMMAND_EXTENSION_REPORTER,
                 /* attemptNumber= */ 1,
+                /* buildIdOverride= */ null,
                 ConfigFlagDefinitions.NONE);
     return env;
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -192,7 +192,7 @@ public final class RemoteModuleTest {
         /* shutdownReasonConsumer= */ s -> {},
         NO_OP_COMMAND_EXTENSION_REPORTER,
         /* attemptNumber= */ 1,
-        /* buildIdOverride= */ null,
+        /* buildRequestIdOverride= */ null,
         ConfigFlagDefinitions.NONE);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -192,6 +192,7 @@ public final class RemoteModuleTest {
         /* shutdownReasonConsumer= */ s -> {},
         NO_OP_COMMAND_EXTENSION_REPORTER,
         /* attemptNumber= */ 1,
+        /* buildIdOverride= */ null,
         ConfigFlagDefinitions.NONE);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
@@ -258,7 +258,7 @@ public class BlazeRuntimeTest {
         /* shutdownReasonConsumer= */ shutdownReason::set,
         NO_OP_COMMAND_EXTENSION_REPORTER,
         /* attemptNumber= */ 1,
-        /* buildIdOverride= */ null,
+        /* buildRequestIdOverride= */ null,
         ConfigFlagDefinitions.NONE);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
@@ -258,6 +258,7 @@ public class BlazeRuntimeTest {
         /* shutdownReasonConsumer= */ shutdownReason::set,
         NO_OP_COMMAND_EXTENSION_REPORTER,
         /* attemptNumber= */ 1,
+        /* buildIdOverride= */ null,
         ConfigFlagDefinitions.NONE);
   }
 


### PR DESCRIPTION
Retries use new invocation IDs, but are linked together by using the same build request ID.