### PR TITLE
[8.2.0] Include output path in Remote Asset API client errors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.remote.ReferenceCountedChannel;
 import com.google.devtools.build.lib.remote.RemoteRetrier;
+import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -172,6 +173,9 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
             try (OutputStream out = newOutputStream(destination, checksum)) {
               Utils.getFromFuture(
                   cacheClient.downloadBlob(remoteActionExecutionContext, blobDigest, out));
+            } catch (OutputDigestMismatchException e) {
+              e.setOutputPath(destination.getPathString());
+              throw e;
             }
             return null;
           });


### PR DESCRIPTION
Closes #25298.

PiperOrigin-RevId: 728297901
Change-Id: Iad223ae19c8b8f589129223771420f9627500a9b

Commit https://github.com/bazelbuild/bazel/commit/ddde16b267eeb239d8b16272cc4b2ff7d94f27b9