### PR TITLE
[8.1.1] Fall back to `rctx.name` if `$original_name` is empty

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.bazel.repository.starlark;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.github.difflib.patch.PatchFailedException;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
@@ -168,7 +169,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     // backing Bazel modules. In case of the former, the original name is the same as the name, in
     // the latter the original name doesn't matter as the restricted set of rules that can back
     // Bazel modules do not use the name.
-    return originalName != null ? originalName : rule.getName();
+    return Strings.isNullOrEmpty(originalName) ? rule.getName() : originalName;
   }
 
   @StarlarkMethod(


### PR DESCRIPTION
The default for the attribute is the empty string, not `null`.

Fixes #25286

Closes #25296.

PiperOrigin-RevId: 728298504
Change-Id: Ibc7209e248c3abb57a5fb2487e7dab7202960bbd

Commit https://github.com/bazelbuild/bazel/commit/fa7900a64c31427bddc1730a6b60178fa866fa6c