### PR TITLE
Stub code attribute in ijar instead of deleting it

### DIFF
--- a/third_party/ijar/ijar.cc
+++ b/third_party/ijar/ijar.cc
@@ -163,7 +163,7 @@ void JarStripperProcessor::Process(const char *filename, const u4 /*attr*/,
     memcpy(q, data, size);
     builder_->FinishFile(size, /* compress: */ false, /* compute_crc: */ true);
   } else {
-    u1 *buf = reinterpret_cast<u1 *>(malloc(size));
+    u1 *buf = reinterpret_cast<u1 *>(malloc(size * 2));
     u1 *classdata_out = buf;
     if (!StripClass(buf, data, size)) {
       free(classdata_out);
@@ -404,7 +404,7 @@ static void OpenFilesAndProcessJar(const char *file_out, const char *file_in,
   output_length +=
       EstimateManifestOutputSize(target_label, injecting_rule_kind);
 
-  std::unique_ptr<ZipBuilder> out(ZipBuilder::Create(file_out, output_length));
+  std::unique_ptr<ZipBuilder> out(ZipBuilder::Create(file_out, output_length * 2));
   if (out == NULL) {
     fprintf(stderr, "Unable to open output file %s: %s\n", file_out,
             strerror(errno));


### PR DESCRIPTION
Ijar simply drops the body of all public methods. However this might generate classes that are considered invalid per JVM specs. Tools that try and inspect the jar, might fail because of that. Instead of dropping the code, we can replace it with a fixed one. Particularly, throwing an unchecked exception is a valid code for all method signatures, so we just sub all code attributes with `throw new java.jang.UnsupportedOperationException()`. We have been using this internally for a long time, it fixes https://github.com/bazelbuild/bazel/issues/13546