### PR TITLE
[8.1.1] Rollback of Use digest function matching the checksum in gRPC remote downloader

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -70,7 +70,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
   private final Optional<CallCredentials> credentials;
   private final RemoteRetrier retrier;
   private final RemoteCacheClient cacheClient;
-  private final DigestFunction.Value defaultDigestFunction;
+  private final DigestFunction.Value digestFunction;
   private final RemoteOptions options;
   private final boolean verboseFailures;
   @Nullable private final Downloader fallbackDownloader;
@@ -100,7 +100,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       Optional<CallCredentials> credentials,
       RemoteRetrier retrier,
       RemoteCacheClient cacheClient,
-      DigestFunction.Value defaultDigestFunction,
+      DigestFunction.Value digestFunction,
       RemoteOptions options,
       boolean verboseFailures,
       @Nullable Downloader fallbackDownloader) {
@@ -110,7 +110,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     this.credentials = credentials;
     this.retrier = retrier;
     this.cacheClient = cacheClient;
-    this.defaultDigestFunction = defaultDigestFunction;
+    this.digestFunction = digestFunction;
     this.options = options;
     this.verboseFailures = verboseFailures;
     this.fallbackDownloader = fallbackDownloader;
@@ -149,7 +149,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
             urls,
             checksum,
             canonicalId,
-            defaultDigestFunction,
+            digestFunction,
             headers,
             credentials);
     try {
@@ -200,12 +200,14 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       List<URL> urls,
       Optional<Checksum> checksum,
       String canonicalId,
-      DigestFunction.Value defaultDigestFunction,
+      DigestFunction.Value digestFunction,
       Map<String, List<String>> headers,
       Credentials credentials)
       throws IOException {
     FetchBlobRequest.Builder requestBuilder =
-        FetchBlobRequest.newBuilder().setInstanceName(instanceName);
+        FetchBlobRequest.newBuilder()
+            .setInstanceName(instanceName)
+            .setDigestFunction(digestFunction);
     for (int i = 0; i < urls.size(); i++) {
       var url = urls.get(i);
       requestBuilder.addUris(url.toString());
@@ -231,21 +233,12 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
     }
 
     if (checksum.isPresent()) {
-      requestBuilder.setDigestFunction(
-          switch (checksum.get().getKeyType()) {
-            case SHA1 -> DigestFunction.Value.SHA1;
-            case SHA256 -> DigestFunction.Value.SHA256;
-            case SHA384 -> DigestFunction.Value.SHA384;
-            case SHA512 -> DigestFunction.Value.SHA512;
-            case BLAKE3 -> DigestFunction.Value.BLAKE3;
-          });
       requestBuilder.addQualifiers(
           Qualifier.newBuilder()
               .setName(QUALIFIER_CHECKSUM_SRI)
               .setValue(checksum.get().toSubresourceIntegrity())
               .build());
     } else {
-      requestBuilder.setDigestFunction(defaultDigestFunction);
       // If no checksum is provided, never accept cached content.
       // Timestamp is offset by an hour to account for clock skew.
       requestBuilder.setOldestContentAccepted(


### PR DESCRIPTION
*** Reason for rollback ***

https://github.com/bazelbuild/bazel/pull/25206#issuecomment-2663193705

*** Original change description ***

Use digest function matching the checksum in gRPC remote downloader

Fixes https://bazelbuild.slack.com/archives/CA31HN1T3/p1738763759125489

Closes #25206.

PiperOrigin-RevId: 728572171
Change-Id: Ifc72c3d48d742ff236ec3424d3989c1738989069

Commit https://github.com/bazelbuild/bazel/commit/6f072751f1ac481b06eeb27aeca88ad58ff8a4e2