### PR TITLE
Delete `--incompatible_remote_use_new_exit_code_for_lost_inputs` 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -302,30 +302,17 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
                     Reason.INPUTS),
             BulkTransferException.class,
             (BulkTransferException e) -> {
-              if (executionOptions.useNewExitCodeForLostInputs
-                  || executionOptions.remoteRetryOnTransientCacheError > 0) {
-                var message =
-                    BulkTransferException.allCausedByCacheNotFoundException(e)
-                        ? "Failed to fetch blobs because they do not exist remotely."
-                        : "Failed to fetch blobs because of a remote cache error.";
-                throw new EnvironmentalExecException(
-                    e,
-                    FailureDetail.newBuilder()
-                        .setMessage(message)
-                        .setSpawn(
-                            FailureDetails.Spawn.newBuilder().setCode(Code.REMOTE_CACHE_EVICTED))
-                        .build());
-              } else if (BulkTransferException.allCausedByCacheNotFoundException(e)) {
-                throw new EnvironmentalExecException(
-                    e,
-                    FailureDetail.newBuilder()
-                        .setMessage("Failed to fetch blobs because they do not exist remotely.")
-                        .setSpawn(
-                            FailureDetails.Spawn.newBuilder().setCode(Code.REMOTE_CACHE_FAILED))
-                        .build());
-              } else {
-                throw e;
-              }
+              var message =
+                  BulkTransferException.allCausedByCacheNotFoundException(e)
+                      ? "Failed to fetch blobs because they do not exist remotely."
+                      : "Failed to fetch blobs because of a remote cache error.";
+              throw new EnvironmentalExecException(
+                  e,
+                  FailureDetail.newBuilder()
+                      .setMessage(message)
+                      .setSpawn(
+                          FailureDetails.Spawn.newBuilder().setCode(Code.REMOTE_CACHE_EVICTED))
+                      .build());
             },
             directExecutor());
       }

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -30,7 +30,6 @@ import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
-import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParsingException;
@@ -533,17 +532,6 @@ public class ExecutionOptions extends OptionsBase {
   public boolean splitXmlGeneration;
 
   @Option(
-      name = "incompatible_remote_use_new_exit_code_for_lost_inputs",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "If set to true, Bazel will use new exit code 39 instead of 34 if remote cache"
-              + "errors, including cache evictions, cause the build to fail.")
-  public boolean useNewExitCodeForLostInputs;
-
-  @Option(
       // TODO: when this flag is moved to non-experimental, rename it to a more general name
       // to reflect the new logic - it's not only about cache evictions.
       name = "experimental_remote_cache_eviction_retries",
@@ -554,12 +542,7 @@ public class ExecutionOptions extends OptionsBase {
           "The maximum number of attempts to retry if the build encountered a transient remote"
               + " cache error that would otherwise fail the build. Applies for example when"
               + " artifacts are evicted from the remote cache, or in certain cache failure"
-              + " conditions. A non-zero value will implicitly set"
-              + " --incompatible_remote_use_new_exit_code_for_lost_inputs to true. A new invocation"
-              + " id will be generated for each attempt. If you generate invocation id and provide"
-              + " it to Bazel with --invocation_id, you should not use this flag. Instead, set flag"
-              + " --incompatible_remote_use_new_exit_code_for_lost_inputs and check for the exit"
-              + " code 39.")
+              + " conditions. A new invocation id will be generated for each attempt.")
   public int remoteRetryOnTransientCacheError;
 
   /** An enum for specifying different formats of test output. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -641,12 +641,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
       catastrophe = true;
     } else if (remoteCacheFailed) {
       status = Status.REMOTE_CACHE_FAILED;
-      if (executionOptions.useNewExitCodeForLostInputs
-          || executionOptions.remoteRetryOnTransientCacheError > 0) {
-        detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_EVICTED;
-      } else {
-        detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_FAILED;
-      }
+      detailedCode = FailureDetails.Spawn.Code.REMOTE_CACHE_EVICTED;
       catastrophe = false;
     } else {
       status = Status.EXECUTION_FAILED;

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -228,8 +228,7 @@ message Spawn {
     //   refactored to prohibit undetailed failures
     UNSPECIFIED_EXECUTION_FAILURE = 12 [(metadata) = { exit_code: 1 }];
     FORBIDDEN_INPUT = 13 [(metadata) = { exit_code: 1 }];
-    // This also includes other remote cache errors, not just evictions,
-    // if --incompatible_remote_use_new_exit_code_for_lost_inputs is set.
+    // This also includes other remote cache errors, not just evictions.
     // TODO: Rename it to a more general name when
     // --experimental_remote_cache_eviction_retries is moved to
     // non-experimental.


### PR DESCRIPTION
The flag has been flipped in Bazel 7 and constitutes a very minor change that nonetheless complicates remote execution exception handling.