### PR TITLE
Consistently use `\n` as line terminator in build and stdout output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWriteNestedSetOfTupleAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWriteNestedSetOfTupleAction.java
@@ -73,7 +73,7 @@ public final class LazyWriteNestedSetOfTupleAction extends AbstractFileWriteActi
         for (int i = 1; i < tuple.size(); i++) {
           stringBuilder.append(delimiter).append(tuple.get(i));
         }
-        stringBuilder.append(System.lineSeparator());
+        stringBuilder.append("\n");
       }
       fileContents = stringBuilder.toString();
     }

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OptionsDiff.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OptionsDiff.java
@@ -246,7 +246,7 @@ public final class OptionsDiff {
   public String prettyPrint() {
     StringBuilder toReturn = new StringBuilder();
     for (String diff : getPrettyPrintList()) {
-      toReturn.append(diff).append(System.lineSeparator());
+      toReturn.append(diff).append("\n");
     }
     return toReturn.toString();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -162,7 +162,7 @@ public class PatchUtil {
   }
 
   private static void writeFile(Path file, List<String> content) throws IOException {
-    FileSystemUtils.writeLinesAs(file, UTF_8, content, "\n");
+    FileSystemUtils.writeLinesAs(file, UTF_8, content);
   }
 
   private static boolean getReadPermission(int permission) {

--- a/src/main/java/com/google/devtools/build/lib/exec/TestLogHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestLogHelper.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.exec;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.exec.ExecutionOptions.TestOutputFormat;
-import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.BufferedOutputStream;
 import java.io.FilterOutputStream;
@@ -57,7 +56,7 @@ public class TestLogHelper {
       throws IOException {
     PrintStream printOut = new PrintStream(new BufferedOutputStream(out));
     try {
-      printOut.println("==================== Test output for " + testName + ":");
+      printOut.print("==================== Test output for " + testName + ":\n");
       printOut.flush();
 
       if (maxTestOutputBytes < 0) {
@@ -73,8 +72,8 @@ public class TestLogHelper {
         }
       }
 
-      printOut.println(
-          "================================================================================");
+      printOut.print(
+          "================================================================================\n");
     } finally {
       printOut.flush();
     }
@@ -111,10 +110,7 @@ public class TestLogHelper {
       } else if (b == NEWLINE) {
         String line = lineBuilder.toString();
         lineBuilder = new StringBuilder();
-        if (line.equals(TestLogHelper.HEADER_DELIMITER)
-            ||
-            // On Windows, the line break could be \r\n, we want this case to work as well.
-            (OS.getCurrent() == OS.WINDOWS && line.equals(TestLogHelper.HEADER_DELIMITER + "\r"))) {
+        if (line.equals(TestLogHelper.HEADER_DELIMITER)) {
           seenDelimiter = true;
         }
       } else if (lineBuilder.length() <= TestLogHelper.HEADER_DELIMITER.length()) {

--- a/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/common/CommonQueryOptions.java
@@ -67,7 +67,7 @@ public class CommonQueryOptions extends OptionsBase {
       return "\0";
     }
 
-    return System.lineSeparator();
+    return "\n";
   }
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallback.java
@@ -103,7 +103,7 @@ class BuildOutputFormatterCallback extends CqueryThreadsafeCallback {
             // selects. Going forward we could expand this to show both the complete select
             // and which path is chosen, which people may find even more informative.
             (rule, attr) -> false,
-            System.lineSeparator(),
+            "\n",
             labelPrinter);
     for (CqueryNode configuredTarget : partialResult) {
       Target target = accessor.getTarget(configuredTarget);

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedJSONProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedJSONProtoOutputFormatter.java
@@ -46,7 +46,7 @@ public class StreamedJSONProtoOutputFormatter extends ProtoOutputFormatter {
                   .omittingInsignificantWhitespace()
                   .print(toTargetProtoBuffer(target, labelPrinter))
                   .getBytes(StandardCharsets.UTF_8));
-          out.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+          out.write('\n');
         }
       }
     };

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -703,55 +703,25 @@ public class FileSystemUtils {
     asByteSink(outputFile).write(content);
   }
 
-  /**
-   * Writes lines to file using the given encoding, ending every line with a system specific line
-   * break character.
-   */
+  /** Writes lines to file using the given encoding, ending every line with '\n'. */
   @ThreadSafe // but not atomic
   public static void writeLinesAs(Path file, Charset charset, String... lines) throws IOException {
     writeLinesAs(file, charset, Arrays.asList(lines));
   }
 
-  /**
-   * Writes lines to file using the given encoding, ending every line with a system specific line
-   * break character.
-   */
+  /** Writes lines to file using the given encoding, ending every line with '\n'. */
   @ThreadSafe // but not atomic
   public static void writeLinesAs(Path file, Charset charset, Iterable<String> lines)
       throws IOException {
     file.getParentDirectory().createDirectoryAndParents();
-    asByteSink(file).asCharSink(charset).writeLines(lines);
+    asByteSink(file).asCharSink(charset).writeLines(lines, "\n");
   }
 
-  /**
-   * Writes lines to file using the given encoding, ending every line with a given line break
-   * character.
-   */
-  @ThreadSafe // but not atomic
-  public static void writeLinesAs(
-      Path file, Charset charset, Iterable<String> lines, String lineBreak) throws IOException {
-    file.getParentDirectory().createDirectoryAndParents();
-    asByteSink(file).asCharSink(charset).writeLines(lines, lineBreak);
-  }
-
-  /**
-   * Appends lines to file using the given encoding, ending every line with a system specific line
-   * break character.
-   */
+  /** Appends lines to file using the given encoding, ending every line with '\n'. */
   @ThreadSafe // but not atomic
   public static void appendLinesAs(Path file, Charset charset, String... lines) throws IOException {
-    appendLinesAs(file, charset, Arrays.asList(lines));
-  }
-
-  /**
-   * Appends lines to file using the given encoding, ending every line with a system specific line
-   * break character.
-   */
-  @ThreadSafe // but not atomic
-  public static void appendLinesAs(Path file, Charset charset, Iterable<String> lines)
-      throws IOException {
     file.getParentDirectory().createDirectoryAndParents();
-    asByteSink(file, true).asCharSink(charset).writeLines(lines);
+    asByteSink(file, true).asCharSink(charset).writeLines(Arrays.asList(lines), "\n");
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/worker/JsonWorkerProtocol.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/JsonWorkerProtocol.java
@@ -51,7 +51,7 @@ final class JsonWorkerProtocol implements WorkerProtocolImpl {
     // WorkRequests are serialized according to ndjson spec.
     // https://github.com/ndjson/ndjson-spec
     jsonPrinter.appendTo(request, jsonWriter);
-    jsonWriter.append(System.lineSeparator());
+    jsonWriter.append("\n");
     jsonWriter.flush();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransportTest.java
@@ -110,7 +110,7 @@ public class TextFormatFileTransportTest {
     transport.close().get();
     String contents =
         trimLines(
-            Joiner.on(System.lineSeparator())
+            Joiner.on("\n")
                 .join(Files.readLines(output, StandardCharsets.UTF_8)));
 
     assertThat(contents).contains(trimLines(TextFormat.printer().printToString(started)));

--- a/src/test/java/com/google/devtools/build/lib/exec/StreamedTestOutputTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/StreamedTestOutputTest.java
@@ -59,8 +59,8 @@ public class StreamedTestOutputTest {
     try (StreamedTestOutput underTest =
         new StreamedTestOutput(OutErr.create(out, err), fileSystem.getPath("/myfile"))) {}
 
-    assertThat(out.toString(StandardCharsets.UTF_8.name())).isEqualTo("random\nlines\n");
-    assertThat(err.toString(StandardCharsets.UTF_8.name())).isEmpty();
+    assertThat(out.toString(StandardCharsets.UTF_8)).isEqualTo("random\nlines\n");
+    assertThat(err.toString(StandardCharsets.UTF_8)).isEmpty();
   }
 
   @Test
@@ -80,9 +80,9 @@ public class StreamedTestOutputTest {
     try (StreamedTestOutput underTest =
         new StreamedTestOutput(OutErr.create(out, err), fileSystem.getPath("/myfile"))) {}
 
-    assertThat(out.toString(StandardCharsets.UTF_8.name()))
-        .isEqualTo("included" + System.lineSeparator() + "lines" + System.lineSeparator());
-    assertThat(err.toString(StandardCharsets.UTF_8.name())).isEmpty();
+    assertThat(out.toString(StandardCharsets.UTF_8))
+        .isEqualTo("included\nlines\n");
+    assertThat(err.toString(StandardCharsets.UTF_8)).isEmpty();
   }
 
   @Test
@@ -136,7 +136,7 @@ public class StreamedTestOutputTest {
       assertThat(Thread.interrupted()).isTrue();
     }
 
-    assertThat(out.toString(StandardCharsets.UTF_8.name())).isEqualTo("blahblahblah");
-    assertThat(err.toString(StandardCharsets.UTF_8.name())).isEmpty();
+    assertThat(out.toString(StandardCharsets.UTF_8)).isEqualTo("blahblahblah");
+    assertThat(err.toString(StandardCharsets.UTF_8)).isEmpty();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/exec/TestLogHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/TestLogHelperTest.java
@@ -44,7 +44,7 @@ public final class TestLogHelperTest extends FoundationTestCase {
   public void testFormatEmptyTestLog() throws IOException {
     Path logPath = scratch.file("/test.log", "");
     String result = getTestLog(logPath, "testFormatEmptyTestLog");
-    assertThat(result.replaceAll(System.lineSeparator(), "\n"))
+    assertThat(result)
         .isEqualTo(
             "==================== Test output for testFormatEmptyTestLog:\n"
                 + "\n"
@@ -56,7 +56,7 @@ public final class TestLogHelperTest extends FoundationTestCase {
     Path logPath =
         scratch.file("/test.log", "Header", TestLogHelper.HEADER_DELIMITER, "Empty line");
     String result = getTestLog(logPath, "testFormatTestLogWithHeader");
-    assertThat(result.replaceAll(System.lineSeparator(), "\n"))
+    assertThat(result)
         .isEqualTo(
             "==================== Test output for testFormatTestLogWithHeader:\n"
                 + "Empty line\n"
@@ -67,7 +67,7 @@ public final class TestLogHelperTest extends FoundationTestCase {
   public void testFormatTestLogWithNoHeader() throws IOException {
     Path logPath = scratch.file("/test.log", "Line 1", "Line 2");
     String result = getTestLog(logPath, "testFormatTestLogWithNoHeader");
-    assertThat(result.replaceAll(System.lineSeparator(), "\n"))
+    assertThat(result)
         .isEqualTo(
             "==================== Test output for testFormatTestLogWithNoHeader:\n"
                 + "Line 1\n"
@@ -81,8 +81,7 @@ public final class TestLogHelperTest extends FoundationTestCase {
 
     ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
     TestLogHelper.writeTestLog(logPath, "myTest", bytesOut, /*maxTestOutputBytes=*/ 10);
-    assertThat(
-            new String(bytesOut.toByteArray(), ISO_8859_1).replaceAll(System.lineSeparator(), "\n"))
+    assertThat(bytesOut.toString(ISO_8859_1))
         .isEqualTo(
             "==================== Test output for myTest:\n"
                 + "Test log too large (1000 > 10), skipping...\n"
@@ -95,8 +94,7 @@ public final class TestLogHelperTest extends FoundationTestCase {
 
     ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
     TestLogHelper.writeTestLog(logPath, "myTest", bytesOut, /*maxTestOutputBytes=*/ 0);
-    assertThat(
-            new String(bytesOut.toByteArray(), ISO_8859_1).replaceAll(System.lineSeparator(), "\n"))
+    assertThat(bytesOut.toString(ISO_8859_1))
         .isEqualTo(
             "==================== Test output for myTest:\n"
                 + "================================================================================\n");
@@ -110,8 +108,7 @@ public final class TestLogHelperTest extends FoundationTestCase {
     ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
     TestLogHelper.writeTestLog(
         logPath, "myTest", bytesOut, /*maxTestOutputBytes=*/ testLogHeaderLength - 1);
-    assertThat(
-            new String(bytesOut.toByteArray(), ISO_8859_1).replaceAll(System.lineSeparator(), "\n"))
+    assertThat(bytesOut.toString(ISO_8859_1))
         .isEqualTo(
             "==================== Test output for myTest:\n"
                 + String.format(
@@ -123,6 +120,6 @@ public final class TestLogHelperTest extends FoundationTestCase {
   private String getTestLog(Path path, String name) throws IOException {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     TestLogHelper.writeTestLog(path, name, output, /*maxTestOutputBytes=*/ -1);
-    return new String(output.toByteArray(), ISO_8859_1);
+    return output.toString(ISO_8859_1);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/metrics/MetricsCollectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/metrics/MetricsCollectorTest.java
@@ -470,9 +470,7 @@ public class MetricsCollectorTest extends BuildIntegrationTestCase {
         .isEqualTo(
             ArtifactMetrics.newBuilder()
                 .setSourceArtifactsRead(
-                    ArtifactMetrics.FilesMetric.newBuilder()
-                        .setSizeInBytes(OS.getCurrent() == OS.WINDOWS ? 6 : 10)
-                        .setCount(OS.getCurrent() == OS.WINDOWS ? 1 : 2))
+                    ArtifactMetrics.FilesMetric.newBuilder().setSizeInBytes(10).setCount(2))
                 .setOutputArtifactsSeen(
                     ArtifactMetrics.FilesMetric.newBuilder()
                         .setSizeInBytes(42L)

--- a/src/test/java/com/google/devtools/build/lib/metrics/MetricsCollectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/metrics/MetricsCollectorTest.java
@@ -237,15 +237,8 @@ public class MetricsCollectorTest extends BuildIntegrationTestCase {
         "genrule(name = 'b', srcs = ['b.in', 'c.in'], outs = ['b.out'], cmd = 'cat $(SRCS) > $@')",
         "genrule(name = 'c', srcs = ['c.in', 'c2.in'], outs = ['c.out'], cmd = 'cat $(SRCS) >"
             + " $@')");
-    if (OS.getCurrent() == OS.WINDOWS) {
-      // On Windows we have \r\n line endings while on other platforms only \n. So make the file one
-      // byte shorter on Windows so that the byte counts below match.
-      write("b/b.in", "1234");
-      write("b/c.in", "1");
-    } else {
-      write("b/b.in", "12345");
-      write("b/c.in", "12");
-    }
+    write("b/b.in", "12345");
+    write("b/c.in", "12");
     createSymlink("c.in", "b/c2.in");
     write(
         "e/BUILD",
@@ -262,13 +255,7 @@ public class MetricsCollectorTest extends BuildIntegrationTestCase {
             cmd = "cat $(SRCS) > $@",
         )
         """);
-    if (OS.getCurrent() == OS.WINDOWS) {
-      // On Windows we have \r\n line endings while on other platforms only \n. So make the file one
-      // byte shorter on Windows so that the byte counts below match.
-      write("e/e.in", "ab");
-    } else {
-      write("e/e.in", "abc");
-    }
+    write("e/e.in", "abc");
 
     // Do one build of a target in a standalone package. Gets us a baseline for analysis/execution.
     buildTarget("//e:facade");

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockToolsConfig.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockToolsConfig.java
@@ -78,7 +78,7 @@ public final class MockToolsConfig {
       StringBuilder newContent = new StringBuilder();
       for (String line : lines) {
         newContent.append(line);
-        newContent.append(System.lineSeparator());
+        newContent.append('\n');
       }
 
       if (!newContent.toString().trim().equals(existingContent.trim())) {

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallbackTest.java
@@ -88,7 +88,7 @@ public class BuildOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
             env.getAccessor(),
             LabelPrinter.legacy());
     env.evaluateQuery(expression, callback);
-    return Arrays.asList(output.toString().split(System.lineSeparator()));
+    return Arrays.asList(output.toString().split("\n"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/FilesOutputFormatterCallbackTest.java
@@ -134,7 +134,7 @@ public class FilesOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
                 false,
                 OutputGroupInfo.determineOutputGroups(outputGroups, ValidationMode.OFF, false)));
     env.evaluateQuery(expression, callback);
-    return Arrays.asList(output.toString(UTF_8).split(System.lineSeparator()));
+    return Arrays.asList(output.toString(UTF_8).split("\n"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallbackTest.java
@@ -88,7 +88,7 @@ public class GraphOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
             ct -> env.getFwdDeps(ImmutableList.of(ct)),
             LabelPrinter.legacy());
     env.evaluateQuery(expression, callback);
-    return ImmutableList.copyOf(output.toString().split(System.lineSeparator()));
+    return ImmutableList.copyOf(output.toString().split("\n"));
   }
 
   /** Convenience method for easily injecting a config hash into an expected output sequence. */

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTest.java
@@ -472,7 +472,7 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
     waitDownloads();
 
     // Assert: target was successfully built
-    assertValidOutputFile("a/bar.out", "foo" + lineSeparator() + "updated bar" + lineSeparator());
+    assertValidOutputFile("a/bar.out", "foo\nupdated bar\n");
   }
 
   @Test
@@ -528,7 +528,7 @@ public class BuildWithoutTheBytesIntegrationTest extends BuildWithoutTheBytesInt
     waitDownloads();
 
     // Assert: target was successfully built
-    assertValidOutputFile("a/bar.out", "file-inside\nupdated bar" + lineSeparator());
+    assertValidOutputFile("a/bar.out", "file-inside\nupdated bar\n");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -604,9 +604,9 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     buildTarget("//:foobar");
     waitDownloads();
 
-    assertValidOutputFile("foobar.out", "foo" + lineSeparator() + "bar\n");
+    assertValidOutputFile("foobar.out", "foo\nbar\n");
     assertOutputDoesNotExist("foo.in.copy");
-    assertValidOutputFile("foo.out.copy", "foo" + lineSeparator());
+    assertValidOutputFile("foo.out.copy", "foo\n");
   }
 
   @Test
@@ -633,9 +633,9 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     buildTarget("//:foobar");
     waitDownloads();
 
-    assertValidOutputFile("foobar.out", "foo" + lineSeparator() + "bar\n");
-    assertValidOutputFile("foo.in.copy", "foo" + lineSeparator());
-    assertValidOutputFile("foo.out.copy", "foo" + lineSeparator());
+    assertValidOutputFile("foobar.out", "foo\nbar\n");
+    assertValidOutputFile("foo.in.copy", "foo\n");
+    assertValidOutputFile("foo.out.copy", "foo\n");
   }
 
   @Test
@@ -662,7 +662,7 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     buildTarget("//:foobar");
     waitDownloads();
 
-    assertValidOutputFile("foobar.out", "foo" + lineSeparator() + "bar\n");
+    assertValidOutputFile("foobar.out", "foo\nbar\n");
     assertOutputDoesNotExist("foo.in.copy");
     assertOutputDoesNotExist("foo.out.copy");
   }
@@ -975,13 +975,13 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     buildTarget("//:foo-link");
 
     assertSymlink("foo-link", getSourcePath("foo.txt").asFragment());
-    assertOnlyOutputContent("//:foo-link", "foo-link", "foo" + lineSeparator());
+    assertOnlyOutputContent("//:foo-link", "foo-link", "foo\n");
 
     // Delete link, re-plant symlink
     getOutputPath("foo-link").delete();
     buildTarget("//:foo-link");
 
-    assertOnlyOutputContent("//:foo-link", "foo-link", "foo" + lineSeparator());
+    assertOnlyOutputContent("//:foo-link", "foo-link", "foo\n");
   }
 
   @Test
@@ -1273,8 +1273,8 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
         ")");
 
     buildTarget("//:foobar");
-    assertValidOutputFile("out/foo.txt", "foo" + lineSeparator());
-    assertValidOutputFile("out/foobar.txt", "foo" + lineSeparator() + "bar\n");
+    assertValidOutputFile("out/foo.txt", "foo\n");
+    assertValidOutputFile("out/foobar.txt", "foo\nbar\n");
 
     // Act: Modify source file and run an incremental build
     write("foo.in", "modified");
@@ -1285,8 +1285,8 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
 
     // Assert: All actions transitively depend on the source file are re-executed and outputs are
     // correct.
-    assertValidOutputFile("out/foo.txt", "modified" + lineSeparator());
-    assertValidOutputFile("out/foobar.txt", "modified" + lineSeparator() + "bar\n");
+    assertValidOutputFile("out/foo.txt", "modified\n");
+    assertValidOutputFile("out/foobar.txt", "modified\nbar\n");
     assertThat(actionEventCollector.getNumActionNodesEvaluated()).isEqualTo(2);
   }
 
@@ -1552,7 +1552,7 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     buildTarget("//a:bar");
 
     // Assert: target was successfully built
-    assertValidOutputFile("a/bar.out", "foo" + lineSeparator() + "updated bar" + lineSeparator());
+    assertValidOutputFile("a/bar.out", "foo\nupdated bar\n");
   }
 
   @Test
@@ -1607,7 +1607,7 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     buildTarget("//a:bar");
 
     // Assert: target was successfully built
-    assertValidOutputFile("a/bar.out", "file-inside\nupdated bar" + lineSeparator());
+    assertValidOutputFile("a/bar.out", "file-inside\nupdated bar\n");
   }
 
   @Test
@@ -1659,7 +1659,7 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     waitDownloads();
 
     // Assert: target was successfully built
-    assertValidOutputFile("a/bar.out", "foo" + lineSeparator() + "updated bar" + lineSeparator());
+    assertValidOutputFile("a/bar.out", "foo\nupdated bar\n");
   }
 
   @Test
@@ -1712,7 +1712,7 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
     waitDownloads();
 
     // Assert: target was successfully built
-    assertValidOutputFile("a/bar.out", "file-inside\nupdated bar" + lineSeparator());
+    assertValidOutputFile("a/bar.out", "file-inside\nupdated bar\n");
   }
 
   @Test
@@ -2030,9 +2030,5 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   protected void restartServer() throws Exception {
     // Simulates a server restart
     createRuntimeWrapper();
-  }
-
-  protected static String lineSeparator() {
-    return System.getProperty("line.separator");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/vfs/util/FileSystems.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/util/FileSystems.java
@@ -28,7 +28,7 @@ public final class FileSystems {
   /** Constructs a platform native (Unix or Windows) file system. */
   public static FileSystem getNativeFileSystem(DigestHashFunction digestHashFunction) {
     if (OS.getCurrent() == OS.WINDOWS) {
-      return new WindowsFileSystem(digestHashFunction, /*createSymbolicLinks=*/ false);
+      return new WindowsFileSystem(digestHashFunction, /*createSymbolicLinks=*/ true);
     }
     try {
       return Class.forName(TestConstants.TEST_REAL_UNIX_FILE_SYSTEM)

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerTest.java
@@ -124,13 +124,13 @@ public final class WorkerTest {
     testWorker.putRequest(WorkRequest.getDefaultInstance());
 
     OutputStream stdout = testWorker.getFakeSubprocess().getOutputStream();
-    assertThat(stdout.toString()).isEqualTo("{}" + System.lineSeparator());
+    assertThat(stdout.toString()).isEqualTo("{}\n");
   }
 
   @Test
   public void testGetResponse_json_success()
       throws IOException, InterruptedException, UserExecException {
-    TestWorker testWorker = createTestWorker(("{}" + System.lineSeparator()).getBytes(UTF_8), JSON);
+    TestWorker testWorker = createTestWorker("{}\n".getBytes(UTF_8), JSON);
     WorkResponse readResponse = testWorker.getResponse(0);
     WorkResponse response = WorkResponse.getDefaultInstance();
 
@@ -159,7 +159,7 @@ public final class WorkerTest {
     String requestJsonString =
         "{\"arguments\":[\"testRequest\"],\"inputs\":"
             + "[{\"path\":\"testPath\",\"digest\":\"dGVzdERpZ2VzdA==\"}],\"requestId\":1,\"verbosity\":11}"
-            + System.lineSeparator();
+            + "\n";
     assertThat(stdout.toString()).isEqualTo(requestJsonString);
   }
 
@@ -178,8 +178,7 @@ public final class WorkerTest {
 
   private void verifyGetResponseFailure(String responseString, String expectedError)
       throws IOException, InterruptedException, UserExecException {
-    TestWorker testWorker =
-        createTestWorker((responseString + System.lineSeparator()).getBytes(UTF_8), JSON);
+    TestWorker testWorker = createTestWorker((responseString + "\n").getBytes(UTF_8), JSON);
     IOException ex = assertThrows(IOException.class, () -> testWorker.getResponse(0));
     assertThat(ex).hasMessageThat().contains(expectedError);
   }


### PR DESCRIPTION
Keep system-dependent line terminators in console output. It's probably okay to switch to `\n` there as well, but as unstructured output it doesn't really matter for cross-platform reproducibility.
