### PR TITLE
[8.2.0] Restore compatibility with any JDK 23 on Windows

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -437,7 +437,6 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
   // https://bugs.openjdk.org/browse/JDK-6942632
   result.push_back("-XX:+IgnoreUnrecognizedVMOptions");
   result.push_back("-XX:+UseAllWindowsProcessorGroups");
-  result.push_back("-XX:-IgnoreUnrecognizedVMOptions");
 #endif
 
   if (startup_options.host_jvm_debug) {


### PR DESCRIPTION
`-XX:-IgnoreUnrecognizedVMOptions` is always evaluated at the beginning of argument parsing and thus can't be used to disable the feature before consuming `--host_jvm_args`.

Fixes #25312

Closes #25342.

PiperOrigin-RevId: 729186918
Change-Id: Iafe65a6ad8774dcb5605bdfe0adeb17547291b4c

Commit https://github.com/bazelbuild/bazel/commit/6d64e2e87e1c2bb069d6f622b0a2b51033252ef5