### PR TITLE
Don't swallow runfiles of `srcs` in data runfiles of `filegroup`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/filegroup/Filegroup.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/filegroup/Filegroup.java
@@ -94,7 +94,7 @@ public class Filegroup implements RuleConfiguredTargetFactory {
             new Runfiles.Builder(
                     ruleContext.getWorkspaceName(), configuration.legacyExternalRunfiles())
                 .addTransitiveArtifacts(filesToBuild)
-                .addDataDeps(ruleContext)
+                .addRunfiles(ruleContext, RunfilesProvider.DATA_RUNFILES)
                 .build());
 
     RuleConfiguredTargetBuilder builder =


### PR DESCRIPTION
The `data_runfiles` of a `filegroup` should contain the `data_runfiles` of all deps in `srcs`, plus the `data_runfiles` of all deps in `data`. Previously, they didn't contain the former.

Related to https://github.com/bazelbuild/bazel/pull/25329#issuecomment-2677881350