### PR TITLE
[8.2.0] Manual merge of --experimental_propagate_custom_flag support.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -2533,6 +2533,7 @@ java_library(
     srcs = ["starlark/FunctionTransitionUtil.java"],
     deps = [
         ":config/build_options",
+        ":config/core_option_converters",
         ":config/core_options",
         ":config/fragment_options",
         ":config/optioninfo",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -98,6 +98,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       name = "experimental_propagate_custom_flag",
       defaultValue = "null",
       allowMultiple = true,
+      converter = CoreOptionConverters.CustomFlagConverter.class,
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.CustomFlagConverter;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.analysis.config.OptionInfo;
@@ -172,14 +173,10 @@ public final class FunctionTransitionUtil {
     fromOptions.getNativeOptions().forEach(o -> defaultBuilder.addFragmentOptions(o.getDefault()));
     // Propagate Starlark options from the source config if allowed.
     if (fromOptions.get(CoreOptions.class).excludeStarlarkFlagsFromExecConfig) {
-      ImmutableMap<Label, Object> starlarkOptions =
+     ImmutableMap<Label, Object> starlarkOptions =
           fromOptions.getStarlarkOptions().entrySet().stream()
               .filter(
-                  (starlarkFlag) ->
-                      fromOptions
-                          .get(CoreOptions.class)
-                          .customFlagsToPropagate
-                          .contains(starlarkFlag.getKey().toString()))
+                  (starlarkFlag) -> propagateStarlarkFlagToExec(starlarkFlag.getKey(), fromOptions))
               .collect(toImmutableMap(Map.Entry::getKey, (e) -> e.getValue()));
       defaultBuilder.addStarlarkOptions(starlarkOptions);
     } else {
@@ -211,6 +208,25 @@ public final class FunctionTransitionUtil {
           fromOptions.get(CoreOptions.class).commandLineBuildVariables;
     }
     return ans;
+  }
+
+  /**
+   * Returns true if the given Starlark flag should propagate from the target to exec configuration.
+   */
+  private static boolean propagateStarlarkFlagToExec(
+      Label starlarkFlag, BuildOptions buildOptions) {
+    return buildOptions.get(CoreOptions.class).customFlagsToPropagate.stream()
+        .anyMatch(
+            flagToPropagate ->
+                (flagToPropagate.equals(starlarkFlag.getUnambiguousCanonicalForm())
+                    || (flagToPropagate.endsWith(CustomFlagConverter.SUBPACKAGES_SUFFIX)
+                        && starlarkFlag
+                            .getUnambiguousCanonicalForm()
+                            .startsWith(
+                                flagToPropagate.substring(
+                                    0,
+                                    flagToPropagate.lastIndexOf(
+                                        CustomFlagConverter.SUBPACKAGES_SUFFIX))))));
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValueTest.java
@@ -324,7 +324,9 @@ public final class BuildConfigurationValueTest extends ConfigurationTestCase {
                 "//my_starlark_flag:other_starlark_flag",
                 "true"),
             "--experimental_exclude_starlark_flags_from_exec_config=true",
-            "--experimental_propagate_custom_flag=//my_starlark_flag:starlark_flag");
+            // Verify that labels are parsed rather than compared as strings by specifying the
+            // label in non-canonical form.
+            "--experimental_propagate_custom_flag=@//my_starlark_flag:starlark_flag");
     assertThat(
             cfg.getOptions()
                 .getStarlarkOptions()
@@ -334,6 +336,55 @@ public final class BuildConfigurationValueTest extends ConfigurationTestCase {
             cfg.getOptions()
                 .getStarlarkOptions()
                 .get(Label.parseCanonicalUnchecked("//my_starlark_flag:other_starlark_flag")))
+        .isNull();
+  }
+
+  @Test
+  public void testExecStarlarkFlag_isPropagatedByTargetPattern() throws Exception {
+    scratch.file("my_starlark_flag/BUILD");
+    scratch.file(
+        "my_starlark_flag/rule_defs.bzl",
+        """
+        bool_flag = rule(
+            implementation = lambda ctx: [],
+            build_setting = config.bool(flag = True),
+        )
+        """);
+    scratch.file(
+        "flags_to_propagate/BUILD",
+        """
+        load("//my_starlark_flag:rule_defs.bzl", "bool_flag")
+        bool_flag(
+            name = "include_me",
+            build_setting_default = False,
+        )
+        """);
+    scratch.file(
+        "flags_to_reset/BUILD",
+        """
+        load("//my_starlark_flag:rule_defs.bzl", "bool_flag")
+        bool_flag(
+            name = "exclude_me",
+            build_setting_default = False,
+        )
+        """);
+
+    BuildConfigurationValue cfg =
+        createExec(
+            ImmutableMap.of(
+                "//flags_to_propagate:include_me", "true", "//flags_to_reset:exclude_me", "true"),
+            "--experimental_exclude_starlark_flags_from_exec_config=true",
+            "--experimental_propagate_custom_flag=//flags_to_propagate/...");
+
+    assertThat(
+            cfg.getOptions()
+                .getStarlarkOptions()
+                .get(Label.parseCanonicalUnchecked("//flags_to_propagate:include_me")))
+        .isEqualTo("true");
+    assertThat(
+            cfg.getOptions()
+                .getStarlarkOptions()
+                .get(Label.parseCanonicalUnchecked("//flags_to_reset:exclude_me")))
         .isNull();
   }
 


### PR DESCRIPTION
Merges:

 - https://github.com/bazelbuild/bazel/commit/324c900110fc5083e03985e0389df9b5e7d63316
 - https://github.com/bazelbuild/bazel/commit/e1d5e86cc1b15cd136ccd76514399a0463004941

Result:

 - support `//foo/...` syntax
 - correctly handle label conversion

Fixes https://github.com/bazelbuild/bazel/issues/25271.