### PR TITLE
Update dynamic execution docs for multiplex sandboxing

### DIFF
--- a/site/en/remote/dynamic.md
+++ b/site/en/remote/dynamic.md
@@ -54,9 +54,11 @@ cache hits take.
 Dynamic execution can be used with local sandboxed strategy as well as with
 [persistent workers](/remote/persistent). Persistent workers will automatically
 run with sandboxing when used with dynamic execution, and cannot use [multiplex
-workers](/remote/multiplex). On Darwin and Windows systems, the sandboxed
-strategy can be slow; you can pass `--reuse_sandbox_directories` to reduce
-overhead of creating sandboxes on these systems.
+workers](/remote/multiplex) unless the worker supports [multiplex
+sandboxing](/remote/multiplex#multiplex_sandboxing). On Darwin and Windows
+systems, the sandboxed strategy can be slow; you can pass
+`--reuse_sandbox_directories` to reduce overhead of creating sandboxes on these
+systems.
 
 Dynamic execution can also run with the `standalone` strategy, though since the
 `standalone` strategy must take the output lock when it starts executing, it


### PR DESCRIPTION
I noticed that the [dynamic execution docs](https://bazel.build/remote/dynamic) conflicted with the [multiplex sandboxing docs](https://bazel.build/remote/multiplex#multiplex_sandboxing) and wanted to fix the discrepancy to avoid confusion.

Dynamic execution docs state:
>Persistent workers will automatically run with sandboxing when used with dynamic execution, and cannot use [multiplex workers](https://bazel.build/remote/multiplex).

Multiplex sandboxing docs state:
>Once a worker supports multiplex sandboxing, the ruleset can declare this support by adding `supports-multiplex-sandboxing` to the `execution_requirements` of an action. Bazel will then use multiplex sandboxing if the `--experimental_worker_multiplex_sandboxing` flag is passed, or if the worker is used with dynamic execution.

If I understand correctly, the multiplex sandboxing docs are correct.