### PR TITLE
fix(downloader): handle invalid regex in downloader config

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
@@ -125,11 +125,18 @@ class UrlRewriterConfig {
           case "rewrite" -> {
             if (parts.size() != 3) {
               throw new UrlRewriterParseException(
-                  "Only the matching pattern and rewrite pattern is allowed after `rewrite`: "
-                      + line,
-                  location);
-            }
-            rewrites.put(Pattern.compile(parts.get(1)), parts.get(2));
+                  "Only the matching pattern and rewrite pattern is allowed after `rewrite`: " + line,
+                  location
+              );
+          }
+          try {
+              rewrites.put(Pattern.compile(parts.get(1)), parts.get(2));
+          } catch (PatternSyntaxException e) {
+              throw new UrlRewriterParseException(
+                  "Invalid regex in `rewrite`: " + e.getDescription() + " at index " + e.getIndex() + " in `" + parts.get(1) + "`",
+                  location
+              );
+          }
           }
           case ALL_BLOCKED_MESSAGE_DIRECTIVE -> {
             if (parts.size() == 1) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import net.starlark.java.syntax.Location;
+import java.util.regex.PatternSyntaxException;
+
 
 /**
  * Models the downloader config file. This file has a line-based format, with each line starting


### PR DESCRIPTION
#### **Description:**  
This pull request addresses **Issue #20832**, where an invalid regex in the `--experimental_downloader_config` file caused Bazel to **crash silently without an error message**.  

#### **Changes Introduced:**  
- **Added a try-catch block** to catch `PatternSyntaxException` when compiling regex patterns in `UrlRewriterConfig.java`.  
- **Throws a `UrlRewriterParseException`** with a clear error message instead of crashing.  
- **Includes details on the regex error**, such as the invalid sequence and its index in the pattern.  

#### **Before the Fix:**  
- An invalid regex in `downloader.cfg` (e.g., `rewrite (.*\maven.org/.*) http://example.com/mirror/$1`) caused **Bazel to crash with error code 37**, but **no explanation was given**.  

#### **After the Fix:**  
- Users now see a **clear error message** pointing out the invalid regex and its exact issue:  
  ```
  Invalid regex in `rewrite`: Illegal/unsupported escape sequence at index 4 in `(.*\maven.org/.*)`
  ```  
- This helps users quickly debug and fix their configuration.  

#### **Testing & Verification:**  
- Manually tested by providing valid and invalid regex patterns in `downloader.cfg`.  
- Verified that valid patterns work correctly and invalid patterns produce a proper error message.  

#### **Impact & Notes:**  
- No breaking changes.  
- Improves **developer experience** by preventing silent crashes and providing actionable feedback.  

#### **Related Issue:**  
Closes #20832  
