### PR TITLE
[8.2.0] Bzlmod: nodep deps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModTidyFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModTidyFunction.java
@@ -112,9 +112,6 @@ public class BazelModTidyFunction implements SkyFunction {
     }
 
     return BazelModTidyValue.create(
-        fixups.build(),
-        buildozer.asPath(),
-        rootModuleFileValue.getModuleFilePaths(),
-        errors.build());
+        fixups.build(), buildozer.asPath(), rootModuleFileValue.moduleFilePaths(), errors.build());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorFunction.java
@@ -60,7 +60,7 @@ public class BazelModuleInspectorFunction implements SkyFunction {
     if (resolutionValue == null) {
       return null;
     }
-    ImmutableMap<String, ModuleOverride> overrides = root.getOverrides();
+    ImmutableMap<String, ModuleOverride> overrides = root.overrides();
     ImmutableMap<ModuleKey, InterimModule> unprunedDepGraph = resolutionValue.getUnprunedDepGraph();
     ImmutableMap<ModuleKey, Module> resolvedDepGraph = resolutionValue.getResolvedDepGraph();
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
@@ -136,7 +136,7 @@ public class BazelModuleResolutionFunction implements SkyFunction {
       finalDepGraph =
           computeFinalDepGraph(
               state.discoverAndSelectResult.selectionResult.resolvedDepGraph(),
-              root.getOverrides(),
+              root.overrides(),
               remoteRepoSpecs.buildOrThrow());
     }
 
@@ -163,11 +163,11 @@ public class BazelModuleResolutionFunction implements SkyFunction {
       return null;
     }
 
-    verifyAllOverridesAreOnExistentModules(discoveryResult.depGraph(), root.getOverrides());
+    verifyAllOverridesAreOnExistentModules(discoveryResult.depGraph(), root.overrides());
 
     Selection.Result selectionResult;
     try (SilentCloseable c = Profiler.instance().profile(ProfilerTask.BZLMOD, "selection")) {
-      selectionResult = Selection.run(discoveryResult.depGraph(), root.getOverrides());
+      selectionResult = Selection.run(discoveryResult.depGraph(), root.overrides());
     } catch (ExternalDepsException e) {
       throw new BazelModuleResolutionFunctionException(e, Transience.PERSISTENT);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
@@ -15,26 +15,25 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.bzlmod.InterimModule.DepSpec;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
-import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyframeLookupResult;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.SequencedMap;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -58,82 +57,179 @@ final class Discovery {
   @Nullable
   public static Result run(Environment env, RootModuleFileValue root)
       throws InterruptedException, ExternalDepsException {
-    String rootModuleName = root.getModule().getName();
-    ImmutableMap<String, ModuleOverride> overrides = root.getOverrides();
-    Map<ModuleKey, InterimModule> depGraph = new LinkedHashMap<>();
-    depGraph.put(
-        ModuleKey.ROOT,
-        root.getModule()
-            .withDepSpecsTransformed(InterimModule.applyOverrides(overrides, rootModuleName)));
-    Queue<ModuleKey> unexpanded = new ArrayDeque<>();
-    Map<ModuleKey, ModuleKey> predecessors = new HashMap<>();
-    SequencedMap<String, Optional<Checksum>> registryFileHashes =
-        new LinkedHashMap<>(root.getRegistryFileHashes());
-    unexpanded.add(ModuleKey.ROOT);
-    while (!unexpanded.isEmpty()) {
-      Set<SkyKey> unexpandedSkyKeys = new LinkedHashSet<>();
-      while (!unexpanded.isEmpty()) {
-        InterimModule module = depGraph.get(unexpanded.remove());
+    // Because of the possible existence of nodep edges, we do multiple rounds of discovery.
+    // In each round, we keep track of unfulfilled nodep edges, and at the end of the round, if any
+    // unfulfilled nodep edge can now be fulfilled, we run another round.
+    ImmutableSet<String> prevRoundModuleNames = ImmutableSet.of(root.module().getName());
+    while (true) {
+      DiscoveryRound discoveryRound = new DiscoveryRound(env, root, prevRoundModuleNames);
+      Result result = discoveryRound.run();
+      if (result == null) {
+        return null;
+      }
+      prevRoundModuleNames =
+          result.depGraph().values().stream().map(InterimModule::getName).collect(toImmutableSet());
+      if (discoveryRound.unfulfilledNodepEdgeModuleNames.stream()
+          .noneMatch(prevRoundModuleNames::contains)) {
+        return result;
+      }
+    }
+  }
+
+  private static class DiscoveryRound {
+    private final Environment env;
+    private final RootModuleFileValue root;
+    private final ImmutableSet<String> prevRoundModuleNames;
+    private final Map<ModuleKey, InterimModule> depGraph = new LinkedHashMap<>();
+
+    /**
+     * Stores a mapping from a module to its "predecessor" -- that is, its first dependent in BFS
+     * order. This is used to report a dependency chain in errors (see {@link
+     * #maybeReportDependencyChain}.
+     */
+    private final Map<ModuleKey, ModuleKey> predecessors = new HashMap<>();
+
+    /**
+     * For all unfulfilled nodep edges seen during this round, this set stores the module names of
+     * those nodep edges. Remember that whether a nodep edge can be fulfilled depends on whether the
+     * module it names already exists in the dep graph.
+     */
+    private final Set<String> unfulfilledNodepEdgeModuleNames = new HashSet<>();
+
+    DiscoveryRound(
+        Environment env, RootModuleFileValue root, ImmutableSet<String> prevRoundModuleNames) {
+      this.env = env;
+      this.root = root;
+      this.prevRoundModuleNames = prevRoundModuleNames;
+    }
+
+    /**
+     * Runs one round of discovery. At its core, this is a simple breadth-first search: we start
+     * from the "horizon" of just the root module, and advance the horizon by discovering the
+     * dependencies of modules in the current horizon. Keep doing this until the horizon is empty.
+     */
+    @Nullable
+    Result run() throws InterruptedException, ExternalDepsException {
+      SequencedMap<String, Optional<Checksum>> registryFileHashes = new LinkedHashMap<>();
+      depGraph.put(ModuleKey.ROOT, root.module().withDepSpecsTransformed(this::applyOverrides));
+      ImmutableSet<ModuleKey> horizon = ImmutableSet.of(ModuleKey.ROOT);
+      while (!horizon.isEmpty()) {
+        ImmutableSet<ModuleFileValue.Key> nextHorizonSkyKeys = advanceHorizon(horizon);
+        SkyframeLookupResult result = env.getValuesAndExceptions(nextHorizonSkyKeys);
+        var nextHorizon = ImmutableSet.<ModuleKey>builder();
+        for (ModuleFileValue.Key skyKey : nextHorizonSkyKeys) {
+          ModuleKey depKey = skyKey.moduleKey();
+          ModuleFileValue moduleFileValue;
+          try {
+            moduleFileValue =
+                (ModuleFileValue) result.getOrThrow(skyKey, ExternalDepsException.class);
+          } catch (ExternalDepsException e) {
+            throw maybeReportDependencyChain(e, depKey);
+          }
+          if (moduleFileValue == null) {
+            // Don't return yet. Try to expand any other unexpanded nodes before returning.
+            depGraph.put(depKey, null);
+          } else {
+            depGraph.put(
+                depKey, moduleFileValue.module().withDepSpecsTransformed(this::applyOverrides));
+            registryFileHashes.putAll(moduleFileValue.registryFileHashes());
+            nextHorizon.add(depKey);
+          }
+        }
+        horizon = nextHorizon.build();
+      }
+      if (env.valuesMissing()) {
+        return null;
+      }
+      return new Result(ImmutableMap.copyOf(depGraph), ImmutableMap.copyOf(registryFileHashes));
+    }
+
+    /**
+     * Returns a new {@link DepSpec} that is transformed according to any existing overrides on the
+     * dependency module.
+     */
+    DepSpec applyOverrides(DepSpec depSpec) {
+      if (root.module().getName().equals(depSpec.name())) {
+        return DepSpec.fromModuleKey(ModuleKey.ROOT);
+      }
+      Version newVersion =
+          switch (root.overrides().get(depSpec.name())) {
+            case NonRegistryOverride nro -> Version.EMPTY;
+            case SingleVersionOverride svo when !svo.version().isEmpty() -> svo.version();
+            case null, default -> depSpec.version();
+          };
+      return new DepSpec(depSpec.name(), newVersion, depSpec.maxCompatibilityLevel());
+    }
+
+    /**
+     * Given a set of module keys to discover (the current "horizon"), return the next horizon
+     * consisting of newly discovered module keys from the current set (mostly, their dependencies).
+     *
+     * <p>The current horizon contains keys to modules that are already in the {@code depGraph}.
+     * Note also that this method mutates {@code predecessors} and {@code
+     * unfulfilledNodepEdgeModuleNames}.
+     */
+    ImmutableSet<ModuleFileValue.Key> advanceHorizon(ImmutableSet<ModuleKey> horizon) {
+      var nextHorizon = ImmutableSet.<ModuleFileValue.Key>builder();
+      for (ModuleKey moduleKey : horizon) {
+        InterimModule module = depGraph.get(moduleKey);
+        // The main group of module keys to discover are the current horizon's normal deps.
         for (DepSpec depSpec : module.getDeps().values()) {
-          if (depGraph.containsKey(depSpec.toModuleKey())) {
+          ModuleKey depKey = depSpec.toModuleKey();
+          if (depGraph.containsKey(depKey)) {
             continue;
           }
-          predecessors.putIfAbsent(depSpec.toModuleKey(), module.getKey());
-          unexpandedSkyKeys.add(
-              ModuleFileValue.key(depSpec.toModuleKey(), overrides.get(depSpec.name())));
+          predecessors.putIfAbsent(depKey, module.getKey());
+          nextHorizon.add(ModuleFileValue.key(depKey));
+        }
+        // Any of the current horizon's nodep deps should also be discovered ("fulfilled"), iff the
+        // module they refer to already exists in the dep graph. Otherwise, record these unfulfilled
+        // nodep edges, so that we can later decide whether to run another round of discovery.
+        for (DepSpec depSpec : module.getNodepDeps()) {
+          ModuleKey depKey = depSpec.toModuleKey();
+          if (depGraph.containsKey(depKey)) {
+            continue;
+          }
+          if (!prevRoundModuleNames.contains(depSpec.name())) {
+            unfulfilledNodepEdgeModuleNames.add(depSpec.name());
+            continue;
+          }
+          predecessors.putIfAbsent(depKey, module.getKey());
+          nextHorizon.add(ModuleFileValue.key(depKey));
         }
       }
-      SkyframeLookupResult result = env.getValuesAndExceptions(unexpandedSkyKeys);
-      for (SkyKey skyKey : unexpandedSkyKeys) {
-        ModuleKey depKey = ((ModuleFileValue.Key) skyKey).getModuleKey();
-        ModuleFileValue moduleFileValue;
-        try {
-          moduleFileValue =
-              (ModuleFileValue) result.getOrThrow(skyKey, ExternalDepsException.class);
-        } catch (ExternalDepsException e) {
-          if (e.getDetailedExitCode().getFailureDetail() == null
-              || e.getDetailedExitCode().getFailureDetail().getExternalDeps().getCode()
-                  != FailureDetails.ExternalDeps.Code.BAD_MODULE) {
-            // This is not due to a bad module, so don't print a dependency chain. This covers cases
-            // such as a parse error in the lockfile or an I/O exception during registry access,
-            // which aren't related to any particular module dep.
-            throw e;
-          }
-          // Trace back a dependency chain to the root module. There can be multiple paths to the
-          // failing module, but any of those is useful for debugging.
-          List<ModuleKey> depChain = new ArrayList<>();
-          depChain.add(depKey);
-          ModuleKey predecessor = depKey;
-          while ((predecessor = predecessors.get(predecessor)) != null) {
-            depChain.add(predecessor);
-          }
-          Collections.reverse(depChain);
-          String depChainString =
-              depChain.stream().map(ModuleKey::toString).collect(joining(" -> "));
-          throw ExternalDepsException.withCauseAndMessage(
-              FailureDetails.ExternalDeps.Code.BAD_MODULE,
-              e,
-              "in module dependency chain %s",
-              depChainString);
-        }
-        if (moduleFileValue == null) {
-          // Don't return yet. Try to expand any other unexpanded nodes before returning.
-          depGraph.put(depKey, null);
-        } else {
-          depGraph.put(
-              depKey,
-              moduleFileValue
-                  .getModule()
-                  .withDepSpecsTransformed(
-                      InterimModule.applyOverrides(overrides, rootModuleName)));
-          registryFileHashes.putAll(moduleFileValue.getRegistryFileHashes());
-          unexpanded.add(depKey);
-        }
+      return nextHorizon.build();
+    }
+
+    /**
+     * When an exception occurs while discovering a new dep, try to add information about the
+     * dependency chain that led to that dep.
+     */
+    private ExternalDepsException maybeReportDependencyChain(
+        ExternalDepsException e, ModuleKey depKey) {
+      if (e.getDetailedExitCode().getFailureDetail() == null
+          || e.getDetailedExitCode().getFailureDetail().getExternalDeps().getCode()
+              != FailureDetails.ExternalDeps.Code.BAD_MODULE) {
+        // This is not due to a bad module, so don't print a dependency chain. This covers cases
+        // such as a parse error in the lockfile or an I/O exception during registry access,
+        // which aren't related to any particular module dep.
+        return e;
       }
+      // Trace back a dependency chain to the root module. There can be multiple paths to the
+      // failing module, but any of those is useful for debugging.
+      List<ModuleKey> depChain = new ArrayList<>();
+      depChain.add(depKey);
+      ModuleKey predecessor = depKey;
+      while ((predecessor = predecessors.get(predecessor)) != null) {
+        depChain.add(predecessor);
+      }
+      Collections.reverse(depChain);
+      String depChainString = depChain.stream().map(ModuleKey::toString).collect(joining(" -> "));
+      return ExternalDepsException.withCauseAndMessage(
+          FailureDetails.ExternalDeps.Code.BAD_MODULE,
+          e,
+          "in module dependency chain %s",
+          depChainString);
     }
-    if (env.valuesMissing()) {
-      return null;
-    }
-    return new Result(ImmutableMap.copyOf(depGraph), ImmutableMap.copyOf(registryFileHashes));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -142,8 +142,12 @@ public class ModuleThreadContext extends StarlarkThreadContext {
     return ignoreDevDeps;
   }
 
-  public void addDep(String repoName, DepSpec depSpec) {
-    deps.put(repoName, depSpec);
+  public void addDep(Optional<String> repoName, DepSpec depSpec) {
+    if (repoName.isPresent()) {
+      deps.put(repoName.get(), depSpec);
+    } else {
+      module.addNodepDep(depSpec);
+    }
   }
 
   List<ModuleExtensionUsageBuilder> getExtensionUsageBuilders() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
@@ -18,7 +18,6 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
 import static java.util.Comparator.naturalOrder;
-import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -97,47 +96,18 @@ final class Selection {
    */
   record Result(
       ImmutableMap<ModuleKey, InterimModule> resolvedDepGraph,
-      ImmutableMap<ModuleKey, InterimModule> unprunedDepGraph) {
-    Result {
-      requireNonNull(resolvedDepGraph, "resolvedDepGraph");
-      requireNonNull(unprunedDepGraph, "unprunedDepGraph");
-    }
-
-    static Result create(
-        ImmutableMap<ModuleKey, InterimModule> resolvedDepGraph,
-        ImmutableMap<ModuleKey, InterimModule> unprunedDepGraph) {
-      return new Result(resolvedDepGraph, unprunedDepGraph);
-    }
-  }
+      ImmutableMap<ModuleKey, InterimModule> unprunedDepGraph) {}
 
   /**
    * During selection, a version is selected for each distinct "selection group".
    *
    * @param targetAllowedVersion This is only used for modules with multiple-version overrides.
    */
-  record SelectionGroup(String moduleName, int compatibilityLevel, Version targetAllowedVersion) {
-    SelectionGroup {
-      requireNonNull(moduleName, "moduleName");
-      requireNonNull(targetAllowedVersion, "targetAllowedVersion");
-    }
-
-    static SelectionGroup create(
-        String moduleName, int compatibilityLevel, Version targetAllowedVersion) {
-      return new SelectionGroup(moduleName, compatibilityLevel, targetAllowedVersion);
-    }
-  }
+  record SelectionGroup(String moduleName, int compatibilityLevel, Version targetAllowedVersion) {}
 
   record ModuleNameAndCompatibilityLevel(
       @SuppressWarnings("unused") String moduleName,
-      @SuppressWarnings("unused") int compatibilityLevel) {
-    ModuleNameAndCompatibilityLevel {
-      requireNonNull(moduleName, "moduleName");
-    }
-
-    static ModuleNameAndCompatibilityLevel create(String moduleName, int compatibilityLevel) {
-      return new ModuleNameAndCompatibilityLevel(moduleName, compatibilityLevel);
-    }
-  }
+      @SuppressWarnings("unused") int compatibilityLevel) {}
 
   /**
    * Computes a mapping from (moduleName, compatibilityLevel) to the set of allowed versions. This
@@ -152,12 +122,10 @@ final class Selection {
         new HashMap<>();
     for (Map.Entry<String, ModuleOverride> overrideEntry : overrides.entrySet()) {
       String moduleName = overrideEntry.getKey();
-      ModuleOverride override = overrideEntry.getValue();
-      if (!(override instanceof MultipleVersionOverride)) {
+      if (!(overrideEntry.getValue() instanceof MultipleVersionOverride mvo)) {
         continue;
       }
-      ImmutableList<Version> allowedVersions = ((MultipleVersionOverride) override).versions();
-      for (Version allowedVersion : allowedVersions) {
+      for (Version allowedVersion : mvo.versions()) {
         InterimModule allowedVersionModule =
             depGraph.get(new ModuleKey(moduleName, allowedVersion));
         if (allowedVersionModule == null) {
@@ -170,7 +138,7 @@ final class Selection {
         }
         ImmutableSortedSet.Builder<Version> allowedVersionSet =
             allowedVersionSets.computeIfAbsent(
-                ModuleNameAndCompatibilityLevel.create(
+                new ModuleNameAndCompatibilityLevel(
                     moduleName, allowedVersionModule.getCompatibilityLevel()),
                 // Remember that the empty version compares greater than any other version, so we
                 // can use it as a sentinel value.
@@ -193,14 +161,13 @@ final class Selection {
           allowedVersionSets) {
     ImmutableSortedSet<Version> allowedVersionSet =
         allowedVersionSets.get(
-            ModuleNameAndCompatibilityLevel.create(
-                module.getName(), module.getCompatibilityLevel()));
+            new ModuleNameAndCompatibilityLevel(module.getName(), module.getCompatibilityLevel()));
     if (allowedVersionSet == null) {
       // This means that this module has no multiple-version override.
-      return SelectionGroup.create(
+      return new SelectionGroup(
           module.getKey().name(), module.getCompatibilityLevel(), Version.EMPTY);
     }
-    return SelectionGroup.create(
+    return new SelectionGroup(
         module.getKey().name(),
         module.getCompatibilityLevel(),
         // We use the `ceiling` method here to quickly locate the lowest allowed version that's
@@ -362,7 +329,7 @@ final class Selection {
                     module ->
                         module.withDepSpecsTransformed(
                             depSpec -> DepSpec.fromModuleKey(resolutionStrategy.apply(depSpec)))));
-        return Result.create(prunedDepGraph, unprunedDepGraph);
+        return new Result(prunedDepGraph, unprunedDepGraph);
       } catch (ExternalDepsException e) {
         if (firstFailure == null) {
           firstFailure = e;
@@ -403,7 +370,7 @@ final class Selection {
       ImmutableMap.Builder<ModuleKey, InterimModule> newDepGraph = ImmutableMap.builder();
       Set<ModuleKey> known = new HashSet<>();
       Queue<ModuleKeyAndDependent> toVisit = new ArrayDeque<>();
-      toVisit.add(ModuleKeyAndDependent.create(ModuleKey.ROOT, null));
+      toVisit.add(new ModuleKeyAndDependent(ModuleKey.ROOT, null));
       known.add(ModuleKey.ROOT);
       while (!toVisit.isEmpty()) {
         ModuleKeyAndDependent moduleKeyAndDependent = toVisit.remove();
@@ -417,7 +384,7 @@ final class Selection {
 
         for (DepSpec depSpec : module.getDeps().values()) {
           if (known.add(depSpec.toModuleKey())) {
-            toVisit.add(ModuleKeyAndDependent.create(depSpec.toModuleKey(), key));
+            toVisit.add(new ModuleKeyAndDependent(depSpec.toModuleKey(), key));
           }
         }
         newDepGraph.put(key, module);
@@ -449,7 +416,7 @@ final class Selection {
       } else {
         ExistingModule existingModuleWithSameName =
             moduleByName.put(
-                module.getName(), ExistingModule.create(key, module.getCompatibilityLevel(), from));
+                module.getName(), new ExistingModule(key, module.getCompatibilityLevel(), from));
         if (existingModuleWithSameName != null) {
           // This has to mean that a module with the same name but a different compatibility level
           // was also selected.
@@ -490,26 +457,9 @@ final class Selection {
       }
     }
 
-    record ModuleKeyAndDependent(ModuleKey moduleKey, @Nullable ModuleKey dependent) {
-      ModuleKeyAndDependent {
-        requireNonNull(moduleKey, "moduleKey");
-      }
-
-      static ModuleKeyAndDependent create(ModuleKey moduleKey, @Nullable ModuleKey dependent) {
-        return new ModuleKeyAndDependent(moduleKey, dependent);
-      }
-    }
+    record ModuleKeyAndDependent(ModuleKey moduleKey, @Nullable ModuleKey dependent) {}
 
     record ExistingModule(
-        ModuleKey moduleKey, int compatibilityLevel, @Nullable ModuleKey dependent) {
-      ExistingModule {
-        requireNonNull(moduleKey, "moduleKey");
-      }
-
-      static ExistingModule create(
-          ModuleKey moduleKey, int compatibilityLevel, ModuleKey dependent) {
-        return new ExistingModule(moduleKey, compatibilityLevel, dependent);
-      }
-    }
+        ModuleKey moduleKey, int compatibilityLevel, @Nullable ModuleKey dependent) {}
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
@@ -91,7 +91,7 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
         RepositoryMapping.create(
             ImmutableMap.<String, RepositoryName>builder()
                 .put("", RepositoryName.MAIN)
-                .put(root.getModule().getRepoName(), RepositoryName.MAIN)
+                .put(root.module().getRepoName(), RepositoryName.MAIN)
                 .buildKeepingLast(),
             RepositoryName.MAIN);
 
@@ -157,11 +157,11 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
 
   private static Optional<RepoSpec> checkRepoFromNonRegistryOverrides(
       RootModuleFileValue root, RepositoryName repositoryName) {
-    String moduleName = root.getNonRegistryOverrideCanonicalRepoNameLookup().get(repositoryName);
+    String moduleName = root.nonRegistryOverrideCanonicalRepoNameLookup().get(repositoryName);
     if (moduleName == null) {
       return Optional.empty();
     }
-    NonRegistryOverride override = (NonRegistryOverride) root.getOverrides().get(moduleName);
+    NonRegistryOverride override = (NonRegistryOverride) root.overrides().get(moduleName);
     return Optional.of(override.repoSpec());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunction.java
@@ -194,12 +194,12 @@ public class StarlarkBuiltinsFunction implements SkyFunction {
         && starlarkSemantics.getBool(BuildLanguageOptions.ENABLE_BZLMOD)) {
       // We can't do autoloads where the rules are implemented (disabling them when running in
       // main repository named rules_python)
-      ModuleFileValue mainModule =
+      ModuleFileValue rootModule =
           (ModuleFileValue) env.getValue(ModuleFileValue.KEY_FOR_ROOT_MODULE);
-      if (mainModule == null) {
+      if (rootModule == null) {
         return null;
       }
-      if (autoloadSymbols.autoloadsDisabledForRepo(mainModule.getModule().getName())) {
+      if (autoloadSymbols.autoloadsDisabledForRepo(rootModule.module().getName())) {
         isWithAutoloads = false;
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunctionTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createModuleKey;
+import static org.junit.Assert.fail;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -492,5 +493,178 @@ public class BazelModuleResolutionFunctionTest extends FoundationTestCase {
     assertDoesNotContainEvent("hello from a@1.0");
     assertDoesNotContainEvent("hello from b@1.0");
     assertDoesNotContainEvent("hello from b@1.1");
+  }
+
+  @Test
+  public void nodep_unfulfilled() throws Exception {
+    scratch.overwriteFile(
+        "MODULE.bazel",
+        """
+        bazel_dep(name='b',version='1.0')
+        bazel_dep(name='c',version='1.0',repo_name=None)
+        """);
+
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("b", "1.0"),
+                "module(name='b', version='1.0');bazel_dep(name='d', version='1.0')")
+            .addModule(
+                createModuleKey("c", "1.0"),
+                "module(name='c', version='1.0');bazel_dep(name='d',version='1.1')")
+            .addModule(createModuleKey("d", "1.0"), "module(name='d', version='1.0')")
+            .addModule(createModuleKey("d", "1.1"), "module(name='d', version='1.1')");
+
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    var depGraph = result.get(BazelModuleResolutionValue.KEY).getResolvedDepGraph();
+    assertThat(depGraph).doesNotContainKey(createModuleKey("c", "1.0"));
+    assertThat(depGraph.get(createModuleKey("b", "1.0")).getDeps().get("d").version())
+        .isEqualTo(Version.parse("1.0"));
+  }
+
+  @Test
+  public void nodep_fulfilled() throws Exception {
+    scratch.overwriteFile(
+        "MODULE.bazel",
+        """
+        bazel_dep(name='b',version='1.0')
+        bazel_dep(name='c',version='1.0')
+        """);
+
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("b", "1.0"),
+                "module(name='b', version='1.0');bazel_dep(name='d', version='1.0')")
+            .addModule(
+                createModuleKey("c", "1.0"),
+                "module(name='c', version='1.0');bazel_dep(name='d',version='1.1',repo_name=None)")
+            .addModule(createModuleKey("d", "1.0"), "module(name='d', version='1.0')")
+            .addModule(createModuleKey("d", "1.1"), "module(name='d', version='1.1')");
+
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    var depGraph = result.get(BazelModuleResolutionValue.KEY).getResolvedDepGraph();
+    assertThat(depGraph).containsKey(createModuleKey("d", "1.1"));
+    assertThat(depGraph.get(createModuleKey("b", "1.0")).getDeps().get("d").version())
+        .isEqualTo(Version.parse("1.1"));
+    assertThat(depGraph.get(createModuleKey("c", "1.0")).getDeps()).doesNotContainKey("d");
+  }
+
+  @Test
+  public void nodep_fulfilledDevDep() throws Exception {
+    scratch.overwriteFile(
+        "MODULE.bazel",
+        """
+        bazel_dep(name='b',version='1.0')
+        bazel_dep(name='c',version='1.1',dev_dependency=True)
+        """);
+
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("b", "1.0"),
+                "module(name='b', version='1.0');bazel_dep(name='c', version='1.0')")
+            .addModule(createModuleKey("c", "1.0"), "module(name='c', version='1.0')")
+            .addModule(createModuleKey("c", "1.1"), "module(name='c', version='1.1')");
+
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    var depGraph = result.get(BazelModuleResolutionValue.KEY).getResolvedDepGraph();
+    assertThat(depGraph).containsKey(createModuleKey("c", "1.1"));
+    assertThat(depGraph.get(createModuleKey("b", "1.0")).getDeps().get("c").version())
+        .isEqualTo(Version.parse("1.1"));
+  }
+
+  @Test
+  public void nodep_wouldBeFulfilledIfNonDevDep() throws Exception {
+    scratch.overwriteFile(
+        "MODULE.bazel",
+        """
+        bazel_dep(name='b',version='1.0')
+        bazel_dep(name='c',version='1.0')
+        """);
+
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("b", "1.0"),
+                "module(name='b', version='1.0');bazel_dep(name='d', version='1.0')")
+            .addModule(
+                createModuleKey("c", "1.0"),
+                "module(name='c', version='1.0')",
+                "bazel_dep(name='d',version='1.1',repo_name=None,dev_dependency=True)")
+            .addModule(createModuleKey("d", "1.0"), "module(name='d', version='1.0')")
+            .addModule(createModuleKey("d", "1.1"), "module(name='d', version='1.1')");
+
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    var depGraph = result.get(BazelModuleResolutionValue.KEY).getResolvedDepGraph();
+    assertThat(depGraph).doesNotContainKey(createModuleKey("d", "1.1"));
+    assertThat(depGraph.get(createModuleKey("b", "1.0")).getDeps().get("d").version())
+        .isEqualTo(Version.parse("1.0"));
+    assertThat(depGraph.get(createModuleKey("c", "1.0")).getDeps()).doesNotContainKey("d");
+  }
+
+  @Test
+  public void nodep_crossesCompatLevelBoundary() throws Exception {
+    scratch.overwriteFile(
+        "MODULE.bazel",
+        """
+        bazel_dep(name='b',version='1.0')
+        bazel_dep(name='c',version='1.0')
+        """);
+
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("b", "1.0"),
+                "module(name='b', version='1.0');bazel_dep(name='d', version='1.0')")
+            .addModule(
+                createModuleKey("c", "1.0"),
+                "module(name='c', version='1.0');bazel_dep(name='d',version='2.0',repo_name=None)")
+            .addModule(createModuleKey("d", "1.0"), "module(name='d', version='1.0')")
+            .addModule(
+                createModuleKey("d", "2.0"),
+                "module(name='d', version='2.0', compatibility_level=3)");
+
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+    EvaluationResult<BazelModuleResolutionValue> result =
+        evaluator.evaluate(ImmutableList.of(BazelModuleResolutionValue.KEY), evaluationContext);
+
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    var depGraph = result.get(BazelModuleResolutionValue.KEY).getResolvedDepGraph();
+    assertThat(depGraph).doesNotContainKey(createModuleKey("d", "2.0"));
+    assertThat(depGraph.get(createModuleKey("b", "1.0")).getDeps().get("d").version())
+        .isEqualTo(Version.parse("1.0"));
+    assertThat(depGraph.get(createModuleKey("c", "1.0")).getDeps()).doesNotContainKey("d");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -125,6 +125,12 @@ public final class BzlmodTestUtil {
     }
 
     @CanIgnoreReturnValue
+    public InterimModuleBuilder addNodepDep(ModuleKey key) {
+      builder.addNodepDep(DepSpec.fromModuleKey(key));
+      return this;
+    }
+
+    @CanIgnoreReturnValue
     public InterimModuleBuilder setKey(ModuleKey value) {
       this.key = value;
       this.builder.setKey(value);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createModuleKey;
-import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Suppliers;
@@ -91,26 +90,16 @@ public class DiscoveryTest extends FoundationTestCase {
   private EvaluationContext evaluationContext;
   private FakeRegistry.Factory registryFactory;
 
+  /**
+   * @param registryFileHashes Uses {@code Optional<String>} rather than {@code Optional<Checksum>}
+   *     for easier testing (Checksum doesn't implement {@code equals()}).
+   */
   record DiscoveryValue(
       ImmutableMap<ModuleKey, InterimModule> depGraph,
       ImmutableMap<String, Optional<String>> registryFileHashes)
       implements SkyValue {
-    DiscoveryValue {
-      requireNonNull(depGraph, "depGraph");
-      requireNonNull(registryFileHashes, "registryFileHashes");
-    }
-
     static final SkyFunctionName FUNCTION_NAME = SkyFunctionName.createHermetic("test_discovery");
     static final SkyKey KEY = () -> FUNCTION_NAME;
-
-    static DiscoveryValue create(
-        ImmutableMap<ModuleKey, InterimModule> depGraph,
-        ImmutableMap<String, Optional<String>> registryFileHashes) {
-      return new DiscoveryValue(depGraph, registryFileHashes);
-    }
-
-    // Uses Optional<String> rather than Optional<Checksum> for easier testing (Checksum doesn't
-    // implement equals()).
   }
 
   static class DiscoveryFunction implements SkyFunction {
@@ -131,7 +120,7 @@ public class DiscoveryTest extends FoundationTestCase {
       }
       return discoveryResult == null
           ? null
-          : DiscoveryValue.create(
+          : new DiscoveryValue(
               discoveryResult.depGraph(),
               ImmutableMap.copyOf(
                   Maps.transformValues(
@@ -366,6 +355,137 @@ public class DiscoveryTest extends FoundationTestCase {
                 .addDep("bbb", createModuleKey("bbb", "1.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("bbb", "1.0").setRegistry(registry).buildEntry());
+  }
+
+  @Test
+  public void testNodep_unfulfilled() throws Exception {
+    scratch.file(
+        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa',version='0.1')",
+        "bazel_dep(name='bbb',version='1.0')",
+        "bazel_dep(name='ccc',version='1.0',repo_name=None)");
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(createModuleKey("bbb", "1.0"), "module(name='bbb', version='1.0')")
+            .addModule(createModuleKey("ccc", "1.0"), "module(name='ccc', version='1.0')");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    EvaluationResult<DiscoveryValue> result =
+        evaluator.evaluate(ImmutableList.of(DiscoveryValue.KEY), evaluationContext);
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    DiscoveryValue discoveryValue = result.get(DiscoveryValue.KEY);
+    assertThat(discoveryValue.depGraph().entrySet())
+        .containsExactly(
+            InterimModuleBuilder.create("aaa", "0.1")
+                .setKey(ModuleKey.ROOT)
+                .addDep("bbb", createModuleKey("bbb", "1.0"))
+                .addNodepDep(createModuleKey("ccc", "1.0"))
+                .buildEntry(),
+            InterimModuleBuilder.create("bbb", "1.0").setRegistry(registry).buildEntry());
+    assertThat(discoveryValue.registryFileHashes().keySet())
+        .containsExactly(registry.getUrl() + "/modules/bbb/1.0/MODULE.bazel");
+  }
+
+  @Test
+  public void testNodep_fulfilled() throws Exception {
+    scratch.file(
+        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa',version='0.1')",
+        "bazel_dep(name='bbb',version='1.0')",
+        "bazel_dep(name='ccc',version='2.0',repo_name=None)");
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("bbb", "1.0"),
+                "module(name='bbb', version='1.0');bazel_dep(name='ccc',version='1.0')")
+            .addModule(createModuleKey("ccc", "1.0"), "module(name='ccc', version='1.0')")
+            .addModule(createModuleKey("ccc", "2.0"), "module(name='ccc', version='2.0')");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    EvaluationResult<DiscoveryValue> result =
+        evaluator.evaluate(ImmutableList.of(DiscoveryValue.KEY), evaluationContext);
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    DiscoveryValue discoveryValue = result.get(DiscoveryValue.KEY);
+    assertThat(discoveryValue.depGraph().entrySet())
+        .containsExactly(
+            InterimModuleBuilder.create("aaa", "0.1")
+                .setKey(ModuleKey.ROOT)
+                .addDep("bbb", createModuleKey("bbb", "1.0"))
+                .addNodepDep(createModuleKey("ccc", "2.0"))
+                .buildEntry(),
+            InterimModuleBuilder.create("bbb", "1.0")
+                .addDep("ccc", createModuleKey("ccc", "1.0"))
+                .setRegistry(registry)
+                .buildEntry(),
+            InterimModuleBuilder.create("ccc", "1.0").setRegistry(registry).buildEntry(),
+            InterimModuleBuilder.create("ccc", "2.0").setRegistry(registry).buildEntry());
+    assertThat(discoveryValue.registryFileHashes().keySet())
+        .containsExactly(
+            registry.getUrl() + "/modules/bbb/1.0/MODULE.bazel",
+            registry.getUrl() + "/modules/ccc/2.0/MODULE.bazel",
+            registry.getUrl() + "/modules/ccc/1.0/MODULE.bazel");
+  }
+
+  @Test
+  public void testNodep_fulfilled_manyRounds() throws Exception {
+    scratch.file(
+        workspaceRoot.getRelative("MODULE.bazel").getPathString(),
+        "module(name='aaa',version='0.1')",
+        "bazel_dep(name='bbb',version='1.0')",
+        "bazel_dep(name='ccc',version='2.0',repo_name=None)",
+        "bazel_dep(name='ddd',version='2.0',repo_name=None)");
+    FakeRegistry registry =
+        registryFactory
+            .newFakeRegistry("/foo")
+            .addModule(
+                createModuleKey("bbb", "1.0"),
+                "module(name='bbb', version='1.0');bazel_dep(name='ccc',version='1.0')")
+            .addModule(createModuleKey("ccc", "1.0"), "module(name='ccc', version='1.0')")
+            .addModule(
+                createModuleKey("ccc", "2.0"),
+                "module(name='ccc', version='2.0');bazel_dep(name='ddd',version='1.0')")
+            .addModule(createModuleKey("ddd", "1.0"), "module(name='ddd', version='1.0')")
+            .addModule(createModuleKey("ddd", "2.0"), "module(name='ddd', version='2.0')");
+    ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
+
+    EvaluationResult<DiscoveryValue> result =
+        evaluator.evaluate(ImmutableList.of(DiscoveryValue.KEY), evaluationContext);
+    if (result.hasError()) {
+      fail(result.getError().toString());
+    }
+    DiscoveryValue discoveryValue = result.get(DiscoveryValue.KEY);
+    assertThat(discoveryValue.depGraph().entrySet())
+        .containsExactly(
+            InterimModuleBuilder.create("aaa", "0.1")
+                .setKey(ModuleKey.ROOT)
+                .addDep("bbb", createModuleKey("bbb", "1.0"))
+                .addNodepDep(createModuleKey("ccc", "2.0"))
+                .addNodepDep(createModuleKey("ddd", "2.0"))
+                .buildEntry(),
+            InterimModuleBuilder.create("bbb", "1.0")
+                .addDep("ccc", createModuleKey("ccc", "1.0"))
+                .setRegistry(registry)
+                .buildEntry(),
+            InterimModuleBuilder.create("ccc", "1.0").setRegistry(registry).buildEntry(),
+            InterimModuleBuilder.create("ccc", "2.0")
+                .setRegistry(registry)
+                .addDep("ddd", createModuleKey("ddd", "1.0"))
+                .buildEntry(),
+            InterimModuleBuilder.create("ddd", "1.0").setRegistry(registry).buildEntry(),
+            InterimModuleBuilder.create("ddd", "2.0").setRegistry(registry).buildEntry());
+    assertThat(discoveryValue.registryFileHashes().keySet())
+        .containsExactly(
+            registry.getUrl() + "/modules/bbb/1.0/MODULE.bazel",
+            registry.getUrl() + "/modules/ccc/2.0/MODULE.bazel",
+            registry.getUrl() + "/modules/ddd/2.0/MODULE.bazel",
+            registry.getUrl() + "/modules/ccc/1.0/MODULE.bazel",
+            registry.getUrl() + "/modules/ddd/1.0/MODULE.bazel");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -36,7 +36,6 @@ import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFile
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.LockfileMode;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryModule;
 import com.google.devtools.build.lib.clock.BlazeClock;
-import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
@@ -225,6 +224,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         ")",
         "bazel_dep(name='bbb',version='1.0')",
         "bazel_dep(name='ccc',version='2.0',repo_name='see')",
+        "bazel_dep(name='ddd',version='3.0',repo_name=None)",
         "register_toolchains('//my:toolchain', '//my:toolchain2')",
         "register_execution_platforms('//my:platform', '//my:platform2')",
         "single_version_override(module_name='ddd',version='18')",
@@ -241,7 +241,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
       fail(result.getError().toString());
     }
     RootModuleFileValue rootModuleFileValue = result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE);
-    assertThat(rootModuleFileValue.getModule())
+    assertThat(rootModuleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("aaa", "0.1", 4)
                 .setKey(ModuleKey.ROOT)
@@ -250,8 +250,9 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 .addToolchainsToRegister(ImmutableList.of("//my:toolchain", "//my:toolchain2"))
                 .addDep("bbb", createModuleKey("bbb", "1.0"))
                 .addDep("see", createModuleKey("ccc", "2.0"))
+                .addNodepDep(createModuleKey("ddd", "3.0"))
                 .build());
-    assertThat(rootModuleFileValue.getOverrides())
+    assertThat(rootModuleFileValue.overrides())
         .containsExactly(
             "ddd",
             SingleVersionOverride.create(
@@ -266,7 +267,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 new ArchiveRepoSpecBuilder()
                     .setUrls(ImmutableList.of("https://hello.com/world.zip"))
                     .build()));
-    assertThat(rootModuleFileValue.getNonRegistryOverrideCanonicalRepoNameLookup())
+    assertThat(rootModuleFileValue.nonRegistryOverrideCanonicalRepoNameLookup())
         .containsExactly(
             RepositoryName.create("eee+"), "eee",
             RepositoryName.create("ggg+"), "ggg");
@@ -287,14 +288,14 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
       fail(result.getError().toString());
     }
     RootModuleFileValue rootModuleFileValue = result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE);
-    assertThat(rootModuleFileValue.getModule())
+    assertThat(rootModuleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("", "")
                 .setKey(ModuleKey.ROOT)
                 .addDep("bbb", createModuleKey("bbb", "1.0"))
                 .build());
-    assertThat(rootModuleFileValue.getOverrides()).isEmpty();
-    assertThat(rootModuleFileValue.getNonRegistryOverrideCanonicalRepoNameLookup()).isEmpty();
+    assertThat(rootModuleFileValue.overrides()).isEmpty();
+    assertThat(rootModuleFileValue.nonRegistryOverrideCanonicalRepoNameLookup()).isEmpty();
   }
 
   @Test
@@ -332,7 +333,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         evaluator.evaluate(
             ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
     ModuleOverride bazelToolsOverride =
-        result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).getOverrides().get("bazel_tools");
+        result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).overrides().get("bazel_tools");
     assertThat(bazelToolsOverride)
         .isEqualTo(new NonRegistryOverride(LocalPathRepoSpecs.create("./bazel_tools_new")));
   }
@@ -354,7 +355,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     EvaluationResult<RootModuleFileValue> result =
         evaluator.evaluate(
             ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
-    assertThat(result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).getOverrides()).isEmpty();
+    assertThat(result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).overrides()).isEmpty();
   }
 
   @Test
@@ -397,13 +398,13 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
             .addDep("python-foo", createModuleKey("py-foo", "1.0"))
             .addToolchainsToRegister(ImmutableList.of("//:whatever", "//:python-whatever"))
             .build();
-    assertThat(rootModuleFileValue.getModule()).isEqualTo(expectedModule);
+    assertThat(rootModuleFileValue.module()).isEqualTo(expectedModule);
     // specifically assert the order of deps, which is significant; Map.equals semantics don't test
     // this.
-    assertThat(rootModuleFileValue.getModule().getDeps())
+    assertThat(rootModuleFileValue.module().getDeps())
         .containsExactlyEntriesIn(expectedModule.getDeps())
         .inOrder();
-    assertThat(rootModuleFileValue.getOverrides())
+    assertThat(rootModuleFileValue.overrides())
         .containsExactly(
             "java-foo",
             SingleVersionOverride.create(
@@ -566,7 +567,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     FakeRegistry registry = registryFactory.newFakeRegistry("/foo");
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
 
-    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bbb", ""), null);
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bbb", ""));
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
     assertThat(result.hasError()).isTrue();
@@ -594,14 +595,14 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     ModuleFileFunction.REGISTRIES.set(
         differencer, ImmutableSet.of(registry1.getUrl(), registry2.getUrl(), registry3.getUrl()));
 
-    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bbb", "1.0"), null);
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bbb", "1.0"));
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
     if (result.hasError()) {
       fail(result.getError().toString());
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("bbb", "1.0")
                 .addDep("ccc", createModuleKey("ccc", "2.0"))
@@ -620,9 +621,9 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 "include('//java:MODULE.bazel.segment')");
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
 
-    EvaluationResult<RootModuleFileValue> result =
+    EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(
-            ImmutableList.of(ModuleFileValue.key(createModuleKey("foo", "1.0"), null)),
+            ImmutableList.of(ModuleFileValue.key(createModuleKey("foo", "1.0"))),
             evaluationContext);
     assertThat(result.hasError()).isTrue();
     assertThat(result.getError().toString()).contains("but it can only be used in the root module");
@@ -650,17 +651,14 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
 
     // The version is empty here due to the override.
-    SkyKey skyKey =
-        ModuleFileValue.key(
-            createModuleKey("bbb", ""),
-            new NonRegistryOverride(LocalPathRepoSpecs.create("code_for_b")));
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bbb", ""));
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
     if (result.hasError()) {
       fail(result.getError().toString());
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("bbb", "1.0")
                 .setKey(createModuleKey("bbb", ""))
@@ -705,17 +703,14 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
 
     // The version is empty here due to the override.
-    SkyKey skyKey =
-        ModuleFileValue.key(
-            createModuleKey("bbb", ""),
-            new NonRegistryOverride(LocalPathRepoSpecs.create("used_override")));
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bbb", ""));
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
     if (result.hasError()) {
       fail(result.getError().toString());
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("bbb", "1.0")
                 .setKey(createModuleKey("bbb", ""))
@@ -739,21 +734,25 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 createModuleKey("bbb", "1.0"),
                 "module(name='bbb',version='1.0',compatibility_level=6)",
                 "bazel_dep(name='ccc',version='3.0')");
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        """
+        module(name='aaa',version='0.1')
+        bazel_dep(name = "bbb", version = "1.0")
+        single_version_override(module_name='bbb', registry='%s')
+        """
+            .formatted(registry2.getUrl()));
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry1.getUrl()));
 
     // Override the registry for B to be registry2 (instead of the default registry1).
-    SkyKey skyKey =
-        ModuleFileValue.key(
-            createModuleKey("bbb", "1.0"),
-            SingleVersionOverride.create(
-                Version.EMPTY, registry2.getUrl(), ImmutableList.of(), ImmutableList.of(), 0));
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bbb", "1.0"));
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
     if (result.hasError()) {
       fail(result.getError().toString());
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("bbb", "1.0", 6)
                 .addDep("ccc", createModuleKey("ccc", "3.0"))
@@ -785,14 +784,14 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
 
     ModuleKey myMod = createModuleKey("mymod", "1.0");
-    SkyKey skyKey = ModuleFileValue.key(myMod, null);
+    SkyKey skyKey = ModuleFileValue.key(myMod);
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
     if (result.hasError()) {
       throw result.getError().getException();
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("mymod", "1.0")
                 .addDep("rules_jvm_external", createModuleKey("rules_jvm_external", "2.0"))
@@ -947,7 +946,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
       throw result.getError().getException();
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("", "")
                 .setKey(ModuleKey.ROOT)
@@ -1072,14 +1071,14 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
 
     ModuleKey myMod = createModuleKey("mymod", "1.0");
-    SkyKey skyKey = ModuleFileValue.key(myMod, null);
+    SkyKey skyKey = ModuleFileValue.key(myMod);
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
     if (result.hasError()) {
       throw result.getError().getException();
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("mymod", "1.0")
                 .setRegistry(registry)
@@ -1153,7 +1152,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 "use_repo(myext, mymod='some_repo')");
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
 
-    SkyKey skyKey = ModuleFileValue.key(createModuleKey("mymod", "1.0"), null);
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("mymod", "1.0"));
     reporter.removeHandler(failFastHandler); // expect failures
     evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
 
@@ -1173,7 +1172,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                 "use_repo(myext, 'some_repo', again='some_repo')");
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of(registry.getUrl()));
 
-    SkyKey skyKey = ModuleFileValue.key(createModuleKey("mymod", "1.0"), null);
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("mymod", "1.0"));
     reporter.removeHandler(failFastHandler); // expect failures
     evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
 
@@ -1199,7 +1198,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
       throw result.getError().getException();
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("", "")
                 .setKey(ModuleKey.ROOT)
@@ -1421,14 +1420,14 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
       throw result.getError().getException();
     }
     RootModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("", "")
                 .addDep("bazel_tools", createModuleKey("bazel_tools", ""))
                 .addDep("local_config_platform", createModuleKey("local_config_platform", ""))
                 .addDep("foo", createModuleKey("foo", "1.0"))
                 .build());
-    assertThat(moduleFileValue.getOverrides()).containsExactlyEntriesIn(builtinModules);
+    assertThat(moduleFileValue.overrides()).containsExactlyEntriesIn(builtinModules);
   }
 
   @Test
@@ -1451,15 +1450,14 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         "bazel_dep(name='foo',version='2.0')");
     ModuleFileFunction.REGISTRIES.set(differencer, ImmutableSet.of());
 
-    SkyKey skyKey =
-        ModuleFileValue.key(createModuleKey("bazel_tools", ""), builtinModules.get("bazel_tools"));
+    SkyKey skyKey = ModuleFileValue.key(createModuleKey("bazel_tools", ""));
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(skyKey), evaluationContext);
     if (result.hasError()) {
       throw result.getError().getException();
     }
     ModuleFileValue moduleFileValue = result.get(skyKey);
-    assertThat(moduleFileValue.getModule())
+    assertThat(moduleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("bazel_tools", "1.0")
                 .setKey(createModuleKey("bazel_tools", ""))
@@ -1483,7 +1481,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
       fail(result.getError().toString());
     }
     RootModuleFileValue rootModuleFileValue = result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE);
-    assertThat(rootModuleFileValue.getModule())
+    assertThat(rootModuleFileValue.module())
         .isEqualTo(
             InterimModuleBuilder.create("aaa", "0.1")
                 .setKey(ModuleKey.ROOT)
@@ -1703,7 +1701,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         evaluator.evaluate(
             ImmutableList.of(ModuleFileValue.KEY_FOR_ROOT_MODULE), evaluationContext);
     assertThat(result.hasError()).isFalse();
-    assertThat(result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).getModule().getExtensionUsages())
+    assertThat(result.get(ModuleFileValue.KEY_FOR_ROOT_MODULE).module().getExtensionUsages())
         .isEmpty();
   }
 
@@ -1788,27 +1786,29 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
              module(name='bbb',version='1.0',bazel_compatibility=[">=7.0.0"])
             +bazel_dep(name='ccc',version='3.0')
             """);
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        """
+        single_version_override(
+          module_name="bbb",
+          patches = [
+            "//:patch.diff",
+            "@@other_repo//:patch.diff",
+            "//other/pkg:other_patch.diff",
+          ],
+          patch_strip = 1,
+        )
+        """);
 
-    var moduleFileKey =
-        ModuleFileValue.key(
-            bbb,
-            SingleVersionOverride.create(
-                Version.EMPTY,
-                "",
-                ImmutableList.of(
-                    Label.parseCanonicalUnchecked("//:patch.diff"),
-                    Label.parseCanonicalUnchecked("@other_repo//:patch.diff"),
-                    Label.parseCanonicalUnchecked("//other/pkg:other_patch.diff")),
-                ImmutableList.of(),
-                1));
+    var moduleFileKey = ModuleFileValue.key(bbb);
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(moduleFileKey), evaluationContext);
     if (result.hasError()) {
       throw result.getError().getException();
     }
-    assertThat(result.get(moduleFileKey).getModule().getBazelCompatibility())
-        .isEqualTo(ImmutableList.of(">=7.0.0"));
-    assertThat(result.get(moduleFileKey).getModule().getDeps())
+    assertThat(result.get(moduleFileKey).module().getBazelCompatibility())
+        .containsExactly(">=7.0.0");
+    assertThat(result.get(moduleFileKey).module().getDeps())
         .containsExactly(
             "ccc", InterimModule.DepSpec.fromModuleKey(new ModuleKey("ccc", Version.parse("3.0"))));
 
@@ -1829,9 +1829,9 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
     if (result.hasError()) {
       throw result.getError().getException();
     }
-    assertThat(result.get(moduleFileKey).getModule().getBazelCompatibility())
-        .isEqualTo(ImmutableList.of(">=7.0.0"));
-    assertThat(result.get(moduleFileKey).getModule().getDeps())
+    assertThat(result.get(moduleFileKey).module().getBazelCompatibility())
+        .containsExactly(">=7.0.0");
+    assertThat(result.get(moduleFileKey).module().getDeps())
         .containsExactly(
             "ccc", InterimModule.DepSpec.fromModuleKey(new ModuleKey("ccc", Version.parse("2.0"))));
   }
@@ -1853,16 +1853,17 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
         rename to MODULE.bazel.bak
         index 3f855b5..949dd15 100644
         """);
+    scratch.overwriteFile(
+        rootDirectory.getRelative("MODULE.bazel").getPathString(),
+        """
+        single_version_override(
+          module_name="bbb",
+          patches = ["//:patch.diff"],
+          patch_strip = 1,
+        )
+        """);
 
-    var moduleFileKey =
-        ModuleFileValue.key(
-            bbb,
-            SingleVersionOverride.create(
-                Version.EMPTY,
-                "",
-                ImmutableList.of(Label.parseCanonicalUnchecked("//:patch.diff")),
-                ImmutableList.of(),
-                1));
+    var moduleFileKey = ModuleFileValue.key(bbb);
     EvaluationResult<ModuleFileValue> result =
         evaluator.evaluate(ImmutableList.of(moduleFileKey), evaluationContext);
     assertThat(result.hasError()).isTrue();


### PR DESCRIPTION
This PR implements the "nodep" edges from https://docs.google.com/document/d/1JsfbH9kdMe3dyOY-IR8SUakS541A7OM8pQcKpxTRMRs/edit?tab=t.0, using the syntax of `bazel_dep(..., repo_name=None)`. The behavior is that these edges are "unfulfilled" unless the module they refer to already exist in the dep graph by some other means.

Most of the changes are in the Discovery class -- I reorganized the code in there to hopefully help with readability, given the new multi-round discovery logic.

Also changed `ModuleFileValue.Key` to no longer take the applicable override next to the module key -- `ModuleFileFunction` now gets the root module from Skyframe itself and looks up the correct override. The old setup was always weird (what does it mean to request `foo@1.0` with an incorrect override??).

Beyond that, I changed `ModuleFileValue` implementations to become records. Just for the heck of it.

Work towards https://github.com/bazelbuild/bazel/issues/25214

RELNOTES: The `repo_name` parameter of `bazel_dep` can now be set to `None` to mark it a "nodep" dependency -- that is, the `bazel_dep` specification is only honored if the target module already exists in the dependency graph by some other means.

PiperOrigin-RevId: 730962587
Change-Id: I1ca7a7a1228da5e4c2e4b5d6983a2ec97b31a4b8