### PR TITLE
Fixing Auth With Redirects

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -141,7 +141,13 @@ final class HttpConnectorMultiplexer {
       ImmutableMap.Builder<String, List<String>> headers = new ImmutableMap.Builder<>();
       headers.putAll(baseHeaders);
       try {
-        headers.putAll(credentials.getRequestMetadata(url.toURI()));
+        URI originalUri = url.toURI();
+        // Check against the host as a fallback.
+        // Needs protocol as well due to input data path using URL->URI.
+        URI hostUri = new URI(url.getProtocol() + "://" + url.getHost());
+        // Put more-general host headers first, allowing the more-specific url headers to override.
+        headers.putAll(credentials.getRequestMetadata(hostUri));
+        headers.putAll(credentials.getRequestMetadata(originalUri));
       } catch (URISyntaxException | IOException e) {
         // If we can't convert the URL to a URI (because it is syntactically malformed), or fetching
         // credentials fails for any other reason, still try to do the connection, not adding

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.events.EventHandler;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -715,7 +715,7 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
             name = "auth",
             defaultValue = "{}",
             named = true,
-            doc = "An optional dict specifying authentication information for some of the URLs."),
+            doc = "An optional dict specifying authentication information for some of the URLs or hosts."),
         @Param(
             name = "headers",
             defaultValue = "{}",
@@ -948,7 +948,7 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
             name = "auth",
             defaultValue = "{}",
             named = true,
-            doc = "An optional dict specifying authentication information for some of the URLs."),
+            doc = "An optional dict specifying authentication information for some of the URLs or hosts."),
         @Param(
             name = "headers",
             defaultValue = "{}",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
@@ -224,5 +224,96 @@ public class HttpConnectorMultiplexerTest {
     assertThat(combinedHeaders.apply(new URL("http://unreleated.example.org/user/foo/file.txt")))
         .containsExactly(
             "Authentication", ImmutableList.of("YW5vbnltb3VzOmZvb0BleGFtcGxlLm9yZw=="));
+
+    // Verify that host fallback headers are passed / overridden when appropriate.
+    additionalHeaders =
+        ImmutableMap.of(
+            new URI("http://hosting.example.com/user/foo/file.txt"),
+            ImmutableMap.of("Authentication", ImmutableList.of("Zm9vOmZvb3NlY3JldA==")),
+            new URI("http://hosting.example.com"),
+            ImmutableMap.of("Authentication", ImmutableList.of("YmFyOmJhcnNlY3JldA==")),
+            new URI("http://hosting9001.example.com"),
+            ImmutableMap.of("Authentication", ImmutableList.of("cXV4OnF1eHNlY3JldA==")),
+            new URI("http://hosting42.example.com/user/foo/file.txt"),
+            ImmutableMap.of("Authentication", ImmutableList.of("Zm9vOmZvb3NlY3JldA==")));
+    headerFunction =
+        HttpConnectorMultiplexer.getHeaderFunction(
+            baseHeaders, new StaticCredentials(additionalHeaders), eventHandler);
+
+    // Unrelated URL
+    assertThat(headerFunction.apply(new URL("http://example.org/some/path/file.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"));
+
+    // With exact url
+    assertThat(headerFunction.apply(new URL("http://hosting.example.com/user/foo/file.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"),
+            "Authentication",
+            ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
+
+    // With different url of covered domain.
+    assertThat(headerFunction.apply(new URL("http://hosting.example.com/user/bar/file99.xml")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"),
+            "Authentication",
+            ImmutableList.of("YmFyOmJhcnNlY3JldA=="));
+
+    // Some url of different covered domain.
+    assertThat(headerFunction.apply(new URL("http://hosting9001.example.com/user/foo/file.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"),
+            "Authentication",
+            ImmutableList.of("cXV4OnF1eHNlY3JldA=="));
+
+    // Other url with only exact matching (no domain fallback).
+    assertThat(headerFunction.apply(new URL("http://hosting42.example.com/user/foo/file.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"),
+            "Authentication",
+            ImmutableList.of("Zm9vOmZvb3NlY3JldA=="));
+
+    // Other hosts
+    assertThat(headerFunction.apply(new URL("http://hosting2.example.com/user/foo/file.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"));
+    assertThat(headerFunction.apply(new URL("http://sub.hosting.example.com/user/foo/file.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"));
+    assertThat(headerFunction.apply(new URL("http://example.com/user/foo/file.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"));
+    assertThat(
+            headerFunction.apply(
+                new URL("http://hosting.example.com.evil.example/user/foo/file.txt")))
+        .containsExactly(
+            "Accept-Encoding",
+            ImmutableList.of("gzip"),
+            "User-Agent",
+            ImmutableList.of("Bazel/testing"));
   }
 }

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -1579,6 +1579,21 @@ expected = {
       "pattern" : "Bearer <password>",
       "password" : "TOKEN",
     },
+    "https://foo.example.org" : {
+      "type" : "basic",
+      "login": "foousername",
+      "password" : "foopass",
+    },
+    "https://bar.example.org" : {
+      "type" : "basic",
+      "login": "barusername",
+      "password" : "passbar🌱",
+    },
+    "https://oauthlife.com": {
+      "type" : "pattern",
+      "pattern" : "Bearer <password>",
+      "password" : "TOKEN",
+    },
 }
 EOF
   cat > verify.bzl <<'EOF'


### PR DESCRIPTION
This addresses an issue where HTTP redirects for `ctx.download()`/`ctx.download_and_extract()` do not properly forward auth headers after an HTTP redirect (3** status code). This was due to auth headers being tied to the exact URL given in the `urls` parameter.

This PR addresses this by additionally tying auth data to the host name (matching what is given in `auth`). This is backwards compatible with existing "exact URL matching" functionality by having the host auth functionality largely function as a fallback.

For more detail see: https://github.com/bazelbuild/bazel/issues/25068

Changes:
* Updating `use_netrc()` in `tools/build_defs/repo/utils.bzl`.
  * The resultant dict contains keys for both exact urls (just as it did before) and the protocol + hosts to match to `patterns` dict.
    * Must include protocol because Java-side converts these strings to `URL`s (requires protocol).
    * This does not include hosts from `patterns` which do not appear in the `urls` at all (so redirects would need to be still among the same set of hosts).
  * Updating `Returns` section of doc string to mention the pattern hosts.
  * This will affect/fix functionality for repo rules such as `http_archive()` and others which use `use_netrc()` (possibly through `get_auth()`) for generating auth data.
* Updating `HttpConnectorMultiplexer.getHeaderFunction()` in `src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java`.
  * Adding host-based fallback checks.
    * This will check the given `credentials` for both the exact URI and a URI of only the host, where the host is a fallback (overridden by the exact URI).
    * The host fallback URI must include protocol, due to elsewhere converting String->URL->URI (`URL` requires protocol).
  * This will pick up the auth data originating from `use_netrc()` (and passed through various functions/transformations).
  * If the host name is not given (for some other call to download functionality), then the exact URI will be used only (just like the existing flow).
* Updating `download()` and `download_and_extract()` doc strings in `src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java`.
* Updating tests.
  * Updating `test_use_netrc` test case in `src/test/shell/bazel/starlark_repository_test.sh`.
    * Adding hosts (with protocol) into `expected` dict auth data.
  * Adding test assertions for auth header logic for `testHeaderComputationFunction()` in `src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java`.

Fixes https://github.com/bazelbuild/bazel/issues/25068.