### PR TITLE
Use `apple_support` toolchain to build Bazel on macOS

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,7 +24,6 @@ bazel_dep(name = "stardoc", version = "0.7.1", repo_name = "io_bazel_skydoc")
 bazel_dep(name = "zstd-jni", version = "1.5.6-9")
 bazel_dep(name = "blake3", version = "1.5.1.bcr.1")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
-bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_java", version = "8.9.0")
 bazel_dep(name = "rules_graalvm", version = "0.11.1")
 bazel_dep(name = "rules_proto", version = "7.0.2")
@@ -35,6 +34,11 @@ bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googl
 bazel_dep(name = "with_cfg.bzl", version = "0.6.0")
 bazel_dep(name = "abseil-cpp", version = "20240722.0.bcr.2")
 bazel_dep(name = "rules_shell", version = "0.3.0")
+
+# Depend on apple_support first and then rules_cc so that the Xcode toolchain
+# from apple_support wins over the generic Unix toolchain from rules_cc.
+bazel_dep(name = "apple_support", version = "1.18.1")
+bazel_dep(name = "rules_cc", version = "0.0.17")
 
 # repo_name needs to be used, until WORKSPACE mode is to be supported in bazel_tools
 bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
@@ -77,7 +81,6 @@ local_path_override(
 
 # The following Bazel modules are not direct dependencies for building Bazel,
 # but are required for visibility from DIST_ARCHIVE_REPOS in repositories.bzl
-bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(name = "rules_apple", version = "3.16.0")
 bazel_dep(name = "bazel_features", version = "1.21.0")
 bazel_dep(name = "c-ares", version = "1.15.0")
@@ -294,8 +297,8 @@ use_repo(
     "debian_proto_deps",
     "openjdk_linux_aarch64_vanilla",
     "openjdk_linux_ppc64le_vanilla",
-    "openjdk_linux_s390x_vanilla",
     "openjdk_linux_riscv64_vanilla",
+    "openjdk_linux_s390x_vanilla",
     "openjdk_linux_vanilla",
     "openjdk_macos_aarch64_vanilla",
     "openjdk_macos_x86_64_vanilla",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -16,13 +16,15 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20240722.0.bcr.2/source.json": "464f3012c8f40cd51facbfc6962563971c6bd55f45ba16bd98313f2de73340c5",
     "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
-    "https://bcr.bazel.build/modules/apple_support/1.15.1/source.json": "517f2b77430084c541bc9be2db63fdcbb7102938c5f64c17ee60ffda2e5cf07b",
+    "https://bcr.bazel.build/modules/apple_support/1.18.1/MODULE.bazel": "019f8538997d93ac84661ab7a55b5343d2758ddbff3a0501a78b573708de90b4",
+    "https://bcr.bazel.build/modules/apple_support/1.18.1/source.json": "fcfd4548abb27da98f69213a04a51cf7dab7c634f80795397f646056dab5f09f",
     "https://bcr.bazel.build/modules/apple_support/1.8.1/MODULE.bazel": "500f7aa32c008222e360dc9a158c248c2dbaeb3b6246c19e7269981dbd61e29b",
     "https://bcr.bazel.build/modules/bazel_ci_rules/1.0.0/MODULE.bazel": "0f92c944b9c466066ed484cfc899cf43fca765df78caca18984c62479f7925eb",
     "https://bcr.bazel.build/modules/bazel_ci_rules/1.0.0/source.json": "3405a2a7f9f827a44934b01470faeac1b56fb1304955c98ee9fcd03ad2ca5dcc",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
@@ -435,8 +437,8 @@
     },
     "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "okb7JAyJ9zeL+SDmtbWT0XBLq8WRoLJ0zWAG783RLVI=",
-        "usagesDigest": "D4pmKMi+AKU6GdJ8ZxoDKj1muCYIcreeg1ilywlspTc=",
+        "bzlTransitiveDigest": "J/NQ9In4Dg+9Bu7xOlqFrCZ9x7w25IkV6Zke2d84AuY=",
+        "usagesDigest": "nEoekyRWrUccMx7uNuYEOcpi+ylQW78TC6yqvHcVUHw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -903,7 +905,7 @@
     },
     "@@rules_apple+//apple:apple.bzl%provisioning_profile_repository_extension": {
       "general": {
-        "bzlTransitiveDigest": "iO8wA55gsKP/G7za42fx5LIrxDi5gsm8UECsBBL99ss=",
+        "bzlTransitiveDigest": "H+cK6ZkpFsi9ulPs4B7qa9dl0LWFpjDXx6bH0o1+btA=",
         "usagesDigest": "vsJl8Rw5NL+5Ag2wdUDoTeRF/5klkXO8545Iy7U1Q08=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/src/main/tools/daemonize.cc
+++ b/src/main/tools/daemonize.cc
@@ -112,6 +112,7 @@ static void WritePidFile(pid_t pid, const char* pid_path, int pid_done_fd) {
   close(pid_done_fd);
 }
 
+#ifdef __linux__
 static bool ShellEscapeNeeded(const char* arg) {
   static const char kDontNeedShellEscapeChars[] =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -232,6 +233,7 @@ static void WriteSystemdWrapper(const char* systemd_wrapper_path,
 static bool IsBinaryExecutable(const char* binary_path) {
   return access(binary_path, X_OK) == 0;
 }
+#endif
 
 static void ExecAsDaemon(const char* log_path, bool log_append,
                          const char* systemd_wrapper_path, int pid_done_fd,


### PR DESCRIPTION
The Xcode toolchain in `apple_support` used to be part of Bazel and was used to build Bazel itself back then. Since it has been moved to `apple_support`, Bazel has been building with the generic Unix toolchain, which isn't frequently used with Xcode and much less actively maintained than the one in `apple_support`. Switching back also gets rid of a number of warnings.

Also avoid compiling unused functions on macOS to get rid of the last C/C++ compilation warnings.