### PR TITLE
Don't download all artifacts with BwoB when their TTL expires 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -240,7 +240,7 @@ public class ActionCacheChecker {
     if (outputChecker == null || metadata == null) {
       return true;
     }
-    return outputChecker.shouldTrustArtifact(artifact, metadata);
+    return outputChecker.shouldTrustMetadata(artifact, metadata);
   }
 
   private static boolean shouldTrustTreeMetadata(
@@ -262,7 +262,7 @@ public class ActionCacheChecker {
               .getArchivedRepresentation()
               .map(ArchivedRepresentation::archivedFileValue)
               .orElseThrow();
-      if (!outputChecker.shouldTrustArtifact(archivedArtifact, archivedMetadata)) {
+      if (!outputChecker.shouldTrustMetadata(archivedArtifact, archivedMetadata)) {
         return false;
       }
     }
@@ -270,7 +270,7 @@ public class ActionCacheChecker {
         treeMetadata.getChildValues().entrySet()) {
       TreeFileArtifact child = entry.getKey();
       FileArtifactValue childMetadata = entry.getValue();
-      if (!outputChecker.shouldTrustArtifact(child, childMetadata)) {
+      if (!outputChecker.shouldTrustMetadata(child, childMetadata)) {
         return false;
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/OutputChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/OutputChecker.java
@@ -14,14 +14,18 @@
 package com.google.devtools.build.lib.actions;
 
 /**
- * An interface used to check whether the metadata for an output should be trusted.
- *
- * <p>Used to invalidate metadata when the respective contents are stored with a bounded lifetime.
+ * An interface used to check whether an output should be downloaded or its metadata revalidated
+ * when it is stored with a bounded lifetime.
  */
 public interface OutputChecker {
   static final OutputChecker TRUST_ALL = (file, metadata) -> true;
   static final OutputChecker TRUST_LOCAL_ONLY = (file, metadata) -> !metadata.isRemote();
 
+  /** Returns whether the given output should be downloaded. */
+  default boolean shouldDownloadOutput(ActionInput output, FileArtifactValue metadata) {
+    return !shouldTrustMetadata(output, metadata);
+  }
+
   /** Returns whether the given metadata should be trusted. */
-  boolean shouldTrustArtifact(ActionInput file, FileArtifactValue metadata);
+  boolean shouldTrustMetadata(ActionInput file, FileArtifactValue metadata);
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -724,15 +724,17 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       }
 
       if (output.isTreeArtifact()) {
-        var children =
-            outputMetadataStore.getTreeArtifactValue((SpecialArtifact) output).getChildren();
-        for (var file : children) {
-          if (remoteOutputChecker.shouldDownloadOutput(file)) {
-            outputsToDownload.add(file);
-          }
-        }
+        outputMetadataStore
+            .getTreeArtifactValue((SpecialArtifact) output)
+            .getChildValues()
+            .forEach(
+                (child, childMetadata) -> {
+                  if (remoteOutputChecker.shouldDownloadOutput(child, childMetadata)) {
+                    outputsToDownload.add(child);
+                  }
+                });
       } else {
-        if (remoteOutputChecker.shouldDownloadOutput(output)) {
+        if (remoteOutputChecker.shouldDownloadOutput(output, metadata)) {
           outputsToDownload.add(output);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
@@ -44,7 +44,10 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
-/** An {@link OutputChecker} that checks the TTL of remote metadata. */
+/**
+ * An {@link OutputChecker} that checks the TTL of remote metadata and decides which outputs to
+ * download.
+ */
 public class RemoteOutputChecker implements OutputChecker {
   private enum CommandMode {
     UNKNOWN,
@@ -272,14 +275,15 @@ public class RemoteOutputChecker implements OutputChecker {
   }
 
   /** Returns whether this {@link ActionInput} should be downloaded. */
-  public boolean shouldDownloadOutput(ActionInput output) {
+  @Override
+  public boolean shouldDownloadOutput(ActionInput output, FileArtifactValue metadata) {
     checkState(
         !(output instanceof Artifact && ((Artifact) output).isTreeArtifact()),
         "shouldDownloadOutput should not be called on a tree artifact");
-    return shouldDownloadOutput(output.getExecPath());
+    return metadata.isRemote() && shouldDownloadOutput(output.getExecPath());
   }
 
-  /** Returns whether an {@link ActionInput} with the given path should be downloaded. */
+  /** Returns whether a remote {@link ActionInput} with the given path should be downloaded. */
   public boolean shouldDownloadOutput(PathFragment execPath) {
     return outputsMode == RemoteOutputsMode.ALL
         || pathsToDownload.contains(execPath)
@@ -287,7 +291,7 @@ public class RemoteOutputChecker implements OutputChecker {
   }
 
   @Override
-  public boolean shouldTrustArtifact(ActionInput file, FileArtifactValue metadata) {
+  public boolean shouldTrustMetadata(ActionInput file, FileArtifactValue metadata) {
     // Local metadata is always trusted.
     if (!metadata.isRemote()) {
       return true;
@@ -300,12 +304,12 @@ public class RemoteOutputChecker implements OutputChecker {
     if (lastRemoteOutputChecker != null) {
       // This is an incremental build. If the file was downloaded by previous build and is now
       // missing, invalidate the action.
-      if (lastRemoteOutputChecker.shouldDownloadOutput(file)) {
+      if (lastRemoteOutputChecker.shouldDownloadOutput(file, metadata)) {
         return false;
       }
     }
 
-    if (shouldDownloadOutput(file)) {
+    if (shouldDownloadOutput(file, metadata)) {
       return false;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
@@ -455,7 +455,7 @@ public final class CompletionFunction<
       for (var child : treeMetadata.getChildValues().entrySet()) {
         var treeFile = child.getKey();
         var metadata = child.getValue();
-        if (!outputChecker.shouldTrustArtifact(treeFile, metadata)) {
+        if (outputChecker.shouldDownloadOutput(treeFile, metadata)) {
           filesToDownload.add(treeFile);
         }
       }
@@ -473,7 +473,7 @@ public final class CompletionFunction<
         return;
       }
 
-      if (!outputChecker.shouldTrustArtifact(artifact, metadata)) {
+      if (outputChecker.shouldDownloadOutput(artifact, metadata)) {
         var action =
             ActionUtils.getActionForLookupData(env, derivedArtifact.getGeneratingActionKey());
         var future =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -527,7 +527,7 @@ public class FilesystemValueChecker {
       boolean isTrustedRemoteValue =
           fileMetadata.getType() == FileStateType.NONEXISTENT
               && lastKnownData.isRemote()
-              && outputChecker.shouldTrustArtifact(file, lastKnownData);
+              && outputChecker.shouldTrustMetadata(file, lastKnownData);
       if (!isTrustedRemoteValue && fileMetadata.couldBeModifiedSince(lastKnownData)) {
         modifiedOutputsReceiver.reportModifiedOutputFile(
             fileMetadata.getType() != FileStateType.NONEXISTENT

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -724,7 +724,7 @@ public class ActionCacheCheckerTest {
             /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
             outputChecker);
     verify(outputChecker)
-        .shouldTrustArtifact(argThat(arg -> arg.getExecPathString().endsWith("bin/dummy")), any());
+        .shouldTrustMetadata(argThat(arg -> arg.getExecPathString().endsWith("bin/dummy")), any());
     // Not cached since local file changed
     runAction(
         action,
@@ -787,7 +787,7 @@ public class ActionCacheCheckerTest {
     fakeOutputMetadataStore.injectFile(output, metadata);
 
     OutputChecker outputChecker = mock(OutputChecker.class);
-    when(outputChecker.shouldTrustArtifact(any(), any())).thenReturn(false);
+    when(outputChecker.shouldTrustMetadata(any(), any())).thenReturn(false);
 
     runAction(
         action,
@@ -1072,7 +1072,7 @@ public class ActionCacheCheckerTest {
     runAction(action);
     writeIsoLatin1(output.getPath().getRelative("file2"), "modified_local");
     var outputChecker = mock(OutputChecker.class);
-    when(outputChecker.shouldTrustArtifact(any(), any())).thenReturn(true);
+    when(outputChecker.shouldTrustMetadata(any(), any())).thenReturn(true);
     var token =
         cacheChecker.getTokenIfNeedToExecute(
             action,
@@ -1086,9 +1086,9 @@ public class ActionCacheCheckerTest {
             /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
             outputChecker);
     verify(outputChecker)
-        .shouldTrustArtifact(argThat(arg -> arg.getExecPathString().endsWith("file1")), any());
+        .shouldTrustMetadata(argThat(arg -> arg.getExecPathString().endsWith("file1")), any());
     verify(outputChecker)
-        .shouldTrustArtifact(argThat(arg -> arg.getExecPathString().endsWith("file2")), any());
+        .shouldTrustMetadata(argThat(arg -> arg.getExecPathString().endsWith("file2")), any());
     // Not cached since local file changed
     runAction(
         action,
@@ -1143,7 +1143,7 @@ public class ActionCacheCheckerTest {
     runAction(action);
     writeIsoLatin1(ArchivedTreeArtifact.createForTree(output).getPath(), "modified");
     var outputChecker = mock(OutputChecker.class);
-    when(outputChecker.shouldTrustArtifact(any(), any())).thenReturn(true);
+    when(outputChecker.shouldTrustMetadata(any(), any())).thenReturn(true);
     var token =
         cacheChecker.getTokenIfNeedToExecute(
             action,
@@ -1156,7 +1156,7 @@ public class ActionCacheCheckerTest {
             /* artifactExpander= */ null,
             /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
             outputChecker);
-    when(outputChecker.shouldTrustArtifact(any(), any())).thenReturn(true);
+    when(outputChecker.shouldTrustMetadata(any(), any())).thenReturn(true);
     // Not cached since local file changed
     runAction(
         action,
@@ -1439,7 +1439,7 @@ public class ActionCacheCheckerTest {
     fakeOutputMetadataStore.injectTree(tree, treeMetadata);
 
     OutputChecker outputChecker = mock(OutputChecker.class);
-    when(outputChecker.shouldTrustArtifact(any(), any())).thenReturn(false);
+    when(outputChecker.shouldTrustMetadata(any(), any())).thenReturn(false);
 
     runAction(
         action,


### PR DESCRIPTION
The TLL governs the lifetime of the remote metadata, but shouldn't by itself result in files being downloaded that otherwise wouldn't be (e.g., with `--remote_download_minimal`). This fixes a bug that causes warm Bazel servers with default settings apart from `--remote_download_minimal` to start downloading all top-level artifacts after three hours.

This change also renames `shouldTrustArtifact` to `shouldTrustMetadata` and updates some comments on `{Remote,}OutputChecker` to avoid confusion between its two distinct purposes in the future: validating metadata and deciding which artifacts to download.

Example of the effect: https://github.com/buildbuddy-io/buildbuddy/pull/8502#issuecomment-2687734121