### PR TITLE
Fix race condition with multiplex sandboxed workers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -95,7 +95,8 @@ public class WorkerFactory {
     if (key.isSandboxed()) {
       if (key.isMultiplex()) {
         WorkerMultiplexer workerMultiplexer = WorkerMultiplexerManager.getInstance(key, logFile);
-        Path workDir = getSandboxedWorkerPath(key);
+        int multiplexerId = workerMultiplexer.getMultiplexerId();
+        Path workDir = getMultiplexSandboxedWorkerPath(key, multiplexerId);
         worker =
             new SandboxedWorkerProxy(
                 key, workerId, logFile, workerMultiplexer, workDir, treeDeleter);
@@ -145,10 +146,11 @@ public class WorkerFactory {
         .getRelative(workspaceName);
   }
 
-  Path getSandboxedWorkerPath(WorkerKey key) {
+  Path getMultiplexSandboxedWorkerPath(WorkerKey key, int multiplexerId) {
     String workspaceName = key.getExecRoot().getBaseName();
     return workerBaseDir
-        .getRelative(key.getMnemonic() + "-" + key.getWorkerTypeName() + "-workdir")
+        .getRelative(
+              key.getMnemonic() + "-" + key.getWorkerTypeName() + "-" + multiplexerId + "-workdir")
         .getRelative(workspaceName);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -61,6 +61,14 @@ public class WorkerMultiplexer {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   /**
+   * An ID for this multiplexer that can be used by sandboxed multiplex workers to generate their
+   * workdir. The workdir needs to be the same for all {@code SandboxedWorkerProxy} instances
+   * associated with a {@code WorkerMultiplexer}, but needs to be unique across multiplexers for the
+   * same mnemonic. This is analogous to the @{code workerId} created in {@code WorkerFactory}.
+   */
+  private final int multiplexerId;
+
+  /**
    * A queue of {@link WorkRequest} instances that need to be sent to the worker. {@link
    * WorkerProxy} instances add to this queue, while the requestSender subthread remove requests and
    * send them to the worker. This prevents dynamic execution interrupts from corrupting the {@code
@@ -125,10 +133,11 @@ public class WorkerMultiplexer {
    */
   private Thread shutdownHook;
 
-  WorkerMultiplexer(Path logFile, WorkerKey workerKey) {
+  WorkerMultiplexer(Path logFile, WorkerKey workerKey, int multiplexerId) {
     this.status = new WorkerProcessStatus();
     this.logFile = logFile;
     this.workerKey = workerKey;
+    this.multiplexerId = multiplexerId;
   }
 
   /** Sets or clears the reporter for outputting verbose info. */
@@ -484,5 +493,9 @@ public class WorkerMultiplexer {
       return -1;
     }
     return process.getProcessId();
+  }
+
+  public int getMultiplexerId() {
+    return this.multiplexerId;
   }
 }


### PR DESCRIPTION
Prior to this change, multiplex sandboxed workers shared a working directory per mnemonic. This caused a race condition when a new multiplex sandboxed worker with the same mnemonic was launched because when launching it cleaned the working directory. That could cause problems for any actions executing in that directory.

This change makes it so each multiplex sandbox worker process has a unique working directory. It does so while ensuring each SandboxedWorkerProxy and the associated sandbox are still associated with the correct multiplexer process and working directory.

Resolves #22589

I couldn't figure out if the Bazel repo has an autoformatter somewhere, so I did my best to manually format the code with a style that follows the existing code.