### PR TITLE
Always include `java.management` in Java module deps

### DIFF
--- a/src/test/shell/bazel/jdeps_test.sh
+++ b/src/test/shell/bazel/jdeps_test.sh
@@ -79,6 +79,9 @@ function test_jdeps() {
 
   # Keep java.instrument for allocation_instrumenter, which is supplied by the user.
   echo "java.instrument" >> jdeps
+  # java.management is needed for JMX Beans, but for some reason ends up missing from
+  # the jdeps output in some cases.
+  echo "java.management" >> jdeps
 
   # Make the list sorted and unique and compare it with expected results.
   cat jdeps | \


### PR DESCRIPTION
This works around inexplicable absences of this module in `jdeps_test` when run with RBE.

Fixes https://github.com/bazelbuild/bazel/issues/12685