### PR TITLE
[8.2.0] Fix bootstrap test by setting C++ standard to `c++17`

### DIFF
--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -50,6 +50,8 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --java_language_version=${JAVA_VERSION} \
       --tool_java_runtime_version=${JAVA_VERSION} \
       --tool_java_language_version=${JAVA_VERSION} \
+      --cxxopt=-std=c++17 \
+      --host_cxxopt=-std=c++17 \
       ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"
 


### PR DESCRIPTION
The `apple_support` toolchain doesn't pass `-std=c++17` by default (like the `rules_cc` toolchain did), which broke boostrapping on macOS.

Closes #25407.

PiperOrigin-RevId: 731754906
Change-Id: Ida37babf9837a8e841b31d1d64e2e47376f37fe1

Commit https://github.com/bazelbuild/bazel/commit/1fb83714fd3c34d48c994fc837a331a582849f10