### PR TITLE
Add `testing.failure_or_none`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
@@ -13,10 +13,14 @@
 // limitations under the License.
 package com.google.devtools.build.lib.rules.test;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.BazelRuleAnalysisThreadContext;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
 import com.google.devtools.build.lib.analysis.RunEnvironmentInfo;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleClassFunctions;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleClassFunctions.StarlarkRuleFunction;
+import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleContext;
 import com.google.devtools.build.lib.analysis.test.ExecutionInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
@@ -27,10 +31,12 @@ import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.starlarkbuildapi.test.TestingModuleApi;
 import com.google.devtools.build.lib.util.Fingerprint;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkFunction;
 import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkThread;
@@ -177,5 +183,27 @@ public class StarlarkTestingModule implements TestingModuleApi {
     args.put("name", name);
     args.putAll(attrValues);
     starlarkRuleFunction.call(thread, Tuple.of(), args.buildImmutable());
+  }
+
+  @Override
+  @Nullable
+  public String failureOrNone(StarlarkCallable callable, StarlarkThread thread)
+      throws EvalException, InterruptedException {
+    StarlarkRuleContext ruleContext =
+        BazelRuleAnalysisThreadContext.fromOrFail(
+                thread, "testing.%s".formatted(FAILURE_OR_NONE_NAME))
+            .getRuleContext()
+            .getStarlarkRuleContext();
+    if (!ruleContext.getRuleContext().getRule().isAnalysisTest()) {
+      throw Starlark.errorf(
+          "testing.%s can only be called from an analysis_test", FAILURE_OR_NONE_NAME);
+    }
+    try {
+      Starlark.call(thread, callable, ImmutableList.of(), ImmutableMap.of());
+      return null;
+    } catch (EvalException e) {
+      // Distinguish between no failure and a failure with a null message.
+      return e.getMessage() != null ? e.getMessage() : "<no message>";
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/TestingModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/TestingModuleApi.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.starlarkbuildapi.test;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.starlarkbuildapi.RunEnvironmentInfoApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkRuleFunctionsApi;
+import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
@@ -24,6 +25,7 @@ import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Sequence;
+import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkFunction;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
@@ -144,5 +146,26 @@ public interface TestingModuleApi extends StarlarkValue {
       Sequence<?> toolchains,
       Object argsValue,
       StarlarkThread thread)
+      throws EvalException, InterruptedException;
+
+  String FAILURE_OR_NONE_NAME = "failure_or_none";
+
+  @StarlarkMethod(
+      name = FAILURE_OR_NONE_NAME,
+      doc =
+          "Executes the given function and returns the message of the first failure it encounters"
+              + " or None if it runs without encountering any. This is useful for testing that a"
+              + " function fails in a specific way (e.g., by calling <code>fail()</code>.",
+      parameters = {
+        @Param(
+            name = "function",
+            named = true,
+            allowedTypes = {@ParamType(type = StarlarkCallable.class)},
+            doc = "The function to call without any arguments."),
+      },
+      allowReturnNones = true,
+      useStarlarkThread = true)
+  @Nullable
+  String failureOrNone(StarlarkCallable callable, StarlarkThread thread)
       throws EvalException, InterruptedException;
 }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -6588,6 +6588,89 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         "Error in analysis_test: 'name' cannot be set or overridden in 'attr_values'");
   }
 
+  @Test
+  public void testAnalysisTestFailureOrNone() throws Exception {
+    scratch.file(
+        "p/b.bzl",
+        """
+        def impl(ctx):
+            failure = testing.failure_or_none(lambda: fail("failure"))
+            if failure != "failure":
+                fail("Expected failure, got: %s" % failure)
+            no_failure = testing.failure_or_none(lambda: None)
+            if no_failure != None:
+                fail("Expected None, got: %s" % no_failure)
+            return [AnalysisTestResultInfo(
+                success = True,
+                message = "",
+            )]
+
+        def my_test_macro(name):
+            testing.analysis_test(name = name, implementation = impl)
+        """);
+    scratch.file(
+        "p/BUILD",
+        """
+        load(":b.bzl", "my_test_macro")
+
+        my_test_macro(name = "my_test_target")
+        """);
+
+    getConfiguredTarget("//p:my_test_target");
+
+    assertNoEvents();
+  }
+
+  @Test
+  public void testAnalysisTestFailureOrNoneCalledInBuildFile() throws Exception {
+    scratch.file(
+        "p/b.bzl",
+        """
+        def catch_failure():
+            testing.failure_or_none(lambda: fail("failure"))
+        """);
+    scratch.file(
+        "p/BUILD",
+        """
+        load(":b.bzl", "catch_failure")
+        catch_failure()
+        filegroup(name = "my_target")
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//p:my_target");
+
+    assertContainsEvent(
+        "testing.failure_or_none can only be called from a rule or aspect implementation");
+  }
+
+  @Test
+  public void testAnalysisTestFailureOrNoneCalledInNonAnalysisTestRule() throws Exception {
+    scratch.file(
+        "p/b.bzl",
+        """
+        def impl(ctx):
+            failure = testing.failure_or_none(lambda: fail("failure"))
+            if failure != "failure":
+                fail("Expected failure, got: %s" % failure)
+
+        my_rule = rule(impl)
+        """);
+    scratch.file(
+        "p/BUILD",
+        """
+        load(":b.bzl", "my_rule")
+
+        my_rule(name = "my_target")
+        """);
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//p:my_target");
+
+    assertContainsEvent(
+        "testing.failure_or_none can only be called from an analysis_test");
+  }
+
   private Object eval(Module module, String... lines) throws Exception {
     ParserInput input = ParserInput.fromLines(lines);
     return Starlark.eval(input, FileOptions.DEFAULT, module, ev.getStarlarkThread());


### PR DESCRIPTION
The new function is restricted to analysis test implementation functions to avoid concerns described in https://github.com/bazelbuild/bazel/issues/18008#issuecomment-1502152199.

RELNOTES: In Starlark tests, the new function `testing.failure_or_none` can be used to run a function and return its failure message (e.g., from a call to `fail()`) or `None` if there is none.

Related to #18008