### PR TITLE
[7.6.0] Emit BAZEL_CURRENT_REPOSITORY when using @rules_cc//cc/runfiles

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -971,11 +971,12 @@ def _is_stamping_enabled_for_aspect(ctx):
         stamp = ctx.rule.attr.stamp
     return stamp
 
-_RUNFILES_LIBRARY_TARGET = Label("@bazel_tools//tools/cpp/runfiles")
+_RUNFILES_LIBRARY_TARGET = Label("@rules_cc//cc/runfiles")
+_LEGACY_RUNFILES_LIBRARY_TARGET = Label("@bazel_tools//tools/cpp/runfiles")
 
 def _get_local_defines_for_runfiles_lookup(ctx, all_deps):
     for dep in all_deps:
-        if dep.label == _RUNFILES_LIBRARY_TARGET:
+        if dep.label == _RUNFILES_LIBRARY_TARGET or dep.label == _LEGACY_RUNFILES_LIBRARY_TARGET:
             return ["BAZEL_CURRENT_REPOSITORY=\"{}\"".format(ctx.label.workspace_name)]
     return []
 

--- a/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_repo_mapping_test.py
@@ -256,7 +256,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
         env_add={'RUNFILES_LIB_DEBUG': '1'},
     )
 
-  def testCppRunfilesLibraryRepoMapping(self):
+  def testLegacyCppRunfilesLibraryRepoMapping(self):
     self.main_registry.setModuleBasePath('projects')
     projects_dir = self.main_registry.projects
 
@@ -288,6 +288,58 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
             '#include <fstream>',
             '#include "tools/cpp/runfiles/runfiles.h"',
             'using bazel::tools::cpp::runfiles::Runfiles;',
+            'int main(int argc, char** argv) {',
+            (
+                '  Runfiles* runfiles = Runfiles::Create(argv[0],'
+                ' BAZEL_CURRENT_REPOSITORY);'
+            ),
+            '  std::ifstream f1(runfiles->Rlocation(argv[1]));',
+            '  if (!f1.good()) std::exit(1);',
+            '  std::ifstream f2(runfiles->Rlocation("data/foo.txt"));',
+            '  if (!f2.good()) std::exit(2);',
+            '}',
+        ],
+    )
+
+    self.ScratchFile('MODULE.bazel', ['bazel_dep(name="test",version="1.0")'])
+
+    # Run sandboxed on Linux and macOS.
+    self.RunBazel(['test', '@test//:test', '--test_output=errors'])
+    # Run unsandboxed on all platforms.
+    self.RunBazel(['run', '@test//:test'])
+
+  def testCppRunfilesLibraryRepoMapping(self):
+    self.main_registry.setModuleBasePath('projects')
+    projects_dir = self.main_registry.projects
+
+    self.main_registry.createLocalPathModule('data', '1.0', 'data')
+    scratchFile(projects_dir.joinpath('data', 'foo.txt'), ['hello'])
+    scratchFile(
+        projects_dir.joinpath('data', 'BUILD'), ['exports_files(["foo.txt"])']
+    )
+
+    self.main_registry.createLocalPathModule(
+        'test', '1.0', 'test', {'data': '1.0', 'rules_cc': '0.0.17'}
+    )
+    scratchFile(
+        projects_dir.joinpath('test', 'BUILD'),
+        [
+            'cc_test(',
+            '    name = "test",',
+            '    srcs = ["test.cpp"],',
+            '    data = ["@data//:foo.txt"],',
+            '    args = ["$(rlocationpath @data//:foo.txt)"],',
+            '    deps = ["@rules_cc//cc/runfiles"],',
+            ')',
+        ],
+    )
+    scratchFile(
+        projects_dir.joinpath('test', 'test.cpp'),
+        [
+            '#include <cstdlib>',
+            '#include <fstream>',
+            '#include "rules_cc/cc/runfiles/runfiles.h"',
+            'using rules_cc::cc::runfiles::Runfiles;',
             'int main(int argc, char** argv) {',
             (
                 '  Runfiles* runfiles = Runfiles::Create(argv[0],'


### PR DESCRIPTION
Bazel 7 emits the `BAZEL_CURRENT_REPOSITORY` preprocessor macro only
when depending on the copy of the cc runfiles library in `@bazel_tools`,
breaking users who want to write forwards-compatible code which pulls that
library from `@rules_cc`.  In commit 6f7faa659, a backport of 8a5e70c78,
Bazel 8.1 replaced its own implementation with a passthrough and updated
the check that macro uses to permit both locations.

This patch gives rules_cc users forwards-compatibility by backporting
the portion of that commit which emits the `BAZEL_CURRENT_REPOSITORY`
variable when using the runfiles library from rules_cc, but stops short
of actually removing the built-in runfiles library.