### PR TITLE
[8.2.0] Remove an unnecessary large dep from `DigestUtil`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -55,8 +55,8 @@ java_library(
         "DigestUtil.java",
     ],
     deps = [
-        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/util:stream_writer",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/protobuf:spawn_java_proto",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.io.BaseEncoding;
-import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
+import com.google.devtools.build.lib.util.StreamWriter;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.DigestUtils;
 import com.google.devtools.build.lib.vfs.FileStatus;
@@ -91,10 +91,9 @@ public class DigestUtil {
         DigestUtils.getDigestWithManualFallback(path, xattrProvider, status), status.getSize());
   }
 
-  public static Digest compute(VirtualActionInput input, HashFunction hashFunction)
-      throws IOException {
-    // Stream the virtual action input as parameter files, which can be very large, are lazily
-    // computed from the in-memory CommandLine object. This avoids allocating large byte arrays.
+  public static Digest compute(StreamWriter input, HashFunction hashFunction) throws IOException {
+    // Stream the input as parameter files, which can be very large, are lazily computed from the
+    // in-memory CommandLine object. This avoids allocating large byte arrays.
     try (DigestOutputStream digestOutputStream =
         new DigestOutputStream(hashFunction, OutputStream.nullOutputStream())) {
       input.writeTo(digestOutputStream);
@@ -102,7 +101,7 @@ public class DigestUtil {
     }
   }
 
-  public Digest compute(VirtualActionInput input) throws IOException {
+  public Digest compute(StreamWriter input) throws IOException {
     return compute(input, hashFn.getHashFunction());
   }
 


### PR DESCRIPTION
Closes #25390.

PiperOrigin-RevId: 732260576
Change-Id: I51bfa5ecb0916e90608b6323cbd657859b0393c4

Commit https://github.com/bazelbuild/bazel/commit/13092462982d3d1fa6d7336962a75f78b52a8604