### PR TITLE
Skip strategies incompatible with path mapping during resolution

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -68,10 +68,10 @@ public final class Spawns {
   }
 
   /**
-   * Returns whether a Spawn must be executed on a separate exec root, for exampke, because it
-   * expects output paths to be rewritten or may not arbitrarily write its outputs.
+   * Returns whether a Spawn must be executed on a separate exec root (i.e. in a sandbox) since it
+   * references rewritten input and output paths.
    */
-  public static boolean requiresSandboxing(Spawn spawn) {
+  public static boolean usesPathMapping(Spawn spawn) {
     return !spawn.getPathMapper().isNoop();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -67,6 +67,14 @@ public final class Spawns {
         && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.LOCAL);
   }
 
+  /**
+   * Returns whether a Spawn must be executed on a separate exec root, for exampke, because it
+   * expects output paths to be rewritten or may not arbitrarily write its outputs.
+   */
+  public static boolean requiresSandboxing(Spawn spawn) {
+    return !spawn.getPathMapper().isNoop();
+  }
+
   /** Returns whether a Spawn needs network access in order to run successfully. */
   public static boolean requiresNetwork(Spawn spawn, boolean defaultSandboxDisallowNetwork) {
     if (spawn.getExecutionInfo().containsKey(ExecutionRequirements.BLOCK_NETWORK)) {

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -68,7 +68,7 @@ public final class Spawns {
   }
 
   /**
-   * Returns whether a Spawn must be executed on a separate exec root (i.e. in a sandbox) since it
+   * Returns whether a Spawn must be executed on a separate exec root (i.e., in a sandbox) since it
    * references rewritten input and output paths.
    */
   public static boolean usesPathMapping(Spawn spawn) {

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyResolver.java
@@ -92,7 +92,9 @@ public final class SpawnStrategyResolver implements ActionContext {
                     + " too strict. Visit https://github.com/bazelbuild/bazel/issues/7480 for"
                     + " advice",
                 spawn.getMnemonic(),
-                Spawns.requiresSandboxing(spawn) ? ", which requires sandboxing," : "",
+                Spawns.usesPathMapping(spawn)
+                    ? ", which requires sandboxing due to path mapping,"
+                    : "",
                 strategies);
         throw new UserExecException(
             FailureDetail.newBuilder()

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyResolver.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnStrategy;
+import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
@@ -86,11 +87,13 @@ public final class SpawnStrategyResolver implements ActionContext {
       if (fallbackStrategies.isEmpty()) {
         String message =
             String.format(
-                "%s spawn cannot be executed with any of the available strategies: %s. Your"
+                "%s spawn%s cannot be executed with any of the available strategies: %s. Your"
                     + " --spawn_strategy, --genrule_strategy and/or --strategy flags are probably"
                     + " too strict. Visit https://github.com/bazelbuild/bazel/issues/7480 for"
                     + " advice",
-                spawn.getMnemonic(), strategies);
+                spawn.getMnemonic(),
+                Spawns.requiresSandboxing(spawn) ? ", which requires sandboxing," : "",
+                strategies);
         throw new UserExecException(
             FailureDetail.newBuilder()
                 .setMessage(message)

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -168,7 +168,7 @@ public class LocalSpawnRunner implements SpawnRunner {
 
   @Override
   public boolean canExec(Spawn spawn) {
-    return !Spawns.requiresSandboxing(spawn);
+    return !Spawns.usesPathMapping(spawn);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -168,7 +168,7 @@ public class LocalSpawnRunner implements SpawnRunner {
 
   @Override
   public boolean canExec(Spawn spawn) {
-    return true;
+    return !Spawns.requiresSandboxing(spawn);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -26,6 +26,7 @@ import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
@@ -477,6 +478,9 @@ public final class SandboxModule extends BlazeModule {
 
     @Override
     public boolean canExecWithLegacyFallback(Spawn spawn) {
+      if (Spawns.requiresSandboxing(spawn)) {
+        return false;
+      }
       boolean canExec = !sandboxSpawnRunner.canExec(spawn) && fallbackSpawnRunner.canExec(spawn);
       if (canExec) {
         // We give a warning to use strategies instead, whether or not we allow the fallback

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -478,7 +478,7 @@ public final class SandboxModule extends BlazeModule {
 
     @Override
     public boolean canExecWithLegacyFallback(Spawn spawn) {
-      if (Spawns.requiresSandboxing(spawn)) {
+      if (Spawns.usesPathMapping(spawn)) {
         return false;
       }
       boolean canExec = !sandboxSpawnRunner.canExec(spawn) && fallbackSpawnRunner.canExec(spawn);

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -132,19 +132,19 @@ public class WorkerParser {
       WorkerProtocolFormat protocolFormat) {
     String workerKeyMnemonic = Spawns.getWorkerKeyMnemonic(spawn);
     boolean mustSandbox = dynamic || Spawns.usesPathMapping(spawn);
-    boolean multiplex, sandboxed;
+    boolean shouldMultiplex = options.workerMultiplex && Spawns.supportsMultiplexWorkers(spawn);
+    boolean sandboxed, multiplex;
     if (mustSandbox) {
       sandboxed = true;
-      multiplex = multiplexRequested(spawn, options)
+      multiplex = shouldMultiplex
           && Spawns.supportsMultiplexSandboxing(spawn);
+    } else if (shouldMultiplex) {
+      sandboxed = options.multiplexSandboxing
+          && Spawns.supportsMultiplexSandboxing(spawn);
+      multiplex = true;
     } else {
-      multiplex = multiplexRequested(spawn, options);
-      if (multiplex) {
-        sandboxed = options.multiplexSandboxing
-            && Spawns.supportsMultiplexSandboxing(spawn);
-      } else {
-        sandboxed = options.workerSandboxing;
-      }
+      sandboxed = options.workerSandboxing;
+      multiplex = false;
     }
     boolean useInMemoryTracking = false;
     if (sandboxed) {
@@ -163,10 +163,6 @@ public class WorkerParser {
         multiplex,
         Spawns.supportsWorkerCancellation(spawn),
         protocolFormat);
-  }
-
-  private static boolean multiplexRequested(Spawn spawn, WorkerOptions options) {
-    return options.workerMultiplex && Spawns.supportsMultiplexWorkers(spawn);
   }
 
   private static boolean isFlagFileArg(String arg) {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -132,15 +132,15 @@ public class WorkerParser {
       WorkerProtocolFormat protocolFormat) {
     String workerKeyMnemonic = Spawns.getWorkerKeyMnemonic(spawn);
     boolean mustSandbox = dynamic || Spawns.usesPathMapping(spawn);
-    boolean multiplex = canMultiplex(spawn, options)
-        && (!mustSandbox || canSandboxWithMultiplexing(spawn, options));
-    boolean sandboxed;
+    boolean multiplex, sandboxed;
     if (mustSandbox) {
       sandboxed = true;
-    } else if (multiplex) {
-      sandboxed = canSandboxWithMultiplexing(spawn, options);
+      multiplex = canMultiplex(spawn, options)
+          && canSandboxWithMultiplexing(spawn, options);
     } else {
-      sandboxed = options.workerSandboxing;
+      multiplex = canMultiplex(spawn, options);
+      sandboxed = (multiplex && canSandboxWithMultiplexing(spawn, options))
+          || options.workerSandboxing;
     }
     boolean useInMemoryTracking = false;
     if (sandboxed) {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -135,12 +135,16 @@ public class WorkerParser {
     boolean multiplex, sandboxed;
     if (mustSandbox) {
       sandboxed = true;
-      multiplex = canMultiplex(spawn, options)
-          && canSandboxWithMultiplexing(spawn, options);
+      multiplex = multiplexRequested(spawn, options)
+          && Spawns.supportsMultiplexSandboxing(spawn);
     } else {
-      multiplex = canMultiplex(spawn, options);
-      sandboxed = (multiplex && canSandboxWithMultiplexing(spawn, options))
-          || options.workerSandboxing;
+      multiplex = multiplexRequested(spawn, options);
+      if (multiplex) {
+        sandboxed = options.multiplexSandboxing
+            && Spawns.supportsMultiplexSandboxing(spawn);
+      } else {
+        sandboxed = options.workerSandboxing;
+      }
     }
     boolean useInMemoryTracking = false;
     if (sandboxed) {
@@ -161,13 +165,8 @@ public class WorkerParser {
         protocolFormat);
   }
 
-  private static boolean canMultiplex(Spawn spawn, WorkerOptions options) {
+  private static boolean multiplexRequested(Spawn spawn, WorkerOptions options) {
     return options.workerMultiplex && Spawns.supportsMultiplexWorkers(spawn);
-  }
-
-  private static boolean canSandboxWithMultiplexing(
-      Spawn spawn, WorkerOptions options) {
-    return options.multiplexSandboxing && Spawns.supportsMultiplexSandboxing(spawn);
   }
 
   private static boolean isFlagFileArg(String arg) {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -133,14 +133,14 @@ public class WorkerParser {
     String workerKeyMnemonic = Spawns.getWorkerKeyMnemonic(spawn);
     boolean mustSandbox = dynamic || Spawns.usesPathMapping(spawn);
     boolean shouldMultiplex = options.workerMultiplex && Spawns.supportsMultiplexWorkers(spawn);
+    boolean canSandboxMultiplex =
+        options.multiplexSandboxing && Spawns.supportsMultiplexSandboxing(spawn);
     boolean sandboxed, multiplex;
     if (mustSandbox) {
       sandboxed = true;
-      multiplex = shouldMultiplex
-          && Spawns.supportsMultiplexSandboxing(spawn);
+      multiplex = shouldMultiplex && canSandboxMultiplex;
     } else if (shouldMultiplex) {
-      sandboxed = options.multiplexSandboxing
-          && Spawns.supportsMultiplexSandboxing(spawn);
+      sandboxed = canSandboxMultiplex;
       multiplex = true;
     } else {
       sandboxed = options.workerSandboxing;

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -154,8 +154,7 @@ public class WorkerParser {
   static boolean isMultiplexed(Spawn spawn, WorkerOptions options, boolean dynamic) {
     return options.workerMultiplex
         && Spawns.supportsMultiplexWorkers(spawn)
-        && !(dynamic
-            && !(Spawns.supportsMultiplexSandboxing(spawn) && options.multiplexSandboxing));
+        && (!dynamic || (Spawns.supportsMultiplexSandboxing(spawn) && options.multiplexSandboxing));
   }
 
   static boolean isSandboxed(Spawn spawn, WorkerOptions options, boolean dynamic) {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -162,14 +162,12 @@ public class WorkerParser {
   }
 
   private static boolean canMultiplex(Spawn spawn, WorkerOptions options) {
-    return options.workerMultiplex
-        && Spawns.supportsMultiplexWorkers(spawn);
+    return options.workerMultiplex && Spawns.supportsMultiplexWorkers(spawn);
   }
 
   private static boolean canSandboxWithMultiplexing(
       Spawn spawn, WorkerOptions options) {
-    return Spawns.supportsMultiplexSandboxing(spawn)
-        && options.multiplexSandboxing;
+    return options.multiplexSandboxing && Spawns.supportsMultiplexSandboxing(spawn);
   }
 
   private static boolean isFlagFileArg(String arg) {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -138,6 +138,12 @@ final class WorkerSpawnRunner implements SpawnRunner {
     if (spawn.getToolFiles().isEmpty()) {
       return false;
     }
+    // Dynamic execution only makes it more likely that the spawn is sandboxed.
+    // TODO: Verify that spawns that require sandboxing can run with dynamic execution.
+    if (Spawns.requiresSandboxing(spawn)
+        && !WorkerParser.isSandboxed(spawn, workerOptions, /* dynamic= */ false)) {
+      return false;
+    }
     return true;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -140,7 +140,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
     }
     // Dynamic execution only makes it more likely that the spawn is sandboxed.
     // TODO: Verify that spawns that require sandboxing can run with dynamic execution.
-    if (Spawns.requiresSandboxing(spawn)
+    if (Spawns.usesPathMapping(spawn)
         && !WorkerParser.isSandboxed(spawn, workerOptions, /* dynamic= */ false)) {
       return false;
     }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -138,12 +138,6 @@ final class WorkerSpawnRunner implements SpawnRunner {
     if (spawn.getToolFiles().isEmpty()) {
       return false;
     }
-    // Dynamic execution only makes it more likely that the spawn is sandboxed.
-    // TODO: Verify that spawns that require sandboxing can run with dynamic execution.
-    if (Spawns.usesPathMapping(spawn)
-        && !WorkerParser.isSandboxed(spawn, workerOptions, /* dynamic= */ false)) {
-      return false;
-    }
     return true;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ExecutionRequirements.WorkerProtocolFormat;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ResourceManager;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -103,6 +104,7 @@ public class WorkerSpawnRunnerTest {
         .registerWorker(
             anyInt(), anyLong(), any(), anyString(), anyBoolean(), anyBoolean(), anyInt(), any());
     when(spawn.getLocalResources()).thenReturn(ResourceSet.createWithRamCpu(100, 1));
+    when(spawn.getPathMapper()).thenReturn(PathMapper.NOOP);
     when(resourceManager.acquireResources(any(), any(), any())).thenReturn(resourceHandle);
     when(resourceHandle.getWorker()).thenReturn(worker);
   }

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -140,11 +140,6 @@ function test_path_stripping_sandboxed() {
 }
 
 function test_path_stripping_singleplex_worker() {
-  if is_windows; then
-    echo "Skipping test_path_stripping_singleplex_worker on Windows as it requires sandboxing"
-    return
-  fi
-
   cache_dir=$(mktemp -d)
 
   # Worker sandboxing is enabled automatically, multiplexing is disabled since

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -181,11 +181,11 @@ EOF
 
   cache_dir=$(mktemp -d)
 
-  # Multiplex sandboxing is enabled automatically if supported by the toolchain.
   bazel run -c fastbuild \
     --disk_cache=$cache_dir \
     --experimental_output_paths=strip \
     --strategy=Javac=worker \
+    --experimental_worker_multiplex_sandboxing \
     --extra_toolchains=//toolchain:java_toolchain_definition \
     --java_language_version=17 \
     //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"
@@ -200,6 +200,7 @@ EOF
     --disk_cache=$cache_dir \
     --experimental_output_paths=strip \
     --strategy=Javac=worker \
+    --experimental_worker_multiplex_sandboxing \
     --extra_toolchains=//toolchain:java_toolchain_definition \
     --java_language_version=17 \
     //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -97,6 +97,17 @@ function tear_down() {
   stop_worker
 }
 
+function test_path_stripping_local_fails() {
+  cache_dir=$(mktemp -d)
+
+  bazel build -c fastbuild \
+    --disk_cache=$cache_dir \
+    --experimental_output_paths=strip \
+    --strategy=Javac=local \
+    //src/main/java/com/example:Main &> $TEST_log && fail "build succeeded unexpectedly"
+  expect_log 'Javac spawn, which requires sandboxing, cannot be executed with any of the available strategies'
+}
+
 function test_path_stripping_sandboxed() {
   if is_windows; then
     echo "Skipping test_path_stripping_sandboxed on Windows as it requires sandboxing"
@@ -105,10 +116,12 @@ function test_path_stripping_sandboxed() {
 
   cache_dir=$(mktemp -d)
 
+  # Validate that the sandboxed strategy is preferred over the local strategy
+  # with path mapping.
   bazel run -c fastbuild \
     --disk_cache=$cache_dir \
     --experimental_output_paths=strip \
-    --strategy=Javac=sandboxed \
+    --strategy=Javac=local,sandboxed \
     //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"
   expect_log 'Hello, World!'
   # JavaToolchainCompileBootClasspath, JavaToolchainCompileClasses, 1x header compilation and 2x
@@ -124,6 +137,19 @@ function test_path_stripping_sandboxed() {
   expect_log 'Hello, World!'
   expect_log '5 disk cache hit'
   expect_not_log '[0-9] \(linux\|darwin\|processwrapper\)-sandbox'
+}
+
+function test_path_stripping_unsandboxed_singleplex_worker_fails() {
+  cache_dir=$(mktemp -d)
+
+  bazel build -c fastbuild \
+    --disk_cache=$cache_dir \
+    --experimental_output_paths=strip \
+    --strategy=Javac=worker \
+    --noworker_sandboxing \
+    --noexperimental_worker_multiplex \
+    //src/main/java/com/example:Main &> $TEST_log && fail "build succeeded unexpectedly"
+  expect_log 'Javac spawn, which requires sandboxing, cannot be executed with any of the available strategies'
 }
 
 function test_path_stripping_singleplex_worker() {
@@ -159,6 +185,18 @@ function test_path_stripping_singleplex_worker() {
   expect_log '5 disk cache hit'
   expect_not_log '[0-9] \(linux\|darwin\|processwrapper\)-sandbox'
   expect_not_log '[0-9] worker'
+}
+
+function test_path_stripping_unsandboxed_multiplex_worker_fails() {
+  cache_dir=$(mktemp -d)
+
+  bazel run -c fastbuild \
+    --disk_cache=$cache_dir \
+    --experimental_output_paths=strip \
+    --strategy=Javac=worker \
+    --noexperimental_worker_multiplex_sandboxing \
+    //src/main/java/com/example:Main &> $TEST_log && fail "build succeeded unexpectedly"
+  expect_log 'Javac spawn, which requires sandboxing, cannot be executed with any of the available strategies'
 }
 
 function test_path_stripping_multiplex_worker() {

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -143,7 +143,7 @@ function test_path_stripping_singleplex_worker() {
   cache_dir=$(mktemp -d)
 
   # Worker sandboxing is enabled automatically, multiplexing is disabled since
-  # the default toolchain does not support it yet.
+  # the default toolchain does not support sandboxing yet.
   bazel run -c fastbuild \
     --disk_cache=$cache_dir \
     --experimental_output_paths=strip \

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -105,7 +105,7 @@ function test_path_stripping_local_fails() {
     --experimental_output_paths=strip \
     --strategy=Javac=local \
     //src/main/java/com/example:Main &> $TEST_log && fail "build succeeded unexpectedly"
-  expect_log 'Javac spawn, which requires sandboxing, cannot be executed with any of the available strategies'
+  expect_log 'Javac spawn, which requires sandboxing due to path mapping, cannot be executed with any of the available strategies'
 }
 
 function test_path_stripping_sandboxed() {
@@ -149,7 +149,7 @@ function test_path_stripping_unsandboxed_singleplex_worker_fails() {
     --noworker_sandboxing \
     --noexperimental_worker_multiplex \
     //src/main/java/com/example:Main &> $TEST_log && fail "build succeeded unexpectedly"
-  expect_log 'Javac spawn, which requires sandboxing, cannot be executed with any of the available strategies'
+  expect_log 'Javac spawn, which requires sandboxing due to path mapping, cannot be executed with any of the available strategies'
 }
 
 function test_path_stripping_singleplex_worker() {
@@ -196,7 +196,7 @@ function test_path_stripping_unsandboxed_multiplex_worker_fails() {
     --strategy=Javac=worker \
     --noexperimental_worker_multiplex_sandboxing \
     //src/main/java/com/example:Main &> $TEST_log && fail "build succeeded unexpectedly"
-  expect_log 'Javac spawn, which requires sandboxing, cannot be executed with any of the available strategies'
+  expect_log 'Javac spawn, which requires sandboxing due to path mapping, cannot be executed with any of the available strategies'
 }
 
 function test_path_stripping_multiplex_worker() {

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -181,11 +181,11 @@ EOF
 
   cache_dir=$(mktemp -d)
 
-  # Multiplex worker sandboxing is enabled automatically.
   bazel run -c fastbuild \
     --disk_cache=$cache_dir \
     --experimental_output_paths=strip \
     --strategy=Javac=worker \
+    --experimental_worker_multiplex_sandboxing \
     --extra_toolchains=//toolchain:java_toolchain_definition \
     --java_language_version=17 \
     //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"
@@ -200,6 +200,7 @@ EOF
     --disk_cache=$cache_dir \
     --experimental_output_paths=strip \
     --strategy=Javac=worker \
+    --experimental_worker_multiplex_sandboxing \
     --extra_toolchains=//toolchain:java_toolchain_definition \
     --java_language_version=17 \
     //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -181,11 +181,11 @@ EOF
 
   cache_dir=$(mktemp -d)
 
+  # Multiplex sandboxing is enabled automatically if supported by the toolchain.
   bazel run -c fastbuild \
     --disk_cache=$cache_dir \
     --experimental_output_paths=strip \
     --strategy=Javac=worker \
-    --experimental_worker_multiplex_sandboxing \
     --extra_toolchains=//toolchain:java_toolchain_definition \
     --java_language_version=17 \
     //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"
@@ -200,7 +200,6 @@ EOF
     --disk_cache=$cache_dir \
     --experimental_output_paths=strip \
     --strategy=Javac=worker \
-    --experimental_worker_multiplex_sandboxing \
     --extra_toolchains=//toolchain:java_toolchain_definition \
     --java_language_version=17 \
     //src/main/java/com/example:Main &> $TEST_log || fail "run failed unexpectedly"


### PR DESCRIPTION
Spawn strategies that aren't sandboxed are now skipped while resolving a strategy for a path mapped spawn, which allows non-sandboxed strategies to be listed first and also results in a better error message if no compatible strategy is available (instead of an obscure exec failure). 

Worker execution is special in that it can always sandbox if needed, but may not do so based on options. For this purpose, path mapped spawns are now treated just like dynamically executed spawns by forcing sandboxing.

In the future, the same mechanism can potentially be used to run spawns for rewound actions in Bazel, which must not delete or override their previous outputs.

Work towards https://github.com/bazelbuild/bazel/discussions/22658#discussioncomment-12431355
Fixes https://github.com/bazel-contrib/rules_go/issues/4366