### PR TITLE
Enable sparse checkout in git_repository rule

### DIFF
--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -721,4 +721,84 @@ EOF
   bazel build //:all >& $TEST_log || fail "Expect bazel build to succeed."
 }
 
+# Message printed by the rule to indicate that the Git executable does not support sparse checkout,
+# and that it is falling back to a full checkout.
+sparse_checkout_fallback_message="WARNING: Sparse checkout is not supported\. Doing a full checkout\."
+
+function test_git_repository_with_sparse_checkout_patterns() {
+  local pluto_repo_dir=$(get_pluto_repo)
+
+  # Use sparse-checkout to only checkout the BUILD and WORKSPACE files.
+  cat >> MODULE.bazel <<EOF
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
+    name = "pluto",
+    remote = "$pluto_repo_dir",
+    tag = "1-build",
+    sparse_checkout_patterns = ["BUILD", "WORKSPACE"],
+)
+EOF
+  bazel fetch --noshow_progress @pluto >& $TEST_log
+
+  repo_dir=$(bazel info output_base)/external/+git_repository+pluto
+  assert_exists "$repo_dir/BUILD"
+  assert_exists "$repo_dir/WORKSPACE"
+  # If the Git executable does not support sparse checkout, then the implementation will fall back
+  # to a full checkout.
+  if grep -sq -- "$sparse_checkout_fallback_message" $TEST_log; then
+    assert_exists "$repo_dir/info"
+  else
+    assert_not_exists "$repo_dir/info"
+  fi
+}
+
+function test_git_repository_with_sparse_checkout_file() {
+  local pluto_repo_dir=$(get_pluto_repo)
+
+  # Use sparse-checkout to checkout everything but the `info` file
+  cat >> pluto-sparse-checkout.txt <<EOF
+/*
+!/info
+EOF
+  touch BUILD
+
+  cat >> MODULE.bazel <<EOF
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
+    name = "pluto",
+    remote = "$pluto_repo_dir",
+    tag = "1-build",
+    sparse_checkout_file = "pluto-sparse-checkout.txt",
+)
+EOF
+  bazel fetch --noshow_progress @pluto >& $TEST_log
+
+  repo_dir=$(bazel info output_base)/external/+git_repository+pluto
+  echo $repo_dir
+  assert_exists "$repo_dir/BUILD"
+  assert_exists "$repo_dir/WORKSPACE"
+  # If the Git executable does not support sparse checkout, then the implementation will fall back
+  # to a full checkout.
+  if grep -sq -- "$sparse_checkout_fallback_message" $TEST_log; then
+    assert_exists "$repo_dir/info"
+  else
+    assert_not_exists "$repo_dir/info"
+  fi
+}
+
+function test_git_repository_with_sparse_checkout_patterns_and_file_fails() {
+  cat >> MODULE.bazel <<EOF
+git_repository = use_repo_rule('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
+    name = "pluto",
+    remote = "does-not-matter",
+    tag = "1-build",
+    sparse_checkout_file = "foobar",
+    sparse_checkout_patterns = ["foo", "bar"],
+)
+EOF
+  bazel fetch @pluto >& $TEST_log && fail "Fetch succeeded"
+  expect_log "Only one of sparse_checkout_patterns and sparse_checkout_file can be provided."
+}
+
 run_suite "Starlark git_repository tests"

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -176,11 +176,24 @@ _common_attrs = {
             "Either `workspace_file` or `workspace_file_content` can be " +
             "specified, or neither, but not both.",
     ),
+    "sparse_checkout_patterns": attr.string_list(
+        default = [],
+        doc = "Sequence of patterns for a sparse checkout of files in this repository.",
+    ),
+    "sparse_checkout_file": attr.label(
+        doc =
+            "File containing .gitignore-style patterns for a sparse checkout of files " +
+            "in this repository. Either `sparse_checkout_patterns` or `sparse_checkout_file` " +
+            "may be specified, or neither, but not both.",
+    ),
 }
 
 def _git_repository_implementation(ctx):
     if ctx.attr.build_file and ctx.attr.build_file_content:
         fail("Only one of build_file and build_file_content can be provided.")
+    if ctx.attr.sparse_checkout_patterns and ctx.attr.sparse_checkout_file:
+        fail("Only one of sparse_checkout_patterns and sparse_checkout_file can be provided.")
+
     update = _clone_or_update_repo(ctx)
     workspace_and_buildfile(ctx)
     patch(ctx)

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -102,6 +102,28 @@ def git_repo(ctx, directory):
 
     return struct(commit = actual_commit, shallow_since = shallow_date)
 
+def _git_version(ctx):
+    """Gets the version of the Git executable."""
+    command = ["git", "--version"]
+    st = ctx.execute(command)
+    if st.return_code != 0:
+        _error(ctx.name, command, st.stderr)
+
+    # The output of `git --version` is in the format:
+    #
+    #     git version <major>.<minor>.<revision>[ ...]
+    #
+    # The revision may be a non-integer, so it is not converted to an int. Any additional text
+    # after <revision> is discarded.
+    version_str = st.stdout.split(" ")[2].rstrip("\n")
+    version_arr = version_str.split(".")
+    return struct(
+        major=int(version_arr[0]),
+        minor=int(version_arr[1]),
+        revision=version_arr[2],
+        full_str=version_str,
+    )
+
 def _report_progress(ctx, git_repo, *, shallow_failed = False):
     warning = ""
     if shallow_failed:
@@ -135,7 +157,21 @@ def add_origin(ctx, git_repo, remote):
 
 def fetch(ctx, git_repo):
     args = ["fetch", "origin", git_repo.fetch_ref]
+
+    sparse_checkout_patterns_or_file = ctx.attr.sparse_checkout_patterns or ctx.attr.sparse_checkout_file
+    if sparse_checkout_patterns_or_file:
+        if _git_sparse_checkout_config(ctx, git_repo):
+            # Use filter to disable downloading file contents until we set the `sparse-checkout` patterns.
+            args.append("--filter=blob:none")
+        else:
+            print("WARNING: Sparse checkout is not supported. Doing a full checkout.")
+            sparse_checkout_patterns_or_file = None
+
     st = _git_maybe_shallow(ctx, git_repo, *args)
+
+    if sparse_checkout_patterns_or_file:
+        _git_sparse_checkout(ctx, git_repo, sparse_checkout_patterns_or_file)
+
     if st.return_code == 0:
         return
     if ctx.attr.commit:
@@ -194,6 +230,52 @@ def _git_maybe_shallow(ctx, git_repo, command, *args):
         if st.return_code == 0:
             return st
     return _execute(ctx, git_repo, start + args_list)
+
+def _git_sparse_checkout_config(ctx, git_repo):
+    """Configures the repo for a sparse checkout.
+
+    If the Git executable does not support sparse checkout, this function prints a warning and returns False.
+    Otherwise, it returns True."""
+
+    git_version = _git_version(ctx)
+    # Sparse checkout was added in version 2.25.0.
+    if git_version.major < 2 or (git_version.major == 2 and git_version.minor < 25):
+        print("WARNING: Git v%s does not support sparse checkout." % (git_version.full_str))
+        return False
+
+    # Older versions of Git require this config to be set to the name of the promisor remote.
+    config_command = ["config", "extensions.partialClone", "origin"]
+    st = _execute(ctx, git_repo, config_command)
+    if st.return_code != 0:
+        _error(ctx.name, config_command, st.stderr)
+    return True
+
+def _git_sparse_checkout(ctx, git_repo, sparse_checkout_patterns_or_file):
+    """Initialize the repo with patterns for a sparse checkout.
+
+    Args:
+        ctx: Context of the calling rules.
+        git_repo: The Git repository to initialize for sparse checkout.
+        sparse_checkout_patterns_or_file: Either a list of patterns or a Label for a sparse-checkout file.
+    """
+    # Note: `init` is deprecated, but needed for older versions of Git. This command may be removed
+    # in future versions.
+    init_command = ["sparse-checkout", "init", "--no-cone"]
+    st = _execute(ctx, git_repo, init_command)
+    if st.return_code != 0:
+        _error(ctx.name, init_command, st.stderr)
+
+    if type(sparse_checkout_patterns_or_file) == "list":
+        sparse_checkout_patterns = sparse_checkout_patterns_or_file
+        set_command = ["sparse-checkout", "set"] + sparse_checkout_patterns
+        st = _execute(ctx, git_repo, set_command)
+        if st.return_code != 0:
+            _error(ctx.name, set_command, st.stderr)
+    else:
+        sparse_checkout_file = sparse_checkout_patterns_or_file
+        link_name = str(git_repo.directory) + "/.git/info/sparse-checkout"
+        ctx.delete(link_name)
+        ctx.symlink(sparse_checkout_file, link_name)
 
 # List of variables to unset when calling `git` to ensure no interference of
 # operation. This is in the form of a dict that can be passed to `execute()`.


### PR DESCRIPTION
Add a sparse_checkout_patterns argument to the git_repository rule. If non-empty, this will cause the rule to perform a sparse checkout of the repository, only checking out files that match the .gitignore-style patterns in this list.

Fixes issue #24069.