### PR TITLE
Attach context string to gRPC downloader requests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DelegatingDownloader.java
@@ -54,7 +54,8 @@ public class DelegatingDownloader implements Downloader {
       Path destination,
       ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
-      Optional<String> type)
+      Optional<String> type,
+      String context)
       throws IOException, InterruptedException {
     Downloader downloader = defaultDelegate;
     if (delegate != null) {
@@ -69,6 +70,7 @@ public class DelegatingDownloader implements Downloader {
         destination,
         eventHandler,
         clientEnv,
-        type);
+        type,
+        context);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -332,7 +332,8 @@ public class DownloadManager {
             destination,
             eventHandler,
             clientEnv,
-            type);
+            type,
+            context);
         break;
       } catch (InterruptedIOException e) {
         throw new InterruptedException(e.getMessage());

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
@@ -37,6 +37,7 @@ public interface Downloader {
    * @param checksum valid checksum which is checked, or absent to disable
    * @param output path to the destination file to write
    * @param type extension, e.g. "tar.gz" to force on downloaded filename, or empty to not do this
+   * @param context free-form string that describes the origin of the download for logging
    * @throws IOException if download was attempted and ended up failing
    * @throws InterruptedException if this thread is being cast into oblivion
    */
@@ -49,6 +50,7 @@ public interface Downloader {
       Path output,
       ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
-      Optional<String> type)
+      Optional<String> type,
+      String context)
       throws IOException, InterruptedException;
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -81,7 +81,8 @@ public class HttpDownloader implements Downloader {
       Path destination,
       ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
-      Optional<String> type)
+      Optional<String> type,
+      String context)
       throws IOException, InterruptedException {
     HttpConnectorMultiplexer multiplexer = setUpConnectorMultiplexer(eventHandler, clientEnv);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -138,10 +138,17 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       Path destination,
       ExtendedEventHandler eventHandler,
       Map<String, String> clientEnv,
-      Optional<String> type)
+      Optional<String> type,
+      String context)
       throws IOException, InterruptedException {
     RequestMetadata metadata =
-        TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "remote_downloader", null);
+        TracingMetadataUtils.buildMetadata(
+            buildRequestId,
+            commandId,
+            "remote_downloader",
+            /* mnemonic= */ null,
+            /* label= */ context,
+            /* configurationId= */ null);
     RemoteActionExecutionContext remoteActionExecutionContext =
         RemoteActionExecutionContext.create(metadata);
 
@@ -198,7 +205,8 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
           destination,
           eventHandler,
           clientEnv,
-          type);
+          type,
+          context);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
-import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import io.grpc.ClientInterceptor;
 import io.grpc.Context;
@@ -52,6 +51,24 @@ public class TracingMetadataUtils {
       String commandId,
       String actionId,
       @Nullable ActionExecutionMetadata actionMetadata) {
+    return buildMetadata(
+        buildRequestId,
+        commandId,
+        actionId,
+        actionMetadata != null ? actionMetadata.getProgressMessage() : null,
+        actionMetadata != null && actionMetadata.getOwner().getLabel() != null
+            ? actionMetadata.getOwner().getLabel().getCanonicalForm()
+            : null,
+        actionMetadata != null ? actionMetadata.getOwner().getConfigurationChecksum() : null);
+  }
+
+  public static RequestMetadata buildMetadata(
+      String buildRequestId,
+      String commandId,
+      String actionId,
+      @Nullable String mnemonic,
+      @Nullable String label,
+      @Nullable String configurationId) {
     Preconditions.checkNotNull(buildRequestId);
     Preconditions.checkNotNull(commandId);
     Preconditions.checkNotNull(actionId);
@@ -64,13 +81,14 @@ public class TracingMetadataUtils {
                 ToolDetails.newBuilder()
                     .setToolName("bazel")
                     .setToolVersion(BlazeVersionInfo.instance().getVersion()));
-    if (actionMetadata != null) {
-      builder.setActionMnemonic(actionMetadata.getMnemonic());
-      Label label = actionMetadata.getOwner().getLabel();
-      if (label != null) {
-        builder.setTargetId(label.getCanonicalForm());
-      }
-      builder.setConfigurationId(actionMetadata.getOwner().getConfigurationChecksum());
+    if (mnemonic != null) {
+      builder.setActionMnemonic(mnemonic);
+    }
+    if (label != null) {
+      builder.setTargetId(label);
+    }
+    if (configurationId != null) {
+      builder.setConfigurationId(configurationId);
     }
     return builder.build();
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
@@ -389,7 +390,8 @@ public class HttpDownloaderTest {
           destination,
           eventHandler,
           Collections.emptyMap(),
-          Optional.empty());
+          Optional.empty(),
+          "context");
 
       assertThat(new String(readFile(destination), UTF_8)).isEqualTo("hello");
     }
@@ -429,7 +431,8 @@ public class HttpDownloaderTest {
                   fs.getPath(workingDir.newFile().getAbsolutePath()),
                   eventHandler,
                   Collections.emptyMap(),
-                  Optional.empty()));
+                  Optional.empty(),
+                  "context"));
     }
   }
 
@@ -490,7 +493,8 @@ public class HttpDownloaderTest {
           destination,
           eventHandler,
           Collections.emptyMap(),
-          Optional.empty());
+          Optional.empty(),
+          "context");
 
       assertThat(new String(readFile(destination), UTF_8)).isEqualTo("content2");
     }
@@ -660,7 +664,7 @@ public class HttpDownloaderTest {
                   throw new ContentLengthMismatchException(0, data.length);
                 })
         .when(downloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
 
     assertThrows(
         ContentLengthMismatchException.class,
@@ -705,7 +709,7 @@ public class HttpDownloaderTest {
                   return null;
                 })
         .when(downloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
 
     Path result =
         download(
@@ -753,7 +757,7 @@ public class HttpDownloaderTest {
                   return null;
                 })
         .when(downloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
 
     Path result =
         download(
@@ -798,7 +802,7 @@ public class HttpDownloaderTest {
                   return null;
                 })
         .when(downloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
 
     Path result =
         download(
@@ -846,7 +850,7 @@ public class HttpDownloaderTest {
                   return null;
                 })
         .when(downloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("testRepo"));
 
     Path result =
         download(

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -201,7 +202,8 @@ public class GrpcRemoteDownloaderTest {
         destination,
         eventHandler,
         clientEnv,
-        Optional.<String>empty());
+        Optional.<String>empty(),
+        "context");
 
     try (InputStream in = destination.getInputStream()) {
       return ByteStreams.toByteArray(in);
@@ -266,7 +268,7 @@ public class GrpcRemoteDownloaderTest {
               return null;
             })
         .when(fallbackDownloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any(), eq("context"));
     final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
 
     final byte[] downloaded =


### PR DESCRIPTION
This makes it possible to correlate individual requests sent to the remote downloader with the repo rule or module extension they originated from.