### PR TITLE
[8.2.0] Fix Unicode encoding issues in Bazel's use of Starlark

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -825,6 +825,17 @@ public final class BuildLanguageOptions extends OptionsBase {
               + " number of files is not 1.")
   public boolean incompatibleLocationsPrefersExecutable;
 
+  @Option(
+      name = "internal_starlark_utf_8_byte_strings",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {OptionMetadataTag.HIDDEN},
+      help =
+          "Internal use only. Forces the Starlark implementation to operate on strings as raw"
+              + " UTF-8 byte arrays, matching Bazel's internal string encoding.")
+  public boolean internalStarlarkUtf8ByteStrings;
+
   /** An enum for specifying different modes for UTF-8 checking of Starlark files. */
   public enum Utf8EnforcementMode {
     OFF,
@@ -974,6 +985,9 @@ public final class BuildLanguageOptions extends OptionsBase {
                 INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE, incompatibleLocationsPrefersExecutable)
             .setBool(
                 StarlarkSemantics.EXPERIMENTAL_ENABLE_STARLARK_SET, experimentalEnableStarlarkSet)
+            .setBool(
+                StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS,
+                internalStarlarkUtf8ByteStrings)
             .build();
     return INTERNER.intern(semantics);
   }

--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -583,17 +583,20 @@ public final class Starlark {
    * processors interpreting indented parts of the original string as special formatting (e.g. code
    * blocks in the case of Markdown).
    */
+  // TODO: Pass in StarlarkSemantics as an argument rather than using StarlarkSemantics.DEFAULT.
   public static String trimDocString(String docString) {
     ImmutableList<String> lines = expandTabs(docString, 8).lines().collect(toImmutableList());
     if (lines.isEmpty()) {
       return "";
     }
     // First line is special: we fully strip it and ignore it for leading spaces calculation
-    String firstLineTrimmed = StringModule.INSTANCE.strip(lines.get(0), NONE);
+    String firstLineTrimmed =
+        StringModule.INSTANCE.stripSemantics(lines.get(0), NONE, StarlarkSemantics.DEFAULT);
     Iterable<String> subsequentLines = Iterables.skip(lines, 1);
     int minLeadingSpaces = Integer.MAX_VALUE;
     for (String line : subsequentLines) {
-      String strippedLeading = StringModule.INSTANCE.lstrip(line, NONE);
+      String strippedLeading =
+          StringModule.INSTANCE.lstripSemantics(line, NONE, StarlarkSemantics.DEFAULT);
       if (!strippedLeading.isEmpty()) {
         int leadingSpaces = line.length() - strippedLeading.length();
         minLeadingSpaces = min(leadingSpaces, minLeadingSpaces);
@@ -611,11 +614,14 @@ public final class Starlark {
         result.append("\n");
       }
       if (line.length() > minLeadingSpaces) {
-        result.append(StringModule.INSTANCE.rstrip(line.substring(minLeadingSpaces), NONE));
+        result.append(
+            StringModule.INSTANCE.rstripSemantics(
+                line.substring(minLeadingSpaces), NONE, StarlarkSemantics.DEFAULT));
       }
     }
     // Remove trailing empty lines
-    return StringModule.INSTANCE.rstrip(result.toString(), NONE);
+    return StringModule.INSTANCE.rstripSemantics(
+        result.toString(), NONE, StarlarkSemantics.DEFAULT);
   }
 
   /**

--- a/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
@@ -174,6 +174,9 @@ public class StarlarkSemantics {
 
     /** Returns an immutable StarlarkSemantics. */
     public StarlarkSemantics build() {
+      if (map.isEmpty()) {
+        return DEFAULT;
+      }
       return new StarlarkSemantics(ImmutableMap.copyOf(map));
     }
   }
@@ -259,4 +262,8 @@ public class StarlarkSemantics {
 
   /** Whether StarlarkSet objects may be constructed by the interpreter. */
   public static final String EXPERIMENTAL_ENABLE_STARLARK_SET = "+experimental_enable_starlark_set";
+
+  /** Whether the Starlark interpreter uses UTF-8 byte strings instead of UTF-16 strings. */
+  public static final String INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS =
+      "-internal_bazel_only_utf_8_byte_strings";
 }

--- a/src/main/java/net/starlark/java/eval/StringModule.java
+++ b/src/main/java/net/starlark/java/eval/StringModule.java
@@ -188,8 +188,20 @@ final class StringModule implements StarlarkValue {
   // whitespace, matching Python 3.
   private static final CharMatcher LATIN1_WHITESPACE =
       CharMatcher.anyOf(
-          "\u0009" + "\n" + "\u000B" + "\u000C" + "\r" + "\u001C" + "\u001D" + "\u001E" + "\u001F "
-              + "\u0085" + "\u00A0");
+          Joiner.on("") // to prevent autoformatter from concatenating the strings
+              .join(
+                  "\u0009", "\n", "\u000B", "\u000C", "\r", "\u001C", "\u001D", "\u001E", "\u001F",
+                  " ", "\u0085", "\u00A0"));
+
+  // This is used instead of LATIN1_WHITESPACE when strings are represented as raw UTF-8 byte
+  // arrays. In that case, we should not strip any bytes that are not ASCII whitespace, but part of
+  // a multibyte UTF-8 character.
+  private static final CharMatcher ASCII_WHITESPACE =
+      CharMatcher.anyOf(
+          Joiner.on("") // to prevent autoformatter from concatenating the strings
+              .join(
+                  "\u0009", "\n", "\u000B", "\u000C", "\r", "\u001C", "\u001D", "\u001E", "\u001F",
+                  " "));
 
   private static String stringLStrip(String self, CharMatcher matcher) {
     for (int i = 0; i < self.length(); i++) {
@@ -232,11 +244,15 @@ final class StringModule implements StarlarkValue {
             },
             doc = "The characters to remove, or all whitespace if None.",
             defaultValue = "None")
-      })
-  public String lstrip(String self, Object charsOrNone) {
-    CharMatcher matcher =
-        charsOrNone != Starlark.NONE ? CharMatcher.anyOf((String) charsOrNone) : LATIN1_WHITESPACE;
-    return stringLStrip(self, matcher);
+      },
+      useStarlarkThread = true)
+  public String lstrip(String self, Object charsOrNone, StarlarkThread starlarkThread) {
+    return lstripSemantics(self, charsOrNone, starlarkThread.getSemantics());
+  }
+
+  public String lstripSemantics(
+      String self, Object charsOrNone, StarlarkSemantics starlarkSemantics) {
+    return stringLStrip(self, matcher(charsOrNone, starlarkSemantics));
   }
 
   @StarlarkMethod(
@@ -258,11 +274,15 @@ final class StringModule implements StarlarkValue {
             },
             doc = "The characters to remove, or all whitespace if None.",
             defaultValue = "None")
-      })
-  public String rstrip(String self, Object charsOrNone) {
-    CharMatcher matcher =
-        charsOrNone != Starlark.NONE ? CharMatcher.anyOf((String) charsOrNone) : LATIN1_WHITESPACE;
-    return stringRStrip(self, matcher);
+      },
+      useStarlarkThread = true)
+  public String rstrip(String self, Object charsOrNone, StarlarkThread starlarkThread) {
+    return rstripSemantics(self, charsOrNone, starlarkThread.getSemantics());
+  }
+
+  public String rstripSemantics(
+      String self, Object charsOrNone, StarlarkSemantics starlarkSemantics) {
+    return stringRStrip(self, matcher(charsOrNone, starlarkSemantics));
   }
 
   @StarlarkMethod(
@@ -285,11 +305,26 @@ final class StringModule implements StarlarkValue {
             },
             doc = "The characters to remove, or all whitespace if None.",
             defaultValue = "None")
-      })
-  public String strip(String self, Object charsOrNone) {
-    CharMatcher matcher =
-        charsOrNone != Starlark.NONE ? CharMatcher.anyOf((String) charsOrNone) : LATIN1_WHITESPACE;
-    return stringStrip(self, matcher);
+      },
+      useStarlarkThread = true)
+  public String strip(String self, Object charsOrNone, StarlarkThread starlarkThread) {
+    return stripSemantics(self, charsOrNone, starlarkThread.getSemantics());
+  }
+
+  public String stripSemantics(
+      String self, Object charsOrNone, StarlarkSemantics starlarkSemantics) {
+    return stringStrip(self, matcher(charsOrNone, starlarkSemantics));
+  }
+
+  private static CharMatcher matcher(Object charsOrNone, StarlarkSemantics starlarkSemantics) {
+    return charsOrNone != Starlark.NONE
+        // When using the latin-1 hack, each utf-8 code unit is stored as a distinct string element.
+        // To avoid matching an element that doesn't correspond to a whole code point, we exclude
+        // anything that's not in the ASCII range.
+        ? CharMatcher.anyOf((String) charsOrNone)
+        : (starlarkSemantics.getBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS)
+            ? ASCII_WHITESPACE
+            : LATIN1_WHITESPACE);
   }
 
   @StarlarkMethod(

--- a/src/main/java/net/starlark/java/lib/json/Json.java
+++ b/src/main/java/net/starlark/java/lib/json/Json.java
@@ -14,6 +14,15 @@
 
 package net.starlark.java.lib.json;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
 import java.util.Arrays;
 import java.util.Map;
 import net.starlark.java.annot.Param;
@@ -27,6 +36,7 @@ import net.starlark.java.eval.StarlarkFloat;
 import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkIterable;
 import net.starlark.java.eval.StarlarkList;
+import net.starlark.java.eval.StarlarkSemantics;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
 import net.starlark.java.eval.Structure;
@@ -306,7 +316,13 @@ public final class Json implements StarlarkValue {
       useStarlarkThread = true)
   public Object decode(String x, Object defaultValue, StarlarkThread thread) throws EvalException {
     try {
-      return new Decoder(thread.mutability(), x).decode();
+      return new Decoder(
+              thread.mutability(),
+              x,
+              thread
+                  .getSemantics()
+                  .getBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS))
+          .decode();
     } catch (EvalException e) {
       if (defaultValue != Starlark.UNBOUND) {
         return defaultValue;
@@ -325,11 +341,13 @@ public final class Json implements StarlarkValue {
 
     private final Mutability mu;
     private final String s; // the input string
+    private final boolean utf8ByteStrings;
     private int i = 0; // current index in s
 
-    private Decoder(Mutability mu, String s) {
+    private Decoder(Mutability mu, String s, boolean utf8ByteStrings) {
       this.mu = mu;
       this.s = s;
+      this.utf8ByteStrings = utf8ByteStrings;
     }
 
     // decode is the entry point into the decoder.
@@ -441,6 +459,22 @@ public final class Json implements StarlarkValue {
       throw Starlark.errorf("unexpected character %s", quoteChar(c));
     }
 
+    // The default encoding behavior for Java's UTF-8 encoder is to replace with '?', not the
+    // Unicode replacement character U+FFFD. This also applies to String#getBytes(...).
+    private static final CharsetEncoder UTF_8_ENCODER =
+        UTF_8
+            .newEncoder()
+            .onMalformedInput(CodingErrorAction.REPLACE)
+            .onUnmappableCharacter(CodingErrorAction.REPLACE)
+            .replaceWith("\uFFFD".getBytes(UTF_8));
+    // The default encoding behavior for Java's UTF-16 encoder is to replace with the Unicode
+    // replacement character U+FFFD, but this doesn't apply to String#getBytes(...).
+    private static final CharsetEncoder UTF_16_ENCODER =
+        UTF_16
+            .newEncoder()
+            .onMalformedInput(CodingErrorAction.REPLACE)
+            .onUnmappableCharacter(CodingErrorAction.REPLACE);
+
     private String parseString() throws EvalException {
       i++; // '"'
       StringBuilder str = new StringBuilder();
@@ -472,53 +506,67 @@ public final class Json implements StarlarkValue {
         c = s.charAt(i);
         i++; // consume c
         switch (c) {
-          case '\\':
-          case '/':
-          case '"':
-            str.append(c);
-            break;
-          case 'b':
-            str.append('\b');
-            break;
-          case 'f':
-            str.append('\f');
-            break;
-          case 'n':
-            str.append('\n');
-            break;
-          case 'r':
-            str.append('\r');
-            break;
-          case 't':
-            str.append('\t');
-            break;
-          case 'u': // \ uXXXX
+          case '\\', '/', '"' -> str.append(c);
+          case 'b' -> str.append('\b');
+          case 'f' -> str.append('\f');
+          case 'n' -> str.append('\n');
+          case 'r' -> str.append('\r');
+          case 't' -> str.append('\t');
+          case 'u' -> {
             if (i + 4 >= s.length()) {
               throw Starlark.errorf("incomplete \\uXXXX escape");
             }
-            int hex = 0;
-            for (int j = 0; j < 4; j++) {
-              c = s.charAt(i + j);
-              int nybble = 0;
-              if (isdigit(c)) {
-                nybble = c - '0';
-              } else if ('a' <= c && c <= 'f') {
-                nybble = 10 + c - 'a';
-              } else if ('A' <= c && c <= 'F') {
-                nybble = 10 + c - 'A';
-              } else {
-                throw Starlark.errorf("invalid hex char %s in \\uXXXX escape", quoteChar(c));
-              }
-              hex = (hex << 4) | nybble;
+            StringBuilder utf16String = new StringBuilder();
+            utf16String.append(parseUnicodeEscape());
+            // Parse any additional \\uXXXX escapes so that surrogate pairs are decoded correctly.
+            while (i + 6 < s.length() && s.charAt(i) == '\\' && s.charAt(i + 1) == 'u') {
+              i += 2;
+              utf16String.append(parseUnicodeEscape());
             }
-            str.append((char) hex);
-            i += 4;
-            break;
-          default:
-            throw Starlark.errorf("invalid escape '\\%s'", c);
+            // Append the unescaped Unicode string as raw UTF-{8,16} bytes. See the comment on the
+            // CharsetEncoder instances above for why we can't use String#getBytes(...).
+            ByteBuffer byteBuffer;
+            try {
+              byteBuffer =
+                  (utf8ByteStrings ? UTF_8_ENCODER : UTF_16_ENCODER)
+                      .encode(CharBuffer.wrap(utf16String));
+            } catch (CharacterCodingException e) {
+              // Cannot happen because we replace with U+FFFD.
+              throw new IllegalStateException(e);
+            }
+            byte[] bytes = new byte[byteBuffer.remaining()];
+            byteBuffer.get(bytes);
+            if (utf8ByteStrings) {
+              str.append(new String(bytes, ISO_8859_1));
+            } else {
+              str.append(new String(bytes, UTF_16));
+            }
+          }
+          default -> throw Starlark.errorf("invalid escape '\\%s'", c);
         }
       }
       throw Starlark.errorf("unclosed string literal");
+    }
+
+    private char parseUnicodeEscape() throws EvalException {
+      int hex = 0;
+      for (int j = 0; j < 4; j++) {
+        char c = s.charAt(i + j);
+        int nybble;
+        if (isdigit(c)) {
+          nybble = c - '0';
+        } else if ('a' <= c && c <= 'f') {
+          nybble = 10 + c - 'a';
+        } else if ('A' <= c && c <= 'F') {
+          nybble = 10 + c - 'A';
+        } else {
+          throw Starlark.errorf("invalid hex char %s in \\uXXXX escape", quoteChar(c));
+        }
+        hex = (hex << 4) | nybble;
+      }
+      i += 4;
+      // 4 hex bytes -> 1 UTF-16 code unit
+      return (char) hex;
     }
 
     private Object parseNumber(char c) throws EvalException {
@@ -628,8 +676,10 @@ public final class Json implements StarlarkValue {
         @Param(name = "x"),
         @Param(name = "prefix", positional = false, named = true, defaultValue = "''"),
         @Param(name = "indent", positional = false, named = true, defaultValue = "'\\t'"),
-      })
-  public String encodeIndent(Object x, String prefix, String indent) throws EvalException {
+      },
+      useStarlarkThread = true)
+  public String encodeIndent(Object x, String prefix, String indent, StarlarkThread starlarkThread)
+      throws EvalException {
     return indent(encode(x), prefix, indent);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -97,7 +97,11 @@ public class ConsistencyTest {
   @Test
   public void checkDefaultsMatch() {
     BuildLanguageOptions defaultOptions = Options.getDefaults(BuildLanguageOptions.class);
-    StarlarkSemantics defaultSemantics = StarlarkSemantics.DEFAULT;
+    StarlarkSemantics defaultSemantics =
+        StarlarkSemantics.DEFAULT.toBuilder()
+            // This flag must be false in Starlark, but true in Bazel by default.
+            .setBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS, true)
+            .build();
     StarlarkSemantics semanticsFromOptions = defaultOptions.toStarlarkSemantics();
     assertThat(semanticsFromOptions).isEqualTo(defaultSemantics);
   }
@@ -159,6 +163,7 @@ public class ConsistencyTest {
         "--incompatible_use_cc_configure_from_rules_cc=" + rand.nextBoolean(),
         "--incompatible_unambiguous_label_stringification=" + rand.nextBoolean(),
         "--internal_starlark_flag_test_canary=" + rand.nextBoolean(),
+        "--internal_starlark_utf_8_byte_strings=" + rand.nextBoolean(),
         "--max_computation_steps=" + rand.nextLong());
   }
 
@@ -218,6 +223,7 @@ public class ConsistencyTest {
         .setBool(
             BuildLanguageOptions.INCOMPATIBLE_UNAMBIGUOUS_LABEL_STRINGIFICATION, rand.nextBoolean())
         .setBool(StarlarkSemantics.PRINT_TEST_MARKER, rand.nextBoolean())
+        .setBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS, rand.nextBoolean())
         .set(BuildLanguageOptions.MAX_COMPUTATION_STEPS, rand.nextLong())
         .build();
   }

--- a/src/test/java/net/starlark/java/eval/BUILD
+++ b/src/test/java/net/starlark/java/eval/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_binary", "java_test")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
 
 package(default_testonly = 1)
 
@@ -50,12 +50,10 @@ java_test(
 )
 
 # Script-based tests of the Starlark interpreter.
-java_test(
-    name = "ScriptTest",
+java_library(
+    name = "ScriptTest_lib",
     srcs = ["ScriptTest.java"],
     data = glob(["testdata/*.star"]),
-    jvm_flags = ["-Dfile.encoding=UTF8"],
-    use_testrunner = False,
     deps = [
         "//src/main/java/net/starlark/java/annot",
         "//src/main/java/net/starlark/java/eval",
@@ -64,6 +62,21 @@ java_test(
         "//third_party:error_prone_annotations",
         "//third_party:guava",
     ],
+)
+
+java_test(
+    name = "ScriptTest",
+    main_class = "net.starlark.java.eval.ScriptTest",
+    use_testrunner = False,
+    runtime_deps = [":ScriptTest_lib"],
+)
+
+java_test(
+    name = "ScriptTest_Latin1",
+    jvm_flags = ["-Dnet.starlark.java.eval.ScriptTest.utf8ByteStrings=true"],
+    main_class = "net.starlark.java.eval.ScriptTest",
+    use_testrunner = False,
+    runtime_deps = [":ScriptTest_lib"],
 )
 
 # Script-based benchmarks of the Starlark interpreter.

--- a/src/test/java/net/starlark/java/eval/testdata/sorted.star
+++ b/src/test/java/net/starlark/java/eval/testdata/sorted.star
@@ -96,13 +96,16 @@ assert_([d1] <= [d2])  # distinct objects
 assert_([d1] <= [d1, d2])
 assert_([None] <= [None])
 
-# Starlark/Java Strings are ordered lexicographically by elements (chars).
-# With UTF-16, this is not the same as code point order, because
-# surrogates DXXX are not at the top of the 16-bit range. For example:
+# Starlark/Java Strings are ordered lexicographically by elements.
+# With UTF-16, where elements are chars, this is not the same as code point
+# order, because surrogates DXXX are not at the top of the 16-bit range.
+# For example:
 #  U+FFFD  � 	= [FFFD]       REPLACEMENT CHAR
 #  U+1F33F 🌿	= [D83C DF3F]  HERB
 # The first compares greater than the second.
-assert_eq(sorted(["�", "🌿"]), ["🌿", "�"])
+# With UTF-8 byte strings, the order is just the lexicographic order of the
+# bytes.
+assert_eq(sorted(["�", "🌿"]), ["�", "🌿"] if _utf8_byte_strings else ["🌿", "�"])
 
 assert_(False < True)
 assert_fails(lambda: False < 1, "unsupported comparison: bool <=> int")

--- a/src/test/java/net/starlark/java/eval/testdata/string_misc.star
+++ b/src/test/java/net/starlark/java/eval/testdata/string_misc.star
@@ -187,10 +187,12 @@ assert_eq("".removeprefix(""), "")
 assert_eq("".removeprefix("a"), "")
 assert_eq("Apricot".removeprefix("pr"), "Apricot")
 assert_eq("AprApricot".removeprefix("Apr"), "Apricot")
+
 def removeprefix_self_unmodified():
     original_string = "Apricot"
     assert_eq(original_string.removeprefix("Apr"), "icot")
     assert_eq(original_string, "Apricot")
+
 removeprefix_self_unmodified()
 assert_fails(lambda: "1234".removeprefix(1), "got value of type 'int', want 'string")
 
@@ -203,9 +205,17 @@ assert_eq("".removesuffix(""), "")
 assert_eq("".removesuffix("a"), "")
 assert_eq("Apricot".removesuffix("co"), "Apricot")
 assert_eq("Apricotcot".removesuffix("cot"), "Apricot")
+
 def removesuffix_self_unmodified():
     original_string = "Apricot"
     assert_eq(original_string.removesuffix("cot"), "Apri")
     assert_eq(original_string, "Apricot")
+
 removesuffix_self_unmodified()
 assert_fails(lambda: "1234".removesuffix(4), "got value of type 'int', want 'string")
+
+# strip
+assert_eq("  abc  ".strip(), "abc")
+assert_eq("薠".strip(), "薠")
+assert_eq("薠".lstrip(), "薠")
+assert_eq("薠".rstrip(), "薠")


### PR DESCRIPTION
Bazel internally uses `String` as a container for raw bytes assumed to be UTF-8, which differs from ordinary usage of `String` as a container for UTF-16 characters. This requires special implementations of certain Starlark functions that care about the notion of a "character":

* `{l,r,}strip` must not strip non-ASCII whitespace as it may be part of a UTF-8-encoded non-whitespace character.
* `json.decode` has to emit UTF-8 bytes rather than UTF-16 characters.

To avoid affecting other users of the Starlark interpreter, a new `StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS` setting, defaulting to false but overridden to true for Bazel, determines which of the two behaviors to adopt.

Compatibility is verified by running all script-based tests under both values of the setting.

Closes #24417.

PiperOrigin-RevId: 733329982
Change-Id: I3e1605be28a844ab52a3239a2f753a29d4eb217a

Commit https://github.com/bazelbuild/bazel/commit/fcd3d1976cdace885c43fb5b00da3e98150eb77a