### PR TITLE
[8.2.0] Fix a severe performance bug for builds with many top-level targets.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3113,13 +3113,14 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         executionProgressReceiver.evaluated(skyKey, state, newValue, newError, directDeps);
       }
 
-      // After a PACKAGE node is evaluated, all targets and the labels associated with this package
-      // should have been added to the InMemoryGraph. So it is safe to remove relevant labels from
-      // weak interner.
+      // After a PACKAGE node is freshly computed, all targets and the labels associated with this
+      // package should have been added to the InMemoryGraph. So it is safe to remove relevant
+      // labels from weak interner.
       LabelInterner labelInterner = Label.getLabelInterner();
       if (labelInterner.enabled()
           && skyKey.functionName().equals(SkyFunctions.PACKAGE)
-          && newValue != null) {
+          && newValue != null
+          && directDeps != null) {
         checkState(newValue instanceof PackageValue, newValue);
 
         Package pkg = ((PackageValue) newValue).getPackage();


### PR DESCRIPTION
This one-line fix speeds up some real-life builds by 90%, saving over 20 minutes!

We only need to remove labels from the weak interner when a package is freshly computed (`directDeps != null`), not when it is already up-to-date as a top-level key in a skyframe evaluation. Without this guard, the removal code is being superfluously executed (in sequence) for each top-level target's package (without deduplication) twice during `BuildView#update`: once when computing the `labelToTargets` map, and again during `checkTargetEnvironmentRestrictions()`.

PiperOrigin-RevId: 733025147
Change-Id: Ief68c375a5d8444df1869968b4008af4a314b9c9

Commit https://github.com/bazelbuild/bazel/commit/3e115b937d7f6eff5c819667c6f6226c8fdba466