### PR TITLE
[7.6.0] Also download test outputs for coverage commands when building without the bytes.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
@@ -217,8 +217,9 @@ public class RemoteOutputChecker implements RemoteArtifactChecker {
 
   private void addTargetUnderTest(ProviderCollection target) {
     TestProvider testProvider = checkNotNull(target.getProvider(TestProvider.class));
-    if (outputsMode != RemoteOutputsMode.MINIMAL && commandMode == CommandMode.TEST) {
-      // In test mode, download the outputs of the test runner action.
+    if (outputsMode != RemoteOutputsMode.MINIMAL
+        && (commandMode == CommandMode.TEST || commandMode == CommandMode.COVERAGE)) {
+      // In test or coverage mode, download the outputs of the test runner action.
       addOutputsToDownload(testProvider.getTestParams().getOutputs());
     }
     if (commandMode == CommandMode.COVERAGE) {


### PR DESCRIPTION
This was an unintentional regression introduced by unknown commit.

PiperOrigin-RevId: 732063949
Change-Id: I619f17077dd8409cbe75662d3a680847f39102ef

Commit https://github.com/bazelbuild/bazel/commit/2b784aa7a9117d9759f9c450d5fe58c636598930