### PR TITLE
Support indented comments when parsing netrc files

### DIFF
--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -1416,6 +1416,7 @@ mget *
 quit
 
 # this is a comment
+    # this is an indented comment
 machine example.com login
 myusername password mysecret default
 login anonymous password myusername@example.com

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -312,7 +312,7 @@ def parse_netrc(contents, filename = None):
     currentmacro = ""
     cmd = None
     for line in contents.splitlines():
-        if line.startswith("#"):
+        if line.lstrip().startswith("#"):
             # Comments start with #. Ignore these lines.
             continue
         elif macdef:


### PR DESCRIPTION
This is a slight improvement over a previous fix for #10215.

It's a duplicate PR of https://github.com/bazelbuild/bazel/pull/14088.