### PR TITLE
[7.6.0] Avoid downloading the empty `Tree` message

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -454,8 +454,9 @@ public class RemoteExecutionServiceTest {
 
     // arrange
     Tree barTreeMessage = Tree.newBuilder().setRoot(Directory.getDefaultInstance()).build();
-    Digest barTreeDigest =
-        cache.addContents(remoteActionExecutionContext, barTreeMessage.toByteArray());
+    // Don't add barTreeMessage to the cache, the Tree proto for an empty output directory is
+    // recognized by its digest.
+    Digest barTreeDigest = digestUtil.compute(barTreeMessage);
     ActionResult.Builder builder = ActionResult.newBuilder();
     builder.addOutputDirectoriesBuilder().setPath("outputs/a/bar").setTreeDigest(barTreeDigest);
     RemoteActionResult result =


### PR DESCRIPTION
Valid empty `Tree` messages, which correspond to empty output directories, serialize to two bytes since they always contain an empty but present `Tree` message in the `root` field. Since such directories are very common (for example, as undeclared test output directories), it pays off to avoid downloading them.

Closes #25374.

PiperOrigin-RevId: 731614115
Change-Id: I64902afbecb55f718eb4d04fdd1f6207a7e8b97a (cherry picked from commit 6795c28a7be0b79c47ef94c42f6d128d2615f39a)