### PR TITLE
[8.2.0] Make Bazel itself build under an output base with Unicode characters

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5121,7 +5121,7 @@
     },
     "@@rules_python+//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "Ktlvuwl7iL6H5Xizfvv0C5YgMwxj7b5iMqQlU33QDP4=",
+        "bzlTransitiveDigest": "gI+deLdiN3HoT5y7LcbvZLpdyCTx17lAymkg9ZvugLE=",
         "usagesDigest": "OLoIStnzNObNalKEMRq99FqenhPGLFZ5utVLV4sz7OI=",
         "recordedFileInputs": {
           "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",

--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -461,6 +461,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis:event_listener",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis:frontier_serializer",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/analysis:options",
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:TestType",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",

--- a/src/main/java/com/google/devtools/build/lib/actions/ParameterFile.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ParameterFile.java
@@ -37,8 +37,6 @@ import java.io.OutputStream;
  */
 public class ParameterFile {
 
-  public static final StringUnsafe STRING_UNSAFE = StringUnsafe.getInstance();
-
   /** Different styles of parameter files. */
   public enum ParameterFileType {
     /**
@@ -100,7 +98,7 @@ public class ParameterFile {
   private static void writeContent(OutputStream out, Iterable<String> arguments)
       throws IOException {
     for (String line : arguments) {
-      out.write(STRING_UNSAFE.getInternalStringBytes(line));
+      out.write(StringUnsafe.getInternalStringBytes(line));
       out.write('\n');
     }
     out.flush();

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredRuleClassProvider.java
@@ -134,7 +134,7 @@ public /*final*/ class ConfiguredRuleClassProvider
     protected synchronized byte[] getDigest(PathFragment path) {
       return getDigestFunction()
           .getHashFunction()
-          .hashBytes(StringUnsafe.getInstance().getInternalStringBytes(path.getPathString()))
+          .hashBytes(StringUnsafe.getInternalStringBytes(path.getPathString()))
           .asBytes();
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/FileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/FileWriteAction.java
@@ -225,7 +225,7 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
 
     @Override
     public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
-      return out -> out.write(getFileContents().getBytes(ISO_8859_1));
+      return out -> out.write(StringUnsafe.getInternalStringBytes(getFileContents()));
     }
 
     @Override
@@ -255,7 +255,7 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
 
       // Grab the string's internal byte array. Calling getBytes() makes a copy, which can cause
       // memory spikes resulting in OOMs (b/290807073). Do not mutate this!
-      byte[] dataToCompress = StringUnsafe.getInstance().getByteArray(fileContents);
+      byte[] dataToCompress = StringUnsafe.getByteArray(fileContents);
 
       // Empirically, compressed sizes range from roughly 1/100 to 3/4 of the uncompressed size.
       // Presize on the small end to avoid over-allocating memory.
@@ -270,7 +270,7 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
 
       this.compressedBytes = byteStream.toByteArray();
       this.uncompressedSize = dataToCompress.length;
-      this.coder = StringUnsafe.getInstance().getCoder(fileContents);
+      this.coder = StringUnsafe.getCoder(fileContents);
     }
 
     @Override
@@ -291,7 +291,7 @@ public abstract class FileWriteAction extends AbstractFileWriteAction
         throw new IllegalStateException(e);
       }
 
-      return StringUnsafe.getInstance().newInstance(uncompressedBytes, coder);
+      return StringUnsafe.newInstance(uncompressedBytes, coder);
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWriteNestedSetOfTupleAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWriteNestedSetOfTupleAction.java
@@ -49,8 +49,7 @@ public final class LazyWriteNestedSetOfTupleAction extends AbstractFileWriteActi
 
   @Override
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
-    return out ->
-        out.write(StringUnsafe.getInstance().getInternalStringBytes(getContents(delimiter)));
+    return out -> out.write(StringUnsafe.getInternalStringBytes(getContents(delimiter)));
   }
 
   /** Computes the Action key for this action by computing the fingerprint for the file contents. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWritePathsFileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/LazyWritePathsFileAction.java
@@ -71,7 +71,7 @@ public final class LazyWritePathsFileAction extends AbstractFileWriteAction {
 
   @Override
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx) {
-    return out -> out.write(StringUnsafe.getInstance().getInternalStringBytes(getContents()));
+    return out -> out.write(StringUnsafe.getInternalStringBytes(getContents()));
   }
 
   /** Computes the Action key for this action by computing the fingerprint for the file contents. */

--- a/src/main/java/com/google/devtools/build/lib/authandtls/BasicHttpAuthenticationEncoder.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/BasicHttpAuthenticationEncoder.java
@@ -36,7 +36,6 @@ public final class BasicHttpAuthenticationEncoder {
     // basic authentication.
     return "Basic "
         + Base64.getEncoder()
-            .encodeToString(
-                StringUnsafe.getInstance().getInternalStringBytes(username + ":" + password));
+            .encodeToString(StringUnsafe.getInternalStringBytes(username + ":" + password));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/ArFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/ArFunction.java
@@ -18,7 +18,6 @@ import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -37,12 +36,6 @@ public class ArFunction implements Decompressor {
   // This is the same value as picked for .tar files, which appears to have worked well.
   private static final int BUFFER_SIZE = 32 * 1024;
 
-  private InputStream getDecompressorStream(DecompressorDescriptor descriptor) throws IOException {
-    return new BufferedInputStream(
-        new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE);
-  }
-  ;
-
   @Override
   public Path decompress(DecompressorDescriptor descriptor)
       throws InterruptedException, IOException {
@@ -52,7 +45,8 @@ public class ArFunction implements Decompressor {
 
     Map<String, String> renameFiles = descriptor.renameFiles();
 
-    try (InputStream decompressorStream = getDecompressorStream(descriptor)) {
+    try (InputStream decompressorStream =
+        new BufferedInputStream(descriptor.archivePath().getInputStream(), BUFFER_SIZE)) {
       ArArchiveInputStream arStream = new ArArchiveInputStream(decompressorStream);
       ArArchiveEntry entry;
       while ((entry = arStream.getNextArEntry()) != null) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarBz2Function.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarBz2Function.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
@@ -26,17 +25,12 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
  */
 public class TarBz2Function extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarBz2Function();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
-  private TarBz2Function() {
-  }
+  private TarBz2Function() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
       throws IOException {
-    return new BZip2CompressorInputStream(
-        new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE),
-        true);
+    return new BZip2CompressorInputStream(compressedInputStream, true);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarFunction.java
@@ -16,21 +16,16 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 /** Creates a repository by unarchiving a plain .tar file. */
 public class TarFunction extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarFunction();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
   private TarFunction() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
-      throws IOException {
-    return new BufferedInputStream(
-        new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE);
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream) {
+    return compressedInputStream;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
@@ -26,17 +25,12 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
  */
 public class TarGzFunction extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarGzFunction();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
-  private TarGzFunction() {
-  }
+  private TarGzFunction() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
       throws IOException {
-    return new GzipCompressorInputStream(
-        new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE),
-        true);
+    return new GzipCompressorInputStream(compressedInputStream, true);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarXzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarXzFunction.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.tukaani.xz.XZInputStream;
@@ -26,16 +25,12 @@ import org.tukaani.xz.XZInputStream;
  */
 class TarXzFunction extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarXzFunction();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
-  private TarXzFunction() {
-  }
+  private TarXzFunction() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
       throws IOException {
-    return new XZInputStream(
-        new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
+    return new XZInputStream(compressedInputStream);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarZstFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarZstFunction.java
@@ -17,22 +17,18 @@ package com.google.devtools.build.lib.bazel.repository;
 import com.github.luben.zstd.ZstdInputStreamNoFinalizer;
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 /** Creates a repository by unarchiving a zstandard-compressed .tar file. */
 final class TarZstFunction extends CompressedTarFunction {
   static final Decompressor INSTANCE = new TarZstFunction();
-  private static final int BUFFER_SIZE = 32 * 1024;
 
   private TarZstFunction() {}
 
   @Override
-  protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+  protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
       throws IOException {
-    return new ZstdInputStreamNoFinalizer(
-        new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
+    return new ZstdInputStreamNoFinalizer(compressedInputStream);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -78,9 +78,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -1050,10 +1048,7 @@ the same path on case-insensitive filesystems.
     Path downloadDirectory;
     try {
       // Download to temp directory inside the outputDirectory and delete it after extraction
-      java.nio.file.Path tempDirectory =
-          Files.createTempDirectory(Paths.get(outputPath.toString()), "temp");
-      downloadDirectory =
-          workingDirectory.getFileSystem().getPath(tempDirectory.toFile().getAbsolutePath());
+      downloadDirectory = outputPath.getPath().createTempDirectory("temp");
 
       Phaser downloadPhaser = new Phaser();
       Future<Path> pendingDownload =
@@ -1388,7 +1383,7 @@ the same path on case-insensitive filesystems.
       makeDirectories(p.getPath());
       p.getPath().delete();
       try (OutputStream stream = p.getPath().getOutputStream()) {
-        stream.write(StringUnsafe.getInstance().getInternalStringBytes(content));
+        stream.write(StringUnsafe.getInternalStringBytes(content));
       }
       if (executable) {
         p.getPath().setExecutable(true);

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -63,7 +63,6 @@ import com.google.errorprone.annotations.FormatString;
 import java.io.File;
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -180,11 +179,7 @@ public class LocalSpawnRunner implements SpawnRunner {
   }
 
   protected Path createActionTemp(Path execRoot) throws IOException {
-    return execRoot.getRelative(
-        Files.createTempDirectory(
-                java.nio.file.Paths.get(execRoot.getPathString()), "local-spawn-runner.")
-            .getFileName()
-            .toString());
+    return execRoot.createTempDirectory("local-spawn-runner.");
   }
 
   private final class SubprocessHandler {

--- a/src/main/java/com/google/devtools/build/lib/runtime/InfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/InfoItem.java
@@ -14,13 +14,12 @@
 
 package com.google.devtools.build.lib.runtime;
 
+
 import com.google.common.base.Supplier;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.unsafe.StringUnsafe;
 import com.google.devtools.build.lib.util.AbruptExitException;
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 /** An item that is returned by <code>blaze info</code>. */
 public abstract class InfoItem {
@@ -74,14 +73,12 @@ public abstract class InfoItem {
       throws AbruptExitException, InterruptedException;
 
   protected static byte[] print(Object value) {
-    if (value instanceof byte[]) {
-      return (byte[]) value;
+    if (value instanceof byte[] bytes) {
+      return bytes;
     }
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    PrintWriter writer =
-        new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
-    writer.print(value + "\n");
-    writer.flush();
-    return outputStream.toByteArray();
+    byte[] unsafeBytes = StringUnsafe.getInternalStringBytes(String.valueOf(value));
+    byte[] bytes = Arrays.copyOf(unsafeBytes, unsafeBytes.length + 1);
+    bytes[bytes.length - 1] = '\n';
+    return bytes;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BUILD
@@ -29,6 +29,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/skyframe:skyframe_cluster",
         "//src/main/java/com/google/devtools/build/lib/skyframe:starlark_builtins_value",
+        "//src/main/java/com/google/devtools/build/lib/unsafe:string",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:debug-logger-configurator",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BuildLanguageInfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/BuildLanguageInfoItem.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.skyframe.StarlarkBuiltinsValue;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.skyframe.EvaluationResult;
 import com.google.devtools.build.skyframe.SkyValue;
 import java.util.Collection;
@@ -172,7 +173,7 @@ public final class BuildLanguageInfoItem extends InfoItem {
       // TODO(adonovan): need dual function of parseDistributions.
       // Treat as empty list for now.
     } else if (t == Type.STRING) {
-      b.setString((String) v);
+      b.setString(StringEncoding.internalToUnicode((String) v));
     } else if (t == Type.INTEGER) {
       b.setInt(((StarlarkInt) v).toIntUnchecked());
     } else if (t == Type.BOOLEAN) {
@@ -180,7 +181,7 @@ public final class BuildLanguageInfoItem extends InfoItem {
     } else if (t == BuildType.TRISTATE) {
       b.setInt(((TriState) v).toInt());
     } else if (BuildType.isLabelType(t)) { // case order matters!
-      b.setString(v.toString());
+      b.setString(StringEncoding.internalToUnicode(v.toString()));
     } else {
       // No native rule attribute of this type (FilesetEntry?) has a default value.
       throw new IllegalStateException("unexpected type of attribute default value: " + t);

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/info/WorkerMetricsInfoItem.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/info/WorkerMetricsInfoItem.java
@@ -87,9 +87,9 @@ public final class WorkerMetricsInfoItem extends InfoItem {
                 .map(e -> e.toString())
                 .collect(joining(", "));
         if (workerMetrics.getWorkerIdsList().size() == 1) {
-          stringBuilder.append("id ").append(workerIds).append("\n");
+          stringBuilder.append("id ").append(workerIds);
         } else {
-          stringBuilder.append("ids [").append(workerIds).append("]\n");
+          stringBuilder.append("ids [").append(workerIds).append("]");
         }
       }
       return print(stringBuilder.toString());

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
@@ -106,11 +106,7 @@ final class WindowsSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   }
 
   private static Path createActionTemp(Path execRoot) throws IOException {
-    return execRoot.getRelative(
-        java.nio.file.Files.createTempDirectory(
-                java.nio.file.Paths.get(execRoot.getPathString()), "windows-sandbox.")
-            .getFileName()
-            .toString());
+    return execRoot.createTempDirectory("windows-sandbox.");
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/shell/SubprocessBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/SubprocessBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.jni.JniLoader;
 import com.google.devtools.build.lib.util.OS;
+import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.File;
 import java.io.IOException;
@@ -110,7 +111,7 @@ public class SubprocessBuilder {
   public SubprocessBuilder setArgv(ImmutableList<String> argv) {
     this.argv = Preconditions.checkNotNull(argv);
     Preconditions.checkArgument(!this.argv.isEmpty());
-    File argv0 = new File(this.argv.get(0));
+    File argv0 = new File(StringEncoding.internalToPlatform(this.argv.get(0)));
     Preconditions.checkArgument(
         argv0.isAbsolute() || argv0.getParent() == null,
         "argv[0] = '%s'; it should be either absolute or just a single file name"

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/strings/UnsafeStringCodec.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/strings/UnsafeStringCodec.java
@@ -38,8 +38,6 @@ public final class UnsafeStringCodec extends LeafObjectCodec<String> {
    */
   private static final UnsafeStringCodec INSTANCE = new UnsafeStringCodec();
 
-  private static final StringUnsafe STRING_UNSAFE = StringUnsafe.getInstance();
-
   public static UnsafeStringCodec stringCodec() {
     return INSTANCE;
   }
@@ -52,8 +50,8 @@ public final class UnsafeStringCodec extends LeafObjectCodec<String> {
   @Override
   public void serialize(LeafSerializationContext context, String obj, CodedOutputStream codedOut)
       throws SerializationException, IOException {
-    byte coder = STRING_UNSAFE.getCoder(obj);
-    byte[] value = STRING_UNSAFE.getByteArray(obj);
+    byte coder = StringUnsafe.getCoder(obj);
+    byte[] value = StringUnsafe.getByteArray(obj);
     // Optimize for the case that coder == 0, in which case we can just write the length here,
     // potentially using just one byte. If coder != 0, we'll use 4 bytes, but that's vanishingly
     // rare.
@@ -79,6 +77,6 @@ public final class UnsafeStringCodec extends LeafObjectCodec<String> {
       length = -length;
     }
     byte[] value = codedIn.readRawBytes(length);
-    return STRING_UNSAFE.newInstance(value, coder);
+    return StringUnsafe.newInstance(value, coder);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/unsafe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/unsafe/BUILD
@@ -22,8 +22,5 @@ java_library(
     add_opens = [
         "java.base/java.lang",
     ],
-    deps = [
-        ":unsafe-provider",
-        "//third_party:guava",
-    ],
+    deps = ["//third_party:guava"],
 )

--- a/src/main/java/com/google/devtools/build/lib/unsafe/StringUnsafe.java
+++ b/src/main/java/com/google/devtools/build/lib/unsafe/StringUnsafe.java
@@ -13,13 +13,11 @@
 // limitations under the License.
 package com.google.devtools.build.lib.unsafe;
 
-import static com.google.devtools.build.lib.unsafe.UnsafeProvider.unsafe;
-
 import com.google.common.base.Ascii;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
@@ -37,9 +35,10 @@ public final class StringUnsafe {
   public static final byte LATIN1 = 0;
   public static final byte UTF16 = 1;
 
-  private static final StringUnsafe INSTANCE = new StringUnsafe();
-
+  private static final MethodHandle CONSTRUCTOR;
   private static final MethodHandle HAS_NEGATIVES;
+  private static final VarHandle VALUE_HANDLE;
+  private static final VarHandle CODE_HANDLE;
 
   static {
     try {
@@ -48,42 +47,23 @@ public final class StringUnsafe {
           stringCoding.getDeclaredMethod("hasNegatives", byte[].class, int.class, int.class);
       hasNegatives.setAccessible(true);
       HAS_NEGATIVES = MethodHandles.lookup().unreflect(hasNegatives);
-    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+
+      Constructor<String> constructor =
+          String.class.getDeclaredConstructor(byte[].class, byte.class);
+      constructor.setAccessible(true);
+      CONSTRUCTOR = MethodHandles.lookup().unreflectConstructor(constructor);
+
+      var stringLookup = MethodHandles.privateLookupIn(String.class, MethodHandles.lookup());
+      VALUE_HANDLE = stringLookup.unreflectVarHandle(String.class.getDeclaredField("value"));
+      CODE_HANDLE = stringLookup.unreflectVarHandle(String.class.getDeclaredField("coder"));
+    } catch (ReflectiveOperationException e) {
       throw new IllegalStateException(e);
     }
   }
 
-  private final Constructor<String> constructor;
-  private final long valueOffset;
-  private final long coderOffset;
-
-  public static StringUnsafe getInstance() {
-    return INSTANCE;
-  }
-
-  private StringUnsafe() {
-    Field valueField;
-    Field coderField;
-    try {
-      this.constructor = String.class.getDeclaredConstructor(byte[].class, byte.class);
-      valueField = String.class.getDeclaredField("value");
-      coderField = String.class.getDeclaredField("coder");
-    } catch (ReflectiveOperationException e) {
-      throw new IllegalStateException(
-          "Bad fields/constructor: "
-              + Arrays.toString(String.class.getDeclaredConstructors())
-              + ", "
-              + Arrays.toString(String.class.getDeclaredFields()),
-          e);
-    }
-    this.constructor.setAccessible(true);
-    valueOffset = unsafe().objectFieldOffset(valueField);
-    coderOffset = unsafe().objectFieldOffset(coderField);
-  }
-
   /** Returns the coder used for this string. See {@link #LATIN1} and {@link #UTF16}. */
-  public byte getCoder(String obj) {
-    return unsafe().getByte(obj, coderOffset);
+  public static byte getCoder(String obj) {
+    return (byte) CODE_HANDLE.get(obj);
   }
 
   /**
@@ -92,8 +72,8 @@ public final class StringUnsafe {
    * <p>Use of this is unsafe. The representation may change from one JDK version to the next.
    * Ensure you do not mutate this byte array in any way.
    */
-  public byte[] getByteArray(String obj) {
-    return (byte[]) unsafe().getObject(obj, valueOffset);
+  public static byte[] getByteArray(String obj) {
+    return (byte[]) VALUE_HANDLE.get(obj);
   }
 
   /**
@@ -103,7 +83,7 @@ public final class StringUnsafe {
    * <p>Use of this is unsafe. The representation may change from one JDK version to the next.
    * Ensure you do not mutate this byte array in any way.
    */
-  public byte[] getInternalStringBytes(String obj) {
+  public static byte[] getInternalStringBytes(String obj) {
     // This is both a performance optimization and a correctness check: internal strings must
     // always be coded in Latin-1, otherwise they have been constructed out of a non-ASCII string
     // that hasn't been converted to internal encoding.
@@ -118,7 +98,7 @@ public final class StringUnsafe {
   }
 
   /** Returns whether the string is ASCII-only. */
-  public boolean isAscii(String obj) {
+  public static boolean isAscii(String obj) {
     // This implementation uses java.lang.StringCoding#hasNegatives, which is implemented as a JVM
     // intrinsic. On a machine with 512-bit SIMD registers, this is 5x as fast as a naive loop
     // over getByteArray(obj), which in turn is 5x as fast as obj.chars().anyMatch(c -> c > 0x7F) in
@@ -143,13 +123,15 @@ public final class StringUnsafe {
    * <p>The new string shares the byte array instance, which must not be modified after calling this
    * method.
    */
-  public String newInstance(byte[] bytes, byte coder) {
+  public static String newInstance(byte[] bytes, byte coder) {
     try {
-      return constructor.newInstance(bytes, coder);
-    } catch (ReflectiveOperationException e) {
-      // The constructor never throws and has been made accessible, so this is not expected.
+      return (String) CONSTRUCTOR.invokeExact(bytes, coder);
+    } catch (Throwable e) {
+      // The constructor never throws, so this is not expected.
       throw new IllegalStateException(
           "Could not instantiate string: " + Arrays.toString(bytes) + ", " + coder, e);
     }
   }
+
+  private StringUnsafe() {}
 }

--- a/src/main/java/com/google/devtools/build/lib/unsafe/UnsafeProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/unsafe/UnsafeProvider.java
@@ -15,9 +15,6 @@
 package com.google.devtools.build.lib.unsafe;
 
 import java.lang.reflect.Field;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import sun.misc.Unsafe;
 
 /**
@@ -25,6 +22,7 @@ import sun.misc.Unsafe;
  *
  * <p>Used for serialization.
  */
+@SuppressWarnings("SunApi") // TODO: b/331765692 - clean this up
 public class UnsafeProvider {
 
   private static final Unsafe UNSAFE = getUnsafe();
@@ -44,28 +42,24 @@ public class UnsafeProvider {
    * location.
    */
   private static Unsafe getUnsafe() {
-    try {
-      // sun.misc.Unsafe is intentionally difficult to get a hold of - it gives us the power to
-      // do things like access raw memory and segfault the JVM.
-      return AccessController.doPrivileged(
-          new PrivilegedExceptionAction<Unsafe>() {
-            @Override
-            public Unsafe run() throws Exception {
-              Class<Unsafe> unsafeClass = Unsafe.class;
-              // Unsafe usually exists in the field 'theUnsafe', however check all fields
-              // in case it's somewhere else in this VM's version of Unsafe.
-              for (Field f : unsafeClass.getDeclaredFields()) {
-                f.setAccessible(true);
-                Object fieldValue = f.get(null);
-                if (unsafeClass.isInstance(fieldValue)) {
-                  return unsafeClass.cast(fieldValue);
-                }
-              }
-              throw new AssertionError("Failed to find sun.misc.Unsafe instance");
-            }
-          });
-    } catch (PrivilegedActionException pae) {
-      throw new AssertionError("Unable to get sun.misc.Unsafe", pae);
+    // sun.misc.Unsafe is intentionally difficult to get a hold of - it gives us the power to
+    // do things like access raw memory and segfault the JVM.
+    Class<Unsafe> unsafeClass = Unsafe.class;
+    // Unsafe usually exists in the field 'theUnsafe', however check all fields
+    // in case it's somewhere else in this VM's version of Unsafe.
+    for (Field f : unsafeClass.getDeclaredFields()) {
+      f.setAccessible(true);
+      Object fieldValue;
+      try {
+        fieldValue = f.get(null);
+      } catch (IllegalAccessException e) {
+        throw new IllegalStateException(
+            "Failed to get value of %s even though it has been made accessible".formatted(f), e);
+      }
+      if (unsafeClass.isInstance(fieldValue)) {
+        return unsafeClass.cast(fieldValue);
+      }
     }
+    throw new AssertionError("Failed to find sun.misc.Unsafe instance");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/util/BUILD
@@ -77,6 +77,7 @@ java_library(
     deps = [
         ":os",
         ":single_line_formatter",
+        ":string_encoding",
         ":util",
         "//third_party:error_prone_annotations",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/util/StringEncoding.java
+++ b/src/main/java/com/google/devtools/build/lib/util/StringEncoding.java
@@ -104,7 +104,7 @@ public final class StringEncoding {
    */
   public static String internalToPlatform(String s) {
     return needsReencodeForPlatform(s)
-        ? new String(STRING_UNSAFE.getInternalStringBytes(s), UTF_8)
+        ? new String(StringUnsafe.getInternalStringBytes(s), UTF_8)
         : s;
   }
 
@@ -115,7 +115,7 @@ public final class StringEncoding {
    */
   public static String platformToInternal(String s) {
     return needsReencodeForPlatform(s)
-        ? STRING_UNSAFE.newInstance(s.getBytes(UTF_8), StringUnsafe.LATIN1)
+        ? StringUnsafe.newInstance(s.getBytes(UTF_8), StringUnsafe.LATIN1)
         : s;
   }
 
@@ -126,7 +126,7 @@ public final class StringEncoding {
    */
   public static String internalToUnicode(String s) {
     return needsReencodeForUnicode(s)
-        ? new String(STRING_UNSAFE.getInternalStringBytes(s), UTF_8)
+        ? new String(StringUnsafe.getInternalStringBytes(s), UTF_8)
         : s;
   }
 
@@ -137,11 +137,9 @@ public final class StringEncoding {
    */
   public static String unicodeToInternal(String s) {
     return needsReencodeForUnicode(s)
-        ? STRING_UNSAFE.newInstance(s.getBytes(UTF_8), StringUnsafe.LATIN1)
+        ? StringUnsafe.newInstance(s.getBytes(UTF_8), StringUnsafe.LATIN1)
         : s;
   }
-
-  private static final StringUnsafe STRING_UNSAFE = StringUnsafe.getInstance();
 
   /**
    * The {@link Charset} with which the JVM encodes any strings passed to or returned from Java
@@ -170,7 +168,7 @@ public final class StringEncoding {
     if (BAZEL_UNICODE_STRINGS) {
       return false;
     }
-    return !STRING_UNSAFE.isAscii(s);
+    return !StringUnsafe.isAscii(s);
   }
 
   private StringEncoding() {}

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -31,6 +31,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileAlreadyExistsException;
+import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -841,5 +842,21 @@ public abstract class FileSystem {
   protected java.nio.file.Path getNioPath(PathFragment path) {
     throw new UnsupportedOperationException(
         "getNioPath() not supported for " + getClass().getName());
+  }
+
+  /**
+   * Returns the path of a new temporary directory with the given prefix created under the given
+   * parent path, but <b>not</b> necessarily with secure permissions.
+   */
+  protected PathFragment createTempDirectory(PathFragment parent, String prefix)
+      throws IOException {
+    SecureRandom rand = new SecureRandom();
+    while (true) {
+      PathFragment candidate = parent.getRelative(prefix + Long.toUnsignedString(rand.nextLong()));
+      if (createDirectory(candidate)) {
+        chmod(candidate, 0700);
+        return candidate;
+      }
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -22,6 +22,7 @@ import com.google.common.hash.Hasher;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.util.FileType;
+import com.google.devtools.build.lib.util.StringEncoding;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -459,6 +460,14 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   }
 
   /**
+   * Returns the path of a new temporary directory with the given prefix created under the given
+   * parent path, but <b>not</b> necessarily with secure permissions.
+   */
+  public Path createTempDirectory(String prefix) throws IOException {
+    return fileSystem.getPath(fileSystem.createTempDirectory(asFragment(), prefix));
+  }
+
+  /**
    * Creates a symbolic link with the name of the current path, following symbolic links. The
    * referent of the created symlink is is the absolute path "target"; it is not possible to create
    * relative symbolic links via this method.
@@ -777,7 +786,7 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
    * <p>Caveat: the result may be useless if this path's getFileSystem() is not the UNIX filesystem.
    */
   public File getPathFile() {
-    return new File(getPathString());
+    return new File(StringEncoding.internalToPlatform(getPathString()));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathTransformingDelegateFileSystem.java
@@ -295,6 +295,12 @@ public abstract class PathTransformingDelegateFileSystem extends FileSystem {
     return delegateFs.getNioPath(toDelegatePath(path));
   }
 
+  @Override
+  protected PathFragment createTempDirectory(PathFragment parent, String prefix)
+      throws IOException {
+    return delegateFs.createTempDirectory(toDelegatePath(parent), prefix);
+  }
+
   /** Transform original path to a different one to be used with the {@code delegateFs}. */
   protected abstract PathFragment toDelegatePath(PathFragment path);
 

--- a/src/main/java/com/google/devtools/build/lib/worker/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/worker/BUILD
@@ -338,6 +338,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/sandbox:cgroups_info",
         "//src/main/java/com/google/devtools/build/lib/sandbox:sandbox_helpers",
         "//src/main/java/com/google/devtools/build/lib/shell",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/protobuf:failure_details_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.shell.Subprocess;
 import com.google.devtools.build.lib.shell.SubprocessBuilder;
 import com.google.devtools.build.lib.shell.SubprocessFactory;
+import com.google.devtools.build.lib.util.StringEncoding;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.worker.WorkerProcessStatus.Status;
@@ -200,10 +201,14 @@ public class WorkerMultiplexer {
               });
       Runtime.getRuntime().addShutdownHook(shutdownHook);
       ImmutableList<String> args = workerKey.getArgs();
-      File executable = new File(args.get(0));
+      File executable = new File(StringEncoding.internalToPlatform(args.get(0)));
       if (!executable.isAbsolute() && executable.getParent() != null) {
         List<String> newArgs = new ArrayList<>(args);
-        newArgs.set(0, new File(workDir.getPathFile(), newArgs.get(0)).getAbsolutePath());
+        newArgs.set(
+            0,
+            StringEncoding.platformToInternal(
+                new File(workDir.getPathFile(), StringEncoding.internalToPlatform(newArgs.get(0)))
+                    .getAbsolutePath()));
         args = ImmutableList.copyOf(newArgs);
       }
       SubprocessBuilder processBuilder =

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -29,6 +29,15 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
+# Force a UTF-8 compatible locale for Java tools to operate under paths with
+# Unicode characters.
+if [[ $(locale charmap) != "UTF-8" ]]; then
+  export LC_CTYPE=C.UTF-8
+fi
+if [[ $(locale charmap) != "UTF-8" ]]; then
+  export LC_CTYPE=en_US.UTF-8
+fi
+
 if [ "$1" == "--allmodules" ]; then
   shift
   modules="ALL-MODULE-PATH"

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunctionTest.java
@@ -19,7 +19,7 @@ import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescript
 import static com.google.devtools.build.lib.bazel.repository.TestArchiveDescriptor.ROOT_FOLDER_NAME;
 
 import com.google.devtools.build.lib.vfs.Path;
-import java.io.FileInputStream;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -105,9 +105,9 @@ public class CompressedTarFunctionTest {
   private Path decompress(DecompressorDescriptor descriptor) throws Exception {
     return new CompressedTarFunction() {
       @Override
-      protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
+      protected InputStream getDecompressorStream(BufferedInputStream compressedInputStream)
           throws IOException {
-        return new GZIPInputStream(new FileInputStream(descriptor.archivePath().getPathFile()));
+        return new GZIPInputStream(compressedInputStream);
       }
     }.decompress(descriptor);
   }

--- a/src/test/java/com/google/devtools/build/lib/unsafe/StringUnsafeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/unsafe/StringUnsafeTest.java
@@ -28,42 +28,38 @@ public final class StringUnsafeTest {
 
   @Test
   public void testGetCoder() {
-    StringUnsafe stringUnsafe = StringUnsafe.getInstance();
-    assertThat(stringUnsafe.getCoder("")).isEqualTo(StringUnsafe.LATIN1);
-    assertThat(stringUnsafe.getCoder("hello")).isEqualTo(StringUnsafe.LATIN1);
-    assertThat(stringUnsafe.getCoder("lambda λ")).isEqualTo(StringUnsafe.UTF16);
+    assertThat(StringUnsafe.getCoder("")).isEqualTo(StringUnsafe.LATIN1);
+    assertThat(StringUnsafe.getCoder("hello")).isEqualTo(StringUnsafe.LATIN1);
+    assertThat(StringUnsafe.getCoder("lambda λ")).isEqualTo(StringUnsafe.UTF16);
   }
 
   @Test
   public void testGetBytes() {
-    StringUnsafe stringUnsafe = StringUnsafe.getInstance();
-    assertThat(ByteBuffer.wrap(stringUnsafe.getByteArray("hello")))
+    assertThat(ByteBuffer.wrap(StringUnsafe.getByteArray("hello")))
         .isEqualTo(StandardCharsets.ISO_8859_1.encode("hello"));
 
     if (ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN)) {
-      assertThat(ByteBuffer.wrap(stringUnsafe.getByteArray("lambda λ")))
+      assertThat(ByteBuffer.wrap(StringUnsafe.getByteArray("lambda λ")))
           .isEqualTo(StandardCharsets.UTF_16BE.encode("lambda λ"));
     } else {
-      assertThat(ByteBuffer.wrap(stringUnsafe.getByteArray("lambda λ")))
+      assertThat(ByteBuffer.wrap(StringUnsafe.getByteArray("lambda λ")))
           .isEqualTo(StandardCharsets.UTF_16LE.encode("lambda λ"));
     }
   }
 
   @Test
   public void testNewInstance() throws Exception {
-    StringUnsafe stringUnsafe = StringUnsafe.getInstance();
     String s = "hello";
-    assertThat(stringUnsafe.newInstance(stringUnsafe.getByteArray(s), stringUnsafe.getCoder(s)))
+    assertThat(StringUnsafe.newInstance(StringUnsafe.getByteArray(s), StringUnsafe.getCoder(s)))
         .isEqualTo("hello");
   }
 
   @Test
   public void testIsAscii() {
-    StringUnsafe stringUnsafe = StringUnsafe.getInstance();
-    assertThat(stringUnsafe.isAscii("")).isTrue();
-    assertThat(stringUnsafe.isAscii("hello")).isTrue();
-    assertThat(stringUnsafe.isAscii("hällo")).isFalse();
-    assertThat(stringUnsafe.isAscii("hållo")).isFalse();
-    assertThat(stringUnsafe.isAscii("h👋llo")).isFalse();
+    assertThat(StringUnsafe.isAscii("")).isTrue();
+    assertThat(StringUnsafe.isAscii("hello")).isTrue();
+    assertThat(StringUnsafe.isAscii("hällo")).isFalse();
+    assertThat(StringUnsafe.isAscii("hållo")).isFalse();
+    assertThat(StringUnsafe.isAscii("h👋llo")).isFalse();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/util/StringEncodingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/StringEncodingTest.java
@@ -138,9 +138,9 @@ public class StringEncodingTest {
 
     String internal = platformToInternal(s);
     // In the internal encoding, raw bytes are encoded as Latin-1.
-    assertThat(StringUnsafe.getInstance().getCoder(internal)).isEqualTo(StringUnsafe.LATIN1);
+    assertThat(StringUnsafe.getCoder(internal)).isEqualTo(StringUnsafe.LATIN1);
     String roundtripped = internalToPlatform(internal);
-    if (StringUnsafe.getInstance().isAscii(s)) {
+    if (StringUnsafe.isAscii(s)) {
       assertThat(roundtripped).isSameInstanceAs(s);
     } else {
       assertThat(roundtripped).isEqualTo(s);
@@ -169,9 +169,9 @@ public class StringEncodingTest {
       @TestParameter({"ascii", "äöüÄÖÜß", "🌱", "羅勒罗勒学名"}) String s) {
     String internal = unicodeToInternal(s);
     // In the internal encoding, raw bytes are encoded as Latin-1.
-    assertThat(StringUnsafe.getInstance().getCoder(internal)).isEqualTo(StringUnsafe.LATIN1);
+    assertThat(StringUnsafe.getCoder(internal)).isEqualTo(StringUnsafe.LATIN1);
     String roundtripped = internalToUnicode(internal);
-    if (StringUnsafe.getInstance().isAscii(s)) {
+    if (StringUnsafe.isAscii(s)) {
       assertThat(roundtripped).isSameInstanceAs(s);
     } else {
       assertThat(roundtripped).isEqualTo(s);

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -50,6 +50,8 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -2055,5 +2057,19 @@ public abstract class FileSystemTest {
   protected static void assumeUtf8CompatibleEncoding() {
     Charset sunJnuEncoding = Charset.forName(System.getProperty("sun.jnu.encoding"));
     assume().that(ImmutableList.of(UTF_8, ISO_8859_1)).contains(sunJnuEncoding);
+  }
+
+  @Test
+  public void testCreateTempDirectory() throws Exception {
+    Set<Path> tempDirs = new HashSet<>();
+    for (int i = 0; i < 10; i++) {
+      Path tempDir = workingDir.createTempDirectory("prefix" + i);
+      assertThat(tempDir.isDirectory()).isTrue();
+      assertThat(tempDir.isReadable()).isTrue();
+      assertThat(tempDir.isWritable()).isTrue();
+      assertThat(tempDir.getBaseName()).startsWith("prefix" + i);
+      assertThat(tempDirs).doesNotContain(tempDir);
+      tempDirs.add(tempDir);
+    }
   }
 }

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -46,6 +46,15 @@ else
   fail "Could not find sha1sum or shasum on the PATH"
 fi
 
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*|darwin)
+  declare -r is_linux=false
+  ;;
+*)
+  declare -r is_linux=true
+  ;;
+esac
+
 function hash_outputs() {
   # runfiles/MANIFEST & runfiles_manifest contain absolute path, ignore.
   # ar on OS-X is non-deterministic, ignore .a files.
@@ -72,8 +81,20 @@ function test_determinism()  {
     cp derived/maven/BUILD.vendor derived/maven/BUILD
 
     # Build Bazel once.
+    #
+    # Use an output base with spaces and non-ASCII characters to verify that
+    # Bazel supports this. Characters with a 4-byte UTF-8 encoding would cause
+    # Java compilation to fail due to
+    # https://bugs.openjdk.org/browse/JDK-8258246.
+    # On Linux, the host needs to provide the C.UTF-8 locale for this to work,
+    # otherwise the DumpPlatformClasspath action will fail.
+    if [[ $is_linux && "$(LC_CTYPE=C.UTF-8 locale charmap)" != "UTF-8" ]]; then
+      output_base_1="${TEST_TMPDIR}/out 1"
+    else
+      output_base_1="${TEST_TMPDIR}/ouäöü€t 1"
+    fi
     bazel \
-      --output_base="${TEST_TMPDIR}/out 1" \
+      --output_base="${output_base_1}" \
       build \
       --extra_toolchains=@rules_python//python:autodetecting_toolchain \
       --enable_bzlmod \
@@ -81,14 +102,23 @@ function test_determinism()  {
       --lockfile_mode=update \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       --nostamp \
-      //src:bazel
+      //src:bazel &> $TEST_log || fail "First build failed"
+    assert_exists "${output_base_1}/java.log"
+    expect_not_log ERROR
+    expect_not_log "Exception:"
+    expect_not_log "Error:"
     hash_outputs >"${TEST_TMPDIR}/sum1"
 
     # Build Bazel twice.
+    if [[ $is_linux && "$(LC_CTYPE=C.UTF-8 locale charmap)" != "UTF-8" ]]; then
+      output_base_2="${TEST_TMPDIR}/out 2"
+    else
+      output_base_2="${TEST_TMPDIR}/ouäöü€t 2"
+    fi
     bazel-bin/src/bazel \
       --bazelrc="${TEST_TMPDIR}/bazelrc" \
-      --install_base="${TEST_TMPDIR}/install_base2" \
-      --output_base="${TEST_TMPDIR}/out 2" \
+      --install_base="${TEST_TMPDIR}/install_baseäöü€t 2" \
+      --output_base="${output_base_2}" \
       build \
       --extra_toolchains=@rules_python//python:autodetecting_toolchain \
       --enable_bzlmod \
@@ -96,7 +126,11 @@ function test_determinism()  {
       --lockfile_mode=update \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       --nostamp \
-      //src:bazel
+      //src:bazel &> $TEST_log || fail "Second build failed"
+    assert_exists "${output_base_2}/java.log"
+    expect_not_log ERROR
+    expect_not_log "Exception:"
+    expect_not_log "Error:"
     hash_outputs >"${TEST_TMPDIR}/sum2"
 
     if ! diff -U0 "${TEST_TMPDIR}/sum1" "${TEST_TMPDIR}/sum2" >$TEST_log; then

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_import", "java_library", "java_plugin")
+load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library", "java_plugin")
 load("@rules_license//rules:license.bzl", "license")
 load("//src/tools/bzlmod:utils.bzl", "get_repo_root")
 load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup", "distrib_java_import")
@@ -328,13 +328,17 @@ genrule(
         "@rules_java//toolchains:platformclasspath",
     ],
     outs = ["fastutil-stripped.jar"],
+    # ProGuard output is silenced below because it prints
+    # ...
+    # Caused by: java.net.UnknownHostException: bk-docker-3gmr: Temporary failure in name resolution
+    # ...
+    # when running in the Bazel sandbox, which throws off bazel_determinism_test.
     cmd = """
     $(location :proguard) \
         -injars $(execpath @maven//:it_unimi_dsi_fastutil_file) \
         -outjars $@ \
         -libraryjars $(execpath @rules_java//toolchains:platformclasspath) \
-        @$(location //tools:fastutil.proguard) \
-      | tail -n +2 # Skip the "ProGuard, version X" line
+        @$(location //tools:fastutil.proguard) > /dev/null
     # Null out the file times stored in the jar to make the output reproducible.
     TMPDIR=$$(mktemp -d)
     trap 'rm -rf $$TMPDIR' EXIT
@@ -352,6 +356,10 @@ genrule(
 
 java_binary(
     name = "proguard",
+    jvm_flags = [
+        # Prevent ProGuard from calling out to the internet through log4j.
+        "-Dlog4j.rootLogger=OFF",
+    ],
     main_class = "proguard.ProGuard",
     runtime_deps = ["@maven//:com_guardsquare_proguard_base"],
 )


### PR DESCRIPTION
This reverts commit https://github.com/bazelbuild/bazel/commit/5463126ab94e949eeaaa00c73292ebe79b0bbf08, thus relanding https://github.com/bazelbuild/bazel/commit/6982c14667440980665c536b8f1b7b6e57f5a808 (https://github.com/bazelbuild/bazel/pull/24457).

Additional fixes:
* Fix the encoding of attribute default values in `bazel info build-language` output.
* Do not append a newline to binary `bazel info` output.

Closes #25291.

PiperOrigin-RevId: 728206660
Change-Id: Ia291c3c0c75d4fc43bd1efba156442bdfcb7f51a 
(cherry picked from commit 2e3b24bb3a03b91dffcb21317d55fef39bc51d57)

The cherry-pick additionally includes 76bcfe34370590cddc10ff0aeae04484ced275c1 and updates rules_java to 8.9.0.

Closes #25305