### PR TITLE
[8.2.0] Add support for cache eviction retries with fixed invocation ID

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -245,7 +245,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
       BlazeCommandResult result;
       int attemptNumber = 0;
       Set<UUID> attemptedCommandIds = new HashSet<>();
-      BlazeCommandResult lastResult = null;
+      String buildRequestIdOverride = null;
       while (true) {
         attemptNumber += 1;
         try {
@@ -263,12 +263,14 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
                   commandExtensions,
                   attemptNumber,
                   attemptedCommandIds,
-                  lastResult,
+                  buildRequestIdOverride,
                   commandExtensionReporter);
           break;
         } catch (RemoteCacheTransientErrorException e) {
           attemptedCommandIds.add(e.getCommandId());
-          lastResult = e.getResult();
+          // Use a fixed build request ID across cache eviction retries to tie together the
+          // individual invocations, which all have different invocation IDs.
+          buildRequestIdOverride = e.getBuildRequestId();
         }
       }
       if (result.shutdown()) {
@@ -324,7 +326,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
       List<Any> commandExtensions,
       int attemptNumber,
       Set<UUID> attemptedCommandIds,
-      @Nullable BlazeCommandResult lastResult,
+      @Nullable String buildRequestIdOverride,
       CommandExtensionReporter commandExtensionReporter)
       throws RemoteCacheTransientErrorException {
     // Record the start time for the profiler. Do not put anything before this!
@@ -359,18 +361,11 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
             commandExtensions,
             this::setShutdownReason,
             commandExtensionReporter,
-            attemptNumber);
+            attemptNumber,
+            buildRequestIdOverride);
 
-    if (!attemptedCommandIds.isEmpty()) {
-      if (attemptedCommandIds.contains(env.getCommandId())) {
-        outErr.printErrLn(
-            String.format(
-                "Failed to retry the build: invocation id `%s` has already been used.",
-                env.getCommandId()));
-        return Preconditions.checkNotNull(lastResult);
-      } else {
-        outErr.printErrLn("Found transient remote cache error, retrying the build...");
-      }
+    if (attemptNumber > 1) {
+      outErr.printErrLn("Found transient remote cache error, retrying the build...");
     }
 
     CommonCommandOptions commonOptions = options.getOptions(CommonCommandOptions.class);
@@ -712,7 +707,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
         var executionOptions =
             Preconditions.checkNotNull(options.getOptions(ExecutionOptions.class));
         if (attemptedCommandIds.size() < executionOptions.remoteRetryOnTransientCacheError) {
-          throw new RemoteCacheTransientErrorException(env.getCommandId(), newResult);
+          throw new RemoteCacheTransientErrorException(env.getBuildRequestId(), env.getCommandId());
         }
       }
 
@@ -758,20 +753,22 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
   }
 
   private static class RemoteCacheTransientErrorException extends IOException {
+    // Remains constant across retries.
+    private final String buildRequestId;
+    // Changes across retries.
     private final UUID commandId;
-    private final BlazeCommandResult result;
 
-    private RemoteCacheTransientErrorException(UUID commandId, BlazeCommandResult result) {
+    private RemoteCacheTransientErrorException(String buildRequestId, UUID commandId) {
+      this.buildRequestId = buildRequestId;
       this.commandId = commandId;
-      this.result = result;
+    }
+
+    public String getBuildRequestId() {
+      return buildRequestId;
     }
 
     public UUID getCommandId() {
       return commandId;
-    }
-
-    public BlazeCommandResult getResult() {
-      return result;
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeWorkspace.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeWorkspace.java
@@ -233,7 +233,8 @@ public final class BlazeWorkspace {
       List<Any> commandExtensions,
       Consumer<String> shutdownReasonConsumer,
       CommandExtensionReporter commandExtensionReporter,
-      int attemptNumber) {
+      int attemptNumber,
+      @Nullable String buildRequestIdOverride) {
     quiescingExecutors.resetParameters(options);
     CommandEnvironment env =
         new CommandEnvironment(
@@ -253,7 +254,8 @@ public final class BlazeWorkspace {
             commandExtensions,
             shutdownReasonConsumer,
             commandExtensionReporter,
-            attemptNumber);
+            attemptNumber,
+            buildRequestIdOverride);
     skyframeExecutor.setClientEnv(env.getClientEnv());
     BuildRequestOptions buildRequestOptions = options.getOptions(BuildRequestOptions.class);
     if (buildRequestOptions != null && !buildRequestOptions.useActionCache) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -225,7 +225,8 @@ public class CommandEnvironment {
       List<Any> commandExtensions,
       Consumer<String> shutdownReasonConsumer,
       CommandExtensionReporter commandExtensionReporter,
-      int attemptNumber) {
+      int attemptNumber,
+      @Nullable String buildRequestIdOverride) {
     checkArgument(attemptNumber >= 1);
 
     this.runtime = runtime;
@@ -309,11 +310,13 @@ public class CommandEnvironment {
             "CommandEnvironment needs its options provider to have ClientOptions loaded.");
 
     this.clientEnv = makeMapFromMapEntries(clientOptions.clientEnv);
-    this.commandId = computeCommandId(commandOptions.invocationId, warnings);
+    this.commandId = computeCommandId(commandOptions.invocationId, warnings, attemptNumber);
     this.buildRequestId =
         commandOptions.buildRequestId != null
             ? commandOptions.buildRequestId
-            : UUID.randomUUID().toString();
+            : buildRequestIdOverride != null
+                ? buildRequestIdOverride
+                : UUID.randomUUID().toString();
 
     this.repoEnv.putAll(clientEnv);
     if (command.buildPhase().analyzes() || command.name().equals("info")) {
@@ -527,7 +530,7 @@ public class CommandEnvironment {
     return ImmutableMap.copyOf(result);
   }
 
-  private UUID computeCommandId(UUID idFromOptions, List<String> warnings) {
+  private UUID computeCommandId(UUID idFromOptions, List<String> warnings, int attemptNumber) {
     // TODO(b/67895628): Stop reading ids from the environment after the compatibility window has
     // passed.
     UUID commandId = idFromOptions;
@@ -541,11 +544,17 @@ public class CommandEnvironment {
                   + "--invocation_id. Please switch to using the flag.");
         } catch (IllegalArgumentException e) {
           // String was malformed, so we will resort to generating a random UUID
-          commandId = UUID.randomUUID();
+          return UUID.randomUUID();
         }
       } else {
-        commandId = UUID.randomUUID();
+        return UUID.randomUUID();
       }
+    }
+    // When retrying a command, the retry has to use a different command ID. BES backends can still
+    // link the invocations since their build ID will be the same and the attempt number will be
+    // increased.
+    if (attemptNumber > 1) {
+      return UUID.randomUUID();
     }
     return commandId;
   }

--- a/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/util/BlazeRuntimeWrapper.java
@@ -204,7 +204,8 @@ public class BlazeRuntimeWrapper {
                 extensions.stream().map(Any::pack).collect(toImmutableList()),
                 this.crashMessages::add,
                 NO_OP_COMMAND_EXTENSION_REPORTER,
-                /* attemptNumber= */ 1);
+                /* attemptNumber= */ 1,
+                /* buildRequestIdOverride= */ null);
     return env;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteModuleTest.java
@@ -187,7 +187,8 @@ public final class RemoteModuleTest {
         /* commandExtensions= */ ImmutableList.of(),
         /* shutdownReasonConsumer= */ s -> {},
         NO_OP_COMMAND_EXTENSION_REPORTER,
-        /* attemptNumber= */ 1);
+        /* attemptNumber= */ 1,
+        /* buildRequestIdOverride= */ null);
   }
 
   static class CapabilitiesImpl extends CapabilitiesImplBase {

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
@@ -257,7 +257,8 @@ public class BlazeRuntimeTest {
         /* commandExtensions= */ ImmutableList.of(),
         /* shutdownReasonConsumer= */ shutdownReason::set,
         NO_OP_COMMAND_EXTENSION_REPORTER,
-        /* attemptNumber= */ 1);
+        /* attemptNumber= */ 1,
+        /* buildRequestIdOverride= */ null);
   }
 
   private static class FooCommandModule extends BlazeModule {

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -2073,17 +2073,31 @@ EOF
 
   echo "updated bar" > a/bar.in
 
-  # Incremental build triggers remote cache eviction error and Bazel tries to
-  # retry the build but failed because the invocation id is the same.
+  # Incremental build triggers remote cache eviction error and Bazel retries
+  # the build with a new invocation ID
   bazel build \
       --invocation_id=91648f28-6081-4af7-9374-cdfd3cd36ef2 \
       --remote_executor=grpc://localhost:${worker_port} \
       --remote_download_minimal \
       --experimental_remote_cache_eviction_retries=1 \
-      //a:bar >& $TEST_log && fail "Expected build to fail"
+      --build_event_text_file=bes.txt \
+      //a:bar >& $TEST_log || fail "Failed to build"
 
   expect_log 'Failed to fetch blobs because they do not exist remotely.'
-  expect_log 'Failed to retry the build: invocation id `91648f28-6081-4af7-9374-cdfd3cd36ef2` has already been used.'
+  expect_log "Found transient remote cache error, retrying the build..."
+
+  local invocation_ids=$(grep "Invocation ID:" $TEST_log)
+  local first_id=$(echo "$invocation_ids" | head -n 1)
+  if [[ "$first_id" != *"Invocation ID: 91648f28-6081-4af7-9374-cdfd3cd36ef2" ]]; then
+    fail "Expected fixed invocation ID to be preserved for the first invocation, got: $first_id"
+  fi
+  local second_id=$(echo "$invocation_ids" | tail -n 1)
+  if [[ "$second_id" == "$first_id" ]]; then
+    fail "Expected second invocation ID to be different from the fixed invocation ID"
+  fi
+
+  cat bes.txt | tr '\n' ' ' > $TEST_log
+  expect_log "uuid: \"${second_id#INFO: Invocation ID: }\""
 }
 
 function test_download_toplevel_symlinks_runfiles() {


### PR DESCRIPTION
Retries use new invocation IDs, but are linked together by using the same build request ID.

Closes #25303.

PiperOrigin-RevId: 728645945
Change-Id: Ie482a79c4ddbe23133a1cae50843fc2116f2ed0d 
(cherry picked from commit d3e663dbd6a1ee77df4e1220dff2a23df163c9c1)

Fixes #25304