### PR TITLE
[8.2.0] Don't download all artifacts with BwoB when their TTL expires

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/RemoteArtifactChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/RemoteArtifactChecker.java
@@ -20,6 +20,11 @@ public interface RemoteArtifactChecker {
   RemoteArtifactChecker TRUST_ALL = (file, metadata) -> true;
   RemoteArtifactChecker IGNORE_ALL = (file, metadata) -> false;
 
+  /** Returns whether the given output should be downloaded. */
+  default boolean shouldDownloadOutput(ActionInput output, RemoteFileArtifactValue metadata) {
+    return !shouldTrustRemoteArtifact(output, metadata);
+  }
+
   /**
    * Returns true if Bazel should trust (and not verify) build artifacts that were last seen
    * remotely and do not exist locally.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/CompletionFunction.java
@@ -460,7 +460,7 @@ public final class CompletionFunction<
         var treeFile = child.getKey();
         var metadata = child.getValue();
         if (metadata.isRemote()
-            && !remoteArtifactChecker.shouldTrustRemoteArtifact(
+            && remoteArtifactChecker.shouldDownloadOutput(
                 treeFile, (RemoteFileArtifactValue) metadata)) {
           filesToDownload.add(treeFile);
         }
@@ -480,7 +480,7 @@ public final class CompletionFunction<
       }
 
       if (metadata.isRemote()
-          && !remoteArtifactChecker.shouldTrustRemoteArtifact(
+          && remoteArtifactChecker.shouldDownloadOutput(
               artifact, (RemoteFileArtifactValue) metadata)) {
         var action =
             ActionUtils.getActionForLookupData(env, derivedArtifact.getGeneratingActionKey());

--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -23,6 +23,7 @@ import static org.junit.Assume.assumeFalse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.eventbus.Subscribe;
 import com.google.devtools.build.lib.actions.ActionExecutedEvent;
 import com.google.devtools.build.lib.actions.Artifact;
@@ -1663,6 +1664,68 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   @Test
+  public void remoteFilesExpiredBetweenBuilds_rerunGeneratingActions_notDownloadedWithMinimal()
+      throws Exception {
+    // Arrange: Prepare workspace and populate remote cache
+    addOptions("--experimental_remote_cache_eviction_retries=0");
+    write(
+        "a/BUILD",
+        """
+        genrule(
+            name = "foo",
+            srcs = ["foo.in"],
+            outs = ["foo.out"],
+            cmd = "cat $(SRCS) > $@",
+        )
+
+        genrule(
+            name = "bar",
+            srcs = [
+                "foo.out",
+                "bar.in",
+            ],
+            outs = ["bar.out"],
+            cmd = "cat $(SRCS) > $@",
+        )
+        """);
+    write("a/foo.in", "foo");
+    write("a/bar.in", "bar");
+
+    // Populate remote cache
+    buildTarget("//a:bar");
+    assertOutputDoesNotExist("a/foo.out");
+    assertOutputDoesNotExist("a/bar.out");
+    getOutputBase().getRelative("action_cache").deleteTreesBelow();
+    restartServer();
+
+    // Clean build, foo.out and bar.out aren't downloaded
+    addOptions("--experimental_remote_cache_ttl=0s");
+    buildTarget("//a:bar");
+    assertOutputDoesNotExist("a/foo.out");
+    assertOutputDoesNotExist("a/bar.out");
+
+    // Evict blobs from remote cache
+    evictAllBlobs();
+
+    // Act: Do an incremental build
+    write("a/bar.in", "updated bar");
+    buildTarget("//a:bar");
+    waitDownloads();
+
+    // Assert: target was successfully built
+    assertOutputDoesNotExist("a/foo.out");
+    assertOutputDoesNotExist("a/bar.out");
+    var metadata = Iterables.getOnlyElement(getMetadata("//a:bar").values());
+    assertThat(metadata.isRemote()).isTrue();
+    assertThat(metadata.getDigest())
+        .isEqualTo(
+            getDigestHashFunction()
+                .getHashFunction()
+                .hashString("foo" + lineSeparator() + "updated bar" + lineSeparator(), UTF_8)
+                .asBytes());
+  }
+
+  @Test
   public void remoteTreeFilesExpiredBetweenBuilds_rerunGeneratingActions() throws Exception {
     // Arrange: Prepare workspace and populate remote cache
     write("BUILD");
@@ -1713,6 +1776,70 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
 
     // Assert: target was successfully built
     assertValidOutputFile("a/bar.out", "file-inside\nupdated bar" + lineSeparator());
+  }
+
+  @Test
+  public void remoteTreeFilesExpiredBetweenBuilds_rerunGeneratingActions_notDownloadedWithMinimal()
+      throws Exception {
+    // Arrange: Prepare workspace and populate remote cache
+    addOptions("--experimental_remote_cache_eviction_retries=0");
+    write("BUILD");
+    writeOutputDirRule();
+    write(
+        "a/BUILD",
+        """
+        load("//:output_dir.bzl", "output_dir")
+
+        output_dir(
+            name = "foo.out",
+            content_map = {"file-inside": "hello world"},
+        )
+
+        genrule(
+            name = "bar",
+            srcs = [
+                "foo.out",
+                "bar.in",
+            ],
+            outs = ["bar.out"],
+            cmd = "( ls $(location :foo.out); cat $(location :bar.in) ) > $@",
+        )
+        """);
+    write("a/bar.in", "bar");
+
+    // Populate remote cache
+    buildTarget("//a:bar");
+    assertThat(getOutputPath("a/foo.out").getDirectoryEntries()).isEmpty();
+    assertOutputDoesNotExist("a/bar.out");
+    getOutputBase().getRelative("action_cache").deleteTreesBelow();
+    restartServer();
+
+    // Clean build, foo.out and bar.out aren't downloaded
+    addOptions("--experimental_remote_cache_ttl=0s");
+    buildTarget("//a:bar");
+    assertOutputDoesNotExist("a/foo.out/file-inside");
+    assertOutputDoesNotExist("a/bar.out");
+
+    // Evict blobs from remote cache
+    evictAllBlobs();
+
+    // Act: Do an incremental build
+    write("a/bar.in", "updated bar");
+    // Also request foo.out to verify that tree files aren't downloaded.
+    buildTarget("//a:bar", "//a:foo.out");
+    waitDownloads();
+
+    // Assert: target was successfully built
+    assertOutputDoesNotExist("a/foo.out/file-inside");
+    assertOutputDoesNotExist("a/bar.out");
+    var metadata = Iterables.getOnlyElement(getMetadata("//a:bar").values());
+    assertThat(metadata.isRemote()).isTrue();
+    assertThat(metadata.getDigest())
+        .isEqualTo(
+            getDigestHashFunction()
+                .getHashFunction()
+                .hashString("file-inside\nupdated bar" + lineSeparator(), UTF_8)
+                .asBytes());
   }
 
   @Test


### PR DESCRIPTION
The TLL governs the lifetime of the remote metadata, but shouldn't by itself result in files being downloaded that otherwise wouldn't be (e.g., with `--remote_download_minimal`). This fixes a bug that causes warm Bazel servers with default settings apart from `--remote_download_minimal` to start downloading all top-level artifacts after three hours.

~This change also renames `shouldTrustArtifact` to `shouldTrustMetadata` and updates some comments on `{Remote,}OutputChecker` to avoid confusion between its two distinct purposes in the future: validating metadata and deciding which artifacts to download.~ This part isn't cherry-picked.

Example of the effect:
https://github.com/buildbuddy-io/buildbuddy/pull/8502#issuecomment-2687734121

Closes #25398.

PiperOrigin-RevId: 733280515
Change-Id: I35348a2a9b648ba0a563fb4f75b551349293754d (cherry picked from commit 23d03e1a066b0ef346ce85c3a89f500ed0189fa1)

Closes #25404