### PR TITLE
[7.6.0] Bzlmod: nodep deps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModTidyFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModTidyFunction.java
@@ -102,6 +102,6 @@ public class BazelModTidyFunction implements SkyFunction {
     }
 
     return BazelModTidyValue.create(
-        fixups.build(), buildozer.asPath(), rootModuleFileValue.getModuleFilePaths());
+        fixups.build(), buildozer.asPath(), rootModuleFileValue.moduleFilePaths());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleInspectorFunction.java
@@ -60,7 +60,7 @@ public class BazelModuleInspectorFunction implements SkyFunction {
     if (resolutionValue == null) {
       return null;
     }
-    ImmutableMap<String, ModuleOverride> overrides = root.getOverrides();
+    ImmutableMap<String, ModuleOverride> overrides = root.overrides();
     ImmutableMap<ModuleKey, InterimModule> unprunedDepGraph = resolutionValue.getUnprunedDepGraph();
     ImmutableMap<ModuleKey, Module> resolvedDepGraph = resolutionValue.getResolvedDepGraph();
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
@@ -15,26 +15,25 @@
 
 package com.google.devtools.build.lib.bazel.bzlmod;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.bzlmod.InterimModule.DepSpec;
 import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFileValue;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
-import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyframeLookupResult;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.SequencedMap;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -58,82 +57,179 @@ final class Discovery {
   @Nullable
   public static Result run(Environment env, RootModuleFileValue root)
       throws InterruptedException, ExternalDepsException {
-    String rootModuleName = root.getModule().getName();
-    ImmutableMap<String, ModuleOverride> overrides = root.getOverrides();
-    Map<ModuleKey, InterimModule> depGraph = new HashMap<>();
-    depGraph.put(
-        ModuleKey.ROOT,
-        root.getModule()
-            .withDepSpecsTransformed(InterimModule.applyOverrides(overrides, rootModuleName)));
-    Queue<ModuleKey> unexpanded = new ArrayDeque<>();
-    Map<ModuleKey, ModuleKey> predecessors = new HashMap<>();
-    SequencedMap<String, Optional<Checksum>> registryFileHashes =
-        new LinkedHashMap<>(root.getRegistryFileHashes());
-    unexpanded.add(ModuleKey.ROOT);
-    while (!unexpanded.isEmpty()) {
-      Set<SkyKey> unexpandedSkyKeys = new LinkedHashSet<>();
-      while (!unexpanded.isEmpty()) {
-        InterimModule module = depGraph.get(unexpanded.remove());
+    // Because of the possible existence of nodep edges, we do multiple rounds of discovery.
+    // In each round, we keep track of unfulfilled nodep edges, and at the end of the round, if any
+    // unfulfilled nodep edge can now be fulfilled, we run another round.
+    ImmutableSet<String> prevRoundModuleNames = ImmutableSet.of(root.module().getName());
+    while (true) {
+      DiscoveryRound discoveryRound = new DiscoveryRound(env, root, prevRoundModuleNames);
+      Result result = discoveryRound.run();
+      if (result == null) {
+        return null;
+      }
+      prevRoundModuleNames =
+          result.depGraph().values().stream().map(InterimModule::getName).collect(toImmutableSet());
+      if (discoveryRound.unfulfilledNodepEdgeModuleNames.stream()
+          .noneMatch(prevRoundModuleNames::contains)) {
+        return result;
+      }
+    }
+  }
+
+  private static class DiscoveryRound {
+    private final Environment env;
+    private final RootModuleFileValue root;
+    private final ImmutableSet<String> prevRoundModuleNames;
+    private final Map<ModuleKey, InterimModule> depGraph = new HashMap<>();
+
+    /**
+     * Stores a mapping from a module to its "predecessor" -- that is, its first dependent in BFS
+     * order. This is used to report a dependency chain in errors (see {@link
+     * #maybeReportDependencyChain}.
+     */
+    private final Map<ModuleKey, ModuleKey> predecessors = new HashMap<>();
+
+    /**
+     * For all unfulfilled nodep edges seen during this round, this set stores the module names of
+     * those nodep edges. Remember that whether a nodep edge can be fulfilled depends on whether the
+     * module it names already exists in the dep graph.
+     */
+    private final Set<String> unfulfilledNodepEdgeModuleNames = new HashSet<>();
+
+    DiscoveryRound(
+        Environment env, RootModuleFileValue root, ImmutableSet<String> prevRoundModuleNames) {
+      this.env = env;
+      this.root = root;
+      this.prevRoundModuleNames = prevRoundModuleNames;
+    }
+
+    /**
+     * Runs one round of discovery. At its core, this is a simple breadth-first search: we start
+     * from the "horizon" of just the root module, and advance the horizon by discovering the
+     * dependencies of modules in the current horizon. Keep doing this until the horizon is empty.
+     */
+    @Nullable
+    Result run() throws InterruptedException, ExternalDepsException {
+      SequencedMap<String, Optional<Checksum>> registryFileHashes = new LinkedHashMap<>();
+      depGraph.put(ModuleKey.ROOT, root.module().withDepSpecsTransformed(this::applyOverrides));
+      ImmutableSet<ModuleKey> horizon = ImmutableSet.of(ModuleKey.ROOT);
+      while (!horizon.isEmpty()) {
+        ImmutableSet<ModuleFileValue.Key> nextHorizonSkyKeys = advanceHorizon(horizon);
+        SkyframeLookupResult result = env.getValuesAndExceptions(nextHorizonSkyKeys);
+        var nextHorizon = ImmutableSet.<ModuleKey>builder();
+        for (ModuleFileValue.Key skyKey : nextHorizonSkyKeys) {
+          ModuleKey depKey = skyKey.moduleKey();
+          ModuleFileValue moduleFileValue;
+          try {
+            moduleFileValue =
+                (ModuleFileValue) result.getOrThrow(skyKey, ExternalDepsException.class);
+          } catch (ExternalDepsException e) {
+            throw maybeReportDependencyChain(e, depKey);
+          }
+          if (moduleFileValue == null) {
+            // Don't return yet. Try to expand any other unexpanded nodes before returning.
+            depGraph.put(depKey, null);
+          } else {
+            depGraph.put(
+                depKey, moduleFileValue.module().withDepSpecsTransformed(this::applyOverrides));
+            registryFileHashes.putAll(moduleFileValue.registryFileHashes());
+            nextHorizon.add(depKey);
+          }
+        }
+        horizon = nextHorizon.build();
+      }
+      if (env.valuesMissing()) {
+        return null;
+      }
+      return new Result(ImmutableMap.copyOf(depGraph), ImmutableMap.copyOf(registryFileHashes));
+    }
+
+    /**
+     * Returns a new {@link DepSpec} that is transformed according to any existing overrides on the
+     * dependency module.
+     */
+    DepSpec applyOverrides(DepSpec depSpec) {
+      if (root.module().getName().equals(depSpec.getName())) {
+        return DepSpec.fromModuleKey(ModuleKey.ROOT);
+      }
+      Version newVersion =
+          switch (root.overrides().get(depSpec.getName())) {
+            case NonRegistryOverride nro -> Version.EMPTY;
+            case SingleVersionOverride svo when !svo.getVersion().isEmpty() -> svo.getVersion();
+            case null, default -> depSpec.getVersion();
+          };
+      return DepSpec.create(depSpec.getName(), newVersion, depSpec.getMaxCompatibilityLevel());
+    }
+
+    /**
+     * Given a set of module keys to discover (the current "horizon"), return the next horizon
+     * consisting of newly discovered module keys from the current set (mostly, their dependencies).
+     *
+     * <p>The current horizon contains keys to modules that are already in the {@code depGraph}.
+     * Note also that this method mutates {@code predecessors} and {@code
+     * unfulfilledNodepEdgeModuleNames}.
+     */
+    ImmutableSet<ModuleFileValue.Key> advanceHorizon(ImmutableSet<ModuleKey> horizon) {
+      var nextHorizon = ImmutableSet.<ModuleFileValue.Key>builder();
+      for (ModuleKey moduleKey : horizon) {
+        InterimModule module = depGraph.get(moduleKey);
+        // The main group of module keys to discover are the current horizon's normal deps.
         for (DepSpec depSpec : module.getDeps().values()) {
-          if (depGraph.containsKey(depSpec.toModuleKey())) {
+          ModuleKey depKey = depSpec.toModuleKey();
+          if (depGraph.containsKey(depKey)) {
             continue;
           }
-          predecessors.putIfAbsent(depSpec.toModuleKey(), module.getKey());
-          unexpandedSkyKeys.add(
-              ModuleFileValue.key(depSpec.toModuleKey(), overrides.get(depSpec.getName())));
+          predecessors.putIfAbsent(depKey, module.getKey());
+          nextHorizon.add(ModuleFileValue.key(depKey));
+        }
+        // Any of the current horizon's nodep deps should also be discovered ("fulfilled"), iff the
+        // module they refer to already exists in the dep graph. Otherwise, record these unfulfilled
+        // nodep edges, so that we can later decide whether to run another round of discovery.
+        for (DepSpec depSpec : module.getNodepDeps()) {
+          ModuleKey depKey = depSpec.toModuleKey();
+          if (depGraph.containsKey(depKey)) {
+            continue;
+          }
+          if (!prevRoundModuleNames.contains(depSpec.getName())) {
+            unfulfilledNodepEdgeModuleNames.add(depSpec.getName());
+            continue;
+          }
+          predecessors.putIfAbsent(depKey, module.getKey());
+          nextHorizon.add(ModuleFileValue.key(depKey));
         }
       }
-      SkyframeLookupResult result = env.getValuesAndExceptions(unexpandedSkyKeys);
-      for (SkyKey skyKey : unexpandedSkyKeys) {
-        ModuleKey depKey = ((ModuleFileValue.Key) skyKey).getModuleKey();
-        ModuleFileValue moduleFileValue;
-        try {
-          moduleFileValue =
-              (ModuleFileValue) result.getOrThrow(skyKey, ExternalDepsException.class);
-        } catch (ExternalDepsException e) {
-          if (e.getDetailedExitCode().getFailureDetail() == null
-              || e.getDetailedExitCode().getFailureDetail().getExternalDeps().getCode()
-                  != FailureDetails.ExternalDeps.Code.BAD_MODULE) {
-            // This is not due to a bad module, so don't print a dependency chain. This covers cases
-            // such as a parse error in the lockfile or an I/O exception during registry access,
-            // which aren't related to any particular module dep.
-            throw e;
-          }
-          // Trace back a dependency chain to the root module. There can be multiple paths to the
-          // failing module, but any of those is useful for debugging.
-          List<ModuleKey> depChain = new ArrayList<>();
-          depChain.add(depKey);
-          ModuleKey predecessor = depKey;
-          while ((predecessor = predecessors.get(predecessor)) != null) {
-            depChain.add(predecessor);
-          }
-          Collections.reverse(depChain);
-          String depChainString =
-              depChain.stream().map(ModuleKey::toString).collect(joining(" -> "));
-          throw ExternalDepsException.withCauseAndMessage(
-              FailureDetails.ExternalDeps.Code.BAD_MODULE,
-              e,
-              "in module dependency chain %s",
-              depChainString);
-        }
-        if (moduleFileValue == null) {
-          // Don't return yet. Try to expand any other unexpanded nodes before returning.
-          depGraph.put(depKey, null);
-        } else {
-          depGraph.put(
-              depKey,
-              moduleFileValue
-                  .getModule()
-                  .withDepSpecsTransformed(
-                      InterimModule.applyOverrides(overrides, rootModuleName)));
-          registryFileHashes.putAll(moduleFileValue.getRegistryFileHashes());
-          unexpanded.add(depKey);
-        }
+      return nextHorizon.build();
+    }
+
+    /**
+     * When an exception occurs while discovering a new dep, try to add information about the
+     * dependency chain that led to that dep.
+     */
+    private ExternalDepsException maybeReportDependencyChain(
+        ExternalDepsException e, ModuleKey depKey) {
+      if (e.getDetailedExitCode().getFailureDetail() == null
+          || e.getDetailedExitCode().getFailureDetail().getExternalDeps().getCode()
+              != FailureDetails.ExternalDeps.Code.BAD_MODULE) {
+        // This is not due to a bad module, so don't print a dependency chain. This covers cases
+        // such as a parse error in the lockfile or an I/O exception during registry access,
+        // which aren't related to any particular module dep.
+        return e;
       }
+      // Trace back a dependency chain to the root module. There can be multiple paths to the
+      // failing module, but any of those is useful for debugging.
+      List<ModuleKey> depChain = new ArrayList<>();
+      depChain.add(depKey);
+      ModuleKey predecessor = depKey;
+      while ((predecessor = predecessors.get(predecessor)) != null) {
+        depChain.add(predecessor);
+      }
+      Collections.reverse(depChain);
+      String depChainString = depChain.stream().map(ModuleKey::toString).collect(joining(" -> "));
+      return ExternalDepsException.withCauseAndMessage(
+          FailureDetails.ExternalDeps.Code.BAD_MODULE,
+          e,
+          "in module dependency chain %s",
+          depChainString);
     }
-    if (env.valuesMissing()) {
-      return null;
-    }
-    return new Result(ImmutableMap.copyOf(depGraph), ImmutableMap.copyOf(registryFileHashes));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -231,7 +231,7 @@ public class ModuleFileFunction implements SkyFunction {
           module.getVersion());
     }
 
-    return new NonRootModuleFileValue(
+    return NonRootModuleFileValue.create(
         module,
         RegistryFileDownloadEvent.collectToMap(
             getModuleFileResult.downloadEventHandler.getPosts()));
@@ -493,7 +493,7 @@ public class ModuleFileFunction implements SkyFunction {
                 includeLabelToCompiledModuleFile.keySet().stream()
                     .map(label -> Label.parseCanonicalUnchecked(label).toPathFragment()))
             .collect(toImmutableSet());
-    return new RootModuleFileValue(
+    return RootModuleFileValue.create(
         module, overrides, nonRegistryOverrideCanonicalRepoNameLookup, moduleFilePaths);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -138,8 +138,12 @@ public class ModuleThreadContext {
     return ignoreDevDeps;
   }
 
-  public void addDep(String repoName, DepSpec depSpec) {
-    deps.put(repoName, depSpec);
+  public void addDep(Optional<String> repoName, DepSpec depSpec) {
+    if (repoName.isPresent()) {
+      deps.put(repoName.get(), depSpec);
+    } else {
+      module.addNodepDep(depSpec);
+    }
   }
 
   List<ModuleExtensionUsageBuilder> getExtensionUsageBuilders() {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlmodRepoRuleFunction.java
@@ -144,11 +144,11 @@ public final class BzlmodRepoRuleFunction implements SkyFunction {
 
   private static Optional<RepoSpec> checkRepoFromNonRegistryOverrides(
       RootModuleFileValue root, RepositoryName repositoryName) {
-    String moduleName = root.getNonRegistryOverrideCanonicalRepoNameLookup().get(repositoryName);
+    String moduleName = root.nonRegistryOverrideCanonicalRepoNameLookup().get(repositoryName);
     if (moduleName == null) {
       return Optional.empty();
     }
-    NonRegistryOverride override = (NonRegistryOverride) root.getOverrides().get(moduleName);
+    NonRegistryOverride override = (NonRegistryOverride) root.overrides().get(moduleName);
     return Optional.of(override.getRepoSpec());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuiltinsFunction.java
@@ -172,12 +172,12 @@ public class StarlarkBuiltinsFunction implements SkyFunction {
     if (autoloadSymbols.isEnabled()) {
       // We can't do autoloads where the rules are implemented (disabling them when running in
       // main repository named rules_python)
-      ModuleFileValue mainModule =
+      ModuleFileValue rootModule =
           (ModuleFileValue) env.getValue(ModuleFileValue.KEY_FOR_ROOT_MODULE);
-      if (mainModule == null) {
+      if (rootModule == null) {
         return null;
       }
-      if (autoloadSymbols.autoloadsDisabledForRepo(mainModule.getModule().getName())) {
+      if (autoloadSymbols.autoloadsDisabledForRepo(rootModule.module().getName())) {
         isWithAutoloads = false;
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -125,6 +125,12 @@ public final class BzlmodTestUtil {
     }
 
     @CanIgnoreReturnValue
+    public InterimModuleBuilder addNodepDep(ModuleKey key) {
+      builder.addNodepDep(DepSpec.fromModuleKey(key));
+      return this;
+    }
+
+    @CanIgnoreReturnValue
     public InterimModuleBuilder setKey(ModuleKey value) {
       this.key = value;
       this.builder.setKey(value);

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionTest.java
@@ -54,7 +54,7 @@ public class SelectionTest {
             .buildOrThrow();
 
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -71,7 +71,7 @@ public class SelectionTest {
             InterimModuleBuilder.create("ddd", "2.0", 1).buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -112,7 +112,7 @@ public class SelectionTest {
             .buildOrThrow();
 
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -129,7 +129,7 @@ public class SelectionTest {
             InterimModuleBuilder.create("ddd", "2.0", 1).buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -170,7 +170,7 @@ public class SelectionTest {
             .buildOrThrow();
 
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -188,7 +188,7 @@ public class SelectionTest {
             InterimModuleBuilder.create("ddd", "2.0", 1).buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -236,7 +236,7 @@ public class SelectionTest {
             .build();
 
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -253,7 +253,7 @@ public class SelectionTest {
             InterimModuleBuilder.create("ddd", "2.0").buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -299,7 +299,7 @@ public class SelectionTest {
             .buildOrThrow();
 
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -315,7 +315,7 @@ public class SelectionTest {
         .inOrder();
     // D is completely gone.
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -421,7 +421,7 @@ public class SelectionTest {
             .buildOrThrow();
 
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -438,7 +438,7 @@ public class SelectionTest {
             InterimModuleBuilder.create("ddd", "2.0", 2).buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -478,7 +478,7 @@ public class SelectionTest {
             .buildOrThrow();
 
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -495,7 +495,7 @@ public class SelectionTest {
             InterimModuleBuilder.create("ddd", "2.0", 2).buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -585,7 +585,7 @@ public class SelectionTest {
     //        \-> ddd 1.0 -> bbb 1.1
     //         \-> eee 1.0 -> ccc 1.1
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", "1.0")
                 .setKey(ModuleKey.ROOT)
@@ -606,7 +606,7 @@ public class SelectionTest {
                 .buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", "1.0")
                 .setKey(ModuleKey.ROOT)
@@ -672,7 +672,7 @@ public class SelectionTest {
     //        \-> ddd 1.0 -> bbb 1.1
     //         \-> eee 1.0 -> ccc 1.1
     Selection.Result selectionResult = Selection.run(depGraph, /* overrides= */ ImmutableMap.of());
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", "1.0")
                 .setKey(ModuleKey.ROOT)
@@ -693,7 +693,7 @@ public class SelectionTest {
                 .buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", "1.0")
                 .setKey(ModuleKey.ROOT)
@@ -769,7 +769,7 @@ public class SelectionTest {
                 ImmutableList.of(Version.parse("1.0"), Version.parse("2.0")), ""));
 
     Selection.Result selectionResult = Selection.run(depGraph, overrides);
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -780,8 +780,8 @@ public class SelectionTest {
             InterimModuleBuilder.create("bbb", "2.0").buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph())
-        .isEqualTo(selectionResult.getResolvedDepGraph());
+    assertThat(selectionResult.unprunedDepGraph())
+        .isEqualTo(selectionResult.resolvedDepGraph());
   }
 
   @Test
@@ -842,7 +842,7 @@ public class SelectionTest {
                 ImmutableList.of(Version.parse("1.0"), Version.parse("2.0")), ""));
 
     Selection.Result selectionResult = Selection.run(depGraph, overrides);
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -859,8 +859,8 @@ public class SelectionTest {
             InterimModuleBuilder.create("ddd", "2.0", 2).buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph())
-        .isEqualTo(selectionResult.getResolvedDepGraph());
+    assertThat(selectionResult.unprunedDepGraph())
+        .isEqualTo(selectionResult.resolvedDepGraph());
   }
 
   @Test
@@ -891,7 +891,7 @@ public class SelectionTest {
                 ImmutableList.of(Version.parse("1.0"), Version.parse("2.0")), ""));
 
     Selection.Result selectionResult = Selection.run(depGraph, overrides);
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -908,8 +908,8 @@ public class SelectionTest {
             InterimModuleBuilder.create("ddd", "2.0").buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph())
-        .isEqualTo(selectionResult.getResolvedDepGraph());
+    assertThat(selectionResult.unprunedDepGraph())
+        .isEqualTo(selectionResult.resolvedDepGraph());
   }
 
   @Test
@@ -969,7 +969,7 @@ public class SelectionTest {
     //     \-> bbb4@1.0 -> ccc@1.7  [allowed]
     //     \-> bbb5@1.0 -> ccc@2.0  [allowed]
     Selection.Result selectionResult = Selection.run(depGraph, overrides);
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -1001,7 +1001,7 @@ public class SelectionTest {
             InterimModuleBuilder.create("ccc", "2.0", 2).buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -1182,7 +1182,7 @@ public class SelectionTest {
     //     \-> bbb4@1.1
     // ccc@1.5 and ccc@3.0, the versions violating the allowlist, are gone.
     Selection.Result selectionResult = Selection.run(depGraph, overrides);
-    assertThat(selectionResult.getResolvedDepGraph().entrySet())
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)
@@ -1207,7 +1207,7 @@ public class SelectionTest {
             InterimModuleBuilder.create("ccc", "2.0", 2).buildEntry())
         .inOrder();
 
-    assertThat(selectionResult.getUnprunedDepGraph().entrySet())
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
         .containsExactly(
             InterimModuleBuilder.create("aaa", Version.EMPTY)
                 .setKey(ModuleKey.ROOT)


### PR DESCRIPTION
This PR implements the "nodep" edges from https://docs.google.com/document/d/1JsfbH9kdMe3dyOY-IR8SUakS541A7OM8pQcKpxTRMRs/edit?tab=t.0, using the syntax of `bazel_dep(..., repo_name=None)`. The behavior is that these edges are "unfulfilled" unless the module they refer to already exist in the dep graph by some other means.

Most of the changes are in the Discovery class -- I reorganized the code in there to hopefully help with readability, given the new multi-round discovery logic.

Also changed `ModuleFileValue.Key` to no longer take the applicable override next to the module key -- `ModuleFileFunction` now gets the root module from Skyframe itself and looks up the correct override. The old setup was always weird (what does it mean to request `foo@1.0` with an incorrect override??).

Work towards https://github.com/bazelbuild/bazel/issues/25214

RELNOTES: The `repo_name` parameter of `bazel_dep` can now be set to `None` to mark it a "nodep" dependency -- that is, the `bazel_dep` specification is only honored if the target module already exists in the dependency graph by some other means.

PiperOrigin-RevId: 730962587
Change-Id: I1ca7a7a1228da5e4c2e4b5d6983a2ec97b31a4b8