### PR TITLE
(wip): Verbose startup arguments when restarted or killed

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -986,6 +986,9 @@ static bool IsVolatileArg(const string &arg) {
 // (c) runningServerArgumentsNew is assigned when old_args is not empty in AreStartupOptionsDifferent
 static string runningStartupOptionsString() {
   std::ostringstream appendArgumentsWithSpaces;
+  if (runningServerArgumentsNew.empty()) {
+    return "";
+  }
   for (const string &a : runningServerArgumentsNew) {
     appendArgumentsWithSpaces << a << " ";
   }


### PR DESCRIPTION
Adding flags that triggered running server to be killed. The warning message would look like such:

```sh
$TEST_TMPDIR defined, some defaults will be overridden
WARNING: Running Bazel server needs to be killed, because the startup options --default_system_javabase=/usr/lib/jvm/java-21-zulu-openjdk-ca are different.
```