### PR TITLE
[7.6.0] Fix unicode_test on macos sequoia

### DIFF
--- a/src/test/shell/integration/unicode_test.sh
+++ b/src/test/shell/integration/unicode_test.sh
@@ -30,7 +30,11 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-export LC_ALL="C.UTF-8"
+if [[ "$(uname -s)" == "Linux" ]]; then
+  export LC_ALL=C.UTF-8
+else
+  export LC_ALL=en_US.UTF-8
+fi
 
 function set_up {
   touch WORKSPACE


### PR DESCRIPTION
C.UTF-8 is not available: https://storage.googleapis.com/bazel-testing-buildkite-artifacts/01956bf0-7263-4136-89f2-4e2d785b8762/src/test/shell/integration/unicode_test/test_attempts/attempt_1.log

With this CL we'll set LC_ALL as we already do in other tests (e.g. unicode_filenames_test.sh).

PiperOrigin-RevId: 734232499
Change-Id: I2a2c6ddbbfb4e9e7ac4c53dc80a9b0d28e007ab9

Commit https://github.com/bazelbuild/bazel/commit/8dbfcfae924b014366a0b47cd26632c5076b51a2