### PR TITLE
Fail if metadata is unavailable in `AbstractActionInputPrefetcher#prefetchFile`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -377,7 +377,8 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       PathFragment execPath = input.getExecPath();
 
       // input is known to be a non-source artifact and thus must have metadata.
-      FileArtifactValue metadata = checkNotNull(metadataSupplier.getMetadata(input));
+      FileArtifactValue metadata =
+          checkNotNull(metadataSupplier.getMetadata(input), "no metadata for %s", input);
       if (!canDownloadFile(execRoot.getRelative(execPath), metadata)) {
         return immediateVoidFuture();
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -376,8 +376,9 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
 
       PathFragment execPath = input.getExecPath();
 
-      FileArtifactValue metadata = metadataSupplier.getMetadata(input);
-      if (metadata == null || !canDownloadFile(execRoot.getRelative(execPath), metadata)) {
+      // input is known to be a non-source artifact and thus must have metadata.
+      FileArtifactValue metadata = checkNotNull(metadataSupplier.getMetadata(input));
+      if (!canDownloadFile(execRoot.getRelative(execPath), metadata)) {
         return immediateVoidFuture();
       }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -343,13 +343,7 @@ public final class ActionExecutionFunction implements SkyFunction {
     try {
       result =
           checkCacheAndExecuteIfNeeded(
-              action,
-              state,
-              env,
-              clientEnv,
-              actionLookupData,
-              previousExecution,
-              actionStartTime);
+              action, state, env, clientEnv, actionLookupData, previousExecution, actionStartTime);
     } catch (LostInputsActionExecutionException e) {
       return handleLostInputs(
           e,
@@ -1198,11 +1192,9 @@ public final class ActionExecutionFunction implements SkyFunction {
       }
     }
 
-    if (actionExecutionFunctionExceptionHandler != null) {
-      // After accumulating the inputs, we might find some mandatory artifact with
-      // SourceFileInErrorArtifactValue.
-      actionExecutionFunctionExceptionHandler.maybeThrowException();
-    }
+    // After accumulating the inputs, we might find some mandatory artifact with
+    // SourceFileInErrorArtifactValue.
+    actionExecutionFunctionExceptionHandler.maybeThrowException();
 
     return new CheckInputResults(inputArtifactData, filesetsInsideRunfiles, topLevelFilesets);
   }


### PR DESCRIPTION
The metadata is expected to be present for non-source input files and silently skipping downloads makes related test failures more obscure.

Also unwrap a tautologically true `if` in related code.