### PR TITLE
[8.2.0] Retry build when `RemoteActionFileSystem` encounters a missing digest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.actions.FilesetOutputTree;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.RemoteArtifactChecker;
 import com.google.devtools.build.lib.actions.cache.MetadataInjector;
+import com.google.devtools.build.lib.actions.LostInputsActionExecutionException;
 import com.google.devtools.build.lib.actions.cache.OutputMetadataStore;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.buildtool.buildevent.ExecutionPhaseCompleteEvent;
@@ -240,5 +241,13 @@ public class RemoteOutputService implements OutputService {
             fileCacheSupplier.get(),
             actionInputFetcher);
     return ArtifactPathResolver.createPathResolver(remoteFileSystem, fileSystem.getPath(execRoot));
+  }
+
+  @Override
+  public void checkActionFileSystemForLostInputs(FileSystem actionFileSystem, Action action)
+      throws LostInputsActionExecutionException {
+    if (actionFileSystem instanceof RemoteActionFileSystem remoteFileSystem) {
+      remoteFileSystem.checkForLostInputs(action);
+    }
   }
 }


### PR DESCRIPTION
Cache evictions encountered during reads of remote files in `RemoteActionFileSystem` now result in the build being retried when `--experimental_remote_cache_eviction_retries` is set to a positive value (the default).

This is enabled by implementing the `checkForLostInputs` method on the `RemoteOutputService`,  building on the refactoring performed in https://github.com/bazelbuild/bazel/pull/25396.

Closes #25358.

PiperOrigin-RevId: 736064349
Change-Id: Idc70d55138c3366d22ece7f0579b242b3c217da8

Commit https://github.com/bazelbuild/bazel/commit/85d9cc9cc6e1bc46116fb6163d43cad9aa17ffc7