### PR TITLE
[7.6.0] Use runfiles path instead of root relative path in `JavaStarlarkCommon.collectNativeLibsDirs`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -351,7 +351,7 @@ public class JavaStarlarkCommon
                   }
                   return true;
                 })
-            .map(artifact -> artifact.getRootRelativePath().getParentDirectory().getPathString())
+            .map(artifact -> artifact.getRunfilesPath().getParentDirectory().getPathString())
             .distinct()
             .collect(toImmutableList());
     return StarlarkList.immutableCopyOf(uniqueDirs);

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1595,6 +1595,7 @@ function setup_jni_targets() {
   repo="${1:-.}"
   if [ "$repo" != "." ]; then
     mkdir $repo
+    touch $repo/WORKSPACE
     cat >> WORKSPACE <<EOF
 load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1595,9 +1595,8 @@ function setup_jni_targets() {
   repo="${1:-.}"
   if [ "$repo" != "." ]; then
     mkdir $repo
-    touch $repo/REPO.bazel
-    cat > $(setup_module_dot_bazel) <<EOF
-local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+    cat >> WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
   name="$repo",
   path="./$repo",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/25012

Closes #25043.

PiperOrigin-RevId: 719211390
Change-Id: I91267b3ce546a54cd065e4424f3e80aaa36cff28

Commit https://github.com/bazelbuild/bazel/commit/8fba20855f7979ecc61cb05bf9e3ec8890aeed90