### PR TITLE
Don't delete a file before moving to it

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -442,7 +442,6 @@ public class FileSystemUtils {
   @ThreadSafe // but not atomic
   public static MoveResult moveFile(Path from, Path to) throws IOException {
     // We don't try-catch here for better performance.
-    to.delete();
     try {
       from.renameTo(to);
       return MoveResult.FILE_MOVED;
@@ -471,7 +470,15 @@ public class FileSystemUtils {
         }
         to.setExecutable(from.isExecutable()); // Copy executable bit.
       } else if (stat.isSymbolicLink()) {
-        to.createSymbolicLink(from.readSymbolicLink());
+        PathFragment fromTarget = from.readSymbolicLink();
+        try {
+          to.createSymbolicLink(fromTarget);
+        } catch (IOException unused2) {
+          // May have failed due the target file existing, but not being a symlink.
+          // TODO: Only catch FileAlreadyExistsException once we throw that.
+          to.delete();
+          to.createSymbolicLink(fromTarget);
+        }
       } else {
         throw new IOException("Don't know how to copy " + from);
       }

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -449,6 +449,9 @@ public class FileSystemUtils {
       // Fallback to a copy.
       FileStatus stat = from.stat(Symlinks.NOFOLLOW);
       if (stat.isFile()) {
+        // Target may be a symlink, in which case opening a stream below would not actually replace
+        // it.
+        to.delete();
         try (InputStream in = from.getInputStream();
             OutputStream out = to.getOutputStream()) {
           copyLargeBuffer(in, out);

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -1581,7 +1581,7 @@ public abstract class FileSystemTest {
     createSymbolicLink(symlink, PathFragment.create("something"));
     xFile.renameTo(symlink); // succeeds
     assertThat(xFile.exists()).isFalse();
-    assertThat(symlink.isFile()).isTrue();
+    assertThat(symlink.isFile(Symlinks.NOFOLLOW)).isTrue();
   }
 
   @Test
@@ -1596,7 +1596,7 @@ public abstract class FileSystemTest {
     assertThat(symlink.isWritable()).isFalse();
     xFile.renameTo(symlink); // succeeds
     assertThat(xFile.exists()).isFalse();
-    assertThat(symlink.isFile()).isTrue();
+    assertThat(symlink.isFile(Symlinks.NOFOLLOW)).isTrue();
     assertThat(symlink.isWritable()).isTrue();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemUtilsTest.java
@@ -32,6 +32,8 @@ import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.vfs.FileSystem.NotASymlinkException;
 import com.google.devtools.build.lib.vfs.FileSystemUtils.MoveResult;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
@@ -39,10 +41,9 @@ import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** This class tests the file system utilities. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public class FileSystemUtilsTest {
   private ManualClock clock;
   private FileSystem fileSystem;
@@ -346,13 +347,14 @@ public class FileSystemUtilsTest {
   }
 
   @Test
-  public void testMoveFile() throws IOException {
+  public void testMoveFile(@TestParameter boolean targetIsWritable) throws IOException {
     createTestDirectoryTree();
     Path originalFile = file1;
     byte[] content = new byte[] { 'a', 'b', 'c', 23, 42 };
     FileSystemUtils.writeContent(originalFile, content);
 
     Path moveTarget = file2;
+    moveTarget.setWritable(targetIsWritable);
 
     assertThat(moveFile(originalFile, moveTarget)).isEqualTo(MoveResult.FILE_MOVED);
 


### PR DESCRIPTION
Deleting the target file is not necessary for `renameTo` to succeed and neither for copying it. Only the slow path of `FileSystemUtils#moveFile` for a symlink may need to delete the file, but can optimistically attempt to create the symlink first.