### PR TITLE
Add and set `--guard_against_concurrent_changes=lite`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -69,11 +69,13 @@ import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.Spawns;
+import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.analysis.constraints.ConstraintConstants;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformUtils;
@@ -104,6 +106,7 @@ import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOptions.ConcurrentChangesCheckLevel;
 import com.google.devtools.build.lib.remote.salt.CacheSalt;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
@@ -1832,8 +1835,18 @@ public class RemoteExecutionService {
     }
   }
 
-  /** Upload outputs of a remote action which was executed locally to remote cache. */
+  @VisibleForTesting
   public void uploadOutputs(RemoteAction action, SpawnResult spawnResult, Runnable onUploadComplete)
+      throws InterruptedException, ExecException {
+    uploadOutputs(action, spawnResult, onUploadComplete, ConcurrentChangesCheckLevel.OFF);
+  }
+
+  /** Upload outputs of a remote action which was executed locally to remote cache. */
+  public void uploadOutputs(
+      RemoteAction action,
+      SpawnResult spawnResult,
+      Runnable onUploadComplete,
+      ConcurrentChangesCheckLevel concurrentChangesCheckLevel)
       throws InterruptedException, ExecException {
     checkState(!shutdown.get(), "shutdown");
     checkState(
@@ -1842,6 +1855,19 @@ public class RemoteExecutionService {
     checkState(
         SpawnResult.Status.SUCCESS.equals(spawnResult.status()) && spawnResult.exitCode() == 0,
         "shouldn't upload outputs of failed local action");
+
+    try (SilentCloseable c = Profiler.instance().profile("checkForConcurrentModifications")) {
+      checkForConcurrentModifications(action, concurrentChangesCheckLevel);
+    } catch (IOException | ForbiddenActionInputException e) {
+      report(
+          Event.warn(
+              String.format(
+                  "%s: Skipping uploading outputs because of concurrent modifications with"
+                      + " --guard_against_concurrent_changes enabled: %s",
+                  action.getSpawn().getTargetLabel(), e.getMessage())));
+      onUploadComplete.run();
+      return;
+    }
 
     if (remoteOptions.remoteCacheAsync
         && !action.getSpawn().getResourceOwner().mayModifySpawnOutputsAfterExecution()) {
@@ -1886,6 +1912,41 @@ public class RemoteExecutionService {
         reportUploadError(e);
       } finally {
         onUploadComplete.run();
+      }
+    }
+  }
+
+  private void checkForConcurrentModifications(
+      RemoteAction action, ConcurrentChangesCheckLevel level)
+      throws IOException, ForbiddenActionInputException {
+    if (level == ConcurrentChangesCheckLevel.OFF) {
+      return;
+    }
+
+    // As this check runs after the action has been executed, we can reuse the input map if it
+    // has already been created with willAccessRepeatedly = true, but do not need to force its
+    // retention.
+    for (ActionInput input : action.getInputMap(/* willAccessRepeatedly= */ false).values()) {
+      // In lite mode, only check source artifacts in the main repository for modifications.
+      // Non-source artifacts are made read-only after execution, and external repositories are
+      // rarely modified, with local_repository being the notable exception.
+      // TODO: Find a way to include repositories that are symlinks to source directories.
+      // On Bazel itself, this reduces the number of wasModifiedSinceDigest calls by 99% compared to
+      // the full check. By not checking output files, this mode also avoids spurious false
+      // positives (see https://github.com/bazelbuild/bazel/issues/3360).
+      if (level == ConcurrentChangesCheckLevel.LITE
+          && !(input instanceof Artifact artifact
+              && artifact.isSourceArtifact()
+              && !artifact.getRoot().isExternal())) {
+        continue;
+      } else if (input instanceof VirtualActionInput) {
+        continue;
+      }
+      FileArtifactValue metadata =
+          action.getSpawnExecutionContext().getInputMetadataProvider().getInputMetadata(input);
+      Path path = execRoot.getRelative(input.getExecPath());
+      if (metadata.wasModifiedSinceDigest(path)) {
+        throw new IOException(path + " was modified during execution");
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1835,12 +1835,6 @@ public class RemoteExecutionService {
     }
   }
 
-  @VisibleForTesting
-  public void uploadOutputs(RemoteAction action, SpawnResult spawnResult, Runnable onUploadComplete)
-      throws InterruptedException, ExecException {
-    uploadOutputs(action, spawnResult, onUploadComplete, ConcurrentChangesCheckLevel.OFF);
-  }
-
   /** Upload outputs of a remote action which was executed locally to remote cache. */
   public void uploadOutputs(
       RemoteAction action,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -43,7 +43,6 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
-import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.authandtls.credentialhelper.CredentialHelperException;
 import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.clock.BlazeClock.MillisSinceEpochToNanosConverter;
@@ -67,6 +66,7 @@ import com.google.devtools.build.lib.remote.common.BulkTransferException;
 import com.google.devtools.build.lib.remote.common.OperationObserver;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionCapabilitiesException;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOptions.ConcurrentChangesCheckLevel;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
@@ -75,7 +75,6 @@ import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Path;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
@@ -83,9 +82,6 @@ import com.google.protobuf.util.Timestamps;
 import io.grpc.Status.Code;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -700,47 +696,16 @@ public class RemoteSpawnRunner implements SpawnRunner {
         .build();
   }
 
-  private Map<Path, Long> getInputCtimes(SortedMap<PathFragment, ActionInput> inputMap) {
-    HashMap<Path, Long> ctimes = new HashMap<>();
-    for (Map.Entry<PathFragment, ActionInput> e : inputMap.entrySet()) {
-      ActionInput input = e.getValue();
-      if (input instanceof VirtualActionInput) {
-        continue;
-      }
-      Path path = execRoot.getRelative(input.getExecPathString());
-      try {
-        ctimes.put(path, path.stat().getLastChangeTime());
-      } catch (IOException ex) {
-        // Put a token value indicating an exception; this is used so that if the exception
-        // is raised both before and after the execution, it is ignored, but if it is raised only
-        // one of the times, it triggers a remote cache upload skip.
-        ctimes.put(path, -1L);
-      }
-    }
-    return ctimes;
-  }
-
   @VisibleForTesting
   SpawnResult execLocallyAndUpload(
       RemoteAction action, Spawn spawn, SpawnExecutionContext context, boolean uploadLocalResults)
       throws ExecException, IOException, ForbiddenActionInputException, InterruptedException {
-    Map<Path, Long> ctimesBefore = getInputCtimes(action.getInputMap(true));
     SpawnResult result = execLocally(spawn, context);
-    Map<Path, Long> ctimesAfter = getInputCtimes(action.getInputMap(true));
-    uploadLocalResults =
-        uploadLocalResults && Status.SUCCESS.equals(result.status()) && result.exitCode() == 0;
-    if (!uploadLocalResults) {
-      return result;
+    if (uploadLocalResults && Status.SUCCESS.equals(result.status()) && result.exitCode() == 0) {
+      // FULL is used here to retain historic behavior.
+      remoteExecutionService.uploadOutputs(
+          action, result, () -> {}, ConcurrentChangesCheckLevel.FULL);
     }
-
-    for (Map.Entry<Path, Long> e : ctimesBefore.entrySet()) {
-      // Skip uploading to remote cache, because an input was modified during execution.
-      if (!ctimesAfter.get(e.getKey()).equals(e.getValue())) {
-        return result;
-      }
-    }
-
-    remoteExecutionService.uploadOutputs(action, result, () -> {});
     return result;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -109,6 +109,7 @@ import com.google.devtools.build.lib.remote.common.RemotePathResolver.DefaultRem
 import com.google.devtools.build.lib.remote.common.RemotePathResolver.SiblingRepositoryLayoutResolver;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOptions.ConcurrentChangesCheckLevel;
 import com.google.devtools.build.lib.remote.salt.CacheSalt;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.FakeSpawnExecutionContext;
@@ -2762,7 +2763,7 @@ public class RemoteExecutionServiceTest {
   private static void uploadOutputsAndWait(
       RemoteExecutionService service, RemoteAction action, SpawnResult result) throws Exception {
     SettableFuture<Void> future = SettableFuture.create();
-    service.uploadOutputs(action, result, () -> future.set(null));
+    service.uploadOutputs(action, result, () -> future.set(null), ConcurrentChangesCheckLevel.OFF);
     future.get();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -377,7 +377,10 @@ public class RemoteSpawnCacheTest {
     verify(service)
         .downloadOutputs(
             any(), eq(RemoteActionResult.createFromCache(CachedActionResult.remote(actionResult))));
-    verify(service, never()).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService = verify(service, never());
+    RemoteAction action = any();
+    SpawnResult spawnResult = any();
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
     assertThat(result.getDigest())
         .isEqualTo(digestUtil.asSpawnLogProto(actionKeyCaptor.getValue()));
     assertThat(result.setupSuccess()).isTrue();
@@ -411,9 +414,15 @@ public class RemoteSpawnCacheTest {
             .setStatus(Status.SUCCESS)
             .setRunnerName("test")
             .build();
-    doNothing().when(service).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
+    RemoteAction action1 = any();
+    SpawnResult spawnResult1 = any();
+    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
     entry.store(result);
-    verify(service).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService = verify(service);
+    RemoteAction action = any();
+    SpawnResult spawnResult = any();
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
   }
 
   @Test
@@ -619,7 +628,10 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
     entry.store(result);
-    verify(service, never()).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService = verify(service, never());
+    RemoteAction action = any();
+    SpawnResult spawnResult = any();
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
   }
 
   @Test
@@ -643,9 +655,15 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
 
-    doNothing().when(service).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
+    RemoteAction action1 = any();
+    SpawnResult spawnResult1 = any();
+    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
     entry.store(result);
-    verify(service).uploadOutputs(any(), eq(result), any());
+    RemoteExecutionService remoteExecutionService = verify(service);
+    RemoteAction action = any();
+    SpawnResult spawnResult = eq(result);
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
 
     assertThat(eventHandler.getEvents()).hasSize(1);
     Event evt = eventHandler.getEvents().get(0);
@@ -692,9 +710,15 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
 
-    doNothing().when(service).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
+    RemoteAction action1 = any();
+    SpawnResult spawnResult1 = any();
+    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
     entry.store(result);
-    verify(service).uploadOutputs(any(), eq(result), any());
+    RemoteExecutionService remoteExecutionService = verify(service);
+    RemoteAction action = any();
+    SpawnResult spawnResult = eq(result);
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
     assertThat(eventHandler.getEvents()).isEmpty(); // no warning is printed.
   }
 
@@ -799,13 +823,14 @@ public class RemoteSpawnCacheTest {
     // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
     // concurrency to this test.
     AtomicReference<Runnable> onUploadComplete = new AtomicReference<>();
-    Mockito.doAnswer(
-            invocationOnMock -> {
-              onUploadComplete.set(invocationOnMock.getArgument(2));
-              return null;
-            })
-        .when(remoteExecutionService)
-        .uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService1 = doAnswer(
+        invocationOnMock -> {
+          onUploadComplete.set(invocationOnMock.getArgument(2));
+          return null;
+        }).when(remoteExecutionService);
+    RemoteAction action = any();
+    SpawnResult spawnResult = any();
+    remoteExecutionService1.uploadOutputs(action, spawnResult, any(), any());
 
     // act
     try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
@@ -884,7 +909,7 @@ public class RemoteSpawnCacheTest {
                   return null;
                 })
         .when(remoteExecutionService)
-        .uploadOutputs(any(), any(), any());
+        .uploadOutputs(any(), any(), any(), any());
 
     // act
     // Simulate the first spawn writing to the output, but delay its completion.
@@ -974,13 +999,14 @@ public class RemoteSpawnCacheTest {
     // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
     // concurrency to this test.
     AtomicReference<Runnable> onUploadComplete = new AtomicReference<>();
-    Mockito.doAnswer(
+    RemoteExecutionService remoteExecutionService1 = doAnswer(
             invocationOnMock -> {
               onUploadComplete.set(invocationOnMock.getArgument(2));
               return null;
-            })
-        .when(remoteExecutionService)
-        .uploadOutputs(any(), any(), any());
+            }).when(remoteExecutionService);
+    RemoteAction action = any();
+    SpawnResult spawnResult = any();
+    remoteExecutionService1.uploadOutputs(action, spawnResult, any(), any());
 
     // act
     try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
@@ -1045,7 +1071,7 @@ public class RemoteSpawnCacheTest {
               .setRunnerName("test")
               .build());
     }
-    Mockito.verify(remoteExecutionService, never()).uploadOutputs(any(), any(), any());
+    Mockito.verify(remoteExecutionService, never()).uploadOutputs(any(), any(), any(), any());
     CacheHandle secondCacheHandle = cache.lookup(secondSpawn, secondPolicy);
 
     // assert
@@ -1078,13 +1104,14 @@ public class RemoteSpawnCacheTest {
     // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
     // concurrency to this test.
     AtomicReference<Runnable> onUploadComplete = new AtomicReference<>();
-    Mockito.doAnswer(
+    RemoteExecutionService remoteExecutionService1 = doAnswer(
             invocationOnMock -> {
               onUploadComplete.set(invocationOnMock.getArgument(2));
               return null;
-            })
-        .when(remoteExecutionService)
-        .uploadOutputs(any(), any(), any());
+            }).when(remoteExecutionService);
+    RemoteAction action = any();
+    SpawnResult spawnResult = any();
+    remoteExecutionService1.uploadOutputs(action, spawnResult, any(), any());
 
     // act
     try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -377,10 +377,7 @@ public class RemoteSpawnCacheTest {
     verify(service)
         .downloadOutputs(
             any(), eq(RemoteActionResult.createFromCache(CachedActionResult.remote(actionResult))));
-    RemoteExecutionService remoteExecutionService = verify(service, never());
-    RemoteAction action = any();
-    SpawnResult spawnResult = any();
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service, never()).uploadOutputs(any(), any(), any(), any());
     assertThat(result.getDigest())
         .isEqualTo(digestUtil.asSpawnLogProto(actionKeyCaptor.getValue()));
     assertThat(result.setupSuccess()).isTrue();
@@ -414,15 +411,9 @@ public class RemoteSpawnCacheTest {
             .setStatus(Status.SUCCESS)
             .setRunnerName("test")
             .build();
-    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
-    RemoteAction action1 = any();
-    SpawnResult spawnResult1 = any();
-    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any(), any());
     entry.store(result);
-    RemoteExecutionService remoteExecutionService = verify(service);
-    RemoteAction action = any();
-    SpawnResult spawnResult = any();
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service).uploadOutputs(any(), any(), any(), any());
   }
 
   @Test
@@ -628,10 +619,7 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
     entry.store(result);
-    RemoteExecutionService remoteExecutionService = verify(service, never());
-    RemoteAction action = any();
-    SpawnResult spawnResult = any();
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service, never()).uploadOutputs(any(), any(), any(), any());
   }
 
   @Test
@@ -655,15 +643,9 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
 
-    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
-    RemoteAction action1 = any();
-    SpawnResult spawnResult1 = any();
-    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any(), any());
     entry.store(result);
-    RemoteExecutionService remoteExecutionService = verify(service);
-    RemoteAction action = any();
-    SpawnResult spawnResult = eq(result);
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service).uploadOutputs(any(), eq(result), any(), any());
 
     assertThat(eventHandler.getEvents()).hasSize(1);
     Event evt = eventHandler.getEvents().get(0);
@@ -710,15 +692,9 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
 
-    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
-    RemoteAction action1 = any();
-    SpawnResult spawnResult1 = any();
-    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any(), any());
     entry.store(result);
-    RemoteExecutionService remoteExecutionService = verify(service);
-    RemoteAction action = any();
-    SpawnResult spawnResult = eq(result);
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service).uploadOutputs(any(), eq(result), any(), any());
     assertThat(eventHandler.getEvents()).isEmpty(); // no warning is printed.
   }
 
@@ -823,14 +799,13 @@ public class RemoteSpawnCacheTest {
     // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
     // concurrency to this test.
     AtomicReference<Runnable> onUploadComplete = new AtomicReference<>();
-    RemoteExecutionService remoteExecutionService1 = doAnswer(
-        invocationOnMock -> {
-          onUploadComplete.set(invocationOnMock.getArgument(2));
-          return null;
-        }).when(remoteExecutionService);
-    RemoteAction action = any();
-    SpawnResult spawnResult = any();
-    remoteExecutionService1.uploadOutputs(action, spawnResult, any(), any());
+    Mockito.doAnswer(
+            invocationOnMock -> {
+              onUploadComplete.set(invocationOnMock.getArgument(2));
+              return null;
+            })
+        .when(remoteExecutionService)
+        .uploadOutputs(any(), any(), any(), any());
 
     // act
     try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
@@ -999,14 +974,13 @@ public class RemoteSpawnCacheTest {
     // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
     // concurrency to this test.
     AtomicReference<Runnable> onUploadComplete = new AtomicReference<>();
-    RemoteExecutionService remoteExecutionService1 = doAnswer(
+    Mockito.doAnswer(
             invocationOnMock -> {
               onUploadComplete.set(invocationOnMock.getArgument(2));
               return null;
-            }).when(remoteExecutionService);
-    RemoteAction action = any();
-    SpawnResult spawnResult = any();
-    remoteExecutionService1.uploadOutputs(action, spawnResult, any(), any());
+            })
+        .when(remoteExecutionService)
+        .uploadOutputs(any(), any(), any(), any());
 
     // act
     try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {
@@ -1104,14 +1078,13 @@ public class RemoteSpawnCacheTest {
     // deduplicated rather than a cache hit. This is a slight hack, but also avoid introducing
     // concurrency to this test.
     AtomicReference<Runnable> onUploadComplete = new AtomicReference<>();
-    RemoteExecutionService remoteExecutionService1 = doAnswer(
+    Mockito.doAnswer(
             invocationOnMock -> {
               onUploadComplete.set(invocationOnMock.getArgument(2));
               return null;
-            }).when(remoteExecutionService);
-    RemoteAction action = any();
-    SpawnResult spawnResult = any();
-    remoteExecutionService1.uploadOutputs(action, spawnResult, any(), any());
+            })
+        .when(remoteExecutionService)
+        .uploadOutputs(any(), any(), any(), any());
 
     // act
     try (CacheHandle firstCacheHandle = cache.lookup(firstSpawn, firstPolicy)) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -256,7 +256,10 @@ public class RemoteSpawnRunnerTest {
     // TODO(olaola): verify that the uploaded action has the doNotCache set.
 
     verify(service, never()).lookupCache(any());
-    verify(service, never()).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService = verify(service, never());
+    RemoteAction action = any();
+    SpawnResult spawnResult = any();
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
     verifyNoMoreInteractions(localRunner);
   }
 
@@ -334,7 +337,10 @@ public class RemoteSpawnRunnerTest {
 
     RemoteSpawnRunner runner = spy(newSpawnRunner());
     RemoteExecutionService service = runner.getRemoteExecutionService();
-    doNothing().when(service).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
+    RemoteAction action1 = any();
+    SpawnResult spawnResult1 = any();
+    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
 
     // Throw an IOException to trigger the local fallback.
     when(executor.executeRemotely(
@@ -360,7 +366,10 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    verify(service).uploadOutputs(any(), eq(res), any());
+    RemoteExecutionService remoteExecutionService = verify(service);
+    RemoteAction action = any();
+    SpawnResult spawnResult = eq(res);
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
   }
 
   @Test
@@ -393,7 +402,10 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    verify(service, never()).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService = verify(service, never());
+    RemoteAction action = any();
+    SpawnResult spawnResult = any();
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
   }
 
   @Test
@@ -421,7 +433,10 @@ public class RemoteSpawnRunnerTest {
             any(ExecuteRequest.class),
             any(OperationObserver.class)))
         .thenThrow(IOException.class);
-    doNothing().when(service).uploadOutputs(any(), any(), any());
+    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
+    RemoteAction action1 = any();
+    SpawnResult spawnResult1 = any();
+    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -439,7 +454,10 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    verify(service).uploadOutputs(any(), eq(result), any());
+    RemoteExecutionService remoteExecutionService = verify(service);
+    RemoteAction action = any();
+    SpawnResult spawnResult = eq(result);
+    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
     verify(service, never()).downloadOutputs(any(), any());
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -256,10 +256,7 @@ public class RemoteSpawnRunnerTest {
     // TODO(olaola): verify that the uploaded action has the doNotCache set.
 
     verify(service, never()).lookupCache(any());
-    RemoteExecutionService remoteExecutionService = verify(service, never());
-    RemoteAction action = any();
-    SpawnResult spawnResult = any();
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service, never()).uploadOutputs(any(), any(), any(), any());
     verifyNoMoreInteractions(localRunner);
   }
 
@@ -337,10 +334,7 @@ public class RemoteSpawnRunnerTest {
 
     RemoteSpawnRunner runner = spy(newSpawnRunner());
     RemoteExecutionService service = runner.getRemoteExecutionService();
-    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
-    RemoteAction action1 = any();
-    SpawnResult spawnResult1 = any();
-    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any(), any());
 
     // Throw an IOException to trigger the local fallback.
     when(executor.executeRemotely(
@@ -366,10 +360,7 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    RemoteExecutionService remoteExecutionService = verify(service);
-    RemoteAction action = any();
-    SpawnResult spawnResult = eq(res);
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service).uploadOutputs(any(), eq(res), any(), any());
   }
 
   @Test
@@ -402,10 +393,7 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    RemoteExecutionService remoteExecutionService = verify(service, never());
-    RemoteAction action = any();
-    SpawnResult spawnResult = any();
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service, never()).uploadOutputs(any(), any(), any(), any());
   }
 
   @Test
@@ -433,10 +421,7 @@ public class RemoteSpawnRunnerTest {
             any(ExecuteRequest.class),
             any(OperationObserver.class)))
         .thenThrow(IOException.class);
-    RemoteExecutionService remoteExecutionService1 = doNothing().when(service);
-    RemoteAction action1 = any();
-    SpawnResult spawnResult1 = any();
-    remoteExecutionService1.uploadOutputs(action1, spawnResult1, any(), any());
+    doNothing().when(service).uploadOutputs(any(), any(), any(), any());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -454,10 +439,7 @@ public class RemoteSpawnRunnerTest {
     verify(localRunner).exec(eq(spawn), eq(policy));
     verify(runner)
         .execLocallyAndUpload(any(), eq(spawn), eq(policy), /* uploadLocalResults= */ eq(true));
-    RemoteExecutionService remoteExecutionService = verify(service);
-    RemoteAction action = any();
-    SpawnResult spawnResult = eq(result);
-    remoteExecutionService.uploadOutputs(action, spawnResult, any(), any());
+    verify(service).uploadOutputs(any(), eq(result), any(), any());
     verify(service, never()).downloadOutputs(any(), any());
   }
 


### PR DESCRIPTION
Without `--guard_against_concurrent_changes`, locally executed actions can easily pollute the disk or remote cache when inputs are modified during execution, which is in stark contrast to Bazel's correctness guarantees. But with the flag enabled, the additional file system operations can unnecessarily slow down non-interactive builds and also, in rare but not negligible cases, result in false positives, which has made it difficult to flip the flag.

This change aims to resolve this issue by introducing a "lite" value of the flag that only checks source files in the main repository. Since output files are made read-only after digesting and files in external repositories are rarely modified during execution (`local_repository` being a notable exception), this gets most of the benefits for correctness while requiring far fewer stats (99% fewer calls to `wasModifiedSinceDigest` on the Bazel project). It also avoids the false positives that can arise for output files, which makes it possible to enable by default.

Along the way, this change unifies concurrent change detection between `RemoteSpawnCache` and `RemoteSpawnRunner` by moving it into `RemoteExecutionService#uploadOutputs`. The implementation in `RemoteSpawnRunner` required two stats per input and the `RemoteSpawnCache` implementation unnecessarily retained the spawn input mapping, both of which is fixed in the new, centralized implementation.

Work towards #3360