### PR TITLE
Reduce memory footprint of `DirectoryTree.FileNode`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
@@ -124,8 +124,7 @@ class DirectoryTreeBuilder {
             throw new IOException(String.format("Input '%s' is not a file.", input));
           }
           Digest d = digestUtil.compute(input);
-          boolean childAdded =
-              currDir.addChild(FileNode.createExecutable(path.getBaseName(), input, d));
+          boolean childAdded = currDir.addChild(FileNode.create(path.getBaseName(), input, d));
           return childAdded ? 1 : 0;
         });
   }
@@ -156,7 +155,7 @@ class DirectoryTreeBuilder {
             Digest d = digestUtil.compute(virtualActionInput);
             boolean childAdded =
                 currDir.addChild(
-                    FileNode.createExecutable(
+                    FileNode.create(
                         path.getBaseName(), virtualActionInput, d, toolInputs.contains(path)));
             return childAdded ? 1 : 0;
           }
@@ -172,8 +171,7 @@ class DirectoryTreeBuilder {
               Path inputPath = artifactPathResolver.toPath(input);
               boolean childAdded =
                   currDir.addChild(
-                      FileNode.createExecutable(
-                          path.getBaseName(), inputPath, d, toolInputs.contains(path)));
+                      FileNode.create(path.getBaseName(), inputPath, d, toolInputs.contains(path)));
               return childAdded ? 1 : 0;
             }
             case DIRECTORY -> {

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -397,7 +397,12 @@ public class MerkleTree {
         FileNode.newBuilder()
             .setName(internalToUnicode(file.getPathSegment()))
             .setDigest(file.getDigest())
-            .setIsExecutable(file.isExecutable());
+            // We always treat files as executable since Bazel will `chmod 555` on the output files
+            // of an action within ActionOutputMetadataStore#getMetadata after action execution if
+            // no metadata was injected. We can't use real executable bit of the file until this
+            // behavior is changed. See https://github.com/bazelbuild/bazel/issues/13262 for more
+            // details.
+            .setIsExecutable(true);
     if (file.isToolInput()) {
       node.getNodePropertiesBuilder().addPropertiesBuilder().setName(BAZEL_TOOL_INPUT_MARKER);
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
@@ -84,9 +84,9 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
     assertThat(directoriesAtDepth(1, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+        FileNode.create("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
     FileNode expectedBarNode =
-        FileNode.createExecutable("bar.cc", bar, digestUtil.computeAsUtf8("bar"), false);
+        FileNode.create("bar.cc", bar, digestUtil.computeAsUtf8("bar"), false);
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode, expectedBarNode);
   }
@@ -137,12 +137,12 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
     assertThat(directoriesAtDepth(3, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+        FileNode.create("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
     FileNode expectedBarNode =
-        FileNode.createExecutable(
+        FileNode.create(
             "bar.cc", execRoot.getRelative(bar.getExecPath()), digestUtil.computeAsUtf8("bar"));
     FileNode expectedBuzzNode =
-        FileNode.createExecutable(
+        FileNode.create(
             "buzz.cc", execRoot.getRelative(buzz.getExecPath()), digestUtil.computeAsUtf8("buzz"));
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode);
@@ -185,7 +185,7 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
     assertThat(directoriesAtDepth(1, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable(
+        FileNode.create(
             "foo.cc", execRoot.getRelative(foo.getExecPath()), digestUtil.computeAsUtf8("foo"));
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode);

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
@@ -78,12 +78,9 @@ public abstract class DirectoryTreeTest {
     assertThat(directoriesAtDepth(1, tree)).containsExactly("fizz");
     assertThat(directoriesAtDepth(2, tree)).isEmpty();
 
-    FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo, digestUtil.computeAsUtf8("foo"));
-    FileNode expectedBarNode =
-        FileNode.createExecutable("bar.cc", bar, digestUtil.computeAsUtf8("bar"));
-    FileNode expectedBuzzNode =
-        FileNode.createExecutable("buzz.cc", buzz, digestUtil.computeAsUtf8("buzz"));
+    FileNode expectedFooNode = FileNode.create("foo.cc", foo, digestUtil.computeAsUtf8("foo"));
+    FileNode expectedBarNode = FileNode.create("bar.cc", bar, digestUtil.computeAsUtf8("bar"));
+    FileNode expectedBuzzNode = FileNode.create("buzz.cc", buzz, digestUtil.computeAsUtf8("buzz"));
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode, expectedBarNode);
     assertThat(fileNodesAtDepth(tree, 2)).containsExactly(expectedBuzzNode);


### PR DESCRIPTION
The instance size is reduced from 32 to 24 bytes, which matters for builds with high `--jobs` count, where `MerkleTree`s take up a significant chunk of memory.