### PR TITLE
Intern Bzlmod fake package metadata

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Interner;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.bugreport.BugReport;
 import com.google.devtools.build.lib.cmdline.BazelModuleContext;
@@ -33,6 +34,7 @@ import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.cmdline.StarlarkThreadContext;
 import com.google.devtools.build.lib.cmdline.TargetPattern;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.EventKind;
@@ -832,21 +834,32 @@ public class Package extends Packageoid {
         /* trackFullMacroInformation= */ true);
   }
 
+  // Bzlmod creates one fake package per external repository. The repos created by a given
+  // extension, which can be 1000s, share the same metadata.
+  private static final Interner<Metadata> bzlmodMetadataInterner = BlazeInterners.newWeakInterner();
+
   public static Builder newExternalPackageBuilderForBzlmod(
       RootedPath moduleFilePath,
       boolean noImplicitFileExport,
       boolean simplifyUnconditionalSelectsInRuleAttrs,
       PackageIdentifier basePackageId,
       RepositoryMapping repoMapping) {
+    // moduleFilePath is turned into a string and retained as the Location of
+    // the created package. Ensure that this string is the same instance as
+    // the one in the interned Metadata object.
+    RootedPath absoluteRootModuleFilePath =
+        RootedPath.toRootedPath(
+            Root.absoluteRoot(moduleFilePath.getRoot().getFileSystem()), moduleFilePath.asPath());
     return new Builder(
-            Metadata.builder()
-                .packageIdentifier(basePackageId)
-                .buildFilename(moduleFilePath)
-                .isRepoRulePackage(true)
-                .repositoryMapping(repoMapping)
-                .succinctTargetNotFoundErrors(
-                    PackageSettings.DEFAULTS.succinctTargetNotFoundErrors())
-                .build(),
+            bzlmodMetadataInterner.intern(
+                Metadata.builder()
+                    .packageIdentifier(basePackageId)
+                    .buildFilename(absoluteRootModuleFilePath)
+                    .isRepoRulePackage(true)
+                    .repositoryMapping(repoMapping)
+                    .succinctTargetNotFoundErrors(
+                        PackageSettings.DEFAULTS.succinctTargetNotFoundErrors())
+                    .build()),
             SymbolGenerator.create(basePackageId),
             PackageSettings.DEFAULTS.precomputeTransitiveLoads(),
             noImplicitFileExport,


### PR DESCRIPTION
Bzlmod creates a fake package per repo, each of which retains a unique instance of the module file path as well as the fake package ID, both of which can be deduplicated across all repos created by an extension.