### PR TITLE
Don't retain `ExecutionProgressReceiver` after a build

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionProgressReceiver.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionProgressReceiver.java
@@ -63,7 +63,6 @@ public final class ExecutionProgressReceiver
 
   private final Set<ActionLookupData> enqueuedActions = Sets.newConcurrentHashSet();
   private final Set<ActionLookupData> completedActions = Sets.newConcurrentHashSet();
-  private final Set<ActionLookupData> ignoredActions = Sets.newConcurrentHashSet();
   private final EventBus eventBus;
 
   /** Number of exclusive tests. To be accounted for in progress messages. */
@@ -82,13 +81,11 @@ public final class ExecutionProgressReceiver
   public void enqueueing(SkyKey skyKey) {
     if (skyKey.functionName().equals(SkyFunctions.ACTION_EXECUTION)) {
       ActionLookupData actionLookupData = (ActionLookupData) skyKey.argument();
-      if (!ignoredActions.contains(actionLookupData)) {
-        // Remember all enqueued actions for the benefit of progress reporting.
-        // We discover most actions early in the build, well before we start executing them.
-        // Some of these will be cache hits and won't be executed, so we'll need to account for them
-        // in the evaluated method too.
-        enqueuedActions.add(actionLookupData);
-      }
+      // Remember all enqueued actions for the benefit of progress reporting.
+      // We discover most actions early in the build, well before we start executing them.
+      // Some of these will be cache hits and won't be executed, so we'll need to account for them
+      // in the evaluated method too.
+      enqueuedActions.add(actionLookupData);
     }
   }
 
@@ -174,10 +171,8 @@ public final class ExecutionProgressReceiver
    */
   @Override
   public void actionCompleted(ActionLookupData actionLookupData) {
-    if (!ignoredActions.contains(actionLookupData)) {
-      enqueuedActions.add(actionLookupData);
-      completedActions.add(actionLookupData);
-    }
+    enqueuedActions.add(actionLookupData);
+    completedActions.add(actionLookupData);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -106,7 +106,7 @@ public final class UiEventHandler implements EventHandler {
   private final EventBus eventBus;
   private final AnsiTerminal terminal;
   private final boolean debugAllEvents;
-  private final UiStateTracker stateTracker;
+  private UiStateTracker stateTracker;
   private final LocationPrinter locationPrinter;
   private volatile boolean showProgress;
   private final boolean progressInTermTitle;

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -479,6 +479,7 @@ class UiStateTracker {
 
   Event buildComplete(BuildCompleteEvent event) {
     setBuildComplete();
+    executionProgressReceiver = null;
 
     status = null;
     additionalMessage = "";


### PR DESCRIPTION
Also delete a set that is always empty.