### PR TITLE
unix_jni.cc: fix unused variable

### DIFF
--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -822,7 +822,7 @@ static void PostDeleteTreesBelowException(
     path = entry;
   }
   BAZEL_CHECK(!env->ExceptionOccurred());
-  PostException(env, errno, std::string(function) + " (" + path + ")");
+  PostException(env, error, std::string(function) + " (" + path + ")");
 }
 
 // Tries to open a directory and, if the first attempt fails, retries after


### PR DESCRIPTION
Fix a bug in PostDeleteTreesBelowException: it used "errno" instead of the passed-in "error" argument.