### PR TITLE
Optimize empty mutable Starlark lists

### DIFF
--- a/src/main/java/net/starlark/java/eval/MutableStarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/MutableStarlarkList.java
@@ -30,15 +30,15 @@ final class MutableStarlarkList<E> extends StarlarkList<E> {
   // elems.getClass() == Object[].class. This is necessary to avoid ArrayStoreException.
   private int size;
   private int iteratorCount; // number of active iterators (unused once frozen)
-  Object[] elems = StarlarkList.EMPTY_ARRAY; // elems[i] == null  iff  i >= size
+  private Object[] elems; // elems[i] == null  iff  i >= size
 
   /** Final except for {@link #unsafeShallowFreeze}; must not be modified any other way. */
   private Mutability mutability;
 
-  MutableStarlarkList(@Nullable Mutability mutability, Object[] elems, int size) {
+  MutableStarlarkList(@Nullable Mutability mutability, Object[] elems) {
     Preconditions.checkArgument(elems.getClass() == Object[].class);
-    this.elems = elems;
-    this.size = size;
+    this.elems = elems.length == 0 ? StarlarkList.EMPTY_ARRAY : elems;
+    this.size = elems.length;
     this.mutability = mutability == null ? Mutability.IMMUTABLE : mutability;
   }
 

--- a/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -96,16 +96,13 @@ public abstract class StarlarkList<E> extends AbstractCollection<E>
    */
   static <T> StarlarkList<T> wrap(@Nullable Mutability mutability, Object[] elems) {
     if (mutability == null || mutability.isFrozen()) {
-      switch (elems.length) {
-        case 0:
-          return empty();
-        case 1:
-          return new ImmutableSingletonStarlarkList<>(elems[0]);
-        default:
-          return new RegularImmutableStarlarkList<>(elems);
-      }
+      return switch (elems.length) {
+        case 0 -> empty();
+        case 1 -> new ImmutableSingletonStarlarkList<>(elems[0]);
+        default -> new RegularImmutableStarlarkList<>(elems);
+      };
     }
-    return new MutableStarlarkList<>(mutability, elems, elems.length);
+    return new MutableStarlarkList<>(mutability, elems);
   }
 
   @Override


### PR DESCRIPTION
The existing assignment of `StarlarkList.EMPTY_ARRAY` wasn't effective at ensuring that an empty list uses the same empty array as a backing instance.