### PR TITLE
[8.2.0] build metrics: Do not set start/end of mnemonics that were only created but not executed.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/MetricsCollector.java
@@ -355,16 +355,21 @@ class MetricsCollector {
   private ActionData buildActionData(ActionStats actionStats) {
     NanosToMillisSinceEpochConverter nanosToMillisSinceEpochConverter =
         BlazeClock.createNanosToMillisSinceEpochConverter();
+    long numActionsExecuted = actionStats.numActionsExecuted.get();
     ActionData.Builder builder =
         ActionData.newBuilder()
             .setMnemonic(actionStats.mnemonic)
-            .setFirstStartedMs(
-                nanosToMillisSinceEpochConverter.toEpochMillis(
-                    actionStats.firstStarted.longValue()))
-            .setLastEndedMs(
-                nanosToMillisSinceEpochConverter.toEpochMillis(actionStats.lastEnded.longValue()))
-            .setActionsExecuted(actionStats.numActionsExecuted.get())
+            .setActionsExecuted(numActionsExecuted)
             .setActionsCreated(actionStats.numActionsRegistered.get());
+
+    if (numActionsExecuted > 0) {
+      builder
+          .setFirstStartedMs(
+              nanosToMillisSinceEpochConverter.toEpochMillis(actionStats.firstStarted.longValue()))
+          .setLastEndedMs(
+              nanosToMillisSinceEpochConverter.toEpochMillis(actionStats.lastEnded.longValue()));
+    }
+
     long systemTime = actionStats.systemTime.get();
     if (systemTime > 0) {
       builder.setSystemTime(Durations.fromMillis(systemTime));


### PR DESCRIPTION
This would previously show confusing metrics such as
```
  {
    "mnemonic": "FileWrite",
    "firstStartedMs": "10965232776311",
    "lastEndedMs": "1741860739457",
    "actionsCreated": "10"
  },
```

PiperOrigin-RevId: 737613747
Change-Id: I544f220766c4170318c7f1438584c5613fdc8fa0

Commit https://github.com/bazelbuild/bazel/commit/bcfd3e7be9e0414ecb11f0d0d9d9a55d3d276fd6