### PR TITLE
[7.6.0] Don't retain `ExecutionProgressReceiver` after a build

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionProgressReceiver.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionProgressReceiver.java
@@ -64,7 +64,6 @@ public final class ExecutionProgressReceiver
 
   private final Set<ActionLookupData> enqueuedActions = Sets.newConcurrentHashSet();
   private final Set<ActionLookupData> completedActions = Sets.newConcurrentHashSet();
-  private final Set<ActionLookupData> ignoredActions = Sets.newConcurrentHashSet();
   private final EventBus eventBus;
 
   /** Number of exclusive tests. To be accounted for in progress messages. */
@@ -83,13 +82,11 @@ public final class ExecutionProgressReceiver
   public void enqueueing(SkyKey skyKey) {
     if (skyKey.functionName().equals(SkyFunctions.ACTION_EXECUTION)) {
       ActionLookupData actionLookupData = (ActionLookupData) skyKey.argument();
-      if (!ignoredActions.contains(actionLookupData)) {
-        // Remember all enqueued actions for the benefit of progress reporting.
-        // We discover most actions early in the build, well before we start executing them.
-        // Some of these will be cache hits and won't be executed, so we'll need to account for them
-        // in the evaluated method too.
-        enqueuedActions.add(actionLookupData);
-      }
+      // Remember all enqueued actions for the benefit of progress reporting.
+      // We discover most actions early in the build, well before we start executing them.
+      // Some of these will be cache hits and won't be executed, so we'll need to account for them
+      // in the evaluated method too.
+      enqueuedActions.add(actionLookupData);
     }
   }
 
@@ -178,10 +175,8 @@ public final class ExecutionProgressReceiver
    */
   @Override
   public void actionCompleted(ActionLookupData actionLookupData) {
-    if (!ignoredActions.contains(actionLookupData)) {
-      enqueuedActions.add(actionLookupData);
-      completedActions.add(actionLookupData);
-    }
+    enqueuedActions.add(actionLookupData);
+    completedActions.add(actionLookupData);
   }
 
   private static boolean isActionReportWorthy(Action action) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -464,6 +464,7 @@ class UiStateTracker {
 
   Event buildComplete(BuildCompleteEvent event) {
     setBuildComplete();
+    executionProgressReceiver = null;
 
     status = null;
     additionalMessage = "";


### PR DESCRIPTION
Also delete a set that is always empty.

Closes #25582.

PiperOrigin-RevId: 737927900
Change-Id: I0afa21d8fd3960ee4387254dfbe2ebe3c972056c

Commit https://github.com/bazelbuild/bazel/commit/1b7366a3f0912b0b4d5c99329d803616dfca2212