### PR TITLE
[8.2.0] Prevent concurrent use of the same `CharsetEncoder` in `json.decode`

### DIFF
--- a/src/main/java/net/starlark/java/lib/json/Json.java
+++ b/src/main/java/net/starlark/java/lib/json/Json.java
@@ -459,21 +459,24 @@ public final class Json implements StarlarkValue {
       throw Starlark.errorf("unexpected character %s", quoteChar(c));
     }
 
-    // The default encoding behavior for Java's UTF-8 encoder is to replace with '?', not the
-    // Unicode replacement character U+FFFD. This also applies to String#getBytes(...).
-    private static final CharsetEncoder UTF_8_ENCODER =
-        UTF_8
-            .newEncoder()
-            .onMalformedInput(CodingErrorAction.REPLACE)
-            .onUnmappableCharacter(CodingErrorAction.REPLACE)
-            .replaceWith("\uFFFD".getBytes(UTF_8));
-    // The default encoding behavior for Java's UTF-16 encoder is to replace with the Unicode
-    // replacement character U+FFFD, but this doesn't apply to String#getBytes(...).
-    private static final CharsetEncoder UTF_16_ENCODER =
-        UTF_16
-            .newEncoder()
-            .onMalformedInput(CodingErrorAction.REPLACE)
-            .onUnmappableCharacter(CodingErrorAction.REPLACE);
+    private static CharsetEncoder createUtf8Encoder() {
+      // The default encoding behavior for Java's UTF-8 encoder is to replace with '?', not the
+      // Unicode replacement character U+FFFD. This also applies to String#getBytes(...).
+      return UTF_8
+          .newEncoder()
+          .onMalformedInput(CodingErrorAction.REPLACE)
+          .onUnmappableCharacter(CodingErrorAction.REPLACE)
+          .replaceWith("\uFFFD".getBytes(UTF_8));
+    }
+
+    private static CharsetEncoder createUtf16Encoder() {
+      // The default encoding behavior for Java's UTF-16 encoder is to replace with the Unicode
+      // replacement character U+FFFD, but this doesn't apply to String#getBytes(...).
+      return UTF_16
+          .newEncoder()
+          .onMalformedInput(CodingErrorAction.REPLACE)
+          .onUnmappableCharacter(CodingErrorAction.REPLACE);
+    }
 
     private String parseString() throws EvalException {
       i++; // '"'
@@ -528,7 +531,7 @@ public final class Json implements StarlarkValue {
             ByteBuffer byteBuffer;
             try {
               byteBuffer =
-                  (utf8ByteStrings ? UTF_8_ENCODER : UTF_16_ENCODER)
+                  (utf8ByteStrings ? createUtf8Encoder() : createUtf16Encoder())
                       .encode(CharBuffer.wrap(utf16String));
             } catch (CharacterCodingException e) {
               // Cannot happen because we replace with U+FFFD.


### PR DESCRIPTION
Encoders are stateful, and `json.decode` may be called concurrently by multiple threads. This will (if we're lucky) manifest as an `IllegalStateException` thrown by `CharsetEncoder.encode()`.

We could consider keeping a single instance around for reuse (i.e. a one-element object pool), but I'll refrain from doing so until we have evidence that it's worth optimizing.

PiperOrigin-RevId: 737594384
Change-Id: I8d8c87a9919661ef49490293f54d513ee1fe6b69