### PR TITLE
[7.6.0] Actually use 0777 when creating directories.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -335,7 +335,7 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
     // Use 0777 so that the permissions can be overridden by umask(2).
     // Note: UNIX mkdir(2), FilesystemUtils.mkdir() and createDirectory all
     // have different ways of representing failure!
-    if (NativePosixFiles.mkdir(path.toString(), 0755)) {
+    if (NativePosixFiles.mkdir(path.toString(), 0777)) {
       return true; // successfully created
     }
 
@@ -355,7 +355,7 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
   @Override
   public void createDirectoryAndParents(PathFragment path) throws IOException {
     // Use 0777 so that the permissions can be overridden by umask(2).
-    NativePosixFiles.mkdirs(path.toString(), 0755);
+    NativePosixFiles.mkdirs(path.toString(), 0777);
   }
 
   @Override


### PR DESCRIPTION
This should have been a part of https://github.com/bazelbuild/bazel/pull/23525, but was inexplicably missing when it was cherry-picked from 8c5e9da.