### PR TITLE
[7.6.0] Clear `AsyncTaskCache`s after shutdown

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/util/AsyncTaskCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/AsyncTaskCacheTest.java
@@ -463,6 +463,9 @@ public class AsyncTaskCacheTest {
     assertThat(cache.isShutdown()).isTrue();
     assertThat(cache.isTerminated()).isTrue();
     ob.assertValue("value");
+
+    assertThat(cache.getInProgressTasks()).isEmpty();
+    assertThat(cache.getFinishedTasks()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
`RemoteActionInputPrefetcher` is retained through `RemoteActionFileSystem` and in turn retains all finished `AsyncTaskCache` tasks, which are only relevant intra-build and can thus be dropped after shutdown. This saves ~1% of retained heap on the Bazel frontend example.

Closes #25579.

PiperOrigin-RevId: 738084614
Change-Id: Ia6f5e9a20f026a861f649090e6f72f8b2152443f

Commit https://github.com/bazelbuild/bazel/commit/0ce2f955e3f2516737202a3377ca65838eb3b7c7