### PR TITLE
Have `RunfilesTree#getMapping` return a `SortedMap`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -43,6 +43,7 @@ import com.google.devtools.common.options.OptionsProvider;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
+import java.util.SortedMap;
 import javax.annotation.Nullable;
 
 /** A class that groups services in the scope of the action. Like the FileOutErr object. */
@@ -67,7 +68,7 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
     }
 
     @Override
-    public Map<PathFragment, Artifact> getMapping() {
+    public SortedMap<PathFragment, Artifact> getMapping() {
       return wrapped.getMapping();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/RunfilesTree.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/RunfilesTree.java
@@ -19,7 +19,7 @@ import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue.Run
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import java.util.Map;
+import java.util.SortedMap;
 import javax.annotation.Nullable;
 
 /** Lazy wrapper for a single runfiles tree. */
@@ -30,7 +30,7 @@ public interface RunfilesTree {
   PathFragment getExecPath();
 
   /** Returns the mapping from the location in the runfiles tree to the artifact that's there. */
-  Map<PathFragment, Artifact> getMapping();
+  SortedMap<PathFragment, Artifact> getMapping();
 
   /**
    * Returns artifacts the runfiles tree contain symlinks to.

--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
 
@@ -87,7 +88,7 @@ public final class RunfilesSupport {
   @VisibleForTesting
   public static class RunfilesTreeImpl implements RunfilesTree {
 
-    private static final WeakReference<Map<PathFragment, Artifact>> NOT_YET_COMPUTED =
+    private static final WeakReference<SortedMap<PathFragment, Artifact>> NOT_YET_COMPUTED =
         new WeakReference<>(null);
 
     private final PathFragment execPath;
@@ -108,7 +109,7 @@ public final class RunfilesSupport {
      * com.google.devtools.build.lib.runtime.GcThrashingDetector} may throw a manual OOM before all
      * soft references are collected. See b/322474776.
      */
-    @Nullable private volatile WeakReference<Map<PathFragment, Artifact>> cachedMapping;
+    @Nullable private volatile WeakReference<SortedMap<PathFragment, Artifact>> cachedMapping;
 
     private final boolean buildRunfileLinks;
     private final RunfileSymlinksMode runfileSymlinksMode;
@@ -145,12 +146,12 @@ public final class RunfilesSupport {
     }
 
     @Override
-    public Map<PathFragment, Artifact> getMapping() {
+    public SortedMap<PathFragment, Artifact> getMapping() {
       if (cachedMapping == null) {
         return runfiles.getRunfilesInputs(repoMappingManifest);
       }
 
-      Map<PathFragment, Artifact> result = cachedMapping.get();
+      SortedMap<PathFragment, Artifact> result = cachedMapping.get();
       if (result != null) {
         return result;
       }

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/FakeRunfilesTree.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/FakeRunfilesTree.java
@@ -27,7 +27,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import java.util.Map;
+import java.util.SortedMap;
 import javax.annotation.Nullable;
 
 /** {@link RunfilesTree} implementation wrapping a single {@link Runfiles} directory mapping. */
@@ -74,7 +74,7 @@ public final class FakeRunfilesTree implements RunfilesTree {
   }
 
   @Override
-  public Map<PathFragment, Artifact> getMapping() {
+  public SortedMap<PathFragment, Artifact> getMapping() {
     return runfiles.getRunfilesInputs(repoMappingManifest);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -14,7 +14,7 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -134,8 +134,8 @@ import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Random;
+import java.util.SortedMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -2677,8 +2677,9 @@ public class RemoteExecutionServiceTest {
       }
 
       @Override
-      public Map<PathFragment, Artifact> getMapping() {
-        return artifacts.stream().collect(toImmutableMap(Artifact::getExecPath, a -> a));
+      public SortedMap<PathFragment, Artifact> getMapping() {
+        return artifacts.stream()
+            .collect(toImmutableSortedMap(PathFragment::compareTo, Artifact::getExecPath, a -> a));
       }
 
       @Override


### PR DESCRIPTION
It already always returns a `SortedMap` in production code, but signaling this on the type level makes it safer to consume the map in contexts where sorting is required, e.g. when computing Merkle trees.

Also drop an impossible switch case.