### PR TITLE
[7.6.0] Handle large numeric segments in Bazel module versions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Version.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Version.java
@@ -87,7 +87,7 @@ public abstract class Version implements Comparable<Version> {
 
     abstract boolean isDigitsOnly();
 
-    abstract int asNumber();
+    abstract long asNumber();
 
     abstract String asString();
 
@@ -96,7 +96,11 @@ public abstract class Version implements Comparable<Version> {
         throw new ParseException("identifier is empty");
       }
       if (string.chars().allMatch(Character::isDigit)) {
-        return new AutoValue_Version_Identifier(true, Integer.parseInt(string), string);
+        try {
+          return new AutoValue_Version_Identifier(true, Long.parseUnsignedLong(string), string);
+        } catch (NumberFormatException e) {
+          throw new ParseException("numeric version segment is too large: " + string, e);
+        }
       } else {
         return new AutoValue_Version_Identifier(false, 0, string);
       }
@@ -104,7 +108,7 @@ public abstract class Version implements Comparable<Version> {
 
     private static final Comparator<Identifier> COMPARATOR =
         comparing(Identifier::isDigitsOnly, trueFirst())
-            .thenComparingInt(Identifier::asNumber)
+            .thenComparing((a, b) -> Long.compareUnsigned(a.asNumber(), b.asNumber()))
             .thenComparing(Identifier::asString);
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/VersionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/VersionTest.java
@@ -70,14 +70,18 @@ public class VersionTest {
     assertThat(Version.parse("1.0-pre.99")).isLessThan(Version.parse("1.0-pre.2a"));
     assertThat(Version.parse("1.0-pre.patch.3")).isLessThan(Version.parse("1.0-pre.patch.4"));
     assertThat(Version.parse("1.0--")).isLessThan(Version.parse("1.0----"));
+    assertThat(Version.parse("2.1.1-develop.bcr.20250113215904"))
+        .isGreaterThan(Version.parse("2.1.1-develop.bcr.20250113215903"));
   }
 
   @Test
-  public void testParseException() throws Exception {
+  public void testParseException() {
     assertThrows(ParseException.class, () -> Version.parse("-abc"));
     assertThrows(ParseException.class, () -> Version.parse("1_2"));
     assertThrows(ParseException.class, () -> Version.parse("ßážëł"));
     assertThrows(ParseException.class, () -> Version.parse("1.0-pre?"));
+    assertThrows(
+        ParseException.class, () -> Version.parse("1.0-11111111111111111111111111111111111111111"));
     assertThrows(ParseException.class, () -> Version.parse("1.0-pre///"));
     assertThrows(ParseException.class, () -> Version.parse("1..0"));
     assertThrows(ParseException.class, () -> Version.parse("1.0-pre..erp"));


### PR DESCRIPTION
Numeric segments can now be unsigned longs rather than just signed integers. Segments that exceed this (large) range now result in an error rather than a crash.

Work towards #23461

Closes #24945.

PiperOrigin-RevId: 718451995
Change-Id: I141b707e8c28d5fe764b47b4c35f163a3621e4c5 
(cherry picked from commit a8a2c0c1fa063a0bba4e7222a1b1d2c8a4e0e632)

Fixes #25630