### PR TITLE
[8.2.0] Don't retain ExecutionProgressReceiver after a build

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -479,6 +479,7 @@ class UiStateTracker {
 
   Event buildComplete(BuildCompleteEvent event) {
     setBuildComplete();
+    executionProgressReceiver = null;
 
     status = null;
     additionalMessage = "";


### PR DESCRIPTION
Don't retain ExecutionProgressReceiver after a build
Also delete a set that is always empty.

Closes https://github.com/bazelbuild/bazel/pull/25582.

PiperOrigin-RevId: 737927900
Change-Id: I0afa21d8fd3960ee4387254dfbe2ebe3c972056c

Commit https://github.com/bazelbuild/bazel/commit/1b7366a3f0912b0b4d5c99329d803616dfca2212