### PR TITLE
Delete `--incompatible_sandbox_hermetic_tmp`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -208,11 +208,6 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   }
 
   private boolean useHermeticTmp() {
-    if (!getSandboxOptions().sandboxHermeticTmp) {
-      // No hermetic /tmp requested, so let's not do it
-      return false;
-    }
-
     if (getSandboxOptions().useHermetic) {
       // The hermetic sandbox is, well, already hermetic. Also, it creates an empty /tmp by default
       // so nothing needs to be done to achieve a /tmp that is also hermetic.
@@ -223,7 +218,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         getSandboxOptions().sandboxAdditionalMounts.stream()
             .anyMatch(e -> e.getKey().equals("/tmp"));
     if (tmpExplicitlyBindMounted) {
-      // An explicit mount on /tmp is likely an explicit way to make it non-hermetic.
+      // An explicit mount on /tmp is an explicit way to make it non-hermetic.
       return false;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -364,17 +364,6 @@ public class SandboxOptions extends OptionsBase {
   public boolean useHermetic;
 
   @Option(
-      name = "incompatible_sandbox_hermetic_tmp",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
-      effectTags = {OptionEffectTag.EXECUTION},
-      help =
-          "If set to true, each Linux sandbox will have its own dedicated empty directory mounted"
-              + " as /tmp rather than sharing /tmp with the host filesystem. Use"
-              + " --sandbox_add_mount_pair=/tmp to keep seeing the host's /tmp in all sandboxes.")
-  public boolean sandboxHermeticTmp;
-
-  @Option(
       name = "experimental_sandbox_memory_limit_mb",
       defaultValue = "0",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,

--- a/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunnerTest.java
@@ -165,7 +165,6 @@ public final class LinuxSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTes
 
   @Test
   public void hermeticTmp_tmpCreatedAndMounted() throws Exception {
-    runtimeWrapper.addOptions("--incompatible_sandbox_hermetic_tmp");
     CommandEnvironment commandEnvironment = createCommandEnvironment();
     LinuxSandboxedSpawnRunner runner = setupSandboxAndCreateRunner(commandEnvironment);
     Spawn spawn = new SpawnBuilder().build();
@@ -184,7 +183,7 @@ public final class LinuxSandboxedSpawnRunnerTest extends SandboxedSpawnRunnerTes
 
   @Test
   public void hermeticTmp_sandboxTmpfsOnTmp_tmpNotCreatedOrMounted() throws Exception {
-    runtimeWrapper.addOptions("--incompatible_sandbox_hermetic_tmp", "--sandbox_tmpfs_path=/tmp");
+    runtimeWrapper.addOptions("--sandbox_tmpfs_path=/tmp");
     CommandEnvironment commandEnvironment = createCommandEnvironment();
     LinuxSandboxedSpawnRunner runner = setupSandboxAndCreateRunner(commandEnvironment);
     Spawn spawn = new SpawnBuilder().build();

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -173,7 +173,7 @@ EOF
     && fail "build should have failed with hermetic sandbox" || true
   expect_log "child exited normally with code 1"
 
-  bazel build --verbose_failures --sandbox_debug --incompatible_sandbox_hermetic_tmp :broken &> $TEST_log \
+  bazel build --verbose_failures --sandbox_debug :broken &> $TEST_log \
     && fail "build should have failed with hermetic sandbox /tmp" || true
   expect_log "child exited normally with code 1"
 }
@@ -689,7 +689,7 @@ EOF
 
 function test_hermetic_tmp_under_tmp {
   if [[ "$(uname -s)" != Linux ]]; then
-    echo "Skipping test: --incompatible_sandbox_hermetic_tmp is only supported in Linux" 1>&2
+    echo "Skipping test: hermetic /tmp is only supported in Linux" 1>&2
     return 0
   fi
 
@@ -772,7 +772,6 @@ EOF
   bazel \
     --output_base="${temp_dir}/output-base" \
     build \
-    --incompatible_sandbox_hermetic_tmp \
     --package_path="%workspace%:${temp_dir}/package-path" \
     //a:t || fail "build failed"
 }

--- a/src/test/shell/integration/execution_strategies_test.sh
+++ b/src/test/shell/integration/execution_strategies_test.sh
@@ -218,7 +218,7 @@ EOF
   bazel build --internal_spawn_scheduler --genrule_strategy=dynamic \
     --dynamic_remote_strategy=sandboxed \
     --dynamic_local_strategy=standalone \
-    --sandbox_add_mount_pair=/tmp=/tmp \
+    --sandbox_add_mount_pair=/tmp \
     --experimental_dynamic_ignore_local_signals=8,9,10 \
     --experimental_local_lockfree_output \
     --experimental_local_execution_delay=0 \

--- a/src/test/shell/integration/execution_strategies_test.sh
+++ b/src/test/shell/integration/execution_strategies_test.sh
@@ -218,7 +218,7 @@ EOF
   bazel build --internal_spawn_scheduler --genrule_strategy=dynamic \
     --dynamic_remote_strategy=sandboxed \
     --dynamic_local_strategy=standalone \
-    --noincompatible_sandbox_hermetic_tmp \
+    --sandbox_add_mount_pair=/tmp=/tmp \
     --experimental_dynamic_ignore_local_signals=8,9,10 \
     --experimental_local_lockfree_output \
     --experimental_local_execution_delay=0 \

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -724,7 +724,7 @@ EOF
 
 function test_read_hermetic_tmp {
   if [[ "$(uname -s)" != Linux ]]; then
-    echo "Skipping test: --incompatible_sandbox_hermetic_tmp is only supported in Linux" 1>&2
+    echo "Skipping test: hermetic /tmp is only supported in Linux" 1>&2
     return 0
   fi
 
@@ -745,13 +745,12 @@ EOF
   chmod +x pkg/tmp_test.sh
 
   touch "${temp_dir}/file"
-  bazel test //pkg:tmp_test --incompatible_sandbox_hermetic_tmp \
-    --test_output=errors &>$TEST_log || fail "Expected test to pass"
+  bazel test //pkg:tmp_test --test_output=errors &>$TEST_log || fail "Expected test to pass"
 }
 
 function test_read_hermetic_tmp_user_override {
   if [[ "$(uname -s)" != Linux ]]; then
-    echo "Skipping test: --incompatible_sandbox_hermetic_tmp is only supported in Linux" 1>&2
+    echo "Skipping test: hermetic /tmp is only supported in Linux" 1>&2
     return 0
   fi
 
@@ -772,8 +771,7 @@ EOF
   chmod +x pkg/tmp_test.sh
 
   touch "${temp_dir}/file"
-  bazel test //pkg:tmp_test --incompatible_sandbox_hermetic_tmp --sandbox_add_mount_pair=/tmp \
-    --test_output=errors &>$TEST_log || fail "Expected test to pass"
+  bazel test //pkg:tmp_test --sandbox_add_mount_pair=/tmp --test_output=errors &>$TEST_log || fail "Expected test to pass"
 }
 
 function test_write_non_hermetic_tmp {
@@ -801,7 +799,7 @@ EOF
 
 function test_write_hermetic_tmp {
   if [[ "$(uname -s)" != Linux ]]; then
-    echo "Skipping test: --incompatible_sandbox_hermetic_tmp is only supported in Linux" 1>&2
+    echo "Skipping test: hermetic /tmp is only supported in Linux" 1>&2
     return 0
   fi
 
@@ -822,14 +820,13 @@ touch "${temp_dir}/file"
 EOF
   chmod +x pkg/tmp_test.sh
 
-  bazel test //pkg:tmp_test --incompatible_sandbox_hermetic_tmp \
-    --test_output=errors &>$TEST_log || fail "Expected test to pass"
+  bazel test //pkg:tmp_test --test_output=errors &>$TEST_log || fail "Expected test to pass"
   [[ ! -f "${temp_dir}" ]] || fail "Expected ${temp_dir} to not exit"
 }
 
 function test_write_hermetic_tmp_user_override {
   if [[ "$(uname -s)" != Linux ]]; then
-    echo "Skipping test: --incompatible_sandbox_hermetic_tmp is only supported in Linux" 1>&2
+    echo "Skipping test: hermetic /tmp is only supported in Linux" 1>&2
     return 0
   fi
 
@@ -849,7 +846,7 @@ touch "${temp_dir}/file"
 EOF
   chmod +x pkg/tmp_test.sh
 
-  bazel test //pkg:tmp_test --incompatible_sandbox_hermetic_tmp --sandbox_add_mount_pair=/tmp \
+  bazel test //pkg:tmp_test --sandbox_add_mount_pair=/tmp \
     --test_output=errors &>$TEST_log || fail "Expected test to pass"
   [[ -f "${temp_dir}/file" ]] || fail "Expected ${temp_dir}/file to exist"
 }
@@ -960,8 +957,7 @@ function test_hermetic_tmp_with_tmp_sandbox_base() {
 genrule(name = "pkg", outs = ["pkg.out"], cmd = "echo >\$@")
 EOF
   mkdir /tmp/sandbox_base
-  bazel build --incompatible_sandbox_hermetic_tmp \
-     --sandbox_base=/tmp/sandbox_base  //pkg >"${TEST_log}" 2>&1 \
+  bazel build --sandbox_base=/tmp/sandbox_base  //pkg >"${TEST_log}" 2>&1 \
         || fail "Expected build to succeed"
 }
 
@@ -972,9 +968,7 @@ genrule(name = "pkg", outs = ["pkg.out"], cmd = "echo >\$@")
 EOF
   mkdir /tmp/my_tmpdir
   TMPDIR=/tmp/my_tmpdir \
-    bazel build --incompatible_sandbox_hermetic_tmp \
-     //pkg >"${TEST_log}" 2>&1 \
-        || fail "Expected build to succeed"
+    bazel build //pkg >"${TEST_log}" 2>&1 || fail "Expected build to succeed"
 }
 
 function test_runfiles_from_tests_get_reused_and_tmp_clean() {


### PR DESCRIPTION
The flag was flipped in Bazel 7 and the behavior can still be toggled with the more descriptive and consistent `--sandbox_add_mount_pair=/tmp`.

RELNOTES[inc]: The `--incompatible_sandbox_hermetic_tmp` flag has been removed. To mount the entire `/tmp` directory into the sandbox, specify `--sandbox_add_mount_pair=/tmp`.