### PR TITLE
Flip `--incompatible_modify_execution_info_additive`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -822,7 +822,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
   @Option(
       name = "incompatible_modify_execution_info_additive",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {
         OptionEffectTag.EXECUTION,


### PR DESCRIPTION
RELNOTES[inc]: When `--modify_execution_info` is specified multiple times, the individual values are now all interpreted in order rather than only the value specified last.