### PR TITLE
Delete `--incompatible_merge_fixed_and_default_shell_env`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -686,7 +686,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
         }
         env = env.withAdditionalFixedVariables(environment);
       } else if (useDefaultShellEnvironment) {
-        // This produces the same result as in the previous case, but without the overhead.
+        // This produces the same result as the previous case, but without the overhead.
         env = configuration.getActionEnvironment();
       } else {
         env = ActionEnvironment.create(environment);

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -666,7 +666,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       }
       CommandLines commandLines = result.build();
       ActionEnvironment env;
-      if (useDefaultShellEnvironment && environment != null) {
+      if (useDefaultShellEnvironment && !environment.isEmpty()) {
         // Inherited variables override fixed variables in ActionEnvironment. Since we want the
         // fixed part of the action-provided environment to override the inherited part of the
         // user-provided environment, we have to explicitly filter the inherited part.
@@ -676,8 +676,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
                     configuration.getActionEnvironment().getInheritedEnv(), environment.keySet()));
         // Do not create a new ActionEnvironment in the common case where no vars have been filtered
         // out.
-        if (userFilteredInheritedEnv.equals(
-            configuration.getActionEnvironment().getInheritedEnv())) {
+        if (userFilteredInheritedEnv.size()
+            == configuration.getActionEnvironment().getInheritedEnv().size()) {
           env = configuration.getActionEnvironment();
         } else {
           env =
@@ -686,6 +686,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
         }
         env = env.withAdditionalFixedVariables(environment);
       } else if (useDefaultShellEnvironment) {
+        // This produces the same result as in the previous case, but without the overhead.
         env = configuration.getActionEnvironment();
       } else {
         env = ActionEnvironment.create(environment);
@@ -891,7 +892,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
      *
      * <p><b>All actions should set this if possible and avoid using {@link #setEnvironment}.</b>
      *
-     * <p>When this property is set, the action will use a minimal, standardized environment map.
+     * <p>When this property is set, the action will use a minimal, standardized environment map,
+     * overridden with the specified environment variables (if any).
      *
      * <p>The list of envvars available to the action (the keys in this map) comes from two places:
      * from the rule class provider and from the command line or rc-files via {@code --action_env}
@@ -918,19 +920,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
      * @see BuildConfigurationValue#getLocalShellEnvironment
      */
     @CanIgnoreReturnValue
-    public Builder useDefaultShellEnvironment() {
-      this.environment = null;
-      this.useDefaultShellEnvironment = true;
-      return this;
-    }
-
-    /**
-     * Same as {@link #useDefaultShellEnvironment()}, but additionally sets the provided fixed
-     * environment variables, which take precedence over the variables contained in the default
-     * shell environment.
-     */
-    @CanIgnoreReturnValue
-    public Builder useDefaultShellEnvironmentWithOverrides(Map<String, String> environment) {
+    public Builder useDefaultShellEnvironment(Map<String, String> environment) {
       this.environment = ImmutableMap.copyOf(environment);
       this.useDefaultShellEnvironment = true;
       return this;

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -770,19 +770,13 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
       builder.setProgressMessageFromStarlark((String) progressMessage);
     }
 
-    ImmutableMap<String, String> env = null;
+    ImmutableMap<String, String> env = ImmutableMap.of();
     if (envUnchecked != Starlark.NONE) {
       env = ImmutableMap.copyOf(Dict.cast(envUnchecked, String.class, String.class, "env"));
     }
     if (Starlark.truth(useDefaultShellEnv)) {
-      if (env != null
-          && getSemantics()
-              .getBool(BuildLanguageOptions.INCOMPATIBLE_MERGE_FIXED_AND_DEFAULT_SHELL_ENV)) {
-        builder.useDefaultShellEnvironmentWithOverrides(env);
-      } else {
-        builder.useDefaultShellEnvironment();
-      }
-    } else if (env != null) {
+      builder.useDefaultShellEnvironment(env);
+    } else {
       builder.setEnvironment(env);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -652,19 +652,6 @@ public final class BuildLanguageOptions extends OptionsBase {
   public boolean incompatibleDisableStarlarkHostTransitions;
 
   @Option(
-      name = "incompatible_merge_fixed_and_default_shell_env",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "If enabled, actions registered with ctx.actions.run and ctx.actions.run_shell with both"
-              + " 'env' and 'use_default_shell_env = True' specified will use an environment"
-              + " obtained from the default shell environment by overriding with the values passed"
-              + " in to 'env'. If disabled, the value of 'env' is completely ignored in this case.")
-  public boolean incompatibleMergeFixedAndDefaultShellEnv;
-
-  @Option(
       name = "incompatible_disable_objc_library_transition",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -940,9 +927,6 @@ public final class BuildLanguageOptions extends OptionsBase {
                 INCOMPATIBLE_DISABLE_STARLARK_HOST_TRANSITIONS,
                 incompatibleDisableStarlarkHostTransitions)
             .setBool(
-                INCOMPATIBLE_MERGE_FIXED_AND_DEFAULT_SHELL_ENV,
-                incompatibleMergeFixedAndDefaultShellEnv)
-            .setBool(
                 INCOMPATIBLE_DISABLE_OBJC_LIBRARY_TRANSITION,
                 incompatibleDisableObjcLibraryTransition)
             .setBool(ADD_GO_EXEC_GROUPS_TO_BINARY_RULES, addGoExecGroupsToBinaryRules)
@@ -1052,8 +1036,6 @@ public final class BuildLanguageOptions extends OptionsBase {
       "+incompatible_unambiguous_label_stringification";
   public static final String INCOMPATIBLE_DISABLE_STARLARK_HOST_TRANSITIONS =
       "-incompatible_disable_starlark_host_transitions";
-  public static final String INCOMPATIBLE_MERGE_FIXED_AND_DEFAULT_SHELL_ENV =
-      "+experimental_merge_fixed_and_default_shell_env";
   public static final String INCOMPATIBLE_DISABLE_OBJC_LIBRARY_TRANSITION =
       "+incompatible_disable_objc_library_transition";
   public static final String ADD_GO_EXEC_GROUPS_TO_BINARY_RULES =

--- a/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java
@@ -118,7 +118,7 @@ public class ResourceJarActionBuilder {
     ruleContext.registerAction(
         builder
             .setExecutable(javaToolchain.getSingleJar())
-            .useDefaultShellEnvironment()
+            .useDefaultShellEnvironment(ImmutableMap.of())
             .addOutput(outputJar)
             .addInputs(messages)
             .addInputs(resources.values())

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -423,10 +423,7 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
                     + " href=\"/reference/command-line-reference#flag--action_env\"><code>--action_env</code></a>.<p>If"
                     + " both <code>use_default_shell_env</code> and <code>env</code> are set to"
                     + " <code>True</code>, values set in <code>env</code> will overwrite the"
-                    + " default shell environment if <a "
-                    + "href=\"/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env\"><code>--incompatible_merge_fixed_and_default_shell_env</code></a>"
-                    + " is enabled (default). If the flag is not enabled, <code>env</code> is"
-                    + " ignored."),
+                    + " default shell environment."),
         @Param(
             name = "env",
             allowedTypes = {
@@ -440,10 +437,7 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
                 "Sets the dictionary of environment variables.<p>If both"
                     + " <code>use_default_shell_env</code> and <code>env</code> are set to"
                     + " <code>True</code>, values set in <code>env</code> will overwrite the"
-                    + " default shell environment if <a "
-                    + "href=\"/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env\"><code>--incompatible_merge_fixed_and_default_shell_env</code></a>"
-                    + " is enabled (default). If the flag is not enabled, <code>env</code> is"
-                    + " ignored."),
+                    + " default shell environment."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {
@@ -684,10 +678,7 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
                     + " href=\"/reference/command-line-reference#flag--action_env\"><code>--action_env</code></a>.<p>If"
                     + " both <code>use_default_shell_env</code> and <code>env</code> are set to"
                     + " <code>True</code>, values set in <code>env</code> will overwrite the"
-                    + " default shell environment if <a "
-                    + "href=\"/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env\"><code>--incompatible_merge_fixed_and_default_shell_env</code></a>"
-                    + " is enabled (default). If the flag is not enabled, <code>env</code> is"
-                    + " ignored."),
+                    + " default shell environment."),
         @Param(
             name = "env",
             allowedTypes = {
@@ -701,10 +692,7 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
                 "Sets the dictionary of environment variables.<p>If both"
                     + " <code>use_default_shell_env</code> and <code>env</code> are set to"
                     + " <code>True</code>, values set in <code>env</code> will overwrite the"
-                    + " default shell environment if <a "
-                    + "href=\"/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env\"><code>--incompatible_merge_fixed_and_default_shell_env</code></a>"
-                    + " is enabled (default). If the flag is not enabled, <code>env</code> is"
-                    + " ignored."),
+                    + " default shell environment."),
         @Param(
             name = "execution_requirements",
             allowedTypes = {

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -150,7 +150,6 @@ public class ConsistencyTest {
                 .toString()
                 .toLowerCase(Locale.ROOT),
         "--incompatible_locations_prefers_executable=" + rand.nextBoolean(),
-        "--incompatible_merge_fixed_and_default_shell_env=" + rand.nextBoolean(),
         "--incompatible_no_attr_license=" + rand.nextBoolean(),
         "--incompatible_no_implicit_file_export=" + rand.nextBoolean(),
         "--incompatible_no_rule_outputs_param=" + rand.nextBoolean(),
@@ -203,8 +202,6 @@ public class ConsistencyTest {
             BuildLanguageOptions.Utf8EnforcementMode.values()[
                 rand.nextInt(BuildLanguageOptions.Utf8EnforcementMode.values().length)])
         .setBool(BuildLanguageOptions.INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE, rand.nextBoolean())
-        .setBool(
-            BuildLanguageOptions.INCOMPATIBLE_MERGE_FIXED_AND_DEFAULT_SHELL_ENV, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_ATTR_LICENSE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_IMPLICIT_FILE_EXPORT, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_NO_RULE_OUTPUTS_PARAM, rand.nextBoolean())

--- a/src/test/shell/integration/action_env_test.sh
+++ b/src/test/shell/integration/action_env_test.sh
@@ -231,28 +231,6 @@ function test_use_default_shell_env {
 function test_use_default_shell_env_and_fixed_env {
     ACTION_AND_CLIENT_INHERITED=client CLIENT_INHERITED=client \
         bazel build \
-        --noincompatible_merge_fixed_and_default_shell_env \
-        --action_env=ACTION_AND_CLIENT_FIXED=client \
-        --action_env=ACTION_AND_CLIENT_INHERITED \
-        --action_env=CLIENT_FIXED=client \
-        --action_env=CLIENT_INHERITED \
-        //pkg:with_default_and_fixed_env
-    echo
-    cat bazel-bin/pkg/with_default_and_fixed_env.env
-    echo
-    grep -q ACTION_AND_CLIENT_FIXED=client bazel-bin/pkg/with_default_and_fixed_env.env \
-        || fail "static action environment not honored"
-    grep -q ACTION_AND_CLIENT_INHERITED=client bazel-bin/pkg/with_default_and_fixed_env.env \
-        || fail "dynamic action environment not honored"
-    grep -q ACTION_FIXED bazel-bin/pkg/with_default_and_fixed_env.env \
-        && fail "fixed env provided by action should have been ignored"
-    grep -q CLIENT_FIXED=client bazel-bin/pkg/with_default_and_fixed_env.env \
-        || fail "static action environment not honored"
-    grep -q CLIENT_INHERITED=client bazel-bin/pkg/with_default_and_fixed_env.env \
-        || fail "dynamic action environment not honored"
-
-    ACTION_AND_CLIENT_INHERITED=client CLIENT_INHERITED=client \
-        bazel build \
         --action_env=ACTION_AND_CLIENT_FIXED=client \
         --action_env=ACTION_AND_CLIENT_INHERITED \
         --action_env=CLIENT_FIXED=client \


### PR DESCRIPTION
The flag has been flipped over a year ago and complicates docs as well as `SpawnAction` logic.

RELNOTES[inc]: The `--incompatible_merge_fixed_and_default_shell_env` flag has been removed.