### PR TITLE
Disambiguate anchor links on the CLI reference page

### DIFF
--- a/src/main/java/com/google/devtools/common/options/OptionsParser.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParser.java
@@ -551,7 +551,7 @@ public class OptionsParser implements OptionsParsingResult {
    * intuitive short description for the options.
    */
   public String describeOptionsHtml(
-      Escaper escaper, String productName, List<String> optionsToIgnore) {
+      Escaper escaper, String productName, List<String> optionsToIgnore, String commandName) {
     StringBuilder desc = new StringBuilder();
     LinkedHashMap<OptionDocumentationCategory, List<OptionDefinition>> optionsByCategory =
         getOptionsSortedByCategory();
@@ -576,7 +576,7 @@ public class OptionsParser implements OptionsParsingResult {
 
       desc.append("<dl>").append(escaper.escape(categoryDescription)).append(":\n");
       for (OptionDefinition optionDef : categorizedOptionsList) {
-        OptionsUsage.getUsageHtml(optionDef, desc, escaper, impl.getOptionsData(), true);
+        OptionsUsage.getUsageHtml(optionDef, desc, escaper, impl.getOptionsData(), true, commandName);
       }
       desc.append("</dl>\n");
     }

--- a/src/main/java/com/google/devtools/common/options/OptionsUsage.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsUsage.java
@@ -197,11 +197,18 @@ class OptionsUsage {
       StringBuilder usage,
       Escaper escaper,
       OptionsData optionsData,
-      boolean includeTags) {
+      boolean includeTags,
+      String commandName) {
     String plainFlagName = optionDefinition.getOptionName();
     String flagName = getFlagName(optionDefinition);
     String valueDescription = optionDefinition.getValueTypeHelpText();
     String typeDescription = getTypeDescription(optionDefinition);
+
+    StringBuilder anchorId = new StringBuilder();
+    if (commandName != null) {
+      anchorId.append(commandName).append("-");
+    }
+    anchorId.append("flag--").append(plainFlagName);
 
     // String.format is a lot slower, sometimes up to 10x.
     // https://stackoverflow.com/questions/925423/is-it-better-practice-to-use-string-format-over-string-concatenation-in-java
@@ -209,13 +216,26 @@ class OptionsUsage {
     // Considering that this runs for every flag in the CLI reference, it's better to use regular
     // appends here.
     usage
+        .append("<dt id=\"")
         // Add the id of the flag to point anchor hrefs to it
-        .append("<dt id=\"flag--")
-        .append(plainFlagName)
+        .append(anchorId)
         .append("\">")
         // Add the href to the id hash
-        .append("<code><a href=\"#flag--")
-        .append(plainFlagName)
+        .append("<code");
+        // Historically, we used `flag--${plainFlagName}` as the anchor id, but this is not unique 
+        // across commands. We now use the per-command `anchorId` defined above, but we moved the old 
+        // `flag--${plainFlagName}` to be an id on the code block for backwards compatibility with
+        // old links.
+        if (commandName != null) {
+          usage
+              .append(" id=\"")
+              .append(plainFlagName)
+              .append("\"");
+        }
+    usage
+        .append(">")
+        .append("<a href=\"#")
+        .append(anchorId)
         .append("\">")
         .append("--")
         .append(flagName)

--- a/src/test/java/com/google/devtools/common/options/OptionsUsageTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsUsageTest.java
@@ -38,14 +38,21 @@ public final class OptionsUsageTest {
   private String getHtmlUsageWithoutTags(String fieldName) {
     StringBuilder builder = new StringBuilder();
     OptionsUsage.getUsageHtml(
-        data.getOptionDefinitionFromName(fieldName), builder, HTML_ESCAPER, data, false);
+        data.getOptionDefinitionFromName(fieldName), builder, HTML_ESCAPER, data, false, null);
     return builder.toString();
   }
 
   private String getHtmlUsageWithTags(String fieldName) {
     StringBuilder builder = new StringBuilder();
     OptionsUsage.getUsageHtml(
-        data.getOptionDefinitionFromName(fieldName), builder, HTML_ESCAPER, data, true);
+        data.getOptionDefinitionFromName(fieldName), builder, HTML_ESCAPER, data, true, null);
+    return builder.toString();
+  }
+
+  private String getHtmlUsageWithCommandName(String fieldName, String commandName) {
+    StringBuilder builder = new StringBuilder();
+    OptionsUsage.getUsageHtml(
+        data.getOptionDefinitionFromName(fieldName), builder, HTML_ESCAPER, data, false, commandName);
     return builder.toString();
   }
 
@@ -65,6 +72,19 @@ public final class OptionsUsageTest {
     OptionsUsage.getUsage(
         data.getOptionDefinitionFromName(fieldName), builder, verbosity, data, true);
     return builder.toString();
+  }
+
+  @Test
+  public void commandNameAnchorId_htmlOutput() {
+    assertThat(getHtmlUsageWithCommandName("test_string", "command_name"))
+        .isEqualTo(
+            "<dt id=\"command_name-flag--test_string\">"
+                + "<code id=\"test_string\"><a href=\"#command_name-flag--test_string\">--test_string</a>"
+                + "=&lt;a string&gt</code> "
+                + "default: \"test string default\"</dt>\n"
+                + "<dd>\n"
+                + "a string-valued option to test simple option operations\n"
+                + "</dd>\n");
   }
 
   @Test


### PR DESCRIPTION
As noted in
[bazelbuild/bazel#14822](https://github.com/bazelbuild/bazel/issues/14822), on the [command-line reference
page](https://bazel.build/reference/command-line-reference), each option flag is assigned an ID tag identical to the flag name. Because some flags appear under more than one command, the duplicated IDs sometimes make it impossible to link directly to a specific command’s flag.

This PR prefixes each flag’s ID tag with the command name, ensuring uniqueness across the page. To maintain backwards compatibility, we move the old (ambiguous) IDs to the <code> element of the documentation, so that existing links still work as before.

This change was tested by running `bazel build
//src/main/java/com/google/devtools/build/lib:gen_command-line-reference`. Here is the relevant output for the `--[no]build` flag.

```html
<dt id="build-flag--build"><code id="build"><a href="#build-flag--build">--[no]build</a></code> default: "true"</dt>
```