### PR TITLE
[8.2.0] Share empty global indices array

### DIFF
--- a/src/main/java/net/starlark/java/eval/Module.java
+++ b/src/main/java/net/starlark/java/eval/Module.java
@@ -298,9 +298,14 @@ public final class Module implements Resolver.Module {
     return i;
   }
 
+  private static final int[] EMPTY_INDICES = new int[0];
+
   /** Returns a list of indices of a list of globals; {@see getIndexOfGlobal}. */
   int[] getIndicesOfGlobals(List<String> globals) {
     int n = globals.size();
+    if (n == 0) {
+      return EMPTY_INDICES;
+    }
     int[] array = new int[n];
     for (int i = 0; i < n; i++) {
       array[i] = getIndexOfGlobal(globals.get(i));


### PR DESCRIPTION
This reduces retained heap by ~0.1% on an example project.

Closes #25596.

PiperOrigin-RevId: 739066647
Change-Id: If394e4e906faaa06a1a83a2bdf8bbe0dba5d3539

Commit https://github.com/bazelbuild/bazel/commit/d7f30657e41d699937d8b32aeb986724edfb02fc