### PR TITLE
macOS: respect DEVELOPER_DIR for Xcode selection.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java
@@ -92,7 +92,12 @@ public final class XcodeLocalEnvProvider implements LocalEnvProvider {
     String developerDir = "";
     if (containsXcodeVersion && !containsDeveloperDir) {
       String version = env.get(AppleConfiguration.XCODE_VERSION_ENV_NAME);
-      developerDir = getDeveloperDir(binTools, DottedVersion.fromStringUnchecked(version));
+      // Directly use version as DEVELOPER_DIR when a path is passed
+      if (version.startsWith("/")) {
+        developerDir = version;
+      } else {
+        developerDir = getDeveloperDir(binTools, DottedVersion.fromStringUnchecked(version));
+      }
       newEnvBuilder.put("DEVELOPER_DIR", developerDir);
     }
     if (containsAppleSdkPlatform) {

--- a/src/main/starlark/builtins_bzl/common/xcode/providers.bzl
+++ b/src/main/starlark/builtins_bzl/common/xcode/providers.bzl
@@ -83,10 +83,14 @@ def _xcode_version_info_init(
     dotted_watchos_sdk = _apple_common.dotted_version(watchos_sdk_version)
     dotted_macos_sdk = _apple_common.dotted_version(macos_sdk_version)
 
-    if xcode_version:
-        dotted_xcode_version = _apple_common.dotted_version(xcode_version)
-    else:
-        dotted_xcode_version = None
+    def _xcode_version(xcode_version):
+        if not xcode_version:
+            return None
+        if xcode_version.startswith("/"):
+            # Versions that represent a path on disk should be propagated as-is since they will
+            # be used directly as DEVELOPER_DIR
+            return xcode_version
+        return _apple_common.dotted_version(xcode_version)
 
     def _minimum_os_for_platform_type(platform_type):
         if platform_type in (platform_type_struct.ios, platform_type_struct.catalyst):
@@ -136,7 +140,7 @@ def _xcode_version_info_init(
     # APIs as functions, not fields. This is atypical for Starlark providers,
     # but the built-in Starlark provider must provide the same API.
     return {
-        "xcode_version": lambda: dotted_xcode_version,
+        "xcode_version": lambda: _xcode_version(xcode_version),
         "minimum_os_for_platform_type": _minimum_os_for_platform_type,
         "sdk_version_for_platform": _sdk_version_for_platform,
         "availability": lambda: availability.lower(),

--- a/src/main/starlark/builtins_bzl/common/xcode/xcode_config.bzl
+++ b/src/main/starlark/builtins_bzl/common/xcode/xcode_config.bzl
@@ -349,12 +349,15 @@ def _resolve_explicitly_defined_version(
         flag_version = alias_to_versions.get(str(xcode_version_flag))
         if flag_version:
             return flag_version.xcode_version_properties
+        elif xcode_version_flag.startswith("/"):
+            return XcodeVersionPropertiesInfo(xcode_version = xcode_version_flag)
         else:
             fail(
                 ("--xcode_version={0} specified, but '{0}' is not an available Xcode version. " +
                  "If you believe you have '{0}' installed, try running \"bazel shutdown\", and then " +
                  "re-run your command.").format(xcode_version_flag),
             )
+
     return alias_to_versions.get(explicit_default_version.xcode_version_properties.xcode_version).xcode_version_properties
 
 def _dotted_version_or_default(field, default):


### PR DESCRIPTION
On macOS, this change ensures that when `DEVELOPER_DIR` environment variable is used, it will be propagated to `/usr/bin/xcrun` to query the SDKROOT. This takes precedence over the `--xcode_version` flag when selecting the Xcode installation. This aligns with the intended use as documented in `man xcrun`:

`The tool xcode-select(1) is used to set a system default for the active developer directory, and may be overridden by the DEVELOPER_DIR environment variable (see ENVIRONMENT).`

To leverage this, developers must propagate the `DEVELOPER_DIR` environment variable to Bazel actions using `--action_env=DEVELOPER_DIR`.