### PR TITLE
[7.6.0] Don't attempt to enable the Security Manager for jdk >= 24

### DIFF
--- a/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl
+++ b/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl
@@ -64,7 +64,8 @@ def _bazel_base_binary_impl(ctx, is_test_rule_class):
     )
 
     if ctx.attr.use_testrunner:
-        if semantics.find_java_runtime_toolchain(ctx).version >= 17:
+        _java_runtime_version = semantics.find_java_runtime_toolchain(ctx).version
+        if _java_runtime_version >= 17 and _java_runtime_version < 24:
             jvm_flags.append("-Djava.security.manager=allow")
         test_class = ctx.attr.test_class if hasattr(ctx.attr, "test_class") else ""
         if test_class == "":


### PR DESCRIPTION
Backports https://github.com/bazelbuild/rules_java/commit/b3a0580e0a9a6b8b28b611c7dd6164c06b279539

Fixes https://github.com/bazelbuild/bazel/issues/25648