### PR TITLE
[8.2.0] feat(RepositoryOptions): make downloader config non-experimental

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -203,7 +203,8 @@ public class RepositoryOptions extends OptionsBase {
   public String experimentalResolvedFileInsteadOfWorkspace;
 
   @Option(
-      name = "experimental_downloader_config",
+      name = "downloader_config",
+      oldName = "experimental_downloader_config",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},


### PR DESCRIPTION
Bazel itself uses this: https://github.com/bazelbuild/bazel/blob/master/bazel_downloader.cfg
And many companies rely on this for security.

Therefore, `--downloader_config` should be non-experimental.

Resolves #25485

RELNOTES: `--experimental_downloader_config` is now no longer experimental, and has been renamed to `--downloader_config`. The old flag name can still be used.

Closes #25649.

PiperOrigin-RevId: 739116828
Change-Id: Icaa0bceb84d088c610f41938b194f209bdbe7f70

Commit https://github.com/bazelbuild/bazel/commit/a3b53de16985aedf6f6d4b9e95eb7507a4eeb500