### PR TITLE
[8.2.0] Stop deleting the whole worker directory when we destroy a worker proxy.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/SandboxedWorkerProxy.java
@@ -38,6 +38,7 @@ import java.util.Set;
  */
 public class SandboxedWorkerProxy extends WorkerProxy {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
   /** The sandbox directory for the current request, inside {@code workDir}. */
   private final Path sandboxDir;
 
@@ -94,7 +95,7 @@ public class SandboxedWorkerProxy extends WorkerProxy {
         treeDeleter);
     // Finally, create anything that is still missing. This is non-strict only for historical
     // reasons, we haven't seen what would break if we make it strict.
-    SandboxHelpers.createDirectories(dirsToCreate, sandboxDir, /* strict=*/ false);
+    SandboxHelpers.createDirectories(dirsToCreate, sandboxDir, /* strict= */ false);
     WorkerExecRoot.createInputs(inputsToCreate, inputFiles, sandboxDir);
   }
 
@@ -118,7 +119,7 @@ public class SandboxedWorkerProxy extends WorkerProxy {
   synchronized void destroy() {
     super.destroy();
     try {
-      workDir.deleteTree();
+      sandboxDir.deleteTree();
     } catch (IOException e) {
       logger.atWarning().withCause(e).log("Caught IOException while deleting workdir.");
     }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -103,6 +103,7 @@ public class WorkerFactory extends BaseKeyedPooledObjectFactory<WorkerKey, Worke
         worker =
             new SandboxedWorkerProxy(
                 key, workerId, logFile, workerMultiplexer, workDir, treeDeleter);
+        workerMultiplexer.setWorkDir(workDir);
       } else {
         Path workDir = getSandboxedWorkerPath(key, workerId);
         worker =

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -102,7 +102,12 @@ public class WorkerFactory extends BaseKeyedPooledObjectFactory<WorkerKey, Worke
         Path workDir = getSandboxedWorkerPath(key);
         worker =
             new SandboxedWorkerProxy(
-                key, workerId, logFile, workerMultiplexer, workDir, treeDeleter);
+                key,
+                workerId,
+                workerMultiplexer.getLogFile(),
+                workerMultiplexer,
+                workDir,
+                treeDeleter);
         workerMultiplexer.setWorkDir(workDir);
       } else {
         Path workDir = getSandboxedWorkerPath(key, workerId);


### PR DESCRIPTION
Manual cherry-pick for bceaf635e945bdd89bbdbb0f8a9f5453ed0686f5.

Fixes #25655 

