### PR TITLE
Add ImportDepsChecker to java_tools.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -517,6 +517,7 @@ JAVA_TOOLS_DEPLOY_JARS = [
     "//src/java_tools/buildjar:VanillaJavaBuilder_deploy.jar",
     "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/genclass:GenClass_deploy.jar",
     "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine:turbine_direct_binary_deploy.jar",
+    "//src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:ImportDepsChecker_deploy.jar",
     "//src/java_tools/junitrunner/java/com/google/testing/coverage:JacocoCoverage_jarjar_deploy.jar",
     "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:Runner_deploy.jar",
 ]

--- a/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD
+++ b/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD
@@ -48,11 +48,6 @@ java_binary(
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
     ],
     main_class = "com.google.devtools.build.importdeps.Main",
-    visibility = [
-        "//src/java_tools/import_deps_checker:__subpackages__",
-        "//tools/android:__pkg__",
-        "//tools/android/runtime_deps:__pkg__",
-    ],
     deps = [
         ":import_deps_checker",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/ImportDepsChecker.java
+++ b/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/ImportDepsChecker.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -141,7 +142,7 @@ public final class ImportDepsChecker implements Closeable {
     ImmutableMultimap<Path, String> indirectJars = resultCollector.getSortedIndirectDeps();
     if (!indirectJars.isEmpty()) {
       Set<String> labels = new LinkedHashSet<>();
-      for (var e : indirectJars.asMap().entrySet()) {
+      for (Map.Entry<Path, Collection<String>> e : indirectJars.asMap().entrySet()) {
         Path jar = e.getKey();
         String label = extractLabel(jar);
         builder.append("Indirect reference to classes from ");

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -102,6 +102,9 @@ function expect_path_in_java_tools_prebuilt() {
   [[ "$count" -gt 0 ]] || fail "Path $path not found in java_tools_prebuilt.zip"
 }
 
+function test_java_tools_has_import_deps_checker() {
+  expect_path_in_java_tools "java_tools/ImportDepsChecker_deploy.jar"
+}
 
 function test_java_tools_has_ijar() {
   expect_path_in_java_tools "java_tools/ijar"

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -20,6 +20,11 @@ SUPRESSED_WARNINGS = select({
 })
 
 filegroup(
+    name = "ImportDepsChecker",
+    srcs = ["java_tools/ImportDepsChecker_deploy.jar"],
+)
+
+filegroup(
     name = "GenClass",
     srcs = ["java_tools/GenClass_deploy.jar"],
 )


### PR DESCRIPTION
Bazel has a handy utility for checking that java_import rules have the correct dependencies. But it wasn't packaged with java_tools, and therefore very hard to use.