### PR TITLE
Don't leak in-flight execution in `RemoteSpawnCache`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1590,8 +1590,7 @@ public class RemoteExecutionService {
     @Override
     public void close() {
       if (!closeManually.get()) {
-        spawnResultFuture.cancel(true);
-        onClose.run();
+        doClose();
       }
     }
 
@@ -1604,7 +1603,12 @@ public class RemoteExecutionService {
       if (!closeManually.compareAndSet(false, true)) {
         throw new IllegalStateException("delayClose has already been called");
       }
-      return this::close;
+      return this::doClose;
+    }
+
+    private void doClose() {
+      spawnResultFuture.cancel(true);
+      onClose.run();
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -82,6 +82,11 @@ final class RemoteSpawnCache implements SpawnCache {
     return remoteExecutionService;
   }
 
+  @VisibleForTesting
+  int getInFlightExecutionsSize() {
+    return inFlightExecutions.size();
+  }
+
   @Override
   public CacheHandle lookup(Spawn spawn, SpawnExecutionContext context)
       throws InterruptedException, IOException, ExecException, ForbiddenActionInputException {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -139,7 +139,7 @@ final class RemoteSpawnCache implements SpawnCache {
                   });
           if (previousOrThisExecution != thisExecution) {
             // The current execution is not the first one to be registered for this action key, so
-            // we need to wait for the previous one to finish before we can upload our result.
+            // we need to wait for the previous one to finish before we can reuse its result.
             previousExecution = previousOrThisExecution;
             thisExecution = null;
           }


### PR DESCRIPTION
The in-flight executions need to be cleaned up also in case of a cache hit or an exception while interacting with the cache, otherwise `inFlightExecutions` grows over time retaining large `Spawn`s.