### PR TITLE
[8.2.0] Add spelling suggestions to `bazel info` error message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/BUILD
@@ -115,6 +115,7 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/java/com/google/devtools/common/options:invocation_policy",
         "//src/main/java/net/starlark/java/eval",
+        "//src/main/java/net/starlark/java/spelling",
         "//src/main/protobuf:bazel_flags_java_proto",
         "//src/main/protobuf:command_server_java_proto",
         "//src/main/protobuf:extra_actions_base_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
@@ -82,6 +82,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import net.starlark.java.spelling.SpellChecker;
 
 /** Implementation of 'blaze info'. */
 @Command(
@@ -207,7 +208,9 @@ public class InfoCommand implements BlazeCommand {
           String message =
               "unknown key(s): "
                   + unknownKeys.stream()
-                      .map(key -> "'" + key + "'")
+                      .map(
+                          key ->
+                              "'%s'%s".formatted(key, SpellChecker.didYouMean(key, items.keySet())))
                       .collect(Collectors.joining(", "));
           env.getReporter().handle(Event.error(message));
           return createFailureResult(


### PR DESCRIPTION
Closes #25662.

PiperOrigin-RevId: 739859052
Change-Id: I794ca50a74ed6b7ebba90ee13ae0a524a1b93b3d

Commit https://github.com/bazelbuild/bazel/commit/97cdefbb991bc9500e100a9d8c023c03c19d4cc3