### PR TITLE
[8.2.0] Add `--experimental_java_classpath=bazel_no_fallback` option

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -51,7 +51,9 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     /** JavaBuilder computes the reduced classpath before invoking javac. */
     JAVABUILDER,
     /** Bazel computes the reduced classpath and tries it in a separate action invocation. */
-    BAZEL
+    BAZEL,
+    /** Bazel uses the reduced classpath, but doesn't fallback to the full transitive classpath */
+    BAZEL_NO_FALLBACK,
   }
 
   /** Values for the --experimental_one_version_enforcement option */

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -565,7 +565,8 @@ public final class JavaHeaderCompileAction extends SpawnAction {
                 // If classPathMode == BAZEL, also make sure to inject the dependencies to be
                 // available to downstream actions. Else just do enough work to locally create the
                 // full .jdeps from the .stripped .jdeps produced on the executor.
-                /* insertDependencies= */ classpathMode == JavaClasspathMode.BAZEL,
+                /* insertDependencies= */ classpathMode == JavaClasspathMode.BAZEL
+                    || classpathMode == JavaClasspathMode.BAZEL_NO_FALLBACK,
                 javaConfiguration.inmemoryJdepsFiles(),
                 additionalArtifactsForPathMapping));
         return;

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -270,6 +270,40 @@ java_custom_library = rule(
 EOF
 }
 
+function write_java_classpath_reduction_files() {
+  local -r pkg="$1"
+  mkdir -p "$pkg/java/hello/" || fail "Expected success"
+  cat > "$pkg/java/hello/A.java" <<'EOF'
+package hello;
+public class A {
+  public void f(B b) { b.getC().getD(); }
+}
+EOF
+  cat > "$pkg/java/hello/B.java" <<'EOF'
+package hello;
+public class B {
+  public C getC() { return null; }
+}
+EOF
+  cat > "$pkg/java/hello/C.java" <<'EOF'
+package hello;
+public class C {
+  public D getD() { return null; }
+}
+EOF
+  cat > "$pkg/java/hello/D.java" <<'EOF'
+package hello;
+public class D {}
+EOF
+  cat > "$pkg/java/hello/BUILD" <<'EOF'
+load("@rules_java//java:java_library.bzl", "java_library")
+java_library(name='a', srcs=['A.java'], deps = [':b'])
+java_library(name='b', srcs=['B.java'], deps = [':c'])
+java_library(name='c', srcs=['C.java'], deps = [':d'])
+java_library(name='d', srcs=['D.java'])
+EOF
+}
+
 function test_build_hello_world() {
   write_hello_library_files
 
@@ -280,6 +314,32 @@ function test_build_hello_world_reduced_classpath() {
   write_hello_library_files
 
   bazel build --experimental_java_classpath=bazel //java/main:main &> $TEST_log || fail "build failed"
+}
+
+function test_build_hello_world_reduced_classpath_no_fallback() {
+  write_hello_library_files
+
+  bazel build --experimental_java_classpath=bazel_no_fallback //java/main:main &> $TEST_log || fail "build failed"
+}
+
+function test_build_reduced_classpath_fallback() {
+  local -r pkg="${FUNCNAME[0]}"
+  write_java_classpath_reduction_files "$pkg"
+
+  bazel build --experimental_java_classpath=bazel //"$pkg"/java/hello:a &> $TEST_log || fail "should build with fallback"
+}
+
+function test_build_reduced_classpath_no_fallback() {
+  if [[ "${JAVA_TOOLS_ZIP}" == released ]]; then
+      # TODO: Enable test after the next java_tools release.
+      return 0
+  fi
+
+  local -r pkg="${FUNCNAME[0]}"
+  write_java_classpath_reduction_files "$pkg"
+
+  bazel build --experimental_java_classpath=bazel_no_fallback //"$pkg"/java/hello:a &> $TEST_log && fail "shouldn't build with no fallback"
+  expect_log 'error: cannot access D'
 }
 
 function test_worker_strategy_is_default() {


### PR DESCRIPTION
This change introduces a new option, `--experimental_java_classpath=bazel_no_fallback`, which operates similarly to `--experimental_java_classpath=bazel` but does not fall back to the full transitive classpath. Instead, the build fails if javac cannot compile with the reduced classpath.

Fixes https://github.com/bazelbuild/bazel/issues/24875

Closes #24876.

PiperOrigin-RevId: 739864240
Change-Id: I53b25c35ac57e4a4ef3baa49eadc1952dac6457d

Commit https://github.com/bazelbuild/bazel/commit/f25433a3c86b267799333325acb114105495086e