### PR TITLE
Enables --experimental_java_classpath=bazel_no_fallback test for released java_tools

### DIFF
--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -330,11 +330,6 @@ function test_build_reduced_classpath_fallback() {
 }
 
 function test_build_reduced_classpath_no_fallback() {
-  if [[ "${JAVA_TOOLS_ZIP}" == released ]]; then
-      # TODO: Enable test after the next java_tools release.
-      return 0
-  fi
-
   local -r pkg="${FUNCNAME[0]}"
   write_java_classpath_reduction_files "$pkg"
 


### PR DESCRIPTION
Enabling test after java_tools upgrade: https://github.com/bazelbuild/bazel/commit/f8f8c28f9fa959fc17d2e79951d66be77a4542b0