### PR TITLE
Move incompatible_macos_set_install_name to graveyard

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -612,6 +612,15 @@ public final class BazelRulesModule extends BlazeModule {
         effectTags = {OptionEffectTag.NO_OP},
         help = "No-op.")
     public boolean experimentalActionResourceSet;
+
+    @Option(
+        name = "incompatible_macos_set_install_name",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+        help = "No-op.")
+    public boolean macosSetInstallName;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -933,7 +933,7 @@ public final class CppConfiguration extends Fragment
 
   @Override
   public boolean macosSetInstallName() {
-    return cppOptions.macosSetInstallName;
+    return true;
   }
 
   private static void checkInExpandedApiAllowlist(StarlarkThread thread, String feature)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -944,20 +944,6 @@ public class CppOptions extends FragmentOptions {
       help = "If enabled, give distinguishing mnemonic to header processing actions")
   public boolean useCppCompileHeaderMnemonic;
 
-  // TODO: When moving this flag to the graveyard, also delete
-  // tools/cpp/osx_cc_wrapper.sh.tpl and make tools/cpp/linux_cc_wrapper.sh.tpl
-  // the generic wrapper for header parsing on all Unix platforms.
-  @Option(
-      name = "incompatible_macos_set_install_name",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "Whether to explicitly set `-install_name` when creating dynamic libraries. "
-              + "See https://github.com/bazelbuild/bazel/issues/12370")
-  public boolean macosSetInstallName;
-
   @Option(
       name = "experimental_use_cpp_compile_action_args_params_file",
       defaultValue = "false",

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CppConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CppConfigurationApi.java
@@ -108,7 +108,7 @@ public interface CppConfigurationApi<InvalidConfigurationExceptionT extends Exce
       structField = true,
       // Only for migration purposes. Intentionally not documented.
       documented = false,
-      doc = "Accessor for <code>--incompatible_macos_set_install_name</code>.")
+      doc = "Deprecated, always true")
   boolean macosSetInstallName();
 
   @StarlarkMethod(name = "force_pic", documented = false, useStarlarkThread = true)

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -318,7 +318,6 @@ bazel_fragments["CppOptions"] = fragment(
         "//command_line_option:experimental_unsupported_and_brittle_include_scanning",
         "//command_line_option:incompatible_use_cpp_compile_header_mnemonic",
         "//command_line_option:experimental_starlark_cc_import",
-        "//command_line_option:incompatible_macos_set_install_name",
         "//command_line_option:experimental_cpp_compile_resource_estimation",
         "//command_line_option:experimental_generate_llvm_lcov",
         "//command_line_option:experimental_omitfp",

--- a/src/test/shell/bazel/cpp_darwin_integration_test.sh
+++ b/src/test/shell/bazel/cpp_darwin_integration_test.sh
@@ -173,7 +173,7 @@ EOF
   }
 EOF
 
-  bazel test --incompatible_macos_set_install_name //cpp:test || \
+  bazel test //cpp:test || \
       fail "bazel test //cpp:test failed"
   # Ensure @rpath is correctly set in the binary.
   ./bazel-bin/cpp/test || \
@@ -219,7 +219,7 @@ EOF
   }
 EOF
 
-  bazel test --incompatible_macos_set_install_name //cpp:test || \
+  bazel test //cpp:test || \
       fail "bazel test //cpp:test failed"
   # Ensure @rpath is correctly set in the binary.
   ./bazel-bin/cpp/test || \

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3244,7 +3244,6 @@ function test_cc_binary_tool_with_dynamic_deps() {
   setup_cc_binary_tool_with_dynamic_deps .
 
   bazel build \
-      --incompatible_macos_set_install_name \
       --remote_executor=grpc://localhost:${worker_port} \
       //pkg:rule >& $TEST_log || fail "Build should succeed"
 }
@@ -3253,7 +3252,6 @@ function test_cc_binary_tool_with_dynamic_deps_sibling_repository_layout() {
   setup_cc_binary_tool_with_dynamic_deps .
 
   bazel build \
-      --incompatible_macos_set_install_name \
       --experimental_sibling_repository_layout \
       --remote_executor=grpc://localhost:${worker_port} \
       //pkg:rule >& $TEST_log || fail "Build should succeed"
@@ -3263,7 +3261,6 @@ function test_external_cc_binary_tool_with_dynamic_deps() {
   setup_cc_binary_tool_with_dynamic_deps other_repo
 
   bazel build \
-      --incompatible_macos_set_install_name \
       --remote_executor=grpc://localhost:${worker_port} \
       @other_repo//pkg:rule >& $TEST_log || fail "Build should succeed"
 }
@@ -3272,7 +3269,6 @@ function test_external_cc_binary_tool_with_dynamic_deps_sibling_repository_layou
   setup_cc_binary_tool_with_dynamic_deps other_repo
 
   bazel build \
-      --incompatible_macos_set_install_name \
       --experimental_sibling_repository_layout \
       --remote_executor=grpc://localhost:${worker_port} \
       @other_repo//pkg:rule >& $TEST_log || fail "Build should succeed"


### PR DESCRIPTION
This was flipped in 8.x. The other TODO is now something we should do in
rules_cc when it drops 7.x support
