### PR TITLE
[8.2.0] Don't add very short compact spawn log spans to profile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/CompactSpawnLogContext.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.exec;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.devtools.build.lib.profiler.ProfilerTask.SPAWN_LOG;
 
 import com.github.luben.zstd.ZstdOutputStream;
 import com.google.common.base.Preconditions;
@@ -217,7 +218,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
       Duration timeout,
       SpawnResult result)
       throws IOException, InterruptedException, ExecException {
-    try (SilentCloseable c = Profiler.instance().profile("logSpawn")) {
+    try (SilentCloseable c = Profiler.instance().profile(SPAWN_LOG, "logSpawn")) {
       ExecLogEntry.Spawn.Builder builder = ExecLogEntry.Spawn.newBuilder();
 
       builder.addAllArgs(spawn.getArguments());
@@ -273,7 +274,7 @@ public class CompactSpawnLogContext extends SpawnLogContext {
 
   @Override
   public void logSymlinkAction(AbstractAction action) throws IOException, InterruptedException {
-    try (SilentCloseable c = Profiler.instance().profile("logSymlinkAction")) {
+    try (SilentCloseable c = Profiler.instance().profile(SPAWN_LOG, "logSymlinkAction")) {
       ExecLogEntry.SymlinkAction.Builder builder = ExecLogEntry.SymlinkAction.newBuilder();
 
       Artifact input = action.getPrimaryInput();
@@ -663,14 +664,15 @@ public class CompactSpawnLogContext extends SpawnLogContext {
    */
   private void logEntryWithoutId(ExecLogEntrySupplier supplier)
       throws IOException, InterruptedException {
-    try (SilentCloseable c = Profiler.instance().profile("logEntryWithoutId")) {
+    try (SilentCloseable c = Profiler.instance().profile(SPAWN_LOG, "logEntryWithoutId")) {
       logEntryWithoutIdSynchronized(supplier);
     }
   }
 
   private synchronized void logEntryWithoutIdSynchronized(ExecLogEntrySupplier supplier)
       throws IOException, InterruptedException {
-    try (SilentCloseable c = Profiler.instance().profile("logEntryWithoutId/synchronized")) {
+    try (SilentCloseable c =
+        Profiler.instance().profile(SPAWN_LOG, "logEntryWithoutId/synchronized")) {
       outputStream.write(supplier.get().build());
     }
   }
@@ -688,14 +690,14 @@ public class CompactSpawnLogContext extends SpawnLogContext {
   @CheckReturnValue
   private int logEntry(@Nullable Object key, ExecLogEntrySupplier supplier)
       throws IOException, InterruptedException {
-    try (SilentCloseable c = Profiler.instance().profile("logEntry")) {
+    try (SilentCloseable c = Profiler.instance().profile(SPAWN_LOG, "logEntry")) {
       return logEntrySynchronized(key, supplier);
     }
   }
 
   private synchronized int logEntrySynchronized(@Nullable Object key, ExecLogEntrySupplier supplier)
       throws IOException, InterruptedException {
-    try (SilentCloseable c = Profiler.instance().profile("logEntry/synchronized")) {
+    try (SilentCloseable c = Profiler.instance().profile(SPAWN_LOG, "logEntry/synchronized")) {
       if (key == null) {
         // No need to check for a previously added entry.
         ExecLogEntry.Builder entry = supplier.get();

--- a/src/main/java/com/google/devtools/build/lib/profiler/ProfilerTask.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/ProfilerTask.java
@@ -88,6 +88,7 @@ public enum ProfilerTask {
   DYNAMIC_LOCK("Acquiring dynamic execution output lock", Threshold.FIFTY_MILLIS),
   REPOSITORY_FETCH("Fetching repository"),
   REPOSITORY_VENDOR("Vendoring repository"),
+  SPAWN_LOG("logging spawn", Threshold.TEN_MILLIS),
 
   UNKNOWN("Unknown event");
 


### PR DESCRIPTION
These ended up spamming the timing profile with very short nested spans.

Closes #25634.

PiperOrigin-RevId: 740188492
Change-Id: I3afc3a7ea6dc43ac999e3ca3d14d036c7b1570f0

Commit https://github.com/bazelbuild/bazel/commit/b5dc94f3b76f5d0436dc76b293c50dadd2ecb2a7