### PR TITLE
[8.2.0] Use ImmutableList in `ListExpression`

### DIFF
--- a/src/main/java/net/starlark/java/syntax/ListExpression.java
+++ b/src/main/java/net/starlark/java/syntax/ListExpression.java
@@ -14,6 +14,7 @@
 package net.starlark.java.syntax;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /** Syntax node for list and tuple expressions. */
@@ -25,14 +26,14 @@ public final class ListExpression extends Expression {
 
   private final boolean isTuple;
   private final int lbracketOffset; // -1 => unparenthesized non-empty tuple
-  private final List<Expression> elements;
+  private final ImmutableList<Expression> elements;
   private final int rbracketOffset; // -1 => unparenthesized non-empty tuple
 
   ListExpression(
       FileLocations locs,
       boolean isTuple,
       int lbracketOffset,
-      List<Expression> elements,
+      ImmutableList<Expression> elements,
       int rbracketOffset) {
     super(locs, Kind.LIST_EXPR);
     // An unparenthesized tuple must be non-empty.


### PR DESCRIPTION
Closes #25600.

PiperOrigin-RevId: 740273301
Change-Id: I70252d84f24a414ea328b4100c886b3f0b188048

Commit https://github.com/bazelbuild/bazel/commit/65676a1b29ed11cc8b5e3a864c9595b2eed8e729