### PR TITLE
[8.2.0] Add `use_target_platform_constraints` attribute to the `toolchain` rule.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
@@ -53,6 +53,23 @@ public record DeclaredToolchainInfo(
     requireNonNull(toolchainLabel, "toolchainLabel");
   }
 
+  public boolean hasTargetToExecConstraints() {
+    // This needs to check identity as the special ConstraintCollection is otherwise equal to the
+    // empty one. This avoids adding a new field or making ConstraintCollection more complex.
+    return execConstraints == USE_TARGET_PLATFORM_CONSTRAINTS
+        && targetConstraints == USE_TARGET_PLATFORM_CONSTRAINTS;
+  }
+
+  private static final ConstraintCollection USE_TARGET_PLATFORM_CONSTRAINTS;
+
+  static {
+    try {
+      USE_TARGET_PLATFORM_CONSTRAINTS = ConstraintCollection.builder().build();
+    } catch (ConstraintCollection.DuplicateConstraintException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   /** Builder class to assist in creating {@link DeclaredToolchainInfo} instances. */
   public static class Builder {
     private ToolchainTypeInfo toolchainType;
@@ -133,6 +150,15 @@ public record DeclaredToolchainInfo(
           toolchainType,
           execConstraints,
           targetConstraints,
+          targetSettings.build(),
+          toolchainLabel);
+    }
+
+    public DeclaredToolchainInfo buildWithTargetToExecConstraints() {
+      return new DeclaredToolchainInfo(
+          toolchainType,
+          USE_TARGET_PLATFORM_CONSTRAINTS,
+          USE_TARGET_PLATFORM_CONSTRAINTS,
           targetSettings.build(),
           toolchainLabel);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Toolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Toolchain.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.BuildType;
+import com.google.devtools.build.lib.packages.Type;
 import javax.annotation.Nullable;
 
 /** Defines a toolchain that can be used by rules. */
@@ -57,17 +58,34 @@ public class Toolchain implements RuleConfiguredTargetFactory {
             .collect(toImmutableList());
     Label toolchainLabel =
         ruleContext.attributes().get(ToolchainRule.TOOLCHAIN_ATTR, BuildType.NODEP_LABEL);
+    boolean targetToExecConstraints =
+        ruleContext
+            .attributes()
+            .get(ToolchainRule.USE_TARGET_PLATFORM_CONSTRAINTS_ATTR, Type.BOOLEAN);
+    if (targetToExecConstraints && !(execConstraints.isEmpty() && targetConstraints.isEmpty())) {
+      ruleContext.attributeError(
+          ToolchainRule.USE_TARGET_PLATFORM_CONSTRAINTS_ATTR,
+          "Cannot set use_target_platform_constraints to True and also set exec_compatible_with or "
+              + "target_compatible_with");
+      return null;
+    }
 
     DeclaredToolchainInfo registeredToolchain;
     try {
-      registeredToolchain =
+      var registeredToolchainBuilder =
           DeclaredToolchainInfo.builder()
               .toolchainType(toolchainType)
-              .addExecConstraints(execConstraints)
-              .addTargetConstraints(targetConstraints)
               .addTargetSettings(targetSettings)
-              .toolchainLabel(toolchainLabel)
-              .build();
+              .toolchainLabel(toolchainLabel);
+      if (targetToExecConstraints) {
+        registeredToolchain = registeredToolchainBuilder.buildWithTargetToExecConstraints();
+      } else {
+        registeredToolchain =
+            registeredToolchainBuilder
+                .addExecConstraints(execConstraints)
+                .addTargetConstraints(targetConstraints)
+                .build();
+      }
     } catch (DeclaredToolchainInfo.DuplicateConstraintException e) {
       if (e.execConstraintsException() != null) {
         ruleContext.attributeError(

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/ToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/ToolchainRule.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.ToolchainResolutionMode;
+import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.packages.Types;
 import com.google.devtools.build.lib.util.FileTypeSet;
 
@@ -37,6 +38,8 @@ public class ToolchainRule implements RuleDefinition {
   public static final String TARGET_COMPATIBLE_WITH_ATTR = "target_compatible_with";
   public static final String TARGET_SETTING_ATTR = "target_settings";
   public static final String TOOLCHAIN_ATTR = "toolchain";
+  public static final String USE_TARGET_PLATFORM_CONSTRAINTS_ATTR =
+      "use_target_platform_constraints";
 
   @Override
   public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
@@ -79,6 +82,16 @@ public class ToolchainRule implements RuleDefinition {
             attr(TARGET_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST)
                 .mandatoryProviders(ConstraintValueInfo.PROVIDER.id())
                 .allowedFileTypes(FileTypeSet.NO_FILE)
+                .nonconfigurable("part of toolchain configuration"))
+        /* <!-- #BLAZE_RULE(toolchain).ATTRIBUTE(use_target_platform_constraints) -->
+        If <code>True</code>, this toolchain behaves as if its <code>exec_compatible_with</code> and
+        <code>target_compatible_with</code> constraints are set to those of the current target
+        platform. <code>exec_compatible_with</code> and <code>target_compatible_with</code> must not
+        be set in that case.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(
+            attr(USE_TARGET_PLATFORM_CONSTRAINTS_ATTR, Type.BOOLEAN)
+                .value(false)
                 .nonconfigurable("part of toolchain configuration"))
         /* <!-- #BLAZE_RULE(toolchain).ATTRIBUTE(target_settings) -->
         A list of <code>config_setting</code>s that must be satisfied by the target configuration

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/SingleToolchainResolutionFunction.java
@@ -184,13 +184,16 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
         targetPlatform.label());
 
     for (DeclaredToolchainInfo toolchain : filteredToolchains) {
-      // Make sure the target platform matches.
-      if (!checkConstraints(
-          resolutionTrace,
-          toolchain.targetConstraints(),
-          /* isTargetPlatform= */ true,
-          targetPlatform,
-          toolchain.toolchainLabel())) {
+      // Make sure the target platform matches. A toolchain with use_target_platform_constraints
+      // matches
+      // any target platform.
+      if (!toolchain.hasTargetToExecConstraints()
+          && !checkConstraints(
+              resolutionTrace,
+              toolchain.targetConstraints(),
+              /* isTargetPlatform= */ true,
+              targetPlatform,
+              toolchain.toolchainLabel())) {
         continue;
       }
 
@@ -235,7 +238,9 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
         // Check if the execution constraints match.
         if (!checkConstraints(
             resolutionTrace,
-            toolchain.execConstraints(),
+            toolchain.hasTargetToExecConstraints()
+                ? targetPlatform.constraints()
+                : toolchain.execConstraints(),
             /* isTargetPlatform= */ false,
             executionPlatform,
             toolchain.toolchainLabel())) {


### PR DESCRIPTION
This causes the toolchain to always match the current target platform, whatever it is. Needed to support test toolchains.

Work towards #25160

Part of #25123.

RELNOTES: Add `use_target_platform_constraints` attribute to the `toolchain` rule, although it is not used, to enable writing custom test toolchains that are valid in 8.2.0 and later releases.

PiperOrigin-RevId: 732123054
Change-Id: I1b65e8881048187fe825bb26812ac6bdfa2b4c16