### PR TITLE
docs: remove cocoapods 404

### DIFF
--- a/site/en/docs/_index.yaml
+++ b/site/en/docs/_index.yaml
@@ -206,5 +206,3 @@ landing_page:
       path: /migrate/maven
     - heading: Xcode to Bazel
       path: /migrate/xcode
-    - heading: CocoaPods Dependencies
-      path: /migrate/cocoapods

--- a/site/en/migrate/index.md
+++ b/site/en/migrate/index.md
@@ -10,4 +10,3 @@ This page links to migration guides for Bazel.
 
 *  [Maven](/migrate/maven)
 *  [Xcode](/migrate/xcode)
-*  [CocoaPods](/migrate/cocoapods)


### PR DESCRIPTION
- https://bazel.build/migrate
- https://bazel.build/migrate/cocoapods

old version: https://bazel.build/versions/6.0.0/migrate/cocoapods