### PR TITLE
[7.6.1] Don't leak in-flight execution in `RemoteSpawnCache`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1455,9 +1455,11 @@ public class RemoteExecutionService {
   }
 
   /** An ongoing local execution of a spawn. */
-  public static final class LocalExecution {
+  public static final class LocalExecution implements SilentCloseable {
     private final RemoteAction action;
     private final SettableFuture<SpawnResult> spawnResultFuture;
+    private final Runnable onClose;
+    private final AtomicBoolean closeManually = new AtomicBoolean(false);
     private final Phaser spawnResultConsumers =
         new Phaser(1) {
           @Override
@@ -1467,9 +1469,10 @@ public class RemoteExecutionService {
           }
         };
 
-    private LocalExecution(RemoteAction action) {
+    private LocalExecution(RemoteAction action, Runnable onClose) {
       this.action = action;
       this.spawnResultFuture = SettableFuture.create();
+      this.onClose = onClose;
     }
 
     /**
@@ -1482,11 +1485,11 @@ public class RemoteExecutionService {
      * builds and clients.
      */
     @Nullable
-    public static LocalExecution createIfDeduplicatable(RemoteAction action) {
+    public static LocalExecution createIfDeduplicatable(RemoteAction action, Runnable onClose) {
       if (action.getSpawn().getPathMapper().isNoop()) {
         return null;
       }
-      return new LocalExecution(action);
+      return new LocalExecution(action, onClose);
     }
 
     /**
@@ -1522,10 +1525,30 @@ public class RemoteExecutionService {
 
     /**
      * Signals to all potential consumers of the {@link #spawnResultFuture} that this execution has
-     * been cancelled and that the result will not be available.
+     * finished or been canceled and that the result will no longer be available.
      */
-    public void cancel() {
+    @Override
+    public void close() {
+      if (!closeManually.get()) {
+        doClose();
+      }
+    }
+
+    /**
+     * Returns a {@link Runnable} that will close this {@link LocalExecution} instance when called.
+     * After this method is called, the {@link LocalExecution} instance will not be closed by the
+     * {@link #close()} method.
+     */
+    public Runnable delayClose() {
+      if (!closeManually.compareAndSet(false, true)) {
+        throw new IllegalStateException("delayClose has already been called");
+      }
+      return this::doClose;
+    }
+
+    private void doClose() {
       spawnResultFuture.cancel(true);
+      onClose.run();
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -78,6 +78,11 @@ final class RemoteSpawnCache implements SpawnCache {
     return remoteExecutionService;
   }
 
+  @VisibleForTesting
+  int getInFlightExecutionsSize() {
+    return inFlightExecutions.size();
+  }
+
   @Override
   public CacheHandle lookup(Spawn spawn, SpawnExecutionContext context)
       throws InterruptedException, IOException, ExecException, ForbiddenActionInputException {
@@ -110,7 +115,9 @@ final class RemoteSpawnCache implements SpawnCache {
       // first one.
       LocalExecution previousExecution = null;
       try {
-        thisExecution = LocalExecution.createIfDeduplicatable(action);
+        thisExecution =
+            LocalExecution.createIfDeduplicatable(
+                action, () -> inFlightExecutions.remove(action.getActionKey()));
         if (shouldUploadLocalResults && thisExecution != null) {
           LocalExecution previousOrThisExecution =
               inFlightExecutions.merge(
@@ -126,8 +133,12 @@ final class RemoteSpawnCache implements SpawnCache {
                       return thisExecutionArg;
                     }
                   });
-          previousExecution =
-              previousOrThisExecution == thisExecution ? null : previousOrThisExecution;
+          if (previousOrThisExecution != thisExecution) {
+            // The current execution is not the first one to be registered for this action key, so
+            // we need to wait for the previous one to finish before we can reuse its result.
+            previousExecution = previousOrThisExecution;
+            thisExecution = null;
+          }
         }
         try {
           RemoteActionResult result;
@@ -138,6 +149,9 @@ final class RemoteSpawnCache implements SpawnCache {
           // In case the remote cache returned a failed action (exit code != 0) we treat it as a
           // cache miss
           if (result != null && result.getExitCode() == 0) {
+            if (thisExecution != null) {
+              thisExecution.close();
+            }
             Stopwatch fetchTime = Stopwatch.createStarted();
             InMemoryOutput inMemoryOutput;
             try (SilentCloseable c = prof.profile(REMOTE_DOWNLOAD, "download outputs")) {
@@ -259,7 +273,9 @@ final class RemoteSpawnCache implements SpawnCache {
           // indefinitely is important to avoid excessive memory pressure - Spawns can be very
           // large.
           remoteExecutionService.uploadOutputs(
-              action, result, () -> inFlightExecutions.remove(action.getActionKey()));
+              action,
+              result,
+              thisExecutionFinal != null ? thisExecutionFinal.delayClose() : () -> {});
           if (thisExecutionFinal != null
               && action.getSpawn().getResourceOwner().mayModifySpawnOutputsAfterExecution()) {
             // In this case outputs have been uploaded synchronously and the callback above has run,
@@ -290,7 +306,7 @@ final class RemoteSpawnCache implements SpawnCache {
         @Override
         public void close() {
           if (thisExecutionFinal != null) {
-            thisExecutionFinal.cancel();
+            thisExecutionFinal.close();
           }
         }
       };


### PR DESCRIPTION
The in-flight executions need to be cleaned up also in case of a cache hit or an exception while interacting with the cache, otherwise `inFlightExecutions` grows over time retaining large `Spawn`s.

Closes #25668.

PiperOrigin-RevId: 740058969
Change-Id: I42045219510df0347e38234d6d3bd1ebb6167d9b 
(cherry picked from commit 0f957c185f671cf9d088cf551818f0442a80c6f9)