### PR TITLE
Minor fix in macros doc

### DIFF
--- a/site/en/extending/macros.md
+++ b/site/en/extending/macros.md
@@ -117,7 +117,7 @@ _my_macro_implementation(name, visibility, tags, **kwargs):
 
 `implementation` accepts a function which contains the logic of the macro.
 Implementation functions often create targets by calling one or more rules, and
-they are are usually private (named with a leading underscore). Conventionally,
+they are usually private (named with a leading underscore). Conventionally,
 they are named the same as their macro, but prefixed with `_` and suffixed with
 `_impl`.
 


### PR DESCRIPTION
Removes a duplicated 'are'