### PR TITLE
[8.2.0] Allow finalizer targets to see targets visible either to BUILD file or to finalizer macro class definition

### DIFF
--- a/site/en/concepts/visibility.md
+++ b/site/en/concepts/visibility.md
@@ -380,6 +380,25 @@ label-typed attributes.
 Note: Visibility delegation does not work for labels that were not passed into
 the macro, such as labels derived by string manipulation.
 
+#### Finalizers {:#finalizers}
+
+Targets declared in a rule finalizer (a symbolic macro with `finalizer = True`),
+in addition to seeing targets following the usual symbolic macro visibility
+rules, can *also* see all targets which are visible to the finalizer target's
+package.
+
+In other words, if you migrate a `native.existing_rules()`-based legacy macro to
+a finalizer, the targets declared by the finalizer will still be able to see
+their old dependencies.
+
+It is possible to define targets that a finalizer can introspect using
+`native.existing_rules()`, but which it cannot use as dependencies under the
+visibility system. For example, if a macro-defined target is not visible to its
+own package or to the finalizer macro's definition, and is not delegated to the
+finalizer, the finalizer cannot see such a target. Note, however, that a
+`native.existing_rules()`-based legacy macro will also be unable to see such a
+target.
+
 ## Load visibility {:#load-visibility}
 
 **Load visibility** controls whether a `.bzl` file may be loaded from other

--- a/site/en/extending/macros.md
+++ b/site/en/extending/macros.md
@@ -338,6 +338,21 @@ Remember that legacy macros are entirely transparent to the visibility system,
 and behave as though their location is whatever BUILD file or symbolic macro
 they were called from.
 
+#### Finalizers and visibility {:#finalizers-and-visibility}
+
+Targets declared in a rule finalizer, in addition to seeing targets following
+the usual symbolic macro visibility rules, can *also* see all targets which are
+visible to the finalizer target's package.
+
+This means that if you migrate a `native.existing_rules()`-based legacy macro to
+a finalizer, the targets declared by the finalizer will still be able to see
+their old dependencies.
+
+However, note that it's possible to declare a target in a symbolic macro such
+that a finalizer's targets cannot see it under the visibility system – even
+though the finalizer can *introspect* its attributes using
+`native.existing_rules()`.
+
 ### Selects {:#selects}
 
 If an attribute is `configurable` (the default) and its value is not `None`,

--- a/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/CommonPrerequisiteValidator.java
@@ -200,14 +200,19 @@ public abstract class CommonPrerequisiteValidator implements PrerequisiteValidat
       }
     }
 
-    PackageIdentifier ruleTargetLocation =
-        declaringMacro != null
-            // Macro's location.
-            ? declaringMacro.getMacroClass().getDefiningBzlLabel().getPackageIdentifier()
-            // BUILD file's location.
-            : pkg.getPackageIdentifier();
-
-    return isVisibleToLocation(prerequisite, ruleTargetLocation);
+    if (declaringMacro != null) {
+      if (declaringMacro.getMacroClass().isFinalizer()
+          && isVisibleToLocation(prerequisite, pkg.getPackageIdentifier())) {
+        // Finalizers, unlike ordinary symbolic macros, are also granted the same visibility
+        // privileges as the consuming package's BUILD file.
+        return true;
+      }
+      PackageIdentifier macroLocation =
+          declaringMacro.getMacroClass().getDefiningBzlLabel().getPackageIdentifier();
+      return isVisibleToLocation(prerequisite, macroLocation);
+    } else {
+      return isVisibleToLocation(prerequisite, pkg.getPackageIdentifier());
+    }
   }
 
   /**


### PR DESCRIPTION
Previously, finalizers used the same visibility semantics as normal symbolic macros. As a result, migrating an epilogue legacy macro to a finalizer could result in visibility errors if, for example, a finalizer-defined target declared a dependency on a legacy-macro-defined target which was visible to the BUILD file but not to the finalizer's definition.

PiperOrigin-RevId: 739300166
Change-Id: I480dde3d2a9704ef85a64ba8346038e784172ee6

Commit
https://github.com/bazelbuild/bazel/commit/4c2d91e762ab6e492853b021408129dd93fb5904