### PR TITLE
[8.2.0] Use ImmutableList.Builders in Parser

### DIFF
--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -249,10 +249,10 @@ final class Parser {
     }
 
     // unparenthesized tuple
-    List<Expression> elems = new ArrayList<>();
+    ImmutableList.Builder<Expression> elems = ImmutableList.builder();
     elems.add(e);
     parseExprList(elems, /*trailingCommaAllowed=*/ false);
-    return new ListExpression(locs, /*isTuple=*/ true, -1, elems, -1);
+    return new ListExpression(locs, /* isTuple= */ true, -1, elems.build(), -1);
   }
 
   @FormatMethod
@@ -517,7 +517,7 @@ final class Parser {
   // It is used to parse tuples and list elements.
   //
   // expr_list = ( ',' expr )* ','?
-  private void parseExprList(List<Expression> list, boolean trailingCommaAllowed) {
+  private void parseExprList(ImmutableList.Builder<Expression> list, boolean trailingCommaAllowed) {
     //  terminating tokens for an expression list
     while (token.kind == TokenKind.COMMA) {
       expect(TokenKind.COMMA);
@@ -533,7 +533,7 @@ final class Parser {
 
   // dict_entry_list = ( (dict_entry ',')* dict_entry ','? )?
   private List<DictExpression.Entry> parseDictEntryList() {
-    List<DictExpression.Entry> list = new ArrayList<>();
+    ImmutableList.Builder<DictExpression.Entry> list = ImmutableList.builder();
     // the terminating token for a dict entry list
     while (token.kind != TokenKind.RBRACE) {
       list.add(parseDictEntry());
@@ -543,7 +543,7 @@ final class Parser {
         break;
       }
     }
-    return list;
+    return list.build();
   }
 
   // dict_entry = test ':' test
@@ -627,11 +627,12 @@ final class Parser {
 
           // non-empty tuple: (e,) or (e, ..., e)
           if (token.kind == TokenKind.COMMA) {
-            List<Expression> elems = new ArrayList<>();
+            ImmutableList.Builder<Expression> elems = ImmutableList.builder();
             elems.add(e);
             parseExprList(elems, /*trailingCommaAllowed=*/ true);
             int rparenOffset = expect(TokenKind.RPAREN);
-            return new ListExpression(locs, /*isTuple=*/ true, lparenOffset, elems, rparenOffset);
+            return new ListExpression(
+                locs, /* isTuple= */ true, lparenOffset, elems.build(), rparenOffset);
           }
 
           // (expr for vars in expr) -- Python generator expression?
@@ -725,7 +726,7 @@ final class Parser {
     }
 
     // unparenthesized tuple
-    List<Expression> elems = new ArrayList<>();
+    ImmutableList.Builder<Expression> elems = ImmutableList.builder();
     elems.add(e1);
     while (token.kind == TokenKind.COMMA) {
       expect(TokenKind.COMMA);
@@ -734,7 +735,7 @@ final class Parser {
       }
       elems.add(parsePrimaryWithSuffix());
     }
-    return new ListExpression(locs, /*isTuple=*/ true, -1, elems, -1);
+    return new ListExpression(locs, /* isTuple= */ true, -1, elems.build(), -1);
   }
 
   // comprehension_suffix = 'FOR' loop_variables 'IN' expr comprehension_suffix
@@ -804,13 +805,13 @@ final class Parser {
       case COMMA:
         // [e, ...], list expression
         {
-          List<Expression> elems = new ArrayList<>();
+          ImmutableList.Builder<Expression> elems = ImmutableList.builder();
           elems.add(expression);
           parseExprList(elems, /*trailingCommaAllowed=*/ true);
           if (token.kind == TokenKind.RBRACKET) {
             int rbracketOffset = nextToken();
             return new ListExpression(
-                locs, /*isTuple=*/ false, lbracketOffset, elems, rbracketOffset);
+                locs, /* isTuple= */ false, lbracketOffset, elems.build(), rbracketOffset);
           }
 
           expect(TokenKind.RBRACKET);
@@ -843,7 +844,7 @@ final class Parser {
       return parseComprehensionSuffix(lbraceOffset, entry, TokenKind.RBRACE);
     }
 
-    List<DictExpression.Entry> entries = new ArrayList<>();
+    ImmutableList.Builder<DictExpression.Entry> entries = ImmutableList.builder();
     entries.add(entry);
     if (token.kind == TokenKind.COMMA) {
       expect(TokenKind.COMMA);
@@ -851,7 +852,7 @@ final class Parser {
     }
     if (token.kind == TokenKind.RBRACE) {
       int rbraceOffset = nextToken();
-      return new DictExpression(locs, lbraceOffset, entries, rbraceOffset);
+      return new DictExpression(locs, lbraceOffset, entries.build(), rbraceOffset);
     }
 
     expect(TokenKind.RBRACE);


### PR DESCRIPTION
This brings code closer to readability standards. The benchmarks show there's no regression or improvement. There's a bit more edenSpaceGarbage, however so small, that I believe readability should be more important.

PiperOrigin-RevId: 739291019
Change-Id: Id037395e812556771789f8ea4b810bff6b933f05

Commit
https://github.com/bazelbuild/bazel/commit/9250141e98e34ebe599145927068550481058fdd