### PR TITLE
Remove the `distribs` from cc_* rules.

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/attrs.bzl
@@ -405,7 +405,6 @@ this option is off.
 """,
     ),
     "env": attr.string_dict(),
-    "distribs": attr.string_list(),
     "licenses": attr.license() if hasattr(attr, "license") else attr.string_list(),
     "_cc_binary": attr.bool(),
     "_is_test": attr.bool(default = False),
@@ -415,4 +414,3 @@ this option is off.
 }
 
 cc_binary_attrs.update(dynamic_deps_attrs)
-cc_binary_attrs.update(semantics.get_distribs_attr())

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -950,7 +950,7 @@ See <a href="${link cc_binary.linkshared}"><code>cc_binary.linkshared</code></a>
         "_stl": semantics.get_stl(),
         "_def_parser": semantics.get_def_parser(),
         "_use_auto_exec_groups": attr.bool(default = True),
-    } | semantics.get_distribs_attr() | semantics.get_implementation_deps_allowed_attr() | semantics.get_nocopts_attr(),
+    } | semantics.get_implementation_deps_allowed_attr() | semantics.get_nocopts_attr(),
     toolchains = cc_helper.use_cpp_toolchain() +
                  semantics.get_runtimes_toolchain(),
     fragments = ["cpp"] + semantics.additional_fragments(),

--- a/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
@@ -43,9 +43,6 @@ def _get_platforms_root():
 def _additional_fragments():
     return []
 
-def _get_distribs_attr():
-    return {}
-
 def _get_licenses_attr():
     # TODO(b/182226065): Change to applicable_licenses
     return {}
@@ -167,7 +164,6 @@ semantics = struct(
     get_repo = _get_repo,
     get_platforms_root = _get_platforms_root,
     additional_fragments = _additional_fragments,
-    get_distribs_attr = _get_distribs_attr,
     get_licenses_attr = _get_licenses_attr,
     get_def_parser = _get_def_parser,
     get_stl = _get_stl,


### PR DESCRIPTION
It is vestigial from when Bazel was Google internal. It is unused globally.