### PR TITLE
Fix metadata mnemonic field

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
@@ -55,7 +55,7 @@ public class TracingMetadataUtils {
         buildRequestId,
         commandId,
         actionId,
-        actionMetadata != null ? actionMetadata.getProgressMessage() : null,
+        actionMetadata != null ? actionMetadata.getMnemonic() : null,
         actionMetadata != null && actionMetadata.getOwner().getLabel() != null
             ? actionMetadata.getOwner().getLabel().getCanonicalForm()
             : null,


### PR DESCRIPTION
This was unintentionally changed to using the progress message in f6aaa32c9f3a250c4b51d2232c58c92b68c537fc.