### PR TITLE
[8.2.0] Add support for riscv64 linux

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -297,6 +297,7 @@ use_repo(
     "openjdk_linux_aarch64_vanilla",
     "openjdk_linux_ppc64le_vanilla",
     "openjdk_linux_s390x_vanilla",
+    "openjdk_linux_riscv64_vanilla",
     "openjdk_linux_vanilla",
     "openjdk_macos_aarch64_vanilla",
     "openjdk_macos_x86_64_vanilla",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -238,7 +238,7 @@
   "moduleExtensions": {
     "//:repositories.bzl%async_profiler_repos": {
       "general": {
-        "bzlTransitiveDigest": "YxAL4mFIGuVkxi1lJ0GZWtS8pWt+Zm9fdvJwlQ9/EpY=",
+        "bzlTransitiveDigest": "Yke2x5sUjmlG+2GhGPMhz8ErEEO8cBJUYJ/IlxyQcbA=",
         "usagesDigest": "5A28PwAsOZuSAXZ8vWJpTa+ii7fTnFSfd1ujDdf5xBg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -101,6 +101,12 @@ def embedded_jdk_repositories():
         url = "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.1%2B11/OpenJDK23U-jdk_ppc64le_linux_hotspot_23.0.1_11.tar.gz",
     )
     http_file(
+        name = "openjdk_linux_riscv64_vanilla",
+        integrity = "sha256-gNe6uflhS9+TTGvEQQMb0f6tOuqF8WdwEjvYprzcUrY=",
+        downloaded_file_path = "adoptopenjdk-riscv64-vanilla.tar.gz",
+        url = "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.1%2B11/OpenJDK23U-jdk_riscv64_linux_hotspot_23.0.1_11.tar.gz",
+    )
+    http_file(
         name = "openjdk_macos_x86_64_vanilla",
         integrity = "sha256-e7KJtJ9+mFFSdKCj68thfTXguWH5zXaSSb9phzXf/lQ=",
         downloaded_file_path = "zulu-macos-vanilla.tar.gz",

--- a/src/BUILD
+++ b/src/BUILD
@@ -173,6 +173,9 @@ filegroup(
         "//src/conditions:linux_s390x": [
             "@openjdk_linux_s390x_vanilla//file",
         ],
+        "//src/conditions:linux_riscv64": [
+            "@openjdk_linux_riscv64_vanilla//file",
+        ],
         "//conditions:default": [
             "@openjdk_linux_vanilla//file",
         ],

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -49,8 +49,8 @@ else
 fi
 fulljdk=$1
 out=$3
-ARCH=`uname -p`
-if [[ "${ARCH}" == 'ppc64le'  ]] || [[ "${ARCH}" == 's390x' ]]; then
+ARCH=`uname -m`
+if [[ "${ARCH}" == 'ppc64le'  ]] || [[ "${ARCH}" == 's390x' ]] || [[ "${ARCH}" == 'riscv64' ]]; then
   FULL_JDK_DIR="jdk*"
   DOCS=""
 else


### PR DESCRIPTION
This patch fixes bootstrapping bazel on riscv64 linux

In `src/minimize_jdk.sh`,

The usage of `uname -p` isn't portable and it returns `unknown` for me on riscv64.
So I changed it to `uname -m`.

Closes #25236.

PiperOrigin-RevId: 725251883
Change-Id: I5ddf82840a958137ddba4a521f4ee8502185d78d

Commit https://github.com/bazelbuild/bazel/commit/5f74b9a84f6270ae8ce9c5c6280d4c0e5428352f