### PR TITLE
[8.2.0] Enable sparse checkout in git_repository rule

### DIFF
--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -176,11 +176,24 @@ _common_attrs = {
             "Either `workspace_file` or `workspace_file_content` can be " +
             "specified, or neither, but not both.",
     ),
+    "sparse_checkout_patterns": attr.string_list(
+        default = [],
+        doc = "Sequence of patterns for a sparse checkout of files in this repository.",
+    ),
+    "sparse_checkout_file": attr.label(
+        doc =
+            "File containing .gitignore-style patterns for a sparse checkout of files " +
+            "in this repository. Either `sparse_checkout_patterns` or `sparse_checkout_file` " +
+            "may be specified, or neither, but not both.",
+    ),
 }
 
 def _git_repository_implementation(ctx):
     if ctx.attr.build_file and ctx.attr.build_file_content:
         fail("Only one of build_file and build_file_content can be provided.")
+    if ctx.attr.sparse_checkout_patterns and ctx.attr.sparse_checkout_file:
+        fail("Only one of sparse_checkout_patterns and sparse_checkout_file can be provided.")
+
     update = _clone_or_update_repo(ctx)
     workspace_and_buildfile(ctx)
     patch(ctx)

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -102,6 +102,28 @@ def git_repo(ctx, directory):
 
     return struct(commit = actual_commit, shallow_since = shallow_date)
 
+def _git_version(ctx):
+    """Gets the version of the Git executable."""
+    command = ["git", "--version"]
+    st = ctx.execute(command)
+    if st.return_code != 0:
+        _error(ctx.name, command, st.stderr)
+
+    # The output of `git --version` is in the format:
+    #
+    #     git version <major>.<minor>.<revision>[ ...]
+    #
+    # The revision may be a non-integer, so it is not converted to an int. Any additional text
+    # after <revision> is discarded.
+    version_str = st.stdout.split(" ")[2].rstrip("\n")
+    version_arr = version_str.split(".")
+    return struct(
+        major = int(version_arr[0]),
+        minor = int(version_arr[1]),
+        revision = version_arr[2],
+        full_str = version_str,
+    )
+
 def _report_progress(ctx, git_repo, *, shallow_failed = False):
     warning = ""
     if shallow_failed:
@@ -135,7 +157,21 @@ def add_origin(ctx, git_repo, remote):
 
 def fetch(ctx, git_repo):
     args = ["fetch", "origin", git_repo.fetch_ref]
+
+    sparse_checkout_patterns_or_file = ctx.attr.sparse_checkout_patterns or ctx.attr.sparse_checkout_file
+    if sparse_checkout_patterns_or_file:
+        if _git_sparse_checkout_config(ctx, git_repo):
+            # Use filter to disable downloading file contents until we set the `sparse-checkout` patterns.
+            args.append("--filter=blob:none")
+        else:
+            print("WARNING: Sparse checkout is not supported. Doing a full checkout.")
+            sparse_checkout_patterns_or_file = None
+
     st = _git_maybe_shallow(ctx, git_repo, *args)
+
+    if sparse_checkout_patterns_or_file:
+        _git_sparse_checkout(ctx, git_repo, sparse_checkout_patterns_or_file)
+
     if st.return_code == 0:
         return
     if ctx.attr.commit:
@@ -194,6 +230,54 @@ def _git_maybe_shallow(ctx, git_repo, command, *args):
         if st.return_code == 0:
             return st
     return _execute(ctx, git_repo, start + args_list)
+
+def _git_sparse_checkout_config(ctx, git_repo):
+    """Configures the repo for a sparse checkout.
+
+    If the Git executable does not support sparse checkout, this function prints a warning and returns False.
+    Otherwise, it returns True."""
+
+    git_version = _git_version(ctx)
+
+    # Sparse checkout was added in version 2.25.0.
+    if git_version.major < 2 or (git_version.major == 2 and git_version.minor < 25):
+        print("WARNING: Git v%s does not support sparse checkout." % (git_version.full_str))
+        return False
+
+    # Older versions of Git require this config to be set to the name of the promisor remote.
+    config_command = ["config", "extensions.partialClone", "origin"]
+    st = _execute(ctx, git_repo, config_command)
+    if st.return_code != 0:
+        _error(ctx.name, config_command, st.stderr)
+    return True
+
+def _git_sparse_checkout(ctx, git_repo, sparse_checkout_patterns_or_file):
+    """Initialize the repo with patterns for a sparse checkout.
+
+    Args:
+        ctx: Context of the calling rules.
+        git_repo: The Git repository to initialize for sparse checkout.
+        sparse_checkout_patterns_or_file: Either a list of patterns or a Label for a sparse-checkout file.
+    """
+
+    # Note: `init` is deprecated, but needed for older versions of Git. This command may be removed
+    # in future versions.
+    init_command = ["sparse-checkout", "init", "--no-cone"]
+    st = _execute(ctx, git_repo, init_command)
+    if st.return_code != 0:
+        _error(ctx.name, init_command, st.stderr)
+
+    if type(sparse_checkout_patterns_or_file) == "list":
+        sparse_checkout_patterns = sparse_checkout_patterns_or_file
+        set_command = ["sparse-checkout", "set"] + sparse_checkout_patterns
+        st = _execute(ctx, git_repo, set_command)
+        if st.return_code != 0:
+            _error(ctx.name, set_command, st.stderr)
+    else:
+        sparse_checkout_file = sparse_checkout_patterns_or_file
+        link_name = str(git_repo.directory) + "/.git/info/sparse-checkout"
+        ctx.delete(link_name)
+        ctx.symlink(sparse_checkout_file, link_name)
 
 # List of variables to unset when calling `git` to ensure no interference of
 # operation. This is in the form of a dict that can be passed to `execute()`.


### PR DESCRIPTION
Add a sparse_checkout_patterns and sparse_checkout_file arguments to the git_repository rule. If non-empty, this will cause the rule to perform a sparse checkout of the repository, only checking out files that match the .gitignore-style patterns in this list.

Fixes issue https://github.com/bazelbuild/bazel/issues/24069.

Cherry-pick of https://github.com/bazelbuild/bazel/commit/4006e059737d214fc4116083d9c4e58d5a2e40c0