### PR TITLE
[8.2.0] Restrict private API allowlisting to `@rules_java//java`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuiltinRestriction.java
@@ -59,8 +59,8 @@ public final class BuiltinRestriction {
               BuiltinRestriction.allowlistEntry("rules_cc", ""),
 
               // Java rules
-              BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_java"),
-              BuiltinRestriction.allowlistEntry("rules_java", ""),
+              BuiltinRestriction.allowlistEntry("", "third_party/bazel_rules/rules_java/java"),
+              BuiltinRestriction.allowlistEntry("rules_java", "java"),
 
               // Rust rules
               BuiltinRestriction.allowlistEntry(


### PR DESCRIPTION
This will permit writing tests in `@rules_java//test` that assert on private API access failures.

PiperOrigin-RevId: 743908855
Change-Id: I520cf57d7719d70866df6bbd99a45142e36839c0 (cherry picked from commit 176b9b4df99299efb1e1e10f0c919ae58be025ba)