### PR TITLE
[8.2.0] Set generator_name, generator_function, generator_location, full Starlark stack for rules in symbolic macros

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -1467,7 +1467,8 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
         throw Starlark.errorf("unexpected positional arguments");
       }
 
-      MacroInstance macroInstance = macroClass.instantiateAndAddMacro(pkgBuilder, kwargs);
+      MacroInstance macroInstance =
+          macroClass.instantiateAndAddMacro(pkgBuilder, kwargs, thread.getCallStack());
 
       // Evaluate the macro now, if it's not a finalizer. Finalizer evaluation will be deferred to
       // the end of the BUILD file evaluation.

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.packages;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -29,6 +30,8 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.syntax.Location;
 
 /**
  * Represents a use of a symbolic macro in a package.
@@ -47,6 +50,10 @@ public final class MacroInstance {
   private final Package pkg;
 
   @Nullable private final MacroInstance parent;
+
+  private final Location buildFileLocation;
+
+  private final CallStack.Node parentCallStack;
 
   private final MacroClass macroClass;
 
@@ -80,12 +87,16 @@ public final class MacroInstance {
   public MacroInstance(
       Package pkg,
       @Nullable MacroInstance parent,
+      Location buildFileLocation,
+      CallStack.Node parentCallStack,
       MacroClass macroClass,
       Map<String, Object> attrValues,
       int sameNameDepth)
       throws EvalException {
     this.pkg = pkg;
     this.parent = parent;
+    this.buildFileLocation = buildFileLocation;
+    this.parentCallStack = parentCallStack;
     this.macroClass = macroClass;
     this.attrValues = ImmutableMap.copyOf(attrValues);
     Preconditions.checkArgument(sameNameDepth > 0);
@@ -105,6 +116,44 @@ public final class MacroInstance {
   @Nullable
   public MacroInstance getParent() {
     return parent;
+  }
+
+  /**
+   * Returns the location in the BUILD file at which this macro was created or its outermost
+   * enclosing symbolic or legacy macro was called.
+   */
+  @VisibleForTesting
+  public Location getBuildFileLocation() {
+    return buildFileLocation;
+  }
+
+  /**
+   * Returns the call stack of the Starlark thread that created this macro instance.
+   *
+   * <p>If this macro was instantiated in a BUILD file thread (as contrasted with a symbolic macro
+   * thread), the call stack does not include the frame for the BUILD file top level, since it's
+   * redundant with {@link #getBuildFileLocation}.
+   */
+  CallStack.Node getParentCallStack() {
+    return parentCallStack;
+  }
+
+  /**
+   * Returns the call stack of the Starlark thread that created this macro instance.
+   *
+   * <p>Requires reconstructing the call stack from a compact representation, so should only be
+   * called when the full call stack is needed.
+   */
+  @VisibleForTesting
+  public ImmutableList<StarlarkThread.CallStackEntry> reconstructParentCallStack() {
+    ImmutableList.Builder<StarlarkThread.CallStackEntry> stack = ImmutableList.builder();
+    if (parent == null) {
+      stack.add(StarlarkThread.callStackEntry(StarlarkThread.TOP_LEVEL, buildFileLocation));
+    }
+    for (CallStack.Node node = parentCallStack; node != null; node = node.next()) {
+      stack.add(node.toCallStackEntry());
+    }
+    return stack.build();
   }
 
   /** Returns the {@link MacroClass} (i.e. schema info) that this instance parameterizes. */

--- a/src/main/java/com/google/devtools/build/lib/packages/Rule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Rule.java
@@ -826,6 +826,7 @@ public class Rule implements Target, DependencyFilter.AttributeInfoProvider {
    * Returns whether this rule was created by a macro.
    */
   public boolean wasCreatedByMacro() {
+    // TODO(bazel-team): do we really need the `hasStringAttribute(GENERATOR_NAME)` check?
     return interiorCallStack != null || hasStringAttribute(GENERATOR_NAME);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
@@ -50,6 +50,10 @@ public class RuleFactory {
    *
    * <p>It is the caller's responsibility to add the rule to the package (the caller may choose not
    * to do so if, for example, the rule has errors).
+   *
+   * @param callstack the stack of the Starlark thread where the rule is created. In the case of
+   *     rules instantiated by a symbolic macro, this is the inner macro's stack, and does not
+   *     include frames for enclosing macros or the BUILD file.
    */
   public static Rule createRule(
       Package.Builder pkgBuilder,
@@ -227,26 +231,28 @@ public class RuleFactory {
    * (and which are not also within a symbolic macro). Its value is the name argument of the
    * top-level macro on the call stack, if its value can be determined statically (see {@link
    * PackageFactory#checkBuildSyntax}), or just the name of the target otherwise.
+   *
+   * @param callstack the stack of the Starlark thread where the rule is created. In the case of
+   *     rules instantiated by a symbolic macro, this is the inner macro's stack, and does not
+   *     include frames for enclosing macros or the BUILD file.
    */
-  // TODO: #19922 - Should we set generator_name on targets created by a symbolic macro instantiated
-  // within a legacy macro? Otherwise tooling may think those targets were not created in a macro.
   @Nullable
   private static String getGeneratorName(
       Package.Builder pkgBuilder,
       BuildLangTypedAttributeValuesMap args,
-      ImmutableList<CallStackEntry> stack) {
-    // The "generator" of a rule is the function outermost in the call stack (regardless of whether
-    // or not it was passed a "name" parameter). For rules with generators, the stack must contain
-    // at least two entries:
-    //   0: the outermost function (e.g. a BUILD file),
-    //   1: the function called by it (e.g. a "macro" in a .bzl file).
-    // optionally followed by other Starlark or built-in functions, and finally the rule
-    // instantiation function.
-    if (stack.size() < 2 || !stack.get(1).location.file().endsWith(".bzl")) {
-      // Not instantiated by a legacy macro.
-      // TODO: #19922 - This stack inspection logic doesn't work for symbolic macros, where it will
-      // likely incorrectly discriminate between targets created in the implementation function
-      // directly and targets created in a helper function called from the implementation function.
+      ImmutableList<CallStackEntry> callstack) {
+    @Nullable MacroInstance macro = pkgBuilder.currentMacro();
+    // The "generator" of a rule is the function outermost in the BUILD file thread's call stack
+    // (regardless of whether or not it was passed a "name" parameter). For rules with generators,
+    // the BUILD file thread's call stack must contain at least two entries:
+    //   0: the outermost function (BUILD file top level),
+    //   1: the function called by it (e.g. a macro in a .bzl file),
+    // optionally followed by other Starlark or built-in functions, and finally - if the rule is
+    // instantiated in the BUILD file thread - the rule instantiation function.
+    if (macro == null
+        && (callstack.size() < 2 || !callstack.get(1).location.file().endsWith(".bzl"))) {
+      // We are in a BUILD file thread, and the rule is being instantiated directly at the top
+      // level of the BUILD file.
       // TODO(bazel-team): Tolerate ".scl" extension in the above if? An .scl file can instantiate a
       // rule if the rule function is passed as an argument.
       return null;
@@ -258,7 +264,9 @@ public class RuleFactory {
       return null;
     }
 
-    String generatorName = pkgBuilder.getGeneratorNameByLocation(stack.get(0).location);
+    String generatorName =
+        pkgBuilder.getGeneratorNameByLocation(
+            macro != null ? macro.getBuildFileLocation() : callstack.get(0).location);
     if (generatorName == null) {
       // Fall back on target name (meh).
       generatorName = (String) args.getAttributeValue("name");

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -375,6 +375,8 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:test/analysis_failure_info",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/net/starlark/java/eval",
+        "//src/main/java/net/starlark/java/syntax",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//third_party:error_prone_annotations",
         "//third_party:guava",

--- a/src/test/java/com/google/devtools/build/lib/analysis/SymbolicMacroTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SymbolicMacroTest.java
@@ -40,6 +40,8 @@ import com.google.testing.junit.testparameterinjector.TestParameters;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.syntax.Location;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1978,5 +1980,164 @@ my_macro = macro(
     assertContainsEvent(
         "a rule or macro callable must be assigned to a global variable in a .bzl file before it"
             + " can be inherited from");
+  }
+
+  @Test
+  public void generatorInfoAndCallStack_atTopLevel() throws Exception {
+    // cc_binary_legacy_macro is a legacy macro instantiating a cc_binary rule.
+    scratch.file(
+        "pkg/inner_legacy_macro.bzl",
+        """
+        def inner_legacy_macro(name, **kwargs):
+              native.cc_binary(name = name, **kwargs)
+        """);
+    // my_macro is a symbolic macro that instantiates 2 cc_binary rules: one directly, and one
+    // wrapped by cc_binary_legacy_macro.
+    scratch.file(
+        "pkg/my_macro.bzl",
+        """
+        load(":inner_legacy_macro.bzl", "inner_legacy_macro")
+
+        def _impl(name, visibility, **kwargs):
+            native.cc_binary(name = name + "_lib")
+            inner_legacy_macro(name  = name + "_legacy_macro_lib")
+
+        my_macro = macro(implementation = _impl)
+        """);
+    scratch.file(
+        "pkg/BUILD",
+        """
+        load(":my_macro.bzl", "my_macro")
+
+        my_macro(name = "foo")
+        """);
+
+    Package pkg = getPackage("pkg");
+    assertPackageNotInError(pkg);
+    MacroInstance foo = getMacroById(pkg, "foo:1");
+    assertThat(foo.getBuildFileLocation())
+        .isEqualTo(Location.fromFileLineColumn("/workspace/pkg/BUILD", 3, 9));
+    assertThat(foo.reconstructParentCallStack())
+        .containsExactly(
+            StarlarkThread.callStackEntry(StarlarkThread.TOP_LEVEL, foo.getBuildFileLocation()),
+            StarlarkThread.callStackEntry("my_macro", Location.BUILTIN))
+        .inOrder();
+
+    Rule fooLib = pkg.getRule("foo_lib");
+    assertThat(fooLib.wasCreatedByMacro()).isTrue();
+    assertThat(fooLib.getLocation()).isEqualTo(foo.getBuildFileLocation());
+    assertThat(fooLib.getAttr("generator_name", Type.STRING)).isEqualTo("foo");
+    assertThat(fooLib.getAttr("generator_function", Type.STRING)).isEqualTo("my_macro");
+    assertThat(fooLib.getAttr("generator_location", Type.STRING)).isEqualTo("pkg/BUILD:3:9");
+    assertThat(fooLib.reconstructCallStack())
+        .isEqualTo(
+            ImmutableList.builder()
+                .addAll(foo.reconstructParentCallStack())
+                .add(
+                    StarlarkThread.callStackEntry(
+                        "_impl", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 4, 21)))
+                .build());
+
+    Rule fooLegacyLib = pkg.getRule("foo_legacy_macro_lib");
+    assertThat(fooLegacyLib.wasCreatedByMacro()).isTrue();
+    assertThat(fooLegacyLib.getLocation()).isEqualTo(foo.getBuildFileLocation());
+    assertThat(fooLegacyLib.getAttr("generator_name", Type.STRING)).isEqualTo("foo");
+    assertThat(fooLegacyLib.getAttr("generator_function", Type.STRING)).isEqualTo("my_macro");
+    assertThat(fooLegacyLib.getAttr("generator_location", Type.STRING)).isEqualTo("pkg/BUILD:3:9");
+    assertThat(fooLegacyLib.reconstructCallStack())
+        .isEqualTo(
+            ImmutableList.builder()
+                .addAll(foo.reconstructParentCallStack())
+                .add(
+                    StarlarkThread.callStackEntry(
+                        "_impl", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 5, 23)))
+                .add(
+                    StarlarkThread.callStackEntry(
+                        "inner_legacy_macro",
+                        Location.fromFileLineColumn(
+                            "/workspace/pkg/inner_legacy_macro.bzl", 2, 23)))
+                .build());
+  }
+
+  @Test
+  public void generatorInfoAndCallStack_nestedMacros() throws Exception {
+    // inner_legacy_wrapper is a legacy macro wrapper around inner_macro, which is a symbolic macro
+    // that instantiates a cc_binary rule.
+    scratch.file(
+        "pkg/inner.bzl",
+        """
+        def _inner_impl(name, visibility, **kwargs):
+            native.cc_binary(name = name, **kwargs)
+
+        inner_macro = macro(implementation = _inner_impl)
+
+        def inner_legacy_wrapper(name, **kwargs):
+            inner_macro(name = name, **kwargs)
+        """);
+    // outer_legacy_wrapper is a legacy wrapper around outer_macro, which is a symbolic macro that
+    // invokes inner_legacy_wrapper.
+    scratch.file(
+        "pkg/outer.bzl",
+        """
+        load(":inner.bzl", "inner_legacy_wrapper")
+
+        def _outer_impl(name, visibility, **kwargs):
+            inner_legacy_wrapper(name  = name + "_inner", **kwargs)
+
+        outer_macro = macro(implementation = _outer_impl)
+
+        def outer_legacy_wrapper(name, **kwargs):
+            outer_macro(name = name, **kwargs)
+        """);
+    scratch.file(
+        "pkg/BUILD",
+        """
+        load(":outer.bzl", "outer_legacy_wrapper")
+
+        outer_legacy_wrapper(name = "foo")
+        """);
+
+    Package pkg = getPackage("pkg");
+    assertPackageNotInError(pkg);
+    MacroInstance foo = getMacroById(pkg, "foo:1");
+    assertThat(foo.getBuildFileLocation())
+        .isEqualTo(Location.fromFileLineColumn("/workspace/pkg/BUILD", 3, 21));
+    assertThat(foo.reconstructParentCallStack())
+        .containsExactly(
+            StarlarkThread.callStackEntry(StarlarkThread.TOP_LEVEL, foo.getBuildFileLocation()),
+            StarlarkThread.callStackEntry(
+                "outer_legacy_wrapper",
+                Location.fromFileLineColumn("/workspace/pkg/outer.bzl", 9, 16)),
+            StarlarkThread.callStackEntry("outer_macro", Location.BUILTIN))
+        .inOrder();
+
+    MacroInstance fooInner = getMacroById(pkg, "foo_inner:1");
+    assertThat(fooInner.getBuildFileLocation()).isEqualTo(foo.getBuildFileLocation());
+    assertThat(fooInner.reconstructParentCallStack())
+        .containsExactly(
+            StarlarkThread.callStackEntry(
+                "_outer_impl", Location.fromFileLineColumn("/workspace/pkg/outer.bzl", 4, 25)),
+            StarlarkThread.callStackEntry(
+                "inner_legacy_wrapper",
+                Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 7, 16)),
+            StarlarkThread.callStackEntry("inner_macro", Location.BUILTIN))
+        .inOrder();
+
+    Rule fooLib = pkg.getRule("foo_inner");
+    assertThat(fooLib.wasCreatedByMacro()).isTrue();
+    assertThat(fooLib.getLocation()).isEqualTo(foo.getBuildFileLocation());
+    assertThat(fooLib.getAttr("generator_name", Type.STRING)).isEqualTo("foo");
+    assertThat(fooLib.getAttr("generator_function", Type.STRING)).isEqualTo("outer_legacy_wrapper");
+    assertThat(fooLib.getAttr("generator_location", Type.STRING)).isEqualTo("pkg/BUILD:3:21");
+    assertThat(fooLib.reconstructCallStack())
+        .isEqualTo(
+            ImmutableList.builder()
+                .addAll(foo.reconstructParentCallStack())
+                .addAll(fooInner.reconstructParentCallStack())
+                .add(
+                    StarlarkThread.callStackEntry(
+                        "_inner_impl",
+                        Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 2, 21)))
+                .build());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
@@ -269,17 +269,20 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
         """);
 
     Rule withMacro = getRuleForTarget("macro_target");
+    assertThat(withMacro.wasCreatedByMacro()).isTrue();
     assertThat(withMacro.getAttr("generator_name")).isEqualTo("macro_target");
     assertThat(withMacro.getAttr("generator_function")).isEqualTo("macro");
     assertThat(withMacro.getAttr("generator_location")).isEqualTo("test/starlark/BUILD:3:11");
 
     // Attributes are only set when the rule was created by a macro
     Rule noMacro = getRuleForTarget("no_macro_target");
+    assertThat(noMacro.wasCreatedByMacro()).isFalse();
     assertThat(noMacro.getAttr("generator_name")).isEqualTo("");
     assertThat(noMacro.getAttr("generator_function")).isEqualTo("");
     assertThat(noMacro.getAttr("generator_location")).isEqualTo("");
 
     Rule nativeMacro = getRuleForTarget("native_macro_target_suffix");
+    assertThat(nativeMacro.wasCreatedByMacro()).isTrue();
     assertThat(nativeMacro.getAttr("generator_name")).isEqualTo("native_macro_target");
     assertThat(nativeMacro.getAttr("generator_function")).isEqualTo("native_macro");
     assertThat(nativeMacro.getAttr("generator_location")).isEqualTo("test/starlark/BUILD:5:18");


### PR DESCRIPTION
Before, we did not set generator_* pseudo-attributes for rules generated in a symbolic macro. However, it turns out that there are existing tools which expect to be able to filter rule targets by generator_name in query expressions; and such tools get broken when legacy macros are migrated to symbolic. The easiest solution is to set generator_name and friends consistently for both legacy and symbolic macro rule targets.

In the long term, we wish to deprecate and remove generator_* pseudo-attrs, since the API has numerous problems and doesn't expose the information users really need:

But for now, however, we ought to support the broken API symmetrically for all varieties of macro.

In addition, take the opportunity to concatenate the Starlark stacks of BUILD and symbolic macro threads for rule targets in symbolic macros, because (1) the generator_* psudo-attributes are derived from the BUILD thread's stack, and (2) the stack is shown in some query output, and truncating it at symbolic macro boundaries is likely to confuse users who rely on it for debugging.

RELNOTES: Set generator_name, generator_function, generator_location, and the full Starlark stack for rule targets instantiated in a symbolic macro.

PiperOrigin-RevId: 744110163
Change-Id: I5216b05f22ee0663343bd4468f4f299d095bb739

Commit https://github.com/bazelbuild/bazel/commit/d6b07eb19209a5426594ca642dfe657d98c624f4