### PR TITLE
Add community-maintained Fedora package

### DIFF
--- a/site/en/install/index.md
+++ b/site/en/install/index.md
@@ -21,6 +21,7 @@ officially support them. Contact the package maintainers for support.
 *   [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=bazel*&branch=edge&repo=&arch=&origin=&flagged=&maintainer=){: .external}
 *   [Arch Linux][arch]{: .external}
 *   [Debian](https://qa.debian.org/developer.php?email=team%2Bbazel%40tracker.debian.org){: .external}
+*   [Fedora](https://copr.fedorainfracloud.org/coprs/lihaohong/bazel){: .external}
 *   [FreeBSD](https://www.freshports.org/devel/bazel){: .external}
 *   [Homebrew](https://formulae.brew.sh/formula/bazel){: .external}
 *   [Nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/build-managers/bazel){: .external}


### PR DESCRIPTION
This COPR repository should also work on CentOS Stream, RHEL, Alma Linux, and Rocky Linux for version 9 and above. I mainly use it on Fedora though, so other platforms won't get much testing.