### PR TITLE
[8.2.0] Fix a deadlock when using `--remote_cache_async` and HTTP cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1864,9 +1864,13 @@ public class RemoteExecutionService {
                   cacheResource -> {
                     Profiler.instance()
                         .completeTask(startTime.get(), ProfilerTask.UPLOAD_TIME, "upload outputs");
-                    backgroundTaskPhaser.arriveAndDeregister();
                     onUploadComplete.run();
+                    // Release the cache first before arriving the backgroundTaskPhaser. Otherwise,
+                    // the release here could make the reference count reach zero and close the
+                    // cache, resulting in a deadlock when using HTTP cache.
+                    // See https://github.com/bazelbuild/bazel/issues/25232.
                     cacheResource.release();
+                    backgroundTaskPhaser.arriveAndDeregister();
                   },
                   /* eager= */ false)
               .subscribeOn(scheduler)


### PR DESCRIPTION
Fixes #25232.

Closes #25786.

PiperOrigin-RevId: 745164203
Change-Id: I58cc9f83b6c6cc8cb2c728cfe132e220a7678cea

Commit https://github.com/bazelbuild/bazel/commit/06455bbcf932355d287960acd7fbac5493daf2b8