### PR TITLE
fix checkContext() string for attr.string_keyed_label_dict()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
@@ -949,7 +949,7 @@ public final class StarlarkAttrModule implements StarlarkAttrModuleApi {
       Sequence<?> aspects,
       StarlarkThread thread)
       throws EvalException {
-    checkContext(thread, "attr.label_keyed_string_dict()");
+    checkContext(thread, "attr.string_keyed_label_dict()");
     Map<String, Object> kwargs =
         optionMap(
             CONFIGURABLE_ARG,


### PR DESCRIPTION
While looking at the code I noticed that the string supplied to checkContext() for the new attr.string_keyed_label_dict() seems to be wrong.