### PR TITLE
[8.2.0] Set macro symbol's exported location as MacroFunction's callable location for Starlark stack

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubrule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubrule.java
@@ -60,6 +60,7 @@ import net.starlark.java.eval.StarlarkFunction;
 import net.starlark.java.eval.StarlarkSemantics;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Tuple;
+import net.starlark.java.syntax.Location;
 
 /**
  * Represents a subrule which can be invoked in a Starlark rule's implementation function.
@@ -247,8 +248,10 @@ public class StarlarkSubrule implements StarlarkExportable, StarlarkCallable, St
     return this.extensionLabel != null && this.exportedName != null;
   }
 
+  // TODO(bazel-team): use exportedLocation as the callable symbol's location.
   @Override
-  public void export(EventHandler handler, Label extensionLabel, String exportedName) {
+  public void export(
+      EventHandler handler, Label extensionLabel, String exportedName, Location exportedLocation) {
     Preconditions.checkState(!isExported());
     this.extensionLabel = extensionLabel;
     this.exportedName = exportedName;

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -554,10 +554,10 @@ public class ModuleFileFunction implements SkyFunction {
         thread.setPrintHandler(Event.makeDebugPrintHandler(eventHandler));
       }
       thread.setPostAssignHook(
-          (name, value) -> {
+          (name, nameStartLocation, value) -> {
             if (value instanceof StarlarkExportable exportable) {
               if (!exportable.isExported()) {
-                exportable.export(eventHandler, null, name);
+                exportable.export(eventHandler, null, name, nameStartLocation);
               }
             }
           });

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -52,6 +52,7 @@ import net.starlark.java.eval.StarlarkValue;
 import net.starlark.java.eval.Structure;
 import net.starlark.java.eval.Tuple;
 import net.starlark.java.syntax.Identifier;
+import net.starlark.java.syntax.Location;
 
 /** A collection of global Starlark build API functions that apply to MODULE.bazel files. */
 @GlobalMethods(environment = Environment.MODULE)
@@ -624,7 +625,8 @@ public class ModuleFileGlobals {
     }
 
     @Override
-    public void export(EventHandler handler, Label bzlFileLabel, String name) {
+    public void export(
+        EventHandler handler, Label bzlFileLabel, String name, Location exportedLocation) {
       proxyBuilder.setProxyName(name);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -56,6 +56,7 @@ import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Tuple;
+import net.starlark.java.syntax.Location;
 
 /**
  * The Starlark module containing the definition of {@code repository_rule} function to define a
@@ -138,7 +139,7 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
       name = "repository_rule",
       category = DocCategory.BUILTIN,
       doc =
-          """
+"""
 A callable value that may be invoked during evaluation of the WORKSPACE file or within \
 the implementation function of a module extension to instantiate and return a repository \
 rule. Created by \
@@ -191,8 +192,13 @@ rule. Created by \
       return true;
     }
 
+    // TODO(bazel-team): use exportedLocation as the callable symbol's location.
     @Override
-    public void export(EventHandler handler, Label extensionLabel, String exportedName) {
+    public void export(
+        EventHandler handler,
+        Label extensionLabel,
+        String exportedName,
+        Location exportedLocation) {
       this.extensionLabel = extensionLabel;
       this.exportedName = exportedName;
     }

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkDefinedAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkDefinedAspect.java
@@ -42,6 +42,7 @@ import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.SymbolGenerator.Symbol;
+import net.starlark.java.syntax.Location;
 
 /** A Starlark value that is a result of an 'aspect(..)' function call. */
 public final class StarlarkDefinedAspect implements StarlarkExportable, StarlarkAspect {
@@ -168,8 +169,10 @@ public final class StarlarkDefinedAspect implements StarlarkExportable, Starlark
     return paramAttributes;
   }
 
+  // TODO(bazel-team): use exportedLocation as the callable symbol's location.
   @Override
-  public void export(EventHandler handler, Label extensionLabel, String name) {
+  public void export(
+      EventHandler handler, Label extensionLabel, String name, Location exportedLocation) {
     Preconditions.checkArgument(!isExported());
     @SuppressWarnings("unchecked")
     var identityToken = (Symbol<BzlLoadValue.Key>) aspectClassOrIdentityToken;

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkExportable.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkExportable.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.packages;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.EventHandler;
 import net.starlark.java.eval.StarlarkValue;
+import net.starlark.java.syntax.Location;
 
 /**
  * {@link StarlarkValue}s that need special handling when they are exported from an extension file.
@@ -31,7 +32,8 @@ public interface StarlarkExportable extends StarlarkValue {
 
   /**
    * Notify the value that it is exported from {@code extensionLabel} extension with name {@code
-   * exportedName}.
+   * exportedName} at {@code exportedLocation}.
    */
-  void export(EventHandler handler, Label extensionLabel, String exportedName);
+  void export(
+      EventHandler handler, Label extensionLabel, String exportedName, Location exportedLocation);
 }

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkProvider.java
@@ -394,8 +394,10 @@ public final class StarlarkProvider implements StarlarkCallable, StarlarkExporta
         "'%s' value has no field or method '%s'", isExported() ? getName() : "struct", name);
   }
 
+  // TODO(bazel-team): use exportedLocation as the callable symbol's location.
   @Override
-  public void export(EventHandler handler, Label extensionLabel, String exportedName) {
+  public void export(
+      EventHandler handler, Label extensionLabel, String exportedName, Location exportedLocation) {
     Preconditions.checkState(!isExported());
     SymbolGenerator.Symbol<?> identifier = (SymbolGenerator.Symbol<?>) keyOrIdentityToken;
     if (identifier.getOwner() instanceof BzlLoadValue.Key bzlKey) {

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetDefinitionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetDefinitionContext.java
@@ -216,6 +216,10 @@ public abstract class TargetDefinitionContext extends StarlarkThreadContext {
             pkg, buildFileLabel, Location.fromFile(metadata.buildFilename().asPath().toString())));
   }
 
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
   SymbolGenerator<?> getSymbolGenerator() {
     return symbolGenerator;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/BUILD
@@ -98,6 +98,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/net/starlark/java/eval",
+        "//src/main/java/net/starlark/java/syntax",
         "//src/main/protobuf:test_status_java_proto",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
@@ -35,6 +35,7 @@ import net.starlark.java.eval.StarlarkFunction;
 import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Tuple;
+import net.starlark.java.syntax.Location;
 
 /** A class that exposes testing infrastructure to Starlark. */
 public class StarlarkTestingModule implements TestingModuleApi {
@@ -158,7 +159,11 @@ public class StarlarkTestingModule implements TestingModuleApi {
     // evaluation in BzlLoadFunction#execAndExport.
     StoredEventHandler handler = new StoredEventHandler();
     starlarkRuleFunction.export(
-        handler, pkgBuilder.getBuildFileLabel(), name + "_test"); // export in BUILD thread
+        handler,
+        pkgBuilder.getBuildFileLabel(),
+        name + "_test",
+        Location.fromFile(
+            pkgBuilder.getMetadata().buildFilename().toString())); // export in BUILD thread
     if (handler.hasErrors()) {
       StringBuilder errors =
           handler.getEvents().stream()

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BzlLoadFunction.java
@@ -1462,10 +1462,10 @@ public class BzlLoadFunction implements SkyFunction {
     // and "export" any newly assigned exportable globals.
     // TODO(adonovan): change the semantics; see b/65374671.
     thread.setPostAssignHook(
-        (name, value) -> {
+        (name, nameStartLocation, value) -> {
           if (value instanceof StarlarkExportable exp) {
             if (!exp.isExported()) {
-              exp.export(handler, label, name);
+              exp.export(handler, label, name, nameStartLocation);
             }
           }
         });

--- a/src/main/java/net/starlark/java/eval/Eval.java
+++ b/src/main/java/net/starlark/java/eval/Eval.java
@@ -100,7 +100,7 @@ final class Eval {
               // identifier when available. This enables an name-based lookup on deserialization.
               ((StarlarkFunction) value).export(fr.thread, id.getName());
             } else {
-              fr.thread.postAssignHook.assign(id.getName(), value);
+              fr.thread.postAssignHook.assign(id.getName(), id.getStartLocation(), value);
             }
           }
         } else if (stmt instanceof DefStatement) {

--- a/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -475,7 +475,7 @@ public final class StarlarkThread {
   /** A hook for notifications of assignments at top level. */
   @FunctionalInterface
   public interface PostAssignHook {
-    void assign(String name, Object value);
+    void assign(String name, Location nameStartLocation, Object value);
   }
 
   public StarlarkSemantics getSemantics() {

--- a/src/test/java/com/google/devtools/build/lib/analysis/SymbolicMacroTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SymbolicMacroTest.java
@@ -2020,7 +2020,8 @@ my_macro = macro(
     assertThat(foo.reconstructParentCallStack())
         .containsExactly(
             StarlarkThread.callStackEntry(StarlarkThread.TOP_LEVEL, foo.getBuildFileLocation()),
-            StarlarkThread.callStackEntry("my_macro", Location.BUILTIN))
+            StarlarkThread.callStackEntry(
+                "my_macro", Location.fromFileLineColumn("/workspace/pkg/my_macro.bzl", 7, 1)))
         .inOrder();
 
     Rule fooLib = pkg.getRule("foo_lib");
@@ -2108,7 +2109,8 @@ my_macro = macro(
             StarlarkThread.callStackEntry(
                 "outer_legacy_wrapper",
                 Location.fromFileLineColumn("/workspace/pkg/outer.bzl", 9, 16)),
-            StarlarkThread.callStackEntry("outer_macro", Location.BUILTIN))
+            StarlarkThread.callStackEntry(
+                "outer_macro", Location.fromFileLineColumn("/workspace/pkg/outer.bzl", 6, 1)))
         .inOrder();
 
     MacroInstance fooInner = getMacroById(pkg, "foo_inner:1");
@@ -2120,7 +2122,8 @@ my_macro = macro(
             StarlarkThread.callStackEntry(
                 "inner_legacy_wrapper",
                 Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 7, 16)),
-            StarlarkThread.callStackEntry("inner_macro", Location.BUILTIN))
+            StarlarkThread.callStackEntry(
+                "inner_macro", Location.fromFileLineColumn("/workspace/pkg/inner.bzl", 4, 1)))
         .inOrder();
 
     Rule fooLib = pkg.getRule("foo_inner");

--- a/src/test/java/com/google/devtools/build/lib/packages/RequiredProvidersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RequiredProvidersTest.java
@@ -47,7 +47,11 @@ public class RequiredProvidersTest {
 
   static {
     try {
-      P_STARLARK.export(ev -> {}, Label.create("foo/bar", "x.bzl"), "p_starlark");
+      P_STARLARK.export(
+          ev -> {},
+          Label.create("foo/bar", "x.bzl"),
+          "p_starlark",
+          Location.fromFile("/workspace/foo/bar/x.bzl"));
     } catch (LabelSyntaxException e) {
       throw new AssertionError(e);
     }

--- a/src/test/java/net/starlark/java/eval/EvaluationTestCase.java
+++ b/src/test/java/net/starlark/java/eval/EvaluationTestCase.java
@@ -94,7 +94,7 @@ class EvaluationTestCase {
           StarlarkThread.create(
               mu, semantics, /* contextDescription= */ "", SymbolGenerator.create("test"));
       // Sets a post-assign hook to enable global export of StarlarkFunction Symbols.
-      this.thread.setPostAssignHook((unusedName, unusedValue) -> {});
+      this.thread.setPostAssignHook((unusedName, unusedLocation, unusedValue) -> {});
     }
     return this.thread;
   }


### PR DESCRIPTION
This ensures Starlark instantiation stack for rule targets defined in a symbolic macro shows both the macro's location and symbol.

Requires changing StarlarkThread to track the location of where symbols are exported.

As follow-up, we should do the same for rules, providers, and aspects.

PiperOrigin-RevId: 745731053
Change-Id: I6732a9762fbc932d823a70d7753a2b6edc140df6

Commit
https://github.com/bazelbuild/bazel/commit/a3e26ed827badf6c4cf4f09aa37747622357635c