### PR TITLE
Add loads to third_party on github

### DIFF
--- a/third_party/grpc-java/BUILD
+++ b/third_party/grpc-java/BUILD
@@ -16,6 +16,7 @@
 
 load("@rules_license//rules:license.bzl", "license")
 load("//tools/distributions:distribution_rules.bzl", "distrib_cc_binary", "distrib_jar_filegroup")
+load("@rules_java//java:java_library.bzl", "java_library")
 
 package(
     default_applicable_licenses = [":license"],

--- a/third_party/py/dataclasses/BUILD
+++ b/third_party/py/dataclasses/BUILD
@@ -1,6 +1,7 @@
 # Description:
 #   dataclasses module from the Python 3.7 standard library.
 #   For backporting to Python 3.6 and below.
+load("@rules_python//python:py_library.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
These are needed to flip --incompatible_disable_autoloads_in_main_repository

The files are only on GitHub, so they require a manual merge.