### PR TITLE
Remove support for strings in attribute's "provides" parameters

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/AbstractConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/AbstractConfiguredTarget.java
@@ -125,13 +125,9 @@ public abstract class AbstractConfiguredTarget implements ConfiguredTarget, Visi
 
   @Override
   public Object getValue(StarlarkSemantics semantics, String name) throws EvalException {
-    if (semantics.getBool(BuildLanguageOptions.INCOMPATIBLE_DISABLE_TARGET_PROVIDER_FIELDS)
-        && !SPECIAL_FIELD_NAMES.contains(name)) {
+    if (!SPECIAL_FIELD_NAMES.contains(name)) {
       throw Starlark.errorf(
-          "Accessing providers via the field syntax on structs is "
-              + "deprecated and will be removed soon. It may be temporarily re-enabled by setting "
-              + "--incompatible_disable_target_provider_fields=false. See "
-              + "https://github.com/bazelbuild/bazel/issues/9014 for details.");
+          "Accessing providers via the field syntax on structs is deprecated and removed.");
     } else if (semantics.getBool(
             BuildLanguageOptions.INCOMPATIBLE_DISABLE_TARGET_DEFAULT_PROVIDER_FIELDS)
         && DEFAULT_PROVIDER_FIELDS.contains(name)) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -997,15 +997,6 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
         FunctionSplitTransitionAllowlist.ATTRIBUTE_NAME,
         FunctionSplitTransitionAllowlist.LABEL);
 
-    for (Object o : providesArg) {
-      if (!StarlarkAttrModule.isProvider(o)) {
-        throw Starlark.errorf(
-            "Illegal argument: element in 'provides' is of unexpected type. "
-                + "Should be list of providers, but got item of type %s.",
-            Starlark.type(o));
-      }
-    }
-
     if (dependencyResolutionRule) {
       if (!subrules.isEmpty()) {
         throw Starlark.errorf("Rules that can be required for materializers cannot have subrules");
@@ -1029,7 +1020,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
     }
 
     for (StarlarkProviderIdentifier starlarkProvider :
-        StarlarkAttrModule.getStarlarkProviderIdentifiers(providesArg)) {
+        StarlarkAttrModule.getStarlarkProviderIdentifiers(providesArg, "provides")) {
       builder.advertiseStarlarkProvider(starlarkProvider);
     }
 
@@ -1317,15 +1308,6 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
       attributes.add(attribute);
     }
 
-    for (Object o : providesArg) {
-      if (!StarlarkAttrModule.isProvider(o)) {
-        throw Starlark.errorf(
-            "Illegal argument: element in 'provides' is of unexpected type. "
-                + "Should be list of providers, but got item of type %s. ",
-            Starlark.type(o));
-      }
-    }
-
     if (applyToGeneratingRules && !requiredProvidersArg.isEmpty()) {
       throw Starlark.errorf(
           "An aspect cannot simultaneously have required providers and apply to generating rules.");
@@ -1381,7 +1363,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi {
         StarlarkAttrModule.buildProviderPredicate(requiredProvidersArg, "required_providers"),
         StarlarkAttrModule.buildProviderPredicate(
             requiredAspectProvidersArg, "required_aspect_providers"),
-        StarlarkAttrModule.getStarlarkProviderIdentifiers(providesArg),
+        StarlarkAttrModule.getStarlarkProviderIdentifiers(providesArg, "provides"),
         requiredParams.build(),
         ImmutableSet.copyOf(Sequence.cast(requiredAspects, StarlarkAspect.class, "requires")),
         propagationPredicate,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -465,6 +465,15 @@ public final class BazelRulesModule extends BlazeModule {
    */
   public static final class AllCommandGraveyardOptions extends OptionsBase {
     @Option(
+        name = "incompatible_disable_target_provider_fields",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+        help = "No-op")
+    public boolean incompatibleDisableTargetProviderFields;
+
+    @Option(
         name = "incompatible_disallow_struct_provider_syntax",
         defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -428,7 +428,7 @@ public final class BuildLanguageOptions extends OptionsBase {
   public boolean incompatibleAlwaysCheckDepsetElements;
 
   @Option(
-      name = "incompatible_disable_target_provider_fields",
+      name = "incompatible_disable_target_default_provider_fields",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
@@ -438,20 +438,6 @@ public final class BuildLanguageOptions extends OptionsBase {
               + "syntax. Use provider-key syntax instead. For example, instead of using "
               + "`ctx.attr.dep.files` to access `files`, utilize `ctx.attr.dep[DefaultInfo].files "
               + "See "
-              + "https://github.com/bazelbuild/bazel/issues/9014 for details.")
-  public boolean incompatibleDisableTargetProviderFields;
-
-  @Option(
-      name = "incompatible_disable_target_default_provider_fields",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
-      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help =
-          "If set to true, disable the ability to access providers on 'target' objects via field "
-              + "syntax. Use provider-key syntax instead. For example, instead of using "
-              + "`ctx.attr.dep.my_info` to access `my_info` from inside a rule implementation "
-              + "function, use `ctx.attr.dep[MyInfo]`. See "
               + "https://github.com/bazelbuild/bazel/issues/9014 for details.")
   public boolean incompatibleDisableTargetDefaultProviderFields;
 
@@ -865,9 +851,6 @@ public final class BuildLanguageOptions extends OptionsBase {
             .setBool(EXPERIMENTAL_REPO_REMOTE_EXEC, experimentalRepoRemoteExec)
             .setBool(EXPERIMENTAL_DISABLE_EXTERNAL_PACKAGE, experimentalDisableExternalPackage)
             .setBool(EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT, experimentalSiblingRepositoryLayout)
-            .setBool(
-                INCOMPATIBLE_DISABLE_TARGET_PROVIDER_FIELDS,
-                incompatibleDisableTargetProviderFields)
             .setBool(
                 INCOMPATIBLE_ALWAYS_CHECK_DEPSET_ELEMENTS, incompatibleAlwaysCheckDepsetElements)
             .setBool(INCOMPATIBLE_DISALLOW_EMPTY_GLOB, incompatibleDisallowEmptyGlob)

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -47,12 +47,11 @@ public interface StarlarkRuleFunctionsApi {
           + " listed here from its return value. However, the implementation function may return"
           + " additional providers not listed here." //
           + "<p>Each element of the list is an <code>*Info</code> object returned by <a"
-          + " href='../globals/bzl.html#provider'><code>provider()</code></a>, except that a legacy"
-          + " provider is represented by its string name instead.When a target of the rule is used"
-          + " as a dependency for a target that declares a required provider, it is not necessary"
-          + " to specify that provider here. It is enough that the implementation function returns"
-          + " it. However, it is considered best practice to specify it, even though this is not"
-          + " required. The <a"
+          + " href='../globals/bzl.html#provider'><code>provider()</code></a>. When a target of the"
+          + " rule is used as a dependency for a target that declares a required provider, it is"
+          + " not necessary to specify that provider here. It is enough that the implementation"
+          + " function returns it. However, it is considered best practice to specify it, even"
+          + " though this is not required. The <a"
           + " href='../globals/bzl.html#aspect.required_providers'><code>required_providers</code></a>"
           + " field of an <a href='../globals/bzl.html#aspect'>aspect</a> does, however, require"
           + " that providers are specified here.";
@@ -202,7 +201,7 @@ public interface StarlarkRuleFunctionsApi {
   @StarlarkMethod(
       name = "macro",
       doc =
-          """
+"""
 Defines a symbolic macro, which may be called in <code>BUILD</code> files or macros (legacy or
 symbolic) to define targets &ndash; possibly multiple ones.
 
@@ -218,7 +217,7 @@ macros.
             positional = false,
             named = true,
             doc =
-                """
+"""
 The Starlark function implementing this macro. The values of the macro's attributes are passed to
 the implementation function as keyword arguments. The implementation function must have at least two
 named parameters, <code>name</code> and <code>visibility</code>, and if the macro inherits
@@ -273,7 +272,7 @@ function it transitively calls:
             positional = false,
             defaultValue = "{}",
             doc =
-                """
+"""
 A dictionary of the attributes this macro supports, analogous to
 <a href="#rule.attrs">rule.attrs</a>. Keys are attribute names, and values are either attribute
 objects like <code>attr.label_list(...)</code> (see the <a href=\"../toplevel/attr.html\">attr</a>
@@ -303,7 +302,7 @@ site of the rule. Such attributes can be assigned a default value (as in
             named = true,
             defaultValue = "None",
             doc =
-                """
+"""
 A rule symbol, macro symbol, or the name of a built-in common attribute list (see below) from which
 the macro should inherit attributes.
 
@@ -391,7 +390,7 @@ care to handle the <code>None</code> default value of non-mandatory inherited at
             named = true,
             defaultValue = "False",
             doc =
-                """
+"""
 Whether this macro is a rule finalizer, which is a macro that, regardless of its position in a
 <code>BUILD</code> file, is evaluated at the end of package loading, after all non-finalizer targets
 have been defined.
@@ -470,7 +469,7 @@ targets defined by any rule finalizer, including this one.
             positional = false,
             defaultValue = "{}",
             doc =
-                """
+"""
 A dictionary to declare all the attributes of the rule. It maps from an attribute \
 name to an attribute object (see
 <a href="../toplevel/attr.html"><code>attr</code></a> module). Attributes starting \

--- a/src/test/java/com/google/devtools/build/lib/analysis/AspectTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/AspectTest.java
@@ -745,15 +745,16 @@ public class AspectTest extends AnalysisTestCase {
     scratch.file(
         "foo/shared_aspect.bzl",
         """
+        MyInfo = provider()
         def _shared_aspect_impl(target, ctx):
             shared_file = ctx.actions.declare_file("shared_file")
             ctx.actions.write(output = shared_file, content = "Shared content")
             lib = ctx.rule.attr.lib
             if lib:
-                result = depset([shared_file], transitive = [ctx.rule.attr.lib.prov])
+                result = depset([shared_file], transitive = [ctx.rule.attr.lib[MyInfo].prov])
             else:
                 result = depset([shared_file])
-            return struct(prov = result)
+            return MyInfo(prov = result)
 
         shared_aspect = aspect(
             implementation = _shared_aspect_impl,
@@ -766,7 +767,7 @@ public class AspectTest extends AnalysisTestCase {
         simple_rule = rule(
             implementation = _rule_impl,
             attrs = {"lib": attr.label(
-                providers = ["prov"],
+                providers = [MyInfo],
                 aspects = [shared_aspect],
             )},
         )

--- a/src/test/java/com/google/devtools/build/lib/analysis/allowlisting/AllowlistTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/allowlisting/AllowlistTest.java
@@ -177,7 +177,7 @@ public final class AllowlistTest extends BuildViewTestCase {
         "    '_allowlist_test': attr.label(",
         "      default = '//allowlist:allowlist',",
         "      cfg = 'exec',",
-        "      providers = ['PackageSpecificationInfo']",
+        "      providers = [PackageSpecificationInfo]",
         "    ),",
         "  },",
         ")");

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BuildResultListenerIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BuildResultListenerIntegrationTest.java
@@ -65,7 +65,7 @@ public class BuildResultListenerIntegrationTest extends BuildIntegrationTestCase
             implementation = _impl,
             attrs = {
                 "srcs": attr.label_list(allow_files = True),
-                "deps": attr.label_list(providers = ["DefaultInfo"]),
+                "deps": attr.label_list(),
             },
         )
         """);

--- a/src/test/java/com/google/devtools/build/lib/buildtool/SkymeldBuildIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/SkymeldBuildIntegrationTest.java
@@ -87,7 +87,7 @@ public class SkymeldBuildIntegrationTest extends BuildIntegrationTestCase {
             implementation = _impl,
             attrs = {
                 "srcs": attr.label_list(allow_files = True),
-                "deps": attr.label_list(providers = ["DefaultInfo"]),
+                "deps": attr.label_list(),
             },
         )
         """);

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -139,7 +139,6 @@ public class ConsistencyTest {
         "--experimental_dormant_deps=" + rand.nextBoolean(),
         "--incompatible_always_check_depset_elements=" + rand.nextBoolean(),
         "--incompatible_depset_for_libraries_to_link_getter=" + rand.nextBoolean(),
-        "--incompatible_disable_target_provider_fields=" + rand.nextBoolean(),
         "--incompatible_disallow_empty_glob=" + rand.nextBoolean(),
         "--incompatible_do_not_split_linking_cmdline=" + rand.nextBoolean(),
         "--incompatible_enable_deprecated_label_apis=" + rand.nextBoolean(),
@@ -189,8 +188,6 @@ public class ConsistencyTest {
         .setBool(
             BuildLanguageOptions.INCOMPATIBLE_DEPSET_FOR_LIBRARIES_TO_LINK_GETTER,
             rand.nextBoolean())
-        .setBool(
-            BuildLanguageOptions.INCOMPATIBLE_DISABLE_TARGET_PROVIDER_FIELDS, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_DISALLOW_EMPTY_GLOB, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_DO_NOT_SPLIT_LINKING_CMDLINE, rand.nextBoolean())
         .setBool(BuildLanguageOptions.INCOMPATIBLE_ENABLE_DEPRECATED_LABEL_APIS, rand.nextBoolean())

--- a/src/test/java/com/google/devtools/build/lib/rules/python/PythonStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/PythonStarlarkApiTest.java
@@ -62,7 +62,7 @@ public class PythonStarlarkApiTest extends BuildViewTestCase {
         "    implementation = _userlib_impl,",
         "    attrs = {",
         "        'srcs': attr.label_list(allow_files=True),",
-        "        'deps': attr.label_list(providers=[['py'], [PyInfo]]),",
+        "        'deps': attr.label_list(providers=[PyInfo]),",
         "        'uses_shared_libraries': attr.bool(),",
         "        'imports': attr.string_list(),",
         "        'has_py2_only_sources': attr.bool(),",

--- a/src/test/java/com/google/devtools/build/lib/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlark/BUILD
@@ -330,6 +330,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/net/starlark/java/annot",
         "//src/main/java/net/starlark/java/eval",
+        "//src/main/java/net/starlark/java/syntax",
         "//src/test/java/com/google/devtools/build/lib/actions/util",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/bazel/bzlmod:util",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkDefinedAspectsTest.java
@@ -985,8 +985,7 @@ my_rule = rule(
       // expect to fail.
     }
     assertContainsEvent(
-        "Aspect implementation should return a struct, a list, or a provider "
-            + "instance, but got int");
+        "Aspect implementation should return a list, or a provider instance, but got int");
   }
 
   @Test
@@ -2446,11 +2445,12 @@ my_rule = rule(
     scratch.file(
         "test/aspect.bzl",
         """
+        MyInfo = provider()
         def _impl(target, ctx):
            s = depset([target.label], transitive =
-             [i.target_labels for i in ctx.rule.attr.runtime_deps]
+             [i[MyInfo].target_labels for i in ctx.rule.attr.runtime_deps]
              if hasattr(ctx.rule.attr, 'runtime_deps') else [])
-           return struct(target_labels = s)
+           return MyInfo(target_labels = s)
 
         MyAspect = aspect(
             implementation=_impl,
@@ -2478,7 +2478,9 @@ my_rule = rule(
         update(ImmutableList.of("test/aspect.bzl%MyAspect"), "//test:foo");
     ConfiguredAspect configuredAspect = analysisResult.getAspectsMap().values().iterator().next();
     assertThat(configuredAspect).isNotNull();
-    Object names = configuredAspect.get("target_labels");
+    Object names =
+        getStarlarkProvider(configuredAspect, "//test:aspect.bzl", "MyInfo")
+            .getValue("target_labels");
     assertThat(names).isInstanceOf(Depset.class);
     assertThat(
             Iterables.transform(
@@ -2805,9 +2807,10 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/aspect.bzl",
         """
+        MyInfo = provider()
         def _impl(target, ctx):
            return []
-        my_aspect = aspect(_impl, provides = ['foo'])
+        my_aspect = aspect(_impl, provides = [MyInfo])
         a_dict = { 'foo' : attr.label_list(aspects = [my_aspect]) }
         """);
     scratch.file(
@@ -2826,7 +2829,7 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     }
     assertContainsEvent(
         "Aspect '//test:aspect.bzl%my_aspect', applied to '//test:xxx', "
-            + "does not provide advertised provider 'foo'");
+            + "does not provide advertised provider 'MyInfo'");
   }
 
   @Test
@@ -7237,16 +7240,19 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
         prov_a = provider()
         prov_b = provider()
         prov_b_forwarded = provider()
+        AspectInfo = provider()
 
         def _aspect_b_impl(target, ctx):
           result = 'aspect_b on target {} '.format(target.label)
           if prov_b in target:
             result += 'found prov_b = {}'.format(target[prov_b].val)
-            return struct(aspect_b_result = result,
-                          providers = [prov_b_forwarded(val = target[prov_b].val)])
+            return [
+              AspectInfo(aspect_b_result = result),
+              prov_b_forwarded(val = target[prov_b].val)
+             ]
           else:
             result += 'cannot find prov_b'
-            return struct(aspect_b_result = result)
+            return AspectInfo(aspect_b_result = result)
         aspect_b = aspect(
           implementation = _aspect_b_impl,
           required_aspect_providers = [prov_b]
@@ -7262,7 +7268,7 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
             result += ' and found prov_b = {}'.format(target[prov_b_forwarded].val)
           else:
             result += ' but cannot find prov_b'
-          return struct(aspect_a_result = result)
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -7312,14 +7318,18 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     Map<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    String aspectAResult = (String) aspectA.get("aspect_a_result");
+    String aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", String.class);
     assertThat(aspectAResult)
         .isEqualTo(
             "aspect_a on target @@//test:main_target found prov_a = a1 and found prov_b = b1");
 
     ConfiguredAspect aspectB = getConfiguredAspect(configuredAspects, "aspect_b");
     assertThat(aspectB).isNotNull();
-    String aspectBResult = (String) aspectB.get("aspect_b_result");
+    String aspectBResult =
+        getStarlarkProvider(aspectB, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_b_result", String.class);
     assertThat(aspectBResult)
         .isEqualTo("aspect_b on target @@//test:main_target found prov_b = b1");
   }
@@ -7332,6 +7342,7 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
         """
         prov_a = provider()
         prov_b = provider()
+        AspectInfo = provider()
 
         def _aspect_b_impl(target, ctx):
           result = 'aspect_b on target {} '.format(target.label)
@@ -7339,7 +7350,7 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
             result += 'found prov_b = {}'.format(target[prov_b].val)
           else:
             result += 'cannot find prov_b'
-          return struct(aspect_b_result = result)
+          return AspectInfo(aspect_b_result = result)
         aspect_b = aspect(
           implementation = _aspect_b_impl,
           required_aspect_providers = [prov_b]
@@ -7351,7 +7362,7 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
             result += 'found prov_a = {}'.format(target[prov_a].val)
           else:
             result += 'cannot find prov_a'
-          return struct(aspect_a_result = result)
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -7391,13 +7402,17 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     Map<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    String aspectAResult = (String) aspectA.get("aspect_a_result");
+    String aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", String.class);
     assertThat(aspectAResult)
         .isEqualTo("aspect_a on target @@//test:main_target found prov_a = a1");
 
     ConfiguredAspect aspectB = getConfiguredAspect(configuredAspects, "aspect_b");
     assertThat(aspectB).isNotNull();
-    String aspectBResult = (String) aspectB.get("aspect_b_result");
+    String aspectBResult =
+        getStarlarkProvider(aspectB, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_b_result", String.class);
     assertThat(aspectBResult)
         .isEqualTo("aspect_b on target @@//test:main_target cannot find prov_b");
   }
@@ -7465,12 +7480,13 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        AspectInfo = provider()
         def _aspect_a_impl(target, ctx):
           result = ['aspect_a on target {}, p1 = {} and a_p = {}'.
                                             format(target.label, ctx.attr.p1, ctx.attr.a_p)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_a_result
-          return struct(aspect_a_result = result)
+            result += ctx.rule.attr.dep[AspectInfo].aspect_a_result
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -7483,8 +7499,8 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
           result = ['aspect_b on target {}, p1 = {} and b_p = {}'.
                                             format(target.label, ctx.attr.p1, ctx.attr.b_p)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_b_result
-          return struct(aspect_b_result = result)
+            result += ctx.rule.attr.dep[AspectInfo].aspect_b_result
+          return AspectInfo(aspect_b_result = result)
 
         aspect_b = aspect(
           implementation = _aspect_b_impl,
@@ -7526,7 +7542,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     Map<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    StarlarkList<?> aspectAResult = (StarlarkList) aspectA.get("aspect_a_result");
+    StarlarkList<?> aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectAResult))
         .containsExactly(
             "aspect_a on target @@//test:main_target, p1 = p1_v1 and a_p = a_p_v1",
@@ -7535,7 +7553,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
 
     ConfiguredAspect aspectB = getConfiguredAspect(configuredAspects, "aspect_b");
     assertThat(aspectB).isNotNull();
-    StarlarkList<?> aspectBResult = (StarlarkList) aspectB.get("aspect_b_result");
+    StarlarkList<?> aspectBResult =
+        getStarlarkProvider(aspectB, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_b_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectBResult))
         .containsExactly(
             "aspect_b on target @@//test:main_target, p1 = p1_v1 and b_p = b_p_v1",
@@ -7627,12 +7647,13 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        AspectInfo = provider()
         def _aspect_a_impl(target, ctx):
           result = ['aspect_a on target {}, p1 = {} and p2 = {}'.
                                             format(target.label, ctx.attr.p1, ctx.attr.p2)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_a_result
-          return struct(aspect_a_result = result)
+            result += ctx.rule.attr.dep[AspectInfo].aspect_a_result
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -7674,7 +7695,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     Map<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    StarlarkList<?> aspectAResult = (StarlarkList) aspectA.get("aspect_a_result");
+    StarlarkList<?> aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectAResult))
         .containsExactly(
             "aspect_a on target @@//test:main_target, p1 = p1_v2 and p2 = p2_v1",
@@ -7687,12 +7710,14 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        AspectAInfo = provider()
+        AspectBInfo = provider()
         def _aspect_b_impl(target, ctx):
           result = ['aspect_b on target {}, p1 = {} and p3 = {}'.
                                             format(target.label, ctx.attr.p1, ctx.attr.p3)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_b_result
-          return struct(aspect_b_result = result)
+            result += ctx.rule.attr.dep[AspectBInfo].aspect_b_result
+          return AspectBInfo(aspect_b_result = result)
 
         aspect_b = aspect(
           implementation = _aspect_b_impl,
@@ -7705,8 +7730,8 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
           result = ['aspect_a on target {}, p1 = {} and p2 = {}'.
                                             format(target.label, ctx.attr.p1, ctx.attr.p2)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_a_result
-          return struct(aspect_a_result = result)
+            result += ctx.rule.attr.dep[AspectAInfo].aspect_a_result
+          return AspectAInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -7749,7 +7774,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     ImmutableMap<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    StarlarkList<?> aspectAResult = (StarlarkList) aspectA.get("aspect_a_result");
+    StarlarkList<?> aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectAInfo")
+            .getValue("aspect_a_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectAResult))
         .containsExactly(
             "aspect_a on target @@//test:main_target, p1 = p1_v1 and p2 = p2_v2",
@@ -7758,7 +7785,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
 
     ConfiguredAspect aspectB = getConfiguredAspect(configuredAspects, "aspect_b");
     assertThat(aspectB).isNotNull();
-    StarlarkList<?> aspectBResult = (StarlarkList) aspectB.get("aspect_b_result");
+    StarlarkList<?> aspectBResult =
+        getStarlarkProvider(aspectB, "//test:defs.bzl", "AspectBInfo")
+            .getValue("aspect_b_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectBResult))
         .containsExactly(
             "aspect_b on target @@//test:main_target, p1 = p1_v1 and p3 = p3_v3",
@@ -8045,12 +8074,13 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        AspectInfo = provider()
         def _aspect_a_impl(target, ctx):
           result = ['aspect_a on target {}, p = {}'.
                                             format(target.label, ctx.attr.p)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_a_result
-          return struct(aspect_a_result = result)
+            result += ctx.rule.attr.dep[AspectInfo].aspect_a_result
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -8091,7 +8121,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     ImmutableMap<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    StarlarkList<?> aspectAResult = (StarlarkList) aspectA.get("aspect_a_result");
+    StarlarkList<?> aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectAResult))
         .containsExactly(
             "aspect_a on target @@//test:main_target, p = p_v",
@@ -8643,12 +8675,13 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        AspectInfo = provider()
         def _aspect_a_impl(target, ctx):
           result = ['aspect_a on target {}, p = {}'.
                                             format(target.label, ctx.attr.p)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_a_result
-          return struct(aspect_a_result = result)
+            result += ctx.rule.attr.dep[AspectInfo].aspect_a_result
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -8689,7 +8722,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     ImmutableMap<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    StarlarkList<?> aspectAResult = (StarlarkList) aspectA.get("aspect_a_result");
+    StarlarkList<?> aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectAResult))
         .containsExactly(
             "aspect_a on target @@//test:main_target, p = 2",
@@ -8702,12 +8737,13 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        AspectInfo = provider()
         def _aspect_a_impl(target, ctx):
           result = ['aspect_a on target {}, p = {}'.
                                             format(target.label, ctx.attr.p)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_a_result
-          return struct(aspect_a_result = result)
+            result += ctx.rule.attr.dep[AspectInfo].aspect_a_result
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -8745,7 +8781,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     ImmutableMap<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    StarlarkList<?> aspectAResult = (StarlarkList) aspectA.get("aspect_a_result");
+    StarlarkList<?> aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectAResult))
         .containsExactly(
             "aspect_a on target @@//test:main_target, p = 1",
@@ -9071,12 +9109,13 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        AspectInfo = provider()
         def _aspect_a_impl(target, ctx):
           result = ['aspect_a on target {}, p = {}'.
                                             format(target.label, ctx.attr.p)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_a_result
-          return struct(aspect_a_result = result)
+            result += ctx.rule.attr.dep[AspectInfo].aspect_a_result
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -9117,7 +9156,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     ImmutableMap<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    StarlarkList<?> aspectAResult = (StarlarkList) aspectA.get("aspect_a_result");
+    StarlarkList<?> aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectAResult))
         .containsExactly(
             "aspect_a on target @@//test:main_target, p = True",
@@ -9130,12 +9171,13 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        AspectInfo = provider()
         def _aspect_a_impl(target, ctx):
           result = ['aspect_a on target {}, p = {}'.
                                             format(target.label, ctx.attr.p)]
           if ctx.rule.attr.dep:
-            result += ctx.rule.attr.dep.aspect_a_result
-          return struct(aspect_a_result = result)
+            result += ctx.rule.attr.dep[AspectInfo].aspect_a_result
+          return AspectInfo(aspect_a_result = result)
 
         aspect_a = aspect(
           implementation = _aspect_a_impl,
@@ -9173,7 +9215,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     ImmutableMap<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "aspect_a");
     assertThat(aspectA).isNotNull();
-    StarlarkList<?> aspectAResult = (StarlarkList) aspectA.get("aspect_a_result");
+    StarlarkList<?> aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "AspectInfo")
+            .getValue("aspect_a_result", StarlarkList.class);
     assertThat(Starlark.toIterable(aspectAResult))
         .containsExactly(
             "aspect_a on target @@//test:main_target, p = False",
@@ -9718,9 +9762,10 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     scratch.file(
         "test/defs.bzl",
         """
+        MyInfo = provider()
         def _a_impl(target, ctx):
           value = 'x from aspect = {}, x from target = {}'.format(ctx.attr.x, ctx.rule.attr.x)
-          return struct(aspect_result = value)
+          return MyInfo(aspect_result = value)
         a = aspect(
           implementation = _a_impl,
           attrs = {
@@ -9749,7 +9794,9 @@ r = rule(_r_impl, attrs = { 'dep' : attr.label(aspects = [a])})
     ImmutableMap<AspectKey, ConfiguredAspect> configuredAspects = analysisResult.getAspectsMap();
     ConfiguredAspect aspectA = getConfiguredAspect(configuredAspects, "a");
     assertThat(aspectA).isNotNull();
-    String aspectAResult = (String) aspectA.get("aspect_result");
+    String aspectAResult =
+        getStarlarkProvider(aspectA, "//test:defs.bzl", "MyInfo")
+            .getValue("aspect_result", String.class);
     assertThat(aspectAResult).isEqualTo("x from aspect = xyz, x from target = 4");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -888,10 +888,6 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
             + " definitions");
   }
 
-  private static StarlarkProviderIdentifier legacy(String legacyId) {
-    return StarlarkProviderIdentifier.forLegacy(legacyId);
-  }
-
   private static StarlarkProviderIdentifier declared(String exportedName) {
     return StarlarkProviderIdentifier.forKey(
         new StarlarkProvider.Key(keyForBuild(FAKE_LABEL), exportedName));
@@ -902,11 +898,13 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     Attribute attr =
         buildAttribute(
             "a1", //
+            "a = provider()",
             "b = provider()",
-            "attr.label_list(allow_files = True, providers = ['a', b])");
+            "attr.label_list(allow_files = True, providers = [a, b])");
     assertThat(attr.starlarkDefined()).isTrue();
-    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(legacy("a"), declared("b")))).isTrue();
-    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(legacy("a")))).isFalse();
+    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(declared("a"), declared("b"))))
+        .isTrue();
+    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(declared("a")))).isFalse();
   }
 
   @Test
@@ -914,8 +912,9 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     Attribute attr =
         buildAttribute(
             "a1",
+            "a = provider()",
             "b = provider()",
-            "attr.label_list(allow_files = True, providers = [['a', b],[]])");
+            "attr.label_list(allow_files = True, providers = [[a, b],[]])");
     assertThat(attr.starlarkDefined()).isTrue();
     assertThat(attr.getRequiredProviders().acceptsAny()).isTrue();
   }
@@ -925,12 +924,15 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     Attribute attr =
         buildAttribute(
             "a1",
+            "a = provider()",
             "b = provider()",
-            "attr.label_list(allow_files = True, providers = [['a', b], ['c']])");
+            "c = provider()",
+            "attr.label_list(allow_files = True, providers = [[a, b], [c]])");
     assertThat(attr.starlarkDefined()).isTrue();
-    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(legacy("a"), declared("b")))).isTrue();
-    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(legacy("c")))).isTrue();
-    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(legacy("a")))).isFalse();
+    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(declared("a"), declared("b"))))
+        .isTrue();
+    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(declared("c")))).isTrue();
+    assertThat(attr.getRequiredProviders().isSatisfiedBy(set(declared("a")))).isFalse();
   }
 
   private static AdvertisedProviderSet set(StarlarkProviderIdentifier... ids) {
@@ -950,24 +952,22 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
   @Test
   public void testAttrWithWrongProvidersList() throws Exception {
     checkAttributeError(
-        "element in 'providers' is of unexpected type. Either all elements should be providers,"
-            + " or all elements should be lists of providers,"
-            + " but got list with an element of type int.",
-        "attr.label_list(allow_files = True,  providers = [['a', 1], ['c']])");
+        "Error in label_list: at index 1 of providers, got element of type int, want Provider",
+        "a = provider()",
+        "c = provider()",
+        "attr.label_list(allow_files = True,  providers = [[a, 1], [c]])");
 
     checkAttributeError(
-        "element in 'providers' is of unexpected type. Either all elements should be providers,"
-            + " or all elements should be lists of providers,"
-            + " but got an element of type string.",
+        "Error in label_list: at index 1 of providers, got element of type string, want sequence",
         "b = provider()",
         "attr.label_list(allow_files = True,  providers = [['a', b], 'c'])");
 
     checkAttributeError(
-        "element in 'providers' is of unexpected type. Either all elements should be providers,"
-            + " or all elements should be lists of providers,"
-            + " but got an element of type string.",
+        "Error in label_list: at index 1 of providers, got element of type Provider, want sequence",
+        "a = provider()",
+        "b = provider()",
         "c = provider()",
-        "attr.label_list(allow_files = True,  providers = [['a', b], c])");
+        "attr.label_list(allow_files = True,  providers = [[a, b], c])");
   }
 
   @Test
@@ -2705,8 +2705,9 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ev,
         "def _impl(target, ctx):",
         "   pass",
+        "java = provider()",
         "cc = provider()",
-        "my_aspect = aspect(_impl, required_aspect_providers=['java', cc])");
+        "my_aspect = aspect(_impl, required_aspect_providers=[java, cc])");
     StarlarkDefinedAspect myAspect = (StarlarkDefinedAspect) ev.lookup("my_aspect");
     RequiredProviders requiredProviders =
         myAspect.getDefinition(AspectParameters.EMPTY).getRequiredProvidersForAspects();
@@ -2716,12 +2717,12 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
             requiredProviders.isSatisfiedBy(
                 AdvertisedProviderSet.builder()
                     .addStarlark(declared("cc"))
-                    .addStarlark("java")
+                    .addStarlark(declared("java"))
                     .build()))
         .isTrue();
     assertThat(
             requiredProviders.isSatisfiedBy(
-                AdvertisedProviderSet.builder().addStarlark("cc").build()))
+                AdvertisedProviderSet.builder().addStarlark(declared("cc")).build()))
         .isFalse();
   }
 
@@ -2731,8 +2732,9 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ev,
         "def _impl(target, ctx):",
         "   pass",
+        "java = provider()",
         "cc = provider()",
-        "my_aspect = aspect(_impl, required_aspect_providers=[['java'], [cc]])");
+        "my_aspect = aspect(_impl, required_aspect_providers=[[java], [cc]])");
     StarlarkDefinedAspect myAspect = (StarlarkDefinedAspect) ev.lookup("my_aspect");
     RequiredProviders requiredProviders =
         myAspect.getDefinition(AspectParameters.EMPTY).getRequiredProvidersForAspects();
@@ -2740,7 +2742,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     assertThat(requiredProviders.isSatisfiedBy(AdvertisedProviderSet.EMPTY)).isFalse();
     assertThat(
             requiredProviders.isSatisfiedBy(
-                AdvertisedProviderSet.builder().addStarlark("java").build()))
+                AdvertisedProviderSet.builder().addStarlark(declared("java")).build()))
         .isTrue();
     assertThat(
             requiredProviders.isSatisfiedBy(
@@ -2748,7 +2750,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         .isTrue();
     assertThat(
             requiredProviders.isSatisfiedBy(
-                AdvertisedProviderSet.builder().addStarlark("prolog").build()))
+                AdvertisedProviderSet.builder().addStarlark(declared("prolog")).build()))
         .isFalse();
   }
 
@@ -2799,8 +2801,9 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ev,
         "def _impl(target, ctx):",
         "   pass",
+        "java = provider()",
         "cc = provider()",
-        "my_aspect = aspect(_impl, required_providers=['java', cc])");
+        "my_aspect = aspect(_impl, required_providers=[java, cc])");
     StarlarkDefinedAspect myAspect = (StarlarkDefinedAspect) ev.lookup("my_aspect");
     RequiredProviders requiredProviders =
         myAspect.getDefinition(AspectParameters.EMPTY).getRequiredProviders();
@@ -2811,7 +2814,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
             requiredProviders.isSatisfiedBy(
                 AdvertisedProviderSet.builder()
                     .addStarlark(declared("cc"))
-                    .addStarlark("java")
+                    .addStarlark(declared("java"))
                     .build()))
         .isTrue();
     assertThat(
@@ -2826,8 +2829,9 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ev,
         "def _impl(target, ctx):",
         "   pass",
+        "java = provider()",
         "cc = provider()",
-        "my_aspect = aspect(_impl, required_providers=[['java'], [cc]])");
+        "my_aspect = aspect(_impl, required_providers=[[java], [cc]])");
     StarlarkDefinedAspect myAspect = (StarlarkDefinedAspect) ev.lookup("my_aspect");
     RequiredProviders requiredProviders =
         myAspect.getDefinition(AspectParameters.EMPTY).getRequiredProviders();
@@ -2836,7 +2840,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     assertThat(requiredProviders.isSatisfiedBy(AdvertisedProviderSet.EMPTY)).isFalse();
     assertThat(
             requiredProviders.isSatisfiedBy(
-                AdvertisedProviderSet.builder().addStarlark("java").build()))
+                AdvertisedProviderSet.builder().addStarlark(declared("java")).build()))
         .isTrue();
     assertThat(
             requiredProviders.isSatisfiedBy(
@@ -2844,7 +2848,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         .isTrue();
     assertThat(
             requiredProviders.isSatisfiedBy(
-                AdvertisedProviderSet.builder().addStarlark("prolog").build()))
+                AdvertisedProviderSet.builder().addStarlark(declared("prolog")).build()))
         .isFalse();
   }
 
@@ -2885,13 +2889,12 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         "def _impl(target, ctx):",
         "   pass",
         "y = provider()",
-        "my_aspect = aspect(_impl, provides = ['x', y])");
+        "my_aspect = aspect(_impl, provides = [y])");
     StarlarkDefinedAspect myAspect = (StarlarkDefinedAspect) ev.lookup("my_aspect");
     AdvertisedProviderSet advertisedProviders =
         myAspect.getDefinition(AspectParameters.EMPTY).getAdvertisedProviders();
     assertThat(advertisedProviders.canHaveAnyProvider()).isFalse();
-    assertThat(advertisedProviders.getStarlarkProviders())
-        .containsExactly(legacy("x"), declared("y"));
+    assertThat(advertisedProviders.getStarlarkProviders()).containsExactly(declared("y"));
   }
 
   @Test
@@ -2902,11 +2905,10 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         "def _impl(target, ctx):",
         "   pass",
         "y = provider()",
-        "my_aspect = aspect(_impl, provides = ['x', 1])");
+        "my_aspect = aspect(_impl, provides = [y, 1])");
     MoreAsserts.assertContainsEvent(
         ev.getEventCollector(),
-        " Illegal argument: element in 'provides' is of unexpected type."
-            + " Should be list of providers, but got item of type int. ");
+        "Error in aspect: at index 1 of provides, got element of type int, want Provider");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -199,12 +199,13 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     scratch.file(
         "test/macros.bzl",
         """
+        SomeInfo = provider()
         def _impl(ctx):
           return
         starlark_rule = rule(
           implementation = _impl,
           attrs = {
-            'deps': attr.label_list(providers = ['some_provider'], allow_files=True)
+            'deps': attr.label_list(providers = [SomeInfo], allow_files=True)
           }
         )
         def macro_native_rule(name, deps):
@@ -235,7 +236,7 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     assertContainsEvent(
         "ERROR /workspace/test/BUILD:5:20: in deps attribute of starlark_rule rule "
             + "//test:m_starlark: '//test:jlib' does not have mandatory providers:"
-            + " 'some_provider'. "
+            + " 'SomeInfo'. "
             + "Since this rule was created by the macro 'macro_starlark_rule', the error might "
             + "have been caused by the macro implementation");
   }
@@ -257,7 +258,7 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     assertContainsEvent(
         "ERROR /workspace/test/BUILD:11:14: in deps attribute of "
             + "starlark_rule rule //test:skyrule: '//test:jlib' does not have mandatory providers: "
-            + "'some_provider'");
+            + "'SomeInfo'");
   }
 
   @Test
@@ -1404,12 +1405,13 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     scratch.file(
         "my_rule.bzl",
         """
+        MyInfo = provider()
         def _impl(ctx):
           return
         my_rule = rule(
           implementation = _impl,
           attrs = {
-            'label_dict': attr.label_keyed_string_dict(providers=[['my_provider']]),
+            'label_dict': attr.label_keyed_string_dict(providers=[[MyInfo]]),
           }
         )
         def _dep_impl(ctx):
@@ -1431,7 +1433,7 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     getConfiguredTarget("//:r");
     assertContainsEvent(
         "in label_dict attribute of my_rule rule //:r: "
-            + "'//:dep' does not have mandatory providers: 'my_provider'");
+            + "'//:dep' does not have mandatory providers: 'MyInfo'");
   }
 
   @Test
@@ -2940,14 +2942,15 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     for (String attribute : attributes) {
       scratch.overwriteFile(
           "test/rules.bzl",
+          "MyInfo = provider()",
           "def _rule_impl(ctx):",
           "  pass",
           "def _aspect_impl(target, ctx):",
           "  if ctx.rule.attr.deps:",
           "    dep = ctx.rule.attr.deps[0]",
           "    file = ctx.actions.declare_file('file.txt')",
-          "    foo = dep." + (attribute.startsWith("rule.") ? "" : "ctx.") + attribute,
-          "  return struct(ctx = ctx, rule=ctx.rule)",
+          "    foo = dep[MyInfo]." + (attribute.startsWith("rule.") ? "" : "ctx.") + attribute,
+          "  return MyInfo(ctx = ctx, rule=ctx.rule)",
           "MyAspect = aspect(implementation=_aspect_impl)",
           "my_rule = rule(",
           "  implementation = _rule_impl,",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -91,6 +91,7 @@ import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.syntax.Location;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1197,9 +1198,15 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
   @Test
   public void testNoSuchProviderErrorMessage() throws Exception {
     setRuleContext(createRuleContext("//foo:bar"));
+    ev.update(
+        "MyInfo",
+        StarlarkProvider.builder(Location.BUILTIN)
+            .buildExported(
+                new StarlarkProvider.Key(
+                    keyForBuild(Label.parseCanonicalUnchecked("//myinfo:myinfo.bzl")), "MyInfo")));
     ev.checkEvalErrorContains(
-        "<target //foo:jl> (rule 'java_library') doesn't have provider 'my_provider'",
-        "ruleContext.attr.srcs[0].my_provider");
+        "<target //foo:jl> (rule 'java_library') doesn't contain declared provider 'MyInfo'",
+        "ruleContext.attr.srcs[0][MyInfo]");
   }
 
   @Test
@@ -1702,9 +1709,7 @@ public final class StarlarkRuleImplementationFunctionsTest extends BuildViewTest
         assertThrows(AssertionError.class, () -> getConfiguredTarget("//test:my_rule"));
     assertThat(expected)
         .hasMessageThat()
-        .contains(
-            "element in 'provides' is of unexpected type. "
-                + "Should be list of providers, but got item of type int");
+        .contains("Error in rule: at index 0 of provides, got element of type int, want Provider");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -608,7 +608,7 @@ public final class ModuleInfoExtractorTest {
 
             my_lib = rule(
                 implementation = _my_impl,
-                provides = [MyInfo, DefaultInfo, "LegacyStructInfo"],
+                provides = [MyInfo, DefaultInfo],
             )
             """);
     ModuleInfo moduleInfo = getExtractor().extractFrom(module);
@@ -622,12 +622,10 @@ public final class ModuleInfoExtractorTest {
                     ProviderNameGroup.newBuilder()
                         .addProviderName("MyInfo")
                         .addProviderName("DefaultInfo")
-                        .addProviderName("LegacyStructInfo")
                         .addOriginKey(
                             OriginKey.newBuilder().setName("MyInfo").setFile(fakeLabelString))
                         .addOriginKey(
-                            OriginKey.newBuilder().setName("DefaultInfo").setFile("<native>"))
-                        .addOriginKey(OriginKey.newBuilder().setName("LegacyStructInfo")))
+                            OriginKey.newBuilder().setName("DefaultInfo").setFile("<native>")))
                 .build());
   }
 
@@ -1021,7 +1019,7 @@ public final class ModuleInfoExtractorTest {
   public void macroInheritedAttributes() throws Exception {
     Module module =
         exec(
-            """
+"""
 def _my_rule_impl(ctx):
     pass
 

--- a/src/test/shell/integration/aquery_test.sh
+++ b/src/test/shell/integration/aquery_test.sh
@@ -1257,7 +1257,7 @@ def _my_jpl_aspect_imp(target, ctx):
 
 my_jpl_aspect = aspect(
   attr_aspects = ['deps', 'exports'],
-  required_aspect_providers = [['proto_java']],
+  required_aspect_providers = [],
   attrs = {
     'aspect_param': attr.string(default = 'x', values = ['x', 'y'])
   },

--- a/src/test/shell/integration/discard_analysis_cache_test.sh
+++ b/src/test/shell/integration/discard_analysis_cache_test.sh
@@ -146,6 +146,7 @@ function test_aspect_and_configured_target_cleared() {
   export DONT_SANITY_CHECK_SERIALIZATION=1
   mkdir -p "foo" || fail "Couldn't make directory"
   cat > foo/simpleaspect.bzl <<'EOF' || fail "Couldn't write bzl file"
+AspectInfo = provider()
 def _simple_aspect_impl(target, ctx):
   result=[]
   for orig_out in target.files.to_list():
@@ -156,10 +157,12 @@ def _simple_aspect_impl(target, ctx):
     result += [aspect_out]
 
   result = depset(result,
-      transitive = [src.aspectouts for src in ctx.rule.attr.srcs])
+      transitive = [src[AspectInfo].aspectouts for src in ctx.rule.attr.srcs])
 
-  return struct(output_groups={
-      "aspect-out" : result }, aspectouts = result)
+  return [
+      OutputGroupInfo(**{"aspect-out" : result}),
+      AspectInfo(aspectouts = result),
+  ]
 
 simple_aspect = aspect(implementation=_simple_aspect_impl,
                        attr_aspects = ["srcs"])

--- a/src/test/shell/integration/discard_graph_edges_test.sh
+++ b/src/test/shell/integration/discard_graph_edges_test.sh
@@ -128,6 +128,7 @@ function test_configured_query() {
 function test_top_level_aspect() {
   mkdir -p "foo" || fail "Couldn't make directory"
   cat > foo/simpleaspect.bzl <<'EOF' || fail "Couldn't write bzl file"
+AspectInfo = provider()
 def _simple_aspect_impl(target, ctx):
   result=[]
   for orig_out in target.files.to_list():
@@ -138,10 +139,13 @@ def _simple_aspect_impl(target, ctx):
     result += [aspect_out]
 
   result = depset(result,
-      transitive = [src.aspectouts for src in ctx.rule.attr.srcs])
+      transitive = [src[AspectInfo].aspectouts for src in ctx.rule.attr.srcs])
 
-  return struct(output_groups={
-      "aspect-out" : result }, aspectouts = result)
+  return [
+      OutputGroupInfo(**{"aspect-out" : result}),
+      AspectInfo(aspectouts = result),
+  ]
+
 
 simple_aspect = aspect(implementation=_simple_aspect_impl,
                        attr_aspects = ["srcs"])


### PR DESCRIPTION
Without legacy struct providers, we also can't be specifying them.

RELNOTES[INC]: strings in attribute's "provides" parameters are no longer supported

PiperOrigin-RevId: 741563954
Change-Id: I8f7a88dee9ca1f2d87f7e135cb45396d9a685588