### PR TITLE
Flip incompatible_disable_autoloads_in_main_repo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -149,7 +149,7 @@ public final class BuildLanguageOptions extends OptionsBase {
 
   @Option(
       name = "incompatible_disable_autoloads_in_main_repo",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
@@ -933,7 +933,7 @@ public final class BuildLanguageOptions extends OptionsBase {
   public static final String INCOMPATIBLE_STOP_EXPORTING_LANGUAGE_MODULES =
       "-incompatible_stop_exporting_language_modules";
   public static final String INCOMPATIBLE_DISABLE_AUTOLOADS_IN_MAIN_REPO =
-      "-incompatible_disable_autoloads_in_main_repo";
+      "+incompatible_disable_autoloads_in_main_repo";
   public static final String INCOMPATIBLE_ALLOW_TAGS_PROPAGATION =
       "+incompatible_allow_tags_propagation";
   public static final String EXPERIMENTAL_BUILTINS_DUMMY = "-experimental_builtins_dummy";

--- a/src/test/shell/integration/incompatible_autoload_externally_test.sh
+++ b/src/test/shell/integration/incompatible_autoload_externally_test.sh
@@ -24,6 +24,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 #### SETUP #############################################################
 
 set -e
+add_to_bazelrc "common --noincompatible_disable_autoloads_in_main_repo"
 
 #### TESTS #############################################################
 


### PR DESCRIPTION
The flag flip forces loads in main repository when using Bazel@HEAD. Flipping it now, so that we can disable autoloads by release of Bazel 9.

PiperOrigin-RevId: 745526309
Change-Id: I7204470c08a66a15b28bc0b0c48f41d69e1694c8