### PR TITLE
Flip `--@bazel_tools//tools/test:incompatible_use_default_test_toolchain`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -953,6 +953,10 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   // target.
   @Option(
       name = "use_target_platform_for_tests",
+      deprecationWarning =
+          "Tests select an execution platform matching all constraints of the target platform by"
+              + " default. Instead of using this flag, make sure that all test target platform are"
+              + " registered as execution platforms.",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -316,7 +316,7 @@ launcher_flag_alias(
 
         bool_flag(
             name = "incompatible_use_default_test_toolchain",
-            build_setting_default = False,
+            build_setting_default = True,
             visibility = ["//visibility:private"],
         )
 

--- a/tools/test/BUILD.tools
+++ b/tools/test/BUILD.tools
@@ -29,7 +29,7 @@ empty_toolchain(name = "empty_toolchain")
 # platform.
 bool_flag(
     name = "incompatible_use_default_test_toolchain",
-    build_setting_default = False,
+    build_setting_default = True,
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/25823

RELNOTES[inc]: `--@bazel_tools//tools/test:incompatible_use_default_test_toolchain` is now enabled by default. All test rules without an explicitly defined `test` exec group now select an execution platform that satisfies all constraints of the target platform. The `--use_target_platform_for_tests` option, which served a similar purpose, is now deprecated. See https://github.com/bazelbuild/bazel/issues/25823 for more details and migration advice.