### PR TITLE
Replace more test deps `filegroup`s with `sh_library`

### DIFF
--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_pip_dev_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
 load("//:workspace_deps.bzl", "gen_workspace_stanza")
 
 package(default_visibility = ["//visibility:private"])
@@ -10,7 +11,7 @@ filegroup(
     visibility = ["//src:__pkg__"],
 )
 
-filegroup(
+sh_library(
     name = "test-deps",
     testonly = 1,
     srcs = ["//src:bazel"],

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -1,3 +1,4 @@
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
 load("//:workspace_deps.bzl", "gen_workspace_stanza")
 
 package(default_visibility = ["//visibility:private"])
@@ -8,7 +9,7 @@ filegroup(
     visibility = ["//src/test/shell:__pkg__"],
 )
 
-filegroup(
+sh_library(
     name = "test-deps",
     testonly = 1,
     srcs = [
@@ -16,7 +17,7 @@ filegroup(
     ],
 )
 
-filegroup(
+sh_library(
     name = "test-deps-minimal-bazel",
     testonly = 1,
     srcs = [
@@ -26,7 +27,7 @@ filegroup(
     ],
 )
 
-filegroup(
+sh_library(
     name = "test-deps-nojdk",
     testonly = 1,
     srcs = [


### PR DESCRIPTION
`filegroup` can swallow runfiles, which breaks the version of the bash runfiles library contained in `rules_shell`. Work around this by using `sh_library` instead.

Fixes #25513