### PR TITLE
Don't crash Bazel when a source directory crosses package boundaries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
@@ -334,16 +334,12 @@ public final class ArtifactFunction implements SkyFunction {
         case FILE_OPERATION_FAILURE:
         case SYMLINK_CYCLE_OR_INFINITE_EXPANSION:
         case CANNOT_TRAVERSE_SOURCE_DIRECTORY:
+        case CANNOT_CROSS_PACKAGE_BOUNDARY:
           throw new ArtifactFunctionException(
               SourceArtifactException.create(artifact, e), Transience.PERSISTENT);
         case INCONSISTENT_FILESYSTEM:
           throw new ArtifactFunctionException(
               SourceArtifactException.create(artifact, e), Transience.TRANSIENT);
-        case CANNOT_CROSS_PACKAGE_BOUNDARY:
-          throw new IllegalStateException(
-              String.format(
-                  "Cannot cross package boundary: %s %s %s", artifact, fileValue, request),
-              e);
         case GENERATED_PATH_CONFLICT:
           throw new IllegalStateException(
               String.format(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1905,6 +1905,26 @@ java_test(
 )
 
 java_test(
+    name = "SourceDirectoryIntegrationTest",
+    timeout = "short",
+    srcs = ["SourceDirectoryIntegrationTest.java"],
+    jvm_flags = [
+        "-DBAZEL_TRACK_SOURCE_DIRECTORIES=1",
+    ],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/test/java/com/google/devtools/build/lib/buildtool/util",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "FileArtifactValueTest",
     timeout = "short",
     srcs = ["FileArtifactValueTest.java"],

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SourceDirectoryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SourceDirectoryIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.BuildFailedException;
-import com.google.devtools.build.lib.bugreport.BugReport;
 import com.google.devtools.build.lib.buildtool.util.BuildIntegrationTestCase;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.vfs.Path;
@@ -228,9 +227,7 @@ public final class SourceDirectoryIntegrationTest extends BuildIntegrationTestCa
   @Test
   public void crossingPackageBoundary_fails() throws Exception {
     createEmptyFile(sourceDir.getRelative("subdir/BUILD"));
-    // TODO(#25834): This should not crash Bazel.
-    assertThrows(IllegalStateException.class, () -> buildTarget("//foo"));
-    BugReport.getAndResetLastCrashingThrowableIfInTest();
+    assertThrows(BuildFailedException.class, () -> buildTarget("//foo"));
     assertContainsEvent(
         "Directory artifact foo/dir crosses package boundary into package rooted at"
             + " foo/dir/subdir");


### PR DESCRIPTION
Also add the target for the test that was missed in the merge of https://github.com/bazelbuild/bazel/commit/ad381cb56804d0d0d1dc95ef7bd4da1e4a3a5c90.

Work towards #25834