### PR TITLE
Make test toolchain requirement mandatory

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -156,9 +156,7 @@ public class RuleClass implements RuleClassData {
   public static final DeclaredExecGroup DEFAULT_TEST_RUNNER_EXEC_GROUP =
       DeclaredExecGroup.builder()
           .addToolchainType(
-              ToolchainTypeRequirement.builder(PlatformConstants.DEFAULT_TEST_TOOLCHAIN_TYPE)
-                  .mandatory(false)
-                  .build())
+              ToolchainTypeRequirement.create(PlatformConstants.DEFAULT_TEST_TOOLCHAIN_TYPE))
           .build();
 
   /** Interface for determining whether a rule needs toolchain resolution or not. */

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -736,10 +736,11 @@ public class TestActionBuilderTest extends BuildViewTestCase {
   }
 
   /**
-   * With the default test toolchain, the first execution platform will be used (matching legacy).
+   * With the default test toolchain, a failure to find a suitable execution platform will result in
+   * a toolchain resolution error.
    */
   @Test
-  public void testFirstMatchingExecPlatformWithDefaultTestToolchain() throws Exception {
+  public void testNoMatchingExecPlatformWithDefaultTestToolchain() throws Exception {
     scratch.file(
         "some_test.bzl",
         """
@@ -792,11 +793,11 @@ public class TestActionBuilderTest extends BuildViewTestCase {
         "--platforms=//:linux_x86_64_target",
         "--host_platform=//:macos_aarch64_exec",
         "--extra_execution_platforms=//:macos_aarch64_exec");
-    ImmutableList<Artifact.DerivedArtifact> testStatusList = getTestStatusArtifacts("//:some_test");
-    TestRunnerAction testAction = (TestRunnerAction) getGeneratingAction(testStatusList.get(0));
-    assertThat(testAction.getExecutionPlatform().label())
-        .isEqualTo(Label.parseCanonicalUnchecked("//:macos_aarch64_exec"));
-    assertThat(testAction.getExecProperties()).isEmpty();
+    reporter.removeHandler(failFastHandler);
+    assertThat(getConfiguredTarget("//:some_test")).isNull();
+    assertContainsEvent(
+        "While resolving toolchains for target //:some_test: No matching toolchains found for"
+            + " types:\n  @@bazel_tools//tools/test:default_test_toolchain_type");
   }
 
   /**


### PR DESCRIPTION
This ensures that a test for which no compatible exec platform is available results in an analysis error (improved by the test toolchain type's `no_match_error`) instead of being run on the first execution platform, which is likely to fail with an uninformative "exec format" error.

RELNOTES[inc]: The toolchain requirement of the default `test` exec group is now mandatory.

Work towards #25160 