### PR TITLE
Fix `bazel build //src/...`

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/api/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/api/BUILD
@@ -16,14 +16,6 @@ java_library(
     ],
 )
 
-java_library(
-    name = "api-android",
-    srcs = glob(["*.java"]),
-    deps = [
-        "//third_party/java/junit:not-testonly-android",
-    ],
-)
-
 filegroup(
     name = "srcs",
     srcs = glob(["**/*.java"]) + ["BUILD"],

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/util/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/util/BUILD
@@ -24,7 +24,6 @@ java_library(
         "CurrentRunningTest.java",
         "TestNameProvider.java",
     ],
-    visibility = ["//testing/web:webtesting"],
     deps = [
         "//third_party:junit4",
     ],


### PR DESCRIPTION
Delete an unused target with non-existent deps as well as a visibility spec referencing a package that doesn't exist in Bazel.