### PR TITLE
Include allowed attribute values in Stardoc proto

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkdocextract/AttributeInfoExtractor.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdocextract/AttributeInfoExtractor.java
@@ -69,6 +69,17 @@ public final class AttributeInfoExtractor {
         builder.setDefaultValue(UNREPRESENTABLE_VALUE);
       }
     }
+    if (attribute.getAllowedValues() instanceof Attribute.AllowedValueSet allowedValueSet) {
+      for (Object value : allowedValueSet.getAllowedValues()) {
+        try {
+          builder.addAllowedValues(
+              StringEncoding.internalToUnicode(
+                  context.labelRenderer().reprWithoutLabelConstructor(value)));
+        } catch (InvalidStarlarkValueException e) {
+          builder.addAllowedValues(UNREPRESENTABLE_VALUE);
+        }
+      }
+    }
     return builder.build();
   }
 

--- a/src/main/protobuf/stardoc_output.proto
+++ b/src/main/protobuf/stardoc_output.proto
@@ -168,6 +168,10 @@ message AttributeInfo {
 
   // If true, the attribute is defined in Bazel's native code, not in Starlark.
   bool natively_defined = 8;
+
+  // If non-empty, the string representations of the allowed values for this
+  // attribute.
+  repeated string allowed_values = 9;
 }
 
 // Representation of a set of providers.


### PR DESCRIPTION
The set of allowed values of a `string` or `int` attribute is crucial information for users of a rule or aspect.