### PR TITLE
Honor `--guard_against_concurrent_changes` in remote execution fallback

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -66,7 +66,6 @@ import com.google.devtools.build.lib.remote.common.BulkTransferException;
 import com.google.devtools.build.lib.remote.common.OperationObserver;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionCapabilitiesException;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
-import com.google.devtools.build.lib.remote.options.RemoteOptions.ConcurrentChangesCheckLevel;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
@@ -702,9 +701,8 @@ public class RemoteSpawnRunner implements SpawnRunner {
       throws ExecException, IOException, ForbiddenActionInputException, InterruptedException {
     SpawnResult result = execLocally(spawn, context);
     if (uploadLocalResults && Status.SUCCESS.equals(result.status()) && result.exitCode() == 0) {
-      // FULL is used here to retain historic behavior.
       remoteExecutionService.uploadOutputs(
-          action, result, () -> {}, ConcurrentChangesCheckLevel.FULL);
+          action, result, () -> {}, remoteOptions.guardAgainstConcurrentChanges);
     }
     return result;
   }


### PR DESCRIPTION
RELNOTES[inc]: When remote execution fails and an action is executed locally, modifications of its inputs during execution are now checked according to the value of the `--guard_against_concurrent_changes` flag rather than as if that flag was set to `full`.