### PR TITLE
Consider action_config tools for cc_toolchain make variables

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -498,7 +498,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
 
     runtimes_copts = semantics.get_cc_runtimes_copts(ctx)
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration = feature_configuration)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     (compilation_context, compilation_outputs) = cc_common.compile(

--- a/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_binary.bzl
@@ -498,7 +498,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
 
     runtimes_copts = semantics.get_cc_runtimes_copts(ctx)
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     (compilation_context, compilation_outputs) = cc_common.compile(

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -507,12 +507,40 @@ def _get_compilation_contexts_from_deps(deps):
             compilation_contexts.append(dep[CcInfo].compilation_context)
     return compilation_contexts
 
+AR_TOOL_NAME = "ar"
+CPP_TOOL_NAME = "cpp"
+GCC_TOOL_NAME = "gcc"
+GCOV_TOOL_NAME = "gcov"
+GCOV_TOOL_TOOL_NAME = "gcov-tool"
+LD_TOOL_NAME = "ld"
+LLVM_PROFDATA_TOOL_NAME = "llvm-profdata"
+LLVM_COV_TOOL_NAME = "llvm-cov"
+NM_TOOL_NAME = "nm"
+OBJCOPY_TOOL_NAME = "objcopy"
+OBJDUMP_TOOL_NAME = "objdump"
+STRIP_TOOL_NAME = "strip"
+
+TOOL_NAMES = struct(
+    ar = AR_TOOL_NAME,
+    cpp = CPP_TOOL_NAME,
+    gcc = GCC_TOOL_NAME,
+    gcov = GCOV_TOOL_NAME,
+    gcov_tool = GCOV_TOOL_TOOL_NAME,
+    ld = LD_TOOL_NAME,
+    llvm_profdata = LLVM_PROFDATA_TOOL_NAME,
+    llvm_cov = LLVM_COV_TOOL_NAME,
+    nm = NM_TOOL_NAME,
+    objcopy = OBJCOPY_TOOL_NAME,
+    objdump = OBJDUMP_TOOL_NAME,
+    strip = STRIP_TOOL_NAME,
+)
+
 _TOOL_NAMES_TO_ACTION_NAMES = {
-    "ar": ACTION_NAMES.cpp_link_static_library,
-    "gcc": ACTION_NAMES.c_compile,
-    "ld": ACTION_NAMES.cpp_link_executable,
-    "objcopy": ACTION_NAMES.objcopy_embed_data,
-    "strip": ACTION_NAMES.strip,
+    TOOL_NAMES.ar: ACTION_NAMES.cpp_link_static_library,
+    TOOL_NAMES.gcc: ACTION_NAMES.c_compile,
+    TOOL_NAMES.ld: ACTION_NAMES.cpp_link_executable,
+    TOOL_NAMES.objcopy: ACTION_NAMES.objcopy_embed_data,
+    TOOL_NAMES.strip: ACTION_NAMES.strip,
 }
 
 def _tool_or_action_path(cc_toolchain, feature_configuration, tool):
@@ -524,19 +552,19 @@ def _tool_or_action_path(cc_toolchain, feature_configuration, tool):
 
 def _get_toolchain_global_make_variables(feature_configuration, cc_toolchain):
     result = {
-        "CC": _tool_or_action_path(cc_toolchain, feature_configuration, "gcc"),
-        "AR": _tool_or_action_path(cc_toolchain, feature_configuration, "ar"),
-        "NM": _tool_or_action_path(cc_toolchain, feature_configuration, "nm"),
-        "LD": _tool_or_action_path(cc_toolchain, feature_configuration, "ld"),
-        "STRIP": _tool_or_action_path(cc_toolchain, feature_configuration, "strip"),
+        "CC": _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.gcc),
+        "AR": _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.ar),
+        "NM": _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.nm),
+        "LD": _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.ld),
+        "STRIP": _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.strip),
         "C_COMPILER": cc_toolchain.compiler,
     }
 
-    obj_copy_tool = _tool_or_action_path(cc_toolchain, feature_configuration, "objcopy")
+    obj_copy_tool = _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.objcopy)
     if obj_copy_tool != None:
         # objcopy is optional in Crostool.
         result["OBJCOPY"] = obj_copy_tool
-    gcov_tool = _tool_or_action_path(cc_toolchain, feature_configuration, "gcov-tool")
+    gcov_tool = _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.gcov_tool)
     if gcov_tool != None:
         # gcovtool is optional in Crostool.
         result["GCOVTOOL"] = gcov_tool
@@ -1037,16 +1065,13 @@ def _report_invalid_options(cc_toolchain, cpp_config):
     if cpp_config.grte_top() != None and cc_toolchain.sysroot == None:
         fail("The selected toolchain does not support setting --grte_top (it doesn't specify builtin_sysroot).")
 
-def _tool_path(cc_toolchain, tool):
-    return cc_toolchain._tool_paths.get(tool, None)
-
 def _get_coverage_environment(ctx, cc_config, cc_toolchain):
     if not ctx.configuration.coverage_enabled:
         return {}
     env = {
-        "COVERAGE_GCOV_PATH": _tool_path(cc_toolchain, "gcov"),
-        "LLVM_COV": _tool_path(cc_toolchain, "llvm-cov"),
-        "LLVM_PROFDATA": _tool_path(cc_toolchain, "llvm-profdata"),
+        "COVERAGE_GCOV_PATH": cc_toolchain._tool_paths.get(TOOL_NAMES.gcov, None),
+        "LLVM_COV": cc_toolchain._tool_paths.get(TOOL_NAMES.llvm_cov, None),
+        "LLVM_PROFDATA": cc_toolchain._tool_paths.get(TOOL_NAMES.llvm_profdata, None),
         "GENERATE_LLVM_LCOV": "1" if cc_config.generate_llvm_lcov() else "0",
     }
     for k in list(env.keys()):

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -544,13 +544,21 @@ _TOOL_NAMES_TO_ACTION_NAMES = {
 }
 
 def _tool_or_action_path(cc_toolchain, feature_configuration, tool):
+    # For backwards compatibility with old rulesets, we must fallback
+    # to the old behaviour when feature_configuration doesn't exist
+    if feature_configuration == None:
+        return cc_toolchain._tool_paths.get(tool, None)
+
     action_name = _TOOL_NAMES_TO_ACTION_NAMES.get(tool, None)
     if action_name != None and cc_common.action_is_enabled(feature_configuration = feature_configuration, action_name = action_name):
         return cc_common.get_tool_for_action(feature_configuration = feature_configuration, action_name = action_name)
     else:
         return cc_toolchain._tool_paths.get(tool, None)
 
-def _get_toolchain_global_make_variables(feature_configuration, cc_toolchain):
+# feature_configuration is an optional parameter so that existing rules
+# that call this function continue to work. We will fallback to the
+# original behaviour if no feature_configuration is passed in.
+def _get_toolchain_global_make_variables(cc_toolchain, feature_configuration = None):
     result = {
         "CC": _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.gcc),
         "AR": _tool_or_action_path(cc_toolchain, feature_configuration, TOOL_NAMES.ar),

--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -516,8 +516,8 @@ _TOOL_NAMES_TO_ACTION_NAMES = {
 }
 
 def _tool_or_action_path(cc_toolchain, feature_configuration, tool):
-    action_name = _TOOL_NAMES_TO_ACTION_NAMES.get(tool, "")
-    if cc_common.action_is_enabled(feature_configuration = feature_configuration, action_name = action_name):
+    action_name = _TOOL_NAMES_TO_ACTION_NAMES.get(tool, None)
+    if action_name != None and cc_common.action_is_enabled(feature_configuration = feature_configuration, action_name = action_name):
         return cc_common.get_tool_for_action(feature_configuration = feature_configuration, action_name = action_name)
     else:
         return cc_toolchain._tool_paths.get(tool, None)

--- a/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
@@ -153,7 +153,7 @@ def _cc_import_impl(ctx):
             linker_inputs = depset([linker_input]),
         )
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     runtimes_deps = semantics.get_cc_runtimes(ctx, True)

--- a/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
@@ -153,7 +153,7 @@ def _cc_import_impl(ctx):
             linker_inputs = depset([linker_input]),
         )
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration = feature_configuration)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     runtimes_deps = semantics.get_cc_runtimes(ctx, True)

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -52,7 +52,7 @@ def _cc_library_impl(ctx):
     compilation_contexts = cc_helper.get_compilation_contexts_from_deps(interface_deps)
     implementation_compilation_contexts = cc_helper.get_compilation_contexts_from_deps(ctx.attr.implementation_deps)
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     (compilation_context, srcs_compilation_outputs) = cc_common.compile(

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -52,7 +52,7 @@ def _cc_library_impl(ctx):
     compilation_contexts = cc_helper.get_compilation_contexts_from_deps(interface_deps)
     implementation_compilation_contexts = cc_helper.get_compilation_contexts_from_deps(ctx.attr.implementation_deps)
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration = feature_configuration)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     (compilation_context, srcs_compilation_outputs) = cc_common.compile(

--- a/src/main/starlark/builtins_bzl/common/cc/cc_toolchain.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_toolchain.bzl
@@ -137,7 +137,7 @@ def _cc_toolchain_impl(ctx):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    template_vars = cc_toolchain._additional_make_variables | cc_helper.get_toolchain_global_make_variables(cc_toolchain) | cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain)
+    template_vars = cc_toolchain._additional_make_variables | cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain) | cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain)
     template_variable_info = TemplateVariableInfo(template_vars)
     toolchain = ToolchainInfo(
         cc = cc_toolchain,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_toolchain.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_toolchain.bzl
@@ -137,7 +137,7 @@ def _cc_toolchain_impl(ctx):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    template_vars = cc_toolchain._additional_make_variables | cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain) | cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain)
+    template_vars = cc_toolchain._additional_make_variables | cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration = feature_configuration) | cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain)
     template_variable_info = TemplateVariableInfo(template_vars)
     toolchain = ToolchainInfo(
         cc = cc_toolchain,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_alias.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_alias.bzl
@@ -26,8 +26,16 @@ def _impl(ctx):
     cc_toolchain = cc_helper.find_cpp_toolchain(ctx, mandatory = ctx.attr.mandatory)
     if not cc_toolchain:
         return []
+
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
     make_variables = cc_toolchain._additional_make_variables
-    cc_provider_make_variables = cc_helper.get_toolchain_global_make_variables(cc_toolchain)
+    cc_provider_make_variables = cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain)
     template_variable_info = TemplateVariableInfo(make_variables | cc_provider_make_variables)
     toolchain = ToolchainInfo(
         cc = cc_toolchain,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_alias.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_alias.bzl
@@ -35,7 +35,7 @@ def _impl(ctx):
     )
 
     make_variables = cc_toolchain._additional_make_variables
-    cc_provider_make_variables = cc_helper.get_toolchain_global_make_variables(feature_configuration, cc_toolchain)
+    cc_provider_make_variables = cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration = feature_configuration)
     template_variable_info = TemplateVariableInfo(make_variables | cc_provider_make_variables)
     toolchain = ToolchainInfo(
         cc = cc_toolchain,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_provider_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_provider_helper.bzl
@@ -15,7 +15,7 @@
 """A helper for creating CcToolchainProvider."""
 
 load(":common/cc/cc_common.bzl", "cc_common")
-load(":common/cc/cc_helper.bzl", "cc_helper")
+load(":common/cc/cc_helper.bzl", "TOOL_NAMES", "cc_helper")
 load(":common/cc/cc_info.bzl", "CcInfo")
 load(":common/cc/cc_toolchain_info.bzl", "CcToolchainInfo")
 load(":common/cc/fdo/fdo_context.bzl", "create_fdo_context")
@@ -24,20 +24,20 @@ load(":common/paths.bzl", "paths")
 cc_internal = _builtins.internal.cc_internal
 
 _TOOL_PATH_ONLY_TOOLS = [
-    "gcov-tool",
-    "gcov",
-    "llvm-profdata",
-    "llvm-cov",
+    TOOL_NAMES.gcov_tool,
+    TOOL_NAMES.gcov,
+    TOOL_NAMES.llvm_profdata,
+    TOOL_NAMES.llvm_cov,
 ]
 
 _REQUIRED_TOOLS = [
-    "ar",
-    "cpp",
-    "gcc",
-    "ld",
-    "nm",
-    "objdump",
-    "strip",
+    TOOL_NAMES.ar,
+    TOOL_NAMES.cpp,
+    TOOL_NAMES.gcc,
+    TOOL_NAMES.ld,
+    TOOL_NAMES.nm,
+    TOOL_NAMES.objdump,
+    TOOL_NAMES.strip,
 ]
 
 _SYSROOT_START = "%sysroot%/"

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderTest.java
@@ -205,7 +205,7 @@ public class CcToolchainProviderTest extends BuildViewTestCase {
       StarlarkThread thread = StarlarkThread.createTransient(mu, StarlarkSemantics.DEFAULT);
       Dict<?, ?> makeVarsDict =
           (Dict<?, ?>)
-              Starlark.positionalOnlyCall(thread, getMakeVariables, FeatureConfigurationForStarlark.from(featureConfiguration), ccToolchainProvider.getValue());
+              Starlark.positionalOnlyCall(thread, getMakeVariables, ccToolchainProvider.getValue(), FeatureConfigurationForStarlark.from(featureConfiguration));
       return ImmutableMap.copyOf(
           Dict.cast(makeVarsDict, String.class, String.class, "make_vars_for_test"));
     }


### PR DESCRIPTION
This change makes `cc_helper.get_toolchain_global_make_variables` consider `action_config`s for tool paths before looking at `tool_path`s. This allows toolchains that can't or don't specify `tool_path`s to have make variables such as `$CC` and `$LD` specified correctly.

The mapping from make variable to action name is:

`$AR` -> `ACTION_NAMES.cpp_link_static_library`
`$CC` -> `ACTION_NAMES.c_compile`
`$LD` -> `ACTION_NAMES.cpp_link_executable`
`$OBJCOPY` -> `ACTION_NAMES.objcopy_embed_data`
`$STRIP` -> `ACTION_NAMES.strip`

All other toolchain make variables are unchanged either because they don't map to tools, or the mapping wasn't obvious to me. I would be happy to change the mappings if there are better ones.

My understanding is that `cc_helper` is not exposed publicly, so this is not a public API breaking change. It is _possibly_ a change of output for any existing `cc_toolchain`s, but I believe the toolchains in `rules_cc` won't change as they either don't specify `action_config`s for these actions, or they don't specify `tool_path`s at all and these variables just don't work.

Fixes #25887