### PR TITLE
[8.3.0] Fix crash on lost inputs that are symlinks (#25856)

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/BuildWithoutTheBytesIntegrationTestBase.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.util.CommandBuilder;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.io.RecordingOutErr;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
@@ -2029,6 +2030,7 @@ public abstract class BuildWithoutTheBytesIntegrationTestBase extends BuildInteg
   }
 
   protected void writeSymlinkRule() throws IOException {
+    FileSystemUtils.touchFile(getWorkspace().getRelative("BUILD"));
     write(
         "symlink.bzl",
         """


### PR DESCRIPTION
The downloads in `AbstractActionInputPrefetcher#prefetchInputs` reported lost inputs that are symlinks to other artifacts with the exec path of the target, which results in a crash when the target is not also an input to the action. This is fixed by always reporting the exec path of the symlink.

Fixes #25841

Closes #25847.

PiperOrigin-RevId: 747819887
Change-Id: Iff9125c95a2598851b8a31ed4ca18fd7218a97aa  (cherry picked from commit a7da0d8e693b6c73a99a8bb7ebff6611fbd994ab)

Closes #25849

Commit https://github.com/bazelbuild/bazel/commit/74da5dd52ecb2a7a3573121ea028992e8e827723