### PR TITLE
Remove Fedora link from /start

### DIFF
--- a/site/en/start/_index.yaml
+++ b/site/en/start/_index.yaml
@@ -48,10 +48,6 @@ landing_page:
       path: /install/windows
       custom_image:
         path: /install/images/windows.svg
-    - description: Fedora and CentOS
-      path: /install/redhat
-      custom_image:
-        path: /install/images/redhat.svg
     - description: Ubuntu
       path: /install/ubuntu
       custom_image:


### PR DESCRIPTION
The link 404s now and there is no official package

Closes #25832