### PR TITLE
Restrict "select() on cpu is deprecated" messages to main repo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -338,7 +338,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
       return false;
     }
 
-    if (DEPRECATED_FLAGS.contains(optionName)) {
+    if (DEPRECATED_FLAGS.contains(optionName) && ruleContext.getLabel().getRepository().equals(RepositoryName.MAIN)) {
       ruleContext.ruleWarning(
           String.format(
               "select() on %s is deprecated. Use platform constraints instead:"

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -338,7 +338,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
       return false;
     }
 
-    if (DEPRECATED_FLAGS.contains(optionName) && ruleContext.getLabel().getRepository().equals(RepositoryName.MAIN)) {
+    if (DEPRECATED_FLAGS.contains(optionName) && ruleContext.getLabel().getRepository().isMain()) {
       ruleContext.ruleWarning(
           String.format(
               "select() on %s is deprecated. Use platform constraints instead:"


### PR DESCRIPTION
De-spamifies Bazel output: see https://github.com/bazelbuild/bazel/issues/24751

Fixes https://github.com/bazelbuild/bazel/issues/24751.

**Before**:

```
$ USE_BAZEL_VERSION=last_green bazelisk build //src:bazel
WARNING: /usr/local/google/home/gregce/bazel/bazel/src/conditions/BUILD:202:15: in config_setting rule //src/conditions:windows_arm64_flag: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
WARNING: /usr/local/google/home/gregce/bazel/bazel/src/conditions/BUILD:193:15: in config_setting rule //src/conditions:windows_x64_arm64_flag: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
WARNING: /usr/local/google/home/gregce/bazel/bazel/src/conditions/BUILD:119:15: in config_setting rule //src/conditions:darwin_arm64_flag: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
WARNING: /usr/local/google/home/gregce/.cache/bazel/_bazel_gregce/f3225a9149c7f352719f88e5dbaca22d/external/bazel_tools/src/conditions/BUILD:149:15: in config_setting rule @@bazel_tools//src/conditions:host_windows_arm64_constraint: select() on host_cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
WARNING: /usr/local/google/home/gregce/.cache/bazel/_bazel_gregce/f3225a9149c7f352719f88e5dbaca22d/external/bazel_tools/src/conditions/BUILD:144:15: in config_setting rule @@bazel_tools//src/conditions:host_windows_x64_constraint: select() on host_cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
WARNING: /usr/local/google/home/gregce/.cache/bazel/_bazel_gregce/f3225a9149c7f352719f88e5dbaca22d/external/protobuf+/build_defs/BUILD.bazel:88:15: in config_setting rule @@protobuf+//build_defs:config_android-default: select() on crosstool_top is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
WARNING: /usr/local/google/home/gregce/.cache/bazel/_bazel_gregce/f3225a9149c7f352719f88e5dbaca22d/external/protobuf+/build_defs/BUILD.bazel:59:15: in config_setting rule @@protobuf+//build_defs:config_android-legacy-default-crosstool: select() on crosstool_top is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
...
```

**After**:

```
$ b/bazel_dev build //src:bazel
WARNING: /usr/local/google/home/gregce/bazel/bazel/src/conditions/BUILD:202:15: in config_setting rule //src/conditions:windows_arm64_flag: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
WARNING: /usr/local/google/home/gregce/bazel/bazel/src/conditions/BUILD:193:15: in config_setting rule //src/conditions:windows_x64_arm64_flag: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
WARNING: /usr/local/google/home/gregce/bazel/bazel/src/conditions/BUILD:119:15: in config_setting rule //src/conditions:darwin_arm64_flag: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
```