### PR TITLE
Deprecate `ctx.configuration.host_path_separator`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/BuildConfigurationApi.java
@@ -43,7 +43,16 @@ public interface BuildConfigurationApi extends StarlarkValue {
   @StarlarkMethod(
       name = "host_path_separator",
       structField = true,
-      doc = "Returns the separator for PATH environment variable, which is ':' on Unix.")
+      doc =
+          """
+          Deprecated: This returns the path separator for the OS on which Bazel runs, which may
+          differ from the execution platforms for actions registered by this rule. Instead, use
+          <code>ctx.target_platform_has_constraint</code> to check for
+          <code>@platforms//os:windows</code>, possibly in a dependency with
+          <code>cfg = "exec"</code>.
+          <p>Returns the separator for PATH environment variable, which is ':' on Unix.
+          """)
+  @Deprecated
   String getHostPathSeparator();
 
   @StarlarkMethod(


### PR DESCRIPTION
Using this field for its intended purpose is essentially almost incorrect as it is based on the OS of the machine running Bazel, not any execution platform. It can be used to sneakily reason about the local machine in a build rule, but that's discouraged and should be done in a repository rule instead.