### PR TITLE
Use /usr/bin/env bash shebang in shell scripts

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2014 The Bazel Authors. All rights reserved.
 #

--- a/examples/shell/bin.sh
+++ b/examples/shell/bin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/examples/shell/lib.sh
+++ b/examples/shell/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/examples/shell/test.sh
+++ b/examples/shell/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/scripts/bash_completion_test.sh
+++ b/scripts/bash_completion_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/bazel-bisect.sh
+++ b/scripts/bazel-bisect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
@@ -74,7 +74,7 @@ WORKING_DIR="$PWD"
   TMP_BIN=/tmp/bazel.bisect
 
   cat >$BISECT_SCRIPT <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 "$BAZEL_BINARY" build //src:bazel >/dev/null 2>&1 || exit 1
 cp -f bazel-bin/src/bazel "$TMP_BIN"

--- a/scripts/bazel-dev.sh
+++ b/scripts/bazel-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/scripts/bazel_lockfile_merge_test.sh
+++ b/scripts/bazel_lockfile_merge_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All rights reserved.
 #

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/docs/get_workspace_status.sh
+++ b/scripts/docs/get_workspace_status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 The Bazel Authors. All rights reserved.
 #

--- a/scripts/kokoro/release/build_linux.sh
+++ b/scripts/kokoro/release/build_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/scripts/kokoro/release/build_macos.sh
+++ b/scripts/kokoro/release/build_macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/scripts/packages/dmg/create_bazel_dmg.sh
+++ b/scripts/packages/dmg/create_bazel_dmg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/scripts/packages/template_bin.sh
+++ b/scripts/packages/template_bin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/release/relnotes.sh
+++ b/scripts/release/relnotes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/scripts/testenv.sh
+++ b/scripts/testenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/create_java_tools_release.sh
+++ b/src/create_java_tools_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/java_tools/import_deps_checker/javatests/com/google/devtools/build/importdeps/golden_test.sh
+++ b/src/java_tools/import_deps_checker/javatests/com/google/devtools/build/importdeps/golden_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/java_tools/junitrunner/javatests/com/google/testing/coverage/jacoco_runner_integration_tests.sh
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/coverage/jacoco_runner_integration_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All Rights Reserved.
 #

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/antxmlresultwriter_integration_test.sh
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/antxmlresultwriter_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All Rights Reserved.
 #

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/deploy_jar_integration_tests.sh
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/deploy_jar_integration_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2012 The Bazel Authors. All Rights Reserved.
 #

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/junit4_testbridge_integration_tests.sh
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/junit4_testbridge_integration_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All Rights Reserved.
 #

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/stack_trace_integration_tests.sh
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/stack_trace_integration_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2010 The Bazel Authors. All Rights Reserved.
 #

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/system_exit_detecting_test.sh
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/system_exit_detecting_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All Rights Reserved.
 #

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/utf8_test_log_test.sh
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/utf8_test_log_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All Rights Reserved.
 #

--- a/src/main/native/windows/build_windows_jni.sh
+++ b/src/main/native/windows/build_windows_jni.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/main/native/windows/build_windows_jni.sh
+++ b/src/main/native/windows/build_windows_jni.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -18,6 +18,8 @@
 # JVM, so we need to build it with Visual Studio. However, Bazel doesn't
 # support multiple compilers in the same build yet, so we need to hack around
 # this limitation using a genrule.
+
+set -eu
 
 DLL="$1"
 shift 1

--- a/src/main/starlark/tests/builtins_bzl/builtin_test_setup.sh
+++ b/src/main/starlark/tests/builtins_bzl/builtin_test_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/main/starlark/tests/builtins_bzl/builtin_test_setup.sh
+++ b/src/main/starlark/tests/builtins_bzl/builtin_test_setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -eu
 
 # This integration test exists so that we can run our Starlark tests
 # for cc_import with Bazel built from head. Once the Stararlark

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test/cc_shared_library_integration_test.sh
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test/cc_shared_library_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test/testenv.sh
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test/testenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test/cc_static_library_integration_test.sh
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test/cc_static_library_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/main/starlark/tests/builtins_bzl/cc_builtin_tests.sh
+++ b/src/main/starlark/tests/builtins_bzl/cc_builtin_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/main/starlark/tests/builtins_bzl/cc_builtin_tests.sh
+++ b/src/main/starlark/tests/builtins_bzl/cc_builtin_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/merge_zip_files.sh
+++ b/src/merge_zip_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/package-bazel.sh
+++ b/src/package-bazel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/py/bazel/testdata/runfiles_test/bar/bar.sh
+++ b/src/test/py/bazel/testdata/runfiles_test/bar/bar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/py/bazel/testdata/runfiles_test/foo/foo.sh
+++ b/src/test/py/bazel/testdata/runfiles_test/foo/foo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/shell/bazel/allowlist_test.sh
+++ b/src/test/shell/bazel/allowlist_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/apple/bazel_apple_test.sh
+++ b/src/test/shell/bazel/apple/bazel_apple_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/apple/bazel_objc_test.sh
+++ b/src/test/shell/bazel/apple/bazel_objc_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/archive_contents_test.sh
+++ b/src/test/shell/bazel/archive_contents_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
+++ b/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_build_event_stream_test.sh
+++ b/src/test/shell/bazel/bazel_build_event_stream_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -196,7 +196,7 @@ sh_binary(
 EOF
 
   cat > a/arg.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 COUNTER=1
 for i in "$@"; do
@@ -234,7 +234,7 @@ sh_binary(
 EOF
 
   cat > a/arg.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 COUNTER=1
 for i in "$@"; do
@@ -276,7 +276,7 @@ sh_test(
 EOF
 
   cat > a/arg_test.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 COUNTER=1
 for i in "$@"; do
@@ -314,7 +314,7 @@ sh_test(
 EOF
 
   cat > a/arg_test.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 COUNTER=1
 for i in "$@"; do

--- a/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -eu
 
 # Unit tests for tools/test/collect_cc_code_coverage.sh
 

--- a/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_coverage_compatibility_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_compatibility_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 The Bazel Authors. All rights reserved.
 #
@@ -51,11 +51,11 @@ exports_files([
 ])
 EOF
   cat <<EOF > compatible_test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 EOF
   cat <<EOF > incompatible_test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 exit 1
 EOF
   chmod +x compatible_test.sh

--- a/src/test/shell/bazel/bazel_coverage_hermetic_py_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_hermetic_py_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_coverage_py_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_py_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_coverage_sh_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_sh_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -53,7 +53,7 @@ sh_library(
 )
 EOF
   cat <<EOF > orange-test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 
 java/com/google/orange/orange-bin
 EOF
@@ -168,7 +168,7 @@ sh_test(
 )
 EOF
   cat <<EOF > num-test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 
 examples/cpp/num-world
 EOF
@@ -317,7 +317,7 @@ sh_test(
 )
 EOF
   cat <<EOF > num-test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 
 examples/cpp/num-world
 java/com/google/orange/orange-bin
@@ -529,7 +529,7 @@ sh_test(
 )
 EOF
   cat <<'EOF' > pull-test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 touch $COVERAGE_DIR/foo.txt
 # We need a non-empty coverage.dat file for the checks below to work.
 echo "FN:2,com/google/orange/orangeLib::<init> ()V" > $COVERAGE_OUTPUT_FILE

--- a/src/test/shell/bazel/bazel_coverage_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_starlark_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Bazel Authors. All rights reserved.
 #
@@ -49,7 +49,7 @@ function test_starlark_rule_without_lcov_merger() {
 def _impl(ctx):
     output = ctx.actions.declare_file(ctx.attr.name)
     ctx.actions.write(output, """\
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ! -r extra ]]; then
   echo "extra file not found" >&2

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_docgen_test.sh
+++ b/src/test/shell/bazel/bazel_docgen_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_docker_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_docker_sandboxing_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_embedded_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_embedded_starlark_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_example_test.sh
+++ b/src/test/shell/bazel/bazel_example_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_execlog_test.sh
+++ b/src/test/shell/bazel/bazel_execlog_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_execute_testlog.sh
+++ b/src/test/shell/bazel/bazel_execute_testlog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_hermetic_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_hermetic_sandboxing_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_java17_test.sh
+++ b/src/test/shell/bazel/bazel_java17_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -1648,7 +1648,7 @@ sh_test(
 EOF
 
   cat > "${pkg}"/run.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_java_test_defaults_prebuilt.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults_prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_java_test_no_windows.sh
+++ b/src/test/shell/bazel/bazel_java_test_no_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_java_tools_dist_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_dist_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_layering_check_test.sh
+++ b/src/test/shell/bazel/bazel_layering_check_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_localtest_test.sh
+++ b/src/test/shell/bazel/bazel_localtest_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_package_loader_test.sh
+++ b/src/test/shell/bazel/bazel_package_loader_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_permissions_test.sh
+++ b/src/test/shell/bazel/bazel_permissions_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_proto_library_test.sh
+++ b/src/test/shell/bazel/bazel_proto_library_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_random_characters_test.sh
+++ b/src/test/shell/bazel/bazel_random_characters_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_repository_cache_test.sh
+++ b/src/test/shell/bazel/bazel_repository_cache_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_rules_cc_test.sh
+++ b/src/test/shell/bazel/bazel_rules_cc_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_rules_java_override_test.sh
+++ b/src/test/shell/bazel/bazel_rules_java_override_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_rules_java_test.sh
+++ b/src/test/shell/bazel/bazel_rules_java_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -105,7 +105,7 @@ function test_extra_action() {
   # action file. This file is a proto, but I don't want to bother implementing
   # a program that parses the proto here.
   cat > mypkg/echoer.sh << 'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # --- begin runfiles.bash initialization ---
 if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then

--- a/src/test/shell/bazel/bazel_sandboxing_cpp_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_cpp_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_sandboxing_networking_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_networking_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -203,7 +203,7 @@ mkdata = rule(
 EOF
 
   cat > mkdata_test.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/src/test/shell/bazel/bazel_spawnstats_test.sh
+++ b/src/test/shell/bazel/bazel_spawnstats_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_strategy_test.sh
+++ b/src/test/shell/bazel/bazel_strategy_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_symlink_test.sh
+++ b/src/test/shell/bazel/bazel_symlink_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -524,7 +524,7 @@ function write_test_xml_timeout_files() {
   add_rules_shell "MODULE.bazel"
 
   cat <<'EOF' > dir/test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 echo "xmltest"
 echo -n "before "
 # Invalid XML character
@@ -859,7 +859,7 @@ function setup_undeclared_outputs_test() {
   add_rules_shell "MODULE.bazel"
 
   cat <<'EOF' > dir/test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 mkdir -p "$TEST_UNDECLARED_OUTPUTS_DIR/deeply/nested"
 echo "some text" > "$TEST_UNDECLARED_OUTPUTS_DIR/text.txt"
 echo "<!DOCTYPE html>" > "$TEST_UNDECLARED_OUTPUTS_DIR/deeply/nested/index.html"

--- a/src/test/shell/bazel/bazel_thinlto_obj_dir_test.sh
+++ b/src/test/shell/bazel/bazel_thinlto_obj_dir_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_thinlto_test.sh
+++ b/src/test/shell/bazel/bazel_thinlto_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_tools_test.sh
+++ b/src/test/shell/bazel/bazel_tools_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_ui_test.sh
+++ b/src/test/shell/bazel/bazel_ui_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/bazel_with_jdk_test.sh
+++ b/src/test/shell/bazel/bazel_with_jdk_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
@@ -158,7 +158,7 @@ function test_bazel_detects_local_jdk_version8() {
   touch jdk/bin/javac
   chmod +x jdk/bin/javac
   cat >jdk/bin/java <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo " Property settings:" >&2
 echo "  java.version = 1.8.0 " >&2
@@ -193,7 +193,7 @@ function test_bazel_detects_local_jdk_version11() {
   touch jdk/bin/javac
   chmod +x jdk/bin/javac
   cat >jdk/bin/java <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo " Property settings:" >&2
 echo "  java.version = 11.0.1 " >&2
@@ -228,7 +228,7 @@ function test_bazel_detects_local_jdk_version11_with_only_major() {
   touch jdk/bin/javac
   chmod +x jdk/bin/javac
   cat >jdk/bin/java <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo " Property settings:" >&2
 echo "  java.version = 11 " >&2
@@ -263,7 +263,7 @@ function test_bazel_gracefully_handles_unknown_java() {
   touch jdk/bin/javac
   chmod +x jdk/bin/javac
   cat >jdk/bin/java <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo " Property settings:" >&2
 echo "  java.version = xxx.superfuture.version " >&2

--- a/src/test/shell/bazel/bazel_workspace_status_test.sh
+++ b/src/test/shell/bazel/bazel_workspace_status_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -24,7 +24,7 @@ function test_workspace_status_parameters() {
 
   local cmd=`mktemp $TEST_TMPDIR/wsc-XXXXXXXX`
   cat > $cmd <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo BUILD_SCM_STATUS funky
 EOF
@@ -50,7 +50,7 @@ function test_workspace_status_overrides() {
 
   local cmd=`mktemp $TEST_TMPDIR/wsc-XXXXXXXX`
   cat > $cmd <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo BUILD_USER fake_user
 echo BUILD_HOST fake_host
@@ -83,7 +83,7 @@ function test_workspace_status_cpp() {
 
   local cmd=`mktemp $TEST_TMPDIR/wsc-XXXXXXXX`
   cat > $cmd <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo BUILD_SCM_STATUS funky
 EOF
@@ -144,7 +144,7 @@ function test_stable_and_volatile_status() {
   create_new_workspace
   local wsc=`mktemp $TEST_TMPDIR/wsc-XXXXXXXX`
   cat >$wsc <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 cat $TEST_TMPDIR/status
 EOF
@@ -218,7 +218,7 @@ function test_env_var_in_workspace_status() {
   create_new_workspace
   local wsc=`mktemp $TEST_TMPDIR/wsc-XXXXXXXX`
   cat >$wsc <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "STABLE_ENV" ${STABLE_VAR}
 echo "VOLATILE_ENV" ${VOLATILE_VAR}

--- a/src/test/shell/bazel/bazel_wrapper_test.sh
+++ b/src/test/shell/bazel/bazel_wrapper_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
@@ -47,7 +47,7 @@ wrapper=$(rlocation io_bazel/scripts/packages/bazel.sh)
 mock_bazel() {
   {
     cat <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 if [[ ${1:-""} == "--version" ]]; then
   echo "bazel BAZEL_VERSION"
@@ -234,7 +234,7 @@ test_delegates_to_wrapper_if_present() {
 
   mkdir tools
   cat > tools/bazel <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 echo "Hello from the wrapper tools/bazel!"
 echo "BAZEL_REAL = ${BAZEL_REAL}"
@@ -261,7 +261,7 @@ test_bazel_wrapper_envvar() {
 
   mkdir tooling
   cat > tooling/bazel <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 echo "Hello from the wrapper tooling/bazel!"
 echo "BAZEL_REAL = ${BAZEL_REAL}"
@@ -281,7 +281,7 @@ test_gracefully_handles_bogus_bazelversion() {
 
   mkdir tools
   cat > tools/bazel <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 echo "Hello from the wrapper tools/bazel!"
 echo "My args: $@"

--- a/src/test/shell/bazel/bazel_wrapper_test.sh
+++ b/src/test/shell/bazel/bazel_wrapper_test.sh
@@ -75,6 +75,8 @@ setup_mock() {
   mock_bazel "bin/bazel-1.0.1" "1.0.1"
   mock_bazel "bin/bazel-real" "1.1.0"
 
+  ln -s `which bash` bin/bash
+
   # We don't want USE_BAZEL_VERSION passed by --test_env to affect this test.
   unset USE_BAZEL_VERSION
   cd ws

--- a/src/test/shell/bazel/bazel_wrapper_test.sh
+++ b/src/test/shell/bazel/bazel_wrapper_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
@@ -47,7 +47,7 @@ wrapper=$(rlocation io_bazel/scripts/packages/bazel.sh)
 mock_bazel() {
   {
     cat <<'EOF'
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 if [[ ${1:-""} == "--version" ]]; then
   echo "bazel BAZEL_VERSION"
@@ -74,8 +74,6 @@ setup_mock() {
   mock_bazel "bin/bazel-0.29.1" "0.29.1"
   mock_bazel "bin/bazel-1.0.1" "1.0.1"
   mock_bazel "bin/bazel-real" "1.1.0"
-
-  ln -s `which bash` bin/bash
 
   # We don't want USE_BAZEL_VERSION passed by --test_env to affect this test.
   unset USE_BAZEL_VERSION
@@ -236,7 +234,7 @@ test_delegates_to_wrapper_if_present() {
 
   mkdir tools
   cat > tools/bazel <<'EOF'
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 echo "Hello from the wrapper tools/bazel!"
 echo "BAZEL_REAL = ${BAZEL_REAL}"
@@ -263,7 +261,7 @@ test_bazel_wrapper_envvar() {
 
   mkdir tooling
   cat > tooling/bazel <<'EOF'
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 echo "Hello from the wrapper tooling/bazel!"
 echo "BAZEL_REAL = ${BAZEL_REAL}"
@@ -283,7 +281,7 @@ test_gracefully_handles_bogus_bazelversion() {
 
   mkdir tools
   cat > tools/bazel <<'EOF'
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 echo "Hello from the wrapper tools/bazel!"
 echo "My args: $@"

--- a/src/test/shell/bazel/bazelignore_test.sh
+++ b/src/test/shell/bazel/bazelignore_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/build_files_test.sh
+++ b/src/test/shell/bazel/build_files_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/cc_flags_supplier_test.sh
+++ b/src/test/shell/bazel/cc_flags_supplier_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/cc_import_starlark_test.sh
+++ b/src/test/shell/bazel/cc_import_starlark_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/cc_import_starlark_test.sh
+++ b/src/test/shell/bazel/cc_import_starlark_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -17,6 +17,8 @@
 # This integration test exists so that we can run our Starlark tests
 # for cc_import with Bazel built from head. Once the Stararlark
 # implementation can rely on release Bazel, we can add the tests directly.
+
+set -eu
 
 # Load the test setup defined in the parent directory
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -165,7 +165,7 @@ cc_binary(
 )
 EOF
   cat > "ta_headers/mygen.sh" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -597,7 +597,7 @@ function test_aspect_accessing_args_link_action_with_tree_artifact() {
   local package="${FUNCNAME[0]}"
   mkdir -p "${package}"
   cat > "${package}/makes_tree_artifacts.sh" <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 my_dir=\$1
 
 echo "int a() { return 0; }" > \$my_dir/a.cc
@@ -607,7 +607,7 @@ EOF
   chmod 755 "${package}/makes_tree_artifacts.sh"
 
   cat > "${package}/write.sh" <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 output_file=\$1
 shift;
 
@@ -2036,7 +2036,7 @@ generate_source = rule(
 )
 EOF
   cat > pkg/generate.sh <<'EOF2'
-#!/bin/bash
+#!/usr/bin/env bash
 
 OUTPUT_DIR=$1
 

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 # Tests the behavior of C++ rules.
+
+set -eu
 
 # Load the test setup defined in the parent directory
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/test/shell/bazel/check_external_files_test.sh
+++ b/src/test/shell/bazel/check_external_files_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/client_test.sh
+++ b/src/test/shell/bazel/client_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/shell/bazel/command_profiler_test.sh
+++ b/src/test/shell/bazel/command_profiler_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/coverage_helpers.sh
+++ b/src/test/shell/bazel/coverage_helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/cpp_darwin_integration_test.sh
+++ b/src/test/shell/bazel/cpp_darwin_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/disk_cache_test.sh
+++ b/src/test/shell/bazel/disk_cache_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/embedded_tools_deps_test.sh
+++ b/src/test/shell/bazel/embedded_tools_deps_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/empty_package_test.sh
+++ b/src/test/shell/bazel/empty_package_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/execroot_test.sh
+++ b/src/test/shell/bazel/execroot_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/external_correctness_test.sh
+++ b/src/test/shell/bazel/external_correctness_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/external_patching_test.sh
+++ b/src/test/shell/bazel/external_patching_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/external_path_test.sh
+++ b/src/test/shell/bazel/external_path_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/external_remote_file_test.sh
+++ b/src/test/shell/bazel/external_remote_file_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/external_starlark_execute_test.sh
+++ b/src/test/shell/bazel/external_starlark_execute_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/external_starlark_load_test.sh
+++ b/src/test/shell/bazel/external_starlark_load_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/generate_xml_test.sh
+++ b/src/test/shell/bazel/generate_xml_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/help_test.sh
+++ b/src/test/shell/bazel/help_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/java_launcher_test.sh
+++ b/src/test/shell/bazel/java_launcher_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/jdeps_test.sh
+++ b/src/test/shell/bazel/jdeps_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/location_test.sh
+++ b/src/test/shell/bazel/location_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/maven_starlark_test.sh
+++ b/src/test/shell/bazel/maven_starlark_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/new_local_repo_test.sh
+++ b/src/test/shell/bazel/new_local_repo_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/platforms_test.sh
+++ b/src/test/shell/bazel/platforms_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/profile_test.sh
+++ b/src/test/shell/bazel/profile_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/python_version_test.sh
+++ b/src/test/shell/bazel/python_version_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -1556,7 +1556,7 @@ java_test(
 EOF
 
   cat > a/test.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo 'Hello'
 EOF
   chmod a+x a/test.sh
@@ -2432,7 +2432,7 @@ sh_binary(
 )
 EOF
   cat > foo.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 if ! [[ -f "$0.runfiles/_main/out.txt" ]]; then
   echo "runfile $0.runfiles/_main/out.txt not found" 1>&2
   exit 1

--- a/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
+++ b/src/test/shell/bazel/remote/remote_build_event_uploader_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/remote/remote_execution_http_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_http_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/remote/remote_execution_sandboxing_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_sandboxing_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -827,7 +827,7 @@ sh_test(
 EOF
 
   cat > a/sleep.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 for i in {1..3}
 do
     echo "Sleeping $i..."
@@ -1249,7 +1249,7 @@ function test_nobuild_runfile_links() {
   mkdir data && echo "hello" > data/hello && echo "world" > data/world
   add_rules_shell "MODULE.bazel"
   cat > test.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 [[ -f ${RUNFILES_DIR}/_main/data/hello ]]
 [[ -f ${RUNFILES_DIR}/_main/data/world ]]

--- a/src/test/shell/bazel/remote/remote_execution_tls_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_tls_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/remote/remote_execution_with_xattr_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_with_xattr_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/remote/remote_utils.sh
+++ b/src/test/shell/bazel/remote/remote_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/remote_helpers.sh
+++ b/src/test/shell/bazel/remote_helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/repository_abort_test.sh
+++ b/src/test/shell/bazel/repository_abort_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/resource_compiler_toolchain_test.sh
+++ b/src/test/shell/bazel/resource_compiler_toolchain_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
@@ -129,7 +129,7 @@ dir /s /b /o:n *.dat>>%out%
 eof
   else
     cat > "toolchains/rc-src.bat" <<'eof'
-#!/bin/bash
+#!/usr/bin/env bash
 for a in $*; do
   if [[ "$a" =~ /fo.* ]]; then
     out="${a#/fo}"

--- a/src/test/shell/bazel/rule_test_test.sh
+++ b/src/test/shell/bazel/rule_test_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/run_test.sh
+++ b/src/test/shell/bazel/run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/runfiles_test.sh
+++ b/src/test/shell/bazel/runfiles_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -132,7 +132,7 @@ function test_nobuild_runfile_links() {
   mkdir data && echo "hello" > data/hello && echo "world" > data/world
 
   cat > test.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 [[ -f ${RUNFILES_DIR}/_main/data/hello ]]
 [[ -f ${RUNFILES_DIR}/_main/data/world ]]
@@ -175,14 +175,14 @@ function test_nobuild_runfile_links_with_run_under() {
   mkdir data && echo "hello" > data/hello && echo "world" > data/world
 
   cat > hello.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 [[ -f $0.runfiles/_main/data/hello ]]
 exec "$@"
 EOF
 
   cat > world.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 [[ -f $0.runfiles/_main/data/world ]]
 exit 0

--- a/src/test/shell/bazel/srcs_test.sh
+++ b/src/test/shell/bazel/srcs_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/starlark_rule_test.sh
+++ b/src/test/shell/bazel/starlark_rule_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
@@ -127,7 +127,7 @@ foo = rule(
 EOF
 
   cat >bin.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo hello $0 > $1
 EOF
   chmod +x bin.sh

--- a/src/test/shell/bazel/tags_propagation_native_test.sh
+++ b/src/test/shell/bazel/tags_propagation_native_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/tags_propagation_starlark_test.sh
+++ b/src/test/shell/bazel/tags_propagation_starlark_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/unicode_filenames_test.sh
+++ b/src/test/shell/bazel/unicode_filenames_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/unix_digest_hash_attribute_name_test.sh
+++ b/src/test/shell/bazel/unix_digest_hash_attribute_name_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/verify_workspace.sh
+++ b/src/test/shell/bazel/verify_workspace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/bazel/windows_arg_esc_test.sh
+++ b/src/test/shell/bazel/windows_arg_esc_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/action_aspect_test.sh
+++ b/src/test/shell/integration/action_aspect_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
@@ -56,7 +56,7 @@ add_to_bazelrc "build --package_path=%workspace%"
 function test_directory_args_inspection() {
   mkdir -p package
   cat > package/makes_tree_artifacts.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 my_dir=\$1
 
 touch \$my_dir/a.txt
@@ -66,7 +66,7 @@ EOF
   chmod 755 package/makes_tree_artifacts.sh
 
   cat > package/write.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 output_file=\$1
 shift;
 
@@ -137,7 +137,7 @@ EOF
 function test_directory_args_inspection_param_file() {
   mkdir -p package
   cat > package/makes_tree_artifacts.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 my_dir=\$1
 
 touch \$my_dir/a.txt
@@ -147,7 +147,7 @@ EOF
   chmod 755 package/makes_tree_artifacts.sh
 
   cat > package/write.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 param_file=\$1
 shift;
@@ -346,7 +346,7 @@ function test_aspect_requires_aspect_no_action_conflict() {
   mkdir -p "${package}"
 
   cat > "${package}/write.sh" <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 output_file=\$1
 unused_file=\$2
 

--- a/src/test/shell/integration/action_env_test.sh
+++ b/src/test/shell/integration/action_env_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/analysis_phase_options_test.sh
+++ b/src/test/shell/integration/analysis_phase_options_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/analysis_test_test.sh
+++ b/src/test/shell/integration/analysis_test_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/aquery_test.sh
+++ b/src/test/shell/integration/aquery_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
@@ -424,7 +424,7 @@ foo(
 )
 EOF
   cat > "$pkg/tool.sh" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "$1" > "$2"
 EOF
   chmod +x "$pkg/tool.sh"

--- a/src/test/shell/integration/aspect_test.sh
+++ b/src/test/shell/integration/aspect_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/bash_runfiles_v1_test.sh
+++ b/src/test/shell/integration/bash_runfiles_v1_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/bazel_aquery_test.sh
+++ b/src/test/shell/integration/bazel_aquery_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/bazel_command_log_test.sh
+++ b/src/test/shell/integration/bazel_command_log_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/bazel_java_test.sh
+++ b/src/test/shell/integration/bazel_java_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ function test_server_javabase() {
   MAGIC="the cake is a lie"
 
   cat << EOF > test_server_javabase/bin/java
-#!/bin/bash
+#!/usr/bin/env bash
 echo "$MAGIC"
 EOF
   chmod +x test_server_javabase/bin/java

--- a/src/test/shell/integration/bazel_javabase_test.sh
+++ b/src/test/shell/integration/bazel_javabase_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/bazel_testjobs_test.sh
+++ b/src/test/shell/integration/bazel_testjobs_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/bazel_worker_test.sh
+++ b/src/test/shell/integration/bazel_worker_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/build_event_stream_test.sh
+++ b/src/test/shell/integration/build_event_stream_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -1544,7 +1544,7 @@ sh_test(name="a", srcs=["a.sh"])
 EOF
 
   cat > a/a.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 EOF
 

--- a/src/test/shell/integration/builtins_injection_test.sh
+++ b/src/test/shell/integration/builtins_injection_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/client_sigint_test.sh
+++ b/src/test/shell/integration/client_sigint_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -427,7 +427,7 @@ EOF
   # - one of "read" or "write"
   # - the path to the fifo
   cat > x/x.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$1" == "read" ]]; then
   cat "$2" > /dev/null
 elif [[ "$1" == "write" ]]; then

--- a/src/test/shell/integration/config_stripped_outputs_lib.sh
+++ b/src/test/shell/integration/config_stripped_outputs_lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/config_stripped_outputs_test.sh
+++ b/src/test/shell/integration/config_stripped_outputs_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/cpp_test.sh
+++ b/src/test/shell/integration/cpp_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/discard_analysis_cache_test.sh
+++ b/src/test/shell/integration/discard_analysis_cache_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/discard_graph_edges_lib.sh
+++ b/src/test/shell/integration/discard_graph_edges_lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/discard_graph_edges_test.sh
+++ b/src/test/shell/integration/discard_graph_edges_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/dump_test.sh
+++ b/src/test/shell/integration/dump_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/exec_group_test.sh
+++ b/src/test/shell/integration/exec_group_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
@@ -233,7 +233,7 @@ function test_target_test_properties_sh_test() {
   local -r pkg=${FUNCNAME[0]}
   mkdir $pkg || fail "mkdir $pkg"
   cat > ${pkg}/a.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 echo hello
 EOF
   chmod u+x ${pkg}/a.sh

--- a/src/test/shell/integration/execution_phase_tests.sh
+++ b/src/test/shell/integration/execution_phase_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/execution_statistics_utils.sh
+++ b/src/test/shell/integration/execution_statistics_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/execution_strategies_test.sh
+++ b/src/test/shell/integration/execution_strategies_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/flags_scoping_integration_tests.sh
+++ b/src/test/shell/integration/flags_scoping_integration_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/flagset_test.sh
+++ b/src/test/shell/integration/flagset_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All rights reserved.
 #
@@ -126,7 +126,7 @@ EOF
 
   touch other/other.sh
   cat > other/other.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 echo hi
 EOF
 
@@ -159,7 +159,7 @@ EOF
 
   touch other/other.sh
   cat > other/other.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 echo hi
 EOF
 

--- a/src/test/shell/integration/focus_test.sh
+++ b/src/test/shell/integration/focus_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/force_delete_output_test.sh
+++ b/src/test/shell/integration/force_delete_output_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/implicit_dependency_reporting_test.sh
+++ b/src/test/shell/integration/implicit_dependency_reporting_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/incompatible_autoload_externally_test.sh
+++ b/src/test/shell/integration/incompatible_autoload_externally_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/info_test.sh
+++ b/src/test/shell/integration/info_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/java_integration_test.sh
+++ b/src/test/shell/integration/java_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/java_sandboxing_test.sh
+++ b/src/test/shell/integration/java_sandboxing_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/jvm_flags_escaping_test.sh
+++ b/src/test/shell/integration/jvm_flags_escaping_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/linux-sandbox_network_test.sh
+++ b/src/test/shell/integration/linux-sandbox_network_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/linux-sandbox_test.sh
+++ b/src/test/shell/integration/linux-sandbox_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -415,7 +415,7 @@ function test_cgroups1_memory_limit() {
     return 0
   fi
   cat >${TEST_TMPDIR}/run_sandbox_with_cgroups.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # Runs the sandbox with appropriate cgroups setup
 cgroups_self=$memdir
@@ -452,7 +452,7 @@ function test_cgroups2_memory_limit() {
     return 0
   fi
   cat >${TEST_TMPDIR}/run_sandbox_with_cgroups.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # Runs the sandbox with appropriate cgroups setup
 cgroups_self=/sys/fs/cgroup\$( cut -d: -f3- /proc/self/cgroup)

--- a/src/test/shell/integration/loading_phase_posix_test.sh
+++ b/src/test/shell/integration/loading_phase_posix_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/minimal_jdk_test.sh
+++ b/src/test/shell/integration/minimal_jdk_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/modify_execution_info_test.sh
+++ b/src/test/shell/integration/modify_execution_info_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/nestedset_as_skykey_test.sh
+++ b/src/test/shell/integration/nestedset_as_skykey_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/nojdk_startup_options_test.sh
+++ b/src/test/shell/integration/nojdk_startup_options_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/nonincremental_builds_test.sh
+++ b/src/test/shell/integration/nonincremental_builds_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/output_filter_test.sh
+++ b/src/test/shell/integration/output_filter_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -260,7 +260,7 @@ EOF
   local status_cmd="$TEST_TMPDIR/status_cmd.sh"
 
   cat >"$status_cmd" <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo 'STATUS_COMMAND_RAN' >&2
 EOF

--- a/src/test/shell/integration/outputs_test.sh
+++ b/src/test/shell/integration/outputs_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/param_file_flag_per_line_test.sh
+++ b/src/test/shell/integration/param_file_flag_per_line_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/platform_based_flags_test.sh
+++ b/src/test/shell/integration/platform_based_flags_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2024 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/platform_mapping_test.sh
+++ b/src/test/shell/integration/platform_mapping_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/prelude_test.sh
+++ b/src/test/shell/integration/prelude_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/process-wrapper_test.sh
+++ b/src/test/shell/integration/process-wrapper_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/profiler_test.sh
+++ b/src/test/shell/integration/profiler_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/progress_reporting_test.sh
+++ b/src/test/shell/integration/progress_reporting_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/py_args_escaping_test.sh
+++ b/src/test/shell/integration/py_args_escaping_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/python_stub_test.sh
+++ b/src/test/shell/integration/python_stub_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
@@ -136,7 +136,7 @@ sh_binary(
 EOF
 
   cat > python_through_bash/outer.sh << EOF
-#!/bin/bash
+#!/usr/bin/env bash
 # * Bazel run guarantees that our CWD is the runfiles directory itself, so a
 #   relative path will work.
 # * We can't use the usual shell runfiles library because it doesn't work in the

--- a/src/test/shell/integration/python_test.sh
+++ b/src/test/shell/integration/python_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/rc_options_test.sh
+++ b/src/test/shell/integration/rc_options_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/rule_transition_test.sh
+++ b/src/test/shell/integration/rule_transition_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -527,7 +527,7 @@ sh_test(name = "x", srcs = ["x.sh"])
 sh_binary(name = "control", srcs = ["x.sh"])
 eof
   cat > a/x.sh <<'eof'
-#!/bin/bash
+#!/usr/bin/env bash
 read -n5 FOO
 echo "foo=($FOO)"
 eof
@@ -773,7 +773,7 @@ sh_binary(
 )
 EOF
   cat > "$pkg/foo.sh" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo build_id=\"${BUILD_ID}\"
 EOF
 
@@ -800,7 +800,7 @@ sh_binary(
 )
 EOF
   cat > "$pkg/foo.sh" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo execroot=\"${BUILD_EXECROOT}\"
 EOF
 
@@ -831,7 +831,7 @@ sh_binary(
 )
 EOF
   cat > "$pkg/foo.sh" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -866,7 +866,7 @@ sh_binary(
 )
 EOF
   cat > "$pkg/foo.sh" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/src/test/shell/integration/runfiles_test.sh
+++ b/src/test/shell/integration/runfiles_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -596,7 +596,7 @@ sh_test(
 EOF
   if "$is_windows"; then
     cat > pkg/foo.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$(cat $'pkg/a b .txt')" != "my content" ]]; then
   echo "unexpected content or not found"
   exit 1
@@ -604,7 +604,7 @@ fi
 EOF
   else
     cat > pkg/foo.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$(cat $'pkg/a \n \\ b .txt')" != "my content" ]]; then
   echo "unexpected content or not found"
   exit 1
@@ -654,7 +654,7 @@ sh_test(
 )
 EOF
   cat > pkg/foo.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$(cat pkg/data.txt)" != "my content" ]]; then
   echo "unexpected content or not found"
   exit 1
@@ -700,7 +700,7 @@ sh_test(
 EOF
   if "$is_windows"; then
     cat > pkg/foo.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$(cat $'pkg/a b .txt')" != "my content" ]]; then
   echo "unexpected content or not found"
   exit 1
@@ -708,7 +708,7 @@ fi
 EOF
   else
     cat > pkg/foo.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$(cat $'pkg/a \n \\ b .txt')" != "my content" ]]; then
   echo "unexpected content or not found"
   exit 1
@@ -757,7 +757,7 @@ genrule(
 )
 EOF
   cat > pkg/tool.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
 set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash

--- a/src/test/shell/integration/runfiles_test_utils.sh
+++ b/src/test/shell/integration/runfiles_test_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2022 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/sandboxing_test.sh
+++ b/src/test/shell/integration/sandboxing_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/server_logging_test.sh
+++ b/src/test/shell/integration/server_logging_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/stamping_test.sh
+++ b/src/test/shell/integration/stamping_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/starlark_configurations_external_workspaces_test.sh
+++ b/src/test/shell/integration/starlark_configurations_external_workspaces_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/starlark_configurations_test.sh
+++ b/src/test/shell/integration/starlark_configurations_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/starlark_dependency_pruning_test.sh
+++ b/src/test/shell/integration/starlark_dependency_pruning_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/starlark_flag_test.sh
+++ b/src/test/shell/integration/starlark_flag_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/startup_options_test.sh
+++ b/src/test/shell/integration/startup_options_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/stub_finds_runfiles_test.sh
+++ b/src/test/shell/integration/stub_finds_runfiles_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/subrules_test.sh
+++ b/src/test/shell/integration/subrules_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #
@@ -63,13 +63,13 @@ function set_up() {
   add_rules_shell "MODULE.bazel"
   mkdir -p target_skipping || fail "couldn't create directory"
   cat > target_skipping/pass.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 EOF
   chmod +x target_skipping/pass.sh
 
   cat > target_skipping/fail.sh <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 1
 EOF
   chmod +x target_skipping/fail.sh

--- a/src/test/shell/integration/target_compatible_with_test_external_repo.sh
+++ b/src/test/shell/integration/target_compatible_with_test_external_repo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #
@@ -51,13 +51,13 @@ function set_up() {
   add_rules_shell "target_skipping/MODULE.bazel"
   add_rules_cc "target_skipping/MODULE.bazel"
   cat > target_skipping/pass.sh <<EOF || fail "couldn't create pass.sh"
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 EOF
   chmod +x target_skipping/pass.sh
 
   cat > target_skipping/fail.sh <<EOF || fail "couldn't create fail.sh"
-#!/bin/bash
+#!/usr/bin/env bash
 exit 1
 EOF
   chmod +x target_skipping/fail.sh

--- a/src/test/shell/integration/target_pattern_file_test.sh
+++ b/src/test/shell/integration/target_pattern_file_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/test_test.sh
+++ b/src/test/shell/integration/test_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
@@ -266,7 +266,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 sh_test(name = "x", srcs = ["x.sh"])
 EOF
   cat > "$pkg/x.sh" <<'eof'
-#!/bin/bash
+#!/usr/bin/env bash
 read -n5 FOO
 echo "foo=($FOO)"
 eof

--- a/src/test/shell/integration/toolchain_test.sh
+++ b/src/test/shell/integration/toolchain_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/toolchain_transition_test.sh
+++ b/src/test/shell/integration/toolchain_transition_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/unicode_test.sh
+++ b/src/test/shell/integration/unicode_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/validation_actions_test.sh
+++ b/src/test/shell/integration/validation_actions_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
@@ -192,7 +192,7 @@ chmod +x validation_actions/test_with_rule_with_validation_in_deps.sh
 
 function setup_passing_validation_action() {
     cat > validation_actions/validation_tool <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "validation output" > $1
 EOF
   chmod +x validation_actions/validation_tool
@@ -201,7 +201,7 @@ EOF
 
 function setup_failing_validation_action() {
     cat > validation_actions/validation_tool <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "validation failed!"
 exit 1
 EOF
@@ -210,7 +210,7 @@ EOF
 
 function setup_slow_failing_validation_action() {
     cat > validation_actions/validation_tool <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 sleep 10
 echo "validation failed!"
 exit 1
@@ -527,7 +527,7 @@ validation_aspect = aspect(
 )
 EOF
   cat > aspect/aspect_validation_tool <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "aspect validation output" > $1
 EOF
   chmod +x aspect/aspect_validation_tool
@@ -547,7 +547,7 @@ function test_validation_actions_in_rule_and_aspect_no_use_validation_aspect() {
   assert_exists bazel-bin/validation_actions/foo0.aspect_validation
 
   cat > aspect/aspect_validation_tool <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "aspect validation failed!"
 exit 1
 EOF
@@ -572,7 +572,7 @@ function test_validation_actions_in_rule_and_aspect_use_validation_aspect() {
   assert_exists bazel-bin/validation_actions/foo0.aspect_validation
 
   cat > aspect/aspect_validation_tool <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "aspect validation failed!"
 exit 1
 EOF

--- a/src/test/shell/integration/watchfs_test.sh
+++ b/src/test/shell/integration/watchfs_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/integration/workspace_status_test.sh
+++ b/src/test/shell/integration/workspace_status_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
@@ -61,7 +61,7 @@ add_to_bazelrc "build --package_path=%workspace%"
 function test_workspace_status_with_stderr() {
   local ok="$TEST_TMPDIR/ok.sh"
   cat > "$ok" <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 echo "This is stderr" >&2
 exit 0
 EOF

--- a/src/test/shell/integration_test_setup.sh
+++ b/src/test/shell/integration_test_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/sandboxing_test_utils.sh
+++ b/src/test/shell/sandboxing_test_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/shell_utils.sh
+++ b/src/test/shell/shell_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/shell_utils_symlinks_test.sh
+++ b/src/test/shell/shell_utils_symlinks_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/shell_utils_test.sh
+++ b/src/test/shell/shell_utils_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/test/tools/bzlmod/update_default_lock_file.sh
+++ b/src/test/tools/bzlmod/update_default_lock_file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/test/tools/bzlmod/verify_default_lock_file.sh
+++ b/src/test/tools/bzlmod/verify_default_lock_file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #

--- a/src/tools/singlejar/output_jar_shell_test.sh
+++ b/src/tools/singlejar/output_jar_shell_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -75,5 +75,5 @@ function test_empty_resource_file() {
 }
 
 run_suite "Misc shell tests"
-#!/bin/bash
+#!/usr/bin/env bash
 

--- a/src/tools/singlejar/zip64_test.sh
+++ b/src/tools/singlejar/zip64_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/src/upload_all_java_tools.sh
+++ b/src/upload_all_java_tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/upload_java_tools.sh
+++ b/src/upload_java_tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/src/zip_files.sh
+++ b/src/zip_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/third_party/ijar/test/ijar_test.sh
+++ b/third_party/ijar/test/ijar_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/third_party/ijar/test/ijar_test.sh
+++ b/third_party/ijar/test/ijar_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/third_party/ijar/test/testenv.sh
+++ b/third_party/ijar/test/testenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/third_party/ijar/test/zip_test.sh
+++ b/third_party/ijar/test/zip_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash -eu
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/third_party/ijar/test/zip_test.sh
+++ b/third_party/ijar/test/zip_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +11,8 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
+
+set -eu
 
 # Integration tests for ijar zipper/unzipper
 

--- a/third_party/java/proguard/proguard6.2.2/buildscripts/build.sh
+++ b/third_party/java/proguard/proguard6.2.2/buildscripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # GNU/Linux build script for ProGuard.
 

--- a/third_party/java/proguard/proguard6.2.2/buildscripts/functions.sh
+++ b/third_party/java/proguard/proguard6.2.2/buildscripts/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Support functions for building ProGuard.
 

--- a/tools/build_defs/hash/sha256_test.sh
+++ b/tools/build_defs/hash/sha256_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/tools/build_defs/pkg/build_test.sh
+++ b/tools/build_defs/pkg/build_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 
 # Copyright 2015 The Bazel Authors. All rights reserved.

--- a/tools/build_defs/pkg/testenv.sh
+++ b/tools/build_defs/pkg/testenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/tools/coverage/collect-coverage.sh
+++ b/tools/coverage/collect-coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/genrule/genrule-setup.sh
+++ b/tools/genrule/genrule-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/tools/objc/xcrunwrapper.sh
+++ b/tools/objc/xcrunwrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/tools/osx/xcode_locator_stub.sh
+++ b/tools/osx/xcode_locator_stub.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/build_and_upload.sh
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/build_and_upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
  # Copyright 2016 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/tools/test/dummy.sh
+++ b/tools/test/dummy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/tools/upload_bazel_mirror.sh
+++ b/tools/upload_bazel_mirror.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
`#!/usr/bin/env bash` is more portable than `#!/bin/bash`  because it can pick up Bash from more locations and is also customizable via `PATH`. Some scripts were already using `#!/usr/bin/env bash` but not all.

Note: only touching plain shell script files in this PR, script
      files that are generated in rules are also subject to same
      portability concern but change there may need extra attention

Edge cases:
- replacing arguments with set commands as it isn't universally supported to combine env+cmd+args. So `/bin/bash -eu -> /usr/bin/env bash; set -eu`
- `src/test/shell/bazel/bazel_wrapper_test.sh` sets up mock `bin/` location, adding `bash` there to be picked up is needed, for now not doing that and excluding `scripts/packages/bazel.sh` from changes