### PR TITLE
generate_{bash,fish}_completion: use bazel with --batch

### DIFF
--- a/scripts/generate_bash_completion.sh
+++ b/scripts/generate_bash_completion.sh
@@ -68,7 +68,7 @@ mkdir "${tempdir}/root"
 
 server_javabase_flag=
 [ -z "${javabase}" ] || server_javabase_flag="--server_javabase=${javabase}"
-"${bazel}" --output_user_root="${tempdir}/root" ${server_javabase_flag} \
+"${bazel}" --batch --output_user_root="${tempdir}/root" ${server_javabase_flag} \
     help completion >>"${tempdir}/output"
 
 [ -z "${append}" ] || cat ${append} >>"${tempdir}/output"

--- a/scripts/generate_fish_completion.py
+++ b/scripts/generate_fish_completion.py
@@ -102,7 +102,7 @@ class BazelCompletionWriter(object):
 
   def _get_bazel_output(self, args):
     return subprocess.check_output(
-        (self._bazel, '--output_user_root={}'.format(self._output_user_root)) +
+        (self._bazel, '--batch', '--output_user_root={}'.format(self._output_user_root)) +
         tuple(args),
         universal_newlines=True)
 


### PR DESCRIPTION
Generating completion is often a package install step where starting a daemon may be undesired or even prohibited by sandboxing mechanism.

There seems to be no simple way to customize the use of `--batch`, given the context it might be ok to always generate completions with `bazel --batch`