### PR TITLE
[8.3.0] Allow `mirror_urls` in source.json

### DIFF
--- a/site/en/external/registry.md
+++ b/site/en/external/registry.md
@@ -57,6 +57,8 @@ An index registry must follow the format below:
         *   The default type is "archive", representing an `http_archive` repo,
             with the following fields:
             *   `url`: The URL of the source archive
+            *   `mirror_urls`: A list of string, the mirror URLs of the source archive.
+                The URLs are tried in order after `url` as backups.
             *   `integrity`: The [Subresource
                 Integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description){: .external}
                 checksum of the archive

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -259,6 +260,7 @@ public class IndexRegistry implements Registry {
   /** Represents fields in {@code source.json} for each archive-type version of a module. */
   private static class ArchiveSourceJson {
     URL url;
+    List<String> mirrorUrls;
     String integrity;
     String stripPrefix;
     Map<String, String> patches;
@@ -446,8 +448,13 @@ public class IndexRegistry implements Registry {
         urls.add(constructUrl(mirror, sourceUrl.getAuthority(), sourceUrl.getFile()));
       }
     }
-    // Finally add the original source URL itself.
+    // Add the original source URL itself.
     urls.add(sourceUrl.toString());
+
+    // Add mirror_urls from source.json as backups after the primary url.
+    if (sourceJson.mirrorUrls != null) {
+      urls.addAll(sourceJson.mirrorUrls);
+    }
 
     // Build remote patches as key-value pairs of "url" => "integrity".
     ImmutableMap.Builder<String, String> remotePatches = new ImmutableMap.Builder<>();

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -182,6 +182,8 @@ public class IndexRegistryTest extends FoundationTestCase {
         "/modules/foo/1.0/source.json",
         "{",
         "  \"url\": \"http://mysite.com/thing.zip\",",
+        "  \"mirror_urls\":"
+            + " [\"http://my.mirror/mysite.com/thing.zip\",\"http://another.mirror/mysite.com/thing.zip\"],",
         "  \"integrity\": \"sha256-blah\",",
         "  \"strip_prefix\": \"pref\"",
         "}");
@@ -223,7 +225,9 @@ public class IndexRegistryTest extends FoundationTestCase {
                     ImmutableList.of(
                         "https://mirror.bazel.build/mysite.com/thing.zip",
                         "file:///home/bazel/mymirror/mysite.com/thing.zip",
-                        "http://mysite.com/thing.zip"))
+                        "http://mysite.com/thing.zip",
+                        "http://my.mirror/mysite.com/thing.zip",
+                        "http://another.mirror/mysite.com/thing.zip"))
                 .setIntegrity("sha256-blah")
                 .setStripPrefix("pref")
                 .setRemotePatches(ImmutableMap.of())


### PR DESCRIPTION
Context: https://github.com/bazelbuild/bazel-central-registry/issues/4320

RELNOTES: source.json now supports a new attribute `mirror_urls` as backup URLs for the source archive.

Closes #25928.

PiperOrigin-RevId: 750663220
Change-Id: I23ed94200ad555f7b1a756d76f3621fc0bd1b50f

Commit https://github.com/bazelbuild/bazel/commit/15497ff89b40d346f2bdef4a509f620f72837543