### PR TITLE
Repo contents cache

### DIFF
--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -38,6 +38,7 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --strategy=Javac=worker --worker_quit_after_build --ignore_unsupported_sandboxing \
       --compilation_mode=opt \
       --repository_cache=derived/repository_cache \
+      --repo_contents_cache= \
       --repo_env=BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID=0 \
       --extra_toolchains=//scripts/bootstrap:all \
       --extra_toolchains=@rules_python//python/runtime_env_toolchains:all \

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -356,35 +356,39 @@ public class BazelRepositoryModule extends BlazeModule {
         starlarkRepositoryFunction.setTimeoutScaling(1.0);
         singleExtensionEvalFunction.setTimeoutScaling(1.0);
       }
-      if (repoOptions.experimentalRepositoryCache != null) {
-        Path repositoryCachePath;
-        if (repoOptions.experimentalRepositoryCache.isEmpty()) {
-          // A set but empty path indicates a request to disable the repository cache.
-          repositoryCachePath = null;
-        } else if (repoOptions.experimentalRepositoryCache.isAbsolute()) {
-          repositoryCachePath = filesystem.getPath(repoOptions.experimentalRepositoryCache);
-        } else {
-          repositoryCachePath =
-              env.getBlazeWorkspace()
-                  .getWorkspace()
-                  .getRelative(repoOptions.experimentalRepositoryCache);
-        }
-        repositoryCache.setPath(repositoryCachePath);
+      if (repoOptions.repositoryCache != null) {
+        repositoryCache.setPath(toPath(repoOptions.repositoryCache, env));
       } else {
-        Path repositoryCachePath =
+        repositoryCache.setPath(
             env.getDirectories()
                 .getServerDirectories()
                 .getOutputUserRoot()
-                .getRelative(DEFAULT_CACHE_LOCATION);
-        try {
-          repositoryCachePath.createDirectoryAndParents();
-          repositoryCache.setPath(repositoryCachePath);
-        } catch (IOException e) {
-          env.getReporter()
-              .handle(
-                  Event.warn(
-                      "Failed to set up cache at " + repositoryCachePath + ": " + e.getMessage()));
-        }
+                .getRelative(DEFAULT_CACHE_LOCATION));
+      }
+      // Note that the repo contents cache stuff has to happen _after_ the repo cache stuff, because
+      // the specific settings about the repo contents cache might overwrite the repo cache
+      // settings. In particular, if `--repo_contents_cache` is not set (it's null), we use whatever
+      // default set by `repositoryCache.setPath(...)`.
+      if (repoOptions.repoContentsCache != null) {
+        repositoryCache.getRepoContentsCache().setPath(toPath(repoOptions.repoContentsCache, env));
+      }
+      Path repoContentsCachePath = repositoryCache.getRepoContentsCache().getPath();
+      if (repoContentsCachePath != null
+          && env.getWorkspace() != null
+          && repoContentsCachePath.startsWith(env.getWorkspace())) {
+        // Having the repo contents cache inside the workspace is very dangerous. During the
+        // lifetime of a Bazel invocation, we treat files inside the workspace as immutable. This
+        // can cause mysterious failures if we write files inside the workspace during the
+        // invocation, as is often the case with the repo contents cache.
+        throw new AbruptExitException(
+            detailedExitCode(
+                """
+                The repo contents cache [%s] is inside the workspace [%s]. This can cause spurious \
+                failures. Disable the repo contents cache with `--repo_contents_cache=`, or \
+                specify `--repo_contents_cache=<path outside the workspace>`.
+                """
+                    .formatted(repoContentsCachePath, env.getWorkspace()),
+                Code.BAD_REPO_CONTENTS_CACHE));
       }
 
       try {
@@ -628,6 +632,18 @@ public class BazelRepositoryModule extends BlazeModule {
       path = env.getWorkingDirectory().getRelative(path).getPathString();
     }
     return path;
+  }
+
+  /**
+   * An empty path fragment is turned into {@code null}; otherwise, it's treated as relative to the
+   * workspace root.
+   */
+  @Nullable
+  private Path toPath(PathFragment path, CommandEnvironment env) {
+    if (path.isEmpty()) {
+      return null;
+    }
+    return env.getBlazeWorkspace().getWorkspace().getRelative(path);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -53,6 +53,7 @@ java_library(
     name = "vendor",
     srcs = ["VendorManager.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository/cache",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/profiler",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/VendorManager.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
+import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.profiler.Profiler;
@@ -75,30 +76,56 @@ public class VendorManager {
           continue;
         }
 
-        // At this point, the repo should exist under external dir, but check if the vendor src is
-        // already up-to-date.
         Path markerUnderExternal = externalRepoRoot.getChild(repo.getMarkerFileName());
         Path markerUnderVendor = vendorDirectory.getChild(repo.getMarkerFileName());
-        if (isRepoUpToDate(markerUnderVendor, markerUnderExternal)) {
+        // If the marker file doesn't exist under outputBase/external, then the repo is either local
+        // (which cannot be in this case since local repos aren't vendored) or in the repo contents
+        // cache.
+        boolean isCached = !markerUnderExternal.exists();
+        Path actualMarkerFile;
+        if (isCached) {
+          Path cacheRepoDir = repoUnderExternal.resolveSymbolicLinks();
+          actualMarkerFile =
+              cacheRepoDir.replaceName(
+                  cacheRepoDir.getBaseName() + RepoContentsCache.RECORDED_INPUTS_SUFFIX);
+        } else {
+          actualMarkerFile = markerUnderExternal;
+        }
+
+        // At this point, the repo should exist under external dir, but check if the vendor src is
+        // already up-to-date.
+        if (isRepoUpToDate(markerUnderVendor, actualMarkerFile)) {
           continue;
         }
 
-        // Actually vendor the repo:
+        // Actually vendor the repo. If the repo is cached, copy it; otherwise move it.
         // 1. Clean up existing marker file and vendor dir.
         markerUnderVendor.delete();
         repoUnderVendor.deleteTree();
         repoUnderVendor.createDirectory();
-        // 2. Move the marker file to a temporary one under vendor dir.
-        Path tMarker = vendorDirectory.getChild(repo.getMarkerFileName() + ".tmp");
-        FileSystemUtils.moveFile(markerUnderExternal, tMarker);
-        // 3. Move the external repo to vendor dir. It's fine if this step fails or is interrupted,
-        // because the marker file under external is gone anyway.
-        FileSystemUtils.moveTreesBelow(repoUnderExternal, repoUnderVendor);
+        // 2. Copy/move the marker file to a temporary one under vendor dir.
+        Path tempMarker = vendorDirectory.getChild(repo.getMarkerFileName() + ".tmp");
+        if (isCached) {
+          FileSystemUtils.copyFile(actualMarkerFile, tempMarker);
+        } else {
+          FileSystemUtils.moveFile(actualMarkerFile, tempMarker);
+        }
+        // 3. Move/copy the external repo to vendor dir. Note that, in the "move" case, it's fine if
+        // this step fails or is interrupted, because the marker file under external is gone anyway.
+        if (isCached) {
+          FileSystemUtils.copyTreesBelow(repoUnderExternal.resolveSymbolicLinks(), repoUnderVendor);
+        } else {
+          try {
+            repoUnderExternal.renameTo(repoUnderVendor);
+          } catch (IOException e) {
+            FileSystemUtils.moveTreesBelow(repoUnderExternal, repoUnderVendor);
+          }
+        }
         // 4. Re-plant symlinks pointing a path under the external root to a relative path
         // to make sure the vendor src keep working after being moved or output base changed
         replantSymlinks(repoUnderVendor, externalRepoRoot);
-        // 5. Rename the temporary marker file after the move is done.
-        tMarker.renameTo(markerUnderVendor);
+        // 5. Rename the temporary marker file after the move/copy is done.
+        tempMarker.renameTo(markerUnderVendor);
         // 6. Leave a symlink in external dir to keep things working.
         repoUnderExternal.deleteTree();
         FileSystemUtils.ensureSymbolicLink(repoUnderExternal, repoUnderVendor);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
@@ -96,7 +96,7 @@ public class LocalConfigPlatformFunction extends RepositoryFunction {
             });
 
     // Return the needed info.
-    return new FetchResult(ImmutableMap.of());
+    return new FetchResult(ImmutableMap.of(), Reproducibility.YES);
   }
 
   private static String workspaceFileContent(String repositoryName) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -43,8 +43,26 @@ public class RepositoryOptions extends OptionsBase {
           "Specifies the cache location of the downloaded values obtained "
               + "during the fetching of external repositories. An empty string "
               + "as argument requests the cache to be disabled, "
-              + "otherwise the default of '<output_user_root>/cache/repos/v1' is used")
-  public PathFragment experimentalRepositoryCache;
+              + "otherwise the default of '<--output_user_root>/cache/repos/v1' is used")
+  public PathFragment repositoryCache;
+
+  @Option(
+      name = "repo_contents_cache",
+      oldName = "repository_contents_cache",
+      oldNameWarning = false,
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      converter = OptionsUtils.PathFragmentConverter.class,
+      help =
+          """
+          Specifies the location of the repo contents cache, which contains fetched repo \
+          directories shareable across workspaces. An empty string as argument requests the repo \
+          contents cache to be disabled, otherwise the default of '<--repository_cache>/contents' \
+          is used. Note that this means setting '--repository_cache=' would by default disable the \
+          repo contents cache as well, unless '--repo_contents_cache=<some_path>' is also set.
+          """)
+  public PathFragment repoContentsCache;
 
   @Option(
       name = "registry",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
@@ -21,6 +21,7 @@ java_library(
         "RepositoryCache.java",
     ],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/util:file_system_lock",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs/bazel",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
@@ -14,29 +14,116 @@
 
 package com.google.devtools.build.lib.bazel.repository.cache;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.util.FileSystemLock;
+import com.google.devtools.build.lib.util.FileSystemLock.LockMode;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import javax.annotation.Nullable;
 
 /** A cache directory that stores the contents of fetched repos across different workspaces. */
 public class RepoContentsCache {
+  public final static String RECORDED_INPUTS_SUFFIX = ".recorded_inputs";
+
   @Nullable private Path path;
+
+  // TODO(wyv): implement garbage collection
 
   public void setPath(@Nullable Path path) {
     this.path = path;
+  }
+
+  @Nullable
+  public Path getPath() {
+    return path;
   }
 
   public boolean isEnabled() {
     return path != null;
   }
 
-  public Path recordedInputsFile(String predeclaredInputHash) {
-    Preconditions.checkState(path != null);
-    return path.getRelative(predeclaredInputHash + ".recorded_inputs");
+  public record CandidateRepo(Path recordedInputsFile, Path contentsDir) {
+    private static CandidateRepo fromRecordedInputsFile(Path recordedInputsFile) {
+      String recordedInputsFileBaseName = recordedInputsFile.getBaseName();
+      String contentsDirBaseName =
+          recordedInputsFileBaseName.substring(
+              0, recordedInputsFileBaseName.length() - RECORDED_INPUTS_SUFFIX.length());
+      return new CandidateRepo(
+          recordedInputsFile, recordedInputsFile.replaceName(contentsDirBaseName));
+    }
   }
 
-  public Path contentsDir(String predeclaredInputHash) {
+  public ImmutableList<CandidateRepo> getCandidateRepos(String predeclaredInputHash) {
     Preconditions.checkState(path != null);
-    return path.getRelative(predeclaredInputHash);
+    Path entryDir = path.getRelative(predeclaredInputHash);
+    try {
+      return entryDir.getDirectoryEntries().stream()
+          .filter(path -> path.getBaseName().endsWith(RECORDED_INPUTS_SUFFIX))
+          // We're just sorting for consistency here. (Note that "10.recorded_inputs" would sort
+          // before "1.recorded_inputs".) If necessary, we could use some sort of heuristics here
+          // to speed up the subsequent up-to-date-ness checking.
+          .sorted(Comparator.comparing(Path::getBaseName))
+          .map(CandidateRepo::fromRecordedInputsFile)
+          .collect(toImmutableList());
+    } catch (IOException e) {
+      // This should only happen if `entryDir` doesn't exist yet or is not a directory. Either way,
+      // don't outright fail; just treat it as if the cache is empty.
+      return ImmutableList.of();
+    }
+  }
+
+  /** Moves a freshly fetched repo into the contents cache. */
+  public void moveToCache(
+      Path fetchedRepoDir, Path fetchedRepoMarkerFile, String predeclaredInputHash)
+      throws IOException {
+    Preconditions.checkState(path != null);
+
+    Path entryDir = path.getRelative(predeclaredInputHash);
+    if (!entryDir.isDirectory()) {
+      entryDir.delete();
+    }
+    String counter = getNextCounterInDir(entryDir);
+    Path cacheRecordedInputsFile = entryDir.getChild(counter + RECORDED_INPUTS_SUFFIX);
+    Path cacheRepoDir = entryDir.getChild(counter);
+
+    cacheRepoDir.deleteTree();
+    cacheRepoDir.createDirectoryAndParents();
+    // Move the fetched marker file to a temp location, so that if following operations fail, both
+    // the fetched repo and the cache locations are considered out-of-date.
+    Path tempMarker = entryDir.getChild(counter + ".temp_recorded_inputs");
+    FileSystemUtils.moveFile(fetchedRepoMarkerFile, tempMarker);
+    // Now perform the move, and afterwards, restore the marker file.
+    try {
+      fetchedRepoDir.renameTo(cacheRepoDir);
+    } catch (IOException e) {
+      FileSystemUtils.moveTreesBelow(fetchedRepoDir, cacheRepoDir);
+    }
+    tempMarker.renameTo(cacheRecordedInputsFile);
+    // Set up a symlink at the original fetched repo dir path.
+    fetchedRepoDir.deleteTree();
+    FileSystemUtils.ensureSymbolicLink(fetchedRepoDir, cacheRepoDir);
+  }
+
+  private static String getNextCounterInDir(Path entryDir) throws IOException {
+    Path counterFile = entryDir.getRelative("counter");
+    try (var lock = FileSystemLock.get(entryDir.getRelative("lock"), LockMode.EXCLUSIVE)) {
+      int c = 0;
+      if (counterFile.exists()) {
+        try {
+          c = Integer.parseInt(FileSystemUtils.readContent(counterFile, StandardCharsets.UTF_8));
+        } catch (NumberFormatException e) {
+          // ignored
+        }
+      }
+      String counter = Integer.toString(c + 1);
+      FileSystemUtils.writeContent(counterFile, StandardCharsets.UTF_8, counter);
+      return counter;
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/RepoMetadata.java
@@ -1,0 +1,34 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.starlark;
+
+import com.google.devtools.build.docgen.annot.DocCategory;
+import com.google.devtools.build.lib.rules.repository.RepositoryFunction.Reproducibility;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.StarlarkValue;
+
+/** The Starlark object returned from a {@code repository_rule}'s implementation function. */
+@StarlarkBuiltin(
+    name = "repo_metadata",
+    category = DocCategory.BUILTIN,
+    doc =
+        """
+        See <a href="repository_ctx#repo_metadata"><code>repository_ctx.repo_metadata</code></a>.
+        """)
+public record RepoMetadata(Reproducibility reproducible, Dict<?, ?> attrsForReproducibility)
+    implements StarlarkValue {
+  public static RepoMetadata NONREPRODUCIBLE = new RepoMetadata(Reproducibility.NO, Dict.empty());
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -63,6 +63,7 @@ import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Mutability;
 import net.starlark.java.eval.Starlark;
@@ -222,6 +223,7 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
     }
 
     Map<RepoRecordedInput, String> recordedInputValues = new LinkedHashMap<>();
+    RepoMetadata repoMetadata;
     try (Mutability mu = Mutability.create("Starlark repository");
         StarlarkRepositoryContext starlarkRepositoryContext =
             new StarlarkRepositoryContext(
@@ -276,9 +278,18 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
         starlarkRepositoryContext.markSuccessful();
       }
 
+      repoMetadata =
+          switch (result) {
+            case Dict<?, ?> dict -> new RepoMetadata(Reproducibility.NO, dict);
+            case RepoMetadata rm -> rm;
+            default -> RepoMetadata.NONREPRODUCIBLE;
+          };
       RepositoryResolvedEvent resolved =
           new RepositoryResolvedEvent(
-              rule, starlarkRepositoryContext.getAttr(), outputDirectory, result);
+              rule,
+              starlarkRepositoryContext.getAttr(),
+              outputDirectory,
+              repoMetadata.attrsForReproducibility());
       if (resolved.isNewInformationReturned()) {
         env.getListener().handle(Event.debug(resolved.getMessage()));
         env.getListener().handle(Event.debug(defInfo));
@@ -352,7 +363,7 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
       }
     }
 
-    return new FetchResult(recordedInputValues);
+    return new FetchResult(recordedInputValues, repoMetadata.reproducible());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/google/devtools/build/lib/rules/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/BUILD
@@ -416,6 +416,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe:sky_value_dirtiness_checker",
         "//src/main/java/com/google/devtools/build/lib/skyframe:starlark_util",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:file_system_lock",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/LocalRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/LocalRepositoryFunction.java
@@ -55,7 +55,7 @@ public class LocalRepositoryFunction extends RepositoryFunction {
     if (result != null) {
       env.getListener().post(resolve(rule, directories));
     }
-    return new FetchResult(ImmutableMap.of());
+    return new FetchResult(ImmutableMap.of(), Reproducibility.YES);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
@@ -163,7 +163,7 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
     fileHandler.finishFile(rule, outputDirectory, recordedInputValues);
     env.getListener().post(resolve(rule));
 
-    return new FetchResult(recordedInputValues);
+    return new FetchResult(recordedInputValues, Reproducibility.YES);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.bzlmod.BzlmodRepoRuleValue;
 import com.google.devtools.build.lib.bazel.bzlmod.VendorFileValue;
 import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache;
+import com.google.devtools.build.lib.bazel.repository.cache.RepoContentsCache.CandidateRepo;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.Rule;
@@ -43,6 +44,7 @@ import com.google.devtools.build.lib.repository.RepositoryFetchProgress;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput.NeverUpToDateRepoRecordedInput;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.AlreadyReportedRepositoryAccessException;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
+import com.google.devtools.build.lib.rules.repository.RepositoryFunction.Reproducibility;
 import com.google.devtools.build.lib.skyframe.AlreadyReportedException;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue.Precomputed;
@@ -216,7 +218,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       String predeclaredInputHash =
           DigestWriter.computePredeclaredInputHash(rule, starlarkSemantics);
 
-      if (shouldUseCachedRepos(env, handler, repoRoot, rule)) {
+      if (shouldUseCachedRepos(env, handler, rule)) {
         // Make sure marker file is up-to-date; correctly describes the current repository state
         var repoState = digestWriter.areRepositoryAndMarkerFileConsistent(handler, env);
         if (repoState == null) {
@@ -229,21 +231,22 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
 
         // Then check if the global repo contents cache has this.
         if (repoContentsCache.isEnabled()) {
-          repoState =
-              digestWriter.areRepositoryAndMarkerFileConsistent(
-                  handler, env, repoContentsCache.recordedInputsFile(predeclaredInputHash));
-          if (repoState == null) {
-            return null;
-          }
-          if (repoState instanceof DigestWriter.RepoDirectoryState.UpToDate) {
-            var unused =
-                setupOverride(
-                    repoContentsCache.contentsDir(predeclaredInputHash).asFragment(),
-                    env,
-                    repoRoot,
-                    repositoryName);
-            return new RepositoryDirectoryValue.Success(
-                repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
+          for (CandidateRepo candidate :
+              repoContentsCache.getCandidateRepos(predeclaredInputHash)) {
+            repoState =
+                digestWriter.areRepositoryAndMarkerFileConsistent(
+                    handler, env, candidate.recordedInputsFile());
+            if (repoState == null) {
+              return null;
+            }
+            if (repoState instanceof DigestWriter.RepoDirectoryState.UpToDate) {
+              if (setupOverride(candidate.contentsDir().asFragment(), env, repoRoot, repositoryName)
+                  == null) {
+                return null;
+              }
+              return new RepositoryDirectoryValue.Success(
+                  repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
+            }
           }
         }
       }
@@ -267,6 +270,21 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
         // restart thus calling the possibly very slow (networking, decompression...) fetch()
         // operation again. So we write the marker file here immediately.
         digestWriter.writeMarkerFile(result.recordedInputValues());
+        if (repoContentsCache.isEnabled()
+            && result.reproducible() == Reproducibility.YES
+            && !handler.isLocal(rule)) {
+          // This repo is eligible for the repo contents cache.
+          try {
+            repoContentsCache.moveToCache(repoRoot, digestWriter.markerPath, predeclaredInputHash);
+          } catch (IOException e) {
+            throw new RepositoryFunctionException(
+                new IOException(
+                    "error moving repo @@%s into the repo contents cache: %s"
+                        .formatted(rule.getName(), e.getMessage()),
+                    e),
+                Transience.TRANSIENT);
+          }
+        }
         return new RepositoryDirectoryValue.Success(
             repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
       }
@@ -419,7 +437,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
 
   /* Determines whether we should use the cached repositories */
   private boolean shouldUseCachedRepos(
-      Environment env, RepositoryFunction handler, Path repoRoot, Rule rule)
+      Environment env, RepositoryFunction handler, Rule rule)
       throws InterruptedException {
     boolean forceFetchEnabled = !FORCE_FETCH.get(env).isEmpty();
     boolean forceFetchConfigureEnabled =
@@ -434,9 +452,8 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
 
     /* For the non-local repositories, do NOT use cache if:
      * 1) Force fetch is enabled (bazel sync, or bazel fetch --force), OR
-     * 2) Force fetch configure is enabled (bazel sync --configure), OR
-     * 3) Repository directory does not exist */
-    if (forceFetchEnabled || forceFetchConfigureEnabled || !repoRoot.exists()) {
+     * 2) Force fetch configure is enabled (bazel sync --configure) */
+    if (forceFetchEnabled || forceFetchConfigureEnabled) {
       return false;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -178,6 +178,11 @@ public abstract class RepositoryFunction {
       Rule rule, Path outputDirectory, BlazeDirectories directories, Environment env, SkyKey key)
       throws InterruptedException, RepositoryFunctionException;
 
+  public enum Reproducibility {
+    YES,
+    NO
+  }
+
   /**
    * The result of the {@link #fetch} method.
    *
@@ -186,8 +191,10 @@ public abstract class RepositoryFunction {
    *     The {@link #isAnyRecordedInputOutdated} method is responsible for checking the value added
    *     to that map when checking the content of a marker file. Not an ImmutableMap, because
    *     regrettably the values can be null sometimes.
+   * @param reproducible Whether the fetched repo contents are reproducible, hence cacheable.
    */
-  public record FetchResult(Map<? extends RepoRecordedInput, String> recordedInputValues) {}
+  public record FetchResult(
+      Map<? extends RepoRecordedInput, String> recordedInputValues, Reproducibility reproducible) {}
 
   protected static void ensureNativeRepoRuleEnabled(Rule rule, Environment env, String replacement)
       throws RepositoryFunctionException, InterruptedException {

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -174,7 +174,7 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   }
 
   /**
-   * Returns whether this path is an ancestor of another path.
+   * Returns whether another path is an ancestor of this path.
    *
    * <p>A path is considered an ancestor of itself.
    */
@@ -186,7 +186,7 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   }
 
   /**
-   * Returns whether this path is an ancestor of another path.
+   * Returns whether another path is an ancestor of this path.
    *
    * <p>A path is considered an ancestor of itself.
    *

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -259,6 +259,7 @@ message ExternalRepository {
     BAD_DOWNLOADER_CONFIG = 2 [(metadata) = { exit_code: 2 }];
     REPOSITORY_MAPPING_RESOLUTION_FAILED = 3 [(metadata) = { exit_code: 37 }];
     CREDENTIALS_INIT_FAILURE = 4 [(metadata) = { exit_code: 2 }];
+    BAD_REPO_CONTENTS_CACHE = 5 [(metadata) = { exit_code: 2 }];
   }
   Code code = 1;
   // Additional data could include external repository names.

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -407,6 +407,17 @@ py_test(
 )
 
 py_test(
+    name = "repo_contents_cache_test",
+    size = "large",
+    srcs = ["bzlmod/repo_contents_cache_test.py"],
+    tags = ["requires-network"],
+    deps = [
+        ":bzlmod_test_utils",
+        ":test_base",
+    ],
+)
+
+py_test(
     name = "bzlmod_credentials_test",
     size = "large",
     srcs = ["bzlmod/bzlmod_credentials_test.py"],

--- a/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
@@ -1,0 +1,202 @@
+# pylint: disable=g-backslash-continuation
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=g-long-ternary
+
+import tempfile
+
+from absl.testing import absltest
+from src.test.py.bazel import test_base
+
+
+class RepoContentsCacheTest(test_base.TestBase):
+
+  def setUp(self):
+    test_base.TestBase.setUp(self)
+    self.repo_contents_cache = tempfile.mkdtemp(dir=self._tests_root).replace('\\', '/')
+    self.ScratchFile(
+        '.bazelrc',
+        [
+            'build --verbose_failures',
+            'common --repo_contents_cache=%s' % self.repo_contents_cache,
+        ],
+    )
+
+  def testCachedAfterCleanExpunge(self):
+    self.ScratchFile('MODULE.bazel', [
+        'repo = use_repo_rule("//:repo.bzl", "repo")',
+        'repo(name = "my_repo")',
+    ])
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile('repo.bzl', [
+        'def _repo_impl(rctx):',
+        '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+        '  print("JUST FETCHED")',
+        '  return rctx.repo_metadata(reproducible=True)',
+        'repo = repository_rule(_repo_impl)',
+    ])
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # After expunging: cached
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+
+    # After expunging, without using repo contents cache: not cached
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '--repo_contents_cache=', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+  def testNotCachedWhenPredeclaredInputsChange(self):
+    self.ScratchFile('MODULE.bazel', [
+        'repo = use_repo_rule("//:repo.bzl", "repo")',
+        'repo(name = "my_repo", data = 1)',
+    ])
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile('repo.bzl', [
+        'def _repo_impl(rctx):',
+        '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+        '  print("JUST FETCHED")',
+        '  return rctx.repo_metadata(reproducible=True)',
+        'repo = repository_rule(_repo_impl, attrs={"data":attr.int()})',
+    ])
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Change predeclared inputs: not cached
+    self.ScratchFile('MODULE.bazel', [
+        'repo = use_repo_rule("//:repo.bzl", "repo")',
+        'repo(name = "my_repo", data = 2)',
+    ])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Change back to previous predeclared inputs: cached (even after expunging)
+    self.RunBazel(['clean', '--expunge'])
+    self.ScratchFile('MODULE.bazel', [
+        'repo = use_repo_rule("//:repo.bzl", "repo")',
+        'repo(name = "my_repo", data = 1)',
+    ])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+
+  def testNotCachedWhenRecordedInputsChange(self):
+    self.ScratchFile('MODULE.bazel', [
+        'repo = use_repo_rule("//:repo.bzl", "repo")',
+        'repo(name = "my_repo")',
+    ])
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile('repo.bzl', [
+        'def _repo_impl(rctx):',
+        '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+        '  rctx.watch(Label("@//:data.txt"))',
+        '  print("JUST FETCHED")',
+        '  return rctx.repo_metadata(reproducible=True)',
+        'repo = repository_rule(_repo_impl)',
+    ])
+
+    # First fetch: not cached
+    self.ScratchFile('data.txt', ['one'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Change recorded inputs: not cached
+    self.ScratchFile('data.txt', ['two'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Change back to previous recorded inputs: cached (even after expunging)
+    self.RunBazel(['clean', '--expunge'])
+    self.ScratchFile('data.txt', ['one'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+
+  def testNotCachedWhenRecordedInputsChange_envVar(self):
+    self.ScratchFile('MODULE.bazel', [
+        'repo = use_repo_rule("//:repo.bzl", "repo")',
+        'repo(name = "my_repo")',
+    ])
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile('repo.bzl', [
+        'def _repo_impl(rctx):',
+        '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+        '  rctx.getenv("LOLOL")',
+        '  print("JUST FETCHED")',
+        '  return rctx.repo_metadata(reproducible=True)',
+        'repo = repository_rule(_repo_impl)',
+    ])
+
+    # First fetch: not cached
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], env_add={"LOLOL": "lol"})
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Change recorded inputs: not cached
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], env_add={"LOLOL": "kek"})
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Change back to previous recorded inputs: cached (even after expunging)
+    self.RunBazel(['clean', '--expunge'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], env_add={"LOLOL": "lol"})
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+
+  def testNoThrashingBetweenWorkspaces(self):
+    module_bazel_lines = [
+        'repo = use_repo_rule("//:repo.bzl", "repo")',
+        'repo(name = "my_repo")',
+    ]
+    repo_bzl_lines = [
+        'def _repo_impl(rctx):',
+        '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+        '  rctx.watch(Label("@//:data.txt"))',
+        '  print("JUST FETCHED")',
+        '  return rctx.repo_metadata(reproducible=True)',
+        'repo = repository_rule(_repo_impl)',
+    ]
+    # Set up two workspaces with exactly the same repo definition (same predeclared inputs)
+    dir_a = self.ScratchDir('a')
+    dir_b = self.ScratchDir('b')
+    self.ScratchFile('a/MODULE.bazel', module_bazel_lines)
+    self.ScratchFile('b/MODULE.bazel', module_bazel_lines)
+    self.ScratchFile('a/BUILD.bazel')
+    self.ScratchFile('b/BUILD.bazel')
+    self.ScratchFile('a/repo.bzl', repo_bzl_lines)
+    self.ScratchFile('b/repo.bzl', repo_bzl_lines)
+
+    # First fetch in A: not cached
+    self.ScratchFile('a/data.txt', ['one'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], cwd=dir_a)
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Fetch in B (with same 'data.txt'): cached
+    self.ScratchFile('b/data.txt', ['one'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], cwd=dir_b)
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Change 'b/data.txt': not cached
+    self.ScratchFile('b/data.txt', ['two'])
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], cwd=dir_b)
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Building A again even after expunging: cached
+    self.RunBazel(['clean', '--expunge'], cwd=dir_a)
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], cwd=dir_a)
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
+++ b/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
@@ -142,7 +142,7 @@ EOF
 
     ./output/bazel \
       --server_javabase=$JAVABASE --host_jvm_args=--add-opens=java.base/java.nio=ALL-UNNAMED \
-      build --nobuild --repository_cache=derived/repository_cache \
+      build --nobuild --repository_cache=derived/repository_cache --repo_contents_cache= \
       --override_repository=$(cat derived/maven/MAVEN_CANONICAL_REPO_NAME)=derived/maven \
       --java_language_version=${JAVA_VERSION} --tool_java_language_version=${JAVA_VERSION} \
       --tool_java_runtime_version=local_jdk \

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -336,7 +336,8 @@ function test_sha256_caching() {
 
 function test_cached_across_server_restart() {
   http_archive_helper zip_up
-  local marker_file=$(bazel info output_base)/external/\@+http_archive+endangered.marker
+  local repo_path="$(bazel info output_base)/external/+http_archive+endangered"
+  local marker_file="$(realpath $repo_path).recorded_inputs"
   echo "<MARKER>"
   cat "${marker_file}"
   echo "</MARKER>"

--- a/src/test/shell/bazel/starlark_git_repository_test.sh
+++ b/src/test/shell/bazel/starlark_git_repository_test.sh
@@ -450,6 +450,8 @@ EOF
 }
 
 function test_git_repository_not_refetched_on_server_restart() {
+  # Testing refetch behavior, so disable the repo contents cache
+  add_to_bazelrc "common --repo_contents_cache="
   local repo_dir=$TEST_TMPDIR/repos/refetch
 
   rm MODULE.bazel
@@ -494,6 +496,8 @@ EOF
 }
 
 function test_git_repository_not_refetched_on_server_restart_strip_prefix() {
+  # Testing refetch behavior, so disable the repo contents cache
+  add_to_bazelrc "common --repo_contents_cache="
   local repo_dir=$TEST_TMPDIR/repos/refetch
   # Change the strip_prefix which should cause a new checkout
   rm MODULE.bazel
@@ -517,6 +521,8 @@ EOF
 
 
 function test_git_repository_refetched_when_commit_changes() {
+  # Testing refetch behavior, so disable the repo contents cache
+  add_to_bazelrc "common --repo_contents_cache="
   local repo_dir=$TEST_TMPDIR/repos/refetch
 
   rm MODULE.bazel
@@ -542,6 +548,8 @@ EOF
 }
 
 function test_git_repository_and_nofetch() {
+  # Testing refetch behavior, so disable the repo contents cache
+  add_to_bazelrc "common --repo_contents_cache="
   local repo_dir=$TEST_TMPDIR/repos/refetch
 
   rm MODULE.bazel

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -280,7 +280,7 @@ function test_output_user_root() {
   expect_log "$TEST_TMPDIR/user/[0-9a-f]\{32\}"
 
   # Test relative path
-  bazel --output_user_root=user info output_base >& $TEST_log \
+  bazel --output_user_root=user info --repository_cache= output_base >& $TEST_log \
       || fail "Expected success"
   expect_log "$(pwd)/user/[0-9a-f]\{32\}"
 }

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -154,7 +154,7 @@
     },
     "@@pybind11_bazel+//:python_configure.bzl%extension": {
       "general": {
-        "bzlTransitiveDigest": "d4N/SZrl3ONcmzE98rcV0Fsro0iUbjNQFTIiLiGuH+k=",
+        "bzlTransitiveDigest": "AmLbxv4IaFzGPUmUf54Ry5g9fdyiEq1CPb/JxwMbvvc=",
         "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
         "recordedFileInputs": {
           "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
@@ -188,7 +188,7 @@
     },
     "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "mGiTB79hRNjmeDTQdzkpCHyzXhErMbufeAmySBt7s5s=",
+        "bzlTransitiveDigest": "eh4+G6xahmsV1DQyoJyZfm1Upb1AAa1425mR3Gd2vOY=",
         "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -271,7 +271,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
+        "bzlTransitiveDigest": "wte4vO8DHcoYr2Hdje592YNwYrCOzth2ujMpAuHp4dY=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -335,7 +335,7 @@
     },
     "@@rules_python+//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "6j7OeER97/sUx3f8grT22jx9XEhLfoBOWPtfkHNYcm4=",
+        "bzlTransitiveDigest": "J/xYVrmFnXPDJWMIPK0tE7XN3g07JHbwPY4q5w+KKfQ=",
         "usagesDigest": "OLoIStnzNObNalKEMRq99FqenhPGLFZ5utVLV4sz7OI=",
         "recordedFileInputs": {
           "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",

--- a/tools/android/android_extensions.bzl
+++ b/tools/android/android_extensions.bzl
@@ -17,7 +17,7 @@
 
 """Module extension to declare Android runtime dependencies for Bazel."""
 
-load("//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 
 def _remote_android_tools_extensions_impl(module_ctx):
     http_archive(

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -201,7 +201,9 @@ def _git_repository_implementation(ctx):
         ctx.delete(ctx.path(".tmp_git_root/.git"))
     else:
         ctx.delete(ctx.path(".git"))
-    return _update_git_attrs(ctx.attr, _common_attrs.keys(), update)
+    if ctx.attr.commit:
+        return ctx.repo_metadata(reproducible = True)
+    return ctx.repo_metadata(attrs_for_reproducibility = _update_git_attrs(ctx.attr, _common_attrs.keys(), update))
 
 git_repository = repository_rule(
     implementation = _git_repository_implementation,

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -125,8 +125,10 @@ Authorization: Bearer RANDOM-TOKEN
 
 def _update_integrity_attr(ctx, attrs, download_info):
     # We don't need to override the integrity attribute if sha256 is already specified.
-    integrity_override = {} if ctx.attr.sha256 else {"integrity": download_info.integrity}
-    return update_attrs(ctx.attr, attrs.keys(), integrity_override)
+    if ctx.attr.sha256 or ctx.attr.integrity:
+        return ctx.repo_metadata(reproducible = True)
+    integrity_override = {"integrity": download_info.integrity}
+    return ctx.repo_metadata(attrs_for_reproducibility = update_attrs(ctx.attr, attrs.keys(), integrity_override))
 
 def _http_archive_impl(ctx):
     """Implementation of the http_archive rule."""

--- a/tools/test/extensions.bzl
+++ b/tools/test/extensions.bzl
@@ -14,7 +14,7 @@
 """A module extension to bring in the remote coverage tools under
 @remote_coverage_tools."""
 
-load("//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _remote_coverage_tools_extension_impl(ctx):
     http_archive(


### PR DESCRIPTION
This mostly follows the design doc at https://docs.google.com/document/d/1ZScqiIQi9l7_8eikbsGI-rjupdbCI7wgm1RYD76FJfM/edit?pli=1&tab=t.0#heading=h.5mcn15i0e1ch

- Adds a new flag `--repo_contents_cache` to specify the path of the repo contents cache, where we'll store fetched contents of repos that can be cached safely across workspaces.
  - The flag defaults to `<value of --repository_cache>/contents`.
  - If this path ends up being inside the main repo, we throw an error. This is because files inside the source tree are considered immutable during the lifetime of a Bazel invocation, which means writing into the repo contents cache can cause spurious failures.
- A repo rule can indicate readiness for caching by returning `repository_ctx.repo_metadata(reproducible=True)` from its implementation function, similarly to module extensions.
  - Note that reproducibility/cacheability is not per repo rule (like "local"-ness), but per repo. Example: `http_archive` is only cacheable if the checksum is provided.
- Before we fetch a repo, we first check if matching entries exist in the repo contents cache under the key of the hash of all its predeclared inputs (`HVal(Pre(R))` in the doc). If not, fetch as normal.
   - These include repo attrs, repo rule impl .bzl hashes, Starlark semantics, etc.
- If matching entries exist, we go through each of them and examine if it's up-to-date by examining its "recorded inputs file" (analogous to the marker file in `outputBase/external`). If we find an up-to-date entry, we set up a symlink, and declare victory. Otherwise, fetch as normal.
- After fetching, if the repo rule indicates cacheability, we move the fetched contents into the repo contents cache by appending a new entry under the predeclared inputs hash key.

RELNOTES: Added a new flag `--repo_contents_cache` (defaults to the `contents` directory under the `--repository_cache`) where Bazel stores fetched contents of repos that can be safely cached across workspaces. A repo rule can indicate cacheability by returning `repository_ctx.repo_metadata(reproducible=True)` from its implementation function.