### PR TITLE
fix: broken links in macro and legacy macro docs

### DIFF
--- a/site/en/extending/legacy-macros.md
+++ b/site/en/extending/legacy-macros.md
@@ -24,7 +24,7 @@ Symbolic macros
 *   Take typed attributes, which in turn means automatic label and select
     conversion.
 *   Are more readable
-*   Will soon have [lazy evaluation](macros.md/laziness)
+*   Will soon have [lazy evaluation](macros.md#laziness)
 
 ## Usage {:#usage}
 

--- a/site/en/rules/legacy-macro-tutorial.md
+++ b/site/en/rules/legacy-macro-tutorial.md
@@ -8,7 +8,7 @@ Book: /_book.yaml
 IMPORTANT: This tutorial is for [*legacy macros*](/extending/legacy-macros). If
 you only need to support Bazel 8 or newer, we recommend using [symbolic
 macros](/extending/macros) instead; take a look at [Creating a Symbolic
-Macro](../macro-tutorial).
+Macro](macro-tutorial).
 
 Imagine that you need to run a tool as part of your build. For example, you
 may want to generate or preprocess a source file, or compress a binary. In this

--- a/site/en/rules/macro-tutorial.md
+++ b/site/en/rules/macro-tutorial.md
@@ -8,7 +8,7 @@ Book: /_book.yaml
 IMPORTANT: This tutorial is for [*symbolic macros*](/extending/macros) – the new
 macro system introduced in Bazel 8. If you need to support older Bazel versions,
 you will want to write a [legacy macro](/extending/legacy-macros) instead; take
-a look at [Creating a Legacy Macro](../legacy-macro-tutorial).
+a look at [Creating a Legacy Macro](legacy-macro-tutorial).
 
 Imagine that you need to run a tool as part of your build. For example, you
 may want to generate or preprocess a source file, or compress a binary. In this


### PR DESCRIPTION
ditto