### PR TITLE
Use a real `ActionOwner` for coverage report actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestProvider.java
@@ -16,12 +16,14 @@ package com.google.devtools.build.lib.analysis.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.TestTimeout;
+import javax.annotation.Nullable;
 
 /** A {@link TransitiveInfoProvider} for configured targets that implement test rules. */
 @Immutable
@@ -54,15 +56,20 @@ public final class TestProvider implements TransitiveInfoProvider {
   /** A value class describing the properties of a test. */
   // Non-final only for mocking.
   public static class TestParams {
+    /** A value class describing the coverage-related properties of a test. */
+    record CoverageParams(
+        ImmutableList<Artifact> coverageArtifacts,
+        FilesToRunProvider coverageReportGenerator,
+        ActionOwner actionOwner) {}
+
     private final int runs;
     private final int shards;
     private final boolean runsDetectsFlakes;
     private final TestTimeout timeout;
     private final String testRuleClass;
     private final ImmutableList<Artifact.DerivedArtifact> testStatusArtifacts;
-    private final ImmutableList<Artifact> coverageArtifacts;
-    private final FilesToRunProvider coverageReportGenerator;
     private final ImmutableList<ActionInput> outputs;
+    @Nullable private final CoverageParams coverageParams;
 
     /**
      * Don't call this directly. Instead use {@link
@@ -75,18 +82,16 @@ public final class TestProvider implements TransitiveInfoProvider {
         TestTimeout timeout,
         String testRuleClass,
         ImmutableList<Artifact.DerivedArtifact> testStatusArtifacts,
-        ImmutableList<Artifact> coverageArtifacts,
-        FilesToRunProvider coverageReportGenerator,
-        ImmutableList<ActionInput> outputs) {
+        ImmutableList<ActionInput> outputs,
+        @Nullable CoverageParams coverageParams) {
       this.runs = runs;
       this.shards = shards;
       this.runsDetectsFlakes = runsDetectsFlakes;
       this.timeout = timeout;
       this.testRuleClass = testRuleClass;
       this.testStatusArtifacts = testStatusArtifacts;
-      this.coverageArtifacts = coverageArtifacts;
-      this.coverageReportGenerator = coverageReportGenerator;
       this.outputs = outputs;
+      this.coverageParams = coverageParams;
     }
 
     /** Returns the number of times this test should be run. */
@@ -122,19 +127,34 @@ public final class TestProvider implements TransitiveInfoProvider {
       return testStatusArtifacts;
     }
 
-    /** Returns the coverageArtifacts. */
-    public ImmutableList<Artifact> getCoverageArtifacts() {
-      return coverageArtifacts;
-    }
-
-    /** Returns the coverage report generator tool. */
-    public FilesToRunProvider getCoverageReportGenerator() {
-      return coverageReportGenerator;
-    }
-
     /** Returns the list of mandatory and optional test outputs. */
     public ImmutableList<ActionInput> getOutputs() {
       return outputs;
+    }
+
+    /** Returns the coverageArtifacts. */
+    public ImmutableList<Artifact> getCoverageArtifacts() {
+      return coverageParams != null ? coverageParams.coverageArtifacts() : ImmutableList.of();
+    }
+
+    /**
+     * Returns the coverage report generator tool.
+     *
+     * <p>Returns a non-null value if and only iff coverage is generally enabled.
+     */
+    @Nullable
+    public FilesToRunProvider getCoverageReportGenerator() {
+      return coverageParams != null ? coverageParams.coverageReportGenerator() : null;
+    }
+
+    /**
+     * Returns the test action owner.
+     *
+     * <p>Returns a non-null value if and only iff coverage is generally enabled.
+     */
+    @Nullable
+    public ActionOwner getActionOwnerForCoverage() {
+      return coverageParams != null ? coverageParams.actionOwner() : null;
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageArgs.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageArgs.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.bazel.coverage;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactFactory;
 import com.google.devtools.build.lib.actions.ArtifactOwner;
@@ -40,6 +41,7 @@ public record CoverageArgs(
     FilesToRunProvider reportGenerator,
     String workspaceName,
     boolean htmlReport,
+    ActionOwner actionOwner,
     @Nullable Artifact lcovOutput) {
   public CoverageArgs {
     requireNonNull(directories, "directories");
@@ -49,6 +51,7 @@ public record CoverageArgs(
     requireNonNull(artifactOwner, "artifactOwner");
     requireNonNull(reportGenerator, "reportGenerator");
     requireNonNull(workspaceName, "workspaceName");
+    requireNonNull(actionOwner);
   }
 
   public static CoverageArgs create(
@@ -59,7 +62,8 @@ public record CoverageArgs(
       ArtifactOwner artifactOwner,
       FilesToRunProvider reportGenerator,
       String workspaceName,
-      boolean htmlReport) {
+      boolean htmlReport,
+      ActionOwner actionOwner) {
     return new CoverageArgs(
         directories,
         coverageArtifacts,
@@ -69,10 +73,12 @@ public record CoverageArgs(
         reportGenerator,
         workspaceName,
         htmlReport,
+        actionOwner,
         /* lcovOutput= */ null);
   }
 
-  public static CoverageArgs createCopyWithLcovOutput(CoverageArgs args, Artifact lcovOutput) {
+  public static CoverageArgs createCopyWithLcovOutput(
+      CoverageArgs args,  Artifact lcovOutput) {
     return new CoverageArgs(
         args.directories(),
         args.coverageArtifacts(),
@@ -82,6 +88,7 @@ public record CoverageArgs(
         args.reportGenerator(),
         args.workspaceName(),
         args.htmlReport(),
+        args.actionOwner(),
         lcovOutput);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -14,6 +14,9 @@
 
 package com.google.devtools.build.lib.bazel.coverage;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Comparator.comparing;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -61,6 +64,7 @@ import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Collection;
+import java.util.Comparator;
 import javax.annotation.Nullable;
 
 /**
@@ -94,7 +98,8 @@ public final class CoverageReportActionBuilder {
   private static final ResourceSet LOCAL_RESOURCES =
       ResourceSet.createWithRamCpu(/* memoryMb= */ 750, /* cpu= */ 1);
 
-  private static final ActionOwner ACTION_OWNER = ActionOwner.SYSTEM_ACTION_OWNER;
+  private static final Comparator<ActionOwner> ACTION_OWNER_COMPARATOR =
+      comparing(ActionOwner::getLabel).thenComparing(ActionOwner::getConfigurationChecksum);
 
   // SpawnActions can't be used because they need the AnalysisEnvironment and this action is
   // created specially at the very end of the analysis phase when we don't have it anymore.
@@ -199,6 +204,7 @@ public final class CoverageReportActionBuilder {
     }
     NestedSetBuilder<Artifact> builder = NestedSetBuilder.stableOrder();
     FilesToRunProvider reportGenerator = null;
+    ActionOwner actionOwner = null;
     for (ConfiguredTarget target : targetsToTest) {
       // Skip incompatible tests.
       if (target.get(IncompatiblePlatformProvider.PROVIDER) != null) {
@@ -206,14 +212,22 @@ public final class CoverageReportActionBuilder {
       }
       TestParams testParams = target.getProvider(TestProvider.class).getTestParams();
       builder.addAll(testParams.getCoverageArtifacts());
-      if (reportGenerator == null) {
+      // targetsToTest has non-deterministic order, so we ensure that we pick the same action owner
+      // and matching report generator each time by picking the owner that's lexicographically
+      // smallest. We prefer an owner with exec properties set in case the action is run remotely.
+      if (reportGenerator == null
+          || ACTION_OWNER_COMPARATOR.compare(testParams.getActionOwnerForCoverage(), actionOwner)
+              < 0
+          || actionOwner.getExecProperties().isEmpty()) {
         reportGenerator = testParams.getCoverageReportGenerator();
+        actionOwner = testParams.getActionOwnerForCoverage();
       }
     }
     // If all tests are incompatible, there's nothing to do.
     if (reportGenerator == null) {
       return null;
     }
+    checkNotNull(actionOwner);
     NestedSet<Artifact> coverageArtifacts =
         builder.addTransitive(baselineCoverageArtifacts).build();
     if (!coverageArtifacts.isEmpty()) {
@@ -224,7 +238,7 @@ public final class CoverageReportActionBuilder {
               directories.getBuildDataDirectory(workspaceName),
               artifactOwner);
       Action baselineLcovFileAction =
-          generateLcovFileWriteAction(baselineLcovArtifact, baselineCoverageArtifacts);
+          generateLcovFileWriteAction(baselineLcovArtifact, baselineCoverageArtifacts, actionOwner);
       Action baselineReportAction =
           generateCoverageReportAction(
               CoverageArgs.create(
@@ -235,7 +249,8 @@ public final class CoverageReportActionBuilder {
                   artifactOwner,
                   reportGenerator,
                   workspaceName,
-                  /* htmlReport= */ false),
+                  /* htmlReport= */ false,
+                  actionOwner),
               argsFunction,
               locationFunc,
               "_baseline_report.dat");
@@ -245,7 +260,7 @@ public final class CoverageReportActionBuilder {
               directories.getBuildDataDirectory(workspaceName),
               artifactOwner);
       Action coverageLcovFileAction =
-          generateLcovFileWriteAction(coverageLcovArtifact, coverageArtifacts);
+          generateLcovFileWriteAction(coverageLcovArtifact, coverageArtifacts, actionOwner);
       Action coverageReportAction =
           generateCoverageReportAction(
               CoverageArgs.create(
@@ -256,7 +271,8 @@ public final class CoverageReportActionBuilder {
                   artifactOwner,
                   reportGenerator,
                   workspaceName,
-                  htmlReport),
+                  htmlReport,
+                  actionOwner),
               argsFunction,
               locationFunc,
               "_coverage_report.dat");
@@ -273,9 +289,9 @@ public final class CoverageReportActionBuilder {
   }
 
   private static LazyWritePathsFileAction generateLcovFileWriteAction(
-      Artifact lcovArtifact, NestedSet<Artifact> coverageArtifacts) {
+      Artifact lcovArtifact, NestedSet<Artifact> coverageArtifacts, ActionOwner actionOwner) {
     return new LazyWritePathsFileAction(
-        ACTION_OWNER,
+        actionOwner,
         lcovArtifact,
         coverageArtifacts,
         /* filesToIgnore= */ ImmutableSet.of(),
@@ -317,7 +333,7 @@ public final class CoverageReportActionBuilder {
       inputsBuilder.add(runfilesTree);
     }
     return new CoverageReportAction(
-        ACTION_OWNER,
+        args.actionOwner(),
         inputsBuilder.build(),
         ImmutableSet.of(lcovOutput),
         actionArgs,


### PR DESCRIPTION
This ensures that exec properties are set for some deterministic test exec platform, which may be required if the coverage report action is run remotely.

Fixes #20578