### PR TITLE
Report progress for fetches occuring during Starlark option parsing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -350,7 +350,13 @@ public final class BlazeOptionHandler {
     }
 
     @Override
-    public void post(ExtendedEventHandler.Postable e) {}
+    public void post(ExtendedEventHandler.Postable e) {
+      // Fetches of external repositories are not reported as BES events and important to surface
+      // in the CLI due to their long-running nature.
+      if (e instanceof FetchProgress) {
+        delegate.post(e);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Previously Bazel would just hang on `Computing main repo mapping:` with not further information if any external repo fetch occurs during Starlark option parsing. With this change, fetch and download progress is now reported as usual.