### PR TITLE
Don't forward instrumented files from tool deps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
@@ -479,7 +479,7 @@ public final class InstrumentedFilesCollector {
 
   private static List<? extends TransitiveInfoCollection> attributeDependencyPrerequisites(
       Attribute attribute, RuleContext ruleContext) {
-    if (attribute.getType().getLabelClass() == LabelClass.DEPENDENCY) {
+    if (attribute.getType().getLabelClass() == LabelClass.DEPENDENCY && !attribute.isToolDependency()) {
       return ruleContext.getPrerequisites(attribute.getName());
     }
     return ImmutableList.of();


### PR DESCRIPTION
This restriction was dropped in 9015f383220892b638d47257ddbd407b2ea07055. Tool targets usually don't contribute instrumented files, but this isn't obvious.