### PR TITLE
WIP: Release native `bazel_tools` binaries separately

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,4 +1,5 @@
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//src:release_archive.bzl", "release_archive")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -88,4 +89,35 @@ filegroup(
 sh_binary(
     name = "upload_bazel_mirror",
     srcs = ["upload_bazel_mirror.sh"],
+)
+
+release_archive(
+    name = "remote_bazel_tools_prebuilt_unix_build_file",
+    src_map = {
+        "BUILD.remote_bazel_tools_prebuilt_unix": "BUILD",
+    },
+)
+
+release_archive(
+    name = "remote_bazel_tools_prebuilt_windows_build_file",
+    src_map = {
+        "BUILD.remote_bazel_tools_prebuilt_windows": "BUILD",
+    },
+)
+
+release_archive(
+    name = "remote_bazel_tools_prebuilt",
+    deps = [
+        "//tools/launcher:launcher_prebuilt_all",
+        "//tools/zip:zip_prebuilt_all",
+    ] + select({
+        "@bazel_tools//src/conditions:windows": [
+            "//tools/launcher:launcher_prebuilt_windows",
+            "//tools/test:test_prebuilt_windows",
+            ":remote_bazel_tools_prebuilt_windows_build_file",
+        ],
+        "//conditions:default": [
+            ":remote_bazel_tools_prebuilt_unix_build_file",
+        ],
+    }),
 )

--- a/tools/BUILD.remote_bazel_tools_prebuilt_unix
+++ b/tools/BUILD.remote_bazel_tools_prebuilt_unix
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+filegroup(
+    name = "launcher_maker",
+    srcs = ["launcher/launcher_maker"]
+)
+
+filegroup(
+    name = "zipper",
+    srcs = ["zip/zip"],
+)

--- a/tools/BUILD.remote_bazel_tools_prebuilt_windows
+++ b/tools/BUILD.remote_bazel_tools_prebuilt_windows
@@ -1,0 +1,28 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+filegroup(
+    name = "launcher",
+    srcs = ["launcher/launcher.exe"],
+)
+
+filegroup(
+    name = "launcher_maker",
+    srcs = ["launcher/launcher_maker.exe"],
+)
+
+filegroup(
+    name = "tw",
+    srcs = ["test/tw.exe"],
+)
+
+filegroup(
+    name = "xml",
+    srcs = ["test/xml.exe"],
+)
+
+filegroup(
+    name = "zipper",
+    srcs = ["zip/zipper.exe"],
+)

--- a/tools/launcher/BUILD
+++ b/tools/launcher/BUILD
@@ -1,3 +1,5 @@
+load("//src:release_archive.bzl", "release_archive")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -13,4 +15,19 @@ alias(
 alias(
     name = "launcher_maker",
     actual = "//src/tools/launcher:launcher_maker",
+)
+
+release_archive(
+    name = "launcher_prebuilt_all",
+    srcs = [":launcher_maker"],
+    package_dir = "test",
+    visibility = ["//tools:__pkg__"],
+)
+
+release_archive(
+    name = "launcher_prebuilt_windows",
+    srcs = [":launcher"],
+    package_dir = "test",
+    visibility = ["//tools:__pkg__"],
+    target_compatible_with = ["@bazel_tools//src/conditions:windows"],
 )

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -1,3 +1,5 @@
+load("//src:release_archive.bzl", "release_archive")
+
 package(default_visibility = ["//visibility:public"])
 
 # Members of this filegroup shouldn't have duplicate basenames, otherwise
@@ -135,4 +137,15 @@ filegroup(
         "default_test_toolchain.bzl",
         "extensions.bzl",
     ],
+)
+
+release_archive(
+    name = "test_prebuilt_windows",
+    srcs = [
+        ":tw",
+        ":xml",
+    ],
+    package_dir = "test",
+    visibility = ["//tools:__pkg__"],
+    target_compatible_with = ["@platforms//os:windows"],
 )

--- a/tools/zip/BUILD
+++ b/tools/zip/BUILD
@@ -1,3 +1,5 @@
+load("//src:release_archive.bzl", "release_archive")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -13,4 +15,11 @@ alias(
 alias(
     name = "unzip_fdo",
     actual = "//third_party/ijar:zipper",
+)
+
+release_archive(
+    name = "zip_prebuilt_all",
+    srcs = [":zipper"],
+    package_dir = "zip",
+    visibility = ["//tools:__pkg__"],
 )


### PR DESCRIPTION
This allows binaries such as the Windows test wrapper to be downloaded on non-Windows hosts, thus paving the way for cross platform builds using these tools.

Work towards #19587

TODO:
* Add publishing script
* Add def_parser (?)