### PR TITLE
[8.3.0] Fix a crash when an execution platform is registered twice

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunction.java
@@ -14,10 +14,11 @@
 
 package com.google.devtools.build.lib.skyframe.toolchains;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.ConfiguredTargetValue;
 import com.google.devtools.build.lib.analysis.PlatformConfiguration;
@@ -215,7 +216,7 @@ public class RegisteredExecutionPlatformsFunction implements SkyFunction {
   private static ImmutableList<ConfiguredTargetKey> configureRegisteredExecutionPlatforms(
       Environment env, List<Label> labels)
       throws InterruptedException, RegisteredExecutionPlatformsFunctionException {
-    ImmutableList<ConfiguredTargetKey> keys =
+    ImmutableSet<ConfiguredTargetKey> keys =
         labels.stream()
             .map(
                 label ->
@@ -224,7 +225,7 @@ public class RegisteredExecutionPlatformsFunction implements SkyFunction {
                         .setConfigurationKey(
                             BuildConfigurationKey.create(CommonOptions.EMPTY_OPTIONS))
                         .build())
-            .collect(toImmutableList());
+            .collect(toImmutableSet());
 
     SkyframeLookupResult values = env.getValuesAndExceptions(keys);
     ImmutableList.Builder<ConfiguredTargetKey> validPlatformKeys = new ImmutableList.Builder<>();

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunction.java
@@ -14,12 +14,13 @@
 
 package com.google.devtools.build.lib.skyframe.toolchains;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
 import com.google.devtools.build.lib.actions.ActionLookupKey;
@@ -238,7 +239,7 @@ public class RegisteredToolchainsFunction implements SkyFunction {
   private static ImmutableList<DeclaredToolchainInfo> configureRegisteredToolchains(
       Environment env, BuildConfigurationValue configuration, List<Label> labels)
       throws InterruptedException, RegisteredToolchainsFunctionException {
-    ImmutableList<ActionLookupKey> keys =
+    ImmutableSet<ActionLookupKey> keys =
         labels.stream()
             .map(
                 label ->
@@ -246,7 +247,7 @@ public class RegisteredToolchainsFunction implements SkyFunction {
                         .setLabel(label)
                         .setConfiguration(configuration)
                         .build())
-            .collect(toImmutableList());
+            .collect(toImmutableSet());
 
     SkyframeLookupResult values = env.getValuesAndExceptions(keys);
     ImmutableList.Builder<DeclaredToolchainInfo> toolchains = new ImmutableList.Builder<>();


### PR DESCRIPTION
Fixes:
```
java.lang.RuntimeException: Unrecoverable error while evaluating node 'RegisteredExecutionPlatformsValue.Key{configurationKey=BuildConfigurationKey[9717a88017211d5216fbdbc464e63175f64ccddbf8228373e570ef6207784c59], debug=false}' (requested by nodes 'ToolchainContextKey{configurationKey=BuildConfigurationKey[9717a88017211d5216fbdbc464e63175f64ccddbf8228373e570ef6207784c59], toolchainTypes=[ToolchainTypeRequirement[toolchainType=@@rules_shell+//shell:toolchain_type, mandatory=false, ignoreIfInvalid=false]], execConstraintLabels=[], forceExecutionPlatform=Optional.empty, debugTarget=false}', 'ToolchainContextKey{configurationKey=BuildConfigurationKey[9717a88017211d5216fbdbc464e63175f64ccddbf8228373e570ef6207784c59], toolchainTypes=[], execConstraintLabels=[], forceExecutionPlatform=Optional.empty, debugTarget=false}', 'ToolchainContextKey{configurationKey=BuildConfigurationKey[9717a88017211d5216fbdbc464e63175f64ccddbf8228373e570ef6207784c59], toolchainTypes=[ToolchainTypeRequirement[toolchainType=@@bazel_tools//tools/test:default_test_toolchain_type, mandatory=true, ignoreIfInvalid=false]], execConstraintLabels=[], forceExecutionPlatform=Optional.empty, debugTarget=false}')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:551)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:435)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.IllegalArgumentException: Multiple entries with same key: ConfiguredTargetKey{label=//:exotic_platform, config=BuildConfigurationKey[143f37d1c59dd799b41d79727ea40234e8a728fed9683c1cd6a5d96a9954f9f6]}=PlatformInfo(//:exotic_platform, constraints=<[@@platforms//os:wasi]>) and ConfiguredTargetKey{label=//:exotic_platform, config=BuildConfigurationKey[143f37d1c59dd799b41d79727ea40234e8a728fed9683c1cd6a5d96a9954f9f6]}=PlatformInfo(//:exotic_platform, constraints=<[@@platforms//os:wasi]>)
	at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:382)
	at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:376)
	at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:246)
	at com.google.common.collect.RegularImmutableMap.fromEntryArrayCheckingBucketOverflow(RegularImmutableMap.java:134)
	at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:96)
	at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:579)
	at com.google.common.collect.ImmutableMap$Builder.buildOrThrow(ImmutableMap.java:607)
	at com.google.devtools.build.lib.skyframe.toolchains.RegisteredExecutionPlatformsFunction.configureRegisteredExecutionPlatforms(RegisteredExecutionPlatformsFunction.java:295)
	at com.google.devtools.build.lib.skyframe.toolchains.RegisteredExecutionPlatformsFunction.compute(RegisteredExecutionPlatformsFunction.java:154)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:471)
	... 8 more
```

Also deduplicate toolchain keys for symmetry and to avoid a bit of unnecessary duplicative work.

Closes #25999.

PiperOrigin-RevId: 755293554
Change-Id: I0df716868289eddf83ec57866b70cf26a8dedc1d

Commit https://github.com/bazelbuild/bazel/commit/9123d1d36b857bacc6a4899727c5117961e55f5f