### PR TITLE
Replace `--define=EXECUTOR=remote` with toolchains and selects

### DIFF
--- a/site/en/remote/sandbox.md
+++ b/site/en/remote/sandbox.md
@@ -71,7 +71,6 @@ build:docker-sandbox --javabase=<...>
 build:docker-sandbox --crosstool_top=<...>
 build:docker-sandbox --experimental_docker_image=<...>
 build:docker-sandbox --spawn_strategy=docker --strategy=Javac=docker --genrule_strategy=docker
-build:docker-sandbox --define=EXECUTOR=remote
 build:docker-sandbox --experimental_docker_verbose
 build:docker-sandbox --experimental_enable_docker_sandbox
 ```

--- a/src/MODULE.tools
+++ b/src/MODULE.tools
@@ -45,4 +45,7 @@ bazel_dep(name = "rules_shell", version = "0.3.0")
 # add rules_android
 # add apple_support
 
-register_toolchains("//tools/test:all")
+register_toolchains(
+    "//tools/launcher:all",
+    "//tools/test:all",
+)

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -221,12 +221,6 @@ config_setting(
 )
 
 config_setting(
-    name = "remote",
-    values = {"define": "EXECUTOR=remote"},
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
     name = "debian_build",
     values = {
         "define": "distribution=debian",

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -145,11 +145,13 @@ config_setting(
 
 config_setting(
     name = "host_windows_x64_constraint",
+    deprecation = "No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.",
     values = {"host_cpu": "x64_windows"},
 )
 
 config_setting(
     name = "host_windows_arm64_constraint",
+    deprecation = "No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.",
     values = {"host_cpu": "arm64_windows"},
 )
 
@@ -159,6 +161,7 @@ alias(
         ":host_windows_arm64_constraint": ":host_windows_arm64_constraint",
         "//conditions:default": ":host_windows_x64_constraint",
     }),
+    deprecation = "No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.",
     visibility = ["//visibility:public"],
 )
 

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -164,6 +164,7 @@ alias(
 
 config_setting(
     name = "remote",
+    deprecation = "No longer used by Bazel and may be removed in the future. Migrate to toolchains or define your own version of this setting.",
     values = {"define": "EXECUTOR=remote"},
     visibility = ["//visibility:public"],
 )

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -164,7 +164,7 @@ alias(
 
 config_setting(
     name = "remote",
-    deprecation = "No longer used by Bazel and may be removed in the future. Migrate to toolchains or define your own version of this setting.",
+    deprecation = "No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.",
     values = {"define": "EXECUTOR=remote"},
     visibility = ["//visibility:public"],
 )

--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -165,7 +165,6 @@ class PyRemoteTest(test_base.TestBase):
         '--strategy=Javac=remote',
         '--strategy=Closure=remote',
         '--genrule_strategy=remote',
-        '--define=EXECUTOR=remote',
         '--remote_executor=grpc://localhost:' + str(self._worker_port),
         '--remote_cache=grpc://localhost:' + str(self._worker_port),
         '--remote_timeout=3600',

--- a/src/test/py/bazel/windows_remote_test.py
+++ b/src/test/py/bazel/windows_remote_test.py
@@ -30,7 +30,6 @@ class WindowsRemoteTest(test_base.TestBase):
             '--strategy=Javac=remote',
             '--strategy=Closure=remote',
             '--genrule_strategy=remote',
-            '--define=EXECUTOR=remote',
             '--remote_executor=grpc://localhost:' + str(self._worker_port),
             '--remote_cache=grpc://localhost:' + str(self._worker_port),
             '--remote_timeout=3600',

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1582,8 +1582,7 @@ EOF
 function test_build_hello_world_with_remote_embedded_tool_targets() {
   write_hello_library_files
 
-  bazel build //java/main:main_deploy.jar --define EXECUTOR=remote \
-    &> $TEST_log || fail "build failed"
+  bazel build //java/main:main_deploy.jar &> $TEST_log || fail "build failed"
 }
 
 

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -747,7 +747,7 @@ EOF
   expect_log "ERROR: 'run' only works with tests with one shard"
   # If we would print this again after the run failed, we would overwrite the
   # error message above.
-  expect_log_n "INFO: Build completed successfully, [4567] total actions" 1
+  expect_log_n "INFO: Build completed successfully, [4-9] total actions" 1
 }
 
 function test_exit_code_reported() {

--- a/tools/BUILD.tools
+++ b/tools/BUILD.tools
@@ -1,4 +1,3 @@
-load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load(":build_defs.bzl", "BZLMOD_ENABLED")
 
 package(default_visibility = ["//visibility:public"])
@@ -12,12 +11,6 @@ alias(
 platform(
     name = "internal_platform",
     visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "matches_host_constraints",
-    constraint_values = HOST_CONSTRAINTS,
-    visibility = ["//tools:__subpackages__"],
 )
 
 # All bzl files in the built in repo '@bazel_tools'.

--- a/tools/BUILD.tools
+++ b/tools/BUILD.tools
@@ -1,3 +1,4 @@
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load(":build_defs.bzl", "BZLMOD_ENABLED")
 
 package(default_visibility = ["//visibility:public"])
@@ -11,6 +12,12 @@ alias(
 platform(
     name = "internal_platform",
     visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "matches_host_constraints",
+    constraint_values = HOST_CONSTRAINTS,
+    visibility = ["//tools:__subpackages__"],
 )
 
 # All bzl files in the built in repo '@bazel_tools'.

--- a/tools/build_defs.bzl
+++ b/tools/build_defs.bzl
@@ -63,7 +63,10 @@ def _single_binary_toolchain_rule_impl(ctx):
 _single_binary_toolchain_rule = rule(
     implementation = _single_binary_toolchain_rule_impl,
     attrs = {
-        "binary": attr.label(allow_single_file = True),
+        "binary": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
     },
 )
 

--- a/tools/build_defs.bzl
+++ b/tools/build_defs.bzl
@@ -96,7 +96,12 @@ def single_binary_toolchain(
     )
 
 def _current_toolchain_base_impl(ctx, *, toolchain_type):
-    return DefaultInfo(executable = ctx.toolchains[toolchain_type].binary)
+    executable = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.symlink(
+        output = executable,
+        target_file = ctx.toolchains[toolchain_type].binary,
+    )
+    return DefaultInfo(executable = executable)
 
 def _make_current_toolchain_rule(toolchain_type):
     return rule(

--- a/tools/build_defs.bzl
+++ b/tools/build_defs.bzl
@@ -114,4 +114,3 @@ def _make_current_toolchain_rule(toolchain_type):
     )
 
 current_launcher_binary = _make_current_toolchain_rule("//tools/launcher:launcher_toolchain_type")
-current_launcher_maker_binary = _make_current_toolchain_rule("//tools/launcher:launcher_maker_toolchain_type")

--- a/tools/build_defs.bzl
+++ b/tools/build_defs.bzl
@@ -96,12 +96,13 @@ def single_binary_toolchain(
     )
 
 def _current_toolchain_base_impl(ctx, *, toolchain_type):
-    return DefaultInfo(files = depset([ctx.toolchains[toolchain_type].binary]))
+    return DefaultInfo(executable = ctx.toolchains[toolchain_type].binary)
 
 def _make_current_toolchain_rule(toolchain_type):
     return rule(
         implementation = lambda ctx: _current_toolchain_base_impl(ctx, toolchain_type = toolchain_type),
         toolchains = [toolchain_type],
+        executable = True,
     )
 
 current_launcher_binary = _make_current_toolchain_rule("//tools/launcher:launcher_toolchain_type")

--- a/tools/build_defs.bzl
+++ b/tools/build_defs.bzl
@@ -57,7 +57,7 @@ IS_HOST_WINDOWS = Label("@platforms//os:windows") in [Label(l) for l in HOST_CON
 
 def _single_binary_toolchain_rule_impl(ctx):
     return platform_common.ToolchainInfo(
-        binary = ctx.attr.binary,
+        binary = ctx.file.binary,
     )
 
 _single_binary_toolchain_rule = rule(

--- a/tools/def_parser/BUILD.tools
+++ b/tools/def_parser/BUILD.tools
@@ -1,19 +1,20 @@
+load("//tools:build_defs.bzl", "IS_HOST_WINDOWS")
+
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
-    name = "def_parser_windows",
-    srcs = select({
-        "//src/conditions:remote": ["//third_party/def_parser:def_parser"],
-        "//conditions:default": ["def_parser.exe"],
-    }),
-)
-
+# This should use a toolchain setup like the one for //tools/launcher, but that
+# doesn't provide a good way to bootstrap the def_parser from source build and
+# targets such as `--malloc`, which must not depend on def_parser. Instead,
+# the cc_* rules use a computed default and exclude tags. Since def_parser is
+# only used when targeting Windows and itself only runs on Windows, we only
+# match on the target platform here (which is the exec platform after the exec
+# transition applied by the implicit dep edge from cc_* rules).
+# TODO: Consider improving the situation by wrapping the targets with exclusions
+#  with transitions.
 filegroup(
     name = "def_parser",
     srcs = select({
-        "//src/conditions:host_windows": ["def_parser_windows"],
-        "//conditions:default": [
-            "no_op.bat",
-        ],
+        "@platforms//os:windows": ["def_parser.exe"] if IS_HOST_WINDOWS else ["//third_party/def_parser:def_parser"],
+        "//conditions:default": ["no_op.bat"],
     }),
 )

--- a/tools/launcher/BUILD.tools
+++ b/tools/launcher/BUILD.tools
@@ -49,6 +49,7 @@ single_binary_toolchain(
 
 single_binary_toolchain(
     name = "3_no_launcher_toolchain",
+    binary = "empty.sh",
     toolchain_type = ":launcher_toolchain_type",
 )
 
@@ -69,5 +70,6 @@ single_binary_toolchain(
 
 single_binary_toolchain(
     name = "3_no_launcher_maker_toolchain",
+    binary = "empty.sh",
     toolchain_type = ":launcher_maker_toolchain_type",
 )

--- a/tools/launcher/BUILD.tools
+++ b/tools/launcher/BUILD.tools
@@ -3,29 +3,37 @@ load(
     "//tools:build_defs.bzl",
     "IS_HOST_WINDOWS",
     "current_launcher_binary",
-    "current_launcher_maker_binary",
     "single_binary_toolchain",
 )
 
 package(default_visibility = ["//visibility:public"])
 
+# WARNING: These targets and toolchain types only exist for the purposes of
+# rulesets formerly included in Bazel itself and may change or be removed at any
+# time.
+
 current_launcher_binary(name = "launcher")
 
-current_launcher_maker_binary(name = "launcher_maker")
+# DEPRECATED: Use the `:launcher_maker_toolchain_type` toolchain instead to
+# avoid an unnecessary dependency on a C++ toolchain when building for a
+# non-Windows platform.
+filegroup(
+    name = "launcher_maker",
+    srcs = select({
+        ":is_host": ["launcher_maker.exe" if IS_HOST_WINDOWS else "//src/tools/launcher:launcher_maker"],
+        "//conditions:default": ["//src/tools/launcher:launcher_maker"],
+    }),
+)
 
-# WARNING: These toolchain types and their associated toolchains only exist for
-# the purposes of rulesets formerly included in Bazel itself and may change or
-# be removed at any time.
-
-toolchain_type(
-    name = "launcher_toolchain_type",
+config_setting(
+    name = "is_host",
+    constraint_values = HOST_CONSTRAINTS,
     visibility = ["//visibility:private"],
 )
 
-toolchain_type(
-    name = "launcher_maker_toolchain_type",
-    visibility = ["//visibility:private"],
-)
+toolchain_type(name = "launcher_toolchain_type")
+
+toolchain_type(name = "launcher_maker_toolchain_type")
 
 # Toolchains are prefixed with a number to ensure that their order of definition
 # matches their precedence in the toolchain resolution process when registered

--- a/tools/launcher/BUILD.tools
+++ b/tools/launcher/BUILD.tools
@@ -1,37 +1,73 @@
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+load(
+    "//tools:build_defs.bzl",
+    "IS_HOST_WINDOWS",
+    "current_launcher_binary",
+    "current_launcher_maker_binary",
+    "single_binary_toolchain",
+)
+
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
-    name = "launcher_windows",
-    srcs = select({
-        "//src/conditions:remote": ["//src/tools/launcher:launcher"],
-        "//conditions:default": ["launcher.exe"],
-    }),
+current_launcher_binary(name = "launcher")
+
+current_launcher_maker_binary(name = "launcher_maker")
+
+# WARNING: These toolchain types and their associated toolchains only exist for
+# the purposes of rulesets formerly included in Bazel itself and may change or
+# be removed at any time.
+
+toolchain_type(
+    name = "launcher_toolchain_type",
+    visibility = ["//visibility:private"],
 )
 
-filegroup(
-    name = "launcher",
-    srcs = select({
-        "//src/conditions:host_windows": [":launcher_windows"],
-        "//conditions:default": [
-            "//src/tools/launcher:launcher",
-        ],
-    }),
+toolchain_type(
+    name = "launcher_maker_toolchain_type",
+    visibility = ["//visibility:private"],
 )
 
-filegroup(
-    name = "launcher_maker",
-    srcs = select({
-        "//src/conditions:host_windows": [":launcher_maker_windows"],
-        "//conditions:default": [
-            "//src/tools/launcher:launcher_maker",
-        ],
-    }),
+# Toolchains are prefixed with a number to ensure that their order of definition
+# matches their precedence in the toolchain resolution process when registered
+# with a wildcard pattern (which sorts by name).
+# TODO(#19587): Make all prebuilt binaries available in external repos and add
+#  toolchains for them below so that cross-platform builds can use them without
+#  needing to build from source.
+IS_HOST_WINDOWS and single_binary_toolchain(
+    name = "1_prebuilt_launcher",
+    binary = "launcher.exe",
+    target_compatible_with = HOST_CONSTRAINTS,
+    toolchain_type = ":launcher_toolchain_type",
 )
 
-filegroup(
-    name = "launcher_maker_windows",
-    srcs = select({
-        "//src/conditions:remote": ["//src/tools/launcher:launcher_maker"],
-        "//conditions:default": ["launcher_maker.exe"],
-    }),
+single_binary_toolchain(
+    name = "2_source_launcher_toolchain",
+    binary = "//src/tools/launcher",
+    target_compatible_with = ["@platforms//os:windows"],
+    toolchain_type = ":launcher_toolchain_type",
+)
+
+single_binary_toolchain(
+    name = "3_no_launcher_toolchain",
+    toolchain_type = ":launcher_toolchain_type",
+)
+
+IS_HOST_WINDOWS and single_binary_toolchain(
+    name = "1_prebuilt_launcher_maker",
+    binary = "launcher_maker.exe",
+    exec_compatible_with = HOST_CONSTRAINTS,
+    target_compatible_with = ["@platforms//os:windows"],
+    toolchain_type = ":launcher_maker_toolchain_type",
+)
+
+single_binary_toolchain(
+    name = "2_source_launcher_maker_toolchain",
+    binary = "//src/tools/launcher:launcher_maker",
+    target_compatible_with = ["@platforms//os:windows"],
+    toolchain_type = ":launcher_maker_toolchain_type",
+)
+
+single_binary_toolchain(
+    name = "3_no_launcher_maker_toolchain",
+    toolchain_type = ":launcher_maker_toolchain_type",
 )

--- a/tools/zip/BUILD.tools
+++ b/tools/zip/BUILD.tools
@@ -1,3 +1,5 @@
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -11,4 +13,10 @@ filegroup(
 alias(
     name = "unzip_fdo",
     actual = "zipper",
+)
+
+config_setting(
+    name = "matches_host_constraints",
+    constraint_values = HOST_CONSTRAINTS,
+    visibility = ["//visibility:private"],
 )

--- a/tools/zip/BUILD.tools
+++ b/tools/zip/BUILD.tools
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "zipper",
     srcs = select({
-        "//tools:matches_host_constraints": glob(["zipper/*"]),
+        ":matches_host_constraints": glob(["zipper/*"]),
         "//conditions:default": ["//third_party/ijar:zipper"],
     }),
 )

--- a/tools/zip/BUILD.tools
+++ b/tools/zip/BUILD.tools
@@ -3,8 +3,8 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "zipper",
     srcs = select({
-        "//src/conditions:remote": ["//third_party/ijar:zipper"],
-        "//conditions:default": glob(["zipper/*"]),
+        "//tools:matches_host_constraints": glob(["zipper/*"]),
+        "//conditions:default": ["//third_party/ijar:zipper"],
     }),
 )
 


### PR DESCRIPTION
This allows for cross-platform builds to work seamlessly without a need to manually toggle between prebuilt and from source toolchains.

As a positive side effect, this change also paves the way for dropping a dependency on an exec-configured C++ toolchain of Java and Python targets built for non-Windows platforms. Rulesets will need to migrate to using the launcher maker toolchain instead of the `launcher_maker` target. rules_shell wasn't affected by this as it already defined its own launcher toolchain.


Work towards #19587