### PR TITLE
[8.3.0] Add support for source directories in runfiles with remote execution

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
@@ -176,7 +176,7 @@ class DirectoryTreeBuilder {
             }
             case DIRECTORY -> {
               SortedMap<PathFragment, ActionInput> directoryInputs =
-                  explodeDirectory(input.getExecPath(), execRoot);
+                  explodeDirectory(path, input, artifactPathResolver);
               return buildFromActionInputs(
                   directoryInputs,
                   toolInputs,
@@ -268,30 +268,39 @@ class DirectoryTreeBuilder {
   }
 
   private static SortedMap<PathFragment, ActionInput> explodeDirectory(
-      PathFragment dirname, Path execRoot) throws IOException {
+      PathFragment logicalPath, ActionInput directory, ArtifactPathResolver artifactPathResolver)
+      throws IOException {
     SortedMap<PathFragment, ActionInput> inputs = new TreeMap<>();
-    explodeDirectory(dirname, inputs, execRoot);
+    explodeDirectory(
+        logicalPath, directory.getExecPath(), artifactPathResolver.toPath(directory), inputs);
     return inputs;
   }
 
   private static void explodeDirectory(
-      PathFragment dirname, SortedMap<PathFragment, ActionInput> inputs, Path execRoot)
+      PathFragment logicalPath,
+      PathFragment execPath,
+      Path realPath,
+      SortedMap<PathFragment, ActionInput> inputs)
       throws IOException {
-    Collection<Dirent> entries = execRoot.getRelative(dirname).readdir(Symlinks.FOLLOW);
+    Collection<Dirent> entries = realPath.readdir(Symlinks.FOLLOW);
     for (Dirent entry : entries) {
       String basename = entry.getName();
-      PathFragment path = dirname.getChild(basename);
+      PathFragment childExecPath = execPath.getChild(basename);
       switch (entry.getType()) {
-        case FILE -> inputs.put(path, ActionInputHelper.fromPath(path));
-        case DIRECTORY -> explodeDirectory(path, inputs, execRoot);
+        case FILE ->
+            inputs.put(logicalPath.getChild(basename), ActionInputHelper.fromPath(childExecPath));
+        case DIRECTORY ->
+            explodeDirectory(
+                logicalPath.getChild(basename), childExecPath, realPath.getChild(basename), inputs);
         case SYMLINK ->
             throw new IllegalStateException(
                 String.format(
                     "Encountered symlink input '%s', but all"
                         + " symlinks should have been resolved by readdir. This is a bug.",
-                    path));
+                    childExecPath));
         case UNKNOWN ->
-            throw new IOException(String.format("The file type of '%s' is not supported.", path));
+            throw new IOException(
+                String.format("The file type of '%s' is not supported.", childExecPath));
       }
     }
   }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3711,4 +3711,118 @@ EOF
   assert_contains "input" bazel-bin/a/my_rule
 }
 
+# Verifies that the contents of a directory have the same representation with
+# remote execution regardless of whether they are added as a source directory or
+# via globbing.
+function test_source_directory() {
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+filegroup(
+    name = "source_directory",
+    srcs = ["dir"],
+)
+
+filegroup(
+    name = "glob",
+    srcs = glob(["dir/**"]),
+)
+
+sh_binary(
+    name = "tool_with_source_directory",
+    srcs = ["tool.sh"],
+    data = [":source_directory"],
+)
+
+sh_binary(
+    name = "tool_with_glob",
+    srcs = ["tool.sh"],
+    data = [":glob"],
+)
+
+GENRULE_COMMAND_TEMPLATE = """
+[[ -f a/dir/file.txt ]] || { echo "a/dir/file.txt is not a file"; exit 1; }
+[[ ! -L a/dir/file.txt ]] || { echo "a/dir/file.txt is a symlink"; exit 1; }
+[[ -f a/dir/subdir/file.txt ]] || { echo "a/dir/subdir/file.txt is not a file"; exit 1; }
+[[ ! -L a/dir/subdir/file.txt ]] || { echo "a/dir/subdir/file.txt is a symlink"; exit 1; }
+[[ -f a/dir/symlink.txt ]] || { echo "a/dir/symlink.txt is not a file"; exit 1; }
+[[ ! -L a/dir/symlink.txt ]] || { echo "a/dir/symlink.txt is a symlink"; exit 1; }
+[[ -f a/dir/symlink_dir/file.txt ]] || { echo "a/dir/subdir/file.txt is not a file"; exit 1; }
+[[ ! -L a/dir/symlink_dir ]] || { echo "a/dir/symlink_dir is a symlink"; exit 1; }
+[[ ! -e a/dir/empty_dir ]] || { echo "a/dir/empty_dir exists"; exit 1; }
+[[ ! -e a/dir/symlink_empty_dir ]] || { echo "a/dir/symlink_empty_dir exists"; exit 1; }
+
+runfiles_prefix=$(execpath %s).runfiles/_main
+[[ -f $$runfiles_prefix/a/dir/file.txt ]] || { echo "$$runfiles_prefix/a/dir/file.txt is not a file"; exit 1; }
+[[ ! -L $$runfiles_prefix/a/dir/file.txt ]] || { echo "$$runfiles_prefix/a/dir/file.txt is a symlink"; exit 1; }
+[[ -f $$runfiles_prefix/a/dir/subdir/file.txt ]] || { echo "$$runfiles_prefix/a/dir/subdir/file.txt is not a file"; exit 1; }
+[[ ! -L $$runfiles_prefix/a/dir/subdir/file.txt ]] || { echo "$$runfiles_prefix/a/dir/subdir/file.txt is a symlink"; exit 1; }
+[[ -f $$runfiles_prefix/a/dir/symlink.txt ]] || { echo "$$runfiles_prefix/a/dir/symlink.txt is not a file"; exit 1; }
+[[ ! -L $$runfiles_prefix/a/dir/symlink.txt ]] || { echo "$$runfiles_prefix/a/dir/symlink.txt is a symlink"; exit 1; }
+[[ -f $$runfiles_prefix/a/dir/symlink_dir/file.txt ]] || { echo "$$runfiles_prefix/a/dir/subdir/file.txt is not a file"; exit 1; }
+[[ ! -L $$runfiles_prefix/a/dir/symlink_dir ]] || { echo "$$runfiles_prefix/a/dir/symlink_dir is a symlink"; exit 1; }
+[[ ! -e $$runfiles_prefix/a/dir/empty_dir ]] || { echo "$$runfiles_prefix/a/dir/empty_dir exists"; exit 1; }
+[[ ! -e $$runfiles_prefix/a/dir/symlink_empty_dir ]] || { echo "$$runfiles_prefix/a/dir/symlink_empty_dir exists"; exit 1; }
+
+touch $@
+"""
+
+genrule(
+    name = "gen_source_directory",
+    srcs = [":source_directory"],
+    tools = [":tool_with_source_directory"],
+    outs = ["out1"],
+    cmd = GENRULE_COMMAND_TEMPLATE % ":tool_with_source_directory",
+)
+
+genrule(
+    name = "gen_glob",
+    srcs = [":glob"],
+    tools = [":tool_with_glob"],
+    outs = ["out2"],
+    cmd = GENRULE_COMMAND_TEMPLATE % ":tool_with_glob",
+)
+EOF
+  mkdir -p a/dir
+  touch a/tool.sh
+  chmod +x a/tool.sh
+  touch a/dir/file.txt
+  ln -s file.txt a/dir/symlink.txt
+  mkdir -p a/dir/subdir
+  touch a/dir/subdir/file.txt
+  ln -s subdir a/dir/symlink_dir
+  mkdir a/dir/empty_dir
+  ln -s empty_dir a/dir/symlink_empty_dir
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:gen_glob >& $TEST_log || fail "Failed to build //a:gen_glob"
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:gen_source_directory >& $TEST_log || fail "Failed to build //a:gen_source_directory"
+}
+
+# TODO: Turn this into a more targeted test after enabling proper source
+#  directory tracking (#25834) - it is not specific to remote execution.
+function test_source_directory_dangling_symlink() {
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+    name = "gen",
+    srcs = ["dir"],
+    outs = ["out"],
+    cmd = """
+touch $@
+""",
+)
+EOF
+  mkdir -p a/dir
+  ln -s does_not_exist a/dir/symlink.txt
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:gen >& $TEST_log && fail "build //a:gen should fail"
+  expect_log "The file type of 'a/dir/symlink.txt' is not supported."
+}
+
 run_suite "Remote execution and remote cache tests"


### PR DESCRIPTION
Also add a test verifying that source directories and globbed directory contents have the exact same representation with remote execution.

Fixes #11495
Work towards #25834

Closes #25868.

PiperOrigin-RevId: 755896046
Change-Id: I19d919f7b37e5eb173c0dfb9046f22f9ae7da56c

Commit https://github.com/bazelbuild/bazel/commit/154dae57d1c6616fd2f3ced07f6887326fc812f3