### PR TITLE
[8.3.0] Print exactly what startup options have changed

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -982,10 +982,13 @@ static bool IsVolatileArg(const string &arg) {
 }
 
 // Returns true if the server needs to be restarted to accommodate changes
-// between the two argument lists.
+// between the two argument lists. Populates old_server_options and
+// new_server_options.
 static bool AreStartupOptionsDifferent(
     const vector<string> &running_server_args,
-    const vector<string> &requested_args) {
+    const vector<string> &requested_args,
+    vector<string> *old_server_options,
+    vector<string> *new_server_options) {
   // We need not worry about one side missing an argument and the other side
   // having the default value, since this command line is the canonical one for
   // this version of Bazel: either the default value is listed explicitly or it
@@ -1033,6 +1036,7 @@ static bool AreStartupOptionsDifferent(
                        "included in the current request:";
     for (const string &a : old_args) {
       BAZEL_LOG(INFO) << "  " << a;
+      old_server_options->push_back(a);
     }
   }
   if (!new_args.empty()) {
@@ -1040,6 +1044,7 @@ static bool AreStartupOptionsDifferent(
                        "included when creating the server:";
     for (const string &a : new_args) {
       BAZEL_LOG(INFO) << "  " << a;
+      new_server_options->push_back(a);
     }
   }
 
@@ -1070,11 +1075,31 @@ static bool KillRunningServerIfDifferentStartupOptions(
   // These strings contain null-separated command line arguments. If they are
   // the same, the server can stay alive, otherwise, it needs shuffle off this
   // mortal coil.
-  if (AreStartupOptionsDifferent(old_arguments, server_exe_args)) {
+  vector<string> old_server_options;
+  vector<string> new_server_options;
+  if (AreStartupOptionsDifferent(old_arguments, server_exe_args,
+                                 &old_server_options,
+                                 &new_server_options)) {
     logging_info->restart_reason = NEW_OPTIONS;
-    BAZEL_LOG(WARNING) << "Running " << startup_options.product_name
-                       << " server needs to be killed, because the startup "
-                          "options are different.";
+
+    string different_startup_options_message;
+
+    string old_options_str;
+    blaze_util::JoinStrings(old_server_options, ' ', &old_options_str);
+    different_startup_options_message +=
+        "\n  - Only in old server: " + old_options_str;
+
+    string new_options_str;
+    blaze_util::JoinStrings(new_server_options, ' ', &new_options_str);
+    different_startup_options_message +=
+        "\n  - Only in new server: " + new_options_str;
+
+    BAZEL_LOG(WARNING)
+        << "Running " << startup_options.product_name
+        << " server needs to be killed, because the following startup "
+           "options are different:"
+        << different_startup_options_message;
+
     server->KillRunningServer();
     return true;
   }

--- a/src/test/shell/integration/startup_options_test.sh
+++ b/src/test/shell/integration/startup_options_test.sh
@@ -53,8 +53,10 @@ esac
 function test_different_startup_options() {
   pid=$(bazel --nobatch info server_pid 2> $TEST_log)
   [[ -n $pid ]] || fail "Couldn't run ${PRODUCT_NAME}"
-  newpid=$(bazel --batch info server_pid 2> $TEST_log)
-  expect_log "WARNING: Running B\\(azel\\|laze\\) server needs to be killed, because the startup options are different."
+  newpid=$(bazel --batch --host_jvm_args=-Xmx4321m info server_pid 2> $TEST_log)
+  expect_log "WARNING: Running B\\(azel\\|laze\\) server needs to be killed, because the following startup options are different:
+  - Only in old server: --noshutdown_on_low_sys_mem
+  - Only in new server: --batch --host_jvm_args=-Xmx4321m"
   [[ "$newpid" != "$pid" ]] || fail "pid $pid was the same!"
   if ! "$is_windows"; then
     # On Windows: the kill command of MSYS doesn't work for Windows PIDs.


### PR DESCRIPTION
Recently I was debugging why my bazel server was getting killed seemingly for no reason and noticed that there is no information in stdout. This would be incredibly helpful to have officially in bazel.

Fixes https://github.com/bazelbuild/bazel/issues/25364

Closes #26016.

PiperOrigin-RevId: 756687906
Change-Id: Id3d6565276a2eb15fbd6f83d0a33fab2e31b3ad8

Commit https://github.com/bazelbuild/bazel/commit/cac54c46e5fd14b202066e7da8d05ddc098357c5