### PR TITLE
Record the reason for "no match" in config matching providers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
@@ -165,6 +165,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:transitive_info_provider",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
+        "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import java.util.List;
 import java.util.Map;
 
@@ -45,21 +46,28 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
    * errors, versus a more aggressive future approach could just propagate No.)
    */
   public sealed interface MatchResult {
+    @AutoCodec
     public record Match() implements MatchResult {}
 
     MatchResult MATCH = new Match();
 
+    @AutoCodec
     public record NoMatch(ImmutableList<Diff> diffs) implements MatchResult {
+      @AutoCodec.Instantiator
+      public NoMatch {}
+
       public NoMatch(Diff diff) {
         this(ImmutableList.of(diff));
       }
 
+      @AutoCodec
       public record Diff(Label what, String got, String want) {}
     }
 
     MatchResult ALREADY_REPORTED_NO_MATCH = new NoMatch(ImmutableList.of());
 
     /** Errors make the match question irresolvable. */
+    @AutoCodec
     public record InError(ImmutableList<String> errors) implements MatchResult {}
 
     static MatchResult combine(MatchResult previous, MatchResult current) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.analysis.config;
 
+import com.google.auto.value.AutoBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -23,6 +24,7 @@ import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
+import com.google.errorprone.annotations.DoNotCall;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +63,22 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
       }
 
       @AutoCodec
-      public record Diff(Label what, String got, String want) {}
+      public record Diff(Label what, String got, String want) {
+        public static Builder what(Label what) {
+          return new AutoBuilder_ConfigMatchingProvider_MatchResult_NoMatch_Diff_Builder().what(what);
+        }
+
+        @AutoBuilder
+        public abstract static class Builder {
+          public abstract Builder what(Label what);
+
+          public abstract Builder got(String got);
+
+          public abstract Builder want(String want);
+
+          public abstract Diff build();
+        }
+      }
     }
 
     MatchResult ALREADY_REPORTED_NO_MATCH = new NoMatch(ImmutableList.of());

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ConfigMatchingProvider.java
@@ -24,7 +24,6 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * A "configuration target" that asserts whether or not it matches the configuration it's bound to.
@@ -45,38 +44,56 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
    * <p>e.g. If merging where one is InError and the other is No, then currently will propagate the
    * errors, versus a more aggressive future approach could just propagate No.)
    */
-  // TODO(twigg): This is more cleanly implemented when Java record is available.
-  public static interface MatchResult {
-    // Only InError should return non-null.
-    public abstract @Nullable String getError();
+  public sealed interface MatchResult {
+    public record Match() implements MatchResult {}
 
-    public static final MatchResult MATCH = HasResult.MATCH;
-    public static final MatchResult NOMATCH = HasResult.NOMATCH;
+    MatchResult MATCH = new Match();
 
-    /** Some specified error makes the match question irresolvable. */
-    @AutoValue
-    public abstract class InError implements MatchResult {
-      public static InError create(String error) {
-        return new AutoValue_ConfigMatchingProvider_MatchResult_InError(error);
+    public record NoMatch(ImmutableList<Diff> diffs) implements MatchResult {
+      public NoMatch(Diff diff) {
+        this(ImmutableList.of(diff));
       }
+
+      public record Diff(Label what, String got, String want) {}
     }
 
-    public static MatchResult create(boolean matches) {
-      return matches ? MATCH : NOMATCH;
-    }
+    MatchResult ALREADY_REPORTED_NO_MATCH = new NoMatch(ImmutableList.of());
 
-    /** If previously InError or No, keep previous else convert newData. */
-    public static MatchResult merge(MatchResult previousMatch, boolean andWith) {
-      if (!previousMatch.equals(MATCH)) {
-        return previousMatch;
-      }
-      return andWith ? MATCH : NOMATCH;
+    /** Errors make the match question irresolvable. */
+    public record InError(ImmutableList<String> errors) implements MatchResult {}
+
+    static MatchResult combine(MatchResult previous, MatchResult current) {
+      return switch (previous) {
+        // InError is the most severe state and always takes precedence.
+        case InError(ImmutableList<String> previousErrors) ->
+            switch (current) {
+              case InError(ImmutableList<String> currentErrors) ->
+                  new InError(
+                      ImmutableList.<String>builder()
+                          .addAll(previousErrors)
+                          .addAll(currentErrors)
+                          .build());
+              default -> previous;
+            };
+        case NoMatch(ImmutableList<NoMatch.Diff> previousDiffs) ->
+            switch (current) {
+              case InError(ImmutableList<String> ignored) -> current;
+              case NoMatch(ImmutableList<NoMatch.Diff> currentDiffs) ->
+                  new NoMatch(
+                      ImmutableList.<NoMatch.Diff>builder()
+                          .addAll(previousDiffs)
+                          .addAll(currentDiffs)
+                          .build());
+              case Match() -> previous;
+            };
+        case Match ignored -> current;
+      };
     }
   }
 
   /** Result of accumulating match results: contains any errors or non-matching labels. */
   public record AccumulateResults(
-      ImmutableList<Label> nonMatching, ImmutableMap<Label, String> errors) {
+      ImmutableList<Label> nonMatching, ImmutableMultimap<Label, String> errors) {
     public boolean success() {
       return nonMatching.isEmpty() && errors.isEmpty();
     }
@@ -87,36 +104,18 @@ public abstract class ConfigMatchingProvider implements TransitiveInfoProvider {
    * errors and non-matching providers.
    */
   public static AccumulateResults accumulateMatchResults(List<ConfigMatchingProvider> providers) {
-    ImmutableList.Builder<Label> nonMatching = new ImmutableList.Builder<>();
-    ImmutableMap.Builder<Label, String> errors = new ImmutableMap.Builder<>();
+    ImmutableList.Builder<Label> nonMatching = ImmutableList.builder();
+    ImmutableMultimap.Builder<Label, String> errors = ImmutableMultimap.builder();
     for (ConfigMatchingProvider configProvider : providers) {
-      ConfigMatchingProvider.MatchResult matchResult = configProvider.result();
-      if (matchResult.getError() != null) {
-        String message = matchResult.getError();
-        errors.put(configProvider.label(), message);
-      } else if (matchResult.equals(ConfigMatchingProvider.MatchResult.NOMATCH)) {
+      MatchResult matchResult = configProvider.result();
+      if (matchResult instanceof MatchResult.InError(ImmutableList<String> messages)) {
+        errors.putAll(configProvider.label(), messages);
+      } else if (matchResult instanceof MatchResult.NoMatch) {
         nonMatching.add(configProvider.label());
       }
     }
 
-    return new AccumulateResults(nonMatching.build(), errors.buildKeepingLast());
-  }
-
-  /**
-   * The result was resolved.
-   *
-   * <p>Using an enum to get convenient toString, equals, and hashCode implementations. Interfaces
-   * can't have private members so this is defined here privately and then exported into the
-   * MatchResult interface to allow for ergonomic MatchResult.MATCH checks.
-   */
-  private static enum HasResult implements MatchResult {
-    MATCH,
-    NOMATCH;
-
-    @Override
-    public @Nullable String getError() {
-      return null;
-    }
+    return new AccumulateResults(nonMatching.build(), errors.build());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OutputPathMnemonicComputer.java
@@ -15,7 +15,7 @@
 package com.google.devtools.build.lib.analysis.config;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition.COMMAND_LINE_OPTION_PREFIX;
+import static com.google.devtools.build.lib.cmdline.LabelConstants.COMMAND_LINE_OPTION_PREFIX;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkDefinedConfigTransition.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkDefinedConfigTransition.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputPathsMode
 import com.google.devtools.build.lib.analysis.config.transitions.PatchTransition;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.Label.PackageContext;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.events.Event;
@@ -75,8 +76,6 @@ import net.starlark.java.syntax.Location;
  * <p>Represents a configuration transition across a dependency edge defined in Starlark.
  */
 public abstract sealed class StarlarkDefinedConfigTransition implements ConfigurationTransitionApi {
-
-  public static final String COMMAND_LINE_OPTION_PREFIX = "//command_line_option:";
 
   /**
    * The two groups of build settings that are relevant for a {@link
@@ -136,7 +135,7 @@ public abstract sealed class StarlarkDefinedConfigTransition implements Configur
       throws LabelSyntaxException {
     String canonicalizedString = setting;
     // native options
-    if (setting.startsWith(COMMAND_LINE_OPTION_PREFIX)) {
+    if (setting.startsWith(LabelConstants.COMMAND_LINE_OPTION_PREFIX)) {
       return canonicalizedString;
     }
     canonicalizedString =
@@ -498,7 +497,9 @@ public abstract sealed class StarlarkDefinedConfigTransition implements Configur
       }
       // See if the option's converter knows how to produce to Starlark values.
       OptionDefinition optionDef =
-          optionInfoMap.get(name.substring(COMMAND_LINE_OPTION_PREFIX.length())).getDefinition();
+          optionInfoMap
+              .get(name.substring(LabelConstants.COMMAND_LINE_OPTION_PREFIX.length()))
+              .getDefinition();
       if (!optionDef.getConverter().starlarkConvertible()) {
         throw new UnreadableInputSettingException(name, value.getClass());
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
@@ -73,13 +74,19 @@ public class ConstraintValueInfo extends NativeInfo implements ConstraintValueIn
    * method.
    */
   public ConfigMatchingProvider configMatchingProvider(PlatformInfo platformInfo) {
+    ConstraintValueInfo platformValue = platformInfo.constraints().get(this.constraint());
     return ConfigMatchingProvider.create(
         label,
         ImmutableMultimap.of(),
         ImmutableMap.of(),
         ImmutableSet.of(),
-        ConfigMatchingProvider.MatchResult.create(
-            platformInfo.constraints().hasConstraintValue(this)));
+        equals(platformValue)
+            ? MatchResult.MATCH
+            : new MatchResult.NoMatch(
+                new MatchResult.NoMatch.Diff(
+                    constraint().label(),
+                    label().getName(),
+                    platformValue != null ? platformValue.label().getName() : "<unset>")));
   }
 
   @Override
@@ -103,8 +110,7 @@ public class ConstraintValueInfo extends NativeInfo implements ConstraintValueIn
     if (!(o instanceof ConstraintValueInfo that)) {
       return false;
     }
-    return Objects.equals(constraint, that.constraint)
-        && Objects.equals(label, that.label);
+    return Objects.equals(constraint, that.constraint) && Objects.equals(label, that.label);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
@@ -80,13 +80,17 @@ public class ConstraintValueInfo extends NativeInfo implements ConstraintValueIn
         ImmutableMultimap.of(),
         ImmutableMap.of(),
         ImmutableSet.of(),
-        equals(platformValue)
-            ? MatchResult.MATCH
-            : new MatchResult.NoMatch(
-                new MatchResult.NoMatch.Diff(
-                    constraint().label(),
-                    label().getName(),
-                    platformValue != null ? platformValue.label().getName() : "<unset>")));
+        computeMatchResult(platformValue));
+  }
+
+  private MatchResult computeMatchResult(ConstraintValueInfo platformValue) {
+    return this.equals(platformValue)
+        ? MatchResult.MATCH
+        : new MatchResult.NoMatch(
+            MatchResult.NoMatch.Diff.what(constraint().label())
+                .want(label().getName())
+                .got(platformValue != null ? platformValue.label().getName() : "<unset>")
+                .build());
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition.COMMAND_LINE_OPTION_PREFIX;
+import static com.google.devtools.build.lib.cmdline.LabelConstants.COMMAND_LINE_OPTION_PREFIX;
 import static com.google.devtools.build.lib.analysis.config.transitions.ConfigurationTransition.PATCH_TRANSITION_KEY;
 import static java.util.stream.Collectors.joining;
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransition.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkTransition.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis.starlark;
 
-import static com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition.COMMAND_LINE_OPTION_PREFIX;
+import static com.google.devtools.build.lib.cmdline.LabelConstants.COMMAND_LINE_OPTION_PREFIX;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/LabelConstants.java
@@ -62,4 +62,5 @@ public class LabelConstants {
   // As a result, external repository runfiles are symlinked to:
   // $runfiles_root/$workspace_name/../$repo_name/<path>, i.e. $runfiles_root/$repo_name/<path>.
   public static final PathFragment EXTERNAL_RUNFILES_PATH_PREFIX = PathFragment.create("..");
+  public static final String COMMAND_LINE_OPTION_PREFIX = "//command_line_option:";
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -14,7 +14,7 @@
 
 package com.google.devtools.build.lib.query2.cquery;
 
-import static com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition.COMMAND_LINE_OPTION_PREFIX;
+import static com.google.devtools.build.lib.cmdline.LabelConstants.COMMAND_LINE_OPTION_PREFIX;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigGlobalLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigGlobalLibrary.java
@@ -14,7 +14,7 @@
 
 package com.google.devtools.build.lib.rules.config;
 
-import static com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition.COMMAND_LINE_OPTION_PREFIX;
+import static com.google.devtools.build.lib.cmdline.LabelConstants.COMMAND_LINE_OPTION_PREFIX;
 
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.analysis.config.StarlarkDefinedConfigTransition;

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -259,10 +259,11 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
       var targetPlatformValue = targetPlatformConstraints.get(setting);
       if (!ruleConstraintValue.equals(targetPlatformValue)) {
         diffs.add(
-            new NoMatch.Diff(
-                setting.label(),
-                ruleConstraintValue.label().getName(),
-                targetPlatformValue != null ? targetPlatformValue.label().getName() : "<unset>"));
+            NoMatch.Diff.what(setting.label())
+                .want(ruleConstraintValue.label().getName())
+                .got(
+                    targetPlatformValue != null ? targetPlatformValue.label().getName() : "<unset>")
+                .build());
       }
     }
     return new NoMatch(diffs.build());
@@ -365,7 +366,10 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
         // If TestOptions isn't present then they were trimmed, so any test options set are
         // considered unset by default.
         return new NoMatch(
-            new NoMatch.Diff(toOptionLabel(optionName), expectedRawValue, "<test option trimmed>"));
+            NoMatch.Diff.what(toOptionLabel(optionName))
+                .want(expectedRawValue)
+                .got("<test option trimmed>")
+                .build());
       }
 
       // Report the unknown option as an error.
@@ -419,15 +423,20 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
       return expectedValue == null
           ? MatchResult.MATCH
           : new NoMatch(
-              new NoMatch.Diff(toOptionLabel(optionName), expectedValue.toString(), "null"));
+              NoMatch.Diff.what(toOptionLabel(optionName))
+                  .want(expectedValue.toString())
+                  .got("null")
+                  .build());
 
       // Single-value case:
     } else if (!options.allowsMultipleValues(optionName)) {
       return actualValue.equals(expectedValue)
           ? MatchResult.MATCH
           : new NoMatch(
-              new NoMatch.Diff(
-                  toOptionLabel(optionName), expectedValue.toString(), actualValue.toString()));
+              NoMatch.Diff.what(toOptionLabel(optionName))
+                  .want(expectedValue.toString())
+                  .got(actualValue.toString())
+                  .build());
     }
 
     // Multi-value case:
@@ -440,10 +449,10 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
       return actualList.isEmpty() && expectedList.isEmpty()
           ? MatchResult.MATCH
           : new NoMatch(
-              new NoMatch.Diff(
-                  toOptionLabel(optionName),
-                  expectedList.isEmpty() ? "<empty>" : expectedList.toString(),
-                  actualList.isEmpty() ? "<empty>" : actualList.toString()));
+              NoMatch.Diff.what(toOptionLabel(optionName))
+                  .want(expectedList.isEmpty() ? "<empty>" : expectedList.toString())
+                  .got(actualList.isEmpty() ? "<empty>" : actualList.toString())
+                  .build());
     }
 
     // Multi-value map:
@@ -458,25 +467,27 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
           return actualEntry.getValue().equals(expectedEntry.getValue())
               ? MatchResult.MATCH
               : new NoMatch(
-                  new NoMatch.Diff(
-                      toOptionLabel(optionName),
-                      "%s=%s".formatted(expectedEntry.getKey(), expectedEntry.getValue()),
-                      "%s=%s".formatted(actualEntry.getKey(), actualEntry.getValue())));
+                  NoMatch.Diff.what(toOptionLabel(optionName))
+                      .want("%s=%s".formatted(expectedEntry.getKey(), expectedEntry.getValue()))
+                      .got("%s=%s".formatted(actualEntry.getKey(), actualEntry.getValue()))
+                      .build());
         }
       }
       return new NoMatch(
-          new NoMatch.Diff(
-              toOptionLabel(optionName),
-              "%s=%s".formatted(expectedEntry.getKey(), expectedEntry.getValue()),
-              "<key %s not found>".formatted(expectedEntry.getKey())));
+          NoMatch.Diff.what(toOptionLabel(optionName))
+              .want("%s=%s".formatted(expectedEntry.getKey(), expectedEntry.getValue()))
+              .got("<key %s not found>".formatted(expectedEntry.getKey()))
+              .build());
     }
 
     // Multi-value list:
     return actualList.containsAll(expectedList)
         ? MatchResult.MATCH
         : new NoMatch(
-            new NoMatch.Diff(
-                toOptionLabel(optionName), expectedList.toString(), actualList.toString()));
+            NoMatch.Diff.what(toOptionLabel(optionName))
+                .want(expectedList.toString())
+                .got(actualList.toString())
+                .build());
   }
 
   private static final PackageIdentifier COMMAND_LINE_OPTIONS_PACKAGE =
@@ -572,7 +583,11 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
             deferredErrors.add(provider.getError());
             continue;
           } else if (!provider.getFlagValue().equals(specifiedValue)) {
-            diffs.add(new NoMatch.Diff(specifiedLabel, provider.getFlagValue(), specifiedValue));
+            diffs.add(
+                NoMatch.Diff.what(specifiedLabel)
+                    .got(specifiedValue)
+                    .want(provider.getFlagValue())
+                    .build());
           }
         } else if (target.satisfies(BuildSettingProvider.REQUIRE_BUILD_SETTING_PROVIDER)) {
           // build setting
@@ -632,17 +647,17 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
             } else if (!((List<?>) configurationValue)
                 .contains(Iterables.getOnlyElement(specifiedValueAsIterable))) {
               diffs.add(
-                  new NoMatch.Diff(
-                      specifiedLabel,
-                      configurationValue.toString(),
-                      convertedSpecifiedValue.toString()));
+                  NoMatch.Diff.what(specifiedLabel)
+                      .got(convertedSpecifiedValue.toString())
+                      .want(configurationValue.toString())
+                      .build());
             }
           } else if (!configurationValue.equals(convertedSpecifiedValue)) {
             diffs.add(
-                new NoMatch.Diff(
-                    specifiedLabel,
-                    configurationValue.toString(),
-                    convertedSpecifiedValue.toString()));
+                NoMatch.Diff.what(specifiedLabel)
+                    .got(convertedSpecifiedValue.toString())
+                    .want(configurationValue.toString())
+                    .build());
           }
         } else {
           // This should be configuration-independent error on the attributes of config_setting.

--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigSetting.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.rules.config;
 import static com.google.devtools.build.lib.analysis.config.CoreOptionConverters.BUILD_SETTING_CONVERTERS;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -45,6 +46,8 @@ import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.BuildOptionDetails;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult.NoMatch;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.analysis.platform.ConstraintCollection;
@@ -52,6 +55,7 @@ import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration.TestOptions;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -71,6 +75,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
@@ -136,14 +141,12 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
     }
 
     BuildOptionDetails optionDetails = ruleContext.getConfiguration().getBuildOptionDetails();
-    boolean nativeFlagsMatch =
-        nativeFlagsMatch(nativeFlagSettings.entries(), optionDetails, ruleContext);
-
+    MatchResult nativeFlagsResult =
+        diffNativeFlags(nativeFlagSettings.entries(), optionDetails, ruleContext);
     UserDefinedFlagMatch userDefinedFlags =
         UserDefinedFlagMatch.fromAttributeValueAndPrerequisites(
             userDefinedFlagSettings, optionDetails, ruleContext);
-
-    boolean constraintValuesMatch = constraintValuesMatch(ruleContext);
+    MatchResult constraintValuesResult = diffConstraintValues(ruleContext);
 
     if (ruleContext.hasErrors()) {
       return null;
@@ -155,8 +158,9 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
             nativeFlagSettings,
             userDefinedFlags.getSpecifiedFlagValues(),
             ImmutableSet.copyOf(constraintValueSettings),
-            ConfigMatchingProvider.MatchResult.merge(
-                userDefinedFlags.result(), nativeFlagsMatch && constraintValuesMatch));
+            Stream.of(userDefinedFlags.result(), nativeFlagsResult, constraintValuesResult)
+                .reduce(MatchResult::combine)
+                .get());
 
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addProvider(RunfilesProvider.class, RunfilesProvider.EMPTY)
@@ -206,7 +210,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
    *
    * <p>May generate rule errors on bad settings (e.g. wrong target types).
    */
-  private static boolean constraintValuesMatch(RuleContext ruleContext) {
+  private static MatchResult diffConstraintValues(RuleContext ruleContext) {
     List<ConstraintValueInfo> constraintValues = new ArrayList<>();
     for (TransitiveInfoCollection dep :
         ruleContext.getPrerequisites(ConfigSettingRule.CONSTRAINT_VALUES_ATTRIBUTE)) {
@@ -219,11 +223,11 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
       }
     }
     if (ruleContext.hasErrors()) {
-      return false;
+      return MatchResult.ALREADY_REPORTED_NO_MATCH;
     }
 
     if (constraintValues.isEmpty()) {
-      return true;
+      return MatchResult.MATCH;
     }
 
     // The set of constraint_values in a config_setting should never contain multiple
@@ -234,20 +238,34 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
     } catch (ConstraintCollection.DuplicateConstraintException e) {
       ruleContext.ruleError(
           ConstraintCollection.DuplicateConstraintException.formatError(e.duplicateConstraints()));
-        return false;
+      return MatchResult.ALREADY_REPORTED_NO_MATCH;
     }
 
     if (ruleContext.getToolchainContext() == null) {
       ruleContext.attributeError(
           ConfigSettingRule.CONSTRAINT_VALUES_ATTRIBUTE, "No target platform is present");
-      return false;
+      return MatchResult.ALREADY_REPORTED_NO_MATCH;
     }
 
-    return ruleContext
-        .getToolchainContext()
-        .targetPlatform()
-        .constraints()
-        .containsAll(constraintValues);
+    var targetPlatformConstraints =
+        ruleContext.getToolchainContext().targetPlatform().constraints();
+    if (targetPlatformConstraints.containsAll(constraintValues)) {
+      return MatchResult.MATCH;
+    }
+
+    var diffs = ImmutableList.<NoMatch.Diff>builder();
+    for (var ruleConstraintValue : constraintValues) {
+      var setting = ruleConstraintValue.constraint();
+      var targetPlatformValue = targetPlatformConstraints.get(setting);
+      if (!ruleConstraintValue.equals(targetPlatformValue)) {
+        diffs.add(
+            new NoMatch.Diff(
+                setting.label(),
+                ruleConstraintValue.label().getName(),
+                targetPlatformValue != null ? targetPlatformValue.label().getName() : "<unset>"));
+      }
+    }
+    return new NoMatch(diffs.build());
   }
 
   /**
@@ -268,9 +286,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
     }
   }
 
-  /**
-   * User error when value settings can't be properly parsed.
-   */
+  /** User error when value settings can't be properly parsed. */
   private static final String PARSE_ERROR_MESSAGE = "error while parsing configuration settings: ";
 
   /**
@@ -300,26 +316,24 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
    * Given a list of [flagName, flagValue] pairs for native Blaze flags, returns true if flagName ==
    * flagValue for every item in the list under this configuration, false otherwise.
    */
-  private static boolean nativeFlagsMatch(
+  private static MatchResult diffNativeFlags(
       Collection<Map.Entry<String, String>> expectedSettings,
       BuildOptionDetails options,
       RuleContext ruleContext) {
     // Rather than returning fast when we find a mismatch, continue looking at the other flags
     // to check they're indeed valid flag specifications.
-    boolean foundMismatch = false;
-
-    for (Map.Entry<String, String> setting : expectedSettings) {
-      String optionName = setting.getKey();
-      String expectedRawValue = setting.getValue();
-      if (!checkOptionValue(options, ruleContext, optionName, expectedRawValue)) {
-        foundMismatch = true;
-      }
-    }
-    return !foundMismatch;
+    return expectedSettings.stream()
+        .map(
+            entry -> {
+              String optionName = entry.getKey();
+              String expectedRawValue = entry.getValue();
+              return checkOptionValue(options, ruleContext, optionName, expectedRawValue);
+            })
+        .reduce(MatchResult.MATCH, MatchResult::combine);
   }
 
   /** Returns {@code true} if the option is set to the expected value in the configuration. */
-  private static boolean checkOptionValue(
+  private static MatchResult checkOptionValue(
       BuildOptionDetails options,
       RuleContext ruleContext,
       String optionName,
@@ -335,7 +349,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
                   + "select() on %s is not allowed. Use platform constraints instead:"
                   + " https://bazel.build/docs/configurable-attributes#platforms.",
               optionName));
-      return false;
+      return MatchResult.ALREADY_REPORTED_NO_MATCH;
     }
 
     if (DEPRECATED_FLAGS.contains(optionName) && ruleContext.getLabel().getRepository().isMain()) {
@@ -350,14 +364,15 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
       if (isTestOption(optionName)) {
         // If TestOptions isn't present then they were trimmed, so any test options set are
         // considered unset by default.
-        return false;
+        return new NoMatch(
+            new NoMatch.Diff(toOptionLabel(optionName), expectedRawValue, "<test option trimmed>"));
       }
 
       // Report the unknown option as an error.
       ruleContext.attributeError(
           ConfigSettingRule.SETTINGS_ATTRIBUTE,
           String.format(PARSE_ERROR_MESSAGE + "unknown option: '%s'", optionName));
-      return false;
+      return MatchResult.ALREADY_REPORTED_NO_MATCH;
     }
 
     OptionsParser parser;
@@ -367,7 +382,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
     } catch (OptionsParsingException ex) {
       ruleContext.attributeError(
           ConfigSettingRule.SETTINGS_ATTRIBUTE, PARSE_ERROR_MESSAGE + ex.getMessage());
-      return false;
+      return MatchResult.ALREADY_REPORTED_NO_MATCH;
     }
 
     Object expectedParsedValue = parser.getOptions(optionClass).asMap().get(optionName);
@@ -397,15 +412,22 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
    * no options-parsing support for multiple values in a single clause, e.g. { 'define':
    * 'foo=1,bar=2' } expands to { "foo": "1,bar=2" }, not {"foo": 1, "bar": "2"}.
    */
-  private static boolean optionMatches(
+  private static MatchResult optionMatches(
       BuildOptionDetails options, String optionName, Object expectedValue) {
     Object actualValue = options.getOptionValue(optionName);
     if (actualValue == null) {
-      return expectedValue == null;
+      return expectedValue == null
+          ? MatchResult.MATCH
+          : new NoMatch(
+              new NoMatch.Diff(toOptionLabel(optionName), expectedValue.toString(), "null"));
 
       // Single-value case:
     } else if (!options.allowsMultipleValues(optionName)) {
-      return actualValue.equals(expectedValue);
+      return actualValue.equals(expectedValue)
+          ? MatchResult.MATCH
+          : new NoMatch(
+              new NoMatch.Diff(
+                  toOptionLabel(optionName), expectedValue.toString(), actualValue.toString()));
     }
 
     // Multi-value case:
@@ -415,7 +437,13 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
     List<?> expectedList = (List<?>) expectedValue;
 
     if (actualList.isEmpty() || expectedList.isEmpty()) {
-      return actualList.isEmpty() && expectedList.isEmpty();
+      return actualList.isEmpty() && expectedList.isEmpty()
+          ? MatchResult.MATCH
+          : new NoMatch(
+              new NoMatch.Diff(
+                  toOptionLabel(optionName),
+                  expectedList.isEmpty() ? "<empty>" : expectedList.toString(),
+                  actualList.isEmpty() ? "<empty>" : actualList.toString()));
     }
 
     // Multi-value map:
@@ -427,31 +455,52 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
         Map.Entry<?, ?> actualEntry = (Map.Entry<?, ?>) elem;
         if (actualEntry.getKey().equals(expectedEntry.getKey())) {
           // Found a key match!
-          return actualEntry.getValue().equals(expectedEntry.getValue());
+          return actualEntry.getValue().equals(expectedEntry.getValue())
+              ? MatchResult.MATCH
+              : new NoMatch(
+                  new NoMatch.Diff(
+                      toOptionLabel(optionName),
+                      "%s=%s".formatted(expectedEntry.getKey(), expectedEntry.getValue()),
+                      "%s=%s".formatted(actualEntry.getKey(), actualEntry.getValue())));
         }
       }
-      return false;
+      return new NoMatch(
+          new NoMatch.Diff(
+              toOptionLabel(optionName),
+              "%s=%s".formatted(expectedEntry.getKey(), expectedEntry.getValue()),
+              "<key %s not found>".formatted(expectedEntry.getKey())));
     }
 
     // Multi-value list:
-    return actualList.containsAll(expectedList);
+    return actualList.containsAll(expectedList)
+        ? MatchResult.MATCH
+        : new NoMatch(
+            new NoMatch.Diff(
+                toOptionLabel(optionName), expectedList.toString(), actualList.toString()));
+  }
+
+  private static final PackageIdentifier COMMAND_LINE_OPTIONS_PACKAGE =
+      PackageIdentifier.createInMainRepo(
+          CharMatcher.anyOf(":").trimTrailingFrom(LabelConstants.COMMAND_LINE_OPTION_PREFIX));
+
+  private static Label toOptionLabel(String optionName) {
+    return Label.createUnvalidated(COMMAND_LINE_OPTIONS_PACKAGE, optionName);
   }
 
   private static final class UserDefinedFlagMatch {
-    private final ConfigMatchingProvider.MatchResult result;
+    private final MatchResult result;
     private final ImmutableMap<Label, String> specifiedFlagValues;
 
     private static final Joiner QUOTED_COMMA_JOINER = Joiner.on("', '");
 
     private UserDefinedFlagMatch(
-        ConfigMatchingProvider.MatchResult result,
-        ImmutableMap<Label, String> specifiedFlagValues) {
+        MatchResult result, ImmutableMap<Label, String> specifiedFlagValues) {
       this.result = result;
       this.specifiedFlagValues = specifiedFlagValues;
     }
 
     /** Returns whether the specified flag values matched the actual flag values. */
-    public ConfigMatchingProvider.MatchResult result() {
+    public MatchResult result() {
       return result;
     }
 
@@ -486,7 +535,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
         RuleContext ruleContext) {
       Map<Label, String> specifiedFlagValues = new LinkedHashMap<>();
 
-      boolean matches = true;
+      ArrayList<NoMatch.Diff> diffs = new ArrayList<>();
       // Only configuration-dependent errors should be deferred.
       ArrayList<String> deferredErrors = new ArrayList<>();
       boolean foundDuplicate = false;
@@ -517,14 +566,13 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
                     "error while parsing user-defined configuration values: "
                         + "'%s' is not a valid value for '%s'",
                     specifiedValue, specifiedLabel));
-            matches = false;
             continue;
           }
           if (!Strings.isNullOrEmpty(provider.getError())) {
             deferredErrors.add(provider.getError());
             continue;
           } else if (!provider.getFlagValue().equals(specifiedValue)) {
-            matches = false;
+            diffs.add(new NoMatch.Diff(specifiedLabel, provider.getFlagValue(), specifiedValue));
           }
         } else if (target.satisfies(BuildSettingProvider.REQUIRE_BUILD_SETTING_PROVIDER)) {
           // build setting
@@ -544,7 +592,7 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
             convertedSpecifiedValue =
                 BUILD_SETTING_CONVERTERS
                     .get(provider.getType())
-                    .convert(specifiedValue, /*conversionContext=*/ null);
+                    .convert(specifiedValue, /* conversionContext= */ null);
           } catch (OptionsParsingException e) {
             // This is a configuration-independent error on the attributes of config_setting.
             // So, is appropriate to error immediately.
@@ -554,7 +602,6 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
                     "error while parsing user-defined configuration values: "
                         + "'%s' cannot be converted to %s type %s",
                     specifiedValue, specifiedLabel, provider.getType()));
-            matches = false;
             continue;
           }
 
@@ -582,13 +629,20 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
                           + " allowed. If you want to match multiple values, consider Skylib's "
                           + "selects.config_setting_group",
                       specifiedValue, specifiedLabel));
-              matches = false;
             } else if (!((List<?>) configurationValue)
                 .contains(Iterables.getOnlyElement(specifiedValueAsIterable))) {
-              matches = false;
+              diffs.add(
+                  new NoMatch.Diff(
+                      specifiedLabel,
+                      configurationValue.toString(),
+                      convertedSpecifiedValue.toString()));
             }
           } else if (!configurationValue.equals(convertedSpecifiedValue)) {
-            matches = false;
+            diffs.add(
+                new NoMatch.Diff(
+                    specifiedLabel,
+                    configurationValue.toString(),
+                    convertedSpecifiedValue.toString()));
           }
         } else {
           // This should be configuration-independent error on the attributes of config_setting.
@@ -601,7 +655,6 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
                   "error while parsing user-defined configuration values: "
                       + "%s keys must be build settings or feature flags and %s is not",
                   ConfigSettingRule.FLAG_SETTINGS_ATTRIBUTE, specifiedLabel));
-          matches = false;
         }
       }
 
@@ -623,17 +676,18 @@ public final class ConfigSetting implements RuleConfiguredTargetFactory {
                     actualLabel, QUOTED_COMMA_JOINER.join(aliasList)));
           }
         }
-        matches = false;
       }
+      MatchResult matchResult;
       if (!deferredErrors.isEmpty()) {
-        return new UserDefinedFlagMatch(
-            ConfigMatchingProvider.MatchResult.InError.create(Joiner.on(", ").join(deferredErrors)),
-            ImmutableMap.copyOf(specifiedFlagValues));
+        matchResult = new MatchResult.InError(ImmutableList.copyOf(deferredErrors));
+      } else if (ruleContext.hasErrors()) {
+        matchResult = MatchResult.ALREADY_REPORTED_NO_MATCH;
+      } else if (!diffs.isEmpty()) {
+        matchResult = new NoMatch(ImmutableList.copyOf(diffs));
+      } else {
+        matchResult = MatchResult.MATCH;
       }
-
-      return new UserDefinedFlagMatch(
-          ConfigMatchingProvider.MatchResult.create(matches),
-          ImmutableMap.copyOf(specifiedFlagValues));
+      return new UserDefinedFlagMatch(matchResult, ImmutableMap.copyOf(specifiedFlagValues));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ConfigMatchingUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ConfigMatchingUtil.java
@@ -50,11 +50,12 @@ public final class ConfigMatchingUtil {
       // would be better to just ensure toolchain resolution isn't transitively dependent on
       // feature flags at all.
       String message =
-          accumulateResults.errors().entrySet().stream()
+          accumulateResults.errors().asMap().entrySet().stream()
               .map(
                   entry ->
                       String.format(
-                          "For config_setting %s, %s", entry.getKey().getName(), entry.getValue()))
+                          "For config_setting %s: %s",
+                          entry.getKey().getName(), String.join(", ", entry.getValue())))
               .collect(joining("; "));
       throw new InvalidConfigurationException(
           "Unrecoverable errors resolving config_setting associated with "

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
@@ -521,7 +521,9 @@ public class PlatformInfoTest extends BuildViewTestCase {
             ? MatchResult.MATCH
             : new MatchResult.NoMatch(
                 ImmutableList.of(
-                    new MatchResult.NoMatch.Diff(
-                        Label.parseCanonicalUnchecked("//fake"), "foo", "bar"))));
+                    MatchResult.NoMatch.Diff.what(Label.parseCanonicalUnchecked("//fake"))
+                        .want("foo")
+                        .got("bar")
+                        .build())));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo.ExecPropertiesException;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -516,6 +517,11 @@ public class PlatformInfoTest extends BuildViewTestCase {
         ImmutableMultimap.of(),
         ImmutableMap.of(),
         ImmutableSet.of(),
-        ConfigMatchingProvider.MatchResult.create(match));
+        match
+            ? MatchResult.MATCH
+            : new MatchResult.NoMatch(
+                ImmutableList.of(
+                    new MatchResult.NoMatch.Diff(
+                        Label.parseCanonicalUnchecked("//fake"), "foo", "bar"))));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/ConfigSettingTest.java
@@ -18,6 +18,8 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult.Match;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult.NoMatch;
 import com.google.devtools.build.lib.analysis.config.Fragment;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.analysis.config.RequiresOptions;
@@ -108,11 +110,10 @@ public class ConfigSettingTest extends BuildViewTestCase {
     return getConfiguredTarget(label).getProvider(ConfigMatchingProvider.class);
   }
 
-  private boolean forceConvertMatchResult(ConfigMatchingProvider.MatchResult result)
-      throws Exception {
-    if (result.equals(ConfigMatchingProvider.MatchResult.MATCH)) {
+  private boolean forceConvertMatchResult(ConfigMatchingProvider.MatchResult result) {
+    if (result instanceof Match) {
       return true;
-    } else if (result.equals(ConfigMatchingProvider.MatchResult.NOMATCH)) {
+    } else if (result instanceof NoMatch) {
       return false;
     }
     throw new IllegalStateException("Unexpected MatchResult: " + result);

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTest.java
@@ -17,7 +17,8 @@ package com.google.devtools.build.lib.rules.platform;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
-import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult.InError;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider.MatchResult.Match;
 import com.google.devtools.build.lib.analysis.platform.ConstraintSettingInfo;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.DeclaredToolchainInfo;
@@ -172,13 +173,9 @@ public class ToolchainTest extends BuildViewTestCase {
             ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//toolchain:demo_toolchain")));
     // Ensure target settings completely matches (and not just vacuously e.g. if somehow empty)
     assertThat(provider.targetSettings()).isNotEmpty();
-    assertThat(
-            provider.targetSettings().stream()
-                .allMatch(x -> x.result().equals(ConfigMatchingProvider.MatchResult.MATCH)))
+    assertThat(provider.targetSettings().stream().allMatch(x -> x.result() instanceof Match))
         .isTrue();
-    assertThat(
-            provider.targetSettings().stream()
-                .anyMatch(x -> x.result() instanceof ConfigMatchingProvider.MatchResult.InError))
+    assertThat(provider.targetSettings().stream().anyMatch(x -> x.result() instanceof InError))
         .isFalse();
     assertThat(provider.resolvedToolchainLabel())
         .isEqualTo(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"));
@@ -238,9 +235,7 @@ public class ToolchainTest extends BuildViewTestCase {
     assertThat(provider.toolchainType())
         .isEqualTo(
             ToolchainTypeInfo.create(Label.parseCanonicalUnchecked("//toolchain:demo_toolchain")));
-    assertThat(
-            provider.targetSettings().stream()
-                .anyMatch(x -> x.result().equals(ConfigMatchingProvider.MatchResult.MATCH)))
+    assertThat(provider.targetSettings().stream().anyMatch(x -> x.result() instanceof Match))
         .isFalse();
     assertThat(provider.resolvedToolchainLabel())
         .isEqualTo(Label.parseCanonicalUnchecked("//toolchain:toolchain_def1"));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredExecutionPlatformsFunctionTest.java
@@ -702,7 +702,7 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
         .hasMessageThat()
         .contains(
             "Unrecoverable errors resolving config_setting associated with"
-                + " //extra:required_platform: For config_setting flagged, Feature flag"
+                + " //extra:required_platform: For config_setting flagged: Feature flag"
                 + " //extra:flag was accessed in a configuration it is not present in.");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/RegisteredToolchainsFunctionTest.java
@@ -715,7 +715,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
         .hasMessageThat()
         .contains(
             "Unrecoverable errors resolving config_setting associated with"
-                + " //extra:extra_toolchain: For config_setting flagged, Feature flag"
+                + " //extra:extra_toolchain: For config_setting flagged: Feature flag"
                 + " //extra:flag was accessed in a configuration it is not present in.");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunctionTest.java
@@ -1337,7 +1337,7 @@ For more information on platforms or toolchains see https://bazel.build/concepts
     assertThat(getConfiguredTarget("//rule:me")).isNull();
     assertContainsEvent(
         "Unrecoverable errors resolving config_setting associated with"
-            + " //strange:strange_toolchain: For config_setting flagged, Feature flag"
+            + " //strange:strange_toolchain: For config_setting flagged: Feature flag"
             + " //strange:flag was accessed in a configuration it is not present in.");
   }
 


### PR DESCRIPTION
This prepares for allowing consuming rules, selects as well as toolchain resolution to report why a particular condition didn't match.

I'm submitting this separately as it unlocks a number of other improvements to error messages, but should first be vetted for its potential impact on memory usage.

Work towards #11984 
Work towards #22850