### PR TITLE
Improve part of the output of `--toolchain_resolution_debug`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/BUILD
@@ -362,6 +362,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_key",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:repository_mapping_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe/config",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//src/main/protobuf:failure_details_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionDebugPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionDebugPrinter.java
@@ -13,43 +13,69 @@
 // limitations under the License.
 package com.google.devtools.build.lib.skyframe.toolchains;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.skyframe.RepositoryMappingValue;
+import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
+import java.util.HashSet;
 import java.util.Map;
 
 /** A helper interface for printing debug messages from toolchain resolution. */
 public sealed interface ToolchainResolutionDebugPrinter {
 
-  static ToolchainResolutionDebugPrinter create(boolean debug, ExtendedEventHandler eventHandler) {
-    if (debug) {
-      return new EventHandlerImpl(eventHandler);
+  static ToolchainResolutionDebugPrinter create(boolean debug, SkyFunction.Environment env)
+      throws InterruptedException {
+    if (!debug) {
+      return new NoopPrinter();
     }
-    return new NoopPrinter();
+    var mainRepositoryMapping =
+        (RepositoryMappingValue) env.getValue(RepositoryMappingValue.key(RepositoryName.MAIN));
+    checkNotNull(
+        mainRepositoryMapping,
+        "expected main repository mapping to have been computed when resolving toolchains");
+    return env.getState(() -> new EventHandlerImpl(mainRepositoryMapping.repositoryMapping()));
   }
 
   boolean debugEnabled();
 
-  /** Report on which toolchains were selected. */
-  void reportSelectedToolchains(
+  void startDebugging(
+      EventHandler eventHandler,
       Label targetPlatform,
-      Label executionPlatform,
-      ImmutableSetMultimap<ToolchainTypeInfo, Label> toolchainTypeToResolved);
+      String configurationId,
+      ImmutableSet<ToolchainTypeRequirement> toolchainTypeRequirements);
 
   /** Report on an execution platform that was skipped due to constraint mismatches. */
   void reportRemovedExecutionPlatform(
-      Label label, ImmutableList<ConstraintValueInfo> missingConstraints);
+      EventHandler eventHandler,
+      Label label,
+      ImmutableList<ConstraintValueInfo> missingConstraints);
 
-  void reportRejectedExecutionPlatforms(ImmutableMap<Label, String> rejectedExecutionPlatforms);
+  void reportRejectedExecutionPlatforms(
+      EventHandler eventHandler, ImmutableMap<Label, String> rejectedExecutionPlatforms);
+
+  /** Report on which toolchains were selected. */
+  void finishDebugging(
+      EventHandler eventHandler,
+      Label targetPlatform,
+      String configurationId,
+      Label executionPlatform,
+      ImmutableSetMultimap<ToolchainTypeInfo, Label> toolchainTypeToResolved);
 
   /** A do-nothing implementation for when debug messages are suppressed. */
   final class NoopPrinter implements ToolchainResolutionDebugPrinter {
@@ -62,41 +88,116 @@ public sealed interface ToolchainResolutionDebugPrinter {
     }
 
     @Override
-    public void reportSelectedToolchains(
+    public void startDebugging(
+        EventHandler eventHandler,
         Label targetPlatform,
-        Label executionPlatform,
-        ImmutableSetMultimap<ToolchainTypeInfo, Label> toolchainTypeToResolved) {}
+        String configurationId,
+        ImmutableSet<ToolchainTypeRequirement> toolchainTypeRequirements) {}
 
     @Override
     public void reportRemovedExecutionPlatform(
-        Label label, ImmutableList<ConstraintValueInfo> missingConstraints) {}
+        EventHandler eventHandler,
+        Label label,
+        ImmutableList<ConstraintValueInfo> missingConstraints) {}
 
     @Override
     public void reportRejectedExecutionPlatforms(
-        ImmutableMap<Label, String> rejectedExecutionPlatforms) {}
+        EventHandler eventHandler, ImmutableMap<Label, String> rejectedExecutionPlatforms) {}
+
+    @Override
+    public void finishDebugging(
+        EventHandler eventHandler,
+        Label targetPlatform,
+        String configurationId,
+        Label executionPlatform,
+        ImmutableSetMultimap<ToolchainTypeInfo, Label> toolchainTypeToResolved) {}
   }
 
   /** Implement debug printing using the {@link ExtendedEventHandler}. */
-  final class EventHandlerImpl implements ToolchainResolutionDebugPrinter {
+  final class EventHandlerImpl
+      implements ToolchainResolutionDebugPrinter, SkyFunction.Environment.SkyKeyComputeState {
+    private final RepositoryMapping mainRepositoryMapping;
+
+    public EventHandlerImpl(RepositoryMapping mainRepositoryMapping) {
+      this.mainRepositoryMapping = mainRepositoryMapping;
+    }
+
     @Override
     public boolean debugEnabled() {
       return true;
     }
 
-    private final ExtendedEventHandler eventHandler;
-
-    private EventHandlerImpl(ExtendedEventHandler eventHandler) {
-      this.eventHandler = eventHandler;
-    }
+    private final HashSet<Event> handledEvents = new HashSet<>();
 
     @FormatMethod
-    private void debugMessage(@FormatString String template, Object... args) {
-      eventHandler.handle(Event.info(String.format(template, args)));
+    private void debugMessage(
+        EventHandler eventHandler, @FormatString String template, Object... args) {
+      // Avoid showing the same message multiple times due to Skyframe restarts. This relies on each
+      // message being unique within the lifetime of a single instance.
+      // Note that deduplication is best-effort and may fail if the cache is dropped due to memory
+      // pressure.
+      var event = Event.info("ToolchainResolution: " + String.format(template, args));
+      if (handledEvents.add(event)) {
+        eventHandler.handle(event);
+      }
     }
 
     @Override
-    public void reportSelectedToolchains(
+    public void startDebugging(
+        EventHandler eventHandler,
         Label targetPlatform,
+        String configurationId,
+        ImmutableSet<ToolchainTypeRequirement> toolchainTypeRequirements) {
+      debugMessage(
+          eventHandler,
+          "Starting for target platform %s (config %s)%s",
+          targetPlatform.getShorthandDisplayForm(mainRepositoryMapping),
+          configurationId,
+          toolchainTypeRequirements.isEmpty()
+              ? ""
+              : String.format(
+                  " and types %s",
+                  toolchainTypeRequirements.stream()
+                      .map(
+                          type ->
+                              type.toolchainType().getShorthandDisplayForm(mainRepositoryMapping))
+                      .collect(joining(", "))));
+    }
+
+    @Override
+    public void reportRemovedExecutionPlatform(
+        EventHandler eventHandler,
+        Label label,
+        ImmutableList<ConstraintValueInfo> missingConstraints) {
+      // TODO: jcater - Make this one line listing all constraints.
+      for (ConstraintValueInfo constraint : missingConstraints) {
+        // The value for this setting is not present in the platform, or doesn't match the
+        // expected value.
+        debugMessage(
+            eventHandler,
+            "Skipping execution platform %s from available execution platforms, it is missing constraint %s",
+            label,
+            constraint.label());
+      }
+    }
+
+    @Override
+    public void reportRejectedExecutionPlatforms(
+        EventHandler eventHandler, ImmutableMap<Label, String> rejectedExecutionPlatforms) {
+      if (!rejectedExecutionPlatforms.isEmpty()) {
+        for (Map.Entry<Label, String> entry : rejectedExecutionPlatforms.entrySet()) {
+          Label toolchainLabel = entry.getKey();
+          String message = entry.getValue();
+          debugMessage(eventHandler, "Rejected execution platform %s; %s", toolchainLabel, message);
+        }
+      }
+    }
+
+    @Override
+    public void finishDebugging(
+        EventHandler eventHandler,
+        Label targetPlatform,
+        String configurationId,
         Label executionPlatform,
         ImmutableSetMultimap<ToolchainTypeInfo, Label> toolchainTypeToResolved) {
       String selectedToolchains =
@@ -104,38 +205,18 @@ public sealed interface ToolchainResolutionDebugPrinter {
               .map(
                   e ->
                       String.format(
-                          "type %s -> toolchain %s", e.getKey().typeLabel(), e.getValue()))
+                          "type %s -> toolchain %s",
+                          e.getKey().typeLabel().getShorthandDisplayForm(mainRepositoryMapping),
+                          e.getValue()))
               .collect(joining(", "));
       debugMessage(
-          "ToolchainResolution: Target platform %s: Selected execution platform %s," + " %s",
-          targetPlatform, executionPlatform, selectedToolchains);
-    }
-
-    @Override
-    public void reportRemovedExecutionPlatform(
-        Label label, ImmutableList<ConstraintValueInfo> missingConstraints) {
-      // TODO: jcater - Make this one line listing all constraints.
-      for (ConstraintValueInfo constraint : missingConstraints) {
-        // The value for this setting is not present in the platform, or doesn't match the
-        // expected value.
-        debugMessage(
-            "ToolchainResolution: Removed execution platform %s from"
-                + " available execution platforms, it is missing constraint %s",
-            label, constraint.label());
-      }
-    }
-
-    @Override
-    public void reportRejectedExecutionPlatforms(
-        ImmutableMap<Label, String> rejectedExecutionPlatforms) {
-      if (!rejectedExecutionPlatforms.isEmpty()) {
-        for (Map.Entry<Label, String> entry : rejectedExecutionPlatforms.entrySet()) {
-          Label toolchainLabel = entry.getKey();
-          String message = entry.getValue();
-          debugMessage(
-              "ToolchainResolution: Rejected execution platform %s; %s", toolchainLabel, message);
-        }
-      }
+          eventHandler,
+          "Finished for target platform %s (config %s): execution platform %s%s%s",
+          targetPlatform.getShorthandDisplayForm(mainRepositoryMapping),
+          configurationId,
+          executionPlatform.getShorthandDisplayForm(mainRepositoryMapping),
+          selectedToolchains.isEmpty() ? "" : ", ",
+          selectedToolchains);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/toolchains/ToolchainResolutionFunction.java
@@ -86,7 +86,12 @@ public class ToolchainResolutionFunction implements SkyFunction {
                           .collect(toImmutableSet()));
 
       ToolchainResolutionDebugPrinter debugPrinter =
-          ToolchainResolutionDebugPrinter.create(debug, env.getListener());
+          ToolchainResolutionDebugPrinter.create(debug, env);
+      debugPrinter.startDebugging(
+          env.getListener(),
+          platformConfiguration.getTargetPlatform(),
+          key.configurationKey().getOptions().shortId(),
+          key.toolchainTypes());
 
       // Create keys for all platforms that will be used, and validate them early.
       // Do this early, to catch platform errors early.
@@ -120,8 +125,10 @@ public class ToolchainResolutionFunction implements SkyFunction {
           key.debugTarget());
 
       UnloadedToolchainContext unloadedToolchainContext = builder.build();
-      debugPrinter.reportSelectedToolchains(
-          unloadedToolchainContext.targetPlatform().label(),
+      debugPrinter.finishDebugging(
+          env.getListener(),
+          platformConfiguration.getTargetPlatform(),
+          key.configurationKey().getOptions().shortId(),
           unloadedToolchainContext.executionPlatform().label(),
           unloadedToolchainContext.toolchainTypeToResolved());
       return unloadedToolchainContext;


### PR DESCRIPTION
This improves the debug output of `ToolchainResolutionFunction` (but not `SingleToolchainResolutionFunction`) in several ways:

* messages are no longer duplicated due to Skyframe restarts
* labels are prettified
* start and end of resolution are clearly marked and now reference the configuration

A preexisting problem that hasn't been fixed is that messages about rejected or removed execution platforms is interleaved with other output and thus can't easily be linked to the start/finish messages. How to resolve this in the context of Skyframe restarts and messages printed by the "child" SkyFunction `SingleToolchainResolutionFunction` remains an open problem.

Work towards #11984 