### PR TITLE
[8.3.0] Report progress for fetches occuring during Starlark option parsing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -341,7 +341,13 @@ public final class BlazeOptionHandler {
     }
 
     @Override
-    public void post(ExtendedEventHandler.Postable e) {}
+    public void post(ExtendedEventHandler.Postable e) {
+      // Fetches of external repositories are not reported as BES events and important to surface
+      // in the CLI due to their long-running nature.
+      if (e instanceof FetchProgress) {
+        delegate.post(e);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Previously Bazel would just hang on `Computing main repo mapping:` with no further information if any external repo fetch occurs during Starlark option parsing. With this change, fetch and download progress is now reported as usual.

Closes #25962.

PiperOrigin-RevId: 757646419
Change-Id: I091c7a518d160972ec3370f9fa682be7be9c3f3c

Commit https://github.com/bazelbuild/bazel/commit/040ec46e2237a2f794e3dc5795f486e93c5fce1d