### PR TITLE
Reencode strings obtained from `System.getenv`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BUILD
@@ -88,6 +88,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/python",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:os",
+        "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/java/net/starlark/java/eval",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.bazel.rules;
 
+import static com.google.devtools.build.lib.util.StringEncoding.platformToInternal;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -99,9 +100,10 @@ public class BazelRuleClassProvider {
           .buildOrThrow();
 
   /**
-   * {@link BuildConfigurationFunction} constructs {@link BuildOptions} out of the options required
-   * by the registered fragments. We create and register this fragment exclusively to ensure {@link
-   * StrictActionEnvOptions} is always available.
+   * {@link com.google.devtools.build.lib.skyframe.config.BuildConfigurationFunction} constructs
+   * {@link BuildOptions} out of the options required by the registered fragments. We create and
+   * register this fragment exclusively to ensure {@link StrictActionEnvOptions} is always
+   * available.
    */
   @RequiresOptions(options = {StrictActionEnvOptions.class})
   public static class StrictActionEnvConfiguration extends Fragment {
@@ -117,7 +119,7 @@ public class BazelRuleClassProvider {
     // Honor BAZEL_SH env variable for backwards compatibility.
     String path = System.getenv("BAZEL_SH");
     if (path != null) {
-      return PathFragment.create(path);
+      return PathFragment.create(platformToInternal(path));
     }
     return null;
   }
@@ -163,7 +165,11 @@ public class BazelRuleClassProvider {
           // that is incorrect. We should enable strict_action_env by default and then remove this
           // code, but that change may break Windows users who are relying on the MSYS root being in
           // the PATH.
-          env.put("PATH", pathOrDefault(os, System.getenv("PATH"), shellExecutable));
+          String pathEnv = System.getenv("PATH");
+          if (pathEnv != null) {
+            pathEnv = platformToInternal(pathEnv);
+          }
+          env.put("PATH", pathOrDefault(os, pathEnv, shellExecutable));
         } else {
           // The previous implementation used System.getenv (which uses the server's environment),
           // and fell back to a hard-coded "/bin:/usr/bin" if PATH was not set.
@@ -399,6 +405,8 @@ public class BazelRuleClassProvider {
     String systemRoot = System.getenv("SYSTEMROOT");
     if (Strings.isNullOrEmpty(systemRoot)) {
       systemRoot = "C:\\Windows";
+    } else {
+      systemRoot = platformToInternal(systemRoot);
     }
     newPath += ";" + systemRoot;
     newPath += ";" + systemRoot + "\\System32";

--- a/src/test/shell/bazel/unicode_filenames_test.sh
+++ b/src/test/shell/bazel/unicode_filenames_test.sh
@@ -247,4 +247,35 @@ EOF
   expect_log "changed"
 }
 
+function test_unicode_in_path() {
+  mkdir -p pkg
+  cat >pkg/BUILD <<'EOF'
+load(":defs.bzl", "my_rule")
+
+my_rule(name = "my_rule")
+EOF
+  cat >pkg/defs.bzl <<'EOF'
+def _my_rule_impl(ctx):
+  out = ctx.actions.declare_file(ctx.attr.name)
+  ctx.actions.run_shell(
+    outputs = [out],
+    command = "touch $1",
+    arguments = [out.path],
+    use_default_shell_env = True,
+  )
+  return DefaultInfo(
+    files = depset(direct = [out]),
+  )
+
+my_rule = rule(_my_rule_impl)
+EOF
+
+  # MSYS2 uses : as a path separator even on Windows.
+  export PATH="$PATH:äöüÄÖÜß🌱"
+  # Restart the server since PATH is taken from the server environment on Windows.
+  bazel shutdown > /dev/null 2>&1 || fail "Should shutdown"
+
+  bazel build //pkg:my_rule >$TEST_log 2>&1 || fail "Should build"
+}
+
 run_suite "Tests for handling of Unicode filenames"


### PR DESCRIPTION
Fixes a crash when such strings contain non-ASCII characters.

Fixes #26057