### PR TITLE
Call `Process#destroyForcibly` in `JavaSubprocess#close`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
@@ -104,8 +104,7 @@ public class JavaSubprocessFactory implements SubprocessFactory {
 
     @Override
     public void close() {
-      // java.lang.Process doesn't give us a way to clean things up other than #destroy(), which was
-      // already called by this point.
+      process.destroyForcibly();
     }
 
     @Override


### PR DESCRIPTION
This method wasn't available when the code was written but has since been added.