### PR TITLE
[8.3.0] Call `Process#destroyForcibly` in `JavaSubprocess#close`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
@@ -103,8 +103,7 @@ public class JavaSubprocessFactory implements SubprocessFactory {
 
     @Override
     public void close() {
-      // java.lang.Process doesn't give us a way to clean things up other than #destroy(), which was
-      // already called by this point.
+      process.destroyForcibly();
     }
 
     @Override


### PR DESCRIPTION
This method wasn't available when the code was written but has since been added.

Closes #26067.

PiperOrigin-RevId: 758817223
Change-Id: Ia5b09f45168da37f7db2330f942a201216acb8ad

Commit https://github.com/bazelbuild/bazel/commit/5072ebcd16860228988040e883e6895ef0ecdc52