### PR TITLE
Repo contents cache GC

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -400,12 +400,15 @@ public class BazelRepositoryModule extends BlazeModule {
               detailedExitCode(
                   "could not acquire lock on repo contents cache", Code.BAD_REPO_CONTENTS_CACHE));
         }
-        env.addIdleTask(
-            repositoryCache
-                .getRepoContentsCache()
-                .createGcIdleTask(
-                    repoOptions.repoContentsCacheGcMaxAge,
-                    repoOptions.repoContentsCacheGcIdleDelay));
+        if (!repoOptions.repoContentsCacheGcMaxAge.isZero()
+            && !repoOptions.repoContentsCacheGcIdleDelay.isZero()) {
+          env.addIdleTask(
+              repositoryCache
+                  .getRepoContentsCache()
+                  .createGcIdleTask(
+                      repoOptions.repoContentsCacheGcMaxAge,
+                      repoOptions.repoContentsCacheGcIdleDelay));
+        }
       }
 
       try {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -75,7 +75,7 @@ public class RepositoryOptions extends OptionsBase {
       help =
           """
           Specifies the amount of time an entry in the repo contents cache can stay unused before \
-          it's garbage collected.
+          it's garbage collected. If set to zero, garbage collection is disabled.
           """)
   public Duration repoContentsCacheGcMaxAge;
 
@@ -88,7 +88,7 @@ public class RepositoryOptions extends OptionsBase {
       help =
           """
           Specifies the amount of time the server must remain idle before garbage collection happens
-          to the repo contents cache.
+          to the repo contents cache. If set to zero, garbage collection is disabled.
           """)
   public Duration repoContentsCacheGcIdleDelay;
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.util.OptionsUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Converter;
+import com.google.devtools.common.options.Converters.DurationConverter;
 import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -26,6 +27,7 @@ import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParsingException;
+import java.time.Duration;
 import java.util.List;
 import net.starlark.java.eval.EvalException;
 
@@ -63,6 +65,32 @@ public class RepositoryOptions extends OptionsBase {
           repo contents cache as well, unless '--repo_contents_cache=<some_path>' is also set.
           """)
   public PathFragment repoContentsCache;
+
+  @Option(
+      name = "repo_contents_cache_gc_max_age",
+      defaultValue = "14d",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      converter = DurationConverter.class,
+      help =
+          """
+          Specifies the amount of time an entry in the repo contents cache can stay unused before \
+          it's garbage collected.
+          """)
+  public Duration repoContentsCacheGcMaxAge;
+
+  @Option(
+      name = "repo_contents_cache_gc_idle_delay",
+      defaultValue = "5m",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      converter = DurationConverter.class,
+      help =
+          """
+          Specifies the amount of time the server must remain idle before garbage collection happens
+          to the repo contents cache.
+          """)
+  public Duration repoContentsCacheGcIdleDelay;
 
   @Option(
       name = "registry",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
@@ -21,6 +21,7 @@ java_library(
         "RepositoryCache.java",
     ],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/server:idle_task",
         "//src/main/java/com/google/devtools/build/lib/util:file_system_lock",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs/bazel",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
@@ -117,8 +117,12 @@ public final class RepoContentsCache {
     }
   }
 
-  /** Moves a freshly fetched repo into the contents cache. */
-  public void moveToCache(
+  /**
+   * Moves a freshly fetched repo into the contents cache.
+   *
+   * @return the repo dir in the contents cache.
+   */
+  public Path moveToCache(
       Path fetchedRepoDir, Path fetchedRepoMarkerFile, String predeclaredInputHash)
       throws IOException {
     Preconditions.checkState(path != null);
@@ -147,6 +151,7 @@ public final class RepoContentsCache {
     // Set up a symlink at the original fetched repo dir path.
     fetchedRepoDir.deleteTree();
     FileSystemUtils.ensureSymbolicLink(fetchedRepoDir, cacheRepoDir);
+    return cacheRepoDir;
   }
 
   private static String getNextCounterInDir(Path entryDir) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.UUID;
 import javax.annotation.Nullable;
 
 /**
@@ -227,11 +228,6 @@ public final class RepoContentsCache {
     // (starting with an underscore should suffice).
     Path trashDir = path.getChild("_trash");
     trashDir.createDirectoryAndParents();
-    // To make sure we don't get a name clash when moving things into the trash, we use the current
-    // time as an entry prefix and keep a counter. If the user is messing around with the system
-    // clock, then $DEITY help them.
-    String trashEntryPrefix = path.getLastModifiedTime() + ".";
-    int trashCounter = 1;
 
     for (Path entryDir : path.getDirectoryEntries()) {
       if (!entryDir.isDirectory() || entryDir.equals(trashDir)) {
@@ -249,7 +245,8 @@ public final class RepoContentsCache {
           // Sorry buddy, you're out.
           recordedInputsFile.delete();
           var repoDir = CandidateRepo.fromRecordedInputsFile(recordedInputsFile).contentsDir;
-          repoDir.renameTo(trashDir.getChild(trashEntryPrefix + (trashCounter++)));
+          // Use a UUID to avoid clashes.
+          repoDir.renameTo(trashDir.getChild(UUID.randomUUID().toString()));
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -121,6 +121,10 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
     }
   }
 
+  private static class State extends WorkerSkyKeyComputeState<FetchResult> {
+    @Nullable FetchResult result;
+  }
+
   private record FetchArgs(
       Rule rule, Path outputDirectory, BlazeDirectories directories, Environment env, SkyKey key) {
     FetchArgs toWorkerArgs(Environment env) {
@@ -139,15 +143,22 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
     }
     // See below (the `catch CancellationException` clause) for why there's a `while` loop here.
     while (true) {
-      var state = env.getState(WorkerSkyKeyComputeState<FetchResult>::new);
+      var state = env.getState(State::new);
+      if (state.result != null) {
+        // Escape early if we've already finished fetching once. This can happen if
+        // RepositoryDelegatorFunction triggers a Skyframe restart _after_
+        // StarlarkRepositoryFunction#fetch is finished.
+        return state.result;
+      }
       try {
-        return state.startOrContinueWork(
+        state.result = state.startOrContinueWork(
             env,
             "starlark-repository-" + rule.getName(),
             (workerEnv) -> {
               setupRepoRoot(outputDirectory);
               return fetchInternal(args.toWorkerArgs(workerEnv));
             });
+        return state.result;
       } catch (ExecutionException e) {
         Throwables.throwIfInstanceOf(e.getCause(), RepositoryFunctionException.class);
         Throwables.throwIfInstanceOf(e.getCause(), InterruptedException.class);

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -240,11 +240,11 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
               return null;
             }
             if (repoState instanceof DigestWriter.RepoDirectoryState.UpToDate) {
-              candidate.touch();
               if (setupOverride(candidate.contentsDir().asFragment(), env, repoRoot, repositoryName)
                   == null) {
                 return null;
               }
+              candidate.touch();
               return new RepositoryDirectoryValue.Success(
                   repoRoot, /* isFetchingDelayed= */ false, excludeRepoFromVendoring);
             }

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -240,6 +240,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
               return null;
             }
             if (repoState instanceof DigestWriter.RepoDirectoryState.UpToDate) {
+              candidate.touch();
               if (setupOverride(candidate.contentsDir().asFragment(), env, repoRoot, repositoryName)
                   == null) {
                 return null;

--- a/src/test/java/com/google/devtools/build/lib/buildtool/QueryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/QueryIntegrationTest.java
@@ -1150,6 +1150,9 @@ public class QueryIntegrationTest extends BuildIntegrationTestCase {
               }
             });
     BlazeCommandResult lastBlazeCommandResult = new QueryCommand().exec(env, options);
+    for (BlazeModule module : getRuntime().getBlazeModules()) {
+      module.afterCommand();
+    }
     return new QueryOutput(lastBlazeCommandResult, stdout.toByteArray());
   }
 

--- a/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
+++ b/src/test/py/bazel/bzlmod/repo_contents_cache_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # pylint: disable=g-long-ternary
 
+import os
 import tempfile
 import time
 
@@ -36,6 +37,23 @@ class RepoContentsCacheTest(test_base.TestBase):
             'common --repo_contents_cache=%s' % self.repo_contents_cache,
         ],
     )
+
+  def hasCacheEntry(self):
+    for l1 in os.listdir(self.repo_contents_cache):
+      l1_path = os.path.join(self.repo_contents_cache, l1)
+      if l1 != '_trash' and os.path.isdir(l1_path):
+        for l2 in os.listdir(l1_path):
+          if l2.endswith('.recorded_inputs'):
+            # we still have some cache entries!
+            return True
+    return False
+
+  def sleepUntilCacheEmpty(self):
+    for _ in range(10):
+      if not self.hasCacheEntry():
+        return
+      time.sleep(0.5)
+    self.fail("repo contents cache still not empty after 5 seconds")
 
   def testCachedAfterCleanExpunge(self):
     self.ScratchFile(
@@ -219,6 +237,8 @@ class RepoContentsCacheTest(test_base.TestBase):
     self.ScratchFile('b/BUILD.bazel')
     self.ScratchFile('a/repo.bzl', repo_bzl_lines)
     self.ScratchFile('b/repo.bzl', repo_bzl_lines)
+    self.CopyFile(self.Path('.bazelrc'), 'a/.bazelrc')
+    self.CopyFile(self.Path('.bazelrc'), 'b/.bazelrc')
 
     # First fetch in A: not cached
     self.ScratchFile('a/data.txt', ['one'])
@@ -240,7 +260,7 @@ class RepoContentsCacheTest(test_base.TestBase):
     _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], cwd=dir_a)
     self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
 
-  def testGc(self):
+  def testGc_singleServer(self):
     self.ScratchFile(
         'MODULE.bazel',
         [
@@ -265,14 +285,60 @@ class RepoContentsCacheTest(test_base.TestBase):
 
     # After expunging, but with a very quick GC delay & max age: cached
     self.RunBazel(['clean', '--expunge'])
-    _, _, stderr = self.RunBazel(['build', '--repo_contents_cache_gc_max_age=0',
-                                  '--repo_contents_cache_gc_idle_delay=0',
+    _, _, stderr = self.RunBazel(['build',
+                                  '--repo_contents_cache_gc_max_age=1ms',
+                                  '--repo_contents_cache_gc_idle_delay=1ms',
                                   '@my_repo//:haha'])
     self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
 
     # GC'd while server is alive: not cached, but also no crash
-    time.sleep(0.5)
+    self.sleepUntilCacheEmpty()
     _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'])
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+  def testGc_multipleServers(self):
+    module_bazel_lines = [
+        'repo = use_repo_rule("//:repo.bzl", "repo")',
+        'repo(name = "my_repo")',
+    ]
+    repo_bzl_lines = [
+        'def _repo_impl(rctx):',
+        '  rctx.file("BUILD", "filegroup(name=\'haha\')")',
+        '  print("JUST FETCHED")',
+        '  return rctx.repo_metadata(reproducible=True)',
+        'repo = repository_rule(_repo_impl)',
+    ]
+    # Set up two workspaces with exactly the same repo definition (same
+    # predeclared inputs)
+    dir_a = self.ScratchDir('a')
+    dir_b = self.ScratchDir('b')
+    self.ScratchFile('a/MODULE.bazel', module_bazel_lines)
+    self.ScratchFile('b/MODULE.bazel', module_bazel_lines)
+    self.ScratchFile('a/BUILD.bazel')
+    self.ScratchFile('b/BUILD.bazel')
+    self.ScratchFile('a/repo.bzl', repo_bzl_lines)
+    self.ScratchFile('b/repo.bzl', repo_bzl_lines)
+    self.CopyFile(self.Path('.bazelrc'), 'a/.bazelrc')
+    self.CopyFile(self.Path('.bazelrc'), 'b/.bazelrc')
+
+    # First fetch in A: not cached
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], cwd=dir_a)
+    self.assertIn('JUST FETCHED', '\n'.join(stderr))
+
+    # Fetch in B with very quick GC delay & max age: cached
+    _, _, stderr = self.RunBazel(['build',
+                                  '--repo_contents_cache_gc_max_age=1ms',
+                                  '--repo_contents_cache_gc_idle_delay=1ms',
+                                  '@my_repo//:haha'],
+                                 cwd=dir_b)
+    self.assertNotIn('JUST FETCHED', '\n'.join(stderr))
+
+    # GC'd while A's server is alive: not cached, but also no crash
+    # XXX: THIS IS CURRENTLY FAILING WITH
+    #   BUILD file not found in directory '' of external repository
+    #   @@+repo+my_repo.
+    self.sleepUntilCacheEmpty()
+    _, _, stderr = self.RunBazel(['build', '@my_repo//:haha'], cwd=dir_a)
     self.assertIn('JUST FETCHED', '\n'.join(stderr))
 
 


### PR DESCRIPTION
Very simple GC implementation for the repo contents cache. Entry access is logged by "touching" the recorded inputs file. GC tasks then delete old entries that haven't been accessed in `--repo_contents_cache_gc_max_age` time.

Work towards https://github.com/bazelbuild/bazel/issues/12227.