### PR TITLE
[8.3.0] Fix error message when `single_version_override` patches don't exist

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -805,7 +805,7 @@ public class ModuleFileFunction implements SkyFunction {
       if (!fileValue.isFile()) {
         throw errorf(
             Code.BAD_MODULE,
-            "error reading single_version_override patch %s: not a regular file",
+            "error reading single_version_override patch %s: is a directory or doesn't exist",
             key.argument());
       }
     }


### PR DESCRIPTION
The current message ("not a regular file") is inaccurate -- we actually support "special files" like pipes here, and can mislead people into thinking that symlinks aren't supported here (they totally are).

PiperOrigin-RevId: 750761748
Change-Id: I8ba6e6b420fddf69e0d6a4f2584f9d39914d47f1

Commit https://github.com/bazelbuild/bazel/commit/443012d75ec9c6306ec59c7e3d4804ac135c1aa4