### PR TITLE
[8.3.0] Fix Arbitrary file access during archive extraction (Zip Slip) on `DirectoryWriter`

### DIFF
--- a/third_party/java/proguard/proguard6.2.2/src/proguard/io/DirectoryWriter.java
+++ b/third_party/java/proguard/proguard6.2.2/src/proguard/io/DirectoryWriter.java
@@ -106,13 +106,22 @@ public class DirectoryWriter implements DataEntryWriter
     /**
      * Returns the file for the given data entry.
      */
-    private File getFile(DataEntry dataEntry)
+    private File getFile(DataEntry dataEntry) throws IOException
     {
         // Use the specified file, or construct a new file.
-        return isFile ?
+        File file = isFile ?
             baseFile :
             new File(baseFile,
                      dataEntry.getName().replace(ClassConstants.PACKAGE_SEPARATOR,
                                                  File.separatorChar));
+
+        // Validate that the file path is within the base directory.
+        File canonicalBase = baseFile.getCanonicalFile();
+        File canonicalFile = file.getCanonicalFile();
+        if (!canonicalFile.toPath().startsWith(canonicalBase.toPath())) {
+            throw new IOException("Invalid entry: " + dataEntry.getName());
+        }
+
+        return file;
     }
 }


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/blob/a9dc59524d087217877a40baeaf436d5591c1c05/third_party/java/proguard/proguard6.2.2/src/proguard/io/ZipFileDataEntry.java#L57-L57

Fix the issue need to validate the file paths constructed from zip entry names to ensure they remain within the intended base directory. This can be achieved by normalizing the constructed file path and verifying that it starts with the normalized base directory path. If the validation fails, an exception should be thrown to prevent unsafe file operations.

The fix involves:
1. Modifying the `getFile` method in `DirectoryWriter` to validate the constructed file path.
2. Using `File.getCanonicalFile()` to normalize paths and ensure the constructed path is within the base directory.

---
### References
[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)

