### PR TITLE
Close `--system` files left open by `javac` in `JavaBuilder`

### DIFF
--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -2087,11 +2087,6 @@ EOF
 }
 
 function test_header_compiler_direct_supports_unicode() {
-  if [[ "${JAVA_TOOLS_ZIP}" == released && "$is_windows" ]]; then
-      # TODO: Enable test after the next java_tools release.
-      return 0
-  fi
-
   # JVMs on macOS always support UTF-8 since JEP 400.
   # Windows releases of Turbine are built on a machine with system code page set
   # to UTF-8 so that Graal picks up the correct sun.jnu.encoding value *and*
@@ -2181,6 +2176,59 @@ EOF
   # Verify that the working directory is only stripped from source file paths.
   expect_log "^pkg[\\/]Lib.java:3: error:"
   expect_log "^    String a = 5; // __sandbox/1/_main/pkg/Lib.java:3: error: incompatible types: int cannot be converted to String"
+}
+
+function test_sandboxed_multiplexing_reduced_classpath_fallback() {
+  if [[ "${JAVA_TOOLS_ZIP}" == released && "$is_windows" ]]; then
+      # TODO: Enable test after the next java_tools release.
+      return 0
+  fi
+
+  mkdir -p "pkg/java/hello/" || fail "Expected success"
+  cat > "pkg/java/hello/A.java" <<'EOF'
+package hello;
+public class A {
+  public void f(B b) { b.getC().getD(); }
+}
+EOF
+  cat > "pkg/java/hello/B.java" <<'EOF'
+package hello;
+public class B {
+  public C getC() { return null; }
+}
+EOF
+  cat > "pkg/java/hello/C.java" <<'EOF'
+package hello;
+public class C {
+  public D getD() { return null; }
+}
+EOF
+  cat > "pkg/java/hello/D.java" <<'EOF'
+package hello;
+public class D {}
+EOF
+  cat > "pkg/java/hello/BUILD" <<'EOF'
+load("@rules_java//java:java_library.bzl", "java_library")
+load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
+
+default_java_toolchain(
+    name = "java_toolchain",
+    source_version = "17",
+    target_version = "17",
+    javac_supports_worker_multiplex_sandboxing = True,
+)
+java_library(name='a', srcs=['A.java'], deps = [':b'])
+java_library(name='b', srcs=['B.java'], deps = [':c'])
+java_library(name='c', srcs=['C.java'], deps = [':d'])
+java_library(name='d', srcs=['D.java'])
+EOF
+
+  bazel build //pkg/java/hello:a \
+    --experimental_worker_multiplex_sandboxing \
+    --java_language_version=17 \
+    --experimental_java_classpath=bazel \
+    --extra_toolchains=//pkg/java/hello:java_toolchain_definition \
+    >& $TEST_log || fail "build succeeded"
 }
 
 function test_strict_deps_error_external_repo_starlark_action() {


### PR DESCRIPTION
When using `--system` with a modularized JDK, two of its files are kept open by the JDK after the JavacTask has completed (https://bugs.openjdk.org/browse/JDK-8357249):

* `lib/jrt-fs.jar` is loaded by the host JDK via a `URLClassLoader` that is never closed explicitly.
* `lib/modules` is memory-mapped by the `JrtFileSystem` implementation provided by the system JDK, but never explicitly unmapped (also see https://bugs.openjdk.org/browse/JDK-4724038).

As long as these files are kept open, Bazel can't delete them on Windows, which causes failures when using a sandboxed execution mode (e.g. a sandboxed multiplexed worker) with the reduced classpath optimization, which may delete the input files immediately after compilation when it needs to fall back to the full classpath.

As a workaround, these resources are closed explicitly in `JavaBuilder`.

A reference to the `URLClassLoader` can be obtained from any `Path` backed by the file system. The `Location` of the `java.base` module in the `--system` JDK is used to obtain the `FileSystemProvider` and thus its class loader.

Obtaining and closing the mapped `modules` `ByteBuffer` requires intrusive reflection as well as a call to `Unsafe#invokeCleaner`. All non-`Error` `Throwable`s encountered along the way are ignored to guard against breakages with other JDKs.

Work towards #23384