### PR TITLE
Add a missing null check on `SkyframeLookupResult#getOrThrow`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuildSettingsDetailsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuildSettingsDetailsFunction.java
@@ -163,6 +163,9 @@ final class StarlarkBuildSettingsDetailsFunction implements SkyFunction {
       for (PackageIdentifier packageKey : packageKeys) {
         try {
           SkyValue skyValue = newlyLoaded.getOrThrow(packageKey, NoSuchPackageException.class);
+          if (skyValue == null) {
+            return null;
+          }
           buildSettingPackages.put(packageKey, (PackageValue) skyValue);
         } catch (NoSuchPackageException e) {
           throw new TransitionException(e);


### PR DESCRIPTION
Speculative fix for #22066