### PR TITLE
[Testing AI agent] Fix: experimental_repository_downloader_retries does not retry on 400 HTTP errors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -186,8 +186,6 @@ class HttpConnector {
           if (code == 301) {
             originalUrl = url;
           }
-        } else if (code == 400) { // Specifically handle 400 Bad Request as retriable
-          throw new IOException(describeHttpResponse(connection));
         } else if (code == 403) {
           // jart@ has noticed BitBucket + Amazon AWS downloads frequently flake with this code.
           throw new IOException(describeHttpResponse(connection));
@@ -207,7 +205,6 @@ class HttpConnector {
                     || code == 501     // Server doesn't support function quoth RFC7231 § 6.6.2
                     || code == 505) {  // Server refuses to support version quoth RFC7231 § 6.6.6
           // This is a permanent error so we're not going to retry.
-          // Note: 400 is now handled above
           readAllBytesAndClose(connection.getErrorStream());
           if (code == 404 || code == 410) {
             // For Not Found, we throw a separate unrecoverable exception so that callers can

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -186,6 +186,8 @@ class HttpConnector {
           if (code == 301) {
             originalUrl = url;
           }
+        } else if (code == 400) { // Specifically handle 400 Bad Request as retriable
+          throw new IOException(describeHttpResponse(connection));
         } else if (code == 403) {
           // jart@ has noticed BitBucket + Amazon AWS downloads frequently flake with this code.
           throw new IOException(describeHttpResponse(connection));
@@ -205,6 +207,7 @@ class HttpConnector {
                     || code == 501     // Server doesn't support function quoth RFC7231 § 6.6.2
                     || code == 505) {  // Server refuses to support version quoth RFC7231 § 6.6.6
           // This is a permanent error so we're not going to retry.
+          // Note: 400 is now handled above
           readAllBytesAndClose(connection.getErrorStream());
           if (code == 404 || code == 410) {
             // For Not Found, we throw a separate unrecoverable exception so that callers can

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
@@ -216,6 +216,67 @@ public class HttpConnectorTest {
   }
 
   @Test
+  public void testRetriesOn400() throws Exception {
+    final AtomicInteger requestCount = new AtomicInteger(0);
+    try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError =
+          executor.submit(
+              new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                  // First attempt: respond with 400
+                  try (Socket socket = server.accept()) {
+                    requestCount.incrementAndGet();
+                    readHttpRequest(socket.getInputStream());
+                    sendLines(
+                        socket,
+                        "HTTP/1.1 400 Bad Request",
+                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                        "Connection: close",
+                        "Content-Type: text/plain",
+                        "Content-Length: 0",
+                        "",
+                        "");
+                  }
+                  // Second attempt: respond with 200
+                  try (Socket socket = server.accept()) {
+                    requestCount.incrementAndGet();
+                    readHttpRequest(socket.getInputStream());
+                    sendLines(
+                        socket,
+                        "HTTP/1.1 200 OK",
+                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                        "Connection: close",
+                        "Content-Type: text/plain",
+                        "Content-Length: 5",
+                        "",
+                        "hello");
+                  }
+                  return null;
+                }
+              });
+      HttpConnector customConnector =
+          new HttpConnector(Locale.US, eventHandler, proxyHelper, sleeper, timeoutScaling, 3, java.time.Duration.ZERO);
+      URLConnection connection =
+          customConnector.connect(
+              new URL(String.format("http://localhost:%d/testfile", server.getLocalPort())),
+              url -> ImmutableMap.of());
+      assertThat(connection.getURL())
+          .isEqualTo(
+              new URL(String.format("http://localhost:%d/testfile", server.getLocalPort())));
+      try (Reader payload =
+          new InputStreamReader(connection.getInputStream(), ISO_8859_1)) {
+        assertThat(CharStreams.toString(payload)).isEqualTo("hello");
+      }
+      assertThat(((HttpURLConnection) connection).getResponseCode()).isEqualTo(200);
+      assertThat(requestCount.get()).isEqualTo(2);
+      // Check that some delay happened due to retry
+      assertThat(clock.currentTimeMillis()).isGreaterThan(0L);
+    }
+  }
+
+  @Test
   public void connectionRefused_retries() throws Exception {
     final int port;
 


### PR DESCRIPTION

Bazel's HttpConnector was previously configured to treat HTTP 4xx errors (except for a few specific ones like 403, 408, 429) as unrecoverable. This meant that a transient HTTP 400 "Bad Request" error would cause a download to fail immediately without attempting a retry, even if `experimental_repository_downloader_retries` was set.

This change modifies `HttpConnector.java` to treat HTTP 400 errors as retriable IOExceptions. This allows the existing retry mechanism, governed by `experimental_repository_downloader_retries` and related backoff settings, to engage for these errors.

A new test case, `testRetriesOn400`, has been added to `HttpConnectorTest.java` to verify this behavior. The test uses a mock server that returns a 400 error on the first request and a 200 on the second, ensuring that the connector retries and successfully completes the download.

This addresses issue #26022, improving the resilience of Bazel's repository downloader to transient 400 errors from servers.