### PR TITLE
[8.3.0] Make `local_repository` watch the target path in case it gets removed

### DIFF
--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -1136,6 +1136,28 @@ EOF
   expect_log "(absolute: \"$TEST_TMPDIR/r\") but it does not exist"
 }
 
+function test_local_repository_path_exists_then_doesnt_exist() {
+  local r=$TEST_TMPDIR/r
+  rm -rf $r
+  mkdir -p $r
+  touch $r/REPO.bazel
+  cat > $r/BUILD <<'EOF'
+filegroup(name='r')
+EOF
+  cat >> MODULE.bazel <<EOF
+local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(
+    name = "r",
+    path = "$TEST_TMPDIR/r",
+)
+EOF
+  bazel build @r &> $TEST_log || fail "Build failed unexpectedly"
+
+  rm -rf $r
+  bazel build @r &> $TEST_log && fail "Build succeeded unexpectedly"
+  expect_log "(absolute: \"$TEST_TMPDIR/r\") but it does not exist"
+}
+
 # Regression test for #2841.
 function test_local_repository_missing_workspace_file() {
   local r=$TEST_TMPDIR/r

--- a/tools/build_defs/repo/local.bzl
+++ b/tools/build_defs/repo/local.bzl
@@ -59,7 +59,9 @@ def _get_dir_path(rctx):
     return path
 
 def _local_repository_impl(rctx):
-    rctx.symlink(_get_dir_path(rctx), ".")
+    path = _get_dir_path(rctx)
+    rctx.watch(path)  # In case the target is removed
+    rctx.symlink(path, ".")
 
 local_repository = repository_rule(
     implementation = _local_repository_impl,


### PR DESCRIPTION
This was accidentally found while debugging https://github.com/bazelbuild/bazel/pull/26080. Technically a minor regression introduced by the Starlarkification of `local_repository`.

Closes #26104.

PiperOrigin-RevId: 761143618
Change-Id: Id04a8ace04e812c39bb8c5cd811959e731901606

Commit https://github.com/bazelbuild/bazel/commit/26672bcc2487528da1c8ca437ea13e4db120a69f