### PR TITLE
Add clarifying note to cpp toolchain tutorial

### DIFF
--- a/site/en/tutorials/ccp-toolchain-config.md
+++ b/site/en/tutorials/ccp-toolchain-config.md
@@ -215,7 +215,7 @@ slightly between different versions of clang.
     def _impl(ctx):
         tool_paths = [ # NEW
             tool_path(
-                name = "gcc",
+                name = "gcc",  # Compiler is referenced by the name "gcc" for historic reasons.
                 path = "/usr/bin/clang",
             ),
             tool_path(
@@ -343,7 +343,7 @@ slightly between different versions of clang.
     def _impl(ctx):
         tool_paths = [
             tool_path(
-                name = "gcc",
+                name = "gcc",  # Compiler is referenced by the name "gcc" for historic reasons.
                 path = "/usr/bin/clang",
             ),
             tool_path(


### PR DESCRIPTION
This caused some confusion in the tutorial as reported in #16434. Reading a few times through the tutorial brought me to the important sentence mentioned in https://github.com/bazelbuild/bazel/blob/b95f0a7f0f9b0d8c361822a1badff2bb78919cd5/site/en/tutorials/ccp-toolchain-config.md#L266-L267.

I am adding a comment at the 2 concrete occurrences to make this more clear.

Fixes #16434