### PR TITLE
Simplify `InstrumentedFilesCollector`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/CoverageCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/CoverageCommon.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.analysis.test;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleContext;
@@ -22,7 +21,6 @@ import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleContext;
 import com.google.devtools.build.lib.analysis.test.InstrumentedFilesCollector.InstrumentationSpec;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
-import com.google.devtools.build.lib.collect.nestedset.Depset.TypeException;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -57,7 +55,7 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
       Sequence<?> metadataFiles, // Sequence<Artifact>
       Object reportedToActualSourcesObject,
       StarlarkThread thread)
-      throws EvalException, TypeException {
+      throws EvalException {
     List<String> extensionsList =
         extensions == Starlark.NONE ? null : Sequence.cast(extensions, String.class, "extensions");
     NestedSet<Tuple> reportedToActualSources =
@@ -119,22 +117,6 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
    *     files on the source attributes will be treated as instrumented. Otherwise, only files with
    *     extensions listed in {@code extensions} will be used
    */
-  public static InstrumentedFilesInfo createInstrumentedFilesInfo(
-      RuleContext ruleContext,
-      List<String> sourceAttributes,
-      List<String> dependencyAttributes,
-      @Nullable List<String> extensions) {
-    return createInstrumentedFilesInfo(
-        ruleContext,
-        sourceAttributes,
-        dependencyAttributes,
-        NestedSetBuilder.emptySet(Order.STABLE_ORDER),
-        ImmutableMap.of(),
-        extensions,
-        null,
-        NestedSetBuilder.emptySet(Order.STABLE_ORDER));
-  }
-
   private static InstrumentedFilesInfo createInstrumentedFilesInfo(
       RuleContext ruleContext,
       List<String> sourceAttributes,
@@ -161,12 +143,8 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
     return InstrumentedFilesCollector.collect(
         ruleContext,
         instrumentationSpec,
-        InstrumentedFilesCollector.NO_METADATA_COLLECTOR,
-        /* rootFiles= */ ImmutableList.of(),
         /* coverageSupportFiles= */ supportFiles,
         /* coverageEnvironment= */ environment,
-        /* withBaselineCoverage= */ InstrumentedFilesCollector.shouldIncludeLocalSources(
-            ruleContext.getConfiguration(), ruleContext.getLabel(), ruleContext.isTestTarget()),
         /* reportedToActualSources= */ reportedToActualSources,
         /* additionalMetadata= */ metadataFiles);
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
@@ -17,9 +17,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.analysis.AnalysisEnvironment;
 import com.google.devtools.build.lib.analysis.FileProvider;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
@@ -31,7 +29,6 @@ import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.Type.LabelClass;
-import com.google.devtools.build.lib.util.FileType;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,9 +36,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.Tuple;
 
-/**
- * A helper class for collecting instrumented files and metadata for a target.
- */
+/** A helper class for collecting instrumented files and metadata for a target. */
 public final class InstrumentedFilesCollector {
 
   private InstrumentedFilesCollector() {}
@@ -58,9 +53,7 @@ public final class InstrumentedFilesCollector {
     return collect(
         ruleContext,
         new InstrumentationSpec(FileTypeSet.NO_FILE).withDependencyAttributes(dependencyAttributes),
-        /* localMetadataCollector= */ null,
-        /* rootFiles= */ null,
-        /* reportedToActualSources= */ NestedSetBuilder.<Tuple>emptySet(Order.STABLE_ORDER));
+        /* reportedToActualSources= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER));
   }
 
   public static InstrumentedFilesInfo forwardAll(RuleContext ruleContext) {
@@ -79,9 +72,7 @@ public final class InstrumentedFilesCollector {
     return collect(
         ruleContext,
         spec,
-        NO_METADATA_COLLECTOR,
-        ImmutableList.of(),
-        /* reportedToActualSources= */ NestedSetBuilder.<Tuple>emptySet(Order.STABLE_ORDER));
+        /* reportedToActualSources= */ NestedSetBuilder.emptySet(Order.STABLE_ORDER));
   }
 
   public static InstrumentedFilesInfo collect(
@@ -89,99 +80,23 @@ public final class InstrumentedFilesCollector {
     return collect(
         ruleContext,
         spec,
-        NO_METADATA_COLLECTOR,
-        ImmutableList.of(),
-        NestedSetBuilder.<Artifact>emptySet(Order.STABLE_ORDER),
+        NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         ImmutableMap.of(),
-        false,
-        reportedToActualSources);
-  }
-
-  public static InstrumentedFilesInfo collect(
-      RuleContext ruleContext,
-      InstrumentationSpec spec,
-      LocalMetadataCollector localMetadataCollector,
-      Iterable<Artifact> rootFiles) {
-    return collect(
-        ruleContext,
-        spec,
-        localMetadataCollector,
-        rootFiles,
-        /* reportedToActualSources= */ NestedSetBuilder.<Tuple>emptySet(Order.STABLE_ORDER));
-  }
-
-  public static InstrumentedFilesInfo collect(
-      RuleContext ruleContext,
-      InstrumentationSpec spec,
-      LocalMetadataCollector localMetadataCollector,
-      Iterable<Artifact> rootFiles,
-      NestedSet<Tuple> reportedToActualSources) {
-    return collect(
-        ruleContext,
-        spec,
-        localMetadataCollector,
-        rootFiles,
-        NestedSetBuilder.<Artifact>emptySet(Order.STABLE_ORDER),
-        ImmutableMap.of(),
-        false,
-        reportedToActualSources);
+        reportedToActualSources,
+        /* additionalMetadata= */ null);
   }
 
   /**
    * Collects transitive instrumentation data from dependencies, collects local source files from
    * dependencies, collects local metadata files by traversing the action graph of the current
    * configured target, collect rule-specific instrumentation support files and creates baseline
-   * coverage actions for the transitive closure of source files (if <code>withBaselineCoverage
-   * </code> is true).
+   * coverage actions for the local source files (if any).
    */
   public static InstrumentedFilesInfo collect(
       RuleContext ruleContext,
       InstrumentationSpec spec,
-      LocalMetadataCollector localMetadataCollector,
-      Iterable<Artifact> rootFiles,
       NestedSet<Artifact> coverageSupportFiles,
       ImmutableMap<String, String> coverageEnvironment,
-      boolean withBaselineCoverage) {
-    return collect(
-        ruleContext,
-        spec,
-        localMetadataCollector,
-        rootFiles,
-        coverageSupportFiles,
-        coverageEnvironment,
-        withBaselineCoverage,
-        /* reportedToActualSources= */ NestedSetBuilder.<Tuple>emptySet(Order.STABLE_ORDER));
-  }
-
-  public static InstrumentedFilesInfo collect(
-      RuleContext ruleContext,
-      InstrumentationSpec spec,
-      @Nullable LocalMetadataCollector localMetadataCollector,
-      @Nullable Iterable<Artifact> rootFiles,
-      NestedSet<Artifact> coverageSupportFiles,
-      ImmutableMap<String, String> coverageEnvironment,
-      boolean withBaselineCoverage,
-      NestedSet<Tuple> reportedToActualSources) {
-    return collect(
-        ruleContext,
-        spec,
-        localMetadataCollector,
-        rootFiles,
-        coverageSupportFiles,
-        coverageEnvironment,
-        withBaselineCoverage,
-        reportedToActualSources,
-        /* additionalMetadata= */ null);
-  }
-
-  public static InstrumentedFilesInfo collect(
-      RuleContext ruleContext,
-      InstrumentationSpec spec,
-      @Nullable LocalMetadataCollector localMetadataCollector,
-      @Nullable Iterable<Artifact> rootFiles,
-      NestedSet<Artifact> coverageSupportFiles,
-      ImmutableMap<String, String> coverageEnvironment,
-      boolean withBaselineCoverage,
       NestedSet<Tuple> reportedToActualSources,
       @Nullable Iterable<Artifact> additionalMetadata) {
     Preconditions.checkNotNull(ruleContext);
@@ -196,8 +111,7 @@ public final class InstrumentedFilesCollector {
             ruleContext, coverageSupportFiles, reportedToActualSources);
 
     // Transitive instrumentation data.
-    for (TransitiveInfoCollection dep :
-        getPrerequisitesForAttributes(ruleContext, spec.dependencyAttributes)) {
+    for (var dep : getPrerequisitesForAttributes(ruleContext, spec.dependencyAttributes)) {
       instrumentedFilesInfoBuilder.addFromDependency(dep);
     }
 
@@ -205,30 +119,19 @@ public final class InstrumentedFilesCollector {
     instrumentedFilesInfoBuilder.coverageEnvironmentBuilder.putAll(coverageEnvironment);
 
     // Local sources.
-    ImmutableSet<Artifact> localSources = ImmutableSet.of();
+    var localSources = ImmutableSet.<Artifact>builder();
     if (shouldIncludeLocalSources(
         ruleContext.getConfiguration(), ruleContext.getLabel(), ruleContext.isTestTarget())) {
-      ImmutableSet.Builder<Artifact> localSourcesBuilder = ImmutableSet.builder();
-      for (TransitiveInfoCollection dep :
-          getPrerequisitesForAttributes(ruleContext, spec.sourceAttributes)) {
+      for (var dep : getPrerequisitesForAttributes(ruleContext, spec.sourceAttributes)) {
         for (Artifact artifact : dep.getProvider(FileProvider.class).getFilesToBuild().toList()) {
           if (shouldIncludeArtifact(ruleContext.getConfiguration(), artifact)
               && spec.instrumentedFileTypes.matches(artifact.getFilename())) {
-            localSourcesBuilder.add(artifact);
+            localSources.add(artifact);
           }
         }
       }
-      localSources = localSourcesBuilder.build();
     }
-    instrumentedFilesInfoBuilder.setLocalSources(localSources);
-    if (withBaselineCoverage) {
-      instrumentedFilesInfoBuilder.generateBaselineCoverage();
-    }
-
-    // Local metadata files.
-    if (localMetadataCollector != null) {
-      instrumentedFilesInfoBuilder.collectLocalMetadata(localMetadataCollector, rootFiles);
-    }
+    instrumentedFilesInfoBuilder.setLocalSources(localSources.build());
 
     if (additionalMetadata != null) {
       instrumentedFilesInfoBuilder.addMetadataFiles(additionalMetadata);
@@ -244,8 +147,8 @@ public final class InstrumentedFilesCollector {
    */
   public static boolean shouldIncludeLocalSources(
       BuildConfigurationValue config, TransitiveInfoCollection target) {
-    return shouldIncludeLocalSources(config, target.getLabel(),
-        target.getProvider(TestProvider.class) != null);
+    return shouldIncludeLocalSources(
+        config, target.getLabel(), target.getProvider(TestProvider.class) != null);
   }
 
   /**
@@ -330,39 +233,6 @@ public final class InstrumentedFilesCollector {
     }
   }
 
-  /**
-   * The implementation for the local metadata collection. The intention is that implementations
-   * recurse over the locally (i.e., for that configured target) created actions and collect
-   * metadata files.
-   */
-  public abstract static class LocalMetadataCollector {
-    /**
-     * Recursively runs over the local actions and add metadata files to the metadataFilesBuilder.
-     */
-    public abstract void collectMetadataArtifacts(
-        Iterable<Artifact> artifacts, AnalysisEnvironment analysisEnvironment,
-        NestedSetBuilder<Artifact> metadataFilesBuilder);
-
-    /**
-     * Adds action output of a particular type to metadata files.
-     *
-     * <p>Only adds the first output that matches the given file type.
-     *
-     * @param metadataFilesBuilder builder to collect metadata files
-     * @param action the action whose outputs to scan
-     * @param fileType the filetype of outputs which should be collected
-     */
-    protected void addOutputs(NestedSetBuilder<Artifact> metadataFilesBuilder,
-                              ActionAnalysisMetadata action, FileType fileType) {
-      for (Artifact output : action.getOutputs()) {
-        if (fileType.matches(output.getFilename())) {
-          metadataFilesBuilder.add(output);
-          break;
-        }
-      }
-    }
-  }
-
   private static class InstrumentedFilesInfoBuilder {
 
     final RuleContext ruleContext;
@@ -373,7 +243,6 @@ public final class InstrumentedFilesCollector {
     final ImmutableMap.Builder<String, String> coverageEnvironmentBuilder;
     final NestedSet<Tuple> reportedToActualSources;
     NestedSet<Artifact> localSources;
-    boolean generateBaselineCoverage;
 
     InstrumentedFilesInfoBuilder(
         RuleContext ruleContext,
@@ -392,8 +261,8 @@ public final class InstrumentedFilesCollector {
     InstrumentedFilesInfoBuilder(RuleContext ruleContext) {
       this(
           ruleContext,
-          NestedSetBuilder.<Artifact>emptySet(Order.STABLE_ORDER),
-          NestedSetBuilder.<Tuple>emptySet(Order.STABLE_ORDER));
+          NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+          NestedSetBuilder.emptySet(Order.STABLE_ORDER));
     }
 
     void addFromDependency(TransitiveInfoCollection dep) {
@@ -408,22 +277,13 @@ public final class InstrumentedFilesCollector {
     }
 
     void setLocalSources(ImmutableSet<Artifact> localSources) {
-      // Wrap in a nested set to share the set between the transitive set of instrumented files and
-      // the inputs to the local baseline coverage action.
-      NestedSet<Artifact> localSourcesNestedSet =
-          NestedSetBuilder.wrap(Order.STABLE_ORDER, localSources);
+      // Wrap in a nested set shared between the transitive set of instrumented files and the inputs
+      // to the local baseline coverage action. Avoid NestedSetBuilder#wrap as it caches the list
+      // to nested set mapping and the list is expected to be unique.
+      var localSourcesNestedSet =
+          NestedSetBuilder.<Artifact>stableOrder().addAll(localSources).build();
       instrumentedFilesBuilder.addTransitive(localSourcesNestedSet);
       this.localSources = localSourcesNestedSet;
-    }
-
-    public void generateBaselineCoverage() {
-      generateBaselineCoverage = true;
-    }
-
-    void collectLocalMetadata(
-        LocalMetadataCollector localMetadataCollector, Iterable<Artifact> rootFiles) {
-      localMetadataCollector.collectMetadataArtifacts(
-          rootFiles, ruleContext.getAnalysisEnvironment(), metadataFilesBuilder);
     }
 
     void addMetadataFiles(Iterable<Artifact> files) {
@@ -431,7 +291,7 @@ public final class InstrumentedFilesCollector {
     }
 
     InstrumentedFilesInfo build() {
-      if (generateBaselineCoverage) {
+      if (localSources != null && !localSources.isEmpty()) {
         var baselineCoverageAction = BaselineCoverageAction.create(ruleContext, localSources);
         ruleContext.registerAction(baselineCoverageAction);
         baselineCoverageArtifactsBuilder.add(baselineCoverageAction.getPrimaryOutput());
@@ -446,11 +306,6 @@ public final class InstrumentedFilesCollector {
           reportedToActualSources);
     }
   }
-
-  /**
-   * An explicit constant for a {@link LocalMetadataCollector} that doesn't collect anything.
-   */
-  public static final LocalMetadataCollector NO_METADATA_COLLECTOR = null;
 
   private static Iterable<TransitiveInfoCollection> getPrerequisitesForAttributes(
       RuleContext ruleContext, Collection<String> attributeNames) {


### PR DESCRIPTION
In addition to removing unused classes and methods, this also replaces the explicit `withBaselineCoverage` parameter with the correct condition for when baseline coverage is needed: if there are any local source files.

Work towards #5716 