### PR TITLE
Disable autoloads in all bazel_features repositories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
@@ -695,7 +695,9 @@ public class AutoloadSymbols {
           "build_bazel_apple_support",
           "bazel_skylib",
           "bazel_tools",
-          "bazel_features");
+          "bazel_features",
+          "bazel_features_version",
+          "bazel_features_globals");
 
   private static final ImmutableMap<String, Version> requiredVersionForModules;
 


### PR DESCRIPTION
This fixes the case of rules repositories using bazel_features in WORKSPACE mode.