### PR TITLE
Add `baseline_coverage_files` to `ctx.instrumented_files_info`

### DIFF
--- a/site/en/contribute/codebase.md
+++ b/site/en/contribute/codebase.md
@@ -1336,12 +1336,10 @@ want to compute the test coverage for a binary, it is not enough to merge the
 coverage of all of the tests because there may be code in the binary that is not
 linked into any test. Therefore, what we do is to emit a coverage file for every
 binary which contains only the files we collect coverage for with no covered
-lines. The baseline coverage file for a target is at
-`bazel-testlogs/$PACKAGE/$TARGET/baseline_coverage.dat` . It is also generated
-for binaries and libraries in addition to tests if you pass the
-`--nobuild_tests_only` flag to Bazel.
-
-Baseline coverage is currently broken.
+lines. The default baseline coverage file for a target is at
+`bazel-testlogs/$PACKAGE/$TARGET/baseline_coverage.dat`, but rules are
+encouraged to generate their own baseline coverage files with more meaningful
+content than just the names of the source files.
 
 We track two groups of files for coverage collection for each rule: the set of
 instrumented files and the set of instrumentation metadata files.

--- a/site/en/extending/rules.md
+++ b/site/en/extending/rules.md
@@ -931,9 +931,7 @@ the dependencies' sources should be instrumented:
 ```python
 # Are this rule's sources or any of the sources for its direct dependencies
 # in deps instrumented?
-if (ctx.configuration.coverage_enabled and
-    (ctx.coverage_instrumented() or
-     any([ctx.coverage_instrumented(dep) for dep in ctx.attr.deps]))):
+if ctx.coverage_instrumented() or any([ctx.coverage_instrumented(dep) for dep in ctx.attr.deps]):
     # Do something to turn on coverage for this compile action
 ```
 
@@ -1004,6 +1002,26 @@ with unique names into the directory specified by the `COVERAGE_DIR` environment
 variable. Bazel will then merge these files into a single LCOV file using the
 `_lcov_merger` tool. If present, it will also collect C/C++ coverage using the
 `_collect_cc_coverage` tool.
+
+### Baseline coverage
+
+Since coverage is only collected for code that ends up in the dependency tree of
+a test, coverage reports can be misleading as they don't necessarily cover all
+the code matched by the `--instrumentation_filter` flag.
+
+For this reason, Bazel allows rules to specify baseline coverage files via the
+`baseline_coverage_files` attribute of `ctx.instrumented_files_info`). These
+files must be generated in LCOV format by a user-defined action and are supposed
+to list all lines, branches, functions and/or blocks in the target's source
+files (according to the `sources_attributes` and `extensions` parameters). For
+source files in targets that are instrumented for coverage, Bazel merges their
+baseline coverage into the combined coverage report generated with
+`--combined_report` and thus ensures that untested files still show up as
+uncovered.
+
+If a rule doesn't provide any baseline coverage files, Bazel generates synthetic
+coverage information that only mentions the source file paths, but doesn't
+contain any information about their contents.
 
 ### Validation Actions
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/CoverageCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/CoverageCommon.java
@@ -54,6 +54,7 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
       Object extensions,
       Sequence<?> metadataFiles, // Sequence<Artifact>
       Object reportedToActualSourcesObject,
+      Object baselineCoverageFilesObject, // Sequence<Artifact>|NoneType
       StarlarkThread thread)
       throws EvalException {
     List<String> extensionsList =
@@ -62,6 +63,10 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
         reportedToActualSourcesObject == Starlark.NONE
             ? NestedSetBuilder.create(Order.STABLE_ORDER)
             : Depset.cast(reportedToActualSourcesObject, Tuple.class, "reported_to_actual_sources");
+    List<Artifact> baselineCoverageFiles =
+        baselineCoverageFilesObject == Starlark.NONE
+            ? null
+            : Sequence.cast(baselineCoverageFilesObject, Artifact.class, "baseline_coverage_files");
     Dict<String, String> environmentDict =
         Dict.cast(environment, String.class, String.class, "coverage_environment");
     NestedSetBuilder<Artifact> supportFilesBuilder = NestedSetBuilder.stableOrder();
@@ -100,7 +105,8 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
         ImmutableMap.copyOf(environmentDict),
         extensionsList,
         Sequence.cast(metadataFiles, Artifact.class, "metadata_files"),
-        reportedToActualSources);
+        reportedToActualSources,
+        baselineCoverageFiles);
   }
 
   /**
@@ -116,6 +122,8 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
    * @param extensions file extensions used to filter files from source_attributes. If null, all
    *     files on the source attributes will be treated as instrumented. Otherwise, only files with
    *     extensions listed in {@code extensions} will be used
+   * @param baselineCoverageFiles if not null, the files to use as baseline coverage instead of
+   *     running the default action to generate it
    */
   private static InstrumentedFilesInfo createInstrumentedFilesInfo(
       RuleContext ruleContext,
@@ -125,7 +133,8 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
       ImmutableMap<String, String> environment,
       @Nullable List<String> extensions,
       @Nullable List<Artifact> metadataFiles,
-      NestedSet<Tuple> reportedToActualSources) {
+      NestedSet<Tuple> reportedToActualSources,
+      @Nullable List<Artifact> baselineCoverageFiles) {
     FileTypeSet fileTypeSet = FileTypeSet.ANY_FILE;
     if (extensions != null) {
       if (extensions.isEmpty()) {
@@ -146,7 +155,8 @@ public class CoverageCommon implements CoverageCommonApi<ConstraintValueInfo, St
         /* coverageSupportFiles= */ supportFiles,
         /* coverageEnvironment= */ environment,
         /* reportedToActualSources= */ reportedToActualSources,
-        /* additionalMetadata= */ metadataFiles);
+        /* additionalMetadata= */ metadataFiles,
+        /* baselineCoverageFiles= */ baselineCoverageFiles);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CoverageCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CoverageCommand.java
@@ -55,10 +55,8 @@ import com.google.devtools.common.options.OptionsParsingException;
  * tests, because there may be code in the binary that is not linked into any test. Therefore, what
  * we do is to emit a coverage file for every binary, which contains only the files we collect
  * coverage for with no covered lines. The baseline coverage file for a target is at {@code
- * testlogs/PACKAGE/TARGET/baseline_coverage.dat}. Note that it is also generated for binaries and
- * libraries in addition to tests if you pass the {@code --nobuild_tests_only} flag to Bazel.
- *
- * <p>Baseline coverage collection is currently broken.
+ * testlogs/PACKAGE/TARGET/baseline_coverage.dat}, but rules are encouraged to generate their own
+ * baseline coverage files with more meaningful content than just the names of the source files.
  *
  * <p>We track two groups of files for coverage collection for each rule: the set of instrumented
  * files and the set of instrumentation metadata files.

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/CoverageCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/CoverageCommonApi.java
@@ -117,6 +117,15 @@ public interface CoverageCommonApi<
             allowedTypes = {
               @ParamType(type = Depset.class),
               @ParamType(type = NoneType.class),
+            }),
+        @Param(
+            name = "baseline_coverage_files",
+            positional = false,
+            named = true,
+            defaultValue = "None",
+            allowedTypes = {
+              @ParamType(type = Sequence.class, generic1 = FileApi.class),
+              @ParamType(type = NoneType.class),
             })
       },
       useStarlarkThread = true)
@@ -129,6 +138,7 @@ public interface CoverageCommonApi<
       Object extensions,
       Sequence<?> metadataFiles,
       Object reportedToActualSourcesObject,
+      Object baselineCoverageFiles, // Sequence<FileApi> or NoneType
       StarlarkThread thread)
       throws EvalException, TypeException;
 }

--- a/src/test/shell/bazel/bazel_coverage_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_starlark_test.sh
@@ -427,4 +427,216 @@ end_of_record"
     assert_coverage_result "$expected_baseline_coverage" bazel-out/_coverage/_baseline_report.dat
 }
 
+function test_starlark_rule_custom_baseline_coverage() {
+  mkdir -p test
+  cat <<'EOF' > test/rules.bzl
+def _my_library_impl(ctx):
+    providers = []
+
+    transitive_files = [dep[DefaultInfo].files for dep in (ctx.attr.deps + ctx.attr.srcs)]
+    providers.append(
+        DefaultInfo(
+            files = depset(transitive = transitive_files),
+        )
+    )
+
+    baseline_coverage_files = []
+    for src in ctx.files.srcs:
+        lcov_file = ctx.actions.declare_file(ctx.label.name + "_" + str(hash(src.path)) + ".dat")
+        ctx.actions.write(
+            lcov_file,
+            """
+SF:{}
+DA:1,0
+DA:2,0
+LF:2
+LH:0
+end_of_record
+""".format(src.path),
+        )
+        baseline_coverage_files.append(lcov_file)
+
+    providers.append(
+        coverage_common.instrumented_files_info(
+            ctx = ctx,
+            source_attributes = ["srcs"],
+            dependency_attributes = ["deps"],
+            baseline_coverage_files = baseline_coverage_files,
+        )
+    )
+
+    return providers
+
+my_library = rule(
+    implementation = _my_library_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+        ),
+        "deps": attr.label_list(),
+    },
+)
+
+def _my_test_impl(ctx):
+    providers = []
+
+    out = ctx.actions.declare_file(ctx.label.name)
+    all_files = depset(transitive = [dep[DefaultInfo].files for dep in (ctx.attr.deps + ctx.attr.srcs)])
+    script_content = "#!/bin/bash\n" + "\n".join([
+        """cat <<E_O_F >> "$COVERAGE_DIR/my_test.dat"
+SF:{}
+DA:1,1
+DA:2,0
+LF:2
+LH:1
+end_of_record
+E_O_F
+""".format(f.path)
+        for f in all_files.to_list()
+    ])
+    ctx.actions.write(out, script_content, is_executable = True)
+    providers.append(DefaultInfo(executable = out))
+
+    providers.append(
+        coverage_common.instrumented_files_info(
+            ctx = ctx,
+            source_attributes = ["srcs"],
+            dependency_attributes = ["deps"],
+        )
+    )
+
+    return providers
+
+my_test = rule(
+    implementation = _my_test_impl,
+    test = True,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+        ),
+        "deps": attr.label_list(),
+        "_lcov_merger": attr.label(
+            default = configuration_field(fragment = "coverage", name = "output_generator"),
+            cfg = config.exec(exec_group = "test"),
+        ),
+    },
+)
+EOF
+
+  cat <<'EOF' > test/BUILD
+load(":rules.bzl", "my_library", "my_test")
+
+my_library(
+    name = "untested_lib",
+    srcs = [
+        "untested_1.txt",
+        "untested_2.txt",
+    ],
+)
+
+my_library(
+    name = "covered_lib",
+    srcs = [
+        "covered_1.txt",
+        "covered_2.txt",
+    ],
+)
+
+my_library(
+    name = "all_libs",
+    deps = [
+        ":untested_lib",
+        ":covered_lib",
+    ],
+)
+
+my_library(
+    name = "tested_libs",
+    deps = [
+        ":covered_lib",
+    ],
+)
+
+my_test(
+    name = "my_test",
+    srcs = [
+        "test_1.txt",
+        "test_2.txt",
+    ],
+    deps = [":tested_libs"],
+)
+EOF
+    touch test/{untested_1.txt,untested_2.txt,covered_1.txt,covered_2.txt,test_1.txt,test_2.txt}
+
+    bazel coverage //test:my_test //test:all_libs --combined_report=lcov &> $TEST_log \
+        || fail "Coverage run failed but should have succeeded."
+    local expected_coverage="SF:test/covered_1.txt
+FNF:0
+FNH:0
+DA:1,1
+DA:2,0
+LH:1
+LF:2
+end_of_record
+SF:test/covered_2.txt
+FNF:0
+FNH:0
+DA:1,1
+DA:2,0
+LH:1
+LF:2
+end_of_record
+SF:test/untested_1.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record
+SF:test/untested_2.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record"
+    local expected_baseline_coverage="SF:test/covered_1.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record
+SF:test/covered_2.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record
+SF:test/untested_1.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record
+SF:test/untested_2.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record"
+
+    assert_coverage_result "$expected_coverage" bazel-out/_coverage/_coverage_report.dat
+    assert_coverage_result "$expected_baseline_coverage" bazel-out/_coverage/_baseline_report.dat
+}
+
 run_suite "test tests"


### PR DESCRIPTION
Work towards #5716

RELNOTES: Rules can now register their own baseline coverage files in LCOV format via the new `baseline_coverage_files` parameter of `ctx.instrumented_files_info`. If the target matches the instrumentation filter, Bazel will merge the data into the combined coverage report generated with `--combined_report`.