### PR TITLE
[8.3.0] Initial API changes for header compilation direct deps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
@@ -461,6 +461,11 @@ public sealed class JavaInfo extends NativeInfo
     return StarlarkList.immutableCopyOf(javaConstraints);
   }
 
+  @Override
+  public Depset headerCompilationDirectDeps() {
+    return Depset.of(Artifact.class, NestedSetBuilder.emptySet(Order.STABLE_ORDER));
+  }
+
   /**
    * Gets Provider, check it for not null and call function to get NestedSet&lt;S&gt; from it.
    *

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -129,7 +129,9 @@ public class JavaStarlarkCommon
       Label targetLabel,
       Object injectingRuleKind,
       boolean enableDirectClasspath,
-      Sequence<?> additionalInputs)
+      Sequence<?> additionalInputs,
+      Object headerCompilationJar,
+      Object headerCompilationDirectDeps)
       throws EvalException,
           TypeException,
           RuleErrorException,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -500,6 +500,8 @@ public interface JavaCommonApi<
         @Param(name = "injecting_rule_kind"),
         @Param(name = "enable_direct_classpath"),
         @Param(name = "additional_inputs"),
+        @Param(name = "header_compilation_jar", defaultValue = "None", named = true),
+        @Param(name = "header_compilation_direct_deps", defaultValue = "None", named = true),
       })
   void createHeaderCompilationAction(
       StarlarkRuleContextT ctx,
@@ -518,7 +520,9 @@ public interface JavaCommonApi<
       Label targetLabel,
       Object injectingRuleKind,
       boolean enableDirectClasspath,
-      Sequence<?> additionalInputs)
+      Sequence<?> additionalInputs,
+      Object headerCompilationJar,
+      Object headerCompilationDirectDeps)
       throws EvalException,
           TypeException,
           RuleErrorException,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaInfoApi.java
@@ -40,7 +40,7 @@ public interface JavaInfoApi<
   @StarlarkMethod(
       name = "transitive_runtime_jars",
       doc =
-          """
+"""
 Returns a transitive set of Jars required on the target's runtime classpath.
 <p/>Note: for binary targets (such as java_binary and java_test), this is empty, since such targets
 are not intended to be dependencies of other Java targets.
@@ -51,7 +51,7 @@ are not intended to be dependencies of other Java targets.
   @StarlarkMethod(
       name = "transitive_compile_time_jars",
       doc =
-          """
+"""
 Returns the transitive set of Jars required to build the target.
 <p/>Note: for binary targets (such as java_binary and java_test), this is empty, since such targets
 are not intended to be dependencies of other Java targets.
@@ -86,6 +86,12 @@ are not intended to be dependencies of other Java targets.
               + " href=\"#compile_jars\">JavaInfo.compile_jars</a></code></li>",
       structField = true)
   Depset getFullCompileTimeJars();
+
+  @StarlarkMethod(
+      name = "header_compilation_direct_deps",
+      doc = "Returns the direct dependencies of the header compilation action.",
+      structField = true)
+  Depset headerCompilationDirectDeps();
 
   @StarlarkMethod(
       name = "source_jars",


### PR DESCRIPTION
This adds experimental, unimplemented Java Starlark APIs for header compilation direct deps.

PiperOrigin-RevId: 759653952
Change-Id: If4c6bb7c03dfbba25487b15b8f12d3a9cf0140af (cherry picked from commit eea08821fde648485d08d93daad5c5c34e17dc25)