### PR TITLE
[8.3.0] Don't strip module-info from regular class jars

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java
@@ -106,6 +106,7 @@ public class ResourceJarActionBuilder {
             .add("--normalize")
             .add("--dont_change_compression")
             .add("--exclude_build_data")
+            .add("--no_strip_module_info") // bazelbuild/rules_java/issues/293
             .addExecPath("--output", outputJar);
     if (!resourceJars.isEmpty()) {
       command.addExecPaths("--sources", resourceJars);

--- a/src/test/shell/integration/java_integration_test.sh
+++ b/src/test/shell/integration/java_integration_test.sh
@@ -149,9 +149,15 @@ EOF
 load("@rules_java//java:java_library.bzl", "java_library")
 package(default_visibility=['//visibility:public'])
 java_library(name = 'hello_library',
-             srcs = ['HelloLibrary.java']);
+             srcs = ['HelloLibrary.java', 'module-info.java'],
+             resources = ['hello.properties'],
+             );
 EOF
-
+  touch $pkg/java/hello_library/hello.properties
+  cat > $pkg/java/hello_library/module-info.java <<EOF
+module hello {
+}
+EOF
   cat >$pkg/java/hello_library/HelloLibrary.java <<EOF
 package hello_library;
 public class HelloLibrary {
@@ -888,6 +894,19 @@ EOF
 
   cat "${PRODUCT_NAME}-bin/${package}/aspect_out" | grep "0.params .*1.params" \
       || fail "aspect Args do not contain both params files"
+}
+
+# https://github.com/bazelbuild/rules_java/issues/293
+function test_class_jar_retains_module_info() {
+  local -r pkg="${FUNCNAME[0]}"
+  mkdir "$pkg" || fail "mkdir $pkg"
+  write_hello_library_files "$pkg"
+
+  bazel build -s //$pkg/java/main:main || fail "build failed"
+  unzip -l ${PRODUCT_NAME}-bin/$pkg/java/hello_library/libhello_library.jar \
+    > $TEST_log
+  expect_log "/hello.properties" "missing resources file"
+  expect_log " module-info.class" "missing module-info file"
 }
 
 run_suite "Java integration tests"

--- a/src/tools/singlejar/options.cc
+++ b/src/tools/singlejar/options.cc
@@ -60,7 +60,8 @@ bool Options::ParseToken(ArgTokenStream *tokens) {
       tokens->MatchAndSet("--hermetic_java_home", &hermetic_java_home) ||
       tokens->MatchAndSet("--add_exports", &add_exports) ||
       tokens->MatchAndSet("--add_opens", &add_opens) ||
-      tokens->MatchAndSet("--output_jar_creator", &output_jar_creator)) {
+      tokens->MatchAndSet("--output_jar_creator", &output_jar_creator) ||
+      tokens->MatchAndSet("--no_strip_module_info", &no_strip_module_info)) {
     return true;
   } else if (tokens->MatchAndSet("--build_info_file", &optarg)) {
     build_info_files.push_back(optarg);

--- a/src/tools/singlejar/options.h
+++ b/src/tools/singlejar/options.h
@@ -36,7 +36,8 @@ class Options {
         verbose(false),
         warn_duplicate_resources(false),
         check_desugar_deps(false),
-        multi_release(false) {}
+        multi_release(false),
+        no_strip_module_info(false) {}
 
   virtual ~Options() {}
 
@@ -69,6 +70,7 @@ class Options {
   bool warn_duplicate_resources;
   bool check_desugar_deps;
   bool multi_release;
+  bool no_strip_module_info;
   std::string hermetic_java_home;
   std::vector<std::string> add_exports;
   std::vector<std::string> add_opens;

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -24,6 +24,8 @@
 #include <sys/stat.h>
 #include <time.h>
 
+#include <cstring>
+
 #ifndef _WIN32
 #include <unistd.h>
 #else
@@ -366,6 +368,16 @@ bool OutputJar::AddJar(int jar_path_index) {
     if (ends_with(file_name, file_name_length, ".SF") ||
         ends_with(file_name, file_name_length, ".RSA") ||
         ends_with(file_name, file_name_length, ".DSA")) {
+      continue;
+    }
+
+    // Skip module-info.class files
+    // Deploy jars are not modularized jars, and including module-infos from
+    // modularized dependencies doesn't work. See also b/204112761.
+    if (!options_->no_strip_module_info &&
+        (!strncmp(file_name, "module-info.class", file_name_length) ||
+         (begins_with(file_name, file_name_length, "META-INF/versions/") &&
+          ends_with(file_name, file_name_length, "/module-info.class")))) {
       continue;
     }
 


### PR DESCRIPTION
A separate resource jar action is used for java targets with resources, and we invoke singlejar to create the final combined class jar. In these cases, we shouldn't be stripping the module-info.

Work towards https://github.com/bazelbuild/rules_java/issues/293

Closes #26081.

PiperOrigin-RevId: 762316383
Change-Id: Ifccddd8862186953213a30cc399e1867c68cc7e4 (cherry picked from commit 83255bc52b88e6d8990572a6f75853db5154e70b)