### PR TITLE
Disallow output bases under GC-able directories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -378,6 +378,12 @@ public class BazelRepositoryModule extends BlazeModule {
       }
       Path repoContentsCachePath = repositoryCache.getRepoContentsCache().getPath();
       if (repoContentsCachePath != null) {
+        // Check that the repo contents cache directory, which is managed by a garbage collecting
+        // idle task, does not contain the output base. Since the specified output base path may be
+        // a symlink, we resolve it fully. Intermediate symlinks do not have to be checked as the
+        // garbage collector ignores symlinks. We also resolve the repo contents cache directory,
+        // where intermediate symlinks also don't matter since deletion only occurs under the fully
+        // resolved path.
         Path resolvedOutputBase = env.getOutputBase();
         try {
           resolvedOutputBase = resolvedOutputBase.resolveSymbolicLinks();

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -378,9 +378,11 @@ public class BazelRepositoryModule extends BlazeModule {
       }
       Path repoContentsCachePath = repositoryCache.getRepoContentsCache().getPath();
       if (repoContentsCachePath != null) {
-        Path resolvedOutputBase;
+        Path resolvedOutputBase = env.getOutputBase();
         try {
-          resolvedOutputBase = env.getOutputBase().resolveSymbolicLinks();
+          resolvedOutputBase = resolvedOutputBase.resolveSymbolicLinks();
+        } catch (FileNotFoundException ignored) {
+          // Will be created later.
         } catch (IOException e) {
           throw new AbruptExitException(
               detailedExitCode(
@@ -391,7 +393,7 @@ public class BazelRepositoryModule extends BlazeModule {
         Path resolvedRepoContentsCache = repoContentsCachePath;
         try {
           resolvedRepoContentsCache = resolvedRepoContentsCache.resolveSymbolicLinks();
-        } catch (FileNotFoundException e) {
+        } catch (FileNotFoundException ignored) {
           // Will be created later.
         } catch (IOException e) {
           throw new AbruptExitException(

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -376,6 +376,18 @@ public class BazelRepositoryModule extends BlazeModule {
         repositoryCache.getRepoContentsCache().setPath(toPath(repoOptions.repoContentsCache, env));
       }
       Path repoContentsCachePath = repositoryCache.getRepoContentsCache().getPath();
+      if (repoContentsCachePath != null && env.getOutputBase().startsWith(repoContentsCachePath)) {
+        // This is dangerous as the repo contents cache GC may delete files in the output base.
+        throw new AbruptExitException(
+            detailedExitCode(
+                """
+                The repo contents cache [%s] is inside the output base [%s]. This can cause \
+                spurious failures. Disable the repo contents cache with `--repo_contents_cache=`, \
+                or specify `--repo_contents_cache=<path outside the output base>`.
+                """
+                    .formatted(repoContentsCachePath, env.getOutputBase()),
+                Code.BAD_REPO_CONTENTS_CACHE));
+      }
       if (repoContentsCachePath != null
           && env.getWorkspace() != null
           && repoContentsCachePath.startsWith(env.getWorkspace())) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -344,6 +344,12 @@ public final class RemoteModule extends BlazeModule {
     boolean enableRemoteDownloader = shouldEnableRemoteDownloader(remoteOptions);
 
     if (enableDiskCache) {
+      if (env.getOutputBase().startsWith(remoteOptions.diskCache)) {
+        // This is dangerous as the disk cache GC may delete files in the output base.
+        throw createOptionsExitException(
+            "The --disk_cache directory cannot be a subdirectory of the output base",
+            FailureDetails.RemoteOptions.Code.EXECUTION_WITH_INVALID_CACHE);
+      }
       var gcIdleTask =
           DiskCacheGarbageCollectorIdleTask.create(remoteOptions, env.getWorkingDirectory());
       if (gcIdleTask != null) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -345,9 +345,11 @@ public final class RemoteModule extends BlazeModule {
     boolean enableRemoteDownloader = shouldEnableRemoteDownloader(remoteOptions);
 
     if (enableDiskCache) {
-      Path resolvedOutputBase;
+      Path resolvedOutputBase = env.getOutputBase();
       try {
-        resolvedOutputBase = env.getOutputBase().resolveSymbolicLinks();
+        resolvedOutputBase = resolvedOutputBase.resolveSymbolicLinks();
+      } catch (FileNotFoundException ignored) {
+        // Will be created later.
       } catch (IOException e) {
         throw createOptionsExitException(
             "Failed to resolve output base: %s".formatted(e.getMessage()),

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -345,6 +345,11 @@ public final class RemoteModule extends BlazeModule {
     boolean enableRemoteDownloader = shouldEnableRemoteDownloader(remoteOptions);
 
     if (enableDiskCache) {
+      // Check that the disk cache directory, which is managed by a garbage collecting idle task,
+      // does not contain the output base. Since the specified output base path may be a symlink,
+      // we resolve it fully. Intermediate symlinks do not have to be checked as the garbage
+      // collector ignores symlinks. We also resolve the disk cache directory, where intermediate
+      // symlinks also don't matter since deletion only occurs under the fully resolved path.
       Path resolvedOutputBase = env.getOutputBase();
       try {
         resolvedOutputBase = resolvedOutputBase.resolveSymbolicLinks();


### PR DESCRIPTION
We have had user's report spurious build failures due to the disk cache GC collecting files under the output base when output base and disk cache were set up at the same path.