### PR TITLE
[8.3.0] Disable autoloads in all bazel_features repositories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AutoloadSymbols.java
@@ -693,7 +693,9 @@ public class AutoloadSymbols {
           "build_bazel_apple_support",
           "bazel_skylib",
           "bazel_tools",
-          "bazel_features");
+          "bazel_features",
+          "bazel_features_version",
+          "bazel_features_globals");
 
   private static final ImmutableMap<String, Version> requiredVersionForModules;
 


### PR DESCRIPTION
This fixes the case of rules repositories using bazel_features in WORKSPACE mode.

Closes #26119.

PiperOrigin-RevId: 762346522
Change-Id: I80be8c1b0162f5d0706403af26af21e31a6dc2cc

Commit https://github.com/bazelbuild/bazel/commit/1afba076c4296964a81684769db002121edfbdae