### PR TITLE
[8.3.0] Set memory.swap.max to 0 when memory.max is set

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/CgroupsInfoV2.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/CgroupsInfoV2.java
@@ -75,6 +75,10 @@ public class CgroupsInfoV2 extends CgroupsInfo {
         Files.asCharSink(new File(spawnCgroupDir, "memory.oom.group"), UTF_8).write("1\n");
         Files.asCharSink(new File(spawnCgroupDir, "memory.max"), UTF_8)
             .write(Long.toString(memoryLimitMb * 1024L * 1024L));
+        // Set swap to 0 so that it doesn't unexpecedly consume more than
+        // the memory limit when swap is enabled.
+        Files.asCharSink(new File(spawnCgroupDir, "memory.swap.max"), UTF_8)
+            .write(Long.toString(0L));
       }
     } catch (Exception e) {
       return new InvalidCgroupsInfo(Type.SPAWN, getVersion(), e);

--- a/src/main/java/com/google/devtools/build/lib/sandbox/cgroups/controller/v2/UnifiedMemory.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/cgroups/controller/v2/UnifiedMemory.java
@@ -40,6 +40,9 @@ public class UnifiedMemory extends UnifiedController implements Controller.Memor
   @Override
   public void setMaxBytes(long bytes) throws IOException {
     Files.writeString(path.resolve("memory.max"), Long.toString(bytes));
+    // Set swap to 0 so that it doesn't unexpecedly consume more than
+    // the memory limit when swap is enabled.
+    Files.writeString(path.resolve("memory.swap.max"), Long.toString(0L));
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/sandbox/CgroupsInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/CgroupsInfoTest.java
@@ -224,6 +224,8 @@ public class CgroupsInfoTest {
         .containsExactly("1");
     assertThat(Files.readLines(new File(blazeSpawnsPath + "/spawn_1.scope/memory.max"), UTF_8))
         .containsExactly("104857600");
+    assertThat(Files.readLines(new File(blazeSpawnsPath + "/spawn_1.scope/memory.swap.max"), UTF_8))
+        .containsExactly("0");
   }
 
   @Test
@@ -244,6 +246,7 @@ public class CgroupsInfoTest {
     // written to.
     assertThat(new File(blazeSpawnsPath + "/spawn_1.scope/memory.oom.group").exists()).isFalse();
     assertThat(new File(blazeSpawnsPath + "/spawn_1.scope/memory.max").exists()).isFalse();
+    assertThat(new File(blazeSpawnsPath + "/spawn_1.scope/memory.swap.max").exists()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/sandbox/cgroups/MemoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/cgroups/MemoryTest.java
@@ -57,9 +57,11 @@ public class MemoryTest {
   @Test
   public void setMemoryLimit_v2() throws IOException {
     File limit = scratch.file("cgroup/memory/memory.max", "0").getPathFile();
+    File swap = scratch.file("cgroup/memory/memory.swap.max", "0").getPathFile();
     Memory memory = new UnifiedMemory(scratch.path("cgroup/memory").getPathFile().toPath());
     memory.setMaxBytes(1000);
     assertThat(Files.asCharSource(limit, UTF_8).read()).isEqualTo("1000");
+    assertThat(Files.asCharSource(swap, UTF_8).read()).isEqualTo("0");
   }
 
   @Test


### PR DESCRIPTION
If a maximum memory is set then Bazel should disable swap otherwise the maximum  memory is not really accounted for.

fixes #26076

Closes #26077.

PiperOrigin-RevId: 761949741
Change-Id: Iedba120416c325da7ced0dcfd00db3cdc412022d

Commit https://github.com/bazelbuild/bazel/commit/ab57c897955a77f43341e240b9a156dbcb2ea4fc