### PR TITLE
fix: Remove trailing fullstop from URL in error message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRule.java
@@ -34,7 +34,7 @@ import com.google.devtools.build.lib.util.FileTypeSet;
 public class PlatformRule implements RuleDefinition {
   public static final String DEFAULT_MISSING_TOOLCHAIN_ERROR =
       "For more information on platforms or toolchains see"
-          + " https://bazel.build/concepts/platforms-intro.";
+          + " https://bazel.build/concepts/platforms-intro";
 
   public static final String RULE_NAME = "platform";
   public static final String CONSTRAINT_VALUES_ATTR = "constraint_values";


### PR DESCRIPTION
The `DEFAULT_MISSING_TOOLCHAIN_ERROR` ends with a URL that has a full stop appended to it without whitespace between URL and full stop.

When one clicks on the URL, most terminals/log viewers will assume the full stop belongs to the URL resulting in the viewer getting a 404: https://bazel.build/concepts/platforms-intro.

I think it's better to remove the full stop - the sentence might no longer end with a full stop, but it's more important to save people from going to wrong URLs than it is to end errors with a full stop.

Most other errors error messages don't seem to end with full stops either.