### PR TITLE
[8.3.0] Avoid digesting files in `AbstractActionInputPrefetcher` if possible

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -213,23 +213,29 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
     this.outputPermissions = outputPermissions;
   }
 
-  private boolean shouldDownloadFile(Path path, FileArtifactValue metadata) {
-    if (!path.exists()) {
+  private static boolean shouldDownloadFile(Path path, FileArtifactValue metadata)
+      throws IOException {
+    var stat = path.statIfFound();
+    if (stat == null) {
       return true;
     }
 
-    // In the most cases, skyframe should be able to detect source files modifications and delete
-    // staled outputs before action execution. However, there are some cases where outputs are not
-    // tracked by skyframe. We compare the digest here to make sure we don't use staled files.
-    try {
-      byte[] digest = path.getFastDigest();
-      if (digest == null) {
-        digest = path.getDigest();
-      }
-      return !Arrays.equals(digest, metadata.getDigest());
-    } catch (IOException ignored) {
+    // If an action output is stale, Skyframe will delete it prior to action execution. However,
+    // this doesn't apply to spawn outputs that aren't action outputs. To avoid incorrectly reusing
+    // one such stale output, check for its up-to-dateness here.
+    if (stat.getSize() != metadata.getSize()) {
       return true;
     }
+    var contentsProxy = metadata.getContentsProxy();
+    if (contentsProxy != null && contentsProxy.equals(FileContentsProxy.create(stat))) {
+      return false;
+    }
+
+    byte[] digest = path.getFastDigest();
+    if (digest == null) {
+      digest = path.getDigest();
+    }
+    return !Arrays.equals(digest, metadata.getDigest());
   }
 
   protected abstract boolean canDownloadFile(Path path, FileArtifactValue metadata);

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -291,12 +291,22 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
     return fileSystem.stat(asFragment(), followSymlinks.toBoolean());
   }
 
-  /** Like stat(), but returns null on file-nonexistence instead of throwing. */
+  /**
+   * Like stat(), but returns null in case of any error instead of throwing.
+   *
+   * <p>Use {@link #statIfFound()} instead to throw for errors due to any causes other than
+   * non-existence.
+   */
   public FileStatus statNullable() {
     return statNullable(Symlinks.FOLLOW);
   }
 
-  /** Like stat(), but returns null on file-nonexistence instead of throwing. */
+  /**
+   * Like stat(), but returns null in case of any error instead of throwing.
+   *
+   * <p>Use {@link #statIfFound(Symlinks)} instead to throw for errors due to any causes other than
+   * non-existence.
+   */
   public FileStatus statNullable(Symlinks symlinks) {
     return fileSystem.statNullable(asFragment(), symlinks.toBoolean());
   }
@@ -305,6 +315,8 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
    * Like {@link #stat}, but may return null if the file is not found (corresponding to {@code
    * ENOENT} and {@code ENOTDIR} in Unix's stat(2) function) instead of throwing. Follows symbolic
    * links.
+   *
+   * <p>Use {@link #statNullable(Symlinks)} instead to ignore all types of errors.
    */
   public FileStatus statIfFound() throws IOException {
     return fileSystem.statIfFound(asFragment(), true);
@@ -313,6 +325,8 @@ public class Path implements Comparable<Path>, FileType.HasFileType {
   /**
    * Like {@link #stat}, but may return null if the file is not found (corresponding to {@code
    * ENOENT} and {@code ENOTDIR} in Unix's stat(2) function) instead of throwing.
+   *
+   * <p>Use {@link #statNullable(Symlinks)} instead to ignore all types of errors.
    *
    * @param followSymlinks if {@link Symlinks#FOLLOW}, and this path denotes a symbolic link, the
    *     link is dereferenced until a file other than a symbolic link is found


### PR DESCRIPTION
Remote metadata that is later materialized as a local file frequently hits the code path in `AbstractActionInputPrefetcher` that checks for discrepancies between the metadata and the local filesystem state. Since computing the digest is potentially costly and often unnecessary in this case, short-circuit by comparing sizes and contents proxies, if available.

Also add comments to `Path#statNullable` and `Path#statIfFound` to more clearly explain the subtle difference.

Closes #26146.

PiperOrigin-RevId: 763396727
Change-Id: I081d6d8b4efba661348746ba56c39120d18c31c3

Commit https://github.com/bazelbuild/bazel/commit/914542ba3b97e5cef10127177bef610f7d2ee0e4