### PR TITLE
[8.3.0] Use a real `ActionOwner` for coverage report actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.actions.LazyWriteNestedSetOfTupleAction;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams;
+import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams.CoverageParams;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -53,9 +54,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 
-/**
- * Helper class to create test actions.
- */
+/** Helper class to create test actions. */
 public final class TestActionBuilder {
   private static final String CC_CODE_COVERAGE_SCRIPT = "CC_CODE_COVERAGE_SCRIPT";
   private static final String LCOV_MERGER = "LCOV_MERGER";
@@ -98,8 +97,7 @@ public final class TestActionBuilder {
         "invalid",
         ImmutableList.of(),
         ImmutableList.of(),
-        FilesToRunProvider.EMPTY,
-        ImmutableList.of());
+        /* coverageParams= */ null);
   }
 
   /**
@@ -226,8 +224,7 @@ public final class TestActionBuilder {
         new TestTargetProperties(ruleContext, executionRequirements);
 
     // If the test rule does not provide InstrumentedFilesProvider, there's not much that we can do.
-    final boolean collectCodeCoverage = config.isCodeCoverageEnabled()
-        && instrumentedFiles != null;
+    final boolean collectCodeCoverage = config.isCodeCoverageEnabled() && instrumentedFiles != null;
 
     Artifact testActionExecutable =
         isUsingTestWrapperInsteadOfTestSetupScript
@@ -329,8 +326,8 @@ public final class TestActionBuilder {
       }
 
       Artifact instrumentedFileManifest =
-          InstrumentedFileManifestAction.getInstrumentedFileManifest(ruleContext,
-              instrumentedFiles.getInstrumentedFiles(), metadataFiles);
+          InstrumentedFileManifestAction.getInstrumentedFileManifest(
+              ruleContext, instrumentedFiles.getInstrumentedFiles(), metadataFiles);
       executionSettings =
           new TestTargetExecutionSettings(
               ruleContext,
@@ -456,18 +453,20 @@ public final class TestActionBuilder {
         results.add(cacheStatus);
       }
     }
-    // TODO(bazel-team): Passing the reportGenerator to every TestParams is a bit strange.
-    FilesToRunProvider reportGenerator = null;
+    CoverageParams coverageParams = null;
     if (config.isCodeCoverageEnabled()) {
+      // TODO(bazel-team): Passing the reportGenerator to every TestParams is a bit strange.
       // It's not enough to add this if the rule has coverage enabled because the command line may
       // contain rules with baseline coverage but no test rules that have coverage enabled, and in
       // that case, we still need the report generator.
       TransitiveInfoCollection reportGeneratorTarget =
           ruleContext.getPrerequisite(":coverage_report_generator");
-      reportGenerator = reportGeneratorTarget.getProvider(FilesToRunProvider.class);
+      FilesToRunProvider reportGenerator =
+          reportGeneratorTarget.getProvider(FilesToRunProvider.class);
       if (reportGenerator.getExecutable() == null) {
         ruleContext.ruleError("--coverage_report_generator does not refer to an executable target");
       }
+      coverageParams = new CoverageParams(coverageArtifacts.build(), reportGenerator, actionOwner);
     }
 
     return new TestParams(
@@ -477,8 +476,7 @@ public final class TestActionBuilder {
         TestTimeout.getTestTimeout(ruleContext.getRule()),
         ruleContext.getRule().getRuleClass(),
         ImmutableList.copyOf(results),
-        coverageArtifacts.build(),
-        reportGenerator,
-        testOutputs.build());
+        testOutputs.build(),
+        coverageParams);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageArgs.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageArgs.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.bazel.coverage;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactFactory;
 import com.google.devtools.build.lib.actions.ArtifactOwner;
@@ -41,6 +42,7 @@ public record CoverageArgs(
     FilesToRunProvider reportGenerator,
     String workspaceName,
     boolean htmlReport,
+    ActionOwner actionOwner,
     @Nullable PathFragment coverageDir,
     @Nullable Artifact lcovOutput) {
   public CoverageArgs {
@@ -51,6 +53,7 @@ public record CoverageArgs(
     requireNonNull(artifactOwner, "artifactOwner");
     requireNonNull(reportGenerator, "reportGenerator");
     requireNonNull(workspaceName, "workspaceName");
+    requireNonNull(actionOwner, "actionOwner");
   }
 
   public static CoverageArgs create(
@@ -61,7 +64,8 @@ public record CoverageArgs(
       ArtifactOwner artifactOwner,
       FilesToRunProvider reportGenerator,
       String workspaceName,
-      boolean htmlReport) {
+      boolean htmlReport,
+      ActionOwner actionOwner) {
     return new CoverageArgs(
         directories,
         coverageArtifacts,
@@ -71,14 +75,13 @@ public record CoverageArgs(
         reportGenerator,
         workspaceName,
         htmlReport,
+        actionOwner,
         /* coverageDir= */ null,
         /* lcovOutput= */ null);
   }
 
   public static CoverageArgs createCopyWithCoverageDirAndLcovOutput(
-      CoverageArgs args,
-      PathFragment coverageDir,
-      Artifact lcovOutput) {
+      CoverageArgs args, PathFragment coverageDir, Artifact lcovOutput) {
     return new CoverageArgs(
         args.directories(),
         args.coverageArtifacts(),
@@ -88,6 +91,7 @@ public record CoverageArgs(
         args.reportGenerator(),
         args.workspaceName(),
         args.htmlReport(),
+        args.actionOwner(),
         coverageDir,
         lcovOutput);
   }


### PR DESCRIPTION
This ensures that exec properties are set for some deterministic test exec platform, which may be required if the coverage report action is run remotely.

Fixes #20578

Closes #25960.

PiperOrigin-RevId: 762481198
Change-Id: I55e0514d02f91dffc32ff8fa13fa8f9f458189a1
(cherry picked from commit 3087f179e107b0d746ba9a26189109f8f10c1750)

Fixes #26108