### PR TITLE
Avoid repo thrashing when switching between build and query

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
@@ -29,6 +29,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:no_build_event",
         "//src/main/java/com/google/devtools/build/lib/analysis:no_build_request_finished_event",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:common",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:inspection",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:module_extension",

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.io.CharSource;
 import com.google.devtools.build.lib.analysis.NoBuildEvent;
 import com.google.devtools.build.lib.analysis.NoBuildRequestFinishedEvent;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModTidyValue;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleInspectorValue;
@@ -104,7 +105,12 @@ import javax.annotation.Nullable;
 @Command(
     name = ModCommand.NAME,
     buildPhase = LOADS,
-    options = {ModOptions.class, PackageOptions.class, LoadingPhaseThreadsOption.class},
+    options = {
+      CoreOptions.class, // for --action_env, which affects the repo env
+      ModOptions.class,
+      PackageOptions.class,
+      LoadingPhaseThreadsOption.class
+    },
     help = "resource:mod.txt",
     shortDescription = "Queries the Bzlmod external dependency graph",
     allowResidue = true)

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -334,7 +334,10 @@ public class CommandEnvironment {
                 : UUID.randomUUID().toString();
 
     this.repoEnv.putAll(clientEnv);
-    if (command.buildPhase().analyzes() || command.name().equals("info")) {
+    // TODO: This only needs to check for loads() rather than analyzes() due to
+    //  the effect of --action_env on the repository env. Revert back to
+    //  analyzes() when --action_env no longer affects it.
+    if (command.buildPhase().loads() || command.name().equals("info")) {
       // Compute the set of environment variables that are allowlisted on the commandline
       // for inheritance.
       for (Map.Entry<String, String> entry :
@@ -346,6 +349,8 @@ public class CommandEnvironment {
           repoEnv.put(entry.getKey(), entry.getValue());
         }
       }
+    }
+    if (command.buildPhase().analyzes() || command.name().equals("info")) {
       for (Map.Entry<String, String> entry :
           options.getOptions(TestOptions.class).testEnvironment) {
         if (entry.getValue() == null) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.runtime.commands;
 import static com.google.devtools.build.lib.runtime.Command.BuildPhase.LOADS;
 
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.pkgcache.PackageOptions;
@@ -58,6 +59,7 @@ import java.util.Set;
     name = "query",
     buildPhase = LOADS,
     options = {
+      CoreOptions.class, // for --action_env, which affects the repo env
       PackageOptions.class,
       QueryOptions.class,
       KeepGoingOption.class,

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -779,6 +779,7 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell/bazel/testdata:zstd_test_archive.tar.zst",
+        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
     ],
     shard_count = 15,
     tags = [

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -2971,6 +2971,45 @@ EOF
   expect_log "LAZYEVAL_KEY=xal3"
 }
 
+function test_environ_build_query_build() {
+  # Set up workspace with a repository rule that depends on env vars.
+  # Assert that the repo rule doesn't rerun when performing a sequence of
+  # build/query/build.
+  cat > repo.bzl <<EOF
+def _impl(rctx):
+  rctx.symlink(rctx.attr.build_file, 'BUILD')
+  print('UNTRACKED=%s' % rctx.os.environ.get('UNTRACKED'))
+  print('TRACKED=%s' % rctx.getenv('TRACKED'))
+
+dummy_repository = repository_rule(
+  implementation = _impl,
+  attrs = {'build_file': attr.label()},
+)
+EOF
+  cat > BUILD.dummy <<EOF
+filegroup(name='dummy', srcs=['BUILD'])
+EOF
+  touch BUILD
+  cat > $(setup_module_dot_bazel) <<EOF
+dummy_repository = use_repo_rule('//:repo.bzl', 'dummy_repository')
+dummy_repository(name = 'foo', build_file = '@@//:BUILD.dummy')
+EOF
+  add_to_bazelrc "common --action_env=TRACKED=tracked"
+  add_to_bazelrc "common --action_env=UNTRACKED=untracked"
+
+  bazel build @foo//:BUILD 2>$TEST_log || fail 'Expected build to succeed'
+  expect_log "TRACKED=tracked"
+  expect_log "UNTRACKED=untracked"
+
+  bazel query @foo//:BUILD 2>$TEST_log || fail 'Expected query to succeed'
+  expect_not_log "TRACKED"
+  expect_not_log "UNTRACKED"
+
+  bazel build @foo//:BUILD 2>$TEST_log || fail 'Expected build to succeed'
+  expect_not_log "TRACKED"
+  expect_not_log "UNTRACKED"
+}
+
 function test_external_package_in_other_repo() {
   cat > $(setup_module_dot_bazel) <<EOF
 local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")


### PR DESCRIPTION
This was caused by `query` (and `mod`, for that matter) ignoring `--action_env` when computing the repository environment, which could result in repo rules rerunning if they had a dependency on a value set via `--action_env`.

This is fixed by honoring the value of `--action_env` for all commands that load, not just those that analyze.

Context: https://bazelbuild.slack.com/archives/C014RARENH0/p1748337429642779