### PR TITLE
Add support to http_archive() for password-only authentication

### DIFF
--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -138,7 +138,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:python_configure.bzl%extension": {
       "general": {
-        "bzlTransitiveDigest": "AmLbxv4IaFzGPUmUf54Ry5g9fdyiEq1CPb/JxwMbvvc=",
+        "bzlTransitiveDigest": "SS+7hwxlYaGbaKBE9yP78k+xk3YWTL4mx+0A/oGc0/s=",
         "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
         "recordedFileInputs": {
           "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
@@ -172,7 +172,7 @@
     },
     "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "eh4+G6xahmsV1DQyoJyZfm1Upb1AAa1425mR3Gd2vOY=",
+        "bzlTransitiveDigest": "kpVElVtbvFD/KLIxZQxqKoHZLoHZZuE6w1a9FlZ+tws=",
         "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -255,7 +255,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "wte4vO8DHcoYr2Hdje592YNwYrCOzth2ujMpAuHp4dY=",
+        "bzlTransitiveDigest": "UlhRsTcpT1ZhkSikZAL4NirbIhnRC9PpRMoJDOtFhSw=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -319,7 +319,7 @@
     },
     "@@rules_python+//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "83JB4302dTScgJdy8GngTfQJLG8uAs/uiKvST6B+g50=",
+        "bzlTransitiveDigest": "LyAaVMdAiMGK5lfZKDtwSL3aYhuMHqJ0xCKQl9gi894=",
         "usagesDigest": "OLoIStnzNObNalKEMRq99FqenhPGLFZ5utVLV4sz7OI=",
         "recordedFileInputs": {
           "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -290,7 +290,7 @@ def read_netrc(ctx, filename):
     contents = ctx.read(filename, watch = "no")
     return parse_netrc(contents, filename)
 
-def parse_netrc(contents, filename = None):
+def parse_netrc(contents, filename = "a .netrc file"):
     """Utility function to parse at least a basic .netrc file.
 
     Args:
@@ -373,10 +373,7 @@ def parse_netrc(contents, filename = None):
                     currentmachinename = ""
                     currentmachine = {}
                 else:
-                    if filename == None:
-                        filename = "a .netrc file"
-                    fail("Unexpected token '%s' while reading %s" %
-                         (token, filename))
+                    fail("Unexpected token '%s' while reading %s" % (token, filename))
     if not currentmachinename == None:
         netrc[currentmachinename] = currentmachine
     return netrc
@@ -426,12 +423,21 @@ def use_netrc(netrc, urls, patterns):
                 auth_dict["password"] = authforhost["password"]
 
             auth[url] = auth_dict
-        elif "login" in authforhost and "password" in authforhost:
-            auth[url] = {
-                "type": "basic",
-                "login": authforhost["login"],
-                "password": authforhost["password"],
-            }
+        elif "password" in authforhost:
+            if "login" in authforhost:
+                auth[url] = {
+                    "type": "basic",
+                    "login": authforhost["login"],
+                    "password": authforhost["password"],
+                }
+            else:
+                auth[url] = {
+                    "type": "pattern",
+                    "pattern": "Bearer <password>",
+                    "password": authforhost["password"],
+                }
+        else:
+            print("WARNING: Found machine in .netrc for URL %s, but no password." % url)
 
     return auth
 


### PR DESCRIPTION
Modify `use_netrc()` to use password-only credentials from .netrc, and print a warning when a machine is found with unusable credentials. This notifies the user when there's a problem with his .netrc.

+ Update src/test/tools/bzlmod/MODULE.bazel.lock

Issue: https://github.com/bazelbuild/bazel/issues/26145

Cherry-pick of: https://github.com/bazelbuild/bazel/commit/76e56d4b58f6985be4be725f291e35fa4fcb42fe