### PR TITLE
Update ppc64le constraints

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -52,7 +52,7 @@ config_setting(
     name = "linux_ppc64le",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:ppc",
+        "@platforms//cpu:ppc64le",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -35,7 +35,7 @@ config_setting(
     name = "linux_ppc64le",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:ppc",
+        "@platforms//cpu:ppc64le",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Update ppc64le constraints to match the definitions in version 0.0.11 of the platforms module. Resolves #25985. The platforms module itself was upgraded to version 0.0.11 in #26173.