### PR TITLE
[8.3.0] Add a missing null check on `SkyframeLookupResult#getOrThrow`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuildSettingsDetailsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuildSettingsDetailsFunction.java
@@ -163,6 +163,9 @@ final class StarlarkBuildSettingsDetailsFunction implements SkyFunction {
       for (PackageIdentifier packageKey : packageKeys) {
         try {
           SkyValue skyValue = newlyLoaded.getOrThrow(packageKey, NoSuchPackageException.class);
+          if (skyValue == null) {
+            return null;
+          }
           buildSettingPackages.put(packageKey, (PackageValue) skyValue);
         } catch (NoSuchPackageException e) {
           throw new TransitionException(e);


### PR DESCRIPTION
Speculative fix for #22066

Closes #26101.

PiperOrigin-RevId: 765255882
Change-Id: I7569c3b2175d3bca527673f8aa13d1649c86942a

Commit https://github.com/bazelbuild/bazel/commit/6387e0d8e6c435eb18437d5711ad43f6e7721f58