### PR TITLE
Fix casing of dep error message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/DependencyProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/DependencyProducer.java
@@ -235,7 +235,7 @@ final class DependencyProducer
 
   private String getMessageWithEdgeTransitionInfo(Throwable e) {
     return String.format(
-        "On dependency edge %s (%s) -|%s|-> %s: %s",
+        "on dependency edge %s (%s) -|%s|-> %s: %s",
         parameters.target().getLabel(),
         parameters.configurationKey().getOptions().shortId(),
         kind.getAttribute().getName(),


### PR DESCRIPTION
This is typically not the first part of an error message, so it shouldn't be uppercased.