### PR TITLE
Incur reexecution on waitExecution null lastException

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java
@@ -190,7 +190,11 @@ public class ExperimentalGrpcRemoteExecutor implements RemoteExecutionClient {
 
     @Nullable
     ExecuteResponse waitExecution() throws IOException {
-      Preconditions.checkState(lastOperation != null);
+      // If lastOperation is null, return null to incur reexecution. This can happen in
+      // either an execute stream termination, or a mid-stream waitExecution retriable exception
+      if (lastOperation == null) {
+        return null;
+      }
 
       WaitExecutionRequest request =
           WaitExecutionRequest.newBuilder().setName(lastOperation.getName()).build();

--- a/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
@@ -160,4 +160,17 @@ public class ExperimentalGrpcRemoteExecutorTest extends GrpcRemoteExecutorTestBa
     assertThat(executionService.getWaitTimes()).isEqualTo(2);
     assertThat(response).isEqualTo(DUMMY_RESPONSE);
   }
+
+  @Test
+  public void executeRemotely_executeTerminationPreventsWaitExecution() throws Exception {
+    executionService.whenExecute(DUMMY_REQUEST).finish();
+    executionService.whenExecute(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
+
+    ExecuteResponse response =
+        executor.executeRemotely(context, DUMMY_REQUEST, OperationObserver.NO_OP);
+
+    assertThat(executionService.getExecTimes()).isEqualTo(2);
+    assertThat(executionService.getWaitTimes()).isEqualTo(0);
+    assertThat(response).isEqualTo(DUMMY_RESPONSE);
+  }
 }


### PR DESCRIPTION
If a null response is received from execute without setting
lastExecution, or a retriable error is received midstream in
waitExecution which nulls the lastExecution, the waitExecution should
return null to ensure reexecution (rather than wait).

Fixes #26055 