### PR TITLE
Add `--incompatible_eagerly_resolve_select_keys`

### DIFF
--- a/site/en/extending/legacy-macros.md
+++ b/site/en/extending/legacy-macros.md
@@ -188,6 +188,12 @@ def my_cc_wrapper(name, deps = [], **kwargs):
   )
 ```
 
+With the `--incompatible_eagerly_resolve_select_keys` flag enabled, all keys
+that are label strings will be automatically resolved to `Label` objects
+relative to the package of the file that contains the `select` call. If this is
+not desired, wrap the label string with
+[native.package_relative_label()](/rules/lib/toplevel/native#package_relative_label).
+
 ## Debugging {:#debugging}
 
 *   `bazel query --output=build //my/path:all` will show you how the `BUILD`

--- a/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
@@ -1783,7 +1783,6 @@ public final class Attribute implements Comparable<Attribute> {
               + "configuration.");
       return new LabelLateBoundDefault<>(fragmentClass, defaultValueEvaluator, resolver);
     }
-
   }
 
   /** A {@link LateBoundDefault} for a {@link List} of {@link Label} objects. */
@@ -2459,7 +2458,7 @@ public final class Attribute implements Comparable<Attribute> {
     } else if (x instanceof BuildType.SelectorList<?> selectorList) {
       List<Object> selectors = new ArrayList<>();
       for (BuildType.Selector<?> selector : selectorList.getSelectors()) {
-        Dict.Builder<Object, Object> m = Dict.builder();
+        var m = ImmutableMap.builderWithExpectedSize(selector.getNumEntries());
         selector.forEach(
             (rawKey, rawValue) -> {
               Object key = valueToStarlark(rawKey);
@@ -2470,7 +2469,7 @@ public final class Attribute implements Comparable<Attribute> {
                   !selector.isValueSet(rawKey) ? Starlark.NONE : valueToStarlark(rawValue);
               m.put(key, mapVal);
             });
-        Dict<?, ?> selectorDict = m.build(/* mu= */ null);
+        var selectorDict = m.buildKeepingLast();
         if (!selectorDict.isEmpty()) {
           selectors.add(new SelectorValue(selectorDict, selector.getNoMatchError()));
         }

--- a/src/main/java/com/google/devtools/build/lib/packages/SelectorList.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/SelectorList.java
@@ -264,8 +264,11 @@ public final class SelectorList implements StarlarkValue, HasBinary {
                   "A dict that maps configuration conditions to values. Each key is a "
                       + "<a href=\"../builtins/Label.html\">Label</a> or a label string"
                       + " that identifies a config_setting or constraint_value instance. See the"
-                      + " <a href=\"https://bazel.build/rules/macros#label-resolution\">"
-                      + "documentation on macros</a> for when to use a Label instead of a string."),
+                      + " <a href=\"https://bazel.build/extending/legacy-macros#label-resolution\">"
+                      + "documentation on macros</a> for when to use a Label instead of a string."
+                      + " If <code>--incompatible_resolve_select_keys_eagerly</code> is enabled,"
+                      + " the keys are resolved to <code>Label</code> objects relative to the"
+                      + " package of the file that contains this call to <code>select</code>."),
           @Param(
               name = "no_match_error",
               defaultValue = "''",

--- a/src/main/java/com/google/devtools/build/lib/packages/SelectorList.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/SelectorList.java
@@ -281,7 +281,6 @@ public final class SelectorList implements StarlarkValue, HasBinary {
       // If this is not null, string keys in the dict will be resolved to Labels eagerly using the
       // given context. This is unnecessary for BUILD files and packageContext will remain null in
       // this case.
-      // Non-null in the case of an initializer.
       LabelConverter labelConverter = null;
       if (thread
           .getSemantics()

--- a/src/main/java/com/google/devtools/build/lib/packages/SelectorList.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/SelectorList.java
@@ -279,8 +279,7 @@ public final class SelectorList implements StarlarkValue, HasBinary {
     public Object select(Dict<?, ?> dict, String noMatchError, StarlarkThread thread)
         throws EvalException {
       // If this is not null, string keys in the dict will be resolved to Labels eagerly using the
-      // given context. This is unnecessary for BUILD files and packageContext will remain null in
-      // this case.
+      // given context.
       LabelConverter labelConverter = null;
       if (thread
           .getSemantics()

--- a/src/main/java/com/google/devtools/build/lib/packages/SelectorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/SelectorValue.java
@@ -53,7 +53,7 @@ public final class SelectorValue implements StarlarkValue, HasBinary {
 
   SelectorValue(ImmutableMap<?, ?> dictionary, String noMatchError) {
     Preconditions.checkArgument(!dictionary.isEmpty());
-    this.dictionary = ImmutableMap.copyOf(dictionary);
+    this.dictionary = dictionary;
     // TODO(adonovan): doesn't this assume all the elements have the same type?
     this.type = Iterables.getFirst(dictionary.values(), null).getClass();
     this.noMatchError = noMatchError;

--- a/src/main/java/com/google/devtools/build/lib/packages/SelectorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/SelectorValue.java
@@ -17,7 +17,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import java.util.Map;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.eval.EvalException;
@@ -52,7 +51,7 @@ public final class SelectorValue implements StarlarkValue, HasBinary {
   private final Class<?> type;
   private final String noMatchError;
 
-  SelectorValue(Map<?, ?> dictionary, String noMatchError) {
+  SelectorValue(ImmutableMap<?, ?> dictionary, String noMatchError) {
     Preconditions.checkArgument(!dictionary.isEmpty());
     this.dictionary = ImmutableMap.copyOf(dictionary);
     // TODO(adonovan): doesn't this assume all the elements have the same type?

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java
@@ -793,7 +793,7 @@ public class StarlarkNativeModule implements StarlarkNativeModuleApi {
     if (val instanceof BuildType.SelectorList) {
       List<Object> selectors = new ArrayList<>();
       for (BuildType.Selector<?> selector : ((BuildType.SelectorList<?>) val).getSelectors()) {
-        Dict.Builder<Object, Object> m = Dict.builder();
+        var m = ImmutableMap.builderWithExpectedSize(selector.getNumEntries());
         selector.forEach(
             (rawKey, rawValue) -> {
               Object key = starlarkifyValue(mu, rawKey, pkgMetadata);
@@ -808,7 +808,7 @@ public class StarlarkNativeModule implements StarlarkNativeModuleApi {
                 m.put(key, mapVal);
               }
             });
-        Dict<?, ?> selectorDict = m.build(mu);
+        var selectorDict = m.buildKeepingLast();
         if (!selectorDict.isEmpty()) {
           selectors.add(new SelectorValue(selectorDict, selector.getNoMatchError()));
         }

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -819,6 +819,16 @@ public final class BuildLanguageOptions extends OptionsBase {
       help = "If true enables the repository_ctx `load_wasm` and `execute_wasm` methods.")
   public boolean repositoryCtxExecuteWasm;
 
+  @Option(
+      name = "incompatible_resolve_select_keys_eagerly",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "If enabled, string keys in dicts passed to select() in .bzl files are immediately resolved to Labels relative to the file instead of being interpreted relative to the BUILD file they are ultimately loaded from.")
+  public boolean incompatibleResolveSelectKeysEagerly;
+
   /**
    * An interner to reduce the number of StarlarkSemantics instances. A single Blaze instance should
    * never accumulate a large number of these and being able to shortcut on object identity makes a
@@ -925,6 +935,7 @@ public final class BuildLanguageOptions extends OptionsBase {
                 incompatibleSimplifyUnconditionalSelectsInRuleAttrs)
             .setBool(
                 INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE, incompatibleLocationsPrefersExecutable)
+            .setBool(INCOMPATIBLE_RESOLVE_SELECT_KEYS_EAGERLY, incompatibleResolveSelectKeysEagerly)
             .setBool(
                 StarlarkSemantics.EXPERIMENTAL_ENABLE_STARLARK_SET, experimentalEnableStarlarkSet)
             .setBool(
@@ -1101,6 +1112,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       "+incompatible_locations_prefers_executable";
   public static final String EXPERIMENTAL_REPOSITORY_CTX_EXECUTE_WASM =
       "-experimental_repository_ctx_execute_wasm";
+  public static final String INCOMPATIBLE_RESOLVE_SELECT_KEYS_EAGERLY =
+      "-incompatible_resolve_select_keys_eagerly";
   // non-booleans
   public static final StarlarkSemantics.Key<List<String>> INCOMPATIBLE_DISABLE_TRANSITIONS_OPTIONS =
       new StarlarkSemantics.Key<>("incompatible_disable_transitions_on", ImmutableList.of());

--- a/src/test/java/com/google/devtools/build/lib/packages/SelectTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/SelectTest.java
@@ -16,9 +16,18 @@ package com.google.devtools.build.lib.packages;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkGlobalsImpl;
+import com.google.devtools.build.lib.cmdline.BazelModuleContext;
+import com.google.devtools.build.lib.cmdline.BazelModuleKey;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import java.util.List;
+import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Module;
 import net.starlark.java.eval.Mutability;
@@ -37,16 +46,22 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class SelectTest {
 
-  private static Object eval(String expr)
+  private static Object eval(
+      String expr, StarlarkSemantics semantics, @Nullable BazelModuleContext bazelModuleContext)
       throws SyntaxError.Exception, EvalException, InterruptedException {
     ParserInput input = ParserInput.fromLines(expr);
     Module module =
-        Module.withPredeclared(
-            StarlarkSemantics.DEFAULT, StarlarkGlobalsImpl.INSTANCE.getUtilToplevels());
+        Module.withPredeclaredAndData(
+            semantics, StarlarkGlobalsImpl.INSTANCE.getUtilToplevels(), bazelModuleContext);
     try (Mutability mu = Mutability.create()) {
-      StarlarkThread thread = StarlarkThread.createTransient(mu, StarlarkSemantics.DEFAULT);
+      StarlarkThread thread = StarlarkThread.createTransient(mu, semantics);
       return Starlark.eval(input, FileOptions.DEFAULT, module, thread);
     }
+  }
+
+  private static Object eval(String expr)
+      throws SyntaxError.Exception, EvalException, InterruptedException {
+    return eval(expr, StarlarkSemantics.DEFAULT, /* bazelModuleContext= */ null);
   }
 
   private static void assertFails(String expr, String wantError) {
@@ -137,5 +152,38 @@ public class SelectTest {
 
     assertThat(eval("repr(select({'foo': {'FOO': 123}})|select({'bar': {'BAR': 456}}))"))
         .isEqualTo("select({\"foo\": {\"FOO\": 123}}) | select({\"bar\": {\"BAR\": 456}})");
+  }
+
+  @Test
+  public void testEagerResolution() throws Exception {
+    var ctx =
+        BazelModuleContext.create(
+            BazelModuleKey.createFakeModuleKeyForTesting(
+                Label.parseCanonicalUnchecked("//other/pkg:def.bzl")),
+            RepositoryMapping.create(
+                ImmutableMap.of(
+                    "",
+                    RepositoryName.MAIN,
+                    "other_repo",
+                    RepositoryName.createUnvalidated("other_repo+")),
+                RepositoryName.MAIN),
+            "other/pkg/def.bzl",
+            /* loads= */ ImmutableList.of(),
+            /* bzlTransitiveDigest= */ new byte[0]);
+    var semantics =
+        StarlarkSemantics.builder()
+            .setBool(BuildLanguageOptions.INCOMPATIBLE_RESOLVE_SELECT_KEYS_EAGERLY, true)
+            .build();
+    var result =
+        (SelectorList)
+            eval("select({'a': 1, '//pkg:b': 2, '@other_repo//:file': 3})", semantics, ctx);
+    assertThat(((SelectorValue) Iterables.getOnlyElement(result.getElements())).getDictionary())
+        .containsExactly(
+            Label.parseCanonicalUnchecked("//other/pkg:a"),
+            StarlarkInt.of(1),
+            Label.parseCanonicalUnchecked("//pkg:b"),
+            StarlarkInt.of(2),
+            Label.parseCanonicalUnchecked("@@other_repo+//:file"),
+            StarlarkInt.of(3));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/SelectTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/SelectTest.java
@@ -170,7 +170,9 @@ public class SelectTest {
                 RepositoryName.MAIN),
             "other/pkg/def.bzl",
             /* loads= */ ImmutableList.of(),
-            /* bzlTransitiveDigest= */ new byte[0]);
+            /* bzlTransitiveDigest= */ new byte[0],
+            /* docCommentsMap= */ ImmutableMap.of(),
+            /* unusedDocCommentLines= */ ImmutableList.of());
     var semantics =
         StarlarkSemantics.builder()
             .setBool(

--- a/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/semantics/ConsistencyTest.java
@@ -153,6 +153,7 @@ public class ConsistencyTest {
         "--incompatible_run_shell_command_string=" + rand.nextBoolean(),
         "--incompatible_use_cc_configure_from_rules_cc=" + rand.nextBoolean(),
         "--incompatible_unambiguous_label_stringification=" + rand.nextBoolean(),
+        "--incompatible_resolve_select_keys_eagerly=" + rand.nextBoolean(),
         "--internal_starlark_flag_test_canary=" + rand.nextBoolean(),
         "--internal_starlark_utf_8_byte_strings=" + rand.nextBoolean(),
         "--max_computation_steps=" + rand.nextLong());
@@ -199,6 +200,7 @@ public class ConsistencyTest {
             BuildLanguageOptions.INCOMPATIBLE_USE_CC_CONFIGURE_FROM_RULES_CC, rand.nextBoolean())
         .setBool(
             BuildLanguageOptions.INCOMPATIBLE_UNAMBIGUOUS_LABEL_STRINGIFICATION, rand.nextBoolean())
+        .setBool(BuildLanguageOptions.INCOMPATIBLE_RESOLVE_SELECT_KEYS_EAGERLY, rand.nextBoolean())
         .setBool(StarlarkSemantics.PRINT_TEST_MARKER, rand.nextBoolean())
         .setBool(StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS, rand.nextBoolean())
         .set(BuildLanguageOptions.MAX_COMPUTATION_STEPS, rand.nextLong())


### PR DESCRIPTION
This avoids a common gotcha in which a `select` in a macro with repo names in string keys will generally not work correctly when loaded in the context of a different Bazel (Bzlmod) module that uses a different set of apparent names.

In the rare case where resolution relative to the loading `BUILD` file is necessary (e.g. in Skylib's `selects.config_setting_group` or other macros that generate `config_setting`s and `select`s referring to them), the keys can be preprocessed with `native.package_relative_label`.

RELNOTES: With the new `--incompatible_eagerly_resolve_select_keys` flag, the label string keys of `select` dicts in `.bzl` files are resolved relative to the containing file instead of relative to the BUILD file that ends up using the `select`. Use `native.package_relative_label` if this is not desired.