### PR TITLE
Updating setuptools to patch CVE-2025-47273

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -3271,7 +3271,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_10_host//:python",
               "repo": "pip_deps_310",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "pip_deps_311_numpy": {
@@ -3289,7 +3289,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
               "repo": "pip_deps_311",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "pip_deps_312_numpy": {
@@ -3307,7 +3307,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "pip_deps_312",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "pip_deps_38_numpy": {
@@ -3325,7 +3325,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_8_host//:python",
               "repo": "pip_deps_38",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "pip_deps_39_numpy": {
@@ -3343,7 +3343,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "pip_deps_39",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "rules_fuzzing_py_deps_310_absl_py": {

--- a/src/test/tools/bzlmod/MODULE.bazel.lock
+++ b/src/test/tools/bzlmod/MODULE.bazel.lock
@@ -345,7 +345,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_10_host//:python",
               "repo": "pip_deps_310",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "pip_deps_311_numpy": {
@@ -363,7 +363,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
               "repo": "pip_deps_311",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "pip_deps_312_numpy": {
@@ -381,7 +381,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_12_host//:python",
               "repo": "pip_deps_312",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "pip_deps_38_numpy": {
@@ -399,7 +399,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_8_host//:python",
               "repo": "pip_deps_38",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "pip_deps_39_numpy": {
@@ -417,7 +417,7 @@
               "dep_template": "@pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_9_host//:python",
               "repo": "pip_deps_39",
-              "requirement": "setuptools<=70.3.0"
+              "requirement": "setuptools<=78.1.1"
             }
           },
           "rules_fuzzing_py_deps_310_absl_py": {


### PR DESCRIPTION
Updating setuptools to patch CVE-2025-47273.

I manually updated this in the lock file, since it wasn't clear to me how this particular configuration was originally generated. e.g. nothing in https://github.com/bazel-contrib/rules_python is specifically pinning to "70.3.0" .

Let me know if there is a different / better way to make this change.