### PR TITLE
Clean up Bzlmod code in preparation for facts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValues.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/AttributeValues.java
@@ -20,7 +20,6 @@ import static java.util.Collections.singletonList;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.cmdline.Label;
-import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +30,6 @@ import net.starlark.java.eval.Starlark;
 
 /** Wraps a dictionary of attribute names and values. Always uses a dict to represent them */
 @AutoValue
-@GenerateTypeAdapter
 public abstract class AttributeValues {
 
   public static AttributeValues create(Dict<String, Object> attribs) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileFunction.java
@@ -94,7 +94,8 @@ public class BazelLockFileFunction implements SkyFunction {
         return BazelLockFileValue.EMPTY_LOCKFILE;
       }
       String actionSuffix;
-      if (POSSIBLE_MERGE_CONFLICT_PATTERN.matcher(e.getMessage()).find()) {
+      if (e.getMessage() != null
+          && POSSIBLE_MERGE_CONFLICT_PATTERN.matcher(e.getMessage()).find()) {
         actionSuffix =
             " This looks like a merge conflict. See"
                 + " https://bazel.build/external/lockfile#merge-conflicts for advice.";
@@ -137,7 +138,6 @@ public class BazelLockFileFunction implements SkyFunction {
       return BazelLockFileValue.EMPTY_LOCKFILE;
     }
   }
-
 
   static final class BazelLockfileFunctionException extends SkyFunctionException {
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -112,12 +112,14 @@ public class BazelLockFileModule extends BlazeModule {
     // All nodes corresponding to module extensions that have been evaluated in the current build
     // are done at this point. Look up entries by eval keys to record results even if validation
     // later fails due to invalid imports.
-    // Note: This also picks up up-to-date result from previous builds that are not in the
-    // transitive closure of the current build. Since extension are potentially costly to evaluate,
+    // Note: This also picks up up-to-date results from previous builds that are not in the
+    // transitive closure of the current build. Since extensions are potentially costly to evaluate,
     // this is seen as an advantage. Full reproducibility can be ensured by running 'bazel shutdown'
     // first if needed.
+    int maxNumExtensions = depGraphValue.getExtensionUsagesTable().rowMap().size();
+    // Presize conservatively to avoid blocking for resizing.
     Map<ModuleExtensionId, LockFileModuleExtension.WithFactors> newExtensionInfos =
-        new ConcurrentHashMap<>();
+        new ConcurrentHashMap<>(maxNumExtensions);
     executor
         .getEvaluator()
         .getInMemoryGraph()

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/LockFileModuleExtension.java
@@ -18,7 +18,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableTable;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
-import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
@@ -31,7 +30,7 @@ import java.util.Optional;
  */
 @AutoValue
 @GenerateTypeAdapter
-public abstract class LockFileModuleExtension implements Postable {
+public abstract class LockFileModuleExtension {
 
   public static Builder builder() {
     return new AutoValue_LockFileModuleExtension.Builder()

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionContext.java
@@ -79,10 +79,6 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
     this.rootModuleHasNonDevDependency = rootModuleHasNonDevDependency;
   }
 
-  public Path getWorkingDirectory() {
-    return workingDirectory;
-  }
-
   @Override
   protected boolean shouldDeleteWorkingDirectoryOnClose(boolean successful) {
     // The contents of the working directory are purely ephemeral, only the repos instantiated by
@@ -97,7 +93,7 @@ public class ModuleExtensionContext extends StarlarkBaseExternalContext {
   }
 
   @Override
-  protected ImmutableMap<String, String> getRemoteExecProperties() throws EvalException {
+  protected ImmutableMap<String, String> getRemoteExecProperties() {
     return ImmutableMap.of();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionEvalFunction.java
@@ -473,7 +473,7 @@ public class SingleExtensionEvalFunction implements SkyFunction {
       }
     }
 
-    return SingleExtensionValue.create(
+    return new SingleExtensionValue(
         generatedRepoSpecs,
         generatedRepoSpecs.keySet().stream()
             .collect(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleExtensionValue.java
@@ -57,16 +57,6 @@ public record SingleExtensionValue(
     requireNonNull(fixup, "fixup");
   }
 
-  @AutoCodec.Instantiator
-  public static SingleExtensionValue create(
-      ImmutableMap<String, RepoSpec> generatedRepoSpecs,
-      ImmutableBiMap<RepositoryName, String> canonicalRepoNameToInternalNames,
-      Optional<LockFileModuleExtension.WithFactors> lockFileInfo,
-      Optional<RootModuleFileFixup> fixup) {
-    return new SingleExtensionValue(
-        generatedRepoSpecs, canonicalRepoNameToInternalNames, lockFileInfo, fixup);
-  }
-
   public static Key key(ModuleExtensionId id) {
     return Key.create(id);
   }

--- a/src/main/java/net/starlark/java/lib/json/Json.java
+++ b/src/main/java/net/starlark/java/lib/json/Json.java
@@ -691,9 +691,8 @@ public final class Json implements StarlarkValue {
         @Param(name = "x"),
         @Param(name = "prefix", positional = false, named = true, defaultValue = "''"),
         @Param(name = "indent", positional = false, named = true, defaultValue = "'\\t'"),
-      },
-      useStarlarkThread = true)
-  public String encodeIndent(Object x, String prefix, String indent, StarlarkThread starlarkThread)
+      })
+  public String encodeIndent(Object x, String prefix, String indent)
       throws EvalException, InterruptedException {
     return indent(encode(x), prefix, indent);
   }


### PR DESCRIPTION
This includes minor fixes and improvements that are related to the work on #24777:

* Fixes an NPE when reading the lockfile results in an exception with a `null` message.
* Presizes the concurrent map used to collect Skyframe graph contents to avoid unnecessary blocking for resizing.
* Deletes unused code and annotations.