### PR TITLE
Add `$(dirname ...)` location function

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/be/make-variables.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/make-variables.vm
@@ -391,6 +391,14 @@ instead.
   and <code>//somepkg:foo</code> are all fine.
 </p>
 
+<p>
+  The predefined variable <code>dirname</code> takes a path parameter that
+  may also be supplied by another variable (e.g.
+  <code>$(dirname $(execpath //foo:bar))</code>) and substitutes the parent
+  directory of that path. It operates on paths separated by forward slashes
+  on all platforms and fails if the path contains backslashes.
+</p>
+
 <h2 id="custom_variables">Custom variables</h2>
 
 <p>

--- a/src/main/java/com/google/devtools/build/lib/analysis/LocationExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/LocationExpander.java
@@ -531,6 +531,7 @@ public final class LocationExpander {
   private static final CharMatcher forwardSlashMatcher = CharMatcher.is('/');
 
   private static String dirname(String arg) {
+    arg = ShellEscaper.unescapeString(arg);
     if (arg.isEmpty()) {
       throw new IllegalStateException(
           "$(dirname ...) used with an empty string, which is not a valid path");
@@ -547,7 +548,8 @@ public final class LocationExpander {
       }
       return ".";
     }
-    return forwardSlashMatcher.trimTrailingFrom(arg.substring(0, lastSlash));
+    return ShellEscaper.escapeString(
+        forwardSlashMatcher.trimTrailingFrom(arg.substring(0, lastSlash)));
   }
 
   private static interface ErrorReporter {

--- a/src/main/java/com/google/devtools/build/lib/analysis/LocationExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/LocationExpander.java
@@ -541,7 +541,7 @@ public final class LocationExpander {
           isQuoted = !isQuoted;
         } else if (c == ' ' && !isQuoted) {
           throw new IllegalStateException(
-              "$(dirname ...) used with a path containing unescaped spaces, which is not supported: "
+              "$(dirname ...) used with a path containing unquoted spaces, which is not supported: "
                   + arg);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/LocationTemplateContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/LocationTemplateContext.java
@@ -107,7 +107,7 @@ final class LocationTemplateContext implements TemplateContext {
 
   private String lookupFunctionImpl(String name, String param) throws ExpansionException {
     try {
-      LocationFunction f = functions.get(name);
+      var f = functions.get(name);
       if (f != null) {
         return f.apply(param, repositoryMapping, workspaceRunfilesDirectory);
       }

--- a/src/main/java/com/google/devtools/build/lib/util/ShellEscaper.java
+++ b/src/main/java/com/google/devtools/build/lib/util/ShellEscaper.java
@@ -114,6 +114,15 @@ public final class ShellEscaper extends Escaper {
     return INSTANCE.escape(unescaped);
   }
 
+  public static String unescapeString(String escaped) {
+    if (escaped.isEmpty()
+        || escaped.charAt(0) != '\''
+        || escaped.charAt(escaped.length() - 1) != '\'') {
+      return escaped;
+    }
+    return escaped.substring(1, escaped.length() - 1).replace("'\\''", "'");
+  }
+
   /**
    * Transforms the input {@code Iterable} of unescaped strings to an
    * {@code Iterable} of escaped ones. The escaping is done lazily.

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -626,8 +626,8 @@ java_library(
 )
 
 java_test(
-    name = "LocationFunctionTest",
-    srcs = ["LocationFunctionTest.java"],
+    name = "LabelLocationFunctionTest",
+    srcs = ["LabelLocationFunctionTest.java"],
     deps = [
         ":LocationFunctionBuilder",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",

--- a/src/test/java/com/google/devtools/build/lib/analysis/LabelLocationFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/LabelLocationFunctionTest.java
@@ -18,21 +18,20 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.devtools.build.lib.analysis.LocationExpander.LocationFunction;
+import com.google.devtools.build.lib.analysis.LocationExpander.LabelLocationFunction;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link LocationExpander.LocationFunction}. */
+/** Unit tests for {@link LabelLocationFunction}s. */
 @RunWith(JUnit4.class)
-public class LocationFunctionTest {
+public class LabelLocationFunctionTest {
 
   @Test
   public void absoluteAndRelativeLabels() throws Exception {
-    LocationFunction func =
-        new LocationFunctionBuilder("//foo", false).add("//foo", "/exec/src/bar").build();
+    var func = new LocationFunctionBuilder("//foo", false).add("//foo", "/exec/src/bar").build();
     assertThat(func.apply("//foo", RepositoryMapping.EMPTY, null)).isEqualTo("src/bar");
     assertThat(func.apply(":foo", RepositoryMapping.EMPTY, null)).isEqualTo("src/bar");
     assertThat(func.apply("foo", RepositoryMapping.EMPTY, null)).isEqualTo("src/bar");
@@ -40,14 +39,13 @@ public class LocationFunctionTest {
 
   @Test
   public void pathUnderExecRootUsesDotSlash() throws Exception {
-    LocationFunction func =
-        new LocationFunctionBuilder("//foo", false).add("//foo", "/exec/bar").build();
+    var func = new LocationFunctionBuilder("//foo", false).add("//foo", "/exec/bar").build();
     assertThat(func.apply("//foo", RepositoryMapping.EMPTY, null)).isEqualTo("./bar");
   }
 
   @Test
   public void noSuchLabel() throws Exception {
-    LocationFunction func = new LocationFunctionBuilder("//foo", false).build();
+    var func = new LocationFunctionBuilder("//foo", false).build();
     IllegalStateException expected =
         assertThrows(
             IllegalStateException.class, () -> func.apply("//bar", RepositoryMapping.EMPTY, null));
@@ -60,7 +58,7 @@ public class LocationFunctionTest {
 
   @Test
   public void emptyList() throws Exception {
-    LocationFunction func = new LocationFunctionBuilder("//foo", false).add("//foo").build();
+    var func = new LocationFunctionBuilder("//foo", false).add("//foo").build();
     IllegalStateException expected =
         assertThrows(
             IllegalStateException.class, () -> func.apply("//foo", RepositoryMapping.EMPTY, null));
@@ -71,7 +69,7 @@ public class LocationFunctionTest {
 
   @Test
   public void tooMany() throws Exception {
-    LocationFunction func =
+    var func =
         new LocationFunctionBuilder("//foo", false).add("//foo", "/exec/1", "/exec/2").build();
     IllegalStateException expected =
         assertThrows(
@@ -86,7 +84,7 @@ public class LocationFunctionTest {
 
   @Test
   public void noSuchLabelMultiple() throws Exception {
-    LocationFunction func = new LocationFunctionBuilder("//foo", true).build();
+    var func = new LocationFunctionBuilder("//foo", true).build();
     IllegalStateException expected =
         assertThrows(
             IllegalStateException.class, () -> func.apply("//bar", RepositoryMapping.EMPTY, null));
@@ -99,14 +97,14 @@ public class LocationFunctionTest {
 
   @Test
   public void fileWithSpace() throws Exception {
-    LocationFunction func =
+    var func =
         new LocationFunctionBuilder("//foo", false).add("//foo", "/exec/file/with space").build();
     assertThat(func.apply("//foo", RepositoryMapping.EMPTY, null)).isEqualTo("'file/with space'");
   }
 
   @Test
   public void multipleFiles() throws Exception {
-    LocationFunction func =
+    var func =
         new LocationFunctionBuilder("//foo", true)
             .add("//foo", "/exec/foo/bar", "/exec/out/foo/foobar")
             .build();
@@ -115,7 +113,7 @@ public class LocationFunctionTest {
 
   @Test
   public void filesWithSpace() throws Exception {
-    LocationFunction func =
+    var func =
         new LocationFunctionBuilder("//foo", true)
             .add("//foo", "/exec/file/with space", "/exec/file/with spaces ")
             .build();
@@ -125,9 +123,9 @@ public class LocationFunctionTest {
 
   @Test
   public void execPath() throws Exception {
-    LocationFunction func =
+    var func =
         new LocationFunctionBuilder("//foo", true)
-            .setPathType(LocationFunction.PathType.EXEC)
+            .setPathType(LabelLocationFunction.PathType.EXEC)
             .add("//foo", "/exec/bar", "/exec/out/foobar")
             .build();
     assertThat(func.apply("//foo", RepositoryMapping.EMPTY, null)).isEqualTo("./bar out/foobar");
@@ -135,9 +133,9 @@ public class LocationFunctionTest {
 
   @Test
   public void rlocationPath() throws Exception {
-    LocationFunction func =
+    var func =
         new LocationFunctionBuilder("//foo", true)
-            .setPathType(LocationFunction.PathType.RLOCATION)
+            .setPathType(LabelLocationFunction.PathType.RLOCATION)
             .add("//foo", "/exec/bar", "/exec/out/foobar")
             .build();
     assertThat(func.apply("//foo", RepositoryMapping.EMPTY, "workspace"))
@@ -148,8 +146,7 @@ public class LocationFunctionTest {
   public void locationFunctionWithMappingReplace() throws Exception {
     RepositoryName b = RepositoryName.create("b");
     var repositoryMapping = RepositoryMapping.create(ImmutableMap.of("a", b), RepositoryName.MAIN);
-    LocationFunction func =
-        new LocationFunctionBuilder("//foo", false).add("@b//foo", "/exec/src/bar").build();
+    var func = new LocationFunctionBuilder("//foo", false).add("@b//foo", "/exec/src/bar").build();
     assertThat(func.apply("@a//foo", repositoryMapping, null)).isEqualTo("src/bar");
   }
 
@@ -157,7 +154,7 @@ public class LocationFunctionTest {
   public void locationFunctionWithMappingIgnoreRepo() throws Exception {
     RepositoryName b = RepositoryName.create("b");
     var repositoryMapping = RepositoryMapping.create(ImmutableMap.of("a", b), RepositoryName.MAIN);
-    LocationFunction func =
+    var func =
         new LocationFunctionBuilder("//foo", false).add("@@potato//foo", "/exec/src/bar").build();
     assertThat(func.apply("@@potato//foo", repositoryMapping, null)).isEqualTo("src/bar");
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderIntegrationTest.java
@@ -299,7 +299,32 @@ public class LocationExpanderIntegrationTest extends BuildViewTestCase {
 
   @Test
   public void testDirname() throws Exception {
-    var expander = makeExpander("//files:lib");
+    scratch.file("other_files/subdir/file");
+    scratch.file("other_files/sub dir with spaces/file with spaces");
+
+    scratch.file(
+        "other_files/BUILD",
+        """
+        filegroup(
+            name = "file1",
+            srcs = ["subdir/file"],
+        )
+
+        filegroup(
+            name = "file2",
+            srcs = ["sub dir with spaces/file with spaces"],
+        )
+
+        filegroup(
+            name = "lib",
+            srcs = [
+                ":file1",
+                ":file2",
+            ],
+        )
+        """);
+    var expander = makeExpander("//other_files:lib");
+
     assertThat(expander.expand("$(dirname a/b/c)")).isEqualTo("a/b");
     assertThat(expander.expand("$(dirname a/b/c/)")).isEqualTo("a/b/c");
     assertThat(expander.expand("$(dirname a///b///c)")).isEqualTo("a///b");
@@ -308,12 +333,23 @@ public class LocationExpanderIntegrationTest extends BuildViewTestCase {
     assertThat(expander.expand("$(dirname C:/a/b/c)")).isEqualTo("C:/a/b");
     assertThat(expander.expand("$(dirname /a/)")).isEqualTo("/a");
     assertThat(expander.expand("$(dirname /a/b/c)")).isEqualTo("/a/b");
+    assertThat(expander.expand("foo $(dirname a/b/c) bar")).isEqualTo("foo a/b bar");
 
     assertThat(expander.expand("$(dirname $(dirname a/b/c))")).isEqualTo("a");
     assertThat(expander.expand("$(dirname $(dirname $(dirname a1/b2/c3/d4/e5)))"))
         .isEqualTo("a1/b2");
     assertThat(expander.expand("$(dirname   $(dirname a/b/c  )  )")).isEqualTo("a");
-    assertThat(expander.expand("$(dirname   $(dirnam a/b/c  )  )")).isEqualTo("$(dirnam a/b");
+    assertThat(expander.expand("$(dirname   $(dirnam a/b/c  )  )")).isEqualTo("'$(dirnam a/b'");
+
+    assertThat(expander.expand("$(dirname $(rootpath :file1))"))
+        .isEqualTo("other_files/subdir");
+    assertThat(expander.expand("$(dirname $(dirname $(rootpath :file1)))"))
+        .isEqualTo("other_files");
+
+    assertThat(expander.expand("--out=$(dirname $(rootpath :file2))"))
+        .isEqualTo("--out='other_files/sub dir with spaces'");
+    assertThat(expander.expand("--out=$(dirname $(dirname $(rootpath :file1)))"))
+        .isEqualTo("--out=other_files");
 
     assertThat(assertThrows(AssertionError.class, () -> expander.expand("$(dirname )")))
         .hasMessageThat()

--- a/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderIntegrationTest.java
@@ -344,6 +344,7 @@ public class LocationExpanderIntegrationTest extends BuildViewTestCase {
     assertThat(expander.expand("$(dirname /a/b/c)")).isEqualTo("/a/b");
     assertThat(expander.expand("$(dirname 'a/dir with space/c')")).isEqualTo("'a/dir with space'");
     assertThat(expander.expand("foo $(dirname a/b/c) bar")).isEqualTo("foo a/b bar");
+    assertThat(expander.expand("$(dirname ...)")).isEqualTo(".");
 
     assertThat(expander.expand("$(dirname $(dirname a/b/c))")).isEqualTo("a");
     assertThat(expander.expand("$(dirname $(dirname $(dirname a1/b2/c3/d4/e5)))"))
@@ -378,7 +379,7 @@ public class LocationExpanderIntegrationTest extends BuildViewTestCase {
                 AssertionError.class, () -> expander.expand("$(dirname $(rootpaths :files))")))
         .hasMessageThat()
         .endsWith(
-            "$(dirname ...) used with a path containing unescaped spaces, which is not supported:"
+            "$(dirname ...) used with a path containing unquoted spaces, which is not supported:"
                 + " 'other_files/sub dir with spaces/file with spaces' other_files/subdir/file");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/LocationExpanderTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.LocationExpander.LabelLocationFunction;
 import com.google.devtools.build.lib.analysis.LocationExpander.LocationFunction;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -59,15 +60,15 @@ public class LocationExpanderTest {
   }
 
   private LocationExpander makeExpander(RuleErrorConsumer ruleErrorConsumer) throws Exception {
-    LocationFunction f1 =
+    var f1 =
         new LocationFunctionBuilder("//a", false)
-            .setPathType(LocationFunction.PathType.LOCATION)
+            .setPathType(LabelLocationFunction.PathType.LOCATION)
             .add("//a", "/exec/src/a")
             .build();
 
-    LocationFunction f2 =
+    var f2 =
         new LocationFunctionBuilder("//b", true)
-            .setPathType(LocationFunction.PathType.LOCATION)
+            .setPathType(LabelLocationFunction.PathType.LOCATION)
             .add("//b", "/exec/src/b")
             .build();
 
@@ -128,9 +129,9 @@ public class LocationExpanderTest {
 
   @Test
   public void expansionWithRepositoryMapping() throws Exception {
-    LocationFunction f1 =
+    var f1 =
         new LocationFunctionBuilder("//a", false)
-            .setPathType(LocationFunction.PathType.LOCATION)
+            .setPathType(LabelLocationFunction.PathType.LOCATION)
             .add("@bar//a", "/exec/src/a")
             .build();
 
@@ -140,7 +141,7 @@ public class LocationExpanderTest {
     LocationExpander locationExpander =
         new LocationExpander(
             new Capture(),
-            ImmutableMap.<String, LocationFunction>of("location", f1),
+            ImmutableMap.of("location", f1),
             RepositoryMapping.create(repositoryMapping, RepositoryName.MAIN),
             "workspace");
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/LocationFunctionBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/LocationFunctionBuilder.java
@@ -19,7 +19,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
-import com.google.devtools.build.lib.analysis.LocationExpander.LocationFunction;
+import com.google.devtools.build.lib.analysis.LocationExpander.LabelLocationFunction;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 final class LocationFunctionBuilder {
   private final Label root;
   private final boolean multiple;
-  private LocationFunction.PathType pathType = LocationFunction.PathType.LOCATION;
+  private LabelLocationFunction.PathType pathType = LabelLocationFunction.PathType.LOCATION;
   private final Map<Label, Collection<Artifact>> labelMap = new HashMap<>();
 
   LocationFunctionBuilder(String rootLabel, boolean multiple) {
@@ -44,12 +44,12 @@ final class LocationFunctionBuilder {
     this.multiple = multiple;
   }
 
-  public LocationFunction build() {
-    return new LocationFunction(root, Suppliers.ofInstance(labelMap), pathType, multiple);
+  public LabelLocationFunction build() {
+    return new LabelLocationFunction(root, Suppliers.ofInstance(labelMap), pathType, multiple);
   }
 
   @CanIgnoreReturnValue
-  public LocationFunctionBuilder setPathType(LocationFunction.PathType pathType) {
+  public LocationFunctionBuilder setPathType(LabelLocationFunction.PathType pathType) {
     this.pathType = pathType;
     return this;
   }

--- a/src/test/java/com/google/devtools/build/lib/util/ShellEscaperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/ShellEscaperTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.util;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.util.ShellEscaper.escapeString;
+import static com.google.devtools.build.lib.util.ShellEscaper.unescapeString;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
@@ -45,6 +46,22 @@ public class ShellEscaperTest {
     assertThat(escapeString("external/protobuf+3.19.6/src/goo~gle"))
         .isEqualTo("external/protobuf+3.19.6/src/goo~gle");
     assertThat(escapeString("external/+install_dev_dependencies+foo/pkg"))
+        .isEqualTo("external/+install_dev_dependencies+foo/pkg");
+  }
+
+  @Test
+  public void shellUnescape() {
+    assertThat(unescapeString("''")).isEqualTo("");
+    assertThat(unescapeString("foo")).isEqualTo("foo");
+    assertThat(unescapeString("'foo bar'")).isEqualTo("foo bar");
+    assertThat(unescapeString("''\\''foo'\\'''")).isEqualTo("'foo'");
+    assertThat(unescapeString("'\\'\\''foo\\'\\'''")).isEqualTo("\\'foo\\'");
+    assertThat(unescapeString("'${filename%.c}.o'")).isEqualTo("${filename%.c}.o");
+    assertThat(unescapeString("'<html!>'")).isEqualTo("<html!>");
+    assertThat(unescapeString("'~not_home'")).isEqualTo("~not_home");
+    assertThat(unescapeString("external/protobuf+3.19.6/src/goo~gle"))
+        .isEqualTo("external/protobuf+3.19.6/src/goo~gle");
+    assertThat(unescapeString("external/+install_dev_dependencies+foo/pkg"))
         .isEqualTo("external/+install_dev_dependencies+foo/pkg");
   }
 


### PR DESCRIPTION
RELNOTES: The new `$(dirname ...)` location function can be used to get the directory part of a path separated with forward slashes. It can be nested, also with other location functions such as `$(rootpath ...)` or `$(execpath ...)`.

Fixes #23516
Fixes #23139 