### PR TITLE
windows: remove 8.3 filename recommendation

### DIFF
--- a/site/en/configure/windows.md
+++ b/site/en/configure/windows.md
@@ -28,14 +28,6 @@ For example, add the following line to your bazelrc file:
 startup --output_user_root=C:/tmp
 ```
 
-### Enable 8.3 filename support {:#filename-support}
-
-Bazel attempts to create a short name version for long file paths. But to do so the [8.3 filename support](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-8dot3name){: .external} needs to be enabled for the volume in which the file with the long path resides. You can enable 8.3 name creation in all volumes by running the following command:
-
-```posix-terminal
-fsutil 8dot3name set 0
-```
-
 ### Enable symlink support {:#symlink}
 
 Some features require Bazel to be able to create file symlinks on Windows,


### PR DESCRIPTION
There has been several complaints about this Windows feature having poor
performance.

- https://learn.microsoft.com/en-us/archive/blogs/josebda/windows-server-2012-file-server-tip-disable-8-3-naming-and-strip-those-short-names-too

- https://www.linkedin.com/pulse/dont-forget-disable-short-filenames-83-servers-folders-wes-brown

- https://deep.data.blog/2013/06/19/debugging-story-slowness-due-to-ntfs-short-file-8-3-name-generation/

As a result, GitHub Actions Windows runners disabled this feature by
default in https://github.com/actions/runner-images/pull/9862.

Stop recommending this option. Windows users should explore using flags
such as `--output_base` and/or `--output_user_root` to avoid long path
errors.
