### PR TITLE
Add executable to stateful runfiles if necessary

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtil.java
@@ -40,7 +40,6 @@ import com.google.devtools.build.lib.packages.StarlarkProviderIdentifier;
 import com.google.devtools.build.lib.packages.StructProvider;
 import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.packages.Type;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.FormatMethod;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -430,29 +429,36 @@ public final class StarlarkRuleConfiguredTargetUtil {
       statelessRunfiles = Runfiles.EMPTY;
     }
 
-    RunfilesProvider runfilesProvider =
-        statelessRunfiles != null
-            ? RunfilesProvider.simple(mergeFiles(statelessRunfiles, executable, ruleContext))
-            : RunfilesProvider.withData(
-                // The executable doesn't get into the default runfiles if we have runfiles states.
-                // This is to keep Starlark genrule consistent with the original genrule.
-                defaultRunfiles != null ? defaultRunfiles : Runfiles.EMPTY,
-                dataRunfiles != null ? dataRunfiles : Runfiles.EMPTY);
+    // This works because we only allowed to call a rule *_test iff it's a test type rule.
+    boolean testRule = TargetUtils.isTestRuleName(ruleContext.getRule().getRuleClass());
+    boolean isExecutableOrTest = executable != null || testRule;
+    RunfilesProvider runfilesProvider;
+    if (statelessRunfiles != null) {
+      runfilesProvider =
+          RunfilesProvider.simple(mergeFiles(statelessRunfiles, executable, ruleContext));
+    } else {
+      var mergedDefaultRunfiles = defaultRunfiles != null ? defaultRunfiles : Runfiles.EMPTY;
+      if (isExecutableOrTest) {
+        // The executable is only merged in if needed when using stateful runfiles to preserve
+        // long-standing behavior.
+        mergedDefaultRunfiles = mergeFiles(mergedDefaultRunfiles, executable, ruleContext);
+      }
+      runfilesProvider =
+          RunfilesProvider.withData(
+              mergedDefaultRunfiles, dataRunfiles != null ? dataRunfiles : Runfiles.EMPTY);
+    }
     builder.addProvider(RunfilesProvider.class, runfilesProvider);
 
     Runfiles computedDefaultRunfiles = runfilesProvider.getDefaultRunfiles();
-    // This works because we only allowed to call a rule *_test iff it's a test type rule.
-    boolean testRule = TargetUtils.isTestRuleName(ruleContext.getRule().getRuleClass());
     if (testRule && computedDefaultRunfiles.isEmpty()) {
       throw Starlark.errorf("Test rules have to define runfiles");
     }
-    if (executable != null || testRule) {
+    if (isExecutableOrTest) {
       RunfilesSupport runfilesSupport = null;
       if (!computedDefaultRunfiles.isEmpty()) {
         Preconditions.checkNotNull(executable, "executable must not be null");
         runfilesSupport =
             RunfilesSupport.withExecutable(ruleContext, computedDefaultRunfiles, executable);
-        assertExecutableSymlinkPresent(runfilesSupport.getRunfiles(), executable);
       }
       builder.setRunfilesSupport(runfilesSupport, executable);
     }
@@ -461,16 +467,6 @@ public final class StarlarkRuleConfiguredTargetUtil {
       Info actions =
           ActionsProvider.create(ruleContext.getAnalysisEnvironment().getRegisteredActions());
       builder.addStarlarkDeclaredProvider(actions);
-    }
-  }
-
-  private static void assertExecutableSymlinkPresent(Runfiles runfiles, Artifact executable)
-      throws EvalException {
-    // Extracting the map from Runfiles flattens a depset.
-    // TODO(cparsons): Investigate: Avoiding this flattening may be an efficiency win.
-    Map<PathFragment, Artifact> symlinks = runfiles.asMapWithoutRootSymlinks();
-    if (!symlinks.containsValue(executable)) {
-      throw Starlark.errorf("main program %s not included in runfiles", executable);
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkIntegrationTest.java
@@ -3582,31 +3582,6 @@ public class StarlarkIntegrationTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testExecutableNotInRunfiles() throws Exception {
-    scratch.file(
-        "test/starlark/test_rule.bzl",
-        """
-        def _my_rule_impl(ctx):
-          exe = ctx.actions.declare_file('exe')
-          ctx.actions.run_shell(outputs=[exe], command='touch exe')
-          runfile = ctx.actions.declare_file('rrr')
-          ctx.actions.run_shell(outputs=[runfile], command='touch rrr')
-          return DefaultInfo(executable = exe, default_runfiles = ctx.runfiles(files = [runfile]))
-        my_rule = rule(implementation = _my_rule_impl, executable = True)
-        """);
-    scratch.file(
-        "test/starlark/BUILD",
-        """
-        load('//test/starlark:test_rule.bzl', 'my_rule')
-        my_rule(name = 'target')
-        """);
-
-    reporter.removeHandler(failFastHandler);
-    getConfiguredTarget("//test/starlark:target");
-    assertContainsEvent("exe not included in runfiles");
-  }
-
-  @Test
   public void testCommandStringList() throws Exception {
     setBuildLanguageOptions("--incompatible_run_shell_command_string");
     scratch.file(


### PR DESCRIPTION
This is already being done in the stateless case and avoids a costly check that needs to flatten the runfiles tree.

In fact, the check was not sufficient as it also considered the executable to be present if it is the target of a custom symlink - but both test actions and dependents using location expansion assume that the executable is present in its default location. A new test verifies these cases.

Fixes #26242 