### PR TITLE
[8.3.0] Loosen up repo name rule - Support repos which start with number

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -55,7 +55,7 @@ public final class RepositoryName {
   private static final Pattern VALID_REPO_NAME = Pattern.compile("[\\w\\-.+]*");
 
   // Must start with a letter. Can contain ASCII letters and digits, underscore, dash, and dot.
-  private static final Pattern VALID_USER_PROVIDED_NAME = Pattern.compile("[a-zA-Z][-.\\w]*$");
+  private static final Pattern VALID_USER_PROVIDED_NAME = Pattern.compile("[a-zA-Z0-9][-.\\w]*$");
 
   /**
    * A valid module name must: 1) begin with a lowercase letter; 2) end with a lowercase letter or a
@@ -203,7 +203,7 @@ public final class RepositoryName {
     if (!VALID_USER_PROVIDED_NAME.matcher(name).matches()) {
       throw Starlark.errorf(
           "invalid user-provided repo name '%s': valid names may contain only A-Z, a-z, 0-9, '-',"
-              + " '_', '.', and must start with a letter",
+              + " '_', '.', and must start with a letter or a number",
           StringUtilities.sanitizeControlChars(name));
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/packages/WorkspaceFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/WorkspaceFactoryTest.java
@@ -47,12 +47,6 @@ public class WorkspaceFactoryTest {
   }
 
   @Test
-  public void testWorkspaceStartsWithNumber() throws Exception {
-    helper.parse("workspace(name = '123abc')");
-    assertThat(helper.getParserError()).contains("invalid user-provided repo name '123abc'");
-  }
-
-  @Test
   public void testWorkspaceWithIllegalCharacters() throws Exception {
     helper.parse("workspace(name = 'a+b+c')");
     assertThat(helper.getParserError()).contains("invalid user-provided repo name 'a+b+c'");

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -1005,6 +1005,36 @@ EOF
   expect_log "valid names may contain only A-Z, a-z, 0-9, '-', '_', '.', and must start with a letter"
 }
 
+function test_starting_with_number_in_repo_name() {
+  local r=$TEST_TMPDIR/r
+  rm -fr $r
+  mkdir -p $r/a
+
+  touch $r/a/REPO.bazel
+  cat > $r/a/BUILD <<EOF
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
+cc_binary(
+    name = "bin",
+    srcs = ["bin.cc"],
+)
+EOF
+  cat > $r/a/bin.cc <<EOF
+int main() { return 0; };
+EOF
+
+  cat >> MODULE.bazel <<EOF
+local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+local_repository(
+    name = "1name",
+    path = "$r/a",
+)
+EOF
+  add_rules_cc "MODULE.bazel"
+
+  bazel build @1name//:bin &> $TEST_log || fail "Build failed unexpectedly"
+}
+
 function test_remote_includes() {
   local remote=$TEST_TMPDIR/r
   rm -fr $remote


### PR DESCRIPTION
RELNOTES: User-provided repo names may now start with a number.

Closes #25974.

PiperOrigin-RevId: 753128093
Change-Id: I9e026495f17bace30949b9842307afdba7c44692