### PR TITLE
[8.3.0] Don't lock innate extensions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelLockFileModule.java
@@ -126,7 +126,10 @@ public class BazelLockFileModule extends BlazeModule {
               if (entry.isDone()
                   && entry.getKey() instanceof SingleExtensionValue.EvalKey key
                   // entry.getValue() can be null if the extension evaluation failed.
-                  && entry.getValue() instanceof SingleExtensionValue value) {
+                  && entry.getValue() instanceof SingleExtensionValue value
+                  // The innate extensions are implemented in Java and don't benefit from a lockfile
+                  // entry.
+                  && !key.argument().isInnate()) {
                 newExtensionInfos.put(key.argument(), value.lockFileInfo().get());
               }
             });


### PR DESCRIPTION
These are entirely internal and not meant to be locked.

Closes #26232.

PiperOrigin-RevId: 769783817
Change-Id: Iaafae94fb5d41e74127400c220b9cdbed268a22c

Commit https://github.com/bazelbuild/bazel/commit/b584b91167ba1291bce22046790ee728aecd37ae