### PR TITLE
[8.3.0] Avoid repo thrashing when switching between build and query

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
@@ -27,6 +27,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib:loading-phase-threads-option",
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib:runtime/blaze_command_result",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/core_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:no_build_event",
         "//src/main/java/com/google/devtools/build/lib/analysis:no_build_request_finished_event",

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.io.CharSource;
 import com.google.devtools.build.lib.analysis.NoBuildEvent;
 import com.google.devtools.build.lib.analysis.NoBuildRequestFinishedEvent;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelDepGraphValue;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModTidyValue;
 import com.google.devtools.build.lib.bazel.bzlmod.BazelModuleInspectorValue;
@@ -105,7 +106,12 @@ import javax.annotation.Nullable;
 @Command(
     name = ModCommand.NAME,
     buildPhase = LOADS,
-    options = {ModOptions.class, PackageOptions.class, LoadingPhaseThreadsOption.class},
+    options = {
+      CoreOptions.class, // for --action_env, which affects the repo env
+      ModOptions.class,
+      PackageOptions.class,
+      LoadingPhaseThreadsOption.class
+    },
     help = "resource:mod.txt",
     shortDescription = "Queries the Bzlmod external dependency graph",
     allowResidue = true)

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/SyncCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/SyncCommand.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.NoBuildEvent;
 import com.google.devtools.build.lib.analysis.NoBuildRequestFinishedEvent;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.bazel.ResolvedEvent;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOrderEvent;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryFunction;
@@ -71,6 +72,7 @@ import net.starlark.java.eval.Starlark;
     name = SyncCommand.NAME,
     buildPhase = LOADS,
     options = {
+      CoreOptions.class, // for --action_env, which affects the repo env
       PackageOptions.class,
       KeepGoingOption.class,
       LoadingPhaseThreadsOption.class,

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -319,7 +319,10 @@ public class CommandEnvironment {
                 : UUID.randomUUID().toString();
 
     this.repoEnv.putAll(clientEnv);
-    if (command.buildPhase().analyzes() || command.name().equals("info")) {
+    // TODO: This only needs to check for loads() rather than analyzes() due to
+    //  the effect of --action_env on the repository env. Revert back to
+    //  analyzes() when --action_env no longer affects it.
+    if (command.buildPhase().loads() || command.name().equals("info")) {
       // Compute the set of environment variables that are allowlisted on the commandline
       // for inheritance.
       for (Map.Entry<String, String> entry :
@@ -333,6 +336,8 @@ public class CommandEnvironment {
           }
         }
       }
+    }
+    if (command.buildPhase().analyzes() || command.name().equals("info")) {
       for (Map.Entry<String, String> entry :
           options.getOptions(CoreOptions.class).testEnvironment) {
         if (entry.getValue() == null) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.runtime.commands;
 import static com.google.devtools.build.lib.runtime.Command.BuildPhase.LOADS;
 
 import com.google.common.hash.HashFunction;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.pkgcache.PackageOptions;
@@ -58,6 +59,7 @@ import java.util.Set;
     name = "query",
     buildPhase = LOADS,
     options = {
+      CoreOptions.class, // for --action_env, which affects the repo env
       PackageOptions.class,
       QueryOptions.class,
       KeepGoingOption.class,

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -793,6 +793,7 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell/bazel/testdata:zstd_test_archive.tar.zst",
+        "@local_jdk//:jdk",  # for remote_helpers setup_localjdk_javabase
     ],
     shard_count = 15,
     tags = [


### PR DESCRIPTION
This was caused by `query` (and `mod`, for that matter) ignoring `--action_env` when computing the repository environment, which could result in repo rules rerunning if they had a dependency on a value set via `--action_env`.

This is fixed by honoring the value of `--action_env` for all commands that load, not just those that analyze.

Context: https://bazelbuild.slack.com/archives/C014RARENH0/p1748337429642779

Closes #26177.

PiperOrigin-RevId: 765088399
Change-Id: I276fe83d83407c733be88df797ad8513ecb8ba35
(cherry picked from commit 9b90f4011dd669383cd96c79763163c49d137502)

Fixes #26178