### PR TITLE
lib/remote: add "resource-name" header to ByteStream requests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -38,6 +38,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.util.ResourceNameInterceptor;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.remote.util.Utils;
 import io.grpc.Channel;
@@ -311,7 +312,8 @@ final class ByteStreamUploader {
     private ByteStreamFutureStub bsFutureStub(Channel channel) {
       return ByteStreamGrpc.newFutureStub(channel)
           .withInterceptors(
-              TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()))
+              TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()),
+              new ResourceNameInterceptor(this.resourceName))
           .withCallCredentials(callCredentialsProvider.getCallCredentials())
           .withDeadlineAfter(callTimeoutSecs, SECONDS);
     }
@@ -319,7 +321,8 @@ final class ByteStreamUploader {
     private ByteStreamStub bsAsyncStub(Channel channel) {
       return ByteStreamGrpc.newStub(channel)
           .withInterceptors(
-              TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()))
+              TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()),
+              new ResourceNameInterceptor(this.resourceName))
           .withCallCredentials(callCredentialsProvider.getCallCredentials())
           .withDeadlineAfter(callTimeoutSecs, SECONDS);
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestOutputStream;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.remote.util.ResourceNameInterceptor;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.remote.zstd.ZstdDecompressingOutputStream;
@@ -145,11 +146,13 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
         .withDeadlineAfter(options.remoteTimeout.toSeconds(), TimeUnit.SECONDS);
   }
 
-  private ByteStreamStub bsAsyncStub(RemoteActionExecutionContext context, Channel channel) {
+  private ByteStreamStub bsAsyncStub(
+      RemoteActionExecutionContext context, Channel channel, String resourceName) {
     return ByteStreamGrpc.newStub(channel)
         .withInterceptors(
             TracingMetadataUtils.attachMetadataInterceptor(context.getRequestMetadata()),
-            new NetworkTimeInterceptor(context::getNetworkTime))
+            new NetworkTimeInterceptor(context::getNetworkTime),
+            new ResourceNameInterceptor(resourceName))
         .withCallCredentials(callCredentialsProvider.getCallCredentials())
         .withDeadlineAfter(options.remoteTimeout.toSeconds(), TimeUnit.SECONDS);
   }
@@ -398,7 +401,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
     } catch (IOException e) {
       return Futures.immediateFailedFuture(e);
     }
-    bsAsyncStub(context, channel)
+    bsAsyncStub(context, channel, resourceName)
         .read(
             ReadRequest.newBuilder()
                 .setResourceName(resourceName)

--- a/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -42,6 +42,7 @@ java_library(
         "//third_party/grpc-java:grpc-jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
+        "@googleapis//google/bytestream:bytestream_java_grpc",
         "@googleapis//google/rpc:rpc_java_proto",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/remote/util/ResourceNameInterceptor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/ResourceNameInterceptor.java
@@ -1,0 +1,52 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.util;
+
+import com.google.bytestream.ByteStreamGrpc;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall.Listener;
+
+/** A gRPC client interceptor that adds a "resource-name" header to ByteStream Read/Write calls. */
+public class ResourceNameInterceptor implements ClientInterceptor {
+  public static final Metadata.Key<String> RESOURCE_NAME_KEY =
+      Metadata.Key.of(
+          "build.bazel.remote.execution.v2.resource-name", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final String resourceName;
+
+  public ResourceNameInterceptor(String resourceName) {
+    this.resourceName = resourceName;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        if (resourceName != null && !resourceName.isEmpty()) {
+          headers.put(RESOURCE_NAME_KEY, resourceName);
+        }
+        super.start(responseListener, headers);
+      }
+    };
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.remote.util.ResourceNameInterceptor.RESOURCE_NAME_KEY;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -158,6 +159,77 @@ public class ByteStreamUploaderTest {
 
     server.shutdownNow();
     server.awaitTermination();
+  }
+
+  @Test
+  public void uploadBlob_shouldIncludeResourceNameHeader() throws Exception {
+    RemoteRetrier retrier =
+        TestUtils.newRemoteRetrier(() -> mockBackoff, (e) -> true, retryService);
+    ByteStreamUploader uploader =
+        new ByteStreamUploader(
+            INSTANCE_NAME,
+            referenceCountedChannel,
+            CallCredentialsProvider.NO_CREDENTIALS,
+            /* callTimeoutSecs= */ 60,
+            retrier,
+            /* maximumOpenFiles= */ -1,
+            /* digestFunction= */ DigestFunction.Value.SHA256);
+
+    byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
+    new Random().nextBytes(blob);
+    Digest digest = DIGEST_UTIL.compute(blob);
+    Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
+
+    String expectedResourceNamePrefix = INSTANCE_NAME + "/uploads/";
+    String expectedResourceNameSuffix =
+        String.format("/blobs/%s/%d", digest.getHash(), digest.getSizeBytes());
+
+    BindableService bsService =
+        new ByteStreamImplBase() {
+          @Override
+          public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> streamObserver) {
+            return new StreamObserver<WriteRequest>() {
+              @Override
+              public void onNext(WriteRequest writeRequest) {}
+
+              @Override
+              public void onError(Throwable throwable) {
+                fail("onError should never be called: " + throwable);
+              }
+
+              @Override
+              public void onCompleted() {
+                WriteResponse response =
+                    WriteResponse.newBuilder().setCommittedSize(blob.length).build();
+                streamObserver.onNext(response);
+                streamObserver.onCompleted();
+              }
+            };
+          }
+        };
+    ServerInterceptor headerValidator =
+        new ServerInterceptor() {
+          @Override
+          public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+              ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            if (call.getMethodDescriptor()
+                .getFullMethodName()
+                .equals(
+                    com.google.bytestream.ByteStreamGrpc.getWriteMethod().getFullMethodName())) {
+              String resourceNameHeaderValue = headers.get(RESOURCE_NAME_KEY);
+              assertThat(resourceNameHeaderValue).isNotNull();
+              assertThat(resourceNameHeaderValue).startsWith(expectedResourceNamePrefix);
+              assertThat(resourceNameHeaderValue).endsWith(expectedResourceNameSuffix);
+            }
+            return next.startCall(call, headers);
+          }
+        };
+    serviceRegistry.addService(ServerInterceptors.intercept(bsService, headerValidator));
+
+    uploadBlob(uploader, context, digest, chunker);
+
+    // This test should not have triggered any retries.
+    Mockito.verifyNoInteractions(mockBackoff);
   }
 
   @Test

--- a/third_party/remoteapis/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/third_party/remoteapis/build/bazel/remote/execution/v2/remote_execution.proto
@@ -175,7 +175,7 @@ service ActionCache {
   //
   // In order to allow the server to perform access control based on the type of
   // action, and to assist with client debugging, the client MUST first upload
-  // the [Action][build.bazel.remote.execution.v2.Execution] that produced the
+  // the [Action][build.bazel.remote.execution.v2.Action] that produced the
   // result, along with its
   // [Command][build.bazel.remote.execution.v2.Command], into the
   // `ContentAddressableStorage`.
@@ -324,6 +324,15 @@ service ActionCache {
 // Servers MUST be able to provide data for all recently advertised blobs in
 // each of the compression formats that the server supports, as well as in
 // uncompressed form.
+//
+// Additionally, ByteStream requests MAY come with an additional plain text header
+// that indicates the `resource_name` of the blob being sent.  The header, if
+// present, MUST follow the following convention:
+// * name: `build.bazel.remote.execution.v2.resource-name`.
+// * contents: the plain text resource_name of the request message.
+// If set, the contents of the header MUST match the `resource_name` of the request
+// message.  Servers MAY use this header to assist in routing requests to the
+// appropriate backend.
 //
 // The lifetime of entries in the CAS is implementation specific, but it SHOULD
 // be long enough to allow for newly-added and recently looked-up entries to be
@@ -1534,7 +1543,7 @@ message ExecutionStage {
 // Metadata about an ongoing
 // [execution][build.bazel.remote.execution.v2.Execution.Execute], which
 // will be contained in the [metadata
-// field][google.longrunning.Operation.response] of the
+// field][google.longrunning.Operation.metadata] of the
 // [Operation][google.longrunning.Operation].
 message ExecuteOperationMetadata {
   // The current stage of execution.
@@ -1557,6 +1566,15 @@ message ExecuteOperationMetadata {
   // The client can read this field to view details about the ongoing
   // execution.
   ExecutedActionMetadata partial_execution_metadata = 5;
+
+  // The digest function that was used to compute the action digest.
+  //
+  // If the digest function used is one of BLAKE3, MD5, MURMUR3, SHA1,
+  // SHA256, SHA256TREE, SHA384, SHA512, or VSO, the server MAY leave
+  // this field unset. In that case the client SHOULD infer the digest
+  // function using the length of the action digest hash and the digest
+  // functions announced in the server's capabilities.
+  DigestFunction.Value digest_function = 6;
 }
 
 // A request message for
@@ -1958,7 +1976,7 @@ message ActionCacheUpdateCapabilities {
 
 // Allowed values for priority in
 // [ResultsCachePolicy][build.bazel.remoteexecution.v2.ResultsCachePolicy] and
-// [ExecutionPolicy][build.bazel.remoteexecution.v2.ResultsCachePolicy]
+// [ExecutionPolicy][build.bazel.remoteexecution.v2.ExecutionPolicy]
 // Used for querying both cache and execution valid priority ranges.
 message PriorityCapabilities {
   // Supported range of priorities, including boundaries.
@@ -2047,6 +2065,17 @@ message CacheCapabilities {
   // [BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs]
   // requests.
   repeated Compressor.Value supported_batch_update_compressors = 7;
+
+  // The maximum blob size that the server will accept for CAS blob uploads.
+  // - If it is 0, it means there is no limit set. A client may assume
+  //   arbitrarily large blobs may be uploaded to and downloaded from the cache.
+  // - If it is larger than 0, implementations SHOULD NOT attempt to upload
+  //   blobs with size larger than the limit. Servers SHOULD reject blob
+  //   uploads over the `max_cas_blob_size_bytes` limit with response code
+  //   `INVALID_ARGUMENT`
+  // - If the cache implementation returns a given limit, it MAY still serve
+  //   blobs larger than this limit.
+  int64 max_cas_blob_size_bytes = 8;
 }
 
 // Capabilities of the remote execution system.


### PR DESCRIPTION
This implements https://github.com/bazelbuild/remote-apis/pull/303 in
the remote-apis spec.

Adding the bytestream's resource name to an http header to help
different load balancing service route the requests to the correct
remote cache backend easier.

Also, upgraded remote execution proto to the latest version from https://github.com/bazelbuild/remote-apis/commit/536ec595e1df0064bb37aecc95332a661b8c79b2