### PR TITLE
allow Bazel to build with --incompatible_disable_target_default_provider_fields

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -73,6 +73,7 @@ genrule(
         "//third_party/remoteapis:MODULE.bazel",
         "//third_party:BUILD",
         "//third_party:apple_support.patch",
+        "//third_party:grpc-java.patch",
         "//third_party:grpc_remove_provides_strings.patch",
         "//third_party:rules_java.patch",
         "//third_party:rules_jvm_external_6.5.patch",

--- a/BUILD
+++ b/BUILD
@@ -74,6 +74,7 @@ genrule(
         "//third_party:BUILD",
         "//third_party:apple_support.patch",
         "//third_party:grpc_remove_provides_strings.patch",
+        "//third_party:rules_java.patch",
         "//third_party:rules_jvm_external_6.5.patch",
         "//third_party:rules_graalvm_fix.patch",
         "//third_party:rules_graalvm_unicode.patch",

--- a/BUILD
+++ b/BUILD
@@ -72,6 +72,7 @@ genrule(
         "MODULE.bazel",
         "//third_party/remoteapis:MODULE.bazel",
         "//third_party:BUILD",
+        "//third_party:apple_support.patch",
         "//third_party:grpc_remove_provides_strings.patch",
         "//third_party:rules_jvm_external_6.5.patch",
         "//third_party:rules_graalvm_fix.patch",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -111,6 +111,14 @@ single_version_override(
     version = "8.12.0",
 )
 
+# Remove once https://github.com/grpc/grpc-java/pull/12148 is available in a grpc-java release.
+single_version_override(
+    module_name = "grpc-java",
+    patch_strip = 1,
+    patches = ["//third_party:grpc-java.patch"],
+    version = "1.66.0",
+)
+
 local_path_override(
     module_name = "remoteapis",
     path = "./third_party/remoteapis",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -103,6 +103,14 @@ single_version_override(
     version = "1.21.1",
 )
 
+# Remove once https://github.com/bazelbuild/rules_java/pull/303 is available in a rules_java release.
+single_version_override(
+    module_name = "rules_java",
+    patch_strip = 1,
+    patches = ["//third_party:rules_java.patch"],
+    version = "8.12.0",
+)
+
 local_path_override(
     module_name = "remoteapis",
     path = "./third_party/remoteapis",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -95,6 +95,14 @@ single_version_override(
     version = "0.15.0",
 )
 
+# Remove once https://github.com/bazelbuild/apple_support/pull/413 is available in an apple_support release.
+single_version_override(
+    module_name = "apple_support",
+    patch_strip = 1,
+    patches = ["//third_party:apple_support.patch"],
+    version = "1.21.1",
+)
+
 local_path_override(
     module_name = "remoteapis",
     path = "./third_party/remoteapis",

--- a/third_party/apple_support.patch
+++ b/third_party/apple_support.patch
@@ -1,0 +1,53 @@
+commit c8fecc0002e6fc03419cf106a3c02294e4a67896
+Author: David Sanderson <32687193+dws@users.noreply.github.com>
+Date:   Wed Jun 11 15:28:14 2025 -0400
+
+    use DefaultInfo in apple_support
+    
+    We here address the following obstacles in apple_support to using
+    Bazel's --incompatible_disable_target_default_provider_fields flag:
+    
+        ERROR: /private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/apple_support+/crosstool/BUILD:25:20: in apple_genrule rule @@apple_support+//crosstool:exec_wrapped_clang_pp.target_config:
+        Traceback (most recent call last):
+                File "/private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/apple_support+/rules/private/apple_genrule.bzl", line 52, column 45, in _apple_genrule_impl
+                        resolved_srcs = depset(transitive = [dep.files for dep in ctx.attr.srcs])
+        Error: Accessing the default provider in this manner is deprecated and will be removed soon. It may be temporarily re-enabled by setting --incompatible_disable_target_default_provider_fields=false. See https://github.com/bazelbuild/bazel/issues/20183 for details.
+        ERROR: /private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/apple_support+/crosstool/BUILD:25:20: Analysis of target '@@apple_support+//crosstool:exec_wrapped_clang_pp.target_config' failed
+        ERROR: Analysis of target '//src:bazel' failed; build aborted: Analysis failed
+    
+        ERROR: /private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/apple_support++apple_cc_configure_extension+local_config_apple_cc/BUILD:78:24: in cc_toolchain_config rule @@apple_support++apple_cc_configure_extension+local_config_apple_cc//:darwin_x86_64:
+        Traceback (most recent call last):
+                File "/private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/apple_support++apple_cc_configure_extension+local_config_apple_cc/cc_toolchain_config.bzl", line 2506, column 37, in _impl
+                        modulemaps = ctx.attr.module_map.files.to_list()
+        Error: Accessing the default provider in this manner is deprecated and will be removed soon. It may be temporarily re-enabled by setting --incompatible_disable_target_default_provider_fields=false. See https://github.com/bazelbuild/bazel/issues/20183 for details.
+        ERROR: /private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/apple_support++apple_cc_configure_extension+local_config_apple_cc/BUILD:78:24: Analysis of target '@@apple_support++apple_cc_configure_extension+local_config_apple_cc//:darwin_x86_64' failed
+        ERROR: Analysis of target '//src:bazel' failed; build aborted: Analysis failed
+
+diff --git a/crosstool/cc_toolchain_config.bzl b/crosstool/cc_toolchain_config.bzl
+index 3bb7c26..1ae7198 100644
+--- a/crosstool/cc_toolchain_config.bzl
++++ b/crosstool/cc_toolchain_config.bzl
+@@ -2503,7 +2503,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
+         ],
+     )
+ 
+-    modulemaps = ctx.attr.module_map.files.to_list()
++    modulemaps = ctx.attr.module_map[DefaultInfo].files.to_list()
+     if modulemaps:
+         if len(modulemaps) != 1:
+             fail("internal error: expected 1 modulemap got:", modulemaps)
+diff --git a/rules/private/apple_genrule.bzl b/rules/private/apple_genrule.bzl
+index b00395e..cdfd501 100644
+--- a/rules/private/apple_genrule.bzl
++++ b/rules/private/apple_genrule.bzl
+@@ -49,8 +49,8 @@ def _apple_genrule_impl(ctx):
+             attr = "executable",
+         )
+ 
+-    resolved_srcs = depset(transitive = [dep.files for dep in ctx.attr.srcs])
+-    label_dict = {dep.label: dep.files.to_list() for dep in ctx.attr.srcs}
++    resolved_srcs = depset(transitive = [dep[DefaultInfo].files for dep in ctx.attr.srcs])
++    label_dict = {dep.label: dep[DefaultInfo].files.to_list() for dep in ctx.attr.srcs}
+ 
+     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+ 

--- a/third_party/grpc-java.patch
+++ b/third_party/grpc-java.patch
@@ -1,0 +1,40 @@
+commit 2bf1b927a4d24b6869d7247f91d4af2b50c39a9f
+Author: David Sanderson <32687193+dws@users.noreply.github.com>
+Date:   Wed Jun 11 17:46:26 2025 -0400
+
+    use DefaultInfo in grpc-java
+    
+    We here address the following obstacles in grpc-java to using Bazel's
+    --incompatible_disable_target_default_provider_fields flag:
+    
+        ERROR: /private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/googleapis+/google/devtools/build/v1/BUILD.bazel:81:18: in _java_grpc_library rule @@googleapis+//google/devtools/build/v1:build_java_grpc:
+        Traceback (most recent call last):
+                File "/private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/grpc-java+/java_grpc_library.bzl", line 94, column 30, in _java_rpc_library_impl
+                        args.add(toolchain.plugin.files_to_run.executable, format = "--plugin=protoc-gen-rpc-plugin=%s")
+        Error: Accessing the default provider in this manner is deprecated and will be removed soon. It may be temporarily re-enabled by setting --incompatible_disable_target_default_provider_fields=false. See https://github.com/bazelbuild/bazel/issues/20183 for details.
+        ERROR: /private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/googleapis+/google/devtools/build/v1/BUILD.bazel:81:18: Analysis of target '@@googleapis+//google/devtools/build/v1:build_java_grpc' failed
+        ERROR: Analysis of target '//src:bazel' failed; build aborted: Analysis failed
+
+diff --git a/java_grpc_library.bzl b/java_grpc_library.bzl
+index 630ced383..e7d133a27 100644
+--- a/java_grpc_library.bzl
++++ b/java_grpc_library.bzl
+@@ -91,15 +91,15 @@ def _java_rpc_library_impl(ctx):
+     srcjar = ctx.actions.declare_file("%s-proto-gensrc.jar" % ctx.label.name)
+ 
+     args = ctx.actions.args()
+-    args.add(toolchain.plugin.files_to_run.executable, format = "--plugin=protoc-gen-rpc-plugin=%s")
++    args.add(toolchain.plugin[DefaultInfo].files_to_run.executable, format = "--plugin=protoc-gen-rpc-plugin=%s")
+     args.add("--rpc-plugin_out={0}:{1}".format(toolchain.plugin_arg, srcjar.path))
+     args.add_joined("--descriptor_set_in", descriptor_set_in, join_with = ctx.configuration.host_path_separator)
+     args.add_all(srcs, map_each = _path_ignoring_repository)
+ 
+     ctx.actions.run(
+-        inputs = depset(srcs, transitive = [descriptor_set_in, toolchain.plugin.files]),
++        inputs = depset(srcs, transitive = [descriptor_set_in, toolchain.plugin[DefaultInfo].files]),
+         outputs = [srcjar],
+-        executable = toolchain.protoc.files_to_run,
++        executable = toolchain.protoc[DefaultInfo].files_to_run,
+         arguments = [args],
+         use_default_shell_env = True,
+         toolchain = None,

--- a/third_party/rules_java.patch
+++ b/third_party/rules_java.patch
@@ -1,0 +1,109 @@
+commit c02b7724a5dcf85bb9c87bc06c1cd0504c0507f9
+Author: David Sanderson <32687193+dws@users.noreply.github.com>
+Date:   Wed Jun 11 17:35:01 2025 -0400
+
+    use DefaultInfo in rules_java
+    
+    We here address the following obstacles in rules_java to using
+    Bazel's --incompatible_disable_target_default_provider_fields flag:
+    
+        ERROR: /private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/rules_java+/toolchains/BUILD:359:27: in java_toolchain rule @@rules_java+//toolchains:toolchain_jdk_21:
+        Traceback (most recent call last):
+                File "/private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/rules_java+/java/common/rules/java_toolchain.bzl", line 100, column 45, in _java_toolchain_impl
+                        jacocorunner = ctx.attr.jacocorunner.files_to_run if ctx.attr.jacocorunner else None,
+        Error: Accessing the default provider in this manner is deprecated and will be removed soon. It may be temporarily re-enabled by setting --incompatible_disable_target_default_provider_fields=false. See https://github.com/bazelbuild/bazel/issues/20183 for details.
+        ERROR: /private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/rules_java+/toolchains/BUILD:359:27: Analysis of target '@@rules_java+//toolchains:toolchain_jdk_21' failed
+        ERROR: Analysis of target '//src:bazel' failed; build aborted: Analysis failed
+    
+        ERROR: /Users/dws/src/bazel-dws/third_party/BUILD:578:20: in java_import rule //third_party:netty_tcnative_checked_in:
+        Traceback (most recent call last):
+                File "/private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/rules_java+/java/bazel/rules/bazel_java_import.bzl", line 25, column 34, in _proxy
+                        return bazel_java_import_rule(
+                File "/private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/rules_java+/java/common/rules/impl/bazel_java_import_impl.bzl", line 132, column 35, in bazel_java_import_rule
+                        collected_jars = _collect_jars(ctx, jars)
+                File "/private/var/tmp/_bazel_dws/7fd3cd5077fbf76d9e2ae421c39ef7ed/external/rules_java+/java/common/rules/impl/bazel_java_import_impl.bzl", line 38, column 24, in _collect_jars
+                        for jar in info.files.to_list():
+        Error: Accessing the default provider in this manner is deprecated and will be removed soon. It may be temporarily re-enabled by setting --incompatible_disable_target_default_provider_fields=false. See https://github.com/bazelbuild/bazel/issues/20183 for details.
+        ERROR: /Users/dws/src/bazel-dws/third_party/BUILD:578:20: Analysis of target '//third_party:netty_tcnative_checked_in' failed
+        ERROR: Analysis of target '//src:bazel' failed; build aborted: Analysis failed
+
+diff --git a/java/common/rules/impl/bazel_java_import_impl.bzl b/java/common/rules/impl/bazel_java_import_impl.bzl
+index 4465670..ce338cb 100644
+--- a/java/common/rules/impl/bazel_java_import_impl.bzl
++++ b/java/common/rules/impl/bazel_java_import_impl.bzl
+@@ -35,7 +35,7 @@ def _collect_jars(ctx, jars):
+     for info in jars:
+         if JavaInfo in info:
+             fail("'jars' attribute cannot contain labels of Java targets")
+-        for jar in info.files.to_list():
++        for jar in info[DefaultInfo].files.to_list():
+             jar_path = jar.dirname + jar.basename
+             if jars_dict.get(jar_path) != None:
+                 fail("in jars attribute of java_import rule //" + ctx.label.package + ":" + ctx.attr.name + ": " + jar.basename + " is a duplicate")
+@@ -179,7 +179,7 @@ def bazel_java_import_rule(
+     # TODO(kotlaja): Revise if collected_runtimes can be added into construct_defaultinfo directly.
+     collected_runtimes = []
+     for runtime_dep in ctx.attr.runtime_deps:
+-        collected_runtimes.extend(runtime_dep.files.to_list())
++        collected_runtimes.extend(runtime_dep[DefaultInfo].files.to_list())
+ 
+     target["DefaultInfo"] = construct_defaultinfo(
+         ctx,
+diff --git a/java/common/rules/java_toolchain.bzl b/java/common/rules/java_toolchain.bzl
+index 2e4fc67..fe32fc3 100644
+--- a/java/common/rules/java_toolchain.bzl
++++ b/java/common/rules/java_toolchain.bzl
+@@ -96,13 +96,13 @@ def _java_toolchain_impl(ctx):
+     oneversion_allowlist = ctx.file.oneversion_allowlist if ctx.file.oneversion_allowlist else ctx.file.oneversion_whitelist
+     java_toolchain_info = _new_javatoolchaininfo(
+         bootclasspath = bootclasspath_info.bootclasspath,
+-        ijar = ctx.attr.ijar.files_to_run if ctx.attr.ijar else None,
+-        jacocorunner = ctx.attr.jacocorunner.files_to_run if ctx.attr.jacocorunner else None,
++        ijar = ctx.attr.ijar[DefaultInfo].files_to_run if ctx.attr.ijar else None,
++        jacocorunner = ctx.attr.jacocorunner[DefaultInfo].files_to_run if ctx.attr.jacocorunner else None,
+         java_runtime = java_runtime,
+         jvm_opt = depset(get_internal_java_common().expand_java_opts(ctx, "jvm_opts", tokenize = False, exec_paths = True)),
+         label = ctx.label,
+-        proguard_allowlister = ctx.attr.proguard_allowlister.files_to_run if ctx.attr.proguard_allowlister else None,
+-        single_jar = ctx.attr.singlejar.files_to_run,
++        proguard_allowlister = ctx.attr.proguard_allowlister[DefaultInfo].files_to_run if ctx.attr.proguard_allowlister else None,
++        single_jar = ctx.attr.singlejar[DefaultInfo].files_to_run,
+         source_version = ctx.attr.source_version,
+         target_version = ctx.attr.target_version,
+         tools = depset(ctx.files.tools),
+@@ -131,7 +131,7 @@ def _java_toolchain_impl(ctx):
+         _javac_supports_worker_multiplex_sandboxing = ctx.attr.javac_supports_worker_multiplex_sandboxing,
+         _jspecify_info = _get_jspecify_info(ctx),
+         _local_java_optimization_config = ctx.files._local_java_optimization_configuration,
+-        _one_version_tool = ctx.attr.oneversion.files_to_run if ctx.attr.oneversion else None,
++        _one_version_tool = ctx.attr.oneversion[DefaultInfo].files_to_run if ctx.attr.oneversion else None,
+         _one_version_allowlist = oneversion_allowlist,
+         _one_version_allowlist_for_tests = ctx.file.oneversion_allowlist_for_tests,
+         _package_configuration = [dep[JavaPackageConfigurationInfo] for dep in ctx.attr.package_configuration],
+@@ -171,7 +171,7 @@ def _get_javac_opts(ctx):
+ def _get_android_lint_tool(ctx):
+     if not ctx.attr.android_lint_runner:
+         return None
+-    files_to_run = ctx.attr.android_lint_runner.files_to_run
++    files_to_run = ctx.attr.android_lint_runner[DefaultInfo].files_to_run
+     if not files_to_run or not files_to_run.executable:
+         fail(ctx.attr.android_lint_runner.label, "does not refer to a valid executable target")
+     return struct(
+@@ -186,7 +186,7 @@ def _get_tool_from_ctx(ctx, tool_attr, data_attr, opts_attr):
+     dep = getattr(ctx.attr, tool_attr)
+     if not dep:
+         return None
+-    files_to_run = dep.files_to_run
++    files_to_run = dep[DefaultInfo].files_to_run
+     if not files_to_run or not files_to_run.executable:
+         fail(dep.label, "does not refer to a valid executable target")
+     data = getattr(ctx.attr, data_attr)
+@@ -200,7 +200,7 @@ def _get_tool_from_executable(ctx, attr_name, data = [], jvm_opts = []):
+     dep = getattr(ctx.attr, attr_name)
+     if not dep:
+         return None
+-    files_to_run = dep.files_to_run
++    files_to_run = dep[DefaultInfo].files_to_run
+     if not files_to_run or not files_to_run.executable:
+         fail(dep.label, "does not refer to a valid executable target")
+     return struct(tool = files_to_run, data = depset(data), jvm_opts = depset(jvm_opts))


### PR DESCRIPTION
We here address obstacles to building Bazel with `--incompatible_disable_target_default_provider_fields` enabled.

This includes patches representing

- https://github.com/bazelbuild/apple_support/pull/413
- https://github.com/bazelbuild/rules_java/pull/303
- https://github.com/grpc/grpc-java/pull/12148

which should be removed once these PRs have been included in releases of their respective repos.  All of these pull requests have been approved and merged into their respective repositories.

Once https://github.com/bazelbuild/bazel/pull/26276 is cherry-picked into a Bazel 8 release, we should be able to update `.bazelversion` to that release, and in conjunction with the changes herein, we should be able to enable  `--incompatible_disable_target_default_provider_fields` in `.bazelrc` in order to prevent regressions.  Ideally, we could also flip the default value of this flag once https://github.com/bazelbuild/bazel/pull/26297 also lands.
Note that https://github.com/bazelbuild/bazel/pull/26293 is related, but not strictly needed for builds.
