### PR TITLE
use DefaultInfo in Bazel's embedded Starlark

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -1105,7 +1105,7 @@ def _local_defines(ctx, additional_make_variable_substitutions):
 def _linker_scripts(ctx):
     result = []
     for dep in ctx.attr.deps:
-        for f in dep.files.to_list():
+        for f in dep[DefaultInfo].files.to_list():
             if f.extension in cpp_file_types.LINKER_SCRIPT:
                 result.append(f)
     return result

--- a/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl
@@ -510,7 +510,7 @@ def _check_no_repeated_srcs(ctx):
     seen = {}
     for target in ctx.attr.srcs:
         if DefaultInfo in target:
-            for file in target.files.to_list():
+            for file in target[DefaultInfo].files.to_list():
                 extension = "." + file.extension
                 if extension not in cc_helper.extensions.CC_HEADER:
                     if extension in cc_helper.extensions.CC_AND_OBJC:


### PR DESCRIPTION
The Starlark embedded in Bazel, that can get used when building other repos, has problems exposed by enabling

    --incompatible_disable_target_default_provider_fields

Since this code is embedded in Bazel, there is no way for users to patch it in the course of trying to disable target default provider fields in their own repos.  We here address these issues.