### PR TITLE
[8.3.0] Fix `--target_pattern_file` with Unicode labels

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/TargetPatternsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/TargetPatternsHelper.java
@@ -15,7 +15,7 @@
 package com.google.devtools.build.lib.runtime.commands;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.buildtool.BuildRequestOptions;
@@ -57,7 +57,7 @@ public final class TargetPatternsHelper {
           env.getWorkingDirectory().getRelative(buildRequestOptions.targetPatternFile);
       try {
         targets =
-            FileSystemUtils.readLines(residuePath, UTF_8).stream()
+            FileSystemUtils.readLines(residuePath, ISO_8859_1).stream()
                 .map(s -> s.split("#")[0])
                 .map(String::trim)
                 .filter(Predicate.not(String::isEmpty))

--- a/src/test/shell/integration/target_pattern_file_test.sh
+++ b/src/test/shell/integration/target_pattern_file_test.sh
@@ -94,4 +94,15 @@ function test_target_pattern_file_and_cli_pattern() {
   expect_log "ERROR: Command-line target pattern and --target_pattern_file cannot both be specified"
 }
 
+function test_target_pattern_file_unicode() {
+  mkdir -p foo
+  cat > foo/BUILD <<'EOF'
+filegroup(name = "äöüÄÖÜß🌱")
+EOF
+
+  echo "//foo:äöüÄÖÜß🌱" > my_targets || fail "Could not write my_query"
+  bazel build --target_pattern_file=my_targets >& $TEST_log || fail "Expected success"
+  expect_log "//foo:äöüÄÖÜß🌱"
+}
+
 run_suite "Tests for using target_pattern_file"


### PR DESCRIPTION
Target files specified via `--target_pattern_file` supported Unicode labels prior to Bazel 8 in some (unreliable) capacity, but this regressed due to the Unicode fixes in other parts of Bazel introduced in time for Bazel 8. This change ensures that the file is parsed in the "internal" string encoding, matching the rest of Bazel and restoring support for labels containing Unicode characters.

Closes #26166.

PiperOrigin-RevId: 770609137
Change-Id: Ib8735d2ecd7918c42317952324effb8a50e09820 
(cherry picked from commit 2f51ed6120bbbf9514719f1fa0a33c35ee5183e4)

Fixes #26172