### PR TITLE
Force a UTF-8 locale when `en_US.ISO-8859-1` is not available

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -17,6 +17,8 @@ import static com.google.devtools.build.lib.runtime.BlazeOptionHandler.BAD_OPTIO
 import static com.google.devtools.build.lib.runtime.BlazeOptionHandler.ERROR_SEPARATOR;
 import static com.google.devtools.build.lib.util.DetailedExitCode.DetailedExitCodeComparator.chooseMoreImportantWithFirstIfTie;
 import static com.google.devtools.common.options.Converters.BLAZE_ALIASING_FLAG;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -63,6 +65,7 @@ import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.InterruptedFailureDetails;
 import com.google.devtools.build.lib.util.LoggingUtil;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.io.CommandExtensionReporter;
 import com.google.devtools.build.lib.util.io.DelegatingOutErr;
@@ -79,6 +82,7 @@ import com.google.protobuf.Any;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -531,6 +535,8 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
         }
       }
 
+      warnIfUsingUnusupportedEncoding(runtime.getProductName(), reporter);
+
       try (SilentCloseable closeable = Profiler.instance().profile("replay stored events")) {
         // Now we're ready to replay the events.
         storedEventHandler.replayOn(reporter);
@@ -971,5 +977,19 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
                 .setMessage(message)
                 .setCommand(FailureDetails.Command.newBuilder().setCode(detailedCode))
                 .build()));
+  }
+
+  private static void warnIfUsingUnusupportedEncoding(String productName, Reporter reporter) {
+    // The user can only influence the JVM's encoding on Linux. See blaze.cc for details.
+    if (OS.getCurrent() != OS.LINUX) {
+      return;
+    }
+    var sunJnuEncoding = Charset.forName(System.getProperty("sun.jnu.encoding"));
+    if (!sunJnuEncoding.equals(UTF_8) && !sunJnuEncoding.equals(ISO_8859_1)) {
+      reporter.handle(
+          Event.warn(
+              "%1$s has been started with an unsupported encoding (%2$s) and may not support Unicode filenames. Make sure that the C.UTF-8 or en_US.UTF-8 locale is installed on your system and restart %1$s."
+                  .formatted(productName, sunJnuEncoding)));
+    }
   }
 }


### PR DESCRIPTION
This provides UTF-8 support on systems that don't have valid locale settings by default and also don't provide the `en_US.ISO-8859-1` locale.

Also show a warning if Bazel fails to force such a locale and falls back to ASCII.

Fixes #26259