### PR TITLE
[8.3.0] Implement executing WebAssembly in repository rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -109,6 +109,7 @@ genrule(
 pkg_tar(
     name = "bootstrap-jars",
     srcs = [
+        "//third_party/chicory:dist_jars",
         "//third_party/googleapis:dist_jars",
         "//third_party/grpc-java:grpc_jars",
         "@async_profiler//file",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "grpc", version = "1.66.0.bcr.2", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "grpc-java", version = "1.66.0")
 bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "stardoc", version = "0.7.1", repo_name = "io_bazel_skydoc")
 bazel_dep(name = "zstd-jni", version = "1.5.6-9")
@@ -34,6 +34,7 @@ bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googl
 bazel_dep(name = "with_cfg.bzl", version = "0.6.0")
 bazel_dep(name = "abseil-cpp", version = "20240722.0.bcr.2")
 bazel_dep(name = "rules_shell", version = "0.2.0")
+bazel_dep(name = "chicory", version = "1.1.0")
 
 # Depend on apple_support first and then rules_cc so that the Xcode toolchain
 # from apple_support wins over the generic Unix toolchain from rules_cc.
@@ -382,6 +383,7 @@ use_repo(
 
 bazel_dep(name = "bazel_ci_rules", version = "1.0.0")
 bazel_dep(name = "rules_fuzzing", version = "0.5.2")
+bazel_dep(name = "wabt", version = "1.0.37")
 
 rbe_preconfig = use_repo_rule("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -56,6 +56,8 @@
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/c-ares/1.15.0/MODULE.bazel": "ba0a78360fdc83f02f437a9e7df0532ad1fbaa59b722f6e715c11effebaa0166",
     "https://bcr.bazel.build/modules/c-ares/1.15.0/source.json": "5e3ed991616c5ec4cc09b0893b29a19232de4a1830eb78c567121bfea87453f7",
+    "https://bcr.bazel.build/modules/chicory/1.1.0/MODULE.bazel": "2d31f54e8fdf0963e9f4af6df553def7aab6927b4621da4555bc212021975340",
+    "https://bcr.bazel.build/modules/chicory/1.1.0/source.json": "f37ba2bd7cb3ca62b9a0418b9c250f5391e3c2c31a8f364db727d6d5eeb27f15",
     "https://bcr.bazel.build/modules/curl/8.4.0/MODULE.bazel": "0bc250aa1cb69590049383df7a9537c809591fcf876c620f5f097c58fdc9bc10",
     "https://bcr.bazel.build/modules/curl/8.4.0/source.json": "8b9532397af6a24be4ec118d8637b1f4e3e5a0d4be672c94b2275d675c7f7d6b",
     "https://bcr.bazel.build/modules/gazelle/0.27.0/MODULE.bazel": "3446abd608295de6d90b4a8a118ed64a9ce11dcb3dda2dc3290a22056bd20996",
@@ -85,6 +87,10 @@
     "https://bcr.bazel.build/modules/grpc/1.56.3.bcr.1/MODULE.bazel": "cd5b1eb276b806ec5ab85032921f24acc51735a69ace781be586880af20ab33f",
     "https://bcr.bazel.build/modules/grpc/1.66.0.bcr.2/MODULE.bazel": "0fa2b0fd028ce354febf0fe90f1ed8fecfbfc33118cddd95ac0418cc283333a0",
     "https://bcr.bazel.build/modules/grpc/1.66.0.bcr.2/source.json": "d2b273a925507d47b5e2d6852f194e70d2991627d71b13793cc2498400d4f99e",
+    "https://bcr.bazel.build/modules/javacc/7.0.13/MODULE.bazel": "baaf09536f604cec6f124e1668025ad814f73014822e1d4c458dbd7685ae6e64",
+    "https://bcr.bazel.build/modules/javacc/7.0.13/source.json": "34cfc2dfae2eca5a9eb3c56fb4677859a7c872c2d0b0a88c2bf833ab76150893",
+    "https://bcr.bazel.build/modules/javaparser/3.26.2/MODULE.bazel": "32ff49d7aa587ebe837b14931c2b3bc24b2aaaec308de82ebf0e52f9fdf8966f",
+    "https://bcr.bazel.build/modules/javaparser/3.26.2/source.json": "0e11a098026966aaef482f410b0b671680f3814180552505266c78e5af0e4a90",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -100,13 +106,14 @@
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/source.json": "da1cb1add160f5e5074b7272e9db6fd8f1b3336c15032cd0a653af9d2f484aed",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
-    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.2.4/MODULE.bazel": "0fbe5dcff66311947a3f6b86ebc6a6d9328e31a28413ca864debc4a043f371e5",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.2.4/source.json": "aa58bb10d0bb0dcaf4ad2c509ddcec23d2e94c3935e21517a5adbc2363248a55",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
@@ -224,6 +231,8 @@
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230907-e7430e6/MODULE.bazel": "3a7dedadf70346e678dc059dbe44d05cbf3ab17f1ce43a1c7a42edc7cbf93fd9",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230907-e7430e6/source.json": "6e513de1d26d1ded97a1c98a8ee166ff9be371a71556d4bc91220332dd3aa48e",
+    "https://bcr.bazel.build/modules/wabt/1.0.37/MODULE.bazel": "c3907ead6f98348df098f380061c5c9d8f4ac9a60aefdcf83919e29c30777da0",
+    "https://bcr.bazel.build/modules/wabt/1.0.37/source.json": "d86a91e1a6e4b548d2d80938144340d124defc35a3d59c1c2f02960debf97f32",
     "https://bcr.bazel.build/modules/with_cfg.bzl/0.6.0/MODULE.bazel": "174257966441fb8af45c939854ba38fd8364b7e48e3155c7c0ce5ef869af80aa",
     "https://bcr.bazel.build/modules/with_cfg.bzl/0.6.0/source.json": "4acda83067113064cd7c43f9b9ab4a7e7155d260c1a526f48f02aa3fbb809d17",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
@@ -242,7 +251,7 @@
   "moduleExtensions": {
     "//:repositories.bzl%async_profiler_repos": {
       "general": {
-        "bzlTransitiveDigest": "Yke2x5sUjmlG+2GhGPMhz8ErEEO8cBJUYJ/IlxyQcbA=",
+        "bzlTransitiveDigest": "P6z7IV5BxxzEZWgE8kfcJ7o/7WWAhk2q6dnVSPoxo/A=",
         "usagesDigest": "YfU6hu336ch1mgT1yQgd+ewbSBkMWCLMrk2SXvZMocA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -342,6 +351,11 @@
             "",
             "c-ares",
             "c-ares+"
+          ],
+          [
+            "",
+            "chicory",
+            "chicory+"
           ],
           [
             "",
@@ -5114,7 +5128,7 @@
     },
     "@@rules_python+//python/private/pypi:pip.bzl%pip_internal": {
       "general": {
-        "bzlTransitiveDigest": "ZoQYFNLXlSUUJNWx+TNG2xoMDSdWXnbHjBn7oELQMU0=",
+        "bzlTransitiveDigest": "IEf8nZ0kiULm/izVAYT0Ke4ZpTopmAF/FWPsoX3sJig=",
         "usagesDigest": "OLoIStnzNObNalKEMRq99FqenhPGLFZ5utVLV4sz7OI=",
         "recordedFileInputs": {
           "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",

--- a/distdir.bzl
+++ b/distdir.bzl
@@ -90,18 +90,29 @@ def _repo_cache_tar_impl(ctx):
     registry_files = parse_registry_files(ctx, lockfile_path, ctx.attr.module_files)
 
     archive_files = []
+    integrity_to_sha256 = {}
+    seen_sha256 = {}
     readme_content = "This directory contains repository cache artifacts for the following URLs:\n\n"
     for artifact in http_artifacts + registry_files:
         url = artifact["url"]
         if "integrity" in artifact:
+            integrity = artifact["integrity"]
+            if integrity in integrity_to_sha256:
+                artifact["sha256"] = integrity_to_sha256[integrity]
+                continue
+
             # ./tempfile could be a hard link if --experimental_repository_cache_hardlinks is used,
             # therefore we must delete it before creating or writing it again.
             ctx.delete("./tempfile")
-            checksum = ctx.download(url, "./tempfile", executable = False, integrity = artifact["integrity"])
+            checksum = ctx.download(url, "./tempfile", executable = False, integrity = integrity)
+            integrity_to_sha256[integrity] = checksum.sha256
             artifact["sha256"] = checksum.sha256
 
         if "sha256" in artifact:
             sha256 = artifact["sha256"]
+            if sha256 in seen_sha256:
+                continue
+            seen_sha256[sha256] = True
             output_file = "content_addressable/sha256/%s/file" % sha256
             ctx.download(url, output_file, sha256, executable = False)
             archive_files.append(output_file)

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -34,6 +34,7 @@ DIST_ARCHIVE_REPOS = [get_canonical_repo_name(repo) for repo in [
     "bazel_skylib",
     "blake3",
     "c-ares",
+    "chicory",
     "com_github_grpc_grpc",
     "com_google_protobuf",
     "googleapis",

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/BUILD
@@ -44,6 +44,7 @@ java_library(
         ":workspace_log_java_proto",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/net/starlark/java/syntax",
+        "@com_google_protobuf//:protobuf_java",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -14,14 +14,17 @@
 package com.google.devtools.build.lib.bazel.debug;
 
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos;
+import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.ExecuteWasmEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.ExtractEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.FileEvent;
+import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.LoadWasmEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.OsEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.RenameEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.SymlinkEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.TemplateEvent;
 import com.google.devtools.build.lib.bazel.debug.proto.WorkspaceLogProtos.WhichEvent;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
+import com.google.protobuf.ByteString;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -333,6 +336,53 @@ public final class WorkspaceRuleEvent implements Postable {
     WorkspaceLogProtos.WorkspaceEvent.Builder result =
         WorkspaceLogProtos.WorkspaceEvent.newBuilder();
     result = result.setWhichEvent(e);
+    if (location != null) {
+      result = result.setLocation(location.toString());
+    }
+    if (context != null) {
+      result = result.setContext(context);
+    }
+    return new WorkspaceRuleEvent(result.build());
+  }
+
+  public static WorkspaceRuleEvent newLoadWasmEvent(
+      String modulePath, String allocateFn, String context, Location location) {
+    LoadWasmEvent e =
+        WorkspaceLogProtos.LoadWasmEvent.newBuilder()
+            .setModulePath(modulePath)
+            .setAllocateFn(allocateFn)
+            .build();
+    WorkspaceLogProtos.WorkspaceEvent.Builder result =
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder();
+    result = result.setLoadWasmEvent(e);
+    if (location != null) {
+      result = result.setLocation(location.toString());
+    }
+    if (context != null) {
+      result = result.setContext(context);
+    }
+    return new WorkspaceRuleEvent(result.build());
+  }
+
+  public static WorkspaceRuleEvent newExecuteWasmEvent(
+      String modulePath,
+      String function,
+      byte[] input,
+      int timeout,
+      long memoryLimit,
+      String context,
+      Location location) {
+    ExecuteWasmEvent e =
+        WorkspaceLogProtos.ExecuteWasmEvent.newBuilder()
+            .setModulePath(modulePath)
+            .setFunction(function)
+            .setInput(ByteString.copyFrom(input))
+            .setTimeoutSeconds(timeout)
+            .setMemoryLimitBytes(memoryLimit)
+            .build();
+    WorkspaceLogProtos.WorkspaceEvent.Builder result =
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder();
+    result = result.setExecuteWasmEvent(e);
     if (location != null) {
       result = result.setLocation(location.toString());
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -149,6 +149,19 @@ message WhichEvent {
   string program = 1;
 }
 
+message LoadWasmEvent {
+  string module_path = 1;
+  string allocate_fn = 2;
+}
+
+message ExecuteWasmEvent {
+  string module_path = 1;
+  string function = 2;
+  bytes input = 3;
+  int32 timeout_seconds = 4;
+  int64 memory_limit_bytes = 5;
+}
+
 message WorkspaceEvent {
   // Location in the code (.bzl file) where the event originates.
   string location = 1;
@@ -171,5 +184,7 @@ message WorkspaceEvent {
     DeleteEvent delete_event = 13;
     PatchEvent patch_event = 14;
     RenameEvent rename_event = 15;
+    LoadWasmEvent load_wasm_event = 16;
+    ExecuteWasmEvent execute_wasm_event = 17;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
@@ -64,5 +64,6 @@ java_library(
         "//third_party:guava",
         "//third_party:java-diff-utils",
         "//third_party:jsr305",
+        "//third_party/chicory",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmExecutionResult.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmExecutionResult.java
@@ -1,0 +1,99 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.starlark;
+
+import com.google.devtools.build.docgen.annot.DocCategory;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkValue;
+
+@Immutable
+@StarlarkBuiltin(
+    name = "wasm_exec_result",
+    category = DocCategory.BUILTIN,
+    doc =
+        """
+        The result of executing a WebAssembly function with
+        <code>repository_ctx.execute_wasm()</code>. It contains the function's
+        return value and output buffer.
+
+        <p>If execution failed before the function returned then the return code will be negative
+        and the <code>error_message</code> field will be set.
+        """)
+final class StarlarkWasmExecutionResult implements StarlarkValue {
+  private final long returnCode;
+  private final String output;
+  private final String errorMessage;
+
+  private StarlarkWasmExecutionResult(long returnCode, String output, String errorMessage) {
+    this.returnCode = returnCode;
+    this.output = output;
+    this.errorMessage = errorMessage;
+  }
+
+  public static StarlarkWasmExecutionResult newOk(long returnCode, String output) {
+    return new StarlarkWasmExecutionResult(returnCode, output, "");
+  }
+
+  public static StarlarkWasmExecutionResult newErr(String errorMessage) {
+    return new StarlarkWasmExecutionResult(-1, "", errorMessage);
+  }
+
+  @Override
+  public boolean isImmutable() {
+    return true;
+  }
+
+  @Override
+  public void repr(Printer printer) {
+    printer.append("<wasm_exec_result return_code=");
+    printer.repr(returnCode);
+    printer.append(" output=");
+    printer.repr(output);
+    printer.append(" error_message=");
+    printer.repr(errorMessage);
+    printer.append(">");
+  }
+
+  @StarlarkMethod(
+      name = "return_code",
+      structField = true,
+      doc =
+          """
+          The return value of the WebAssembly function, or a negative value if execution
+          was terminated before the function returned.
+          """)
+  public long getReturnCode() {
+    return returnCode;
+  }
+
+  @StarlarkMethod(
+      name = "output",
+      structField = true,
+      doc = "The content of the output buffer returned by the WebAssembly function.")
+  public String getOutput() {
+    return output;
+  }
+
+  @StarlarkMethod(
+      name = "error_message",
+      structField = true,
+      doc = "Contains an error message if execution failed before the function returned.")
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkWasmModule.java
@@ -1,0 +1,296 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.starlark;
+
+import static com.dylibso.chicory.runtime.Memory.PAGE_SIZE;
+import static com.dylibso.chicory.wasm.types.MemoryLimits.MAX_PAGES;
+import static com.google.devtools.build.lib.profiler.ProfilerTask.WASM_EXEC;
+import static com.google.devtools.build.lib.profiler.ProfilerTask.WASM_LOAD;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
+import com.dylibso.chicory.runtime.ByteArrayMemory;
+import com.dylibso.chicory.runtime.ExportFunction;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.wasm.ChicoryException;
+import com.dylibso.chicory.wasm.WasmModule;
+import com.dylibso.chicory.wasm.types.MemoryLimits;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.docgen.annot.DocCategory;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.profiler.Profiler;
+import com.google.devtools.build.lib.profiler.SilentCloseable;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkValue;
+
+@Immutable
+@StarlarkBuiltin(
+    name = "wasm_module",
+    category = DocCategory.BUILTIN,
+    doc = "A WebAssembly module loaded by <code>repository_ctx.load_wasm()</code>.")
+final class StarlarkWasmModule implements StarlarkValue {
+  private final StarlarkPath path;
+  private final Object origPath;
+  private final WasmModule wasmModule;
+  private final String allocFnName;
+  private final boolean hasInitializeFn;
+
+  public StarlarkWasmModule(
+      StarlarkPath path, Object origPath, byte[] moduleContent, String allocFnName)
+      throws EvalException {
+    WasmModule wasmModule;
+    Profiler prof = Profiler.instance();
+    try (SilentCloseable c1 = prof.profile(WASM_LOAD, () -> "load " + path.toString())) {
+      try (SilentCloseable c2 = prof.profile(WASM_LOAD, "parse")) {
+        try {
+          wasmModule = com.dylibso.chicory.wasm.Parser.parse(moduleContent);
+        } catch (ChicoryException e) {
+          throw new EvalException(e);
+        }
+      }
+      validateModule(wasmModule, allocFnName);
+    }
+
+    this.path = path;
+    this.origPath = origPath;
+    this.wasmModule = wasmModule;
+    this.allocFnName = allocFnName;
+    this.hasInitializeFn = hasInitializeFn(wasmModule);
+  }
+
+  private static boolean hasInitializeFn(WasmModule wasmModule) {
+    var exports = wasmModule.exportSection();
+    int exportCount = exports.exportCount();
+    for (int ii = 0; ii < exportCount; ii++) {
+      if (exports.getExport(ii).name().equals("_initialize")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isImmutable() {
+    return true;
+  }
+
+  @Override
+  public void repr(Printer printer) {
+    printer.append("<wasm_module path=");
+    printer.repr(origPath);
+    printer.append(" allocate_fn=");
+    printer.repr(allocFnName);
+    printer.append(">");
+  }
+
+  public StarlarkPath getPath() {
+    return path;
+  }
+
+  @StarlarkMethod(
+      name = "path",
+      structField = true,
+      doc = "The path this WebAssembly module was loaded from.")
+  public Object getOrigPath() {
+    return origPath;
+  }
+
+  public StarlarkWasmExecutionResult execute(
+      String execFnName, byte[] input, Duration timeout, long memLimitBytes)
+      throws EvalException, InterruptedException {
+    Profiler prof = Profiler.instance();
+    try (SilentCloseable c = prof.profile(WASM_EXEC, () -> "execute " + execFnName)) {
+      var memLimits = getMemLimits(memLimitBytes);
+      // Perform initialization and execution in a separate thread so it can be interrupted
+      // in case of timeout.
+      var wasmThreadFactory =
+          Thread.ofPlatform().name(Thread.currentThread().getName() + "_wasm").factory();
+      StarlarkWasmExecutionResult result;
+      String errMessage;
+      try (var executor = Executors.newSingleThreadExecutor(wasmThreadFactory)) {
+        return executor.invokeAny(
+            ImmutableList.of(() -> run(execFnName, input, memLimits)),
+            timeout.toMillis(),
+            TimeUnit.MILLISECONDS);
+      } catch (TimeoutException e) {
+        errMessage = String.format("Error executing %s: timed out", execFnName);
+      } catch (ExecutionException e) {
+        errMessage = String.format("Error executing %s: %s", execFnName, e.getCause().getMessage());
+      }
+      return StarlarkWasmExecutionResult.newErr(errMessage);
+    }
+  }
+
+  private StarlarkWasmExecutionResult run(String execFnName, byte[] input, MemoryLimits memLimits)
+      throws EvalException, InterruptedException {
+    Instance instance;
+    Profiler prof = Profiler.instance();
+    try {
+      instance =
+          Instance.builder(wasmModule)
+              .withMemoryLimits(memLimits)
+              // Disable calling `_start()`, which is the entry point for WASI-style
+              // command modules.
+              .withStart(false)
+              // Chicory documentation recommends ByteArrayMemory for OpenJDK
+              // https://chicory.dev/docs/advanced/memory
+              .withMemoryFactory(ByteArrayMemory::new)
+              .build();
+      // If `_initialize()` is present then call it to perform early setup.
+      //
+      // Note: The WebAssembly spec describes a "start function", named in a
+      // "start section", that is to be called as part of module initialization.
+      // Actual implementations such as LLVM have instead used the start function
+      // as the equivalent of a native binary's entry point, and expect (or emit)
+      // a function named `_initialize` to be used for early initialization.
+      //
+      // For additional context, see:
+      // - https://bugs.llvm.org/show_bug.cgi?id=37198
+      // - https://reviews.llvm.org/D40559
+      // - https://github.com/WebAssembly/design/issues/1160
+      if (hasInitializeFn) {
+        try (SilentCloseable c = prof.profile(WASM_EXEC, "initialize")) {
+          instance.export("_initialize").apply();
+        }
+      }
+    } catch (ChicoryException e) {
+      throw new EvalException(e);
+    }
+
+    var memory = instance.memory();
+    ExportFunction allocFn = instance.export(allocFnName);
+    // TODO: #26092 - Is this check needed? Might be redundant with validateModule().
+    if (allocFn == null) {
+      throw Starlark.errorf("WebAssembly module doesn't export \"%s\"", allocFnName);
+    }
+    ExportFunction execFn = instance.export(execFnName);
+    // TODO: #26092 - Validate execFn has the expected signature?
+    if (execFn == null) {
+      throw Starlark.errorf("WebAssembly module doesn't export \"%s\"", execFnName);
+    }
+
+    int inputLen = Math.toIntExact(input.length);
+    int inputPtr = alloc(allocFnName, allocFn, inputLen, 1);
+    try (SilentCloseable c = prof.profile(WASM_EXEC, "copy input")) {
+      memory.write(inputPtr, input);
+    }
+
+    // struct { output_ptr_ptr: **u8, output_len_ptr: *u32 }
+    int paramsPtr = alloc(allocFnName, allocFn, 8, 4);
+    int outputPtrPtr = paramsPtr;
+    int outputLenPtr = paramsPtr + 4;
+    memory.writeI32(outputPtrPtr, 0);
+    memory.writeI32(outputLenPtr, 0);
+
+    long[] execResult;
+    try (SilentCloseable c = prof.profile(WASM_EXEC, "execute")) {
+      execResult = execFn.apply(inputPtr, inputLen, outputPtrPtr, outputLenPtr);
+    }
+
+    // TODO: #26092 - Not 100% sure this check is necessary, but the ambiguity between
+    // signed/unsigned in Java vs WebAssembly makes me nervous.
+    //
+    // Might be unnecessary if the function signature is verified before execution?
+    long returnCode = execResult[0];
+    if (returnCode < 0 || returnCode > 0xFFFFFFFFL) {
+      returnCode = 0xFFFFFFFFL;
+    }
+    int outputPtr = memory.readInt(outputPtrPtr);
+    int outputLen = memory.readInt(outputLenPtr);
+
+    String output = "";
+    if (outputLen > 0) {
+      try (SilentCloseable c = prof.profile(WASM_EXEC, "copy output")) {
+        byte[] outputBytes = memory.readBytes(outputPtr, outputLen);
+        output = new String(outputBytes, ISO_8859_1);
+      }
+    }
+    return StarlarkWasmExecutionResult.newOk(returnCode, output);
+  }
+
+  private static void validateModule(WasmModule wasmModule, String allocFnName)
+      throws EvalException {
+    var exports = wasmModule.exportSection();
+    int exportCount = exports.exportCount();
+    for (int ii = 0; ii < exportCount; ii++) {
+      var export = exports.getExport(ii);
+      if (export.name().equals(allocFnName)) {
+        // TODO: #26092 - Validate exported type is a function and has the expected signature?
+        return;
+      }
+    }
+    throw Starlark.errorf("WebAssembly module doesn't contain an export named \"%s\"", allocFnName);
+  }
+
+  MemoryLimits getMemLimits(long memLimitBytes) throws EvalException {
+    int initialPages = 1;
+    int memLimitPages = getMemLimitPages(memLimitBytes);
+
+    if (wasmModule.memorySection().isPresent()) {
+      var memories = wasmModule.memorySection().get();
+      int memoryCount = memories.memoryCount();
+      if (memoryCount > 1) {
+        // TODO: #26092 - Figure out what memory limits mean when applied to
+        // a WebAssembly module with multiple memories.
+        throw Starlark.errorf("WebAssembly modules with multiple memories not yet supported");
+      }
+      if (memoryCount != 0) {
+        MemoryLimits limits = memories.getMemory(0).limits();
+        if (limits.initialPages() > initialPages) {
+          initialPages = limits.initialPages();
+        }
+      }
+    }
+    if (initialPages > memLimitPages) {
+      // TODO: #26092 - Should probably throw an exception. The execution will likely fail anyway,
+      // and
+      // throwing an exception from this point would provide more relevant details.
+      initialPages = memLimitPages;
+    }
+    return new MemoryLimits(initialPages, memLimitPages);
+  }
+
+  static int getMemLimitPages(long memLimitBytes) {
+    if (memLimitBytes == 0) {
+      return 1;
+    }
+    return (int) Math.min((long) MAX_PAGES, Math.ceilDiv(memLimitBytes, PAGE_SIZE));
+  }
+
+  static int alloc(String allocFnName, ExportFunction allocFn, int size, int align)
+      throws ChicoryException, EvalException {
+    long[] allocResult = allocFn.apply(size, align);
+    long ptr = allocResult[0];
+    if (ptr == 0) {
+      throw Starlark.errorf(
+          "allocation failed: %s(%d, %d) returned NULL", allocFnName, size, align);
+    }
+    try {
+      return Math.toIntExact(ptr);
+    } catch (ArithmeticException e) {
+      throw Starlark.errorf(
+          "allocation failed: %s(%d, %d) returned invalid pointer 0x%08X (out of range)",
+          allocFnName, size, align, ptr);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -880,6 +880,15 @@ public final class BuildLanguageOptions extends OptionsBase {
               + " files which are not UTF-8 encoded can cause Bazel to behave inconsistently.")
   public Utf8EnforcementMode incompatibleEnforceStarlarkUtf8;
 
+  @Option(
+      name = "experimental_repository_ctx_execute_wasm",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help = "If true enables the repository_ctx `load_wasm` and `execute_wasm` methods.")
+  public boolean repositoryCtxExecuteWasm;
+
   /**
    * An interner to reduce the number of StarlarkSemantics instances. A single Blaze instance should
    * never accumulate a large number of these and being able to shortcut on object identity makes a
@@ -1002,6 +1011,7 @@ public final class BuildLanguageOptions extends OptionsBase {
             .setBool(
                 StarlarkSemantics.INTERNAL_BAZEL_ONLY_UTF_8_BYTE_STRINGS,
                 internalStarlarkUtf8ByteStrings)
+            .setBool(EXPERIMENTAL_REPOSITORY_CTX_EXECUTE_WASM, repositoryCtxExecuteWasm)
             .build();
     return INTERNER.intern(semantics);
   }
@@ -1112,6 +1122,8 @@ public final class BuildLanguageOptions extends OptionsBase {
       "+incompatible_simplify_unconditional_selects_in_rule_attrs";
   public static final String INCOMPATIBLE_LOCATIONS_PREFERS_EXECUTABLE =
       "+incompatible_locations_prefers_executable";
+  public static final String EXPERIMENTAL_REPOSITORY_CTX_EXECUTE_WASM =
+      "-experimental_repository_ctx_execute_wasm";
   // non-booleans
   public static final StarlarkSemantics.Key<String> EXPERIMENTAL_BUILTINS_BZL_PATH =
       new StarlarkSemantics.Key<>("experimental_builtins_bzl_path", "%bundled%");

--- a/src/main/java/com/google/devtools/build/lib/profiler/ProfilerTask.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/ProfilerTask.java
@@ -90,6 +90,8 @@ public enum ProfilerTask {
   REPOSITORY_VENDOR("Vendoring repository"),
   REPO_CACHE_GC_WAIT("blocked on repo contents cache GC", Threshold.TEN_MILLIS),
   SPAWN_LOG("logging spawn", Threshold.TEN_MILLIS),
+  WASM_LOAD("load WebAssembly module"),
+  WASM_EXEC("execute WebAssembly function"),
 
   UNKNOWN("Unknown event");
 

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -59,6 +59,7 @@ filegroup(
         "//src/test/shell:bashunit",
         "//src/test/shell:integration_test_setup.sh",
         "//src/test/shell:testenv.sh",
+        "//src/test/shell/bazel/testdata:exec_wasm",
         "//src/tools/singlejar",
         "//third_party:srcs",
         "//third_party/ijar",

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -3656,4 +3656,41 @@ EOF
   expect_log "attempted to watch path under external repository directory: invalid repository name '@invalid_name@'"
 }
 
+function test_load_and_execute_wasm() {
+  setup_starlark_repository
+
+  declare -r exec_wasm="$(rlocation "io_bazel/src/test/shell/bazel/testdata/exec_wasm.wasm")"
+  cat >test.bzl <<EOF
+def _impl(repository_ctx):
+  wasm_file = "$exec_wasm"
+  wasm_module = repository_ctx.load_wasm("$exec_wasm")
+
+  result_ok = repository_ctx.execute_wasm(wasm_module, "run_ok", input="")
+  print('result_ok.output: %r' % (result_ok.output,))
+  print('result_ok.return_code: %r' % (result_ok.return_code,))
+  print('result_ok.error_message: %r' % (result_ok.error_message,))
+
+  result_err = repository_ctx.execute_wasm(wasm_module, "run_err", input="")
+  print('result_err.output: %r' % (result_err.output,))
+  print('result_err.return_code: %r' % (result_err.return_code,))
+  print('result_err.error_message: %r' % (result_err.error_message,))
+
+  # Symlink so a repository is created
+  repository_ctx.symlink(repository_ctx.path("$repo2"), repository_ctx.path(""))
+
+repo = repository_rule(implementation=_impl, local=True)
+EOF
+
+  bazel build --experimental_repository_ctx_execute_wasm @foo//:bar >& $TEST_log \
+    || fail "Expected build to succeed"
+
+  expect_log 'result_ok.output: "ok"'
+  expect_log 'result_ok.return_code: 0'
+  expect_log 'result_ok.error_message: ""'
+
+  expect_log 'result_err.output: "err"'
+  expect_log 'result_err.return_code: 1'
+  expect_log 'result_err.error_message: ""'
+}
+
 run_suite "local repository tests"

--- a/src/test/shell/bazel/testdata/BUILD
+++ b/src/test/shell/bazel/testdata/BUILD
@@ -1,3 +1,5 @@
+load("//src/test/tools:wasm.bzl", "wat_binary")
+
 package(default_testonly = True)
 
 filegroup(
@@ -27,3 +29,9 @@ filegroup(
 )
 
 exports_files(["zstd_test_archive.tar.zst"])
+
+wat_binary(
+    name = "exec_wasm",
+    src = "exec_wasm.wat",
+    visibility = ["//src/test/shell/bazel:__pkg__"],
+)

--- a/src/test/shell/bazel/testdata/exec_wasm.wat
+++ b/src/test/shell/bazel/testdata/exec_wasm.wat
@@ -1,0 +1,133 @@
+(module
+  (memory 1)
+
+  (func $allocate (export "allocate")
+    (param $size i32)
+    (param $align i32)
+    (result i32)
+    (local $orig_page_count i32)
+
+    ;; Pass each allocation directly to `memory.grow`, which allocates the
+    ;; requested number of pages (each page is 65536 bytes).
+
+    ;; PAGE_SIZE = 65536
+    ;; page_count = min(1, $size % PAGE_SIZE) + ($size / PAGE_SIZE)
+    local.get $size
+    i32.const 65536
+    i32.rem_u
+    (if (result i32)
+      (then i32.const 1)
+      (else i32.const 0))
+    local.get $size
+    i32.const 65536
+    i32.div_u
+    i32.add
+
+    ;; If allocation is successful then the output pointer will be the original
+    ;; heap size in bytes. If not successful, the pushed value will be -1.
+    memory.grow
+    local.tee $orig_page_count
+    i32.const -1
+    i32.eq
+    (if (result i32)
+      (then i32.const 0)
+      (else
+        local.get $orig_page_count
+        i32.const 65536
+        i32.mul
+      )
+    )
+    return
+  )
+
+  ;; Returns the output buffer "ok" with return code 0.
+  (func (export "run_ok")
+    (param $input_ptr i32)
+    (param $input_len i32)
+    (param $output_ptr_ptr i32)
+    (param $output_len_ptr i32)
+    (result i32)
+    (local $output_ptr i32)
+
+    ;; *output_len_ptr = 2
+    local.get $output_len_ptr
+    i32.const 2
+    i32.store
+
+    ;; output_ptr = allocate(size=2, align=1)
+    i32.const 2
+    i32.const 1
+    call $allocate
+    local.set $output_ptr
+
+    ;; *output_ptr_ptr = output_ptr
+    local.get $output_ptr_ptr
+    local.get $output_ptr
+    i32.store
+
+    ;; output_ptr[0] = b"o"
+    local.get $output_ptr
+    i32.const 0x6F
+    i32.store8
+
+    ;; output_ptr[1] = b"k"
+    local.get $output_ptr
+    i32.const 1
+    i32.add
+    i32.const 0x6B
+    i32.store8
+
+    ;; return 0
+    i32.const 0
+    return
+  )
+
+  ;; Returns the output buffer "err" with return code 1.
+  (func (export "run_err")
+    (param $input_ptr i32)
+    (param $input_len i32)
+    (param $output_ptr_ptr i32)
+    (param $output_len_ptr i32)
+    (result i32)
+    (local $output_ptr i32)
+
+    ;; *output_len_ptr = 3
+    local.get $output_len_ptr
+    i32.const 3
+    i32.store
+
+    ;; output_ptr = allocate(size=3, align=1)
+    i32.const 3
+    i32.const 1
+    call $allocate
+    local.set $output_ptr
+
+    ;; *output_ptr_ptr = output_ptr
+    local.get $output_ptr_ptr
+    local.get $output_ptr
+    i32.store
+
+    ;; output_ptr[0] = b"e"
+    local.get $output_ptr
+    i32.const 0x65
+    i32.store8
+
+    ;; output_ptr[1] = b"r"
+    local.get $output_ptr
+    i32.const 1
+    i32.add
+    i32.const 0x72
+    i32.store8
+
+    ;; output_ptr[2] = b"r"
+    local.get $output_ptr
+    i32.const 2
+    i32.add
+    i32.const 0x72
+    i32.store8
+
+    ;; return 1
+    i32.const 1
+    return
+  )
+)

--- a/src/test/tools/wasm.bzl
+++ b/src/test/tools/wasm.bzl
@@ -1,0 +1,47 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file contains a rule to compile WAT files to WebAssembly.
+"""
+
+def _wat_binary(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".wasm")
+    ctx.actions.run(
+        mnemonic = "Wat2Wasm",
+        executable = ctx.executable._wat2wasm,
+        inputs = [ctx.file.src],
+        outputs = [out],
+        arguments = [
+            ctx.file.src.path,
+            "-o",
+            out.path,
+        ],
+    )
+    return DefaultInfo(files = depset([out]))
+
+wat_binary = rule(
+    implementation = _wat_binary,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = [".wat"],
+            mandatory = True,
+        ),
+        "_wat2wasm": attr.label(
+            default = "@wabt//src/tools:wat2wasm",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/src/tools/bzlmod/utils.bzl
+++ b/src/tools/bzlmod/utils.bzl
@@ -79,6 +79,12 @@ def parse_http_artifacts(ctx, lockfile_path, required_repos):
                 "url": url.rsplit("/", 1)[0] + "/patches/" + patch,
             })
 
+        for overlay_file, integrity in source_json.get("overlay", {}).items():
+            http_artifacts.append({
+                "integrity": integrity,
+                "url": url.rsplit("/", 1)[0] + "/overlay/" + overlay_file,
+            })
+
     for extension_id, extension_entry in lockfile["moduleExtensions"].items():
         if extension_id.startswith("@@"):
             # "@@rules_foo+//:extensions.bzl%foo" --> "rules_foo+"

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -11,6 +11,7 @@ filegroup(
     srcs = glob(["**"]) + [
         "//third_party/allocation_instrumenter:srcs",
         "//third_party/android_dex:srcs",
+        "//third_party/chicory:srcs",
         "//third_party/def_parser:srcs",
         "//third_party/googleapis:srcs",
         "//third_party/grpc:srcs",

--- a/third_party/chicory/BUILD
+++ b/third_party/chicory/BUILD
@@ -1,0 +1,27 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//:__subpackages__"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+)
+
+java_library(
+    name = "chicory",
+    exports = [
+        "@chicory//log",
+        "@chicory//runtime",
+        "@chicory//wasm",
+    ],
+)
+
+# for bootstrapping
+filegroup(
+    name = "dist_jars",
+    srcs = [
+        "@chicory//log",
+        "@chicory//runtime",
+        "@chicory//wasm",
+    ],
+)


### PR DESCRIPTION
RELNOTES: Added the `load_wasm` and `execute_wasm` methods to `repository_ctx` and `module_ctx` that allow repo rules and module extensions to run a WebAssembly binary. These methods are only available if `--experimental_repository_ctx_execute_wasm` is set.

Closes #26248