### PR TITLE
Restore path mapping support with `layering_check`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1341,9 +1341,12 @@ java_library(
     srcs = ["actions/ParameterFileWriteAction.java"],
     deps = [
         ":actions/abstract_file_write_action",
+        ":actions/path_mappers",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_item",
+        "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent",

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
@@ -28,11 +29,13 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.ExecException;
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
 import com.google.devtools.build.lib.actions.ParameterFile;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
 import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.UserExecException;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -58,9 +61,9 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
 
   private final CommandLine commandLine;
   private final ParameterFileType type;
-  private final boolean hasInputArtifactToExpand;
   private final boolean makeExecutable;
   private final String mnemonic;
+  private final boolean usePathStripping;
 
   /**
    * Creates a new instance.
@@ -84,7 +87,9 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
         commandLine,
         type,
         makeExecutable,
-        AbstractFileWriteAction.MNEMONIC);
+        AbstractFileWriteAction.MNEMONIC,
+        /* executionInfo= */ ImmutableMap.of(),
+        CoreOptions.OutputPathsMode.OFF);
   }
 
   /**
@@ -98,6 +103,9 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
    * @param type the type of the file
    * @param makeExecutable whether the output file should be made executable
    * @param mnemonic the mnemonic for this action, or null if the default should be used
+   * @param executionInfo the execution info for this action (only supports-path-mapping is used)
+   * @param outputPathsMode the output paths mode obtained via {@link
+   *     PathMappers#getOutputPathsMode(BuildConfigurationValue)}
    */
   public ParameterFileWriteAction(
       ActionOwner owner,
@@ -106,13 +114,19 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
       CommandLine commandLine,
       ParameterFileType type,
       boolean makeExecutable,
-      String mnemonic) {
+      String mnemonic,
+      ImmutableMap<String, String> executionInfo,
+      CoreOptions.OutputPathsMode outputPathsMode) {
     super(owner, inputs, output);
     this.commandLine = commandLine;
     this.type = type;
-    this.hasInputArtifactToExpand = !inputs.isEmpty();
     this.makeExecutable = makeExecutable;
     this.mnemonic = mnemonic;
+    // Save memory by not storing the full execution info, but only what matters for this particular
+    // action.
+    this.usePathStripping =
+        PathMappers.getEffectiveOutputPathsMode(outputPathsMode, getMnemonic(), executionInfo)
+            == CoreOptions.OutputPathsMode.STRIP;
   }
 
   @Override
@@ -123,6 +137,17 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
   @Override
   public String getMnemonic() {
     return mnemonic;
+  }
+
+  @Override
+  public ImmutableMap<String, String> getExecutionInfo() {
+    return usePathStripping
+        ? ImmutableMap.of(ExecutionRequirements.SUPPORTS_PATH_MAPPING, "")
+        : ImmutableMap.of();
+  }
+
+  private CoreOptions.OutputPathsMode getOutputPathsMode() {
+    return usePathStripping ? CoreOptions.OutputPathsMode.STRIP : CoreOptions.OutputPathsMode.OFF;
   }
 
   @VisibleForTesting
@@ -138,7 +163,7 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
    * includeParamFile option is flag-guarded with warning regarding output size to user.
    *
    * <p>TODO(b/161359171): The list of arguments will be incorrect if the arguments contain tree
-   * artifacts.
+   * artifacts or path mapping is used.
    */
   public Iterable<String> getArguments()
       throws CommandLineExpansionException, InterruptedException {
@@ -156,7 +181,7 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
   @Nullable
   @Override
   public String getStarlarkContent() throws IOException, EvalException, InterruptedException {
-    if (hasInputArtifactToExpand) {
+    if (!getInputs().isEmpty()) {
       // Tree artifact information isn't available at analysis time.
       return null;
     }
@@ -171,10 +196,16 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
   public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx)
       throws ExecException, InterruptedException {
     final ArgChunk arguments;
+    // Other actions consuming this parameter file may have path mapping disabled due to inputs
+    // conflicting across configurations, in which case paths written to the file will not match.
+    // Since this depends on the consumer but the decision is only made at execution time, it is not
+    // clear how to improve that situation. Actions that are prone to such collisions should avoid
+    // depending on parameter files.
+    var pathMapper = PathMappers.create(this, getOutputPathsMode(), /* isStarlarkAction= */ false);
     try {
       InputMetadataProvider inputMetadataProvider =
           Preconditions.checkNotNull(ctx.getInputMetadataProvider());
-      arguments = commandLine.expand(inputMetadataProvider, PathMapper.NOOP);
+      arguments = commandLine.expand(inputMetadataProvider, pathMapper);
     } catch (CommandLineExpansionException e) {
       throw new UserExecException(
           e,
@@ -183,21 +214,23 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
               .setSpawn(Spawn.newBuilder().setCode(Code.COMMAND_LINE_EXPANSION_FAILURE))
               .build());
     }
-    return new ParamFileWriter(arguments, type);
+    return new ParamFileWriter(arguments, pathMapper, type);
   }
 
   private static class ParamFileWriter implements DeterministicWriter {
     private final ArgChunk arguments;
+    private final PathMapper pathMapper;
     private final ParameterFileType type;
 
-    ParamFileWriter(ArgChunk arguments, ParameterFileType type) {
+    ParamFileWriter(ArgChunk arguments, PathMapper pathMapper, ParameterFileType type) {
       this.arguments = arguments;
+      this.pathMapper = pathMapper;
       this.type = type;
     }
 
     @Override
     public void writeTo(OutputStream out) throws IOException {
-      ParameterFile.writeParameterFile(out, arguments.arguments(PathMapper.NOOP), type);
+      ParameterFile.writeParameterFile(out, arguments.arguments(pathMapper), type);
     }
   }
 
@@ -210,7 +243,11 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
     fp.addString(GUID);
     fp.addString(type.toString());
     commandLine.addToFingerprint(
-        actionKeyContext, inputMetadataProvider, CoreOptions.OutputPathsMode.OFF, fp);
+        actionKeyContext,
+        inputMetadataProvider,
+        PathMappers.getEffectiveOutputPathsMode(
+            getOutputPathsMode(), getMnemonic(), getExecutionInfo()),
+        fp);
   }
 
   @Override
@@ -227,7 +264,11 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
       // tell if two contents are equal or not.
       var fp = new Fingerprint();
       commandLine.addToFingerprint(
-          new ActionKeyContext(), null, CoreOptions.OutputPathsMode.OFF, fp);
+          new ActionKeyContext(),
+          null,
+          PathMappers.getEffectiveOutputPathsMode(
+              getOutputPathsMode(), getMnemonic(), getExecutionInfo()),
+          fp);
       message.append(BaseEncoding.base16().lowerCase().encode(fp.digestAndReset()));
       message.append(
           "\n"

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.analysis.actions.AbstractFileWriteAction;
 import com.google.devtools.build.lib.analysis.actions.BuildInfoFileWriteAction;
 import com.google.devtools.build.lib.analysis.actions.FileWriteAction;
 import com.google.devtools.build.lib.analysis.actions.ParameterFileWriteAction;
+import com.google.devtools.build.lib.analysis.actions.PathMappers;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.actions.StarlarkAction;
 import com.google.devtools.build.lib.analysis.actions.Substitution;
@@ -354,7 +355,9 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
               args.build(getMainRepoMappingSupplier()),
               args.getParameterFileType(),
               isExecutable,
-              mnemonic);
+              mnemonic,
+              ruleContext.getConfiguration().modifiedExecutionInfo(ImmutableMap.of(), mnemonic),
+              PathMappers.getOutputPathsMode(ruleContext.getConfiguration()));
     } else {
       throw new AssertionError("Unexpected type: " + content.getClass().getSimpleName());
     }

--- a/src/main/starlark/builtins_bzl/common/cc/compile/cc_compilation_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/compile/cc_compilation_helper.bzl
@@ -306,7 +306,7 @@ def _create_module_map_action(
     tree_artifacts += [h for h in public_headers if h.is_directory]
     content.add_all(tree_artifacts, map_each = lambda x: None, allow_closure = True)
 
-    actions.write(module_map.file(), content = content, is_executable = True)
+    actions.write(module_map.file(), content = content, is_executable = True, mnemonic = "CppModuleMap")
 
 def _init_cc_compilation_context(
         # DO NOT use ctx, this is a temporary placeholder

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/BUILD
@@ -116,6 +116,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/abstract_file_write_action",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/custom_command_line",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/parameter_file_write_action",
+        "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/ParamFileWriteActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/ParamFileWriteActionTest.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.util.ActionTester;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -60,7 +61,7 @@ public class ParamFileWriteActionTest extends BuildViewTestCase {
   private SpecialArtifact treeArtifact;
 
   @Before
-  public void createArtifacts() throws Exception  {
+  public void createArtifacts() throws Exception {
     Path execRoot = scratch.getFileSystem().getPath("/exec");
     rootDir = ArtifactRoot.asDerivedRoot(execRoot, RootType.OUTPUT, "out");
     outputArtifact = getBinArtifactWithNoOwner("destination.txt");
@@ -73,8 +74,8 @@ public class ParamFileWriteActionTest extends BuildViewTestCase {
     Action action =
         createParameterFileWriteAction(
             NestedSetBuilder.emptySet(Order.STABLE_ORDER), createNormalCommandLine(), false);
-    assertThat(Artifact.toRootRelativePaths(action.getOutputs())).containsExactly(
-        "destination.txt");
+    assertThat(Artifact.toRootRelativePaths(action.getOutputs()))
+        .containsExactly("destination.txt");
   }
 
   @Test
@@ -154,7 +155,9 @@ public class ParamFileWriteActionTest extends BuildViewTestCase {
         commandLine,
         ParameterFileType.UNQUOTED,
         executable,
-        AbstractFileWriteAction.MNEMONIC);
+        AbstractFileWriteAction.MNEMONIC,
+        /* executionInfo= */ ImmutableMap.of(),
+        CoreOptions.OutputPathsMode.OFF);
   }
 
   private static CommandLine createNormalCommandLine() {

--- a/src/test/shell/bazel/path_mapping_test.sh
+++ b/src/test/shell/bazel/path_mapping_test.sh
@@ -740,6 +740,7 @@ std::string AsGreeting(const std::string& name) {
 EOF
 
   bazel run \
+    --repo_env=CC=clang \
     --verbose_failures \
     --experimental_output_paths=strip \
     --modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping,CppArchive=+supports-path-mapping \
@@ -754,6 +755,7 @@ EOF
   expect_not_log 'remote cache hit'
 
   bazel run \
+    --repo_env=CC=clang \
     --verbose_failures \
     --experimental_output_paths=strip \
     --modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping,CppArchive=+supports-path-mapping \


### PR DESCRIPTION
`path_mapping_test` didn't set `CC=clang` and thus didn't actually cover the case of compilation with `--features=layering_check`. As a result, it wasn't noticed that 2dd545b4e4fe35aa04a70eacd5ab1ba621b3a09c regressed path mapping support for this feature.

Fixing this requires wiring up `ParameterFileWriteAction` with path mapping and allowing it to be opted in via execution info, as well as restoring the `CppModuleMap` mnemonic it had before Starlarkification.

RELNOTES: `ctx.actions.write` now supports path mapping when passed an `Args` object. Use the `mnemonics` attribute to assign it a dedicated mnemonic, which can then be used with `--modify_execution_info` to opt in to path mapping (see https://github.com/bazelbuild/bazel/discussions/22658 for details on path mapping).