### PR TITLE
[8.3.0] Add strip_include_prefix to cc_import

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_import.bzl
@@ -165,6 +165,7 @@ def _cc_import_impl(ctx):
         public_hdrs = ctx.files.hdrs,
         includes = ctx.attr.includes,
         name = ctx.label.name,
+        strip_include_prefix = ctx.attr.strip_include_prefix,
     )
 
     this_cc_info = CcInfo(compilation_context = compilation_context, linking_context = linking_context)
@@ -406,6 +407,20 @@ The default <code>include</code> path doesn't include generated
 files. If you need to <code>#include</code> a generated header
 file, list it in the <code>srcs</code>.
 </p>
+"""),
+        "strip_include_prefix": attr.string(doc = """
+The prefix to strip from the paths of the headers of this rule.
+
+<p>When set, the headers in the <code>hdrs</code> attribute of this rule are accessible
+at their path with this prefix cut off.
+
+<p>If it's a relative path, it's taken as a package-relative one. If it's an absolute one,
+it's understood as a repository-relative path.
+
+<p>The prefix in the <code>include_prefix</code> attribute is added after this prefix is
+stripped.
+
+<p>This attribute is only legal under <code>third_party</code>.
 """),
         "deps": attr.label_list(doc = """
 The list of other libraries that the target depends upon.

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test_cc_static_library/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test_cc_static_library/BUILD.builtin_test
@@ -38,6 +38,19 @@ cc_import(
     static_library = ":static",
 )
 
+cc_import(
+    name = "static_import_strip_include_prefix",
+    hdrs = ["nested/stripped_bar.h"],
+    static_library = ":static",
+    strip_include_prefix = "nested",
+)
+
+cc_test(
+    name = "test_static_import_strip_include_prefix",
+    srcs = ["test_static_import_strip_include_prefix.cc"],
+    deps = [":static_import_strip_include_prefix"],
+)
+
 cc_test(
     name = "test",
     srcs = ["test.cc"],

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test_cc_static_library/nested/stripped_bar.h
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test_cc_static_library/nested/stripped_bar.h
@@ -1,0 +1,20 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef EXAMPLES_TEST_CC_STATIC_LIBRARY_BAR_H_
+#define EXAMPLES_TEST_CC_STATIC_LIBRARY_BAR_H_
+
+int bar();
+int unused();
+
+#endif  // EXAMPLES_TEST_CC_STATIC_LIBRARY_BAR_H_

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test_cc_static_library/test_static_import_strip_include_prefix.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test_cc_static_library/test_static_import_strip_include_prefix.cc
@@ -1,0 +1,21 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "src/main/starlark/tests/builtins_bzl/cc/cc_static_library/test/nested/stripped_bar.h"
+
+int main() {
+  if (bar() != 84) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/4748

Closes #25710.

PiperOrigin-RevId: 770991345
Change-Id: Ib9af3561acbe0e34624031ee2cf4f0dcbddf4bff

Commit https://github.com/bazelbuild/bazel/commit/9f4448f9ee62a1041030a8fa6b4add2ad7b228c7