### PR TITLE
bazel/native: Add getNetIoCountersNative stub for the BSDs

### DIFF
--- a/src/main/native/unix_jni_bsd.cc
+++ b/src/main/native/unix_jni_bsd.cc
@@ -154,4 +154,10 @@ int portable_cpu_speed() {
   return -1;
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_devtools_build_lib_profiler_SystemNetworkStats_getNetIoCountersNative(
+    JNIEnv *env, jclass clazz, jobject counters_list) {
+  // Currently not implemented.
+}
+
 }  // namespace blaze_jni


### PR DESCRIPTION
Fixes an UnsatisfiedLinkError on FreeBSD when porting 8.2.1.