### PR TITLE
Add ability to unset variables with `--{action,host_action,repo,run,test}_env`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -48,6 +48,7 @@ import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.SkyValue;
+import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.TriState;
 import java.io.PrintStream;
 import java.util.HashMap;
@@ -176,8 +177,12 @@ public class BuildConfigurationValue
     }
     // Order doesn't matter here as ActionEnvironment sorts by key.
     Map<String, String> testEnv = new HashMap<>();
-    for (Map.Entry<String, String> entry : buildOptions.get(TestOptions.class).testEnvironment) {
-      testEnv.put(entry.getKey(), entry.getValue());
+    for (Converters.EnvVar envVar : buildOptions.get(TestOptions.class).testEnvironment) {
+      switch (envVar) {
+        case Converters.EnvVar.Set(String name, String value) -> testEnv.put(name, value);
+        case Converters.EnvVar.Inherit(String name) -> testEnv.put(name, null);
+        case Converters.EnvVar.Unset(String name) -> testEnv.remove(name);
+      }
     }
     return ActionEnvironment.split(testEnv);
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -466,7 +466,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   // environment to skyframe.
   @Option(
       name = "action_env",
-      converter = Converters.OptionalAssignmentConverter.class,
+      converter = Converters.EnvVarsConverter.class,
       allowMultiple = true,
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
@@ -484,11 +484,11 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
           Note that unless <code>--incompatible_repo_env_ignores_action_env</code> is true, all <code>name=value</code> \
           pairs will be available to repository rules.
           """)
-  public List<Map.Entry<String, String>> actionEnvironment;
+  public List<Converters.EnvVar> actionEnvironment;
 
   @Option(
       name = "host_action_env",
-      converter = Converters.OptionalAssignmentConverter.class,
+      converter = Converters.EnvVarsConverter.class,
       allowMultiple = true,
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
@@ -501,7 +501,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
               + " <code>=name</code>, which unsets the variable of that name. This option can"
               + " be used multiple times; for options given for the same variable, the latest"
               + " wins, options for different variables accumulate.")
-  public List<Map.Entry<String, String>> hostActionEnvironment;
+  public List<Converters.EnvVar> hostActionEnvironment;
 
   @Option(
       name = "collect_code_coverage",
@@ -1099,8 +1099,8 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     // Normalize features.
     result.defaultFeatures = getNormalizedFeatures(defaultFeatures);
 
-    result.actionEnvironment = normalizeEntries(actionEnvironment);
-    result.hostActionEnvironment = normalizeEntries(hostActionEnvironment);
+    result.actionEnvironment = normalizeEnvVars(actionEnvironment);
+    result.hostActionEnvironment = normalizeEnvVars(hostActionEnvironment);
     result.commandLineFlagAliases = sortEntries(normalizeEntries(commandLineFlagAliases));
 
     return result;

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -475,9 +475,10 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
           """
           Specifies the set of environment variables available to actions with target \
           configuration. Variables can be either specified by <code>name</code>, in which case
-          the value will be taken from the invocation environment, or by the \
+          the value will be taken from the invocation environment, by the \
           <code>name=value</code> pair which sets the value independent of the invocation \
-          environment. This option can be used multiple times; for options given for the same \
+          environment, or by <code>=name</code>, which unsets the variable of that name. \
+          This option can be used multiple times; for options given for the same \
           variable, the latest wins, options for different variables accumulate.
           <br>
           Note that unless <code>--incompatible_repo_env_ignores_action_env</code> is true, all <code>name=value</code> \
@@ -495,8 +496,9 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       help =
           "Specifies the set of environment variables available to actions with execution"
               + " configurations. Variables can be either specified by name, in which case the"
-              + " value will be taken from the invocation environment, or by the name=value pair"
-              + " which sets the value independent of the invocation environment. This option can"
+              + " value will be taken from the invocation environment, by the name=value pair"
+              + " which sets the value independent of the invocation environment, or by"
+              + " <code>=name</code>, which unsets the variable of that name. This option can"
               + " be used multiple times; for options given for the same variable, the latest"
               + " wins, options for different variables accumulate.")
   public List<Map.Entry<String, String>> hostActionEnvironment;

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
@@ -100,7 +100,11 @@ public abstract class FragmentOptions extends OptionsBase implements Cloneable {
       List<Map.Entry<String, String>> entries) {
     LinkedHashMap<String, String> normalizedEntries = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : entries) {
-      normalizedEntries.put(entry.getKey(), entry.getValue());
+      if (entry.getKey() == null) {
+        normalizedEntries.remove(entry.getValue());
+      } else {
+        normalizedEntries.put(entry.getKey(), entry.getValue());
+      }
     }
     // If we made no changes, return the same instance we got to reduce churn.
     if (normalizedEntries.size() == entries.size()) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
@@ -101,6 +101,8 @@ public abstract class FragmentOptions extends OptionsBase implements Cloneable {
     LinkedHashMap<String, String> normalizedEntries = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : entries) {
       if (entry.getKey() == null) {
+        // A null key is a special indicator to treat the value as the name of a key to consider
+        // unset.
         normalizedEntries.remove(entry.getValue());
       } else {
         normalizedEntries.put(entry.getKey(), entry.getValue());

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/FragmentOptions.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis.config;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsBase;
@@ -100,13 +101,7 @@ public abstract class FragmentOptions extends OptionsBase implements Cloneable {
       List<Map.Entry<String, String>> entries) {
     LinkedHashMap<String, String> normalizedEntries = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : entries) {
-      if (entry.getKey() == null) {
-        // A null key is a special indicator to treat the value as the name of a key to consider
-        // unset.
-        normalizedEntries.remove(entry.getValue());
-      } else {
-        normalizedEntries.put(entry.getKey(), entry.getValue());
-      }
+      normalizedEntries.put(entry.getKey(), entry.getValue());
     }
     // If we made no changes, return the same instance we got to reduce churn.
     if (normalizedEntries.size() == entries.size()) {
@@ -115,6 +110,22 @@ public abstract class FragmentOptions extends OptionsBase implements Cloneable {
     return normalizedEntries.entrySet().stream()
         .map(AbstractMap.SimpleEntry::new)
         .collect(toImmutableList());
+  }
+
+  /**
+   * Helper method for subclasses to normalize list of {@link Converters.EnvVar}s by keeping only
+   * the last entry for each key. The order of the entries is preserved.
+   */
+  protected static List<Converters.EnvVar> normalizeEnvVars(List<Converters.EnvVar> entries) {
+    LinkedHashMap<String, Converters.EnvVar> normalizedEntries = new LinkedHashMap<>();
+    for (var entry : entries) {
+      normalizedEntries.put(entry.name(), entry);
+    }
+    // If we made no changes, return the same instance we got to reduce churn.
+    if (normalizedEntries.size() == entries.size()) {
+      return entries;
+    }
+    return ImmutableList.copyOf(normalizedEntries.values());
   }
 
   /** Tracks limitations on referring to an option in a {@code config_setting}. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -96,6 +96,7 @@ public class TestConfiguration extends Fragment {
             "Specifies additional environment variables to be injected into the test runner "
                 + "environment. Variables can be either specified by name, in which case its value "
                 + "will be read from the Bazel client environment, or by the name=value pair. "
+                + "Previously set variables can be unset via <code>=name</code>."
                 + "This option can be used multiple times to specify several variables. "
                 + "Used only by the 'bazel test' command.")
     public List<Map.Entry<String, String>> testEnvironment;

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -94,9 +94,10 @@ public class TestConfiguration extends Fragment {
         effectTags = {OptionEffectTag.TEST_RUNNER},
         help =
             "Specifies additional environment variables to be injected into the test runner "
-                + "environment. Variables can be either specified by name, in which case its value "
-                + "will be read from the Bazel client environment, or by the name=value pair. "
-                + "Previously set variables can be unset via <code>=name</code>."
+                + "environment. Variables can be either specified by <code>name</code>, in which "
+                + "case its value will be read from the Bazel client environment, or by the "
+                + "<code>name=value</code> pair. "
+                + "Previously set variables can be unset via <code>=name</code>. "
                 + "This option can be used multiple times to specify several variables. "
                 + "Used only by the 'bazel test' command.")
     public List<Converters.EnvVar> testEnvironment;

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -87,7 +87,7 @@ public class TestConfiguration extends Fragment {
 
     @Option(
         name = "test_env",
-        converter = Converters.OptionalAssignmentConverter.class,
+        converter = Converters.EnvVarsConverter.class,
         allowMultiple = true,
         defaultValue = "null",
         documentationCategory = OptionDocumentationCategory.TESTING,
@@ -99,7 +99,7 @@ public class TestConfiguration extends Fragment {
                 + "Previously set variables can be unset via <code>=name</code>."
                 + "This option can be used multiple times to specify several variables. "
                 + "Used only by the 'bazel test' command.")
-    public List<Map.Entry<String, String>> testEnvironment;
+    public List<Converters.EnvVar> testEnvironment;
 
     @Option(
         name = "test_timeout",
@@ -357,7 +357,7 @@ public class TestConfiguration extends Fragment {
     @Override
     public TestOptions getNormalized() {
       TestOptions result = (TestOptions) clone();
-      result.testEnvironment = normalizeEntries(testEnvironment);
+      result.testEnvironment = normalizeEnvVars(testEnvironment);
       return result;
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -177,7 +177,11 @@ public class BazelRuleClassProvider {
         // ones inherited from the fragments. In the long run, these fragments will
         // be replaced by appropriate default rc files anyway.
         for (Map.Entry<String, String> entry : options.get(CoreOptions.class).actionEnvironment) {
-          env.put(entry.getKey(), entry.getValue());
+          if (entry.getKey() != null) {
+            env.put(entry.getKey(), entry.getValue());
+          } else {
+            env.remove(entry.getValue());
+          }
         }
 
         if (!BuildConfigurationValue.runfilesEnabled(options.get(CoreOptions.class))) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -177,10 +177,12 @@ public class BazelRuleClassProvider {
         // ones inherited from the fragments. In the long run, these fragments will
         // be replaced by appropriate default rc files anyway.
         for (Map.Entry<String, String> entry : options.get(CoreOptions.class).actionEnvironment) {
-          if (entry.getKey() != null) {
-            env.put(entry.getKey(), entry.getValue());
-          } else {
+          if (entry.getKey() == null) {
+            // A null key is a special indicator to treat the value as the name of a variable to unset,
+            // see the docs on --action_env for details.
             env.remove(entry.getValue());
+          } else {
+            env.put(entry.getKey(), entry.getValue());
           }
         }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.starlarkbuildapi.core.ContextGuardedValue;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.ResourceFileLoader;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -176,13 +177,11 @@ public class BazelRuleClassProvider {
         // Shell environment variables specified via options take precedence over the
         // ones inherited from the fragments. In the long run, these fragments will
         // be replaced by appropriate default rc files anyway.
-        for (Map.Entry<String, String> entry : options.get(CoreOptions.class).actionEnvironment) {
-          if (entry.getKey() == null) {
-            // A null key is a special indicator to treat the value as the name of a variable to unset,
-            // see the docs on --action_env for details.
-            env.remove(entry.getValue());
-          } else {
-            env.put(entry.getKey(), entry.getValue());
+        for (var envVar : options.get(CoreOptions.class).actionEnvironment) {
+          switch (envVar) {
+            case Converters.EnvVar.Set(String name, String value) -> env.put(name, value);
+            case Converters.EnvVar.Inherit(String name) -> env.put(name, null);
+            case Converters.EnvVar.Unset(String name) -> env.remove(name);
           }
         }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -344,6 +344,8 @@ public class CommandEnvironment {
         if (entry.getValue() == null) {
           visibleActionEnv.add(entry.getKey());
         } else if (entry.getKey() == null) {
+          // A null key is a special indicator to treat the value as the name of a variable to
+          // unset, see the docs on --action_env for details.
           visibleActionEnv.remove(entry.getValue());
           if (!options.getOptions(CommonCommandOptions.class).repoEnvIgnoresActionEnv) {
             repoEnv.remove(entry.getValue());
@@ -369,6 +371,8 @@ public class CommandEnvironment {
       String name = entry.getKey();
       String value = entry.getValue();
       if (name == null) {
+        // A null key is a special indicator to treat the value as the name of a variable to
+        // unset, see the docs on --repo_env for details.
         repoEnv.remove(value);
         repoEnvFromOptions.remove(value);
         continue;

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -343,6 +343,11 @@ public class CommandEnvironment {
           options.getOptions(CoreOptions.class).actionEnvironment) {
         if (entry.getValue() == null) {
           visibleActionEnv.add(entry.getKey());
+        } else if (entry.getKey() == null) {
+          visibleActionEnv.remove(entry.getValue());
+          if (!options.getOptions(CommonCommandOptions.class).repoEnvIgnoresActionEnv) {
+            repoEnv.remove(entry.getValue());
+          }
         } else {
           visibleActionEnv.remove(entry.getKey());
           if (!options.getOptions(CommonCommandOptions.class).repoEnvIgnoresActionEnv) {
@@ -363,6 +368,11 @@ public class CommandEnvironment {
     for (Map.Entry<String, String> entry : commandOptions.repositoryEnvironment) {
       String name = entry.getKey();
       String value = entry.getValue();
+      if (name == null) {
+        repoEnv.remove(value);
+        repoEnvFromOptions.remove(value);
+        continue;
+      }
       if (value == null) {
         value = clientEnv.get(name);
       }

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -570,7 +570,7 @@ public class CommonCommandOptions extends OptionsBase {
 
   @Option(
       name = "repo_env",
-      converter = Converters.OptionalAssignmentConverter.class,
+      converter = Converters.EnvVarsConverter.class,
       allowMultiple = true,
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
@@ -582,7 +582,7 @@ public class CommonCommandOptions extends OptionsBase {
           variables can be set via command-line flags and <code>.bazelrc</code> entries. \
           The special syntax <code>=NAME</code> can be used to explicitly unset a variable.
           """)
-  public List<Map.Entry<String, String>> repositoryEnvironment;
+  public List<Converters.EnvVar> repositoryEnvironment;
 
   @Option(
       name = "incompatible_repo_env_ignores_action_env",

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -579,8 +579,8 @@ public class CommonCommandOptions extends OptionsBase {
           """
           Specifies additional environment variables to be available only for repository rules. \
           Note that repository rules see the full environment anyway, but in this way \
-          configuration information can be passed to repositories through options without \
-          invalidating the action graph.
+          variables can be set via command-line flags and <code>.bazelrc</code> entries. \
+          The special syntax <code>=NAME</code> can be used to explicitly unset a variable.
           """)
   public List<Map.Entry<String, String>> repositoryEnvironment;
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -664,6 +664,11 @@ public class RunCommand implements BlazeCommand {
               environmentProvider.getEnvironment(),
               ImmutableSet.copyOf(environmentProvider.getInheritedEnvironment()));
     }
+    // The final run environment is a combination of the environment constructed here and the
+    // unrestricted client environment. This means that there is a difference between a variable
+    // that isn't included in runEnvironment (which will have its value inherited from the
+    // client environment) and a variable that is explicitly removed (which will be unset in the
+    // run environment). We thus track the environment variables to clear separately.
     TreeMap<String, String> runEnvironment = makeMutableRunEnvironment(env);
     HashSet<String> envVariablesToClear = new HashSet<>();
     ImmutableMap<String, String> clientEnv = env.getClientEnv();
@@ -681,6 +686,8 @@ public class RunCommand implements BlazeCommand {
         }
         envVariablesToClear.remove(key);
       } else if (key == null) {
+        // A null key is a special indicator to treat the value as the name of a variable to unset,
+        // see the docs on --repo_env for details.
         runEnvironment.remove(value);
         envVariablesToClear.add(value);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -176,7 +176,7 @@ public class RunCommand implements BlazeCommand {
         help =
             "Specifies the set of environment variables available to the target to run."
                 + " Variables can be either specified by name, in which case the value will be"
-                + " taken from the invocation environment, by the name=value pair"
+                + " taken from the invocation environment, by the <code>name=value</code> pair"
                 + " which sets the value independent of the invocation environment, or by"
                 + " <code>=name</code>, which unsets the variable of that name. This option can"
                 + " be used multiple times; for options given for the same variable, the latest"

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommandLine.java
@@ -43,6 +43,7 @@ class RunCommandLine {
   @Nullable private final String prettyRunUnderPrefix;
 
   private final ImmutableSortedMap<String, String> runEnvironment;
+  private final ImmutableSortedSet<String> environmentVariablesToClear;
   private final Path workingDir;
 
   private final boolean isTestTarget;
@@ -54,6 +55,7 @@ class RunCommandLine {
       @Nullable String runUnderPrefix,
       @Nullable String prettyRunUnderPrefix,
       ImmutableSortedMap<String, String> runEnvironment,
+      ImmutableSortedSet<String> environmentVariablesToClear,
       Path workingDir,
       boolean isTestTarget) {
     this.args = args;
@@ -62,6 +64,7 @@ class RunCommandLine {
     this.runUnderPrefix = runUnderPrefix;
     this.prettyRunUnderPrefix = prettyRunUnderPrefix;
     this.runEnvironment = runEnvironment;
+    this.environmentVariablesToClear = environmentVariablesToClear;
     this.workingDir = workingDir;
     this.isTestTarget = isTestTarget;
   }
@@ -72,6 +75,10 @@ class RunCommandLine {
 
   ImmutableSortedMap<String, String> getEnvironment() {
     return runEnvironment;
+  }
+
+  ImmutableSortedSet<String> getEnvironmentVariablesToClear() {
+    return environmentVariablesToClear;
   }
 
   boolean isTestTarget() {
@@ -127,12 +134,12 @@ class RunCommandLine {
    * Returns the script form of the command, to be used as the contents of output file in
    * --script_path mode.
    */
-  String getScriptForm(String shExecutable, ImmutableSortedSet<String> environmentVarsToUnset) {
+  String getScriptForm(String shExecutable) {
     return formatter()
         .getScriptForm(
             shExecutable,
             workingDir.getPathString(),
-            environmentVarsToUnset,
+            environmentVariablesToClear,
             runEnvironment,
             runUnderPrefix,
             ImmutableList.<String>builder().addAll(args).addAll(residue).build());
@@ -312,6 +319,7 @@ class RunCommandLine {
 
   static class Builder {
     private final ImmutableSortedMap<String, String> runEnvironment;
+    private final ImmutableSortedSet<String> environmentVariablesToClear;
     private final Path workingDir;
     private final boolean isTestTarget;
 
@@ -323,8 +331,12 @@ class RunCommandLine {
     private final ImmutableList.Builder<String> residueArgs = ImmutableList.builder();
 
     Builder(
-        ImmutableSortedMap<String, String> runEnvironment, Path workingDir, boolean isTestTarget) {
+        ImmutableSortedMap<String, String> runEnvironment,
+        ImmutableSortedSet<String> environmentVariablesToClear,
+        Path workingDir,
+        boolean isTestTarget) {
       this.runEnvironment = runEnvironment;
+      this.environmentVariablesToClear = environmentVariablesToClear;
       this.workingDir = workingDir;
       this.isTestTarget = isTestTarget;
     }
@@ -396,6 +408,7 @@ class RunCommandLine {
           runUnderPrefix,
           prettyRunUnderPrefix,
           runEnvironment,
+          environmentVariablesToClear,
           workingDir,
           isTestTarget);
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -2947,7 +2947,11 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     LinkedHashMap<String, String> actionEnvironment = new LinkedHashMap<>();
     if (opt != null) {
       for (Map.Entry<String, String> v : opt.actionEnvironment) {
-        actionEnvironment.put(v.getKey(), v.getValue());
+        if (v.getKey() != null) {
+          actionEnvironment.put(v.getKey(), v.getValue());
+        } else {
+          actionEnvironment.remove(v.getValue());
+        }
       }
     }
     setActionEnv(actionEnvironment);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -2947,10 +2947,12 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     LinkedHashMap<String, String> actionEnvironment = new LinkedHashMap<>();
     if (opt != null) {
       for (Map.Entry<String, String> v : opt.actionEnvironment) {
-        if (v.getKey() != null) {
-          actionEnvironment.put(v.getKey(), v.getValue());
-        } else {
+        if (v.getKey() == null) {
+          // A null key is a special indicator to treat the value as the name of a variable to
+          // unset, see the docs on --action_env for details.
           actionEnvironment.remove(v.getValue());
+        } else {
+          actionEnvironment.put(v.getKey(), v.getValue());
         }
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
@@ -64,6 +64,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_load_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe:configured_target_and_data",
+        "//src/main/java/com/google/devtools/common/options:options_internal",
         "//src/main/java/net/starlark/java/eval",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/packages:testutil",

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrTransitionProviderTest.java
@@ -50,6 +50,7 @@ import com.google.devtools.build.lib.rules.cpp.CppOptions;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
 import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
+import com.google.devtools.common.options.Converters;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -3566,27 +3567,27 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
         """);
     update(
         ImmutableList.of("//test/starlark:c"),
-        /*keepGoing=*/ false,
+        /* keepGoing= */ false,
         LOADING_PHASE_THREADS,
-        /*doAnalysis=*/ true,
+        /* doAnalysis= */ true,
         new EventBus());
     assertNoEvents();
   }
 
   @Test
-  public void allowMultipleNativeOptionWithOptionalAssignmentConverter() throws Exception {
+  public void allowMultipleNativeOptionWithEnvVarConverter() throws Exception {
     // Added to support --action_env and --host_action_env.
     scratch.file(
         "test/rules.bzl",
         "def _t_impl(settings, attr):",
         "    return {",
-        "        '//command_line_option:allow_multiple_with_optional_assignment_converter':",
+        "        '//command_line_option:allow_multiple_with_env_vars_converter':",
         "        ['a=1', 'b=2', 'c'] }",
         "t = transition(",
         "    implementation = _t_impl,",
         "    inputs = [],",
         "    outputs ="
-            + " ['//command_line_option:allow_multiple_with_optional_assignment_converter'],",
+            + " ['//command_line_option:allow_multiple_with_env_vars_converter'],",
         ")",
         "r = rule(",
         "    implementation = lambda ctx: [],",
@@ -3613,13 +3614,16 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
                 .getConfigurationKey()
                 .getOptions()
                 .get(DummyTestOptions.class)
-                .allowMultipleWithOptionalAssignmentConverter)
-        .containsExactly(Map.entry("a", "1"), Map.entry("b", "2"), Maps.immutableEntry("c", null));
+                .allowMultipleWithEnvVarsConverter)
+        .containsExactly(
+            new Converters.EnvVar.Set("a", "1"),
+            new Converters.EnvVar.Set("b", "2"),
+            new Converters.EnvVar.Inherit("c"));
     assertNoEvents();
   }
 
   @Test
-  public void allowMultipleNativeOptionWithOptionalAssignmentPassTopLevel() throws Exception {
+  public void allowMultipleNativeOptionWithEnvVarPassTopLevel() throws Exception {
     // Check that Starlark transitions faithfully propagate inputs from the top-level command line.
     // In other words String -> Java type -> Starlark type -> Java type stays consistent.
     //
@@ -3628,15 +3632,15 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
         "test/rules.bzl",
         "def _t_impl(settings, attr):",
         "    return {",
-        "        '//command_line_option:allow_multiple_with_optional_assignment_converter':",
+        "        '//command_line_option:allow_multiple_with_env_vars_converter':",
         "       "
-            + " settings['//command_line_option:allow_multiple_with_optional_assignment_converter']",
+            + " settings['//command_line_option:allow_multiple_with_env_vars_converter']",
         "    }",
         "t = transition(",
         "    implementation = _t_impl,",
-        "    inputs = ['//command_line_option:allow_multiple_with_optional_assignment_converter'],",
+        "    inputs = ['//command_line_option:allow_multiple_with_env_vars_converter'],",
         "    outputs ="
-            + " ['//command_line_option:allow_multiple_with_optional_assignment_converter'],",
+            + " ['//command_line_option:allow_multiple_with_env_vars_converter'],",
         ")",
         "r = rule(",
         "    implementation = lambda ctx: [],",
@@ -3658,10 +3662,10 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
         """);
 
     useConfiguration(
-        "--allow_multiple_with_optional_assignment_converter=a=1",
-        "--allow_multiple_with_optional_assignment_converter=b=2",
-        "--allow_multiple_with_optional_assignment_converter=a=2",
-        "--allow_multiple_with_optional_assignment_converter=c");
+        "--allow_multiple_with_env_vars_converter=a=1",
+        "--allow_multiple_with_env_vars_converter=b=2",
+        "--allow_multiple_with_env_vars_converter=a=2",
+        "--allow_multiple_with_env_vars_converter=c");
     ConfiguredTarget parentCt = getConfiguredTarget("//test:c");
     ConfiguredTarget depCt = getDirectPrerequisite(parentCt, "//test:dep");
 
@@ -3670,13 +3674,13 @@ public final class StarlarkAttrTransitionProviderTest extends BuildViewTestCase 
                 .getConfigurationKey()
                 .getOptions()
                 .get(DummyTestOptions.class)
-                .allowMultipleWithOptionalAssignmentConverter)
+                .allowMultipleWithEnvVarsConverter)
         .isEqualTo(
             depCt
                 .getConfigurationKey()
                 .getOptions()
                 .get(DummyTestOptions.class)
-                .allowMultipleWithOptionalAssignmentConverter);
+                .allowMultipleWithEnvVarsConverter);
     assertNoEvents();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/DummyTestFragment.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/DummyTestFragment.java
@@ -23,15 +23,15 @@ import com.google.devtools.build.lib.analysis.config.RequiresOptions;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.common.options.Converter;
+import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Converters.CommaSeparatedOptionListConverter;
-import com.google.devtools.common.options.Converters.OptionalAssignmentConverter;
+import com.google.devtools.common.options.Converters.EnvVarsConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Expose a set of options that can be added to {@link BuildViewTestCase} and friends in order to
@@ -111,14 +111,14 @@ public final class DummyTestFragment extends Fragment {
     public UnreadableStringBox unreadableByStarlark;
 
     @Option(
-        name = "allow_multiple_with_optional_assignment_converter",
+        name = "allow_multiple_with_env_vars_converter",
         defaultValue = "null",
         allowMultiple = true,
-        converter = OptionalAssignmentConverter.class,
+        converter = EnvVarsConverter.class,
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.NO_OP},
-        help = "allowMultiple flag with OptionalAssignmentConverter")
-    public List<Map.Entry<String, String>> allowMultipleWithOptionalAssignmentConverter;
+        help = "allowMultiple flag with EnvVarsConverter")
+    public List<Converters.EnvVar> allowMultipleWithEnvVarsConverter;
 
     @Option(
         name = "allow_multiple_with_list_converter",

--- a/src/test/java/com/google/devtools/common/options/AssignmentConverterTest.java
+++ b/src/test/java/com/google/devtools/common/options/AssignmentConverterTest.java
@@ -18,51 +18,32 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.Maps;
+import com.google.devtools.common.options.Converters.EnvVar;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Test for {@link Converters.AssignmentConverter} and {@link
- * Converters.OptionalAssignmentConverter}.
- */
-public abstract class AssignmentConverterTest {
+/** Test for {@link Converters.AssignmentConverter} and {@link Converters.EnvVarsConverter}. */
+public abstract class AssignmentConverterTest<T> {
 
-  protected Converter.Contextless<Map.Entry<String, String>> converter = null;
+  protected Converter.Contextless<T> converter = null;
 
   protected abstract void setConverter();
 
-  protected Map.Entry<String, String> convert(String input) throws Exception {
+  protected T convert(String input) throws Exception {
     return converter.convert(input);
   }
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     setConverter();
   }
 
-  @Test
-  public void assignment() throws Exception {
-    assertThat(convert("A=1")).isEqualTo(Maps.immutableEntry("A", "1"));
-    assertThat(convert("A=ABC")).isEqualTo(Maps.immutableEntry("A", "ABC"));
-    assertThat(convert("A=")).isEqualTo(Maps.immutableEntry("A", ""));
-    assertThat(convert("A=B,C=D")).isEqualTo(Maps.immutableEntry("A", "B,C=D"));
-  }
-
-  @Test
-  public void emptyString() throws Exception {
-    assertThrows(OptionsParsingException.class, () -> convert(""));
-  }
-
-  @Test
-  public void immutability() {
-    assertThrows(UnsupportedOperationException.class, () -> convert("A=B").setValue("C"));
-  }
-
   @RunWith(JUnit4.class)
-  public static class MandatoryAssignmentConverterTest extends AssignmentConverterTest {
+  public static class MandatoryAssignmentConverterTest
+      extends AssignmentConverterTest<Map.Entry<String, String>> {
 
     @Override
     protected void setConverter() {
@@ -70,32 +51,58 @@ public abstract class AssignmentConverterTest {
     }
 
     @Test
-    public void missingName() throws Exception {
+    public void assignment() throws Exception {
+      assertThat(convert("A=1")).isEqualTo(Maps.immutableEntry("A", "1"));
+      assertThat(convert("A=ABC")).isEqualTo(Maps.immutableEntry("A", "ABC"));
+      assertThat(convert("A=")).isEqualTo(Maps.immutableEntry("A", ""));
+      assertThat(convert("A=B,C=D")).isEqualTo(Maps.immutableEntry("A", "B,C=D"));
+    }
+
+    @Test
+    public void missingName() {
       assertThrows(OptionsParsingException.class, () -> convert("=VALUE"));
     }
 
     @Test
-    public void missingValue() throws Exception {
+    public void missingValue() {
       assertThrows(OptionsParsingException.class, () -> convert("NAME"));
+    }
+
+    @Test
+    public void immutability() {
+      assertThrows(UnsupportedOperationException.class, () -> convert("A=B").setValue("C"));
+    }
+
+    @Test
+    public void emptyString() {
+      assertThrows(OptionsParsingException.class, () -> convert(""));
     }
   }
 
   @RunWith(JUnit4.class)
-  public static class OptionalAssignmentConverterTest extends AssignmentConverterTest {
+  public static class EnvVarsConverterTest extends AssignmentConverterTest<EnvVar> {
 
     @Override
     protected void setConverter() {
-      converter = new Converters.OptionalAssignmentConverter();
+      converter = new Converters.EnvVarsConverter();
+    }
+
+    @Test
+    public void assignment() throws Exception {
+      assertThat(convert("A=1")).isEqualTo(new EnvVar.Set("A", "1"));
+      assertThat(convert("A=ABC")).isEqualTo(new EnvVar.Set("A", "ABC"));
+      assertThat(convert("A=")).isEqualTo(new EnvVar.Set("A", ""));
+      assertThat(convert("A=B,C=D")).isEqualTo(new EnvVar.Set("A", "B,C=D"));
     }
 
     @Test
     public void missingName() throws Exception {
-      assertThat(convert("=VALUE")).isEqualTo(Maps.immutableEntry(null, "VALUE"));
+      assertThat(convert("=NAME")).isEqualTo(new EnvVar.Unset("NAME"));
     }
 
     @Test
     public void missingValue() throws Exception {
-      assertThat(convert("NAME")).isEqualTo(Maps.immutableEntry("NAME", null));
+      assertThat(convert("NAME")).isEqualTo(new EnvVar.Inherit("NAME"));
     }
 
     @Test

--- a/src/test/java/com/google/devtools/common/options/AssignmentConverterTest.java
+++ b/src/test/java/com/google/devtools/common/options/AssignmentConverterTest.java
@@ -52,11 +52,6 @@ public abstract class AssignmentConverterTest {
   }
 
   @Test
-  public void missingName() throws Exception {
-    assertThrows(OptionsParsingException.class, () -> convert("=VALUE"));
-  }
-
-  @Test
   public void emptyString() throws Exception {
     assertThrows(OptionsParsingException.class, () -> convert(""));
   }
@@ -75,6 +70,11 @@ public abstract class AssignmentConverterTest {
     }
 
     @Test
+    public void missingName() throws Exception {
+      assertThrows(OptionsParsingException.class, () -> convert("=VALUE"));
+    }
+
+    @Test
     public void missingValue() throws Exception {
       assertThrows(OptionsParsingException.class, () -> convert("NAME"));
     }
@@ -89,6 +89,11 @@ public abstract class AssignmentConverterTest {
     }
 
     @Test
+    public void missingName() throws Exception {
+      assertThat(convert("=VALUE")).isEqualTo(Maps.immutableEntry(null, "VALUE"));
+    }
+
+    @Test
     public void missingValue() throws Exception {
       assertThat(convert("NAME")).isEqualTo(Maps.immutableEntry("NAME", null));
     }
@@ -97,6 +102,7 @@ public abstract class AssignmentConverterTest {
     public void reverseConversionForStarlark() throws Exception {
       assertThat(converter.reverseForStarlark(converter.convert("a"))).isEqualTo("a");
       assertThat(converter.reverseForStarlark(converter.convert("a=1"))).isEqualTo("a=1");
+      assertThat(converter.reverseForStarlark(converter.convert("=a"))).isEqualTo("=a");
     }
   }
 }

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -535,5 +535,70 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     self.assertIn('FOO bar', os.linesep.join(stderr))
     self.assertNotIn('null value in entry: FOO=null', os.linesep.join(stderr))
 
+  def testRepoEnvUnset(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'dump_env = use_repo_rule("//:main.bzl", "dump_env")',
+            'dump_env(',
+            '    name = "debug"',
+            ')',
+        ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile('main.bzl', [
+        'def _dump_env(ctx):',
+        '    val = ctx.os.environ.get("FOO", "nothing")',
+        '    print("FOO", val)',
+        '    ctx.file("BUILD")',
+        'dump_env = repository_rule(',
+        '    implementation = _dump_env,',
+        '    local = True,',
+        ')',
+    ])
+
+    _, _, stderr = self.RunBazel(
+        args=[
+            'build', '@debug//:all',
+            '--repo_env=FOO=bar1',
+            '--repo_env==FOO'
+        ],
+        env_add={'FOO': 'bar'}
+    )
+    self.assertIn('FOO nothing', os.linesep.join(stderr))
+
+  def testRepoEnvUnsetThenSet(self):
+      self.ScratchFile(
+          'MODULE.bazel',
+          [
+              'dump_env = use_repo_rule("//:main.bzl", "dump_env")',
+              'dump_env(',
+              '    name = "debug"',
+              ')',
+          ],
+      )
+      self.ScratchFile('BUILD')
+      self.ScratchFile('main.bzl', [
+          'def _dump_env(ctx):',
+          '    val = ctx.os.environ.get("FOO", "nothing")',
+          '    print("FOO", val)',
+          '    ctx.file("BUILD")',
+          'dump_env = repository_rule(',
+          '    implementation = _dump_env,',
+          '    local = True,',
+          ')',
+      ])
+
+      _, _, stderr = self.RunBazel(
+          args=[
+              'build', '@debug//:all',
+              '--repo_env=FOO=bar1',
+              '--repo_env==FOO',
+              '--repo_env=FOO=bar2'
+          ],
+          env_add={'FOO': 'bar'},
+      )
+      self.assertIn('FOO bar2', os.linesep.join(stderr))
+
 if __name__ == '__main__':
   absltest.main()

--- a/src/test/shell/integration/action_env_test.sh
+++ b/src/test/shell/integration/action_env_test.sh
@@ -124,6 +124,31 @@ function test_simple_latest_wins() {
   expect_log "BAR=bar"
 }
 
+function test_simple_latest_wins_removed() {
+  export FOO=environmentfoo
+  export BAR=environmentbar
+  bazel build --action_env=FOO=foo \
+      --action_env=BAR=willbeoverridden --action_env==BAR pkg:showenv \
+      || fail "${PRODUCT_NAME} build showenv failed"
+
+  cat `bazel info ${PRODUCT_NAME}-genfiles`/pkg/env.txt > $TEST_log
+  expect_log "FOO=foo"
+  expect_not_log "BAR"
+}
+
+function test_simple_latest_wins_removed_then_added() {
+  export FOO=environmentfoo
+  export BAR=environmentbar
+  bazel build --action_env=FOO=foo \
+      --action_env=BAR=willbeoverridden --action_env==BAR \
+      --action_env=BAR=override pkg:showenv \
+      || fail "${PRODUCT_NAME} build showenv failed"
+
+  cat `bazel info ${PRODUCT_NAME}-genfiles`/pkg/env.txt > $TEST_log
+  expect_log "FOO=foo"
+  expect_log "BAR=override"
+}
+
 function test_client_env() {
   export FOO=startup_foo
   bazel clean --expunge

--- a/src/test/shell/integration/action_env_test.sh
+++ b/src/test/shell/integration/action_env_test.sh
@@ -161,6 +161,18 @@ function test_client_env() {
   expect_log "FOO=client_foo"
 }
 
+function test_empty() {
+  export FOO=startup_foo
+  bazel clean --expunge
+  bazel help build > /dev/null || fail "${PRODUCT_NAME} help failed"
+  export FOO=client_foo
+  bazel build --action_env=FOO= pkg:showenv || \
+    fail "${PRODUCT_NAME} build showenv failed"
+
+  cat `bazel info ${PRODUCT_NAME}-genfiles`/pkg/env.txt > $TEST_log
+  expect_log "FOO=$"
+}
+
 function test_redo_action() {
   export FOO=initial_foo
   export UNRELATED=some_value

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -840,15 +840,21 @@ echo "OVERRIDDEN_RUN_ENV: '$OVERRIDDEN_RUN_ENV'"
 echo "RUN_ENV_ONLY: '$RUN_ENV_ONLY'"
 echo "EMPTY_RUN_ENV: '$EMPTY_RUN_ENV'"
 echo "INHERITED_RUN_ENV: '$INHERITED_RUN_ENV'"
+echo "REMOVED_RUN_ENV: '${REMOVED_RUN_ENV:=<unset>}'"
+echo "SET_UNSET_SET: '$SET_UNSET_SET'"
 EOF
 
   chmod +x "$pkg/foo.sh"
 
-  INHERITED_RUN_ENV=BAZ bazel run \
+  INHERITED_RUN_ENV=BAZ REMOVED_RUN_ENV=QUZ bazel run \
       --run_env=OVERRIDDEN_RUN_ENV=FOO \
       --run_env=RUN_ENV_ONLY=BAR \
       --run_env=EMPTY_RUN_ENV= \
       --run_env=INHERITED_RUN_ENV \
+      --run_env==REMOVED_RUN_ENV \
+      --run_env=SET_UNSET_SET=set1 \
+      --run_env==SET_UNSET_SET \
+      --run_env=SET_UNSET_SET=set2 \
       "//$pkg:foo" >"$TEST_log" || fail "expected run to succeed"
 
   expect_log "FROMBUILD: '1'"
@@ -856,6 +862,111 @@ EOF
   expect_log "RUN_ENV_ONLY: 'BAR'"
   expect_log "EMPTY_RUN_ENV: ''"
   expect_log "INHERITED_RUN_ENV: 'BAZ'"
+  expect_log "REMOVED_RUN_ENV: '<unset>'"
+  expect_log "SET_UNSET_SET: 'set2'"
+}
+
+function test_test_env() {
+  add_rules_shell "MODULE.bazel"
+  local -r pkg="pkg${LINENO}"
+  mkdir -p "${pkg}"
+  cat > "$pkg/BUILD" <<'EOF'
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+sh_test(
+  name = "foo",
+  srcs = ["foo.sh"],
+  env = {
+    "FROMBUILD": "1",
+    "OVERRIDDEN_RUN_ENV": "2",
+  }
+)
+EOF
+  cat > "$pkg/foo.sh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "FROMBUILD: '$FROMBUILD'"
+echo "OVERRIDDEN_TEST_ENV: '$OVERRIDDEN_TEST_ENV'"
+echo "TEST_ENV_ONLY: '$TEST_ENV_ONLY'"
+echo "EMPTY_TEST_ENV: '$EMPTY_TEST_ENV'"
+echo "INHERITED_TEST_ENV: '$INHERITED_TEST_ENV'"
+echo "REMOVED_TEST_ENV: '${REMOVED_TEST_ENV:=<unset>}'"
+echo "SET_UNSET_SET: '$SET_UNSET_SET'"
+EOF
+
+  chmod +x "$pkg/foo.sh"
+
+  INHERITED_TEST_ENV=BAZ REMOVED_TEST_ENV=QUZ bazel run \
+      --test_env=OVERRIDDEN_TEST_ENV=FOO \
+      --test_env=TEST_ENV_ONLY=BAR \
+      --test_env=EMPTY_TEST_ENV= \
+      --test_env=INHERITED_TEST_ENV \
+      --test_env==REMOVED_TEST_ENV \
+      --test_env=SET_UNSET_SET=set1 \
+      --test_env==SET_UNSET_SET \
+      --test_env=SET_UNSET_SET=set2 \
+      "//$pkg:foo" >"$TEST_log" || fail "expected run to succeed"
+
+  expect_log "FROMBUILD: '1'"
+  expect_log "OVERRIDDEN_TEST_ENV: 'FOO'"
+  expect_log "TEST_ENV_ONLY: 'BAR'"
+  expect_log "EMPTY_TEST_ENV: ''"
+  expect_log "INHERITED_TEST_ENV: 'BAZ'"
+  # --test_env==NAME is specified to only remove previous --test_env uses for
+  # NAME, it doesn't remove the NAME from the environment when running the test
+  # non-hermetically via bazel run.
+  expect_log "REMOVED_TEST_ENV: 'QUZ'"
+  expect_log "SET_UNSET_SET: 'set2'"
+}
+
+# Test that --run_env does not apply when running a test. Note that this may or
+# may not be desired, but it is the current behavior.
+function test_run_and_test_env() {
+  add_rules_shell "MODULE.bazel"
+  local -r pkg="pkg${LINENO}"
+  mkdir -p "${pkg}"
+  cat > "$pkg/BUILD" <<'EOF'
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+sh_test(
+  name = "foo",
+  srcs = ["foo.sh"],
+)
+EOF
+  cat > "$pkg/foo.sh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "INHERITED_TEST_ENV: '$INHERITED_TEST_ENV'"
+echo "INHERITED_RUN_ENV: '$INHERITED_RUN_ENV'"
+echo "FIXED_TEST_AND_RUN_ENV: '$FIXED_TEST_AND_RUN_ENV'"
+echo "FIXED_TEST_ENV: '$FIXED_TEST_ENV'"
+echo "FIXED_RUN_ENV: '${FIXED_RUN_ENV:=<unset>}'"
+EOF
+
+  chmod +x "$pkg/foo.sh"
+
+  INHERITED_TEST_ENV=inherited INHERITED_RUN_ENV=inherited bazel run \
+      --test_env=INHERITED_TEST_ENV \
+      --run_env=INHERITED_TEST_ENV=run \
+      --run_env=INHERITED_RUN_ENV \
+      --test_env=INHERITED_RUN_ENV=test \
+      --test_env=FIXED_TEST_AND_RUN_ENV=test \
+      --run_env=FIXED_TEST_AND_RUN_ENV=run \
+      --test_env=FIXED_TEST_ENV=test \
+      --run_env==FIXED_TEST_ENV \
+      --run_env=FIXED_RUN_ENV=run \
+      --test_env==FIXED_RUN_ENV \
+      "//$pkg:foo" >"$TEST_log" || fail "expected run to succeed"
+
+  expect_log "INHERITED_TEST_ENV: 'inherited'"
+  expect_log "INHERITED_RUN_ENV: 'test'"
+  expect_log "FIXED_TEST_AND_RUN_ENV: 'test'"
+  expect_log "FIXED_TEST_ENV: 'test'"
+  expect_log "FIXED_RUN_ENV: '<unset>'"
 }
 
 function test_run_env_script_path() {


### PR DESCRIPTION
The special syntax `--action_env==NAME` (or `--action_env =NAME`) can be used to unset the variable `NAME` (also for all the other `--*_env` flags). For the hermetic environments (`--action_env`, `--host_action_env` and `--test_env`), this clears any previous occurrences of `--action_env=NAME=VALUE` and `--action_env=NAME`. For the non-hermetic environments (`--repo_env`, `--run_env`), it additionally ensures that the given variable is explicitly unset in the final environment.

The particular syntax is somewhat quirky, but it is backwards compatible and doesn't limit the possible space of env variable names and values (as, say, `--action_env=-NAME` would).

This has a number of applications:
1. It makes it possible to unset variables that Bazel adds to the action environment by default, such as `LD_LIBRARY_PATH` and/or `PATH`. This is the primary motivation for this change as the author plans to add `LC_CTYPE=C.UTF-8` in the future, which would result in Bazel actions supporting Unicode by default. Without the ability to remove this variable, users would be bound to have an `LC_CTYPE` variable set in all actions using `use_default_shell_env` (unless they use a Bazel wrapper that forces the variable to be unset and also specify `--action_env=LC_CTYPE`).
2. For the non-hermetic environments, it allows users to ensure that particularly problematic env vars don't make it into the environment. A hardcoded list of such variables was added to the `run` environment in bc83389808d5a970a56fb826e86d0efe56b65d2b, but with the new syntax, users have full flexibility and can apply the same type of "cleaning" to repo rule environments. This provides an onramp for a future in which `--repo_env` and/or `--run_env` could become hermetic.
3. It improves consistency by allowing clean `--config`s inheritance as well as appending to command-line invocations - previously, there was no way to fully undo the effect of an `--action_env=FOO=bar`.

Point 3 also explains why this change doesn't introduce dedicated `--unset_*_env` flags: they would introduce unpleasant confusion around precedence (what does `--action_env=FOO=bar --unset_action_env=FOO --action_env=FOO=bar` mean?) and/or introduce new flags that accumulate repeated uses with no way of resetting any particular ones.

RELNOTES[NEW]: The new `--*_env==NAME` syntax can be used with any of `--action_env`, `--host_action_env`, `--repo_env`, `--run_env`, and `--test_env` to undo any previous occurrences of the respective flags for that environment variable name. For `--repo_env` and `--run_env`, this also results in the variable being unset if it is set in the environment of the Bazel client.