### PR TITLE
feat: add support for `.whl` file extension in `repository_ctx.download_and_extract`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
@@ -96,7 +96,8 @@ public class DecompressorValue implements SkyValue {
         || baseName.endsWith(".jar")
         || baseName.endsWith(".war")
         || baseName.endsWith(".aar")
-        || baseName.endsWith(".nupkg")) {
+        || baseName.endsWith(".nupkg")
+        || baseName.endsWith(".whl")) {
       return ZipDecompressor.INSTANCE;
     } else if (baseName.endsWith(".tar")) {
       return TarFunction.INSTANCE;
@@ -113,7 +114,7 @@ public class DecompressorValue implements SkyValue {
     } else {
       throw new RepositoryFunctionException(
           Starlark.errorf(
-              "Expected a file with a .zip, .jar, .war, .aar, .nupkg, .tar, .tar.gz, .tgz, .tar.xz,"
+              "Expected a file with a .zip, .jar, .war, .aar, .nupkg, .whl, .tar, .tar.gz, .tgz, .tar.xz,"
                   + " , .tar.zst, .tzst, .tar.bz2, .tbz, .ar or .deb suffix (got %s)",
               archivePath),
           Transience.PERSISTENT);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -908,7 +908,7 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
                 The archive type of the downloaded file. By default, the archive type is \
                 determined from the file extension of the URL. If the file has no \
                 extension, you can explicitly specify either "zip", "jar", "war", \
-                "aar", "nupkg", "tar", "tar.gz", "tgz", "tar.xz", "txz", ".tar.zst", \
+                "aar", "nupkg", "whl", "tar", "tar.gz", "tgz", "tar.xz", "txz", ".tar.zst", \
                 ".tzst", "tar.bz2", ".tbz", ".ar", or ".deb" here.
                 """),
         @Param(

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/DecompressorValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/DecompressorValueTest.java
@@ -45,6 +45,8 @@ public class DecompressorValueTest {
     unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.nupkg");
     unused = DecompressorValue.getDecompressor(path);
+    path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.whl");
+    unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.gz");
     unused = DecompressorValue.getDecompressor(path);
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tgz");


### PR DESCRIPTION
The `download_and_extract` function supported various archive formats, but did not recognize `.whl` as a valid file extension for archive extraction. Since wheel files are ZIP archives with a `.whl` extension (per PEP 427), this commit adds support for them by treating `.whl` files the same as other ZIP-based formats.

This enables using Python wheel files directly with rules_multitool and other tools without requiring workarounds, particularly useful for air-gapped environments with private PyPI repositories.

Changes:
- Add .whl to ZIP decompressor condition in DecompressorValue.java
- Update error message to include .whl in supported extensions list  
- Update API documentation to include .whl as supported archive type
- Add test case for .whl file extension handling

Fixes #26307

RELNOTES[NEW]: `repository_ctx.download_and_extract` now supports the `.whl` file extension for Python wheel files, treating them as ZIP archives under PEP 427.