### PR TITLE
[8.3.0] Make strip_include_prefix apply to textual_hdrs

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_compilation_helper.bzl
@@ -102,7 +102,7 @@ def _compute_public_headers(
             headers = public_headers_artifacts + non_module_map_headers,
             module_map_headers = public_headers_artifacts,
             virtual_include_path = None,
-            virtual_to_original_headers = depset(),
+            virtual_to_original_headers = [],
         )
 
     module_map_headers = []
@@ -135,7 +135,7 @@ def _compute_public_headers(
         headers = virtual_headers,
         module_map_headers = module_map_headers,
         virtual_include_path = paths.join(binfiles_dir, virtual_include_dir),
-        virtual_to_original_headers = depset(virtual_to_original_headers_list),
+        virtual_to_original_headers = virtual_to_original_headers_list,
     )
 
 def _generates_header_module(feature_configuration, public_headers, private_headers, generate_action):
@@ -259,15 +259,32 @@ def _init_cc_compilation_context(
         else:
             include_dirs_for_context.append(public_headers.virtual_include_path)
 
+    textual_headers = _compute_public_headers(
+        actions,
+        config,
+        public_textual_headers,
+        include_prefix,
+        strip_include_prefix,
+        label,
+        binfiles_dir,
+        non_module_map_headers,
+        sibling_repo_layout,
+    )
+    if textual_headers.virtual_include_path:
+        if external:
+            external_include_dirs.append(textual_headers.virtual_include_path)
+        else:
+            include_dirs_for_context.append(textual_headers.virtual_include_path)
+
     if config.coverage_enabled:
         # Populate the map only when code coverage collection is enabled, to report the actual
         # source file name in the coverage output file.
-        virtual_to_original_headers = public_headers.virtual_to_original_headers
+        virtual_to_original_headers = public_headers.virtual_to_original_headers + textual_headers.virtual_to_original_headers
     else:
-        virtual_to_original_headers = depset()
+        virtual_to_original_headers = []
 
     declared_include_srcs.extend(public_headers.headers)
-    declared_include_srcs.extend(public_textual_headers)
+    declared_include_srcs.extend(textual_headers.headers)
     declared_include_srcs.extend(private_headers_artifacts)
     declared_include_srcs.extend(additional_inputs)
 
@@ -397,7 +414,7 @@ def _init_cc_compilation_context(
         external_includes = depset(external_include_dirs),
         system_includes = depset(system_include_dirs_for_context),
         includes = depset(include_dirs_for_context),
-        virtual_to_original_headers = virtual_to_original_headers,
+        virtual_to_original_headers = depset(virtual_to_original_headers),
         dependent_cc_compilation_contexts = dependent_cc_compilation_contexts,
         non_code_inputs = additional_inputs,
         defines = depset(defines),
@@ -405,7 +422,7 @@ def _init_cc_compilation_context(
         headers = depset(declared_include_srcs),
         direct_public_headers = public_headers.headers,
         direct_private_headers = private_headers_artifacts,
-        direct_textual_headers = public_textual_headers,
+        direct_textual_headers = textual_headers.headers,
         propagate_module_map_to_compile_action = propagate_module_map_to_compile_action,
         module_map = module_map,
         pic_header_module = pic_header_module,
@@ -426,7 +443,7 @@ def _init_cc_compilation_context(
             external_includes = depset(external_include_dirs),
             system_includes = depset(system_include_dirs_for_context),
             includes = depset(include_dirs_for_context),
-            virtual_to_original_headers = virtual_to_original_headers,
+            virtual_to_original_headers = depset(virtual_to_original_headers),
             dependent_cc_compilation_contexts = dependent_cc_compilation_contexts + implementation_deps,
             non_code_inputs = additional_inputs,
             defines = depset(defines),
@@ -434,7 +451,7 @@ def _init_cc_compilation_context(
             headers = depset(declared_include_srcs),
             direct_public_headers = public_headers.headers,
             direct_private_headers = private_headers_artifacts,
-            direct_textual_headers = public_textual_headers,
+            direct_textual_headers = textual_headers.headers,
             propagate_module_map_to_compile_action = propagate_module_map_to_compile_action,
             module_map = module_map,
             pic_header_module = pic_header_module,

--- a/src/main/starlark/tests/builtins_bzl/cc/basics/test/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/basics/test/BUILD.builtin_test
@@ -1,0 +1,12 @@
+cc_library(
+    name = "lib",
+    srcs = ["nested/lib.cc"],
+    strip_include_prefix = "nested",
+    textual_hdrs = ["nested/lib.h"],
+)
+
+cc_test(
+    name = "test_include_textual",
+    srcs = ["test_include_textual.cc"],
+    deps =[ ":lib"],
+)

--- a/src/main/starlark/tests/builtins_bzl/cc/basics/test/nested/lib.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/basics/test/nested/lib.cc
@@ -1,0 +1,16 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "src/main/starlark/tests/builtins_bzl/cc/basics/test/nested/lib.h"
+
+int foo() { return 42; }

--- a/src/main/starlark/tests/builtins_bzl/cc/basics/test/nested/lib.h
+++ b/src/main/starlark/tests/builtins_bzl/cc/basics/test/nested/lib.h
@@ -1,0 +1,20 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EXAMPLES_TEST_CC__LIB_H
+#define EXAMPLES_TEST_CC__LIB_H
+
+int foo();
+
+#endif  // EXAMPLES_TEST_CC_STATIC_LIBRARY_FOO_H_

--- a/src/main/starlark/tests/builtins_bzl/cc/basics/test/test_include_textual.cc
+++ b/src/main/starlark/tests/builtins_bzl/cc/basics/test/test_include_textual.cc
@@ -1,0 +1,21 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "src/main/starlark/tests/builtins_bzl/cc/basics/test/nested/lib.h"
+
+int main() {
+  if (foo() != 42) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/12424

Closes #25749.

PiperOrigin-RevId: 771948570
Change-Id: Id470ecc19f4c67bf1911c0f568a0150c2a0b381a

Commit https://github.com/bazelbuild/bazel/commit/4f3a4fd92f970d8256f3cf8430d85d3793975d99