### PR TITLE
Don't eagerly invalidate remote metadata when its TTL expires

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -170,8 +170,8 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
   }
 
   /**
-   * Returns the time when the remote file contents expire. If the contents never expire, including
-   * when they're not remote, returns null.
+   * Returns the time when the remote file contents may expire. If the contents never expire,
+   * including when they're not remote, returns null.
    *
    * <p>The expiration time does not factor into equality, as it can be mutated by {@link
    * #setExpirationTime}.
@@ -186,13 +186,6 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
    * nothing.
    */
   public void setExpirationTime(Instant newExpirationTime) {}
-
-  /**
-   * Returns whether the file contents are available (either locally, or remotely and not expired).
-   */
-  public final boolean isAlive(Instant now) {
-    return getExpirationTime() == null || getExpirationTime().isAfter(now);
-  }
 
   /**
    * Provides a best-effort determination whether the file was changed since the digest was
@@ -761,7 +754,6 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
     public void setContentsProxy(FileContentsProxy proxy) {
       this.proxy = proxy;
     }
-
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteLeaseExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteLeaseExtension.java
@@ -193,12 +193,10 @@ public class RemoteLeaseExtension implements LeaseExtension {
     }
 
     var token = getActionCacheToken(action);
-    var delete = false;
     for (var remoteFile : remoteFiles) {
       var artifact = remoteFile.getKey();
       var metadata = remoteFile.getValue();
-      // Mark the lease for the remote output as extended if it is still alive remotely, otherwise
-      // delete the action cache entry.
+      // Only extend the lease for the remote output if it is still alive remotely.
       if (!missingDigests.contains(buildDigest(metadata))) {
         metadata.setExpirationTime(expirationTime);
         if (token != null) {
@@ -208,20 +206,13 @@ public class RemoteLeaseExtension implements LeaseExtension {
             token.extendOutputFile(artifact, expirationTime);
           }
         }
-      } else {
-        delete = true;
-        break;
       }
     }
 
-    if (actionCache != null && token != null) {
-      if (delete) {
-        actionCache.remove(token.key);
-      } else if (token.dirty) {
-        // Only update the action cache entry if the token was updated because it usually involves
-        // serialization.
-        actionCache.put(token.key, token.entry);
-      }
+    if (actionCache != null && token != null && token.dirty) {
+      // Only update the action cache entry if the token was updated because it usually involves
+      // serialization.
+      actionCache.put(token.key, token.entry);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteLeaseExtension.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteLeaseExtension.java
@@ -121,7 +121,7 @@ public class RemoteLeaseExtension implements LeaseExtension {
         if (value != null && ACTION_FILTER.test(key)) {
           var action = getActionFromSkyKey(key);
           var actionExecutionValue = (ActionExecutionValue) value;
-          var remoteFiles = collectRemoteFiles(actionExecutionValue, earliestExpiration);
+          var remoteFiles = collectRemoteFiles(actionExecutionValue);
           if (!remoteFiles.isEmpty()) {
             // Lease extensions are performed on action basis, not by collecting all outputs and
             // issue one giant `FindMissingBlobs` call to avoid increasing memory footprint. Since
@@ -150,25 +150,22 @@ public class RemoteLeaseExtension implements LeaseExtension {
     var unused = scheduledExecutor.schedule(this::extendLeases, delay.toMillis(), MILLISECONDS);
   }
 
-  private static boolean isRemoteMetadataExpiringBefore(
-      FileArtifactValue metadata, Instant expirationTime) {
-    return metadata.isRemote()
-        && metadata.getExpirationTime() != null
-        && metadata.getExpirationTime().isBefore(expirationTime);
+  private static boolean isRemoteMetadataWithTtl(FileArtifactValue metadata) {
+    return metadata.isRemote() && metadata.getExpirationTime() != null;
   }
 
   private ImmutableList<Map.Entry<? extends Artifact, FileArtifactValue>> collectRemoteFiles(
-      ActionExecutionValue actionExecutionValue, Instant earliestExpiration) {
+      ActionExecutionValue actionExecutionValue) {
     var result = ImmutableList.<Map.Entry<? extends Artifact, FileArtifactValue>>builder();
     for (var entry : actionExecutionValue.getAllFileValues().entrySet()) {
-      if (isRemoteMetadataExpiringBefore(entry.getValue(), earliestExpiration)) {
+      if (isRemoteMetadataWithTtl(entry.getValue())) {
         result.add(entry);
       }
     }
 
     for (var treeMetadata : actionExecutionValue.getAllTreeArtifactValues().values()) {
       for (var entry : treeMetadata.getChildValues().entrySet()) {
-        if (isRemoteMetadataExpiringBefore(entry.getValue(), earliestExpiration)) {
+        if (isRemoteMetadataWithTtl(entry.getValue())) {
           result.add(entry);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputChecker.java
@@ -323,11 +323,11 @@ public class RemoteOutputChecker implements OutputChecker {
       }
     }
 
-    if (shouldDownloadOutput(file, metadata)) {
-      return false;
-    }
-
-    return metadata.isAlive(clock.now());
+    // The remote metadata may have passed its TTL, but we optimistically assume that it's still
+    // available remotely. If it isn't, build or action rewinding will take care of rerunning the
+    // actions needed to produce the file and also evict the stale metadata. This incurs roughly the
+    // same performance hit, but only when actually needed.
+    return !shouldDownloadOutput(file, metadata);
   }
 
   public void maybeInvalidateSkyframeValues(MemoizingEvaluator memoizingEvaluator) {

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -82,7 +82,9 @@ import org.junit.runner.RunWith;
 @RunWith(TestParameterInjector.class)
 public class ActionCacheCheckerTest {
   private static final OutputChecker CHECK_TTL =
-      (file, metadata) -> metadata.isAlive(Instant.now());
+      (file, metadata) ->
+          metadata.getExpirationTime() == null
+              || metadata.getExpirationTime().isAfter(Instant.now());
 
   private CorruptibleActionCache cache;
   private ActionCacheChecker cacheChecker;

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -219,6 +219,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/main/protobuf:failure_details_java_proto",
         "//src/test/java/com/google/devtools/build/lib/buildtool/util",
         "//third_party:guava",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -116,7 +116,9 @@ import org.mockito.ArgumentCaptor;
 @RunWith(TestParameterInjector.class)
 public final class FilesystemValueCheckerTest {
   private static final OutputChecker CHECK_TTL =
-      (file, metadata) -> metadata.isAlive(Instant.now());
+      (file, metadata) ->
+          metadata.getExpirationTime() == null
+              || metadata.getExpirationTime().isAfter(Instant.now());
   private static final int FSVC_THREADS_FOR_TEST = 200;
   private static final ActionLookupKey ACTION_LOOKUP_KEY =
       new ActionLookupKey() {


### PR DESCRIPTION
Build and action rewinding can recover from metadata whose corresponding contents are no longer available remotely, but are usually more efficient since they only invalidate action cache entries if the contents really are gone, not simply because their TTL expired.

Fixes #26140