### PR TITLE
[8.3.0] Register `launcher_maker_toolchain` with WORKSPACE

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/tools.WORKSPACE
@@ -7,3 +7,5 @@ bind(
     name = "cc_toolchain",
     actual = "@bazel_tools//tools/cpp:default-toolchain",
 )
+
+register_toolchains("@bazel_tools//tools/launcher:all")


### PR DESCRIPTION
Speculative fix for https://github.com/bazel-contrib/bazel_features/pull/100#issuecomment-2980133474, only `MODULE.tools` registered the toolchain.