### PR TITLE
Delete legacy flow in `cc_test`

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl
@@ -33,7 +33,6 @@ load(":common/paths.bzl", "paths")
 _cc_internal = _builtins.internal.cc_internal
 config_common = _builtins.toplevel.config_common
 coverage_common = _builtins.toplevel.coverage_common
-platform_common = _builtins.toplevel.platform_common
 
 extensions = _extensions
 
@@ -1109,14 +1108,6 @@ def _linker_scripts(ctx):
                 result.append(f)
     return result
 
-def _has_target_constraints(ctx, constraints):
-    # Constraints is a label_list.
-    for constraint in constraints:
-        constraint_value = constraint[platform_common.ConstraintValueInfo]
-        if ctx.target_platform_has_constraint(constraint_value):
-            return True
-    return False
-
 def _should_create_test_dwp_for_statically_linked_test(is_test, linking_mode, cpp_config):
     return is_test and linking_mode != linker_mode.LINKING_DYNAMIC and cpp_config.build_test_dwp()
 
@@ -1179,7 +1170,6 @@ cc_helper = struct(
     get_cc_flags_make_variable = _get_cc_flags_make_variable,
     get_copts = _get_copts,
     get_expanded_env = _get_expanded_env,
-    has_target_constraints = _has_target_constraints,
     is_non_empty_list_or_select = _is_non_empty_list_or_select,
     expand_make_variables_for_copts = _expand_make_variables_for_copts,
     build_linking_context_from_libraries = _build_linking_context_from_libraries,

--- a/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_test.bzl
@@ -23,50 +23,11 @@ load(":common/cc/cc_shared_library.bzl", "dynamic_deps_initializer")
 load(":common/cc/semantics.bzl", "semantics")
 load(":common/paths.bzl", "paths")
 
-config_common = _builtins.toplevel.config_common
-platform_common = _builtins.toplevel.platform_common
-testing = _builtins.toplevel.testing
-
 _CC_TEST_TOOLCHAIN_TYPE = "@" + semantics.get_repo() + "//tools/cpp:test_runner_toolchain_type"
-
-def _legacy_cc_test_impl(ctx):
-    binary_info, providers = cc_binary_impl(ctx, [])
-    test_env = {}
-    test_env.update(cc_helper.get_expanded_env(ctx, {}))
-
-    coverage_runfiles, coverage_env = semantics.get_coverage_env(ctx)
-
-    runfiles_list = [binary_info.runfiles]
-    if coverage_runfiles:
-        runfiles_list.append(coverage_runfiles)
-
-    runfiles = ctx.runfiles()
-    runfiles = runfiles.merge_all(runfiles_list)
-
-    test_env.update(coverage_env)
-    providers.append(testing.TestEnvironment(
-        environment = test_env,
-        inherited_environment = ctx.attr.env_inherit,
-    ))
-    providers.append(DefaultInfo(
-        files = binary_info.files,
-        runfiles = runfiles,
-        executable = binary_info.executable,
-    ))
-
-    if cc_helper.has_target_constraints(ctx, ctx.attr._apple_constraints):
-        # When built for Apple platforms, require the execution to be on a Mac.
-        providers.append(testing.ExecutionInfo({"requires-darwin": ""}))
-    return providers
 
 def _impl(ctx):
     semantics.validate(ctx, "cc_test")
-    cc_test_toolchain = ctx.exec_groups["test"].toolchains[_CC_TEST_TOOLCHAIN_TYPE]
-    if cc_test_toolchain:
-        cc_test_info = cc_test_toolchain.cc_test_info
-    else:
-        # This is the "legacy" cc_test flow
-        return _legacy_cc_test_impl(ctx)
+    cc_test_info = ctx.exec_groups["test"].toolchains[_CC_TEST_TOOLCHAIN_TYPE].cc_test_info
 
     binary_info, providers = cc_binary_impl(ctx, cc_test_info.linkopts, cc_test_info.linkstatic)
     processed_environment = cc_helper.get_expanded_env(ctx, {})
@@ -161,7 +122,7 @@ attributes common to all test rules (*_test)</a>.</p>
     exec_groups = {
         "cpp_link": exec_group(toolchains = cc_helper.use_cpp_toolchain()),
         # testing.ExecutionInfo defaults to an exec_group of "test".
-        "test": exec_group(toolchains = [config_common.toolchain_type(_CC_TEST_TOOLCHAIN_TYPE, mandatory = False)]),
+        "test": exec_group(toolchains = [_CC_TEST_TOOLCHAIN_TYPE]),
     } | semantics.extra_exec_groups,
     toolchains = [] +
                  cc_helper.use_cpp_toolchain() +

--- a/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
@@ -87,9 +87,6 @@ def _get_coverage_attrs():
         ),
     }
 
-def _get_coverage_env(ctx):
-    return ctx.runfiles(), {}
-
 def _get_cc_runtimes(ctx, is_library):
     if is_library:
         return []
@@ -199,7 +196,6 @@ semantics = struct(
     get_cc_runtimes = _get_cc_runtimes,
     get_cc_runtimes_copts = _get_cc_runtimes_copts,
     get_coverage_attrs = _get_coverage_attrs,
-    get_coverage_env = _get_coverage_env,
     get_proto_aspects = _get_proto_aspects,
     get_nocopts_attr = _get_nocopts_attr,
     get_experimental_link_static_libraries_once = _get_experimental_link_static_libraries_once,

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/cc_toolchain_config.bzl
@@ -1701,3 +1701,32 @@ cc_toolchain_config = rule(
     provides = [CcToolchainConfigInfo],
     executable = True,
 )
+
+def _default_test_runner_func(ctx, binary_info, processed_environment):
+    return [
+        DefaultInfo(
+            executable = binary_info.executable,
+            files = binary_info.files,
+            runfiles = binary_info.runfiles,
+        ),
+        RunEnvironmentInfo(
+            environment = processed_environment,
+            inherited_environment = ctx.attr.env_inherit,
+        ),
+    ]
+
+def _default_test_runner_impl(_ctx):
+    return [
+        platform_common.ToolchainInfo(
+            cc_test_info = struct(
+                get_runner = struct(
+                    args = {},
+                    func = _default_test_runner_func,
+                ),
+                linkopts = [],
+                linkstatic = False,
+            ),
+        ),
+    ]
+
+default_test_runner = rule(_default_test_runner_impl)

--- a/src/test/java/com/google/devtools/build/lib/packages/util/Crosstool.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/Crosstool.java
@@ -463,8 +463,7 @@ public final class Crosstool {
       compilationTools.append(
           String.format(
               "filegroup(name = '%s', srcs = ['%s'])\n",
-              compilationTool,
-              Joiner.on("', '").join(archTargets)));
+              compilationTool, Joiner.on("', '").join(archTargets)));
       for (String archTarget : archTargets) {
         compilationTools.append(
             String.format("filegroup(name = '%s', srcs = [':everything-multilib'])\n", archTarget));
@@ -553,7 +552,7 @@ public final class Crosstool {
                 "package(default_visibility=['//visibility:public'])",
                 "licenses(['restricted'])",
                 "",
-                "load(':cc_toolchain_config.bzl', 'cc_toolchain_config')",
+                "load(':cc_toolchain_config.bzl', 'cc_toolchain_config', 'default_test_runner')",
                 "load('"
                     + TestConstants.TOOLS_REPOSITORY
                     + "//third_party/cc_rules/macros:defs.bzl', 'cc_library', 'cc_toolchain')",
@@ -596,6 +595,14 @@ public final class Crosstool {
                 "filegroup(",
                 "    name = 'generate-modmap',",
                 "    srcs = ['generate-modmap.sh'],",
+                ")",
+                "default_test_runner(name = 'default_test_runner')",
+                "toolchain(",
+                "  name = 'cc-test-runner',",
+                "  toolchain_type = '"
+                    + TestConstants.TOOLS_REPOSITORY
+                    + "//tools/cpp:test_runner_toolchain_type',",
+                "  toolchain = ':default_test_runner',",
                 ")");
 
     config.create(crosstoolTop + "/mock_version/x86/bin/gcc");
@@ -625,7 +632,7 @@ public final class Crosstool {
         ImmutableList.<String>builder()
             .add(
                 "package(default_visibility=['//visibility:public'])",
-                "load(':cc_toolchain_config.bzl', 'cc_toolchain_config')",
+                "load(':cc_toolchain_config.bzl', 'cc_toolchain_config', 'default_test_runner')",
                 "load('"
                     + TestConstants.TOOLS_REPOSITORY
                     + "//third_party/cc_rules/macros:defs.bzl', 'cc_library', 'cc_toolchain')",
@@ -647,6 +654,14 @@ public final class Crosstool {
                 "        'libempty.a',",
                 String.format("        '%s//tools/objc:libtool'", TestConstants.TOOLS_REPOSITORY),
                 "    ],",
+                ")",
+                "default_test_runner(name = 'default_test_runner')",
+                "toolchain(",
+                "  name = 'cc-test-runner',",
+                "  toolchain_type = '"
+                    + TestConstants.TOOLS_REPOSITORY
+                    + "//tools/cpp:test_runner_toolchain_type',",
+                "  toolchain = ':default_test_runner',",
                 ")");
     for (CcToolchainConfig toolchainConfig : ccToolchainConfigList) {
       String staticRuntimeLabel =


### PR DESCRIPTION
Since v0.1.3, `rules_cc` always registers a default test toolchain that subsumes the legacy flow.

Work towards #25160