### PR TITLE
Add BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE to opt in to coverage collection for failing tests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.exec;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -78,6 +79,15 @@ import java.util.TreeMap;
 // TODO(bazel-team): add tests for this strategy.
 public class StandaloneTestStrategy extends TestStrategy {
   private static final String TEST_NAME_ENV = "TEST_NAME";
+
+  /**
+   * If set to a non-empty value in the test environment, coverage post-processing runs even when the
+   * test fails. The test is still reported as failed. Keep in sync with
+   * tools/test/collect_coverage.sh.
+   */
+  private static final String COLLECT_COVERAGE_ON_TEST_FAILURE_ENV =
+      "BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE";
+
   private static final ImmutableMap<String, String> ENV_VARS =
       ImmutableMap.<String, String>builder()
           .put("TZ", "UTC")
@@ -745,7 +755,19 @@ public class StandaloneTestStrategy extends TestStrategy {
         .setHasCoverage(testAction.isCoverageMode());
 
     if (testAction.isCoverageMode() && testAction.getSplitCoveragePostProcessing()) {
-      if (testResultDataBuilder.getTestPassed()) {
+      // Coverage post-processing is skipped for a failing test unless the test environment opts
+      // into it. The test is reported as failed either way; only the coverage data differs.
+      boolean collectCoverageForFailedTest =
+          !testResultDataBuilder.getTestPassed()
+              && !isNullOrEmpty(spawn.getEnvironment().get(COLLECT_COVERAGE_ON_TEST_FAILURE_ENV))
+              // A test that failed before the coverage directory was created has nothing to
+              // post-process, and the post-processing spawn requires it as an input.
+              && testAction.getCoverageDirectoryTreeArtifact() != null
+              && actionExecutionContext
+                  .getPathResolver()
+                  .convertPath(testAction.getCoverageDirectoryTreeArtifact().getPath())
+                  .exists();
+      if (testResultDataBuilder.getTestPassed() || collectCoverageForFailedTest) {
         if (testAction.getCoverageDirectoryTreeArtifact() == null) {
           // Otherwise we'll get a NPE https://github.com/bazelbuild/bazel/issues/13185
           TestExecException e =

--- a/src/test/shell/bazel/bazel_coverage_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_starlark_test.sh
@@ -718,4 +718,98 @@ function test_starlark_rule_custom_baseline_coverage_with_split_postprocessing()
   do_test_starlark_rule_custom_baseline_coverage
 }
 
+# Sets up a Starlark test rule whose test always fails, wired to a custom
+# lcov_merger that records that it was invoked in the coverage output file.
+function setup_failing_test_with_custom_lcov_merger() {
+    add_rules_shell "MODULE.bazel"
+    cat <<EOF > lcov_merger.sh
+for var in "\$@"
+do
+    if [[ "\$var" == "--output_file="* ]]; then
+        path="\${var##--output_file=}"
+        mkdir -p "\$(dirname \$path)"
+        echo lcov_merger_called >> \$path
+        exit 0
+    fi
+done
+EOF
+chmod +x lcov_merger.sh
+
+    cat <<EOF > rules.bzl
+UNIX_FAILING_TEST = "exit 1"
+WINDOWS_FAILING_TEST = "@echo off\nexit /b 1"
+
+def _impl(ctx):
+    output = ctx.actions.declare_file(ctx.attr.name + ".bat")
+    ctx.actions.write(output, WINDOWS_FAILING_TEST if ${starlark_is_windows} else UNIX_FAILING_TEST, is_executable = True)
+    return [DefaultInfo(executable=output)]
+
+custom_test = rule(
+    implementation = _impl,
+    test = True,
+    attrs = {
+        "_lcov_merger": attr.label(default = ":lcov_merger", cfg = config.exec(exec_group = "test")),
+    },
+)
+EOF
+
+    cat <<EOF > BUILD
+load(":rules.bzl", "custom_test")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+sh_binary(
+    name = "lcov_merger",
+    srcs = ["lcov_merger.sh"],
+)
+custom_test(name = "foo_test")
+EOF
+}
+
+# Exercises BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE with the given extra flags,
+# which select the coverage post-processing path. Both paths have to be covered
+# explicitly because --experimental_split_coverage_postprocessing defaults to
+# true in Bazel but not in Blaze.
+function do_test_failing_test_coverage_collection() {
+    setup_failing_test_with_custom_lcov_merger
+    local coverage_file="bazel-testlogs/foo_test/coverage.dat"
+
+    # By default no coverage is collected for a failing test.
+    if bazel coverage --test_output=all "$@" //:foo_test > $TEST_log; then
+      fail "Coverage run succeeded but should have failed."
+    fi
+    expect_log "//:foo_test.*FAILED"
+    expect_log "Not collecting coverage for failed test"
+    [[ -e "$coverage_file" ]] || fail "Coverage output file does not exist!"
+    if grep -q "lcov_merger_called" "$coverage_file"; then
+      fail "lcov_merger should not have been run for a failing test by default."
+    fi
+
+    # With BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE set, the test must still be
+    # reported as failed...
+    if bazel coverage --test_output=all "$@" \
+        --test_env=BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE=1 \
+        //:foo_test > $TEST_log; then
+      fail "Coverage run succeeded but should have failed."
+    fi
+    expect_log "//:foo_test.*FAILED"
+    expect_log "Collecting coverage for failed test"
+    expect_not_log "Not collecting coverage for failed test"
+
+    # ...but coverage must have been collected anyway.
+    [[ -e "$coverage_file" ]] || fail "Coverage output file does not exist!"
+    grep -q "lcov_merger_called" "$coverage_file" \
+        || fail "lcov_merger was not run for the failing test."
+}
+
+function test_failing_test_coverage_collection() {
+    do_test_failing_test_coverage_collection \
+        --noexperimental_split_coverage_postprocessing
+}
+
+function test_failing_test_coverage_collection_with_split_postprocessing() {
+    do_test_failing_test_coverage_collection \
+        --experimental_fetch_all_coverage_outputs \
+        --experimental_split_coverage_postprocessing
+}
+
 run_suite "test tests"

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -118,6 +118,9 @@ fi
 # JAVA_RUNTIME_CLASSPATH_FOR_COVERAGE Exec path of a file that contains the
 #                                     relative paths of the jars on the runtime
 #                                     classpath delimited by newline.
+
+TEST_STATUS=0
+
 if [[ ! -z "${JAVA_RUNTIME_CLASSPATH_FOR_COVERAGE}" ]]; then
   JAVA_RUNTIME_CLASSPATH_FOR_COVERAGE="${PWD}/${JAVA_RUNTIME_CLASSPATH_FOR_COVERAGE}"
   SINGLE_JAR_TOOL="${PWD}/${SINGLE_JAR_TOOL}"
@@ -158,10 +161,9 @@ if [[ "$IS_COVERAGE_SPAWN" == "0" ]]; then
 
   if [[ $TEST_STATUS -ne 0 ]]; then
     echo --
-    echo Coverage runner: Not collecting coverage for failed test.
-    echo The following commands failed with status $TEST_STATUS
+    echo Coverage runner: Collected coverage may be off due to the
+    echo following test command failing with status $TEST_STATUS:
     echo "$@"
-    exit $TEST_STATUS
   fi
 fi
 
@@ -251,4 +253,10 @@ fi
 # JAVA_RUNFILES is set to the runfiles of the test, which does not necessarily
 # contain a JVM (it does only if the test has a Java binary somewhere). So let
 # the LCOV merger discover where its own runfiles tree is.
-JAVA_RUNFILES= exec $LCOV_MERGER_CMD
+JAVA_RUNFILES= $LCOV_MERGER_CMD
+LCOV_MERGER_CMD_STATUS=$?
+
+if [[ $TEST_STATUS -ne 0 ]]; then
+  exit $TEST_STATUS
+fi
+exit $LCOV_MERGER_CMD_STATUS

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -22,6 +22,10 @@
 #   COVERAGE_DIR - optional, location of the coverage temp directory
 #   COVERAGE_OUTPUT_FILE - optional, location of the final lcov file
 #   VERBOSE_COVERAGE - optional, print debug info from the coverage scripts
+#   BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE - optional, if non-empty, still run
+#     coverage post-processing when the test fails (the test is still reported
+#     as failed). Useful for local iteration, e.g. via
+#     --test_env=BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE=1.
 #   BAZEL_LLVM_PROFILE_FILE - optional, custom LLVM profile filename pattern
 #     (defaults to "%h-%p-%m.profraw" if not set)
 #
@@ -60,6 +64,11 @@ for name in RUNFILES_DIR RUNFILES_MANIFEST_FILE JAVA_RUNFILES PYTHON_RUNFILES; d
     unset BAZEL_COVERAGE_INTERNAL_${name}
   fi
 done
+
+# Only the test spawn runs the test and thus sets this to the test's exit status;
+# the separate coverage spawn (IS_COVERAGE_SPAWN=1) leaves it at 0 so that the
+# exits below stay well-defined there.
+TEST_STATUS=0
 
 if [[ -z "$COVERAGE_MANIFEST" ]]; then
   echo --
@@ -170,10 +179,17 @@ if [[ "$IS_COVERAGE_SPAWN" == "0" ]]; then
 
   if [[ $TEST_STATUS -ne 0 ]]; then
     echo --
-    echo Coverage runner: Not collecting coverage for failed test.
-    echo The following commands failed with status $TEST_STATUS
-    echo "$@"
-    exit $TEST_STATUS
+    if [[ -n "${BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE:-}" ]]; then
+      echo Coverage runner: Collecting coverage for failed test because
+      echo BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE is set. Collected coverage
+      echo may be off. The following command failed with status $TEST_STATUS:
+      echo "$@"
+    else
+      echo Coverage runner: Not collecting coverage for failed test.
+      echo The following commands failed with status $TEST_STATUS
+      echo "$@"
+      exit $TEST_STATUS
+    fi
   fi
 fi
 
@@ -185,7 +201,7 @@ fi
 unset LLVM_PROFILE_FILE
 
 if [[ "$SPLIT_COVERAGE_POST_PROCESSING" == "1" && "$IS_COVERAGE_SPAWN" == "0" ]]; then
-  exit 0
+  exit $TEST_STATUS
 fi
 
 if [[ "$SPLIT_COVERAGE_POST_PROCESSING" == "1" && "$IS_COVERAGE_SPAWN" == "1" ]]; then
@@ -208,7 +224,7 @@ if [[ -z "$LCOV_MERGER" ]]; then
   # due to conflicts with how things work within Google.
   # The file creation is required because TestActionBuilder has already declared
   # it.
-  exit 0
+  exit $TEST_STATUS
 fi
 
 for name in "$LCOV_MERGER"; do
@@ -269,4 +285,11 @@ fi
 # Runfiles variables are set to the runfiles of the test, which does not contain
 # the runfiles of the LCOV merger. Unset them so that it can find its own
 # runfiles tree.
-JAVA_RUNFILES= RUNFILES_DIR= RUNFILES_MANIFEST_FILE= exec $LCOV_MERGER_CMD
+JAVA_RUNFILES= RUNFILES_DIR= RUNFILES_MANIFEST_FILE= $LCOV_MERGER_CMD
+LCOV_MERGER_CMD_STATUS=$?
+
+# A failing test must still fail, even if coverage was collected for it.
+if [[ $TEST_STATUS -ne 0 ]]; then
+  exit $TEST_STATUS
+fi
+exit $LCOV_MERGER_CMD_STATUS


### PR DESCRIPTION
(Reworked per the review discussion. Default behavior is unchanged: bazel coverage still skips coverage post-processing for a failing test.)

Setting `BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE` in the test environment (e.g. `--test_env=BAZEL_COVERAGE_COLLECT_ON_TEST_FAILURE=1` in a developer's .bazelrc) makes collect_coverage.sh still run the lcov merger for a failing test. The test is still reported as failed and bazel coverage still exits nonzero, so nothing that checks the exit status is affected. The use case is local iteration (e.g. `ibazel coverage` while refactoring), where one failing test in a target currently defeats coverage for every other test in that target.

Because this is opt-in and not on by default, the combined report is not affected unless a user chooses to enable it, which addresses the concern about merging coverage from failing tests into the report.

Also fixes the exit status under `--experimental_split_coverage_postprocessing` and the missing `LCOV_MERGER` path, which previously exit 0 unconditionally; both now propagate the test's status.

Also added tests to `bazel_coverage_starlark_test.sh` to cover the default (no collection, test fails), the opt-in (collection, test still fails), and that a failing test is still reported as failed under split post-processing.

Verified locally: with the env var, a failing test logs "Collecting coverage for failed test," the merger runs, and the build exits 3; without it, the old message and behavior are identical to master.