### PR TITLE
Set `--combined_report` to `lcov` by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/BazelCoverageReportModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/BazelCoverageReportModule.java
@@ -51,7 +51,7 @@ public class BazelCoverageReportModule extends BlazeModule {
         converter = ReportTypeConverter.class,
         documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
         effectTags = {OptionEffectTag.UNKNOWN},
-        defaultValue = "none",
+        defaultValue = "lcov",
         help =
             "Specifies desired cumulative coverage report type. At this point only LCOV "
                 + "is supported.")


### PR DESCRIPTION
It's very likely that someone running `bazel coverage` wants a combined report and the message announcing the report's path makes the effect of `bazel coverage` easier to understand.

RELNOTES[INC]: `--combined_report` now defaults to `lcov` (was: `none`).