### PR TITLE
Enable `--experimental_generate_llvm_lcov` by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -917,7 +917,7 @@ public class CppOptions extends FragmentOptions {
 
   @Option(
       name = "experimental_generate_llvm_lcov",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS, OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
@@ -1102,7 +1102,10 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
 
     assertThat(prettyArtifactNames(target.getInstrumentedFiles())).containsExactly("java/jni.cc");
     assertThat(prettyArtifactNames(target.getInstrumentationMetadataFiles()))
-        .containsExactly("java/_objs/libjni.so/jni.gcno");
+        .containsExactly(
+            "java/libjni.soruntime_objects_list.txt",
+            "java/libjni.so",
+            "java/_objs/libjni.so/jni.gcno");
   }
 
   @Test

--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -64,7 +64,6 @@ function setup_llvm_coverage_tools_for_lcov() {
   add_to_bazelrc "common --repo_env=BAZEL_LLVM_PROFDATA=${llvm_profdata}"
   add_to_bazelrc "common --repo_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1"
   add_to_bazelrc "common --repo_env=CC=${clang}"
-  add_to_bazelrc "common --experimental_generate_llvm_lcov"
 }
 
 # Writes the C++ source files and a corresponding BUILD file for which to

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -2662,7 +2662,6 @@ EOF
     bazel coverage \
       --test_output=all \
       --experimental_fetch_all_coverage_outputs \
-      --experimental_generate_llvm_lcov \
       --experimental_split_coverage_postprocessing \
       --spawn_strategy=remote \
       --remote_executor=grpc://localhost:${worker_port} \

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -188,10 +188,9 @@ function gcov_coverage() {
 function main() {
   init_gcov
 
-  # If llvm code coverage is used, we output the raw code coverage report in
-  # the $COVERAGE_OUTPUT_FILE. This report will not be converted to any other
-  # format by LcovMerger.
-  # TODO(#5881): Convert profdata reports to lcov.
+  # If llvm code coverage is used, we either use the llvm-cov tool to generate
+  # an lcov report or just merge the files into a profdata file, depending on
+  # the --experimental_generate_llvm_lcov flag.
   if uses_llvm; then
     if [[ "${GENERATE_LLVM_LCOV}" == "1" ]]; then
         BAZEL_CC_COVERAGE_TOOL="LLVM_LCOV"


### PR DESCRIPTION
This flag is very hard to discover but required to get `--combined_report` to work with LLVM-based coverage. We keep it for power users that may need to consume `.profdata` files directly.