### PR TITLE
Unset LLVM_PROFILE_FILE after executing test

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -169,6 +169,9 @@ fi
 # ------------------EXPERIMENTAL---------------------
 # After this point we can run the code necessary for the coverage spawn
 
+# Make sure no binaries run later produce coverage data.
+unset LLVM_PROFILE_FILE
+
 if [[ "$SPLIT_COVERAGE_POST_PROCESSING" == "1" && "$IS_COVERAGE_SPAWN" == "0" ]]; then
   exit 0
 fi


### PR DESCRIPTION
In the case of hermetic toolchains it is possible that the llvm-cov used
in the coverage script is built with coverage enabled, in which case we
don't want to accidentally produce extra profraw files for anything but
the test process.
