### PR TITLE
Add baseline coverage support to Java compilation action

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -101,12 +101,14 @@ java_library(
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:errorprone",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:processing",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics",
+        "//src/java_tools/junitrunner/java/com/google/testing/coverage:JacocoCoverageLib",
         "//src/main/java/com/google/devtools/build/lib/worker:work_request_handlers",
         "//third_party:error_prone",
         "//third_party:error_prone_annotations",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/java/jacoco:core",
+        "//third_party/java/jacoco:report",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -169,8 +169,8 @@ public class JavaStarlarkCommon
             JavaHelper.tokenizeJavaOptions(Depset.cast(javacOpts, String.class, "javac_opts")),
             attributesBuilder,
             JavaToolchainProvider.wrap(toolchain),
-            Sequence.cast(additionalInputs, Artifact.class, "additional_inputs")
-                .getImmutableList());
+            Sequence.cast(additionalInputs, Artifact.class, "additional_inputs").getImmutableList(),
+            /* baselineCoverageFile= */ null);
     compilationHelper.enableDirectClasspath(enableDirectClasspath);
     compilationHelper.createHeaderCompilationAction(
         headerJar,
@@ -207,7 +207,8 @@ public class JavaStarlarkCommon
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Object baselineCoverageFile)
       throws EvalException,
           TypeException,
           RuleErrorException,
@@ -261,8 +262,8 @@ public class JavaStarlarkCommon
             JavaHelper.tokenizeJavaOptions(Depset.cast(javacOpts, String.class, "javac_opts")),
             attributesBuilder,
             JavaToolchainProvider.wrap(javaToolchain),
-            Sequence.cast(additionalInputs, Artifact.class, "additional_inputs")
-                .getImmutableList());
+            Sequence.cast(additionalInputs, Artifact.class, "additional_inputs").getImmutableList(),
+            baselineCoverageFile == Starlark.NONE ? null : (Artifact) baselineCoverageFile);
     compilationHelper.javaBuilderJvmFlags(
         Depset.cast(javaBuilderJvmFlags, String.class, "javabuilder_jvm_flags"));
     compilationHelper.enableJspecify(enableJSpecify);

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaCommonApi.java
@@ -525,6 +525,7 @@ public interface JavaCommonApi<
         @Param(name = "enable_direct_classpath", defaultValue = "True", named = true),
         @Param(name = "additional_inputs", defaultValue = "[]", named = true),
         @Param(name = "additional_outputs", defaultValue = "[]", named = true),
+        @Param(name = "baseline_coverage_file", defaultValue = "None", named = true),
       })
   void createCompilationAction(
       StarlarkRuleContextT ctx,
@@ -554,7 +555,8 @@ public interface JavaCommonApi<
       boolean enableJSpecify,
       boolean enableDirectClasspath,
       Sequence<?> additionalInputs,
-      Sequence<?> additionalOutputs)
+      Sequence<?> additionalOutputs,
+      Object baselineCoverageFile)
       throws EvalException,
           TypeException,
           RuleErrorException,

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -232,6 +232,31 @@ LF:6
 end_of_record"
 
   assert_coverage_result "$expected_result" "./bazel-out/_coverage/_coverage_report.dat"
+
+  local expected_baseline_result="SF:src/main/com/example/Collatz.java
+FN:3,com/example/Collatz::<init> ()V
+FN:6,com/example/Collatz::getCollatzFinal (I)I
+FNDA:0,com/example/Collatz::<init> ()V
+FNDA:0,com/example/Collatz::getCollatzFinal (I)I
+FNF:2
+FNH:0
+BRDA:6,0,0,-
+BRDA:6,0,1,-
+BRDA:9,0,0,-
+BRDA:9,0,1,-
+BRF:4
+BRH:0
+DA:3,0
+DA:6,0
+DA:7,0
+DA:9,0
+DA:10,0
+DA:12,0
+LH:0
+LF:6
+end_of_record"
+  # TODO(#5716): Enable this check after the next rules_java update.
+  # assert_coverage_result "$expected_baseline_result" "./bazel-out/_coverage/_baseline_report.dat"
 }
 
 function test_java_test_java_import_coverage() {


### PR DESCRIPTION
* `JacocoInstrumentationProcessor` optionally analyzes all instrumented classes with `null` probes and generates an LCOV baseline report.
* `create_compilation_action` gains a `baseline_coverage_file` parameter that `rules_java` can use to supply the desired output file for the baseline report.

Work towards bazelbuild/bazel#5716