### PR TITLE
Fix: malformed brda records caused bad branching coverage

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.List;
 
 /** Stores coverage information for a specific source file. */
 class SourceFileCoverage {
@@ -241,7 +242,31 @@ class SourceFileCoverage {
   }
 
   void addBranch(Integer lineNumber, BranchCoverage branch) {
-    branches.put(lineNumber, branch);
+    // BA records
+    if (branch.branchNumber().isEmpty()) {
+      branches.put(branch.lineNumber(), branch);
+    }
+    // BRDA records
+    else {
+      boolean exists = false;
+      List<BranchCoverage> branchList = (List<BranchCoverage>) branches.get(branch.lineNumber());
+      if (branchList != null) {
+        for (int i = 0; i < branchList.size(); i++) {
+          BranchCoverage existingBranch = branchList.get(i);
+          if (existingBranch.blockNumber().equals(branch.blockNumber())
+              && existingBranch.branchNumber().equals(branch.branchNumber())) {
+            exists = true;
+            BranchCoverage mergedBranch = BranchCoverage.merge(existingBranch, branch);
+            branchList.set(i, mergedBranch); // Replace the existing branch with the merged one
+            break;
+          }
+        }
+      }
+  
+      if (!exists) {
+        branches.put(branch.lineNumber(), branch);
+      }
+    }
   }
 
   void addAllBranches(ListMultimap<Integer, BranchCoverage> branches) {

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
@@ -270,7 +270,11 @@ class SourceFileCoverage {
   }
 
   void addAllBranches(ListMultimap<Integer, BranchCoverage> branches) {
-    this.branches.putAll(branches);
+    for (Integer line : branches.keySet()) {
+      for (BranchCoverage branch : branches.get(line)) {
+      addBranch(line, branch);
+      }
+    }
   }
 
   void addLine(Integer lineNumber, LineCoverage line) {


### PR DESCRIPTION
While working on a large bazel migration project in Volvo Cars, I noticed that for merged coverage reports (i.e. `bazel coverage target1 target2 ... targetN) bazel would generate different branch coverage on each run. It would also be very inflated compared to running the same in our pre-bazel environment. This essentially made it unusable.

After much detective work it turns out that individual tests in bazel can create malformed BRDA records where the same unique branch (i.e. the same, line, block and branch) have multiple values. When this happens the coverageOutputGenerator simply adds all the incorrect records to the merged file. In the merging logic there are some checks that sometimes drops individual records based on the order in which the BRDA records have been merged. Given that bazel does not guarantee that order, this then leads to each run having different branch coverage. 

E.g. 
Bazel has generated this (counted as 6 branches)
BRDA:131,0,0,1
BRDA:131,0,1,1
BRDA:131,0,0,1
BRDA:131,0,1,0
BRDA:131,0,0,3
BRDA:131,0,1,1

Which should've been only this (counted as 2 branches):
BRDA:131,0,1,2
BRDA:131,0,0,5

This fix ensures that each branch is unique for a particular source file. Duplicates are now merged, ensuring that the tally is correct. I have verified that this works consistently on our large code base and added some regression tests to avoid this bug in the future.