### PR TITLE
Forward `--host_jvmopt` to the exec configuration

### DIFF
--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -383,6 +383,7 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:enforce_proguard_file_extension",
         "//command_line_option:proguard_top",
         "//command_line_option:host_javacopt",
+        "//command_line_option:host_jvmopt",
         "//command_line_option:host_java_launcher",
         "//command_line_option:tool_java_runtime_version",
         "//command_line_option:tool_java_language_version",

--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -397,9 +397,6 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:experimental_limit_android_lint_to_android_constrained_java",
         "//command_line_option:experimental_run_android_lint_on_java_rules",
     ],
-    inputs = [
-        "//command_line_option:host_jvmopt",
-    ],
     outputs = [
         "//command_line_option:jvmopt",
         "//command_line_option:javacopt",


### PR DESCRIPTION
This ports https://github.com/bazelbuild/bazel/pull/15978, which never got merged, to Starlark.