### PR TITLE
Add support for directories in `baseline_coverage_files`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/CoverageCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/CoverageCommonApi.java
@@ -120,6 +120,19 @@ public interface CoverageCommonApi<
             }),
         @Param(
             name = "baseline_coverage_files",
+            doc =
+            """
+            A sequence of files that contain baseline coverage information (i.e., information about
+            lines, functions, and branches in the code without any of them actually having been
+            executed). These files are merged into the combined coverage report.
+            <p>The following file types are supported:
+            <ul>
+              <li><code>*.dat</code>LCOV</li>
+              <li><code>*.gcov</code>GCOV</li>
+              <li><code>*.gcov.json.gz</code>GCOV JSON format</li>
+              <li>directories containing such files</li>
+            </ul>
+            """,
             positional = false,
             named = true,
             defaultValue = "None",

--- a/src/test/shell/bazel/bazel_coverage_starlark_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_starlark_test.sh
@@ -639,4 +639,223 @@ end_of_record"
     assert_coverage_result "$expected_baseline_coverage" bazel-out/_coverage/_baseline_report.dat
 }
 
+function test_starlark_rule_custom_baseline_coverage_directory() {
+  # TODO: Remove after the next release of the coverage generator.
+  if [[ "${COVERAGE_GENERATOR_WORKSPACE_FILE}" == "released" ]]; then
+    return 0
+  fi
+
+  mkdir -p test
+  cat <<'EOF' > test/rules.bzl
+def _my_library_impl(ctx):
+    providers = []
+
+    transitive_files = [dep[DefaultInfo].files for dep in (ctx.attr.deps + ctx.attr.srcs)]
+    providers.append(
+        DefaultInfo(
+            files = depset(transitive = transitive_files),
+        )
+    )
+
+    lcov_dir = ctx.actions.declare_directory(ctx.label.name + "_baseline_coverage")
+    ctx.actions.run_shell(
+        outputs = [lcov_dir],
+        command = "\n".join([
+"""
+cat <<E_O_F > {}/{}.dat
+SF:{}
+DA:1,0
+DA:2,0
+LF:2
+LH:0
+end_of_record
+E_O_F
+""".format(lcov_dir.path, src.basename, src.path)
+for src in ctx.files.srcs
+]),
+    )
+
+    providers.append(
+        coverage_common.instrumented_files_info(
+            ctx = ctx,
+            source_attributes = ["srcs"],
+            dependency_attributes = ["deps"],
+            baseline_coverage_files = [lcov_dir],
+        )
+    )
+
+    return providers
+
+my_library = rule(
+    implementation = _my_library_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+        ),
+        "deps": attr.label_list(),
+    },
+)
+
+def _my_test_impl(ctx):
+    providers = []
+
+    out = ctx.actions.declare_file(ctx.label.name)
+    all_files = depset(transitive = [dep[DefaultInfo].files for dep in (ctx.attr.deps + ctx.attr.srcs)])
+    script_content = "#!/bin/bash\n" + "\n".join([
+        """cat <<E_O_F >> "$COVERAGE_DIR/my_test.dat"
+SF:{}
+DA:1,1
+DA:2,0
+LF:2
+LH:1
+end_of_record
+E_O_F
+""".format(f.path)
+        for f in all_files.to_list()
+    ])
+    ctx.actions.write(out, script_content, is_executable = True)
+    providers.append(DefaultInfo(executable = out))
+
+    providers.append(
+        coverage_common.instrumented_files_info(
+            ctx = ctx,
+            source_attributes = ["srcs"],
+            dependency_attributes = ["deps"],
+        )
+    )
+
+    return providers
+
+my_test = rule(
+    implementation = _my_test_impl,
+    test = True,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+        ),
+        "deps": attr.label_list(),
+        "_lcov_merger": attr.label(
+            default = configuration_field(fragment = "coverage", name = "output_generator"),
+            cfg = config.exec(exec_group = "test"),
+        ),
+    },
+)
+EOF
+
+  cat <<'EOF' > test/BUILD
+load(":rules.bzl", "my_library", "my_test")
+
+my_library(
+    name = "untested_lib",
+    srcs = [
+        "untested_1.txt",
+        "untested_2.txt",
+    ],
+)
+
+my_library(
+    name = "covered_lib",
+    srcs = [
+        "covered_1.txt",
+        "covered_2.txt",
+    ],
+)
+
+my_library(
+    name = "all_libs",
+    deps = [
+        ":untested_lib",
+        ":covered_lib",
+    ],
+)
+
+my_library(
+    name = "tested_libs",
+    deps = [
+        ":covered_lib",
+    ],
+)
+
+my_test(
+    name = "my_test",
+    srcs = [
+        "test_1.txt",
+        "test_2.txt",
+    ],
+    deps = [":tested_libs"],
+)
+EOF
+    touch test/{untested_1.txt,untested_2.txt,covered_1.txt,covered_2.txt,test_1.txt,test_2.txt}
+
+    bazel coverage //test:my_test //test:all_libs --combined_report=lcov &> $TEST_log \
+        || fail "Coverage run failed but should have succeeded."
+    local expected_coverage="SF:test/covered_1.txt
+FNF:0
+FNH:0
+DA:1,1
+DA:2,0
+LH:1
+LF:2
+end_of_record
+SF:test/covered_2.txt
+FNF:0
+FNH:0
+DA:1,1
+DA:2,0
+LH:1
+LF:2
+end_of_record
+SF:test/untested_1.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record
+SF:test/untested_2.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record"
+    local expected_baseline_coverage="SF:test/covered_1.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record
+SF:test/covered_2.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record
+SF:test/untested_1.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record
+SF:test/untested_2.txt
+FNF:0
+FNH:0
+DA:1,0
+DA:2,0
+LH:0
+LF:2
+end_of_record"
+
+    assert_coverage_result "$expected_coverage" bazel-out/_coverage/_coverage_report.dat
+    assert_coverage_result "$expected_baseline_coverage" bazel-out/_coverage/_baseline_report.dat
+}
+
 run_suite "test tests"

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
@@ -72,7 +72,6 @@ public class GcovParser {
           malformedInput = true;
         }
       }
-      bufferedReader.close();
     }
     endSourceFile();
     if (malformedInput) {

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
@@ -72,7 +72,6 @@ class LcovParser {
       while ((line = bufferedReader.readLine()) != null) {
         parseLine(line, allSourceFiles);
       }
-      bufferedReader.close();
     }
     return allSourceFiles;
   }

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -14,12 +14,14 @@
 
 package com.google.devtools.coverageoutputgenerator;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.devtools.coverageoutputgenerator.Constants.GCOV_EXTENSION;
 import static com.google.devtools.coverageoutputgenerator.Constants.GCOV_JSON_EXTENSION;
 import static com.google.devtools.coverageoutputgenerator.Constants.PROFDATA_EXTENSION;
 import static com.google.devtools.coverageoutputgenerator.Constants.TRACEFILE_EXTENSION;
 import static java.lang.Math.max;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -27,23 +29,17 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /** Command line utility to convert raw coverage files to lcov (text) format. */
@@ -61,7 +57,7 @@ public class Main {
   }
 
   static int runWithArgs(String... args) throws ExecutionException, InterruptedException {
-    LcovMergerFlags flags = null;
+    LcovMergerFlags flags;
     try {
       flags = LcovMergerFlags.parseFlags(args);
     } catch (IllegalArgumentException e) {
@@ -69,11 +65,11 @@ public class Main {
       return 1;
     }
 
-    File outputFile = new File(flags.outputFile());
+    Path outputFile = Paths.get(flags.outputFile());
 
-    List<File> filesInCoverageDir =
+    List<Path> filesInCoverageDir =
         flags.coverageDir() != null
-            ? getCoverageFilesInDir(flags.coverageDir())
+            ? getCoverageFilesInDir(Paths.get(flags.coverageDir()))
             : ImmutableList.of();
     Coverage coverage =
         Coverage.merge(
@@ -92,24 +88,19 @@ public class Main {
       coverage.maybeReplaceSourceFileNames(getMapFromFile(flags.sourcesToReplaceFile()));
     }
 
-    File profdataFile = getProfdataFileOrNull(filesInCoverageDir);
+    Path profdataFile = getProfdataFileOrNull(filesInCoverageDir);
     if (coverage.isEmpty()) {
-      int exitStatus = 0;
       if (profdataFile == null) {
         try {
           logger.log(Level.WARNING, "There was no coverage found.");
-          if (!Files.exists(outputFile.toPath())) {
-            Files.createFile(outputFile.toPath()); // Generate empty declared output
+          if (!Files.exists(outputFile)) {
+            Files.createFile(outputFile); // Generate empty declared output
           }
-          exitStatus = 0;
         } catch (IOException e) {
           logger.log(
               Level.SEVERE,
-              "Could not create empty output file "
-                  + outputFile.getName()
-                  + " due to: "
-                  + e.getMessage());
-          exitStatus = 1;
+              "Could not create empty output file " + outputFile + " due to: " + e.getMessage());
+          return 1;
         }
       } else {
         // Bazel doesn't support yet converting profdata files to lcov. We still want to output a
@@ -118,20 +109,20 @@ public class Main {
         // coverage users.
         // TODO(#5881): Add support for profdata files.
         try {
-          Files.copy(profdataFile.toPath(), outputFile.toPath(), REPLACE_EXISTING);
+          Files.copy(profdataFile, outputFile, REPLACE_EXISTING);
         } catch (IOException e) {
           logger.log(
               Level.SEVERE,
               "Could not copy file "
-                  + profdataFile.getName()
+                  + profdataFile
                   + " to output file "
-                  + outputFile.getName()
+                  + outputFile
                   + " due to: "
                   + e.getMessage());
-          exitStatus = 1;
+          return 1;
         }
       }
-      return exitStatus;
+      return 0;
     }
 
     if (!coverage.isEmpty() && profdataFile != null) {
@@ -145,7 +136,10 @@ public class Main {
     }
 
     if (!flags.filterSources().isEmpty()) {
-      coverage = Coverage.filterOutMatchingSources(coverage, flags.filterSources());
+      coverage =
+          Coverage.filterOutMatchingSources(
+              coverage,
+              flags.filterSources().stream().map(Pattern::compile).collect(toImmutableList()));
     }
 
     if (flags.hasSourceFileManifest()) {
@@ -157,32 +151,27 @@ public class Main {
     if (coverage.isEmpty()) {
       try {
         logger.log(Level.WARNING, "There was no coverage found.");
-        if (!Files.exists(outputFile.toPath())) {
-          Files.createFile(outputFile.toPath()); // Generate empty declared output
+        if (!Files.exists(outputFile)) {
+          Files.createFile(outputFile); // Generate empty declared output
         }
         return 0;
       } catch (IOException e) {
         logger.log(
             Level.SEVERE,
-            "Could not create empty output file "
-                + outputFile.getName()
-                + " due to: "
-                + e.getMessage());
+            "Could not create empty output file " + outputFile + " due to: " + e.getMessage());
         return 1;
       }
     }
 
-    int exitStatus = 0;
-
     try {
-      LcovPrinter.print(new FileOutputStream(outputFile), coverage);
+      LcovPrinter.print(Files.newOutputStream(outputFile), coverage);
     } catch (IOException e) {
       logger.log(
           Level.SEVERE,
           "Could not write to output file " + outputFile + " due to " + e.getMessage());
-      exitStatus = 1;
+      return 1;
     }
-    return exitStatus;
+    return 0;
   }
 
   /**
@@ -195,27 +184,21 @@ public class Main {
    * necessary when putting together the final coverage report.
    */
   private static Set<String> getSourcesFromSourceFileManifest(String sourceFileManifest) {
-    Set<String> sourceFiles = new HashSet<>();
-    try (FileInputStream inputStream = new FileInputStream(new File(sourceFileManifest));
-        InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
-        BufferedReader reader = new BufferedReader(inputStreamReader)) {
-      for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-        if (!isMetadataFile(line)) {
-          sourceFiles.add(line);
-        }
-      }
+    try (BufferedReader reader = Files.newBufferedReader(Path.of(sourceFileManifest))) {
+      return reader.lines().filter(line -> !isMetadataFile(line)).collect(toImmutableSet());
     } catch (IOException e) {
       logger.log(Level.SEVERE, "Error reading file " + sourceFileManifest + ": " + e.getMessage());
+      System.exit(1);
+      throw new IllegalStateException("not reached");
     }
-    return sourceFiles;
   }
 
   private static boolean isMetadataFile(String filename) {
     return filename.endsWith(".gcno") || filename.endsWith(".em");
   }
 
-  private static List<File> getGcovInfoFiles(List<File> filesInCoverageDir) {
-    List<File> gcovFiles = getFilesWithExtension(filesInCoverageDir, GCOV_EXTENSION);
+  private static List<Path> getGcovInfoFiles(List<Path> filesInCoverageDir) {
+    List<Path> gcovFiles = getFilesWithExtension(filesInCoverageDir, GCOV_EXTENSION);
     if (gcovFiles.isEmpty()) {
       logger.log(Level.FINE, "No gcov info file found.");
     } else {
@@ -224,8 +207,8 @@ public class Main {
     return gcovFiles;
   }
 
-  private static List<File> getGcovJsonInfoFiles(List<File> filesInCoverageDir) {
-    List<File> gcovJsonFiles = getFilesWithExtension(filesInCoverageDir, GCOV_JSON_EXTENSION);
+  private static List<Path> getGcovJsonInfoFiles(List<Path> filesInCoverageDir) {
+    List<Path> gcovJsonFiles = getFilesWithExtension(filesInCoverageDir, GCOV_JSON_EXTENSION);
     if (gcovJsonFiles.isEmpty()) {
       logger.log(Level.FINE, "No gcov json file found.");
     } else {
@@ -238,8 +221,8 @@ public class Main {
    * Returns a .profdata file from the given files or null if none or more profdata files were
    * found.
    */
-  private static File getProfdataFileOrNull(List<File> files) {
-    List<File> profdataFiles = getFilesWithExtension(files, PROFDATA_EXTENSION);
+  private static Path getProfdataFileOrNull(List<Path> files) {
+    List<Path> profdataFiles = getFilesWithExtension(files, PROFDATA_EXTENSION);
     if (profdataFiles.isEmpty()) {
       logger.log(Level.FINE, "No .profdata file found.");
       return null;
@@ -256,12 +239,14 @@ public class Main {
     return profdataFiles.get(0);
   }
 
-  private static List<File> getTracefiles(LcovMergerFlags flags, List<File> filesInCoverageDir) {
-    List<File> lcovTracefiles = new ArrayList<>();
+  private static List<Path> getTracefiles(LcovMergerFlags flags, List<Path> filesInCoverageDir) {
+    List<Path> lcovTracefiles;
     if (flags.reportsFile() != null) {
-      lcovTracefiles = getTracefilesFromFile(flags.reportsFile());
+      lcovTracefiles = getTracefilesFromFile(Paths.get(flags.reportsFile()));
     } else if (flags.coverageDir() != null) {
       lcovTracefiles = getFilesWithExtension(filesInCoverageDir, TRACEFILE_EXTENSION);
+    } else {
+      lcovTracefiles = ImmutableList.of();
     }
     if (lcovTracefiles.isEmpty()) {
       logger.log(Level.FINE, "No lcov file found.");
@@ -278,26 +263,20 @@ public class Main {
    * in the map with the corresponding key and value.
    */
   private static ImmutableMap<String, String> getMapFromFile(String file) {
-    ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
-
-    try (FileInputStream inputStream = new FileInputStream(file);
-        InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
-        BufferedReader reader = new BufferedReader(inputStreamReader)) {
-      for (String keyToValueLine = reader.readLine();
-          keyToValueLine != null;
-          keyToValueLine = reader.readLine()) {
-        String[] keyAndValue = keyToValueLine.split(":");
-        if (keyAndValue.length == 2) {
-          mapBuilder.put(keyAndValue[0], keyAndValue[1]);
-        }
-      }
+    try (BufferedReader reader = Files.newBufferedReader(Path.of(file))) {
+      return reader
+          .lines()
+          .map(line -> line.split(":"))
+          .filter(entry -> entry.length == 2)
+          .collect(toImmutableMap(entry -> entry[0], entry -> entry[1]));
     } catch (IOException e) {
       logger.log(Level.SEVERE, "Error reading file " + file + ": " + e.getMessage());
+      System.exit(1);
+      throw new IllegalStateException("not reached");
     }
-    return mapBuilder.buildOrThrow();
   }
 
-  static Coverage parseFiles(List<File> files, Parser parser, int parallelism)
+  static Coverage parseFiles(List<Path> files, Parser parser, int parallelism)
       throws ExecutionException, InterruptedException {
     if (parallelism == 1) {
       return parseFilesSequentially(files, parser);
@@ -306,19 +285,19 @@ public class Main {
     }
   }
 
-  static Coverage parseFilesSequentially(List<File> files, Parser parser) {
+  static Coverage parseFilesSequentially(List<Path> files, Parser parser) {
     Coverage coverage = new Coverage();
-    for (File file : files) {
+    for (Path file : files) {
       try {
         logger.log(Level.FINE, "Parsing file " + file);
-        List<SourceFileCoverage> sourceFilesCoverage = parser.parse(new FileInputStream(file));
+        List<SourceFileCoverage> sourceFilesCoverage = parser.parse(Files.newInputStream(file));
         for (SourceFileCoverage sourceFileCoverage : sourceFilesCoverage) {
           coverage.add(sourceFileCoverage);
         }
       } catch (IOException e) {
         logger.log(
             Level.SEVERE,
-            "File " + file.getAbsolutePath() + " could not be parsed due to: " + e.getMessage(),
+            "File " + file.toAbsolutePath() + " could not be parsed due to: " + e.getMessage(),
             e);
         System.exit(1);
       }
@@ -326,61 +305,55 @@ public class Main {
     return coverage;
   }
 
-  static Coverage parseFilesInParallel(List<File> files, Parser parser, int parallelism)
+  static Coverage parseFilesInParallel(List<Path> files, Parser parser, int parallelism)
       throws ExecutionException, InterruptedException {
-    ForkJoinPool pool = new ForkJoinPool(parallelism);
-    int partitionSize = max(1, files.size() / parallelism);
-    List<List<File>> partitions = Lists.partition(files, partitionSize);
-    return pool.submit(
-            () ->
-                partitions.parallelStream()
-                    .map((p) -> parseFilesSequentially(p, parser))
-                    .reduce((c1, c2) -> Coverage.merge(c1, c2))
-                    .orElse(Coverage.create()))
-        .get();
+    try (ForkJoinPool pool = new ForkJoinPool(parallelism)) {
+      int partitionSize = max(1, files.size() / parallelism);
+      List<List<Path>> partitions = Lists.partition(files, partitionSize);
+      return pool.submit(
+              () ->
+                  partitions.parallelStream()
+                      .map((p) -> parseFilesSequentially(p, parser))
+                      .reduce(Coverage::merge)
+                      .orElse(Coverage.create()))
+          .get();
+    }
   }
 
   /**
    * Returns a list of all the files with the given extension found recursively under the given dir.
    */
   @VisibleForTesting
-  static List<File> getCoverageFilesInDir(String dir) {
-    List<File> files = new ArrayList<>();
-    try (Stream<Path> stream = Files.walk(Paths.get(dir))) {
-      files =
-          stream
-              .filter(
-                  p ->
-                      p.toString().endsWith(TRACEFILE_EXTENSION)
-                          || p.toString().endsWith(GCOV_EXTENSION)
-                          || p.toString().endsWith(GCOV_JSON_EXTENSION)
-                          || p.toString().endsWith(PROFDATA_EXTENSION))
-              .map(path -> path.toFile())
-              .collect(Collectors.toList());
+  static List<Path> getCoverageFilesInDir(Path dir) {
+    try (Stream<Path> stream = Files.walk(dir)) {
+      return stream
+          .filter(
+              p ->
+                  p.toString().endsWith(TRACEFILE_EXTENSION)
+                      || p.toString().endsWith(GCOV_EXTENSION)
+                      || p.toString().endsWith(GCOV_JSON_EXTENSION)
+                      || p.toString().endsWith(PROFDATA_EXTENSION))
+          .collect(toImmutableList());
     } catch (IOException ex) {
       logger.log(Level.SEVERE, "Error reading folder " + dir + ": " + ex.getMessage());
+      System.exit(1);
+      throw new IllegalStateException("not reached");
     }
-    return files;
   }
 
-  static List<File> getFilesWithExtension(List<File> files, String extension) {
+  static List<Path> getFilesWithExtension(List<Path> files, String extension) {
     return files.stream()
         .filter(file -> file.toString().endsWith(extension))
-        .collect(Collectors.toList());
+        .collect(toImmutableList());
   }
 
-  static List<File> getTracefilesFromFile(String reportsFile) {
-    List<File> datFiles = new ArrayList<>();
-    try (FileInputStream inputStream = new FileInputStream(reportsFile)) {
-      InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
-      BufferedReader reader = new BufferedReader(inputStreamReader);
-      for (String tracefile = reader.readLine(); tracefile != null; tracefile = reader.readLine()) {
-        datFiles.add(new File(tracefile));
-      }
-
+  static List<Path> getTracefilesFromFile(Path reportsFile) {
+    try (BufferedReader reader = Files.newBufferedReader(reportsFile)) {
+      return reader.lines().map(Paths::get).collect(toImmutableList());
     } catch (IOException e) {
       logger.log(Level.SEVERE, "Error reading file " + reportsFile + ": " + e.getMessage());
+      System.exit(1);
+      throw new IllegalStateException("not reached");
     }
-    return datFiles;
   }
 }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/CoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/CoverageTest.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -112,7 +113,8 @@ public class CoverageTest {
     SourceFileCoverage validSource2 = new SourceFileCoverage("/valid/package/file4.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
-        Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/filterOut/package/.+"))
+        Coverage.filterOutMatchingSources(
+                coverage, ImmutableList.of(Pattern.compile("/filterOut/package/.+")))
             .getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);
@@ -125,7 +127,8 @@ public class CoverageTest {
     coverage.add(new SourceFileCoverage("/filterOut/package/file1.c"));
     coverage.add(new SourceFileCoverage("/filterOut/package/file2.c"));
     Collection<SourceFileCoverage> filteredSources =
-        Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/filterOut/package/.+"))
+        Coverage.filterOutMatchingSources(
+                coverage, ImmutableList.of(Pattern.compile("/filterOut/package/.+")))
             .getAllSourceFiles();
 
     assertThat(filteredSources).isEmpty();
@@ -140,7 +143,8 @@ public class CoverageTest {
     SourceFileCoverage validSource2 = new SourceFileCoverage("/valid/package/file4.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
-        Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/something/else/.+"))
+        Coverage.filterOutMatchingSources(
+                coverage, ImmutableList.of(Pattern.compile("/something/else/.+")))
             .getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);
@@ -159,7 +163,9 @@ public class CoverageTest {
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
         Coverage.filterOutMatchingSources(
-                coverage, ImmutableList.of("/filterOut/package/.+", ".+external.+"))
+                coverage,
+                ImmutableList.of(
+                    Pattern.compile("/filterOut/package/.+"), Pattern.compile(".+external.+")))
             .getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovMergerTestUtils.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovMergerTestUtils.java
@@ -54,6 +54,7 @@ public final class LcovMergerTestUtils {
   static List<Path> generateLcovFiles(
       String srcPrefix, int numLcovFiles, int numSrcFiles, int numLinesPerSrcFile, Path coverageDir)
       throws IOException {
+    Files.createDirectories(coverageDir);
     Path lcovFile = Files.createFile(Paths.get(coverageDir.toString(), "coverage0.dat"));
     List<Path> lcovFiles = new ArrayList<>();
     Files.write(lcovFile, generateLcovContents(srcPrefix, numSrcFiles, numLinesPerSrcFile));

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/MainTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/MainTest.java
@@ -48,7 +48,7 @@ public class MainTest {
 
   @Test
   public void testMainEmptyCoverageDir() {
-    assertThat(Main.getCoverageFilesInDir(coverageDir.toAbsolutePath().toString())).isEmpty();
+    assertThat(Main.getCoverageFilesInDir(coverageDir)).isEmpty();
   }
 
   @Test
@@ -59,8 +59,8 @@ public class MainTest {
     Files.createTempFile(ccCoverageDir, "tracefile1", ".dat");
     Files.createTempFile(javaCoverageDir, "tracefile2", ".dat");
 
-    List<File> coverageFiles = Main.getCoverageFilesInDir(coverageDir.toAbsolutePath().toString());
-    List<File> tracefiles = Main.getFilesWithExtension(coverageFiles, TRACEFILE_EXTENSION);
+    List<Path> coverageFiles = Main.getCoverageFilesInDir(coverageDir);
+    List<Path> tracefiles = Main.getFilesWithExtension(coverageFiles, TRACEFILE_EXTENSION);
     assertThat(tracefiles).hasSize(2);
   }
 
@@ -119,7 +119,7 @@ public class MainTest {
     LcovMergerTestUtils.generateLcovFiles(
         "test_data/simple_test", numLcovFiles, numSourceFiles, numLinesPerSourceFile, coverageDir);
 
-    List<File> coverageFiles = Main.getCoverageFilesInDir(coverageDir.toAbsolutePath().toString());
+    List<Path> coverageFiles = Main.getCoverageFilesInDir(coverageDir);
 
     Coverage sequentialCoverage = Main.parseFilesSequentially(coverageFiles, LcovParser::parse);
     LcovPrinter.print(sequentialOutput, sequentialCoverage);


### PR DESCRIPTION
Files in `baseline_coverage_files` can now be tree artifacts that themselves contain coverage files. In addition, `.gcov` and `.gcov.json.gz` files can now also be provided for baseline coverage. Both is needed for support of GCC-style baseline coverage, which will be added in a follow-up PR.

Along the way, clean up CoverageOutputGenerator:

* Don't reparse regexes for each source file.
* Fail on "SEVERE" errors rather than continuing with arbitrarily truncated data.
* Consistently use `Path`.

Work towards #5716