### PR TITLE
doc: add "best practices" for module `version` and `compatibility_level`

### DIFF
--- a/site/en/external/faq.md
+++ b/site/en/external/faq.md
@@ -12,6 +12,74 @@ Bazel.
 
 ## MODULE.bazel {:#module-bazel}
 
+### How should I version a Bazel module? {:#module-versioning-best-practices}
+
+Setting `version` with the [`module`] directive in the source archive
+`MODULE.bazel` can have several downsides and unintended side effects if not
+managed carefully:
+
+*   Duplication: releasing a new version of a module typically involves both
+    incrementing the version in `MODULE.bazel` and tagging the release, two
+    separate steps that can easily fall out of sync. While automation can
+    reduce this risk, it's simpler and safer to avoid it altogether.
+
+*   Inconsistency: users overriding a module with a specific commit via a
+    [non-registry override] will see an incorrect version. For instance, if the
+    `MODULE.bazel` in the source archive sets `version = "0.3.0"` but
+    additional commits have been made since that release, a user overriding
+    with one of those commits would still see `0.3.0`. In reality, the version
+    should reflect that it's ahead of the release, e.g. `0.3.1-rc1`.
+
+*   Non-registry override issues: using placeholder values can cause issues
+    when users override a module with a non-registry override. For example,
+    `0.0.0` doesn't sort as the highest version, which is usually the expected
+    behavior users want when doing a non-registry override.
+
+Thus, it's best to avoid setting the version in the source archive
+`MODULE.bazel`. Instead, set it in the `MODULE.bazel` stored in the registry
+(e.g., the [Bazel Central Registry]), which is the actual source of truth for
+the module version during Bazel's external dependency resolution (see [Bazel
+registries]).
+
+This is usually automated, e.g. the [`rules-template`] example rule repository
+uses a [bazel-contrib/publish-to-bcr publish.yaml Github Action] to publish the
+release to the BCR. The action [generates a patch for the source archive
+`MODULE.bazel`] with the release version. This patch is stored in the registry
+and is applied when the module is fetched during Bazel's external dependency
+resolution.
+
+This way, the version in the releases in the registry will be correctly set to
+the released version and thus, `bazel_dep`, `single_version_override` and
+`multiple_version_override` will work as expected, while avoiding potential
+issues when doing a non-registry override because the version in the source
+archive will be the default value (`''`), which will always be handled
+correctly (it's the default version value after all) and will behave as
+expected when sorting (the empty string is treated as the highest version).
+
+[Bazel Central Registry]: https://registry.bazel.build/
+[Bazel registries]: https://bazel.build/external/registry
+[bazel-contrib/publish-to-bcr publish.yaml Github Action]: https://github.com/bazel-contrib/publish-to-bcr/blob/v0.2.2/.github/workflows/publish.yaml
+[generates a patch for the source archive `MODULE.bazel`]: https://github.com/bazel-contrib/publish-to-bcr/blob/v0.2.2/src/domain/create-entry.ts#L176-L216
+[`module`]: /rules/lib/globals/module#module
+[non-registry override]: module.md#non-registry_overrides
+[`rules-template`]: https://github.com/bazel-contrib/rules-template
+
+### When should I increment the compatibility level? {:#incrementing-compatibility-level}
+
+The [`compatibility_level`](module.md#compatibility_level) of a Bazel module
+should be incremented _in the same commit_ that introduces a backwards
+incompatible ("breaking") change.
+
+However, Bazel can throw an error if it detects that versions of the _same
+module_ with _different compatibility levels_ exist in the resolved dependency
+graph. This can happen when e.g. two modules depend on versions of a third
+module with different compatibility levels.
+
+Thus, incrementing `compatibility_level` too frequently can be very disruptive
+and is discouraged. To avoid this situation, the `compatibility_level` should be
+incremented _only_ when the breaking change affects most use cases and isn't
+easy to migrate and/or work-around.
+
 ### Why does MODULE.bazel not support `load`s? {:#why-does-module-bazel-not-support-loads}
 
 During dependency resolution, the MODULE.bazel file of all referenced external

--- a/site/en/external/module.md
+++ b/site/en/external/module.md
@@ -58,6 +58,9 @@ Any valid SemVer version is a valid Bazel module version. Additionally, two
 SemVer versions `a` and `b` compare `a < b` if and only if the same holds when
 they're compared as Bazel module versions.
 
+Finally, to learn more about module versioning, [see the `MODULE.bazel`
+FAQ](faq#module-versioning-best-practices).
+
 ## Version selection {:#version-selection}
 
 Consider the diamond dependency problem, a staple in the versioned dependency
@@ -96,14 +99,19 @@ backwards incompatible versions of a module as a separate module. In terms of
 SemVer, that means `A 1.x` and `A 2.x` are considered distinct modules, and can
 coexist in the resolved dependency graph. This is, in turn, made possible by
 encoding the major version in the package path in Go, so there aren't any
-compile-time or linking-time conflicts.
+compile-time or linking-time conflicts. Bazel, however, cannot provide such
+guarantees because it follows [a relaxed version of SemVer](#version-format).
 
-Bazel, however, cannot provide such guarantees, so it needs the "major version"
-number in order to detect backwards incompatible versions. This number is called
-the *compatibility level*, and is specified by each module version in its
-`module()` directive. With this information, Bazel can throw an error when it
-detects that versions of the same module with different compatibility levels
-exist in the resolved dependency graph.
+Thus, Bazel needs the equivalent of the SemVer major version number to detect
+backwards incompatible ("breaking") versions. This number is called the
+*compatibility level*, and is specified by each module version in its
+[`module()`](/rule/lib/globals/module#module) directive. With this information,
+Bazel can throw an error if it detects that versions of the _same module_ with
+_different compatibility levels_ exist in the resolved dependency graph.
+
+Finally, incrementing the compatibility level can be disruptive to the users.
+To learn more about when and how to increment it, [check the `MODULE.bazel`
+FAQ](faq#incrementing-compatibility-level).
 
 ## Overrides
 
@@ -172,6 +180,11 @@ Bazel supports the following non-registry overrides:
 *   [`archive_override`](/rules/lib/globals/module#archive_override)
 *   [`git_override`](/rules/lib/globals/module#git_override)
 *   [`local_path_override`](/rules/lib/globals/module#local_path_override)
+
+Note that setting a version value in the source archive `MODULE.bazel` can have
+downsides when the module is being overriden with a non-registry override. To
+learn more about this [see the `MODULE.bazel`
+FAQ](faq#module-versioning-best-practices).
 
 ## Define repos that don't represent Bazel modules {:#use_repo_rule}
 

--- a/site/en/external/registry.md
+++ b/site/en/external/registry.md
@@ -30,7 +30,11 @@ An index registry must have the following format:
     *   `MODULE.bazel`: The `MODULE.bazel` file of this module version. Note
         that this is the `MODULE.bazel` file read during Bazel's external
         dependency resolution, _not_ the one from the source archive (unless
-        there's a non-registry override).
+        there's a [non-registry
+        override](/external/module#non-registry_overrides)). Also note that it's
+        best to use this file to set the version of a release and avoid doing so
+        in the source archive `MODULE.bazel` file. To learn more about module
+        versioning, [see the FAQ](faq.md#module-versioning-best-practices).
     *   [`source.json`](#source-json): A JSON file containing information on how
         to fetch the source of this module version
     *   `patches/`: An optional directory containing patch files, only used when


### PR DESCRIPTION
While asking about best practices regarding releasing Bazel modules in Slack, I learned a few things that I would have loved to see in the Bazel docs (e.g. leaving the version unset or set to the default `""` value can prevent issues like bazel-contrib/rules_go#4380 when the module is used via non-registry overrides).

For more info, see bazel-contrib/rules-template/pull/148 and this Slack thread:
https://bazelbuild.slack.com/archives/CA31HN1T3/p1750406404452179