### PR TITLE
WIP: Removes dropping of branch coverage

### DIFF
--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/SourceFileCoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/SourceFileCoverageTest.java
@@ -77,22 +77,6 @@ public class SourceFileCoverageTest {
   }
 
   @Test
-  public void testIncompatibleBaBranchMergeDrops() throws Exception {
-    sourceFile1 = new SourceFileCoverage("source");
-    sourceFile2 = new SourceFileCoverage("source");
-    sourceFile1.addBranch(800, BranchCoverage.create(800, 2));
-    sourceFile1.addBranch(800, BranchCoverage.create(800, 1));
-    sourceFile2.addBranch(800, BranchCoverage.create(800, 2));
-    sourceFile2.addBranch(800, BranchCoverage.create(800, 2));
-    sourceFile2.addBranch(800, BranchCoverage.create(800, 1));
-
-    SourceFileCoverage merged = SourceFileCoverage.merge(sourceFile1, sourceFile2);
-
-    assertThat(merged.getAllBranches())
-        .containsExactly(BranchCoverage.create(800, 2), BranchCoverage.create(800, 1));
-  }
-
-  @Test
   public void testIncompatibleBrdaBranchMergeDrops() throws Exception {
     sourceFile1 = new SourceFileCoverage("source");
     sourceFile2 = new SourceFileCoverage("source");


### PR DESCRIPTION
Previously, bazel would drop branch coverage when two source files had different numbers of branches reported. Since bazel does not guarantee order, on larger projects the branch coverage could thus oscillate, since the source of truth always dependend on which file was considered first.

This PR implements a simple "superset" logic that while still 'incorrect' (just like the arbitrary dropping of data) makes branch coverage commutative. It is meant as an example that can be used to further the conversation in [this issue](https://github.com/bazelbuild/bazel/issues/26350). 