### PR TITLE
Revert "[8.3.0] Bazel CI: Stop building binaries on CentOS 7 (#26071)"

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -1,13 +1,6 @@
 ---
 platforms:
-  rockylinux8:
-    build_targets:
-      - "//src:bazel"
-      - "//src:bazel_nojdk"
-    build_flags:
-      - "-c"
-      - "opt"
-  rockylinux8_arm64:
+  centos7:
     build_targets:
       - "//src:bazel"
       - "//src:bazel_nojdk"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -1,7 +1,7 @@
 ---
 
 tasks:
-  rockylinux8:
+  centos7:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
@@ -19,6 +19,8 @@ tasks:
       - "//src/tools/execlog/..."
     test_flags:
       - "--config=ci-linux"
+      # Override REMOTE_NETWORK_ADDRESS since bazel_sandboxing_networking_test doesn't work on this platform
+      - "--test_env=REMOTE_NETWORK_ADDRESS="
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -33,7 +35,7 @@ tasks:
       - "//tools/compliance/..."
       - "//tools/python/..."
       - "//tools/bash/..."
-      # These tests are not compatible with the gcov version of Rocky Linux 8.
+      # These tests are not compatible with the gcov version of CentOS 7.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
       - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,7 +1,7 @@
 ---
 
 tasks:
-  rockylinux8:
+  centos7:
     shards: 4
     shell_commands:
       - rm -rf $HOME/bazeltest
@@ -20,6 +20,8 @@ tasks:
       - "//src/tools/execlog/..."
     test_flags:
       - "--config=ci-linux"
+      # Override REMOTE_NETWORK_ADDRESS since bazel_sandboxing_networking_test doesn't work on this platform
+      - "--test_env=REMOTE_NETWORK_ADDRESS="
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -34,7 +36,7 @@ tasks:
       - "//tools/compliance/..."
       - "//tools/python/..."
       - "//tools/bash/..."
-      # These tests are not compatible with the gcov version of Rocky Linux 8.
+      # These tests are not compatible with the gcov version of CentOS 7.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
       - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
@@ -44,24 +46,6 @@ tasks:
     include_json_profile:
       - build
       - test
-  rockylinux8_arm64:
-    shell_commands:
-      - rm -rf $HOME/bazeltest
-      - mkdir $HOME/bazeltest
-    build_flags:
-      - "--config=ci-linux"
-    build_targets:
-      - "//:bazel-distfile.zip"
-      - "//scripts/packages/debian:bazel-debian.deb"
-      - "//scripts/packages:with-jdk/install.sh"
-      - "//src:bazel"
-      - "//src:bazel_jdk_minimal"
-      - "//src:test_repos"
-      - "//src/main/java/..."
-      - "//src/tools/diskcache/..."
-      - "//src/tools/execlog/..."
-    include_json_profile:
-      - build
   fedora39:
     shell_commands:
       - rm -rf $HOME/bazeltest

--- a/src/test/shell/bazel/bazel_example_test.sh
+++ b/src/test/shell/bazel/bazel_example_test.sh
@@ -135,7 +135,7 @@ function test_native_python_with_zip() {
     || fail "//examples/py_native:bin execution failed"
   expect_log "Fib(5) == 8"
   # Using python <zipfile> to run the python package
-  python3 ./bazel-bin/examples/py_native/bin >& $TEST_log \
+  python ./bazel-bin/examples/py_native/bin >& $TEST_log \
     || fail "//examples/py_native:bin execution failed"
   expect_log "Fib(5) == 8"
   assert_test_ok //examples/py_native:test --build_python_zip

--- a/src/test/shell/bazel/bazel_sandboxing_networking_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_networking_test.sh
@@ -55,7 +55,7 @@ function setup_network_tests() {
   local socket_dir
   socket_dir="$(mktemp -d /tmp/test.XXXXXX)" || fail "mktemp failed"
   local socket="${socket_dir}/socket"
-  python3 $python_server --unix_socket="${socket}" always file_to_serve &
+  python $python_server --unix_socket="${socket}" always file_to_serve &
   local pid="${!}"
 
   trap "kill_nc || true; kill '${pid}' || true; rm -f '${socket}'; rmdir '${socket_dir}'" EXIT
@@ -79,7 +79,7 @@ genrule(
 genrule(
   name = "loopback",
   outs = [ "loopback.txt" ],
-  cmd = "python3 $python_server always $(pwd)/file_to_serve >port.txt & "
+  cmd = "python $python_server always $(pwd)/file_to_serve >port.txt & "
       + "pid=\$\$!; "
       + "while ! grep started port.txt; do sleep 1; done; "
       + "port=\$\$(head -n 1 port.txt); "


### PR DESCRIPTION
This reverts commit cae0831c8ec0a6d06fa64cc05b04b88c20761a7b.

Moving from c7 to Rocky 8 has implicitly bumped the min glibc version needed from 2.17 to 2.25 due to the newly-in-use glibc-2.28 containing `getentropy@GLIBC_2.25`. While it's overall acceptable to move versions forward, this version bump appears to have been an inadvertent and unanticipated consequence of the builder OS change and was not announced as part of the 8.3.0 release. For more discussion see the thread on the [bazel slack](https://bazelbuild.slack.com/archives/CA31HN1T3/p1750709660087719).

A reasonable approach seems to be to revert the PR temporarily, publish an 8.3.1 release without the new glibc dependency, and then re-release this change with 8.4.0 and announce that 8.4.0 bumps the minimum glibc version in the release notes for that release. Curious for thoughts.

cc @fweikert