### PR TITLE
[8.4.0] Add better defaults for mobile-install flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/mobileinstall/MobileInstallCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/mobileinstall/MobileInstallCommand.java
@@ -137,17 +137,16 @@ public class MobileInstallCommand implements BlazeCommand {
     public Mode mode;
 
     @Option(
-      name = "mobile_install_aspect",
-      defaultValue = "@android_test_support//tools/android/mobile_install:mobile-install.bzl",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS, OptionEffectTag.CHANGES_INPUTS},
-      help = "The aspect to use for mobile-install."
-    )
+        name = "mobile_install_aspect",
+        defaultValue = "@rules_android//mobile_install:mi.bzl",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS, OptionEffectTag.CHANGES_INPUTS},
+        help = "The aspect to use for mobile-install.")
     public String mobileInstallAspect;
 
     @Option(
         name = "mobile_install_supported_rules",
-        defaultValue = "",
+        defaultValue = "android_binary",
         converter = Converters.CommaSeparatedOptionListConverter.class,
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},


### PR DESCRIPTION
--mobile_install_aspect points to the rules_android MI aspect, rather than the non-existent one in android_test_support

--mobile_install_supported_rules defaults to android_binary. No other rules are planned to the supported in the forseeable future.

RELNOTES: Add better defaults for mobile-install flags
PiperOrigin-RevId: 746132439
Change-Id: I562ffa76148f9be498e7048a6e99f420f1a62e4f