### PR TITLE
[8.4.0] Fix `bazel mod tidy` handling of Unicode filenames

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/ModCommand.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.devtools.build.lib.bazel.bzlmod.modcommand.ModOptions.Charset.UTF8;
 import static com.google.devtools.build.lib.runtime.Command.BuildPhase.LOADS;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
@@ -584,7 +585,7 @@ public final class ModCommand implements BlazeCommand {
       buildozerInput.append("format\n");
     }
 
-    try (var stdin = CharSource.wrap(buildozerInput).asByteSource(UTF_8).openStream()) {
+    try (var stdin = CharSource.wrap(buildozerInput).asByteSource(ISO_8859_1).openStream()) {
       new CommandBuilder()
           .setWorkingDir(env.getWorkspace())
           .addArg(modTidyValue.buildozer().getPathString())
@@ -601,7 +602,9 @@ public final class ModCommand implements BlazeCommand {
           return reportAndCreateTidyResult(env, modTidyValue);
         }
         suffix =
-            ":\n" + new String(((AbnormalTerminationException) e).getResult().getStderr(), UTF_8);
+            ":\n"
+                + new String(
+                    ((AbnormalTerminationException) e).getResult().getStderr(), ISO_8859_1);
       }
       return reportAndCreateFailureResult(
           env,

--- a/src/test/py/bazel/bzlmod/mod_command_test.py
+++ b/src/test/py/bazel/bzlmod/mod_command_test.py
@@ -1199,7 +1199,7 @@ class ModCommandTest(test_base.TestBase):
         'MODULE.bazel',
         [
             'include("//:firstProd.MODULE.bazel")',
-            'include("//:second.MODULE.bazel")',
+            'include("//:secondäöüÄÖÜß🌱.MODULE.bazel")',
         ],
     )
     self.ScratchFile(
@@ -1221,7 +1221,7 @@ class ModCommandTest(test_base.TestBase):
         ],
     )
     self.ScratchFile(
-        'second.MODULE.bazel',
+        'secondäöüÄÖÜß🌱.MODULE.bazel',
         [
             'ext = use_extension("//:extension.bzl", "ext")',
             'use_repo(ext, "blad_dep")',
@@ -1273,12 +1273,12 @@ class ModCommandTest(test_base.TestBase):
         'INFO: Updated use_repo calls for @//:extension.bzl%ext', stderr
     )
 
-    with open('MODULE.bazel', 'r') as module_file:
+    with open('MODULE.bazel', 'r', encoding='utf-8') as module_file:
       self.assertEqual(
           [
               'include("//:firstProd.MODULE.bazel")',
               '',  # formatted despite no extension usages!
-              'include("//:second.MODULE.bazel")',
+              'include("//:secondäöüÄÖÜß🌱.MODULE.bazel")',
               '',
           ],
           module_file.read().split('\n'),
@@ -1306,7 +1306,7 @@ class ModCommandTest(test_base.TestBase):
           ],
           module_file.read().split('\n'),
       )
-    with open('second.MODULE.bazel', 'r') as module_file:
+    with open('secondäöüÄÖÜß🌱.MODULE.bazel', 'r') as module_file:
       self.assertEqual(
           [
               'ext = use_extension("//:extension.bzl", "ext")',


### PR DESCRIPTION
Closes #26354.

PiperOrigin-RevId: 775388941
Change-Id: I99f2f824a097a24477dcdf96de030a7716fc8e57

Commit https://github.com/bazelbuild/bazel/commit/326416f7316e1a0b41f1839cdb7a01095f039191