### PR TITLE
Fix stale action key with `expand_directories=False` and manual expansion

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -547,11 +547,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
           // fingerprinting stringificationType here.
           CommandLineItemMapEachAdaptor commandLineItemMapFn =
               new CommandLineItemMapEachAdaptor(
-                  mapEach,
-                  location,
-                  starlarkSemantics,
-                  (features & EXPAND_DIRECTORIES) != 0 ? inputMetadataProvider : null,
-                  outputPathsMode);
+                  mapEach, location, starlarkSemantics, inputMetadataProvider, outputPathsMode);
           try {
             actionKeyContext.addNestedSetToFingerprint(commandLineItemMapFn, fingerprint, values);
           } finally {

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/BUILD
@@ -91,6 +91,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:starlark/starlark_custom_command_line",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:core_options",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils:round-tripping",
         "//src/main/java/com/google/devtools/build/lib/util",
@@ -104,6 +105,7 @@ java_test(
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
+        "@maven//:com_google_testparameterinjector_test_parameter_injector",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLineTest.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionLookupData;
 import com.google.devtools.build.lib.actions.ArgChunk;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifactType;
@@ -45,6 +46,8 @@ import com.google.devtools.build.lib.cmdline.BazelModuleContext;
 import com.google.devtools.build.lib.cmdline.BazelModuleKey;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.exec.util.FakeActionInputFileCache;
 import com.google.devtools.build.lib.skyframe.TreeArtifactValue;
 import com.google.devtools.build.lib.skyframe.serialization.testutils.RoundTripping;
@@ -53,6 +56,8 @@ import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import net.starlark.java.eval.Module;
 import net.starlark.java.eval.Mutability;
@@ -67,10 +72,9 @@ import net.starlark.java.syntax.ParserInput;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Tests for {@link StarlarkCustomCommandLine}. */
-@RunWith(JUnit4.class)
+@RunWith(TestParameterInjector.class)
 public final class StarlarkCustomCommandLineTest {
 
   private ArtifactRoot derivedRoot;
@@ -572,6 +576,7 @@ public final class StarlarkCustomCommandLineTest {
             .add(
                 vectorArg(tree)
                     .setExpandDirectories(false)
+                    .setLocation(Location.BUILTIN)
                     .setMapEach(
                         (StarlarkFunction)
                             execStarlark(
@@ -600,6 +605,69 @@ public final class StarlarkCustomCommandLineTest {
     assertThrows(
         CommandLineExpansionException.class,
         () -> commandLine.arguments(new FakeActionInputFileCache(), PathMapper.NOOP));
+  }
+
+  @Test
+  public void vectorArgArguments_expandDirectoriesDisabled_manualExpansionReflectedInActionKey(
+      @TestParameter boolean useNestedSet) throws Exception {
+    SpecialArtifact tree = createTreeArtifact("tree");
+    TreeFileArtifact child1 = TreeFileArtifact.createTreeOutput(tree, "child1");
+    TreeFileArtifact child2 = TreeFileArtifact.createTreeOutput(tree, "child2");
+    // The files won't be read so MISSING_FILE_MARKER will do
+    TreeArtifactValue treeArtifactValueBefore =
+        TreeArtifactValue.newBuilder(tree)
+            .putChild(child1, FileArtifactValue.MISSING_FILE_MARKER)
+            .putChild(child2, FileArtifactValue.MISSING_FILE_MARKER)
+            .build();
+    TreeArtifactValue treeArtifactValueAfter =
+        TreeArtifactValue.newBuilder(tree)
+            .putChild(child1, FileArtifactValue.MISSING_FILE_MARKER)
+            .build();
+    var vectorArg =
+        useNestedSet
+            ? new VectorArg.Builder(
+                NestedSetBuilder.wrap(Order.STABLE_ORDER, ImmutableList.of(tree)), Artifact.class)
+            : new VectorArg.Builder(Tuple.of(tree));
+    CommandLine commandLine =
+        builder
+            .add(
+                vectorArg
+                    .setExpandDirectories(false)
+                    .setLocation(Location.BUILTIN)
+                    .setMapEach(
+                        (StarlarkFunction)
+                            execStarlark(
+                                """
+                        def map_each(x, expander):
+                          return [f.path for f in expander.expand(x)]
+                        map_each
+                        """)))
+            .build(/* flagPerLine= */ false, RepositoryMapping.EMPTY);
+
+    var inputMetadataProviderBefore = new FakeActionInputFileCache();
+    inputMetadataProviderBefore.putTreeArtifact(tree, treeArtifactValueBefore);
+    var argumentsBefore = commandLine.arguments(inputMetadataProviderBefore, PathMapper.NOOP);
+    var fingerprintBefore = new Fingerprint();
+    commandLine.addToFingerprint(
+        new ActionKeyContext(),
+        inputMetadataProviderBefore,
+        CoreOptions.OutputPathsMode.OFF,
+        fingerprintBefore);
+    assertThat(argumentsBefore).containsExactly("bin/tree/child1", "bin/tree/child2");
+
+    var inputMetadataProviderAfter = new FakeActionInputFileCache();
+    inputMetadataProviderAfter.putTreeArtifact(tree, treeArtifactValueAfter);
+    var argumentsAfter = commandLine.arguments(inputMetadataProviderAfter, PathMapper.NOOP);
+    var fingerprintAfter = new Fingerprint();
+    commandLine.addToFingerprint(
+        new ActionKeyContext(),
+        inputMetadataProviderAfter,
+        CoreOptions.OutputPathsMode.OFF,
+        fingerprintAfter);
+    assertThat(argumentsAfter).containsExactly("bin/tree/child1");
+
+    assertThat(fingerprintBefore.hexDigestAndReset())
+        .isNotEqualTo(fingerprintAfter.hexDigestAndReset());
   }
 
   private static VectorArg.Builder vectorArg(Object... elems) {


### PR DESCRIPTION
The action key for an `Args` did not include the expansion of a tree artifact with a `map_each` callback that manually expands a tree artifact while setting `expand_directories = False`.