### PR TITLE
Fix hang with force fetching + repo contents cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
@@ -119,10 +119,16 @@ public final class RepoContentsCache {
     try {
       return entryDir.getDirectoryEntries().stream()
           .filter(path -> path.getBaseName().endsWith(RECORDED_INPUTS_SUFFIX))
-          // We're just sorting for consistency here. (Note that "10.recorded_inputs" would sort
-          // before "1.recorded_inputs".) If necessary, we could use some sort of heuristics here
-          // to speed up the subsequent up-to-date-ness checking.
-          .sorted(Comparator.comparing(Path::getBaseName))
+          // Prefer newer cache entries over older ones. They're more likely to be up-to-date; plus,
+          // if a repo is force-fetched, we want to use the new repo instead of always being stuck
+          // with the old one.
+          // To "prefer newer cache entries", we sort the entry file names by length DESC and then
+          // lexicographically DESC. This approximates sorting by converting to int and then DESC,
+          // but is defensive against non-numerically named entries.
+          .sorted(
+              Comparator.comparing((Path path) -> path.getBaseName().length())
+                  .thenComparing(Path::getBaseName)
+                  .reversed())
           .map(CandidateRepo::fromRecordedInputsFile)
           .collect(toImmutableList());
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -141,19 +141,21 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
   public FetchResult fetch(
       Rule rule, Path outputDirectory, BlazeDirectories directories, Environment env, SkyKey key)
       throws RepositoryFunctionException, InterruptedException {
+    var state = env.getState(State::new);
+    if (state.result != null) {
+      // Escape early if we've already finished fetching once. This can happen if
+      // RepositoryDelegatorFunction triggers a Skyframe restart _after_
+      // StarlarkRepositoryFunction#fetch is finished.
+      return state.result;
+    }
     var args = new FetchArgs(rule, outputDirectory, directories, env, key);
     if (!useWorkers) {
-      return fetchInternal(args);
+      state.result = fetchInternal(args);
+      return state.result;
     }
     // See below (the `catch CancellationException` clause) for why there's a `while` loop here.
     while (true) {
-      var state = env.getState(State::new);
-      if (state.result != null) {
-        // Escape early if we've already finished fetching once. This can happen if
-        // RepositoryDelegatorFunction triggers a Skyframe restart _after_
-        // StarlarkRepositoryFunction#fetch is finished.
-        return state.result;
-      }
+      state = env.getState(State::new);
       try {
         state.result =
             state.startOrContinueWork(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -124,6 +124,11 @@ public final class StarlarkRepositoryFunction extends RepositoryFunction {
     @Nullable FetchResult result;
   }
 
+  @Override
+  public boolean wasJustFetched(Environment env) {
+    return env.getState(State::new).result != null;
+  }
+
   private record FetchArgs(
       Rule rule, Path outputDirectory, BlazeDirectories directories, Environment env, SkyKey key) {
     FetchArgs toWorkerArgs(Environment env) {

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -393,6 +393,14 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
   /* Determines whether we should use the cached repositories */
   private boolean shouldUseCachedRepos(Environment env, RepositoryFunction handler, Rule rule)
       throws InterruptedException {
+    if (handler.wasJustFetched(env)) {
+      // If this SkyFunction has finished fetching once, then we should always use the cached
+      // result. This means that we _very_ recently (as in, in the same command invocation) fetched
+      // this repo (possibly with --force or --configure), and are only here again due to a Skyframe
+      // restart very late into RepositoryDelegatorFunction.
+      return true;
+    }
+
     boolean forceFetchEnabled = !FORCE_FETCH.get(env).isEmpty();
     boolean forceFetchConfigureEnabled =
         handler.isConfigure(rule) && !FORCE_FETCH_CONFIGURE.get(env).isEmpty();

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -198,6 +198,15 @@ public abstract class RepositoryFunction {
       Map<? extends RepoRecordedInput, String> recordedInputValues, Reproducibility reproducible) {}
 
   /**
+   * We sometimes get to the point before fetching a repo when we have <em>just</em> fetched it,
+   * particularly because of Skyframe restarts very late into RepositoryDelegatorFunction. In that
+   * case, this method can be used to report that fact.
+   */
+  public boolean wasJustFetched(Environment env) {
+    return false;
+  }
+
+  /**
    * Verify the data provided by the marker file to check if a refetch is needed. Returns an empty
    * Optional if the data is up to date and no refetch is needed and an Optional with a
    * human-readable reason if the data is obsolete and a refetch is needed.

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -363,9 +363,12 @@ class BazelFetchTest(test_base.TestBase):
     self.assertIn('name is bar', ''.join(stderr))
     self.RunBazel(['build', '@hello//:bar'])
 
-    # Restart the server. Make sure the cache entry with "bar" is selected.
-    self.RunBazel(['shutdown'])
-    self.RunBazel(['build', '@hello//:bar'])
+    # Clean expunge. Assert the cache entry with "bar" is selected (despite
+    # "foo" also still existing in the cache).
+    self.RunBazel(['clean', '--expunge'])
+    self.ScratchFile('name.txt', ['quux'])
+    _, _, stderr = self.RunBazel(['build', '@hello//:bar'])
+    self.assertNotIn('name is ', ''.join(stderr))
 
   def testForceFetchWithRepoCacheNoRepoWorkers(self):
     self.ScratchFile('.bazelrc',

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -16,7 +16,9 @@
 
 import os
 import tempfile
+
 from absl.testing import absltest
+
 from src.test.py.bazel import test_base
 from src.test.py.bazel.bzlmod.test_utils import BazelRegistry
 
@@ -364,6 +366,12 @@ class BazelFetchTest(test_base.TestBase):
     # Restart the server. Make sure the cache entry with "bar" is selected.
     self.RunBazel(['shutdown'])
     self.RunBazel(['build', '@hello//:bar'])
+
+  def testForceFetchWithRepoCacheNoRepoWorkers(self):
+    self.ScratchFile('.bazelrc',
+                     ['common --experimental_worker_for_repo_fetching=off'],
+                     mode='a')
+    self.testForceFetchWithRepoCache()
 
   def testFetchTarget(self):
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(


### PR DESCRIPTION
With the repo contents cache enabled, `bazel fetch --force` (and the now-removed `bazel sync`) would cause Bazel to hang forever. The reason is that writing into the repo contents cache causes a Skyframe restart very late into `RepositoryDelegatorFunction`, and the force-fetch bit causes the restarted function to consider it a cache miss, writing into the repo contents cache again, causing an infinite loop.

This PR changes it so that a restarted `RepositoryDelegatorFunction` will remember whether it had _just_ finished a fetch before; if so, it will use the cache, even if force-fetch is on.

Fixes https://github.com/bazelbuild/bazel/issues/26389.