### PR TITLE
[8.3.1] Fix hang with force fetching + repo contents cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -450,6 +450,14 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
   /* Determines whether we should use the cached repositories */
   private boolean shouldUseCachedRepos(Environment env, RepositoryFunction handler, Rule rule)
       throws InterruptedException {
+    if (handler.wasJustFetched(env)) {
+      // If this SkyFunction has finished fetching once, then we should always use the cached
+      // result. This means that we _very_ recently (as in, in the same command invocation) fetched
+      // this repo (possibly with --force or --configure), and are only here again due to a Skyframe
+      // restart very late into RepositoryDelegatorFunction.
+      return true;
+    }
+
     boolean forceFetchEnabled = !FORCE_FETCH.get(env).isEmpty();
     boolean forceFetchConfigureEnabled =
         handler.isConfigure(rule) && !FORCE_FETCH_CONFIGURE.get(env).isEmpty();

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -219,6 +219,15 @@ public abstract class RepositoryFunction {
   }
 
   /**
+   * We sometimes get to the point before fetching a repo when we have <em>just</em> fetched it,
+   * particularly because of Skyframe restarts very late into RepositoryDelegatorFunction. In that
+   * case, this method can be used to report that fact.
+   */
+  public boolean wasJustFetched(Environment env) {
+    return false;
+  }
+
+  /**
    * Verify the data provided by the marker file to check if a refetch is needed. Returns an empty
    * Optional if the data is up to date and no refetch is needed and an Optional with a
    * human-readable reason if the data is obsolete and a refetch is needed.

--- a/src/test/py/bazel/bzlmod/bazel_fetch_test.py
+++ b/src/test/py/bazel/bzlmod/bazel_fetch_test.py
@@ -16,6 +16,7 @@
 
 import os
 import tempfile
+
 from absl.testing import absltest
 from src.test.py.bazel import test_base
 from src.test.py.bazel.bzlmod.test_utils import BazelRegistry
@@ -304,6 +305,64 @@ class BazelFetchTest(test_base.TestBase):
     # One more time to validate force is invoked and not cached by skyframe
     _, _, stderr = self.RunBazel(['fetch', '--repo=@hello', '--force'])
     self.assertIn('No more Orange Juice!', ''.join(stderr))
+
+  def testForceFetchWithRepoCache(self):
+    self.ScratchFile(
+        'MODULE.bazel',
+        [
+            'ext = use_extension("extension.bzl", "ext")',
+            'use_repo(ext, "hello")',
+        ],
+    )
+    self.ScratchFile('BUILD')
+    self.ScratchFile('name.txt', ['foo'])
+    file_path = self.Path('name.txt').replace('\\', '\\\\')
+    self.ScratchFile(
+        'extension.bzl',
+        [
+            'def impl(ctx):',
+            '    file_content = ctx.read("' + file_path + '", watch="no")',
+            '    print("name is " + file_content)',
+            '    ctx.file("BUILD",',
+            '             "filegroup(name=\'" + file_content.strip() + "\')")',
+            '    return ctx.repo_metadata(reproducible=True)',
+            'repo_rule = repository_rule(implementation=impl)',
+            '',
+            'def _ext_impl(ctx):',
+            '    repo_rule(name="hello")',
+            'ext = module_extension(implementation=_ext_impl)',
+        ],
+    )
+
+    _, _, stderr = self.RunBazel(['fetch', '--repo=@hello'])
+    self.assertIn('name is foo', ''.join(stderr))
+    self.RunBazel(['build', '@hello//:foo'])
+
+    # Change file content and run WITHOUT force, assert no fetching!
+    self.ScratchFile('name.txt', ['bar'])
+    _, _, stderr = self.RunBazel(['fetch', '--repo=@hello'])
+    self.assertNotIn('name is bar', ''.join(stderr))
+    self.RunBazel(['build', '@hello//:foo'])
+
+    # Run again WITH --force and assert fetching
+    _, _, stderr = self.RunBazel(['fetch', '--repo=@hello', '--force'])
+    self.assertIn('name is bar', ''.join(stderr))
+    self.RunBazel(['build', '@hello//:bar'])
+
+    # Clean expunge. Assert the cache entry with "bar" is selected (despite
+    # "foo" also still existing in the cache).
+    self.RunBazel(['clean', '--expunge'])
+    self.ScratchFile('name.txt', ['quux'])
+    _, _, stderr = self.RunBazel(['build', '@hello//:bar'])
+    self.assertNotIn('name is ', ''.join(stderr))
+
+  def testForceFetchWithRepoCacheNoRepoWorkers(self):
+    self.ScratchFile(
+        '.bazelrc',
+        ['common --experimental_worker_for_repo_fetching=off'],
+        mode='a',
+    )
+    self.testForceFetchWithRepoCache()
 
   def testFetchTarget(self):
     self.main_registry.createCcModule('aaa', '1.0').createCcModule(


### PR DESCRIPTION
With the repo contents cache enabled, `bazel fetch --force` (and the now-removed `bazel sync`) would cause Bazel to hang forever. The reason is that writing into the repo contents cache causes a Skyframe restart very late into `RepositoryDelegatorFunction`, and the force-fetch bit causes the restarted function to consider it a cache miss, writing into the repo contents cache again, causing an infinite loop.

This PR changes it so that a restarted `RepositoryDelegatorFunction` will remember whether it had _just_ finished a fetch before; if so, it will use the cache, even if force-fetch is on.

Fixes https://github.com/bazelbuild/bazel/issues/26389.

Closes #26409.

PiperOrigin-RevId: 776306095
Change-Id: I52ad7aeb6581a16268d26a8b142041dc0e748768

Commit https://github.com/bazelbuild/bazel/commit/bf67251521eef5bd9effafd76f0c9739c86a355d