### PR TITLE
Flip `--incompatible_filegroup_runfiles_for_data`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -64,7 +64,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
   @Option(
       name = "incompatible_filegroup_runfiles_for_data",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,
       effectTags = {OptionEffectTag.UNKNOWN},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},


### PR DESCRIPTION
RELNOTES[INC]: `--incompatible_filegroup_runfiles_for_data` is now enabled by default. See https://github.com/bazelbuild/bazel/issues/26330 for details.