### PR TITLE
[8.4.0] Fix fast path in repo contents cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepoContentsCache.java
@@ -166,7 +166,7 @@ public final class RepoContentsCache {
     Path cacheRepoDir = entryDir.getChild(counter);
 
     cacheRepoDir.deleteTree();
-    cacheRepoDir.createDirectoryAndParents();
+    cacheRepoDir.getParentDirectory().createDirectoryAndParents();
     // Move the fetched marker file to a temp location, so that if following operations fail, both
     // the fetched repo and the cache locations are considered out-of-date.
     Path temporaryMarker = ensureTrashDir().getChild(UUID.randomUUID().toString());
@@ -175,6 +175,7 @@ public final class RepoContentsCache {
     try {
       fetchedRepoDir.renameTo(cacheRepoDir);
     } catch (IOException e) {
+      cacheRepoDir.createDirectoryAndParents();
       FileSystemUtils.moveTreesBelow(fetchedRepoDir, cacheRepoDir);
     }
     temporaryMarker.renameTo(cacheRecordedInputsFile);


### PR DESCRIPTION
This always failed since the target of the move was an existing directory.

Closes #26401.

PiperOrigin-RevId: 776662445
Change-Id: Ideac0547efda8e2e44b0f962c8e0f9af6b6a0c65

Commit https://github.com/bazelbuild/bazel/commit/f5cf3c593e0f9de33f060b2aee77152935c46f3e