### PR TITLE
Add more details for `--bes_upload_mode`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
@@ -153,9 +153,10 @@ public class BuildEventServiceOptions extends OptionsBase {
       effectTags = {OptionEffectTag.EAGERNESS_TO_EXIT},
       help =
           "Specifies whether the Build Event Service upload should block the build completion "
-              + "or should end the invocation immediately and finish the upload in the background. "
-              + "Either 'wait_for_upload_complete' (default), 'nowait_for_upload_complete', "
-              + "or 'fully_async'.")
+              + "or should end the invocation immediately and finish the upload in the background.\n\n"
+              + "  - `wait_for_upload_complete`: blocks at the end of the current invocation until all events (including lifecycle events if applicable) are uploaded and acknowledged by the backend.\n"
+              + "  - `nowait_for_upload_complete`: blocks at the beginning of the next invocation until all events (including lifecycle events if applicable) are uploaded and acknowledged by the backend.\n"
+              + "  - `fully_async`: blocks at the beginning of the next invocation until all events are uploaded but does not wait for acknowledgements. Events may be lost in case of (transient) failures and backends may report streams as incomplete in this mode. There is no guarantee that `FinishInvocationAttempt` or `FinishBuild` lifecycle events are sent.")
   public BesUploadMode besUploadMode;
 
   @Option(


### PR DESCRIPTION
The previous documentation only mentioned the options, but did not provide guidance on what they do.

This is especially important for `fully_async`, as it's not immediately clear from the name that lifecycle events are almost always dropped without warning. In general, I think the options should be renamed for clarity as `nowait_for_upload_complete` also waits for uploads to complete, just at a different time.