### PR TITLE
[8.4.0] Extend `BazelFlagInfo` with additional metadata

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.runtime.commands;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.devtools.build.lib.runtime.Command.BuildPhase.NONE;
 
 import com.google.common.base.Ascii;
@@ -45,7 +46,9 @@ import com.google.devtools.build.lib.server.FailureDetails.HelpCommand.Code;
 import com.google.devtools.build.lib.util.StringUtil;
 import com.google.devtools.build.lib.util.StringUtilities;
 import com.google.devtools.build.lib.util.io.OutErr;
+import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters;
+import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDefinition;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -276,6 +279,13 @@ public final class HelpCommand implements BlazeCommand {
     flagBuilder.setAllowsMultiple(option.allowsMultiple());
     flagBuilder.setRequiresValue(option.requiresValue());
 
+    if (option.getAbbreviation() != '\0') {
+      flagBuilder.setAbbreviation(String.valueOf(option.getAbbreviation()));
+    }
+    if (!option.getOldOptionName().isEmpty()) {
+      flagBuilder.setOldName(option.getOldOptionName());
+    }
+
     List<String> optionEffectTags =
         Arrays.stream(option.getOptionEffectTags())
             .map(Enum::toString)
@@ -292,9 +302,34 @@ public final class HelpCommand implements BlazeCommand {
       flagBuilder.setDocumentationCategory(option.getDocumentationCategory().toString());
     }
 
-    if (option.getAbbreviation() != '\0') {
-      flagBuilder.setAbbreviation(String.valueOf(option.getAbbreviation()));
+    if (!option.isSpecialNullDefault()) {
+      flagBuilder.setDefaultValue(option.getUnparsedDefaultValue());
     }
+
+    if (!option.getDeprecationWarning().isEmpty()) {
+      flagBuilder.setDeprecationWarning(option.getDeprecationWarning());
+    }
+
+    if (option.getOptionExpansion().length > 0) {
+      flagBuilder.addAllOptionExpansions(Arrays.asList(option.getOptionExpansion()));
+    }
+
+    Converter<?> converter = option.getConverter();
+    String converterClassName = converter.getClass().getSimpleName();
+    if (converterClassName.endsWith("Converter")) {
+      String shortName =
+          converterClassName.substring(0, converterClassName.length() - "Converter".length());
+      flagBuilder.setTypeConverter(shortName);
+    }
+    if (converter instanceof EnumConverter) {
+      EnumConverter<?> enumConverter = (EnumConverter) converter;
+      List<String> enumValues =
+          Arrays.stream(enumConverter.getEnumType().getEnumConstants())
+              .map(Object::toString)
+              .collect(toImmutableList());
+      flagBuilder.addAllEnumValues(enumValues);
+    }
+
     return flagBuilder;
   }
 

--- a/src/main/java/com/google/devtools/common/options/EnumConverter.java
+++ b/src/main/java/com/google/devtools/common/options/EnumConverter.java
@@ -68,4 +68,8 @@ public abstract class EnumConverter<T extends Enum<T>> extends Converter.Context
     return Ascii.toLowerCase(
         Converters.joinEnglishList(Arrays.asList(enumType.getEnumConstants())));
   }
+
+  public final Class<T> getEnumType() {
+    return enumType;
+  }
 }

--- a/src/main/protobuf/bazel_flags.proto
+++ b/src/main/protobuf/bazel_flags.proto
@@ -46,6 +46,19 @@ message FlagInfo {
   // but if true a value must be present for all instantiations of the flag,
   // e.g. --jobs=100.
   optional bool requires_value = 10;
+  // The default value
+  optional string default_value = 13;
+  // The old, deprecated name for this option, without leading dashes.
+  optional string old_name = 11;
+  // The deprecation warning for this option, if one is present.
+  optional string deprecation_warning = 12;
+  // Additional options which are added if this option is present.
+  repeated string option_expansions = 14;
+
+  // The expected type/"converter".
+  optional string type_converter = 15;
+  // List of valid enum values.
+  repeated string enum_values = 16;
 }
 
 message FlagCollection {


### PR DESCRIPTION
This commit adds additional metadata to the protobuf dump produced by `bazel help flag-as-proto`.

The old name and the deprecation message are useful to provide diagnostics within bazelrc files using a language server.
The `type_converter` and `enum_values` are usful to validate argument values and to provide auto-completion.
The option expansions can be used, e.g., to warn on contradictions between explicitly specificed flags and expansion flags.

Fixes #25006

Closes #25169.

PiperOrigin-RevId: 777673277
Change-Id: I2df7c7fccf8804b4f98f51f970a248ddd77536db

Commit https://github.com/bazelbuild/bazel/commit/aa4b847b27a44fce102ff97f6f1c90552f672e9b