### PR TITLE
[8.4.0] Forward `--host_jvmopt` to the exec configuration

### DIFF
--- a/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
+++ b/src/main/starlark/builtins_bzl/common/builtin_exec_platforms.bzl
@@ -406,6 +406,7 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:enforce_proguard_file_extension",
         "//command_line_option:proguard_top",
         "//command_line_option:host_javacopt",
+        "//command_line_option:host_jvmopt",
         "//command_line_option:host_java_launcher",
         "//command_line_option:tool_java_runtime_version",
         "//command_line_option:tool_java_language_version",
@@ -419,9 +420,6 @@ bazel_fragments["JavaOptions"] = fragment(
         "//command_line_option:experimental_java_test_auto_create_deploy_jar",
         "//command_line_option:experimental_limit_android_lint_to_android_constrained_java",
         "//command_line_option:experimental_run_android_lint_on_java_rules",
-    ],
-    inputs = [
-        "//command_line_option:host_jvmopt",
     ],
     outputs = [
         "//command_line_option:jvmopt",


### PR DESCRIPTION
This ports https://github.com/bazelbuild/bazel/pull/15978, which never got merged, to Starlark.

Closes #26346.

PiperOrigin-RevId: 777732082
Change-Id: I699c8fc248d18e1e6db168725f49fc051829b45e

Commit https://github.com/bazelbuild/bazel/commit/7c40bbeac7560aabf506c4f3a6cf1c98b156475e