### PR TITLE
Fix docs for `InputMetadataProvider` and `SpawnExecutionContext`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/InputMetadataProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/InputMetadataProvider.java
@@ -114,13 +114,14 @@ public interface InputMetadataProvider {
   ActionInput getInput(String execPath);
 
   /**
-   * Expands runfiles trees and tree artifacts in a sequence of {@link ActionInput}s.
+   * Expands tree artifacts in a sequence of {@link ActionInput}s.
    *
    * <p>If {@code keepEmptyTreeArtifacts} is true, a tree artifact will be included in the
    * constructed list when it expands into zero file artifacts. Otherwise, only the file artifacts
    * the tree artifact expands into will be included.
    *
-   * <p>Runfiles tree artifacts will be returned if {@code keepRunfilesTrees} is set.
+   * <p>Runfiles tree artifacts will be returned if {@code keepRunfilesTrees} is set, otherwise
+   * they will be filtered out.
    *
    * <p>Non-runfiles, non-tree artifacts are returned untouched.
    */

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -159,19 +159,6 @@ public interface SpawnRunner {
      * Prefetches the Spawns input files to the local machine. There are cases where Bazel runs on a
      * network file system, and prefetching the files in parallel is a significant performance win.
      * This should only be called by local strategies when local execution is imminent.
-     *
-     * <p>Should be called with the equivalent of: <code>
-     * policy.prefetchInputs(
-     *      Iterables.filter(policy.getInputMapping().values(), Predicates.notNull()));
-     * </code>
-     *
-     * <p>Note in particular that {@link #getInputMapping} may return {@code null} values, but this
-     * method does not accept {@code null} values.
-     *
-     * <p>The reason why this method requires passing in the inputs is that getInputMapping may be
-     * slow to compute, so if the implementation already called it, we don't want to compute it
-     * again. I suppose we could require implementations to memoize getInputMapping (but not compute
-     * it eagerly), and that may change in the future.
      */
     ListenableFuture<Void> prefetchInputs();
 


### PR DESCRIPTION
The `expandArtifacts` method does not expand runfiles trees and `prefetchInputs` doesn't have parameters.