### PR TITLE
Set working directory in interactive `--sandbox_debug` command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -150,7 +150,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
                 interactiveDebugArguments,
                 getEnvironment(),
                 /* environmentVariablesToClear= */ null,
-                /* cwd= */ null,
+                /* cwd= */ sandboxExecRoot.getPathString(),
                 /* configurationChecksum= */ null,
                 /* executionPlatformLabel= */ null,
                 /* spawnRunner= */ null));


### PR DESCRIPTION
Makes the interactive environment more representative of the actual sandbox environment.