### PR TITLE
Avoid `--guard_against_concurrent_changes` false positives

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -602,6 +602,8 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
         // If the proxy matches, the file certainly hasn't changed.
         return false;
       }
+      // The proxy may change without the file actually being modified, for example
+      // when a hardlink to the file is created or deleted.
       byte[] newDigest = DigestUtils.getDigestWithManualFallback(path, SyscallCache.NO_CACHE, stat);
       return !Arrays.equals(digest, newDigest);
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/FileArtifactValue.java
@@ -593,17 +593,33 @@ public abstract class FileArtifactValue implements SkyValue, HasDigest {
       if (proxy == null) {
         return false;
       }
-      FileStatus stat = path.statIfFound(Symlinks.FOLLOW);
+      var stat = path.statIfFound(Symlinks.FOLLOW);
       if (stat == null || !stat.isFile()) {
         // The file no longer exists or changed type, so it certainly has changed.
         return true;
       }
-      if (proxy.equals(FileContentsProxy.create(stat))) {
-        // If the proxy matches, the file certainly hasn't changed.
+      var newProxy = FileContentsProxy.create(stat);
+      if (proxy.equals(newProxy)) {
+        // If the proxy is the same, then the file certainly hasn't been modified. This is the
+        // common case, so we check it first.
         return false;
       }
-      // The proxy may change without the file actually being modified, for example
-      // when a hardlink to the file is created or deleted.
+      if (proxy.isModified(newProxy)) {
+        // If the non-ctime information in the proxy changed, the file has certainly been modified
+        // between the time the digest was computed and now.
+        return true;
+      }
+      // At this point the ctime changed, so some of the file's metadata has changed since we
+      // computed the digest. Returning true here would allow us to cautiously report modification
+      // even in complex ABA scenarios (file modified, then modified back with its mtime reset).
+      // However, we would also report modification in case a hardlink to the file was created or
+      // removed, such as by the hermetic Linux sandbox or certain optimized copy actions.
+      // As a compromise, we check whether the current state of the file differs from the previous
+      // one, ignoring any inbetween modifications that may have happened.
+      //
+      // Note that this path is always taken when using the hermetic Linux sandbox, but the
+      // associated cost should amortize over the next build as the digest will be cached under the
+      // new stat.
       byte[] newDigest = DigestUtils.getDigestWithManualFallback(path, SyscallCache.NO_CACHE, stat);
       return !Arrays.equals(digest, newDigest);
     }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1915,7 +1915,9 @@ java_test(
     srcs = ["FileArtifactValueTest.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
+        "//src/main/java/com/google/devtools/build/lib/unix",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
@@ -256,7 +256,7 @@ public final class FileArtifactValueTest {
     clock.advanceMillis(1);
     assertThat(value.wasModifiedSinceDigest(path)).isFalse();
     clock.advanceMillis(1);
-    path.setLastModifiedTime(123); // Changing mtime implicitly updates ctime.
+    FileSystemUtils.writeContentAsLatin1(path, "new content");
     assertThat(value.wasModifiedSinceDigest(path)).isTrue();
     clock.advanceMillis(1);
     assertThat(value.wasModifiedSinceDigest(path)).isTrue();

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FileArtifactValueTest.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.skyframe;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
 import static com.google.devtools.build.lib.actions.FileArtifactValue.createForTesting;
 import static org.junit.Assert.assertThrows;
 
@@ -22,7 +23,9 @@ import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.testutil.ManualClock;
+import com.google.devtools.build.lib.unix.UnixFileSystem;
 import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
@@ -30,6 +33,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.time.Instant;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +46,12 @@ public final class FileArtifactValueTest {
   private final FileSystem fs = new InMemoryFileSystem(clock, DigestHashFunction.SHA256);
 
   private Path scratchFile(String name, long mtime, String content) throws IOException {
-    Path path = fs.getPath(name);
+    return scratchFile(name, mtime, content, fs);
+  }
+
+  private Path scratchFile(String name, long mtime, String content, FileSystem fileSystem)
+      throws IOException {
+    Path path = fileSystem.getPath(name);
     path.getParentDirectory().createDirectoryAndParents();
     FileSystemUtils.writeContentAsLatin1(path, content);
     path.setLastModifiedTime(mtime);
@@ -248,7 +257,22 @@ public final class FileArtifactValueTest {
   }
 
   @Test
-  public void testUptodateCheck() throws Exception {
+  public void testUptodateCheckChangeMetadata() throws Exception {
+    Path path = scratchFile("/dir/artifact1", 0L, "content");
+    FileArtifactValue value = createForTesting(path);
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    path.setLastModifiedTime(123);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+  }
+
+  @Test
+  public void testUptodateCheckChangeContent() throws Exception {
     Path path = scratchFile("/dir/artifact1", 0L, "content");
     FileArtifactValue value = createForTesting(path);
     clock.advanceMillis(1);
@@ -260,6 +284,121 @@ public final class FileArtifactValueTest {
     assertThat(value.wasModifiedSinceDigest(path)).isTrue();
     clock.advanceMillis(1);
     assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+  }
+
+  @Test
+  public void testUptodateCheckChangeContentAndResetMetadata() throws Exception {
+    Path path = scratchFile("/dir/artifact1", 0L, "content");
+    FileArtifactValue value = createForTesting(path);
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    FileSystemUtils.writeContentAsLatin1(path, "new content");
+    path.setLastModifiedTime(0);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+  }
+
+  @Test
+  public void testUptodateCheckChangeContentAndResetMetadataWithMatchingSize() throws Exception {
+    Path path = scratchFile("/dir/artifact1", 0L, "content");
+    FileArtifactValue value = createForTesting(path);
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    FileSystemUtils.writeContentAsLatin1(path, "cOntent");
+    path.setLastModifiedTime(0);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+  }
+
+  @Test
+  public void testUptodateCheckChangeContentAndReset() throws Exception {
+    Path path = scratchFile("/dir/artifact1", 0L, "content");
+    FileArtifactValue value = createForTesting(path);
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    FileSystemUtils.writeContentAsLatin1(path, "new content");
+    FileSystemUtils.writeContentAsLatin1(path, "content");
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+  }
+
+  @Test
+  public void testUptodateCheckChangeContentAndResetIncludingMetadata() throws Exception {
+    Path path = scratchFile("/dir/artifact1", 0L, "content");
+    FileArtifactValue value = createForTesting(path);
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    FileSystemUtils.writeContentAsLatin1(path, "new content");
+    FileSystemUtils.writeContentAsLatin1(path, "content");
+    path.setLastModifiedTime(0);
+    // This is not necessarily the intended behavior, but a consequence of the need to avoid
+    // false positives due to hard link creation/deletion. "Breaking" this test in the future while
+    // preserving the behavior on other test cases would thus be a welcome change.
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+  }
+
+  @Test
+  public void testUptodateCheckReplaceWithMove() throws Exception {
+    assume().that(OS.getCurrent()).isNotEqualTo(OS.WINDOWS);
+
+    // Use the real file system as the semantics of moves are subtle and not necessarily fully
+    // captured by the in-memory file system.
+    var realFs = new UnixFileSystem(DigestHashFunction.SHA256, "hash");
+    var tempDirJvm = Files.createTempDirectory(null);
+    tempDirJvm.toFile().deleteOnExit();
+
+    Path path = scratchFile(tempDirJvm + "/dir/artifact1", 0L, "content", realFs);
+    Path newPath = scratchFile(tempDirJvm + "/dir/artifact2", 0L, "new content", realFs);
+    FileArtifactValue value = createForTesting(path);
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    newPath.renameTo(path);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isTrue();
+  }
+
+  @Test
+  public void testUptodateCheckCreateHardlink() throws Exception {
+    assume().that(OS.getCurrent()).isNotEqualTo(OS.WINDOWS);
+
+    // Use the real file system as the semantics of hard links are subtle and not necessarily
+    // fully captured by the in-memory file system.
+    var realFs = new UnixFileSystem(DigestHashFunction.SHA256, "hash");
+    var tempDirJvm = Files.createTempDirectory(null);
+    tempDirJvm.toFile().deleteOnExit();
+
+    Path path = scratchFile(tempDirJvm + "/dir/artifact1", 0L, "content", realFs);
+    FileArtifactValue value = createForTesting(path);
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    path.createHardLink(realFs.getPath(tempDirJvm + "/dir/artifact1_link"));
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
+    clock.advanceMillis(1);
+    assertThat(value.wasModifiedSinceDigest(path)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
If the proxy differs (which should be rare), we can compute a digest to know with certainty whether the input changed. Since a failed check doesn't just skip the cache upload but also emits a warning, it's worth avoiding false positives in this way and keeping the warning actionable. 

Sent in response to two Slack threads about `--guard_against_concurrent_changes` warnings:
* https://bazelbuild.slack.com/archives/CA31HN1T3/p1751448125096509
* https://bazelbuild.slack.com/archives/CA31HN1T3/p1751033926924599