### PR TITLE
Add `mnemonic` parameter to `ctx.actions.write`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteAction.java
@@ -37,6 +37,9 @@ import javax.annotation.Nullable;
  * Abstract Action to write to a file.
  */
 public abstract class AbstractFileWriteAction extends AbstractAction {
+  /** The default mnemonic for a file write action. */
+  public static final String MNEMONIC = "FileWrite";
+
   /**
    * Creates a new AbstractFileWriteAction instance.
    *
@@ -91,7 +94,7 @@ public abstract class AbstractFileWriteAction extends AbstractAction {
 
   @Override
   public String getMnemonic() {
-    return "FileWrite";
+    return MNEMONIC;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/ParameterFileWriteAction.java
@@ -60,6 +60,7 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
   private final ParameterFileType type;
   private final boolean hasInputArtifactToExpand;
   private final boolean makeExecutable;
+  private final String mnemonic;
 
   /**
    * Creates a new instance.
@@ -68,6 +69,7 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
    * @param output the Artifact that will be created by executing this Action
    * @param commandLine the contents to be written to the file
    * @param type the type of the file
+   * @param makeExecutable whether the output file should be made executable
    */
   public ParameterFileWriteAction(
       ActionOwner owner,
@@ -81,7 +83,8 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
         output,
         commandLine,
         type,
-        makeExecutable);
+        makeExecutable,
+        AbstractFileWriteAction.MNEMONIC);
   }
 
   /**
@@ -93,6 +96,8 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
    * @param output the Artifact that will be created by executing this Action
    * @param commandLine the contents to be written to the file
    * @param type the type of the file
+   * @param makeExecutable whether the output file should be made executable
+   * @param mnemonic the mnemonic for this action, or null if the default should be used
    */
   public ParameterFileWriteAction(
       ActionOwner owner,
@@ -100,17 +105,24 @@ public final class ParameterFileWriteAction extends AbstractFileWriteAction {
       Artifact output,
       CommandLine commandLine,
       ParameterFileType type,
-      boolean makeExecutable) {
+      boolean makeExecutable,
+      String mnemonic) {
     super(owner, inputs, output);
     this.commandLine = commandLine;
     this.type = type;
     this.hasInputArtifactToExpand = !inputs.isEmpty();
     this.makeExecutable = makeExecutable;
+    this.mnemonic = mnemonic;
   }
 
   @Override
   public boolean makeExecutable() {
     return makeExecutable;
+  }
+
+  @Override
+  public String getMnemonic() {
+    return mnemonic;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkActionFactoryApi.java
@@ -300,9 +300,19 @@ public interface StarlarkActionFactoryApi extends StarlarkValue {
             name = "is_executable",
             defaultValue = "False",
             doc = "Whether the output file should be executable.",
-            named = true)
+            named = true),
+        @Param(
+            name = "mnemonic",
+            allowedTypes = {
+                @ParamType(type = String.class),
+                @ParamType(type = NoneType.class),
+            },
+            defaultValue = "None",
+            named = true,
+            positional = false,
+            doc = "A one-word description of the action, for example, CppCompile or GoLink."),
       })
-  void write(FileApi output, Object content, Boolean isExecutable)
+  void write(FileApi output, Object content, Boolean isExecutable, Object mnemonicUnchecked)
       throws EvalException, InterruptedException;
 
   @StarlarkMethod(

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/BUILD
@@ -113,6 +113,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/actions:thread_state_receiver",
+        "//src/main/java/com/google/devtools/build/lib/analysis:actions/abstract_file_write_action",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/custom_command_line",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/parameter_file_write_action",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/ParamFileWriteActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/ParamFileWriteActionTest.java
@@ -153,7 +153,8 @@ public class ParamFileWriteActionTest extends BuildViewTestCase {
         outputArtifact,
         commandLine,
         ParameterFileType.UNQUOTED,
-        executable);
+        executable,
+        AbstractFileWriteAction.MNEMONIC);
   }
 
   private static CommandLine createNormalCommandLine() {

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -2516,6 +2516,27 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     ev.update("action", ev.eval("ruleContext.attr.dep[Actions].by_file[file]"));
 
     assertThat(ev.eval("type(action)")).isEqualTo("Action");
+    assertThat(ev.eval("action.mnemonic")).isEqualTo("FileWrite");
+
+    Object contentUnchecked = ev.eval("action.content");
+    assertThat(contentUnchecked).isInstanceOf(String.class);
+    assertThat(contentUnchecked).isEqualTo("foo123");
+  }
+
+  @Test
+  public void testFileWriteActionInterfaceWithCustomMnemonic() throws Exception {
+    scratch.file(
+        "test/rules.bzl",
+        getSimpleUnderTestDefinition("ctx.actions.write(output=out, content='foo123', mnemonic='MyWrite')"),
+        testingRuleDefinition);
+    scratch.file("test/BUILD", simpleBuildDefinition);
+    StarlarkRuleContext ruleContext = createRuleContext("//test:testing");
+    setRuleContext(ruleContext);
+    ev.update("file", ev.eval("ruleContext.attr.dep[DefaultInfo].files.to_list()[0]"));
+    ev.update("action", ev.eval("ruleContext.attr.dep[Actions].by_file[file]"));
+
+    assertThat(ev.eval("type(action)")).isEqualTo("Action");
+    assertThat(ev.eval("action.mnemonic")).isEqualTo("MyWrite");
 
     Object contentUnchecked = ev.eval("action.content");
     assertThat(contentUnchecked).isInstanceOf(String.class);
@@ -2538,6 +2559,31 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     ev.update("action", ev.eval("ruleContext.attr.dep[Actions].by_file[file]"));
 
     assertThat(ev.eval("type(action)")).isEqualTo("Action");
+    assertThat(ev.eval("action.mnemonic")).isEqualTo("FileWrite");
+
+    Object contentUnchecked = ev.eval("action.content");
+    assertThat(contentUnchecked).isInstanceOf(String.class);
+    // Args content ends the file with a newline
+    assertThat(contentUnchecked).isEqualTo("foo123\n");
+  }
+
+  @Test
+  public void testFileWriteActionInterfaceWithArgsAndCustomMnemonic() throws Exception {
+    scratch.file(
+        "test/rules.bzl",
+        getSimpleUnderTestDefinition(
+            "args = ctx.actions.args()",
+            "args.add('foo123')",
+            "ctx.actions.write(output=out, content=args, mnemonic='MyWrite')"),
+        testingRuleDefinition);
+    scratch.file("test/BUILD", simpleBuildDefinition);
+    StarlarkRuleContext ruleContext = createRuleContext("//test:testing");
+    setRuleContext(ruleContext);
+    ev.update("file", ev.eval("ruleContext.attr.dep[DefaultInfo].files.to_list()[0]"));
+    ev.update("action", ev.eval("ruleContext.attr.dep[Actions].by_file[file]"));
+
+    assertThat(ev.eval("type(action)")).isEqualTo("Action");
+    assertThat(ev.eval("action.mnemonic")).isEqualTo("MyWrite");
 
     Object contentUnchecked = ev.eval("action.content");
     assertThat(contentUnchecked).isInstanceOf(String.class);


### PR DESCRIPTION
RELNOTES[NEW]: The mnemonic of a file write action can now be set via the `mnemonic` parameter of `ctx.actions.write`.