### PR TITLE
Don't cache spawn input maps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 
 /**
  * A helper class for spawn strategies to turn runfiles suppliers into input mappings. This class
@@ -219,6 +220,60 @@ public final class SpawnInputExpander {
         spawn.getPathMapper(),
         baseDirectory);
     return inputMap;
+  }
+
+  /**
+   * Returns an iterable over the inputs of the given spawn, expanding tree artifacts, runfiles
+   * trees, and filesets.
+   *
+   * <p>The returned iterable never contains {@code null} values, but may contain duplicates.
+   */
+  public Iterable<ActionInput> lazilyExpandInputs(
+      Spawn spawn, InputMetadataProvider inputMetadataProvider) {
+    return () ->
+        spawn.getInputFiles().toList().stream()
+            .flatMap(
+                input -> {
+                  // Fast path of the common case of a regular artifact.
+                  if (!(input instanceof Artifact.SpecialArtifact artifact)) {
+                    return Stream.of(input);
+                  }
+                  if (artifact.isRunfilesTree()) {
+                    var runfilesMetadata = inputMetadataProvider.getRunfilesMetadata(input);
+                    if (runfilesMetadata == null) {
+                      return Stream.empty();
+                    }
+                    return runfilesMetadata.getRunfilesTree().getArtifacts().toList().stream()
+                        .flatMap(
+                            nestedArtifact ->
+                                nestedArtifact instanceof Artifact.SpecialArtifact specialArtifact
+                                    ? expandTreeArtifactsAndFilesets(
+                                        specialArtifact, inputMetadataProvider)
+                                    : Stream.of(nestedArtifact));
+                  }
+                  return expandTreeArtifactsAndFilesets(artifact, inputMetadataProvider);
+                })
+            .iterator();
+  }
+
+  private static Stream<? extends ActionInput> expandTreeArtifactsAndFilesets(
+      Artifact artifact, InputMetadataProvider inputMetadataProvider) {
+    if (artifact.isTreeArtifact()) {
+      var treeMetadata = inputMetadataProvider.getTreeMetadata(artifact);
+      if (treeMetadata == null || treeMetadata.getChildren().isEmpty()) {
+        // Match the behavior of getInputMapping.
+        return Stream.of(artifact);
+      }
+      return treeMetadata.getChildren().stream();
+    }
+    if (artifact.isFileset()) {
+      var fileset = inputMetadataProvider.getFileset(artifact);
+      if (fileset == null) {
+        return Stream.empty();
+      }
+      return fileset.symlinks().stream().map(FilesetOutputSymlink::target);
+    }
+    return Stream.of(artifact);
   }
 
   private static PathFragment mapForRunfiles(

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -243,8 +243,21 @@ public interface SpawnRunner {
      * mapping is used in a context where the directory relative to which the keys are interpreted
      * is not the same as the execroot.
      */
-    SortedMap<PathFragment, ActionInput> getInputMapping(
-        PathFragment baseDirectory, boolean willAccessRepeatedly);
+    SortedMap<PathFragment, ActionInput> getInputMapping(PathFragment baseDirectory);
+
+    /**
+     * Returns an iterable over all inputs of the spawn, with all giving rise to multiple files
+     * expanded.
+     *
+     * <p>Implementations are expected to return an iterable that contains the same elements as
+     * {@code getInputMapping(PathFragment.EMPTY_FRAGMENT).values()}, but possibly in a different
+     * order and with different multiplicity of individual inputs.
+     *
+     * <p>The returned iterable may contain duplicates.
+     */
+    default Iterable<ActionInput> lazilyExpandInputs() {
+      return getInputMapping(PathFragment.EMPTY_FRAGMENT).values();
+    }
 
     /** Reports a progress update to the Spawn strategy. */
     void report(ProgressStatus progress);

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractActionInputPrefetcher.java
@@ -56,7 +56,9 @@ import io.reactivex.rxjava3.core.Completable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -305,7 +307,9 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
       MetadataSupplier metadataSupplier,
       Priority priority,
       Reason reason) {
-    List<ActionInput> files = new ArrayList<>();
+    // Inputs may be duplicated, which results in unnecessary IO. Use a set with specified iteration
+    // order for best-effort deterministic errors.
+    SequencedSet<ActionInput> files = new LinkedHashSet<>();
 
     for (ActionInput input : inputs) {
       // Source artifacts don't need to be fetched.
@@ -465,10 +469,7 @@ public abstract class AbstractActionInputPrefetcher implements ActionInputPrefet
    */
   @Nullable
   private Symlink maybeGetSymlink(
-      ActionInput input,
-      Path inputPath,
-      FileArtifactValue metadata,
-      MetadataSupplier metadataSupplier)
+      ActionInput input,Path inputPath, FileArtifactValue metadata, MetadataSupplier metadataSupplier)
       throws IOException, InterruptedException {
     if (input instanceof TreeFileArtifact treeFile) {
       SpecialArtifact treeArtifact = treeFile.getParent();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteAction.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.remote;
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
-import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.remote.common.NetworkTime;
@@ -24,8 +23,6 @@ import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.common.RemotePathResolver;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
-import com.google.devtools.build.lib.vfs.PathFragment;
-import java.util.SortedMap;
 
 /**
  * A value class representing an action which can be executed remotely.
@@ -120,14 +117,6 @@ public class RemoteAction {
 
   public MerkleTree getMerkleTree() {
     return merkleTree;
-  }
-
-  /**
-   * Returns a {@link SortedMap} which maps from input paths for remote action to {@link
-   * ActionInput}.
-   */
-  public SortedMap<PathFragment, ActionInput> getInputMap(boolean willAccessRepeatedly) {
-    return remotePathResolver.getInputMapping(spawnExecutionContext, willAccessRepeatedly);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1814,10 +1814,7 @@ public class RemoteExecutionService {
       return;
     }
 
-    // As this check runs after the action has been executed, we can reuse the input map if it
-    // has already been created with willAccessRepeatedly = true, but do not need to force its
-    // retention.
-    for (ActionInput input : action.getInputMap(/* willAccessRepeatedly= */ false).values()) {
+    for (ActionInput input : action.getSpawnExecutionContext().lazilyExpandInputs()) {
       // In lite mode, only check source artifacts in the main repository for modifications.
       // Non-source artifacts are made read-only after execution, and external repositories are
       // rarely modified, with local_repository being the notable exception.

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
@@ -18,10 +18,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.PathMapper;
-import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -35,15 +33,6 @@ public interface RemotePathResolver {
    * input root.
    */
   PathFragment getWorkingDirectory();
-
-  /**
-   * Returns a {@link SortedMap} which maps from input paths for remote action to {@link
-   * ActionInput}.
-   */
-  default SortedMap<PathFragment, ActionInput> getInputMapping(
-      SpawnExecutionContext context, boolean willAccessRepeatedly) {
-    return context.getInputMapping(getWorkingDirectory(), willAccessRepeatedly);
-  }
 
   /** Resolves the output path relative to input root for the given {@link Path}. */
   String localPathToOutputPath(Path path);
@@ -179,12 +168,6 @@ public interface RemotePathResolver {
       @Override
       public PathFragment getWorkingDirectory() {
         return base.getWorkingDirectory();
-      }
-
-      @Override
-      public SortedMap<PathFragment, ActionInput> getInputMapping(
-          SpawnExecutionContext context, boolean willAccessRepeatedly) {
-        return base.getInputMapping(context, willAccessRepeatedly);
       }
 
       @Override

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -216,8 +216,7 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
-            context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            context.getInputMapping(PathFragment.EMPTY_FRAGMENT), execRoot);
     SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 
     final Path sandboxConfigPath = sandboxPath.getRelative("sandbox.sb");

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -217,8 +217,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
-            context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            context.getInputMapping(PathFragment.EMPTY_FRAGMENT), execRoot);
     SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 
     Duration timeout = context.getTimeout();

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -260,8 +260,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
-            context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            context.getInputMapping(PathFragment.EMPTY_FRAGMENT), execRoot);
 
     ImmutableMap<String, String> environment =
         localEnvProvider.rewriteLocalEnv(spawn.getEnvironment(), binTools, "/tmp");
@@ -473,10 +472,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   }
 
   private void checkForConcurrentModifications(SpawnExecutionContext context) throws IOException {
-    for (ActionInput input :
-        context
-            .getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true)
-            .values()) {
+    for (ActionInput input : context.lazilyExpandInputs()) {
       if (input instanceof VirtualActionInput) {
         // Virtual inputs are not existing in file system and can't be tampered with via sandbox. No
         // need to check them.

--- a/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/ProcessWrapperSandboxedSpawnRunner.java
@@ -88,8 +88,7 @@ final class ProcessWrapperSandboxedSpawnRunner extends AbstractSandboxSpawnRunne
 
     SandboxInputs inputs =
         SandboxHelpers.processInputFiles(
-            context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            context.getInputMapping(PathFragment.EMPTY_FRAGMENT), execRoot);
     SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 
     return new SymlinkedSandboxedSpawn(

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
@@ -64,8 +64,7 @@ final class WindowsSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
     SandboxInputs readablePaths =
         SandboxHelpers.processInputFiles(
-            context.getInputMapping(PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-            execRoot);
+            context.getInputMapping(PathFragment.EMPTY_FRAGMENT), execRoot);
 
     ImmutableSet.Builder<Path> writablePaths = ImmutableSet.builder();
     writablePaths.addAll(getWritableDirs(execRoot, environment));

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -195,9 +195,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
           Profiler.instance().profile(ProfilerTask.WORKER_SETUP, "Setting up inputs")) {
         inputFiles =
             SandboxHelpers.processInputFiles(
-                context.getInputMapping(
-                    PathFragment.EMPTY_FRAGMENT, /* willAccessRepeatedly= */ true),
-                execRoot);
+                context.getInputMapping(PathFragment.EMPTY_FRAGMENT), execRoot);
       }
       SandboxOutputs outputs = SandboxHelpers.getOutputs(spawn);
 

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnLogContextTestBase.java
@@ -23,6 +23,7 @@ import static java.util.Comparator.comparing;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Suppliers;
 import com.google.common.base.Utf8;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -96,6 +97,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -2234,12 +2236,12 @@ public abstract class SpawnLogContextTestBase {
     return builder;
   }
 
-  protected static SortedMap<PathFragment, ActionInput> createInputMap(ActionInput... actionInputs)
-      throws Exception {
+  protected static Supplier<SortedMap<PathFragment, ActionInput>> createInputMap(
+      ActionInput... actionInputs) throws Exception {
     return createInputMap(null, actionInputs);
   }
 
-  protected static SortedMap<PathFragment, ActionInput> createInputMap(
+  protected static Supplier<SortedMap<PathFragment, ActionInput>> createInputMap(
       RunfilesTree runfilesTree, ActionInput... actionInputs) throws Exception {
     TreeMap<PathFragment, ActionInput> builder = new TreeMap<>();
 
@@ -2276,7 +2278,7 @@ public abstract class SpawnLogContextTestBase {
         builder.put(actionInput.getExecPath(), actionInput);
       }
     }
-    return ImmutableSortedMap.copyOf(builder);
+    return Suppliers.ofInstance(ImmutableSortedMap.copyOf(builder));
   }
 
   protected static TreeArtifactValue createTreeArtifactValue(Artifact tree) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -2798,7 +2798,11 @@ public class RemoteExecutionServiceTest {
 
     // Check that inputs and outputs of the remote action are mapped correctly.
     var remoteAction = service.buildRemoteAction(spawn, context);
-    assertThat(remoteAction.getInputMap(false))
+    assertThat(
+            remoteAction
+                .getRemoteActionExecutionContext()
+                .getSpawnExecutionContext()
+                .getInputMapping(PathFragment.EMPTY_FRAGMENT))
         .containsExactly(
             PathFragment.create("outputs/bin/input1"), mappedInput,
             PathFragment.create("outputs/bin/input2"), unmappedInput);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemotePathResolverTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemotePathResolverTest.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,7 +28,6 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
-import java.util.SortedMap;
 import java.util.TreeMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +49,7 @@ public class RemotePathResolverTest {
 
     input = ActionInputHelper.fromPath("foo");
     spawnExecutionContext = mock(SpawnExecutionContext.class);
-    when(spawnExecutionContext.getInputMapping(any(), anyBoolean()))
+    when(spawnExecutionContext.getInputMapping(any()))
         .thenAnswer(
             invocationOnMock -> {
               PathFragment baseDirectory = invocationOnMock.getArgument(0);
@@ -77,26 +75,6 @@ public class RemotePathResolverTest {
     String workingDirectory = remotePathResolver.getWorkingDirectory().getPathString();
 
     assertThat(workingDirectory).isEqualTo("main");
-  }
-
-  @Test
-  public void getInputMapping_default_inputsRelativeToExecRoot() throws Exception {
-    RemotePathResolver remotePathResolver = RemotePathResolver.createDefault(execRoot);
-
-    SortedMap<PathFragment, ActionInput> inputs =
-        remotePathResolver.getInputMapping(spawnExecutionContext, false);
-
-    assertThat(inputs).containsExactly(PathFragment.create("foo"), input);
-  }
-
-  @Test
-  public void getInputMapping_sibling_inputsRelativeToInputRoot() throws Exception {
-    RemotePathResolver remotePathResolver = new SiblingRepositoryLayoutResolver(execRoot);
-
-    SortedMap<PathFragment, ActionInput> inputs =
-        remotePathResolver.getInputMapping(spawnExecutionContext, false);
-
-    assertThat(inputs).containsExactly(PathFragment.create("main/foo"), input);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -203,8 +203,7 @@ public class RemoteSpawnCacheTest {
       }
 
       @Override
-      public SortedMap<PathFragment, ActionInput> getInputMapping(
-          PathFragment baseDirectory, boolean willAccessRepeatedly) {
+      public SortedMap<PathFragment, ActionInput> getInputMapping(PathFragment baseDirectory) {
         return new SpawnInputExpander().getInputMapping(spawn, fakeFileCache, baseDirectory);
       }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/util/FakeSpawnExecutionContext.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/FakeSpawnExecutionContext.java
@@ -119,8 +119,7 @@ public class FakeSpawnExecutionContext implements SpawnExecutionContext {
   }
 
   @Override
-  public SortedMap<PathFragment, ActionInput> getInputMapping(
-      PathFragment baseDirectory, boolean willAccessRepeatedly) {
+  public SortedMap<PathFragment, ActionInput> getInputMapping(PathFragment baseDirectory) {
     return new SpawnInputExpander().getInputMapping(spawn, inputMetadataProvider, baseDirectory);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/sandbox/SpawnRunnerTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/SpawnRunnerTestUtil.java
@@ -125,8 +125,7 @@ public final class SpawnRunnerTestUtil {
     }
 
     @Override
-    public SortedMap<PathFragment, ActionInput> getInputMapping(
-        PathFragment baseDirectory, boolean willAccessRepeatedly) {
+    public SortedMap<PathFragment, ActionInput> getInputMapping(PathFragment baseDirectory) {
       TreeMap<PathFragment, ActionInput> inputMapping = new TreeMap<>();
       for (ActionInput actionInput : spawn.getInputFiles().toList()) {
         inputMapping.put(baseDirectory.getRelative(actionInput.getExecPath()), actionInput);


### PR DESCRIPTION
There are only two consumers of the spawn input map that actually look at the keys: the runner that executes the spawn and the deprecated expanded spawn log. All other callers actually just want to walk the expanded inputs. It's thus not clear whether there is any benefit to caching the full map, which may be retained for an extended period of time through `RemoteAction` during async uploads.

Instead, this change introduces a lightweight way for walking the expanded inputs of a spawn as an `Iterable` and updates all other consumers to use it. The only expected regression is that the expanded spawn log now causes the input mapping to be computed twice, but it has very large overhead anyway.

Apart from an expected improvement to memory usage and simpler data flow, the motivation for this change is to give runners more freedom in how they expand spawn inputs. In the future, this could be used to stage special artifacts as a whole rather than expanded into their individual children, which can help with sandbox performance.