### PR TITLE
[8.4.0] Update to use coverage_output_generator-v2.9

### DIFF
--- a/tools/test/extensions.bzl
+++ b/tools/test/extensions.bzl
@@ -16,12 +16,15 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# 1. run tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/build_and_upload.sh
+# 2. Copy the newly uploaded file to https://mirror.bazel.build/bazel_coverage_output_generator/releases.
+# 3. Update this file to point to the new release.
 def _remote_coverage_tools_extension_impl(ctx):
     http_archive(
         name = "remote_coverage_tools",
-        sha256 = "172be177db06b16632335f27d50cee0786fb1873df344852db71b2171cd6d996",
+        sha256 = "aab349130118497d86bc79e3f735f026d3c36e7d38529063e91da1c29cc2ea47",
         urls = [
-            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.8.zip",
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.9.zip",
         ],
     )
     return ctx.extension_metadata(reproducible = True)


### PR DESCRIPTION
Built at commit d49967e8.

Relevant changes:

 * Branches for a given line will not be dropped when the to-be-merged reports disagree on the number of branches for that line; they will simply be merged on a best effort basis.

RELNOTES:
  Branches will always be merged as best as possible based on branch and
  block numbers during coverage report generation.

Closes #26407.

PiperOrigin-RevId: 776513248
Change-Id: I29b2a75e86738aa08650945f9804d73aa9235a6e

Commit https://github.com/bazelbuild/bazel/commit/71cc37f22d96c27994d66614219e68d44e20023b