### PR TITLE
[8.4.0] Set working directory in interactive `--sandbox_debug` command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SymlinkedSandboxedSpawn.java
@@ -150,7 +150,7 @@ public class SymlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpaw
                 interactiveDebugArguments,
                 getEnvironment(),
                 /* environmentVariablesToClear= */ null,
-                /* cwd= */ null,
+                /* cwd= */ sandboxExecRoot.getPathString(),
                 /* configurationChecksum= */ null,
                 /* executionPlatformLabel= */ null,
                 /* spawnRunner= */ null));


### PR DESCRIPTION
Makes the interactive environment more representative of the actual sandbox environment.

Closes #26448.

PiperOrigin-RevId: 778888610
Change-Id: I73f12b29a24b45ef5a072ecb9174b7ef86dffef7

Commit https://github.com/bazelbuild/bazel/commit/8709d090d032ed9e096ba0223ddf9c05e520aa98