### PR TITLE
make generate-modmap deterministic

### DIFF
--- a/tools/cpp/modules_tools/generate-modmap/generate-modmap.cc
+++ b/tools/cpp/modules_tools/generate-modmap/generate-modmap.cc
@@ -37,7 +37,7 @@
 // see also https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Module-Mapper.html
 void write_modmap(std::ostream &modmap_file_stream,
                   std::ostream &modmap_file_dot_input_stream,
-                  const std::unordered_set<ModmapItem> &modmap,
+                  const std::set<ModmapItem> &modmap,
                   const std::string &compiler,
                   const std::optional<ModmapItem> &generated) {
   if (compiler == "gcc") {
@@ -64,14 +64,14 @@ void write_modmap(std::ostream &modmap_file_stream,
   }
 }
 
-std::unordered_set<ModmapItem> process(const ModuleDep &dep,
+std::set<ModmapItem> process(const ModuleDep &dep,
                                        const Cpp20ModulesInfo &info) {
   std::queue<std::string> q;
   for (const auto &item : dep.require_list) {
     q.push(item);
   }
   // Get all dependencies
-  std::unordered_set<std::string> s;
+  std::set<std::string> s;
   while (!q.empty()) {
     std::string name = q.front();
     q.pop();
@@ -90,7 +90,7 @@ std::unordered_set<ModmapItem> process(const ModuleDep &dep,
   }
 
   // Construct modmap
-  std::unordered_set<ModmapItem> modmap;
+  std::set<ModmapItem> modmap;
   for (const auto &name : s) {
     auto it = info.modules.find(name);
     if (it == info.modules.end()) {

--- a/tools/cpp/modules_tools/generate-modmap/generate-modmap.h
+++ b/tools/cpp/modules_tools/generate-modmap/generate-modmap.h
@@ -16,7 +16,7 @@
 #define BAZEL_TOOLS_CPP_MODULE_TOOLS_GENERATE_MODMAP_GENERATE_MODMAP_H_
 
 #include <iostream>
-#include <unordered_set>
+#include <set>
 
 #include "common/common.h"
 
@@ -25,6 +25,11 @@ struct ModmapItem {
   std::string path;
   bool operator==(const ModmapItem &other) const {
     return name == other.name && path == other.path;
+  }
+  bool operator<(const ModmapItem& other) const {
+        if (name < other.name) return true;
+        if (name > other.name) return false;
+        return path < other.path;
   }
   friend std::ostream &operator<<(std::ostream &os, const ModmapItem &item) {
     os << "ModmapItem{name: " << item.name << ", path: " << item.path << "}";
@@ -40,11 +45,11 @@ struct hash<ModmapItem> {
   }
 };
 }  // namespace std
-std::unordered_set<ModmapItem> process(const ModuleDep &dep,
+std::set<ModmapItem> process(const ModuleDep &dep,
                                        const Cpp20ModulesInfo &info);
 void write_modmap(std::ostream &modmap_file_stream,
                   std::ostream &modmap_file_dot_input_stream,
-                  const std::unordered_set<ModmapItem> &modmap,
+                  const std::set<ModmapItem> &modmap,
                   const std::string &compiler,
                   const std::optional<ModmapItem> &generated);
 

--- a/tools/cpp/modules_tools/generate-modmap/generate-modmap_test.cc
+++ b/tools/cpp/modules_tools/generate-modmap/generate-modmap_test.cc
@@ -15,13 +15,14 @@
 #include "tools/cpp/modules_tools/generate-modmap/generate-modmap.h"
 
 #include <gtest/gtest.h>
+#include <sstream>
 
 TEST(ModmapTest, EmptyInput) {
   ModuleDep dep{};
   Cpp20ModulesInfo info{};
   auto modmap = process(dep, info);
 
-  std::unordered_set<ModmapItem> expected_modmap;
+  std::set<ModmapItem> expected_modmap;
   EXPECT_EQ(modmap, expected_modmap);
 }
 
@@ -39,7 +40,7 @@ TEST(ModmapTest, BasicFunctionality) {
 
   auto modmap = process(dep, info);
 
-  std::unordered_set<ModmapItem> expected_modmap = {
+  std::set<ModmapItem> expected_modmap = {
       {"module1", "/path/to/module1"}, {"module2", "/path/to/module2"}};
   EXPECT_EQ(modmap, expected_modmap);
 }
@@ -59,7 +60,7 @@ TEST(ModmapTest, BasicFunctionality2) {
 
   auto modmap = process(dep, info);
 
-  std::unordered_set<ModmapItem> expected_modmap = {
+  std::set<ModmapItem> expected_modmap = {
       {"module1", "/path/to/module1"},
       {"module2", "/path/to/module2"},
       {"module3", "/path/to/module3"}};
@@ -82,9 +83,42 @@ TEST(ModmapTest, BasicFunctionality3) {
 
   auto modmap = process(dep, info);
 
-  std::unordered_set<ModmapItem> expected_modmap = {
+  std::set<ModmapItem> expected_modmap = {
       {"module1", "/path/to/module1"},
       {"module2", "/path/to/module2"},
       {"module4", "/path/to/module4"}};
   EXPECT_EQ(modmap, expected_modmap);
+}
+
+// if use std::unordered_set, the order of iteration is not deterministic
+// therefore, use std::set for ModmapItem
+TEST(ModmapTest, DeterministicIterationOrderOfWriteModmap) {
+  std::stringstream modmap_file_stream1;
+  std::stringstream modmap_file_dot_input_stream1;
+  write_modmap(
+    modmap_file_stream1,
+    modmap_file_dot_input_stream1,
+    {
+      {"module1", "/path/to/module1"},
+      {"module2", "/path/to/module2"},
+      {"module3", "/path/to/module3"},
+    },
+    "clang",
+    std::nullopt
+  );
+  std::stringstream modmap_file_stream2;
+  std::stringstream modmap_file_dot_input_stream2;
+  write_modmap(
+    modmap_file_stream2,
+    modmap_file_dot_input_stream2,
+    {
+      {"module2", "/path/to/module2"},
+      {"module1", "/path/to/module1"},
+      {"module3", "/path/to/module3"},
+    },
+    "clang",
+    std::nullopt
+  );
+  EXPECT_EQ(modmap_file_stream1.str(), modmap_file_stream2.str());
+  EXPECT_EQ(modmap_file_dot_input_stream1.str(), modmap_file_dot_input_stream2.str());
 }


### PR DESCRIPTION
This patch replaces`std::unordered_set` with `std::set` so the modmap is emitted in a stable, sorted order.

see https://github.com/bazelbuild/bazel/pull/22553#discussion_r2169305306