### PR TITLE
[8.4.0] Fix a race condition caused by our semaphore-handling mechanism in WorkerMultiplexer.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -357,7 +357,9 @@ public class WorkerMultiplexer {
       throw new IOException(
           "Attempting to send request " + request.getRequestId() + " to dead process");
     }
-    responseChecker.put(request.getRequestId(), new Semaphore(0));
+    if (!request.getCancel()) {
+      responseChecker.put(request.getRequestId(), new Semaphore(0));
+    }
     pendingRequests.add(request);
   }
 
@@ -367,33 +369,29 @@ public class WorkerMultiplexer {
    * execution.
    */
   public WorkResponse getResponse(Integer requestId) throws InterruptedException, IOException {
-    try {
-      if (!process.isAlive()) {
-        // If the process has died, all we can do is return what may already have been returned.
-        return workerProcessResponse.get(requestId);
-      }
-
-      Semaphore waitForResponse = responseChecker.get(requestId);
-
-      if (waitForResponse == null) {
-        report("Null response semaphore for " + requestId);
-        // If there is no semaphore for this request, it probably failed to send, so we just return
-        // what we got, probably nothing.
-        return workerProcessResponse.get(requestId);
-      }
-
-      // Wait for the multiplexer to get our response and release this semaphore. If the multiplexer
-      // process dies, the semaphore gets released with no response available.
-      waitForResponse.acquire();
-
-      if (workerProcessResponse.get(requestId) == null && !process.isAlive()) {
-        throw new IOException("Worker process for " + workerKey.getMnemonic() + " has died");
-      }
+    if (!process.isAlive()) {
+      // If the process has died, all we can do is return what may already have been returned.
       return workerProcessResponse.get(requestId);
-    } finally {
-      responseChecker.remove(requestId);
-      workerProcessResponse.remove(requestId);
     }
+
+    Semaphore waitForResponse = responseChecker.get(requestId);
+
+    if (waitForResponse == null) {
+      report("Null response semaphore for " + requestId);
+      // If there is no semaphore for this request, it probably failed to send, so we just return
+      // what we got, probably nothing.
+      return workerProcessResponse.get(requestId);
+    }
+
+    waitForResponse.acquire();
+
+    responseChecker.remove(requestId);
+    WorkResponse response = workerProcessResponse.remove(requestId);
+
+    if (response == null && !process.isAlive()) {
+      throw new IOException("Worker process for " + workerKey.getMnemonic() + " has died");
+    }
+    return response;
   }
 
   /**


### PR DESCRIPTION
See #26292.

The user suggested a potential fix "the simplest solution is to have WorkerMultiplexer only remove the work request from requestChecker if an InterruptedException (or CancellationException?) wasn’t thrown."

The suggested fix makes sense. I've also added another check to gracefully handle the cancellation requests.

PiperOrigin-RevId: 779179061
Change-Id: Ieafb404ef03d3e6897b3cb11e8043492d45e623d

Commit https://github.com/bazelbuild/bazel/commit/a40faeda91939b1f50aad758221c9a0aa361332b