### PR TITLE
Flip `--incompatible_repo_env_ignores_action_env`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -586,7 +586,7 @@ public class CommonCommandOptions extends OptionsBase {
 
   @Option(
       name = "incompatible_repo_env_ignores_action_env",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -2915,8 +2915,8 @@ EOF
 dummy_repository = use_repo_rule('//:repo.bzl', 'dummy_repository')
 dummy_repository(name = 'foo', build_file = '@@//:BUILD.dummy')
 EOF
-  add_to_bazelrc "common --action_env=TRACKED=tracked"
-  add_to_bazelrc "common --action_env=UNTRACKED=untracked"
+  add_to_bazelrc "common --repo_env=TRACKED=tracked"
+  add_to_bazelrc "common --repo_env=UNTRACKED=untracked"
 
   bazel build @foo//:BUILD 2>$TEST_log || fail 'Expected build to succeed'
   expect_log "TRACKED=tracked"


### PR DESCRIPTION
For #26222.

Repository tests were making use of `--action=K=V` and have been updated to use `--repo_env=K=V` where appropriate.