### PR TITLE
[8.4.0] Preserve line endings for all checked-in files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,8 +9,8 @@ site/* linguist-documentation
 #   https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files
 **/build/** linguist-generated=false
 
-# Files that should not use CRLF line endings, even on Windows.
-tools/genrule/genrule-setup.sh -text
+# Files should not use CRLF line endings, even on Windows.
+* -text
 
 # A custom merge driver for the Bazel lockfile.
 # https://bazel.build/external/lockfile#automatic-resolution


### PR DESCRIPTION
Fixes #26467

Closes #26469.

PiperOrigin-RevId: 780195145
Change-Id: Icc9835df06dd3e87849a1a54c0eea32b92e36208

Commit https://github.com/bazelbuild/bazel/commit/1dd48679c6d84e60e9a03c00186df437eae13bd6