### PR TITLE
[8.4.0] Add completion support for `common` and `always`

### DIFF
--- a/scripts/bazel-complete-template.bash
+++ b/scripts/bazel-complete-template.bash
@@ -682,7 +682,7 @@ _bazel__all_configs() {
   # specified by the user
   local build_inherit=("aquery" "clean" "coverage" "cquery" "info" "mobile-install" "print_action" "run" "test")
   local test_inherit=("coverage")
-  local command_match="$command"
+  local command_match="$command|common|always"
   if [[ "${build_inherit[@]}" =~ "$command" ]]; then
     command_match="$command_match|build"
   fi


### PR DESCRIPTION
Command completion now picks up configs defined on the `always` and `common` pseudo-commands.

Closes #26473.

PiperOrigin-RevId: 780240383
Change-Id: I373f5bee82b2450f49d5c2a578612d004f47e64d

Commit https://github.com/bazelbuild/bazel/commit/41dcd9f93182c15efa841085af2a1cdd977baa59