### PR TITLE
[platforms] Allow targets to declare themselves incompatible with the target platform

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/IncompatiblePlatformProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/IncompatiblePlatformProvider.java
@@ -59,7 +59,8 @@ import javax.annotation.Nullable;
 public record IncompatiblePlatformProvider(
     @Nullable Label targetPlatform,
     @Nullable ImmutableList<ConfiguredTarget> targetsResponsibleForIncompatibility,
-    @Nullable ImmutableList<ConstraintValueInfo> constraintsResponsibleForIncompatibility)
+    @Nullable ImmutableList<ConstraintValueInfo> constraintsResponsibleForIncompatibility,
+    @Nullable String starlarkMessageResponsibleForIncompatibility)
     implements Info, IncompatiblePlatformProviderApi {
   /** Name used in Starlark for accessing this provider. */
   public static final String STARLARK_NAME = "IncompatiblePlatformProvider";
@@ -80,7 +81,7 @@ public record IncompatiblePlatformProvider(
     Preconditions.checkNotNull(targetsResponsibleForIncompatibility);
     Preconditions.checkArgument(!targetsResponsibleForIncompatibility.isEmpty());
     return new IncompatiblePlatformProvider(
-        targetPlatform, targetsResponsibleForIncompatibility, null);
+        targetPlatform, targetsResponsibleForIncompatibility, null, null);
   }
 
   public static IncompatiblePlatformProvider incompatibleDueToConstraints(
@@ -96,12 +97,17 @@ public record IncompatiblePlatformProvider(
             .distinct()
             .collect(toImmutableList());
 
-    return new IncompatiblePlatformProvider(targetPlatform, null, constraints);
+    return new IncompatiblePlatformProvider(targetPlatform, null, constraints, null);
+  }
+
+  public static IncompatiblePlatformProvider incompatibleDueToStarlark(@Nullable Label targetPlatform, String message) {
+    Preconditions.checkNotNull(message);
+
+    return new IncompatiblePlatformProvider(targetPlatform, null, null, message);
   }
 
   @Override
   public boolean isImmutable() {
     return true; // immutable and Starlark-hashable
   }
-
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/BUILD
@@ -23,6 +23,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:file_provider",
+        "//src/main/java/com/google/devtools/build/lib/analysis:incompatible_platform_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis:platform_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:rule_definition_environment",
         "//src/main/java/com/google/devtools/build/lib/analysis:template_variable_info",

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformCommon.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.rules.platform;
 
+import com.google.devtools.build.lib.analysis.IncompatiblePlatformProvider;
 import com.google.devtools.build.lib.analysis.TemplateVariableInfo;
 import com.google.devtools.build.lib.analysis.platform.ConstraintSettingInfo;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
@@ -23,7 +24,7 @@ import com.google.devtools.build.lib.packages.Provider;
 import com.google.devtools.build.lib.starlarkbuildapi.platform.PlatformCommonApi;
 
 /** Starlark namespace used to interact with the platform APIs. */
-public class PlatformCommon implements PlatformCommonApi {
+public class PlatformCommon implements PlatformCommonApi<IncompatiblePlatformProvider> {
 
   @Override
   public Provider getPlatformInfoConstructor() {
@@ -48,5 +49,10 @@ public class PlatformCommon implements PlatformCommonApi {
   @Override
   public Provider getToolchainInfoConstructor() {
     return ToolchainInfo.PROVIDER;
+  }
+
+  @Override
+  public IncompatiblePlatformProvider incompatibleTarget() {
+    return IncompatiblePlatformProvider.incompatibleDueToStarlark(null, "Hello, World!");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRules.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/PlatformRules.java
@@ -40,7 +40,7 @@ public class PlatformRules implements RuleSet {
 
     builder.addRuleDefinition(new ToolchainRule());
 
-    builder.addStarlarkBootstrap(new PlatformBootstrap(new PlatformCommon()));
+    builder.addStarlarkBootstrap(new PlatformBootstrap<>(new PlatformCommon()));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/PlatformBootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/PlatformBootstrap.java
@@ -18,11 +18,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.starlarkbuildapi.core.Bootstrap;
 
 /** {@link Bootstrap} for Starlark objects related to platforms. */
-public class PlatformBootstrap implements Bootstrap {
+public class PlatformBootstrap<IncompatiblePlatformProviderApiT extends IncompatiblePlatformProviderApi> implements Bootstrap {
 
-  private final PlatformCommonApi platformCommon;
+  private final PlatformCommonApi<IncompatiblePlatformProviderApiT> platformCommon;
 
-  public PlatformBootstrap(PlatformCommonApi platformCommon) {
+  public PlatformBootstrap(PlatformCommonApi<IncompatiblePlatformProviderApiT> platformCommon) {
     this.platformCommon = platformCommon;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/PlatformCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/PlatformCommonApi.java
@@ -25,7 +25,7 @@ import net.starlark.java.eval.StarlarkValue;
     name = "platform_common",
     category = DocCategory.TOP_LEVEL_MODULE,
     doc = "Functions for Starlark to interact with the platform APIs.")
-public interface PlatformCommonApi extends StarlarkValue {
+public interface PlatformCommonApi<IncompatiblePlatformProviderApiT extends IncompatiblePlatformProviderApi> extends StarlarkValue {
   @StarlarkMethod(
       name = "TemplateVariableInfo",
       doc =
@@ -68,4 +68,12 @@ public interface PlatformCommonApi extends StarlarkValue {
               + PlatformInfoApi.EXPERIMENTAL_WARNING,
       structField = true)
   ProviderApi getConstraintValueInfoConstructor();
+
+  @StarlarkMethod(
+      name = "incompatible_target",
+      doc =
+          "The constructor/key for the <a href='../providers/ConstraintValueInfo.html'>"
+              + "ConstraintValueInfo</a> provider."
+              + PlatformInfoApi.EXPERIMENTAL_WARNING)
+  IncompatiblePlatformProviderApiT incompatibleTarget();
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/BUILD
@@ -23,6 +23,7 @@ java_library(
     ),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/analysis:incompatible_platform_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:config_matching_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis/platform",
         "//src/main/java/com/google/devtools/build/lib/analysis/platform:utils",


### PR DESCRIPTION
This is useful for cases where compatibility depends on either an optional toolchain or the content of a toolchain.

One example for when this could be used is for `{java,python}_library` which have a toolchain dependency on `cc_toolchain`: if all transitive sources are Java/Python sources, then not having a `cc_toolchain` for the platform is perfectly fine. If the target has JNI dependencies that would need to be linked into the target, then the target can now mark itself as incompatible if there is no `cc_toolchain` available.

Arguably, the example with the missing `cc_toolchain` isn't perfect as one could argue that the JNI dependency will fail to build first and the scenario can't happen. I have a slightly more complex case internally where it depends on some fields within a toolchain whether the target is compatible with the target/exec platform or not. Expressing this with multiple toolchains or constraints isn't feasible here as that would lead to 100s or 1000s of toolchains or constraints. This change provides a feasible solution to decide compatibility by the rule implementation itself.