### PR TITLE
[8.4.0] Fix nodep deps interaction with overrides

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
@@ -111,7 +111,8 @@ final class Discovery {
     @Nullable
     Result run() throws InterruptedException, ExternalDepsException {
       SequencedMap<String, Optional<Checksum>> registryFileHashes = new LinkedHashMap<>();
-      depGraph.put(ModuleKey.ROOT, root.module().withDepSpecsTransformed(this::applyOverrides));
+      depGraph.put(
+          ModuleKey.ROOT, root.module().withDepsAndNodepDepsTransformed(this::applyOverrides));
       ImmutableSet<ModuleKey> horizon = ImmutableSet.of(ModuleKey.ROOT);
       while (!horizon.isEmpty()) {
         ImmutableSet<ModuleFileValue.Key> nextHorizonSkyKeys = advanceHorizon(horizon);
@@ -131,7 +132,8 @@ final class Discovery {
             depGraph.put(depKey, null);
           } else {
             depGraph.put(
-                depKey, moduleFileValue.module().withDepSpecsTransformed(this::applyOverrides));
+                depKey,
+                moduleFileValue.module().withDepsAndNodepDepsTransformed(this::applyOverrides));
             registryFileHashes.putAll(moduleFileValue.registryFileHashes());
             nextHorizon.add(depKey);
           }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -116,9 +117,20 @@ public abstract class InterimModule extends ModuleBase {
    * Returns a new {@link InterimModule} with all values in {@link #getDeps} transformed using the
    * given function.
    */
-  public InterimModule withDepSpecsTransformed(UnaryOperator<DepSpec> transform) {
+  public InterimModule withDepsTransformed(UnaryOperator<DepSpec> transform) {
     return toBuilder()
         .setDeps(ImmutableMap.copyOf(Maps.transformValues(getDeps(), transform::apply)))
+        .build();
+  }
+
+  /**
+   * Returns a new {@link InterimModule} with all values in {@link #getDeps} and {@link
+   * #getNodepDeps} transformed using the given function.
+   */
+  public InterimModule withDepsAndNodepDepsTransformed(UnaryOperator<DepSpec> transform) {
+    return toBuilder()
+        .setDeps(ImmutableMap.copyOf(Maps.transformValues(getDeps(), transform::apply)))
+        .setNodepDeps(ImmutableList.copyOf(Lists.transform(getNodepDeps(), transform::apply)))
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
@@ -327,7 +327,7 @@ final class Selection {
                 Maps.transformValues(
                     depGraph,
                     module ->
-                        module.withDepSpecsTransformed(
+                        module.withDepsTransformed(
                             depSpec -> DepSpec.fromModuleKey(resolutionStrategy.apply(depSpec)))));
         return new Result(prunedDepGraph, unprunedDepGraph);
       } catch (ExternalDepsException e) {
@@ -378,7 +378,7 @@ final class Selection {
         InterimModule module =
             oldDepGraph
                 .get(key)
-                .withDepSpecsTransformed(
+                .withDepsTransformed(
                     depSpec -> DepSpec.fromModuleKey(resolutionStrategy.apply(depSpec)));
         visit(key, module, moduleKeyAndDependent.dependent(), moduleByName);
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModuleTest.java
@@ -28,13 +28,13 @@ import org.junit.runners.JUnit4;
 public class InterimModuleTest {
 
   @Test
-  public void withDepSpecsTransformed() throws Exception {
+  public void withDepsTransformed() throws Exception {
     assertThat(
             InterimModuleBuilder.create("", "")
                 .addDep("dep_foo", createModuleKey("foo", "1.0"))
                 .addDep("dep_bar", createModuleKey("bar", "2.0"))
                 .build()
-                .withDepSpecsTransformed(
+                .withDepsTransformed(
                     depSpec ->
                         DepSpec.fromModuleKey(
                             createModuleKey(


### PR DESCRIPTION
We didn't properly transform `DepSpec`s in nodep deps when there are overrides.

Fixes https://github.com/bazelbuild/bazel/issues/26495

PiperOrigin-RevId: 781448246
Change-Id: I205eb6c064eb9d0196d9b4861b6c70ac434ed3a4

Commit https://github.com/bazelbuild/bazel/commit/c8eecdd43c4f35fcbf4432819f02096f22bbf297