### PR TITLE
[8.4.0] Remove unused map in `ProtoOutputFormatterCallback`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
@@ -17,7 +17,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.analysis.AnalysisProtosV2;
 import com.google.devtools.build.lib.analysis.AnalysisProtosV2.Configuration;
@@ -160,7 +159,6 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
       new ConfigurationCache(this::getConfiguration);
   private final JsonFormat.Printer jsonPrinter = JsonFormat.printer();
 
-  private final Map<Label, Target> partialResultMap;
   private final LabelPrinter labelPrinter;
   private CqueryNode currentTarget;
 
@@ -177,7 +175,6 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
     this.outputType = outputType;
     this.skyframeExecutor = skyframeExecutor;
     this.resolver = resolver;
-    this.partialResultMap = Maps.newHashMap();
     this.labelPrinter = labelPrinter;
   }
 
@@ -260,8 +257,6 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
   @Override
   public void processOutput(Iterable<CqueryNode> partialResult)
       throws InterruptedException, IOException {
-    partialResult.forEach(
-        kct -> partialResultMap.put(kct.getOriginalLabel(), accessor.getTarget(kct)));
     ConfiguredProtoOutputFormatter formatter = new ConfiguredProtoOutputFormatter();
     formatter.setOptions(options, resolver, skyframeExecutor.getDigestFunction().getHashFunction());
     for (CqueryNode keyedConfiguredTarget : partialResult) {


### PR DESCRIPTION
Closes #26507.

PiperOrigin-RevId: 781525396
Change-Id: I44b587b510add1e6fa5ca7f64b25a3ab1b5bdf00

Commit https://github.com/bazelbuild/bazel/commit/6f84c4910679df05abf53e247b42271958f2a310