### PR TITLE
[8.4.0] Force a UTF-8 locale when `en_US.ISO-8859-1` is not available

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1336,31 +1336,31 @@ static map<string, EnvVarValue> PrepareEnvironmentForJvm() {
   // TODO(bazel-team):  We've also seen a failure during loading (creating
   // threads?) when ulimit -Hs 8192.  Characterize that and check for it here.
 
-  // Make the JVM use ISO-8859-1 for parsing its command line because "blaze
-  // run" doesn't handle non-ASCII command line arguments. This is apparently
-  // the most reliable way to select the platform default encoding.
-  //
-  // On Linux, only do this if the locale is available to avoid the JVM
-  // falling back to ASCII-only mode.
+  // Ensure that the JVM runs with a locale that supports Unicode characters in
+  // filenames, environment variables, etc. The approach differs by OS:
+  // - On macOS, the JVM always uses UTF-8, so we don't need to do anything.
+  // - On Windows, the JVM uses the system code page to determine the encoding.
+  //   For the embedded JDK, we force this to UTF-8 in minimize_jdk.sh.
+  // - On Linux, the JVM goes through the regular locale mechanism. In
+  //   particular, we can only force UTF-8 if we can find a locale that supports
+  //   it. Furthermore, for backwards compatibility with setups using other
+  //   encodings, we pick a Latin-1 locale if possible to support arbitrary byte
+  //   sequences, not just valid UTF-8.
+#ifdef __linux__
+  const char *want_locale = nullptr;
+  for (auto candidate_locale : {"en_US.ISO-8859-1", "C.UTF-8", "en_US.UTF-8"}) {
+    locale_t locale = newlocale(LC_CTYPE_MASK, candidate_locale, nullptr);
+    if (locale != nullptr) {
+      freelocale(locale);
+      want_locale = candidate_locale;
+      break;
+    }
+  }
 
-  const char *want_locale = "en_US.ISO-8859-1";
-  bool override_locale = true;
-#ifndef _WIN32
-  locale_t iso_locale = newlocale(LC_CTYPE_MASK, want_locale, (locale_t)0);
-  if (iso_locale == 0) {
-    // ISO-8859-1 locale not available, use whatever the user has defined.
-    override_locale = false;
-  } else {
-    freelocale(iso_locale);
+  if (want_locale != nullptr) {
+    result["LC_ALL"] = EnvVarValue(EnvVarAction::SET, want_locale);
   }
 #endif
-
-  if (override_locale) {
-    result["LANG"] = EnvVarValue(EnvVarAction::SET, want_locale);
-    result["LANGUAGE"] = EnvVarValue(EnvVarAction::SET, want_locale);
-    result["LC_ALL"] = EnvVarValue(EnvVarAction::SET, want_locale);
-    result["LC_CTYPE"] = EnvVarValue(EnvVarAction::SET, want_locale);
-  }
 
   return result;
 }

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcherTest.java
@@ -244,8 +244,8 @@ public final class BlazeCommandDispatcherTest {
     String[] args = {"foo", "--stdout=Hello, out.",
                      "--stderr=Hello, err.", "--success=false"};
     BlazeCommandResult result = dispatch.exec(Arrays.asList(args), "test", outErr);
-    assertThat(outErr.outAsLatin1()).isEqualTo("Hello, out.");
-    assertThat(outErr.errAsLatin1()).isEqualTo("Hello, err.");
+    assertThat(outErr.outAsLatin1()).endsWith("Hello, out.");
+    assertThat(outErr.errAsLatin1()).endsWith("Hello, err.");
     assertThat(result.getExitCode()).isEqualTo(ExitCode.BUILD_FAILURE);
   }
 
@@ -560,7 +560,7 @@ public final class BlazeCommandDispatcherTest {
     assertThat(outErr.outAsLatin1()).isEqualTo("stdout");
     // TODO(bazel-team): Fix inconsistent line breaks that make the regex match necessary.
     assertThat(outErr.errAsLatin1())
-        .matches(
+        .containsMatch(
             "INFO: Reading rc options for 'foo' from /home/jrluser/.blazerc:\\s+"
                 + "  'foo' options: --stdout stdout --stderr stderr\\s+"
                 + "stderr");
@@ -607,7 +607,7 @@ public final class BlazeCommandDispatcherTest {
     assertThat(outErr.outAsLatin1()).isEqualTo("stdout");
     // TODO(bazel-team): Fix inconsistent line breaks that make the regex match necessary.
     assertThat(outErr.errAsLatin1())
-        .matches(
+        .containsMatch(
             "INFO: Reading rc options for 'wiz' from /home/jrluser/.blazerc:\\s+"
                 + "  Inherited 'foo' options: --stdout stdout --stderr stderr\\s+"
                 + "stderr");


### PR DESCRIPTION
This provides UTF-8 support on systems that don't have valid locale settings by default and also don't provide the `en_US.ISO-8859-1` locale.

Also show a warning if Bazel fails to force such a locale and falls back to ASCII.

Fixes #26259

Closes #26279.

PiperOrigin-RevId: 783689004
Change-Id: Iddb5d57f6095a40402b62be1be84f92ead4bfbf3

Commit https://github.com/bazelbuild/bazel/commit/42aaa4aa474e18933ad46094966f1142c68bf04a