### PR TITLE
Allow Bazel to be cross-compiled on Unix

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -1,5 +1,6 @@
 # Packaging
 
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_java//java:java_binary.bzl", "java_binary")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
@@ -15,7 +16,15 @@ exports_files([
     "MODULE.tools",
 ])
 
-md5_cmd = "set -e -o pipefail && %s $(SRCS) | %s | %s > $@"
+sh_binary(
+    name = "md5",
+    srcs = select({
+        "//src/conditions:darwin": ["md5_darwin_freebsd.sh"],
+        "//src/conditions:freebsd": ["md5_darwin_freebsd.sh"],
+        "//src/conditions:openbsd": ["md5_openbsd.sh"],
+        "//conditions:default": ["md5_default.sh"],
+    }),
+)
 
 [genrule(
     name = "install_base_key-file" + suffix,
@@ -36,14 +45,10 @@ md5_cmd = "set -e -o pipefail && %s $(SRCS) | %s | %s > $@"
         ],
     }) + embedded_tools_target,
     outs = ["install_base_key" + suffix],
-    cmd = select({
-        "//src/conditions:darwin": md5_cmd % ("/sbin/md5", "/sbin/md5", "head -c 32"),
-        "//src/conditions:freebsd": md5_cmd % ("/sbin/md5", "/sbin/md5", "head -c 32"),
-        # We avoid using the `head` tool's `-c` option, since it does not exist
-        # on OpenBSD.
-        "//src/conditions:openbsd": md5_cmd % ("/bin/md5", "/bin/md5", "dd bs=32 count=1"),
-        "//conditions:default": md5_cmd % ("md5sum", "md5sum", "head -c 32"),
-    }),
+    cmd = "$(location :md5) $(SRCS) > $@",
+    tools = [
+        ":md5",
+    ],
 ) for suffix, embedded_tools_target in {
     "_jdk_allmodules": [":embedded_tools_jdk_allmodules"],
     "_jdk_minimal": [":embedded_tools_jdk_minimal"],
@@ -177,6 +182,15 @@ filegroup(
     visibility = ["//src/test/shell/bazel:__pkg__"],
 )
 
+# Only necessary to distinguish between the tool and the target JDK for location
+# expansion.
+copy_file(
+    name = "jdk_for_jlink",
+    src = ":embedded_jdk_vanilla",
+    out = "jdk_for_jlink",
+    allow_symlink = True,
+)
+
 # Reads the app manifest of a Windows executable.
 cc_binary(
     name = "read_manifest",
@@ -217,8 +231,9 @@ genrule(
         ":jdeps_modules.golden",
     ],
     outs = ["minimal_jdk.zip"],
-    cmd = "$(location :minimize_jdk) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $(OUTS)",
+    cmd = "$(location :minimize_jdk) $(location :jdk_for_jlink) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@",
     tools = [
+        ":jdk_for_jlink",
         ":minimize_jdk",
     ],
     visibility = ["//src/test/shell/bazel:__pkg__"],
@@ -231,8 +246,9 @@ genrule(
         ":jdeps_modules.golden",
     ],
     outs = ["allmodules_jdk.zip"],
-    cmd = "$(location :minimize_jdk) --allmodules $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $(OUTS)",
+    cmd = "$(location :minimize_jdk) --allmodules $(location :jdk_for_jlink) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $@",
     tools = [
+        ":jdk_for_jlink",
         ":minimize_jdk",
     ],
     visibility = ["//src/test/shell/bazel:__pkg__"],

--- a/src/md5_darwin_freebsd.sh
+++ b/src/md5_darwin_freebsd.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+/sbin/md5 "$@" | /sbin/md5 | head -c 32

--- a/src/md5_default.sh
+++ b/src/md5_default.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+md5sum "$@" | md5sum | head -c 32

--- a/src/md5_openbsd.sh
+++ b/src/md5_openbsd.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# We avoid using the `head` tool's `-c` option, since it does not exist
+# on OpenBSD.
+/bin/md5 "$@" | /bin/md5 | dd bs=32 count=1

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -42,21 +42,14 @@ if [ "$1" == "--allmodules" ]; then
   shift
   modules="ALL-MODULE-PATH"
 else
-  modules=$(cat "$2" | paste -sd "," - | tr -d '\r')
+  modules=$(cat "$3" | paste -sd "," - | tr -d '\r')
   # We have to add this module explicitly because jdeps doesn't find the
   # dependency on it but it is still necessary for TLSv1.3.
   modules="$modules,jdk.crypto.ec"
 fi
-fulljdk=$1
-out=$3
-ARCH=`uname -m`
-if [[ "${ARCH}" == 'ppc64le'  ]] || [[ "${ARCH}" == 's390x' ]] || [[ "${ARCH}" == 'riscv64' ]]; then
-  FULL_JDK_DIR="jdk*"
-  DOCS=""
-else
-  FULL_JDK_DIR="zulu*"
-  DOCS="DISCLAIMER readme.txt"
-fi
+tooljdk=$1
+fulljdk=$2
+out=$4
 
 UNAME=$(uname -s | tr 'A-Z' 'a-z')
 # Options for the JVM that runs the Bazel server, which are either required or
@@ -71,7 +64,7 @@ if [[ "$UNAME" =~ msys_nt* ]]; then
   mkdir "tmp.$$"
   cd "tmp.$$"
   unzip -q "../$fulljdk"
-  cd $FULL_JDK_DIR
+  cd zulu*
   # We have to add this module explicitly because it is windows specific, it allows
   # the usage of the Windows truststore
   # e.g. -Djavax.net.ssl.trustStoreType=WINDOWS-ROOT
@@ -88,7 +81,7 @@ if [[ "$UNAME" =~ msys_nt* ]]; then
   "$(rlocation io_bazel/src/read_manifest.exe)" reduced/bin/java.exe \
     | sed 's|</asmv3:windowsSettings>|<activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>&|' \
     | "$(rlocation io_bazel/src/write_manifest.exe)" reduced/bin/java.exe
-  cp $DOCS legal/java.base/ASSEMBLY_EXCEPTION \
+  cp DISCLAIMER readme.txt legal/java.base/ASSEMBLY_EXCEPTION \
     reduced/
   # These are necessary for --host_jvm_debug to work.
   cp bin/dt_socket.dll bin/jdwp.dll reduced/bin
@@ -100,20 +93,18 @@ else
   # The --no-same-owner flag instructs tar to not try to chown extracted files
   # to the owner stored in the archive - it will try to do that when running as
   # root, but fail when running inside Docker, so we explicitly disable it.
-  tar xf "$fulljdk" --no-same-owner
-  cd $FULL_JDK_DIR
-  ./bin/jlink --module-path ./jmods/ --add-modules "$modules" \
+  mkdir tool_jdk
+  tar xf "$tooljdk" --no-same-owner --strip-components=1 -C tool_jdk
+  mkdir target_jdk
+  tar xf "$fulljdk" --no-same-owner --strip-components=1 -C target_jdk
+  cd target_jdk
+  "../tool_jdk/bin/jlink" --module-path ./jmods/ --add-modules "$modules" \
     --vm=server --strip-debug --no-man-pages \
     --add-options=" ${JVM_OPTIONS}" \
     --output reduced
-  cp $DOCS legal/java.base/ASSEMBLY_EXCEPTION \
-    reduced/
+  for f in DISCLAIMER readme.txt legal/java.base/ASSEMBLY_EXCEPTION; do [ -f "$f" ] && cp "$f" reduced/; done
   # These are necessary for --host_jvm_debug to work.
-  if [[ "$UNAME" =~ darwin ]]; then
-    cp lib/libdt_socket.dylib lib/libjdwp.dylib reduced/lib
-  else
-    cp lib/libdt_socket.so lib/libjdwp.so reduced/lib
-  fi
+  cp lib/libdt_socket.* lib/libjdwp.* reduced/lib
   find reduced -exec touch -ht 198001010000 {} +
   zip -q -X -r ../reduced.zip reduced/
   cd ..


### PR DESCRIPTION
This contains the minimum amount of changes requires to have `//src:bazel` built with target != exec platform as long as both are Unix.

Tested with `toolchains_musl`, a hermetic musl toolchain targeting Linux on a macOS host.

This required the following changes:
* `genrule`'s `cmd` attribute selects on the target platform, not the execution platform. Replace it with a dedicated `sh_binary` tool to select the appropriate MD5 binary based on the execution platform.
* `minimize_jdk.sh` used `uname`, which matches the execution platform, for decisions that affect the output. This is replaced with globs and file existence checks where necessary.
* minimization now uses two different JDKS: A JDK for the target platform that is embedded into Bazel and a JDK for the exec platform whose `jlink` binary is invoked to minimize the first JDK.