### PR TITLE
Derive enum option value's Starlark convertibility

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
@@ -239,6 +239,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/main/java/net/starlark/java/eval",
         "//third_party:guava",
     ],
 )
@@ -431,7 +432,6 @@ java_library(
     name = "starlark_defined_config_transition",
     srcs = ["StarlarkDefinedConfigTransition.java"],
     deps = [
-        ":core_options",
         ":optioninfo",
         "//src/main/java/com/google/devtools/build/lib/analysis/config/transitions:configuration_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis/config/transitions:patch_transition",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptionConverters.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptionConverters.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.StarlarkInt;
+import net.starlark.java.eval.StarlarkValue;
 
 /**
  * {@link Converter}s for {@link com.google.devtools.common.options.Option}s that aren't
@@ -274,7 +275,7 @@ public class CoreOptionConverters {
   }
 
   /** Values for the --strict_*_deps option */
-  public enum StrictDepsMode {
+  public enum StrictDepsMode implements StarlarkValue {
     /** Silently allow referencing transitive dependencies. */
     OFF,
     /** Warn about transitive dependencies being used directly. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeSet;
+import net.starlark.java.eval.StarlarkValue;
 
 /**
  * Core options affecting a {@link BuildConfigurationValue} that don't belong in domain-specific
@@ -411,7 +412,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public List<String> affectedByStarlarkTransition;
 
   /** Values for the --experimental_exec_configuration_distinguisher options */
-  public enum ExecConfigurationDistinguisherScheme {
+  public enum ExecConfigurationDistinguisherScheme implements StarlarkValue {
     /** Use hash of selected execution platform for platform_suffix. */
     LEGACY,
     /** Do not touch platform_suffix or do anything else. * */
@@ -650,7 +651,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public List<Label> actionListeners;
 
   /** Values for the --experimental_output_directory_naming_scheme options */
-  public enum OutputDirectoryNamingScheme {
+  public enum OutputDirectoryNamingScheme implements StarlarkValue {
     /** Use `affected by starlark transition` to track configuration changes */
     LEGACY,
     /** Produce name based on diff from some baseline BuildOptions (usually top-level) */
@@ -790,7 +791,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public boolean allowUnresolvedSymlinks;
 
   /** Values for --experimental_output_paths. */
-  public enum OutputPathsMode {
+  public enum OutputPathsMode implements StarlarkValue {
     /** Use the production output path model. */
     OFF,
     /**
@@ -1016,7 +1017,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   }
 
   /** Ways configured targets may provide the {@link Fragment}s they require. */
-  public enum IncludeConfigFragmentsEnum {
+  public enum IncludeConfigFragmentsEnum implements StarlarkValue {
     /**
      * Don't offer the provider at all. This is best for most builds, which don't use this
      * information and don't need the extra memory hit over every configured target.

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkDefinedConfigTransition.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkDefinedConfigTransition.java
@@ -22,14 +22,9 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
-import com.google.devtools.build.lib.analysis.config.CoreOptions.ExecConfigurationDistinguisherScheme;
-import com.google.devtools.build.lib.analysis.config.CoreOptions.IncludeConfigFragmentsEnum;
-import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputDirectoryNamingScheme;
-import com.google.devtools.build.lib.analysis.config.CoreOptions.OutputPathsMode;
 import com.google.devtools.build.lib.analysis.config.transitions.PatchTransition;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.Label.PackageContext;
@@ -48,7 +43,6 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDefinition;
-import com.google.devtools.common.options.TriState;
 import com.google.errorprone.annotations.FormatMethod;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -446,26 +440,6 @@ public abstract sealed class StarlarkDefinedConfigTransition implements Configur
     }
 
     /**
-     * Native flag types known to serialize and deserialize cleanly to strings for Starlark
-     * evaluation.
-     *
-     * <p>This is an intentionally conservative list intended to support Starlark exec transitions
-     * ({@link ExecutionTransitionFactory}).
-     *
-     * <p>We'd ideally represent these directly as class types instead of strings. But that would
-     * add dependencies on rule-related library to this class, which breaks Bazel linking.
-     */
-    private static final ImmutableSet<String> SAFE_NATIVE_FLAG_TYPES =
-        ImmutableSet.of(
-            "AndroidManifestMerger",
-            "ManifestMergerOrder",
-            "ImportDepsCheckingLevel",
-            "JavaClasspathMode",
-            "StrictDepsMode",
-            "PythonVersion",
-            "OneVersionEnforcementLevel");
-
-    /**
      * Converts a Java-native flag value to a Starlark-readable string, or throws an exception if
      * the flag's type can't be represented in Starlark.
      *
@@ -484,15 +458,9 @@ public abstract sealed class StarlarkDefinedConfigTransition implements Configur
         // Call toOriginalString, to do that properly.
         return Verify.verifyNotNull(((RegexFilter) value).toOriginalString());
       }
-      if (value instanceof PathFragment
-          || value instanceof TriState
-          || value instanceof ExecConfigurationDistinguisherScheme
-          || value instanceof OutputDirectoryNamingScheme
-          || value instanceof OutputPathsMode
-          || value instanceof IncludeConfigFragmentsEnum
-          || SAFE_NATIVE_FLAG_TYPES.contains(value.getClass().getSimpleName())) {
-        // Starlark#fromJava doesn't understand these Bazel-specific Java types. But their
-        // toString() methods serialize cleanly.
+      if (value instanceof PathFragment) {
+        // Starlark#fromJava doesn't understand this Bazel-specific Java type. But its toString()
+        // method serializes cleanly.
         return value.toString();
       }
       // See if the option's converter knows how to produce to Starlark values.

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -156,7 +156,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   }
 
   /** Types of android manifest mergers. */
-  public enum AndroidManifestMerger {
+  public enum AndroidManifestMerger implements StarlarkValue {
     LEGACY,
     ANDROID,
     FORCE_ANDROID;
@@ -185,7 +185,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   }
 
   /** Orders for merging android manifests. */
-  public enum ManifestMergerOrder {
+  public enum ManifestMergerOrder implements StarlarkValue {
     /** Manifests are sorted alphabetically by exec path. */
     ALPHABETICAL,
     /** Manifests are sorted alphabetically by configuration-relative path. */

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -122,7 +122,7 @@ public final class CppConfiguration extends Fragment
   }
 
   /** This enumeration is used for the --strip option. */
-  public enum StripMode {
+  public enum StripMode implements StarlarkValue {
     ALWAYS("always"), // Always strip.
     SOMETIMES("sometimes"), // Strip iff compilationMode == FASTBUILD.
     NEVER("never"); // Never strip.

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.eval.StarlarkValue;
 
 /** A java compiler configuration containing the flags required for compilation. */
 @Immutable
@@ -45,7 +46,7 @@ import net.starlark.java.eval.StarlarkThread;
 public final class JavaConfiguration extends Fragment implements JavaConfigurationApi {
 
   /** Values for the --java_classpath option */
-  public enum JavaClasspathMode {
+  public enum JavaClasspathMode implements StarlarkValue {
     /** Use full transitive classpaths, the default behavior. */
     OFF,
     /** JavaBuilder computes the reduced classpath before invoking javac. */
@@ -57,7 +58,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   }
 
   /** Values for the --experimental_one_version_enforcement option */
-  public enum OneVersionEnforcementLevel {
+  public enum OneVersionEnforcementLevel implements StarlarkValue {
     /** Don't attempt to check for one version violations (the default) */
     OFF,
     /**

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonVersion.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.rules.python;
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import net.starlark.java.eval.StarlarkValue;
 
 /**
  * An enum representing Python major versions.
@@ -27,7 +28,7 @@ import java.util.List;
  * when this enum is used to denote the degree of compatibility of source code with the target
  * values.
  */
-public enum PythonVersion {
+public enum PythonVersion implements StarlarkValue {
 
   // TODO(#6445): Remove PY2ONLY and PY3ONLY.
 
@@ -167,4 +168,3 @@ public enum PythonVersion {
     return PythonVersion.valueOf(str);
   }
 }
-

--- a/src/main/java/com/google/devtools/common/options/BUILD
+++ b/src/main/java/com/google/devtools/common/options/BUILD
@@ -52,6 +52,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:pair",
         "//src/main/java/com/google/devtools/build/lib/util:string_encoding",
         "//src/main/java/com/google/devtools/build/lib/util/regex:regex_util",
+        "//src/main/java/net/starlark/java/eval",
         "//src/main/java/net/starlark/java/spelling",
         "//third_party:auto_value",
         "//third_party:caffeine",

--- a/src/main/java/com/google/devtools/common/options/EnumConverter.java
+++ b/src/main/java/com/google/devtools/common/options/EnumConverter.java
@@ -16,6 +16,8 @@ package com.google.devtools.common.options;
 
 import com.google.common.base.Ascii;
 import java.util.Arrays;
+import java.util.Locale;
+import net.starlark.java.eval.StarlarkValue;
 
 /**
  * A converter superclass for converters that parse enums.
@@ -33,14 +35,12 @@ public abstract class EnumConverter<T extends Enum<T>> extends Converter.Context
   private final String typeName;
 
   /**
-   * Creates a new enum converter. You *must* implement a zero-argument
-   * constructor that delegates to this constructor, passing in the appropriate
-   * parameters.
+   * Creates a new enum converter. You *must* implement a zero-argument constructor that delegates
+   * to this constructor, passing in the appropriate parameters.
    *
-   * @param enumType The type of your enumeration; usually a class literal
-   *                 like MyEnum.class
-   * @param typeName The intuitive name of your enumeration, for example, the
-   *                 type name for CompilationMode might be "compilation mode".
+   * @param enumType The type of your enumeration; usually a class literal like MyEnum.class
+   * @param typeName The intuitive name of your enumeration, for example, the type name for
+   *     CompilationMode might be "compilation mode".
    */
   protected EnumConverter(Class<T> enumType, String typeName) {
     this.enumType = enumType;
@@ -55,18 +55,30 @@ public abstract class EnumConverter<T extends Enum<T>> extends Converter.Context
         return value;
       }
     }
-    throw new OptionsParsingException("Not a valid " + typeName + ": '"
-                                      + input + "' (should be "
-                                      + getTypeDescription() + ")");
+    throw new OptionsParsingException(
+        "Not a valid %s: '%s' (should be %s)".formatted(typeName, input, getTypeDescription()));
   }
 
-  /**
-   * Implements {@link #getTypeDescription()}.
-   */
+  /** Implements {@link #getTypeDescription()}. */
   @Override
   public final String getTypeDescription() {
     return Ascii.toLowerCase(
         Converters.joinEnglishList(Arrays.asList(enumType.getEnumConstants())));
+  }
+
+  @Override
+  public boolean starlarkConvertible() {
+    return StarlarkValue.class.isAssignableFrom(enumType);
+  }
+
+  @Override
+  public String reverseForStarlark(Object converted) {
+    if (!starlarkConvertible()) {
+      throw new UnsupportedOperationException(
+          "%s is not Starlark convertible. Implement StarlarkValue to enable this."
+              .formatted(enumType));
+    }
+    return ((Enum<T>) converted).name().toLowerCase(Locale.ROOT);
   }
 
   public final Class<T> getEnumType() {

--- a/src/main/java/com/google/devtools/common/options/TriState.java
+++ b/src/main/java/com/google/devtools/common/options/TriState.java
@@ -13,9 +13,11 @@
 // limitations under the License.
 package com.google.devtools.common.options;
 
-/**
- * Enum used to represent tri-state options (yes/no/auto).
- */
-public enum TriState {
-  YES, NO, AUTO
+import net.starlark.java.eval.StarlarkValue;
+
+/** Enum used to represent tri-state options (yes/no/auto). */
+public enum TriState implements StarlarkValue {
+  YES,
+  NO,
+  AUTO
 }


### PR DESCRIPTION
Instead of hardcoding the list of enums that are Starlark convertible, use `StarlarkValue` as a marker interface.

Also make `--strip` Starlark convertible, which is the original motivation for this change.

Fixes #26548