### PR TITLE
[8.4.0] Skip strategies incompatible with path mapping during resolution

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -67,6 +67,14 @@ public final class Spawns {
         && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.LOCAL);
   }
 
+  /**
+   * Returns whether a Spawn must be executed on a separate exec root (i.e., in a sandbox) since it
+   * references rewritten input and output paths.
+   */
+  public static boolean usesPathMapping(Spawn spawn) {
+    return !spawn.getPathMapper().isNoop();
+  }
+
   /** Returns whether a Spawn needs network access in order to run successfully. */
   public static boolean requiresNetwork(Spawn spawn, boolean defaultSandboxDisallowNetwork) {
     if (spawn.getExecutionInfo().containsKey(ExecutionRequirements.BLOCK_NETWORK)) {

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnStrategyResolver.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnStrategy;
+import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
@@ -86,11 +87,15 @@ public final class SpawnStrategyResolver implements ActionContext {
       if (fallbackStrategies.isEmpty()) {
         String message =
             String.format(
-                "%s spawn cannot be executed with any of the available strategies: %s. Your"
+                "%s spawn%s cannot be executed with any of the available strategies: %s. Your"
                     + " --spawn_strategy, --genrule_strategy and/or --strategy flags are probably"
                     + " too strict. Visit https://github.com/bazelbuild/bazel/issues/7480 for"
                     + " advice",
-                spawn.getMnemonic(), strategies);
+                spawn.getMnemonic(),
+                Spawns.usesPathMapping(spawn)
+                    ? ", which requires sandboxing due to path mapping,"
+                    : "",
+                strategies);
         throw new UserExecException(
             FailureDetail.newBuilder()
                 .setMessage(message)

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -170,7 +170,7 @@ public class LocalSpawnRunner implements SpawnRunner {
 
   @Override
   public boolean canExec(Spawn spawn) {
-    return true;
+    return !Spawns.usesPathMapping(spawn);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
@@ -489,6 +490,9 @@ public final class SandboxModule extends BlazeModule {
 
     @Override
     public boolean canExecWithLegacyFallback(Spawn spawn) {
+      if (Spawns.usesPathMapping(spawn)) {
+        return false;
+      }
       boolean canExec = !sandboxSpawnRunner.canExec(spawn) && fallbackSpawnRunner.canExec(spawn);
       if (canExec) {
         // We give a warning to use strategies instead, whether or not we allow the fallback

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -132,16 +132,21 @@ public class WorkerParser {
       boolean dynamic,
       WorkerProtocolFormat protocolFormat) {
     String workerKeyMnemonic = Spawns.getWorkerKeyMnemonic(spawn);
-    boolean multiplex = options.workerMultiplex && Spawns.supportsMultiplexWorkers(spawn);
-    if (dynamic && !(Spawns.supportsMultiplexSandboxing(spawn) && options.multiplexSandboxing)) {
-      multiplex = false;
-    }
+    boolean mustSandbox = dynamic || Spawns.usesPathMapping(spawn);
+    boolean shouldMultiplex = options.workerMultiplex && Spawns.supportsMultiplexWorkers(spawn);
+    boolean canSandboxMultiplex =
+        options.multiplexSandboxing && Spawns.supportsMultiplexSandboxing(spawn);
     boolean sandboxed;
-    if (multiplex) {
-      sandboxed =
-          Spawns.supportsMultiplexSandboxing(spawn) && (options.multiplexSandboxing || dynamic);
+    boolean multiplex;
+    if (mustSandbox) {
+      sandboxed = true;
+      multiplex = shouldMultiplex && canSandboxMultiplex;
+    } else if (shouldMultiplex) {
+      sandboxed = canSandboxMultiplex;
+      multiplex = true;
     } else {
-      sandboxed = options.workerSandboxing || dynamic;
+      sandboxed = options.workerSandboxing;
+      multiplex = false;
     }
     boolean useInMemoryTracking = false;
     if (sandboxed) {

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerSpawnRunnerTest.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ExecutionRequirements.WorkerProtocolFormat;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ResourceManager;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -106,6 +107,7 @@ public class WorkerSpawnRunnerTest {
         .registerWorker(
             anyInt(), anyLong(), any(), anyString(), anyBoolean(), anyBoolean(), anyInt(), any());
     when(spawn.getLocalResources()).thenReturn(ResourceSet.createWithRamCpu(100, 1));
+    when(spawn.getPathMapper()).thenReturn(PathMapper.NOOP);
     when(resourceManager.acquireResources(any(), any(), any())).thenReturn(resourceHandle);
     when(resourceHandle.getWorker()).thenReturn(worker);
   }


### PR DESCRIPTION
Spawn strategies that aren't sandboxed are now skipped while resolving a strategy for a path mapped spawn, which allows non-sandboxed strategies to be listed first and also results in a better error message if no compatible strategy is available (instead of an obscure exec failure).

Worker execution is special in that it can always sandbox if needed, but may not do so based on options. For this purpose, path mapped spawns are now treated just like dynamically executed spawns by forcing sandboxing.

In the future, the same mechanism can potentially be used to run spawns for rewound actions in Bazel, which must not delete or override their previous outputs.

Work towards https://github.com/bazelbuild/bazel/discussions/22658#discussioncomment-12431355
Fixes https://github.com/bazel-contrib/rules_go/issues/4366

Closes #25430.

PiperOrigin-RevId: 784040555
Change-Id: I26e110801ce84c41aef5f3e03e34879c595ebedf

Commit https://github.com/bazelbuild/bazel/commit/a42c98185717661c5425aa4161289381f4811c9c