### PR TITLE
Materialize parameter files with a remote cache if requested

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -124,9 +124,9 @@ public class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Writes intermediate parameter files to output tree even when using "
-              + "remote action execution. Useful when debugging actions. "
-              + "This is implied by --subcommands and --verbose_failures.")
+          "Writes intermediate parameter files to output tree even when using remote action "
+              + "execution or caching. Useful when debugging actions. This is implied by "
+              + "--subcommands and --verbose_failures.")
   public boolean materializeParamFiles;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -183,6 +183,7 @@ final class RemoteActionContextProvider {
               env.getCommandId().toString(),
               digestUtil,
               checkNotNull(env.getOptions().getOptions(RemoteOptions.class)),
+              checkNotNull(env.getOptions().getOptions(ExecutionOptions.class)),
               combinedCache,
               remoteExecutor,
               tempPathGenerator,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -171,6 +171,7 @@ final class RemoteSpawnCache implements SpawnCache {
                     result.getExecutionMetadata().getExecutionCompletedTimestamp(),
                     spawnMetrics.build(),
                     spawn.getMnemonic());
+            remoteExecutionService.maybeWriteParamFilesLocally(spawn);
             return SpawnCache.success(spawnResult);
           }
         } catch (CacheNotFoundException e) {
@@ -210,6 +211,7 @@ final class RemoteSpawnCache implements SpawnCache {
                 .setTotalTime(totalTime.elapsed())
                 .setNetworkTime(action.getNetworkTime().getDuration());
             SpawnMetrics buildMetrics = spawnMetrics.build();
+            remoteExecutionService.maybeWriteParamFilesLocally(spawn);
             return SpawnCache.success(
                 new SpawnResult.DelegateSpawnResult(previousResult) {
                   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -35,8 +35,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
-import com.google.devtools.build.lib.actions.ActionInput;
-import com.google.devtools.build.lib.actions.CommandLines.ParamFileActionInput;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
@@ -198,7 +196,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
             .setInputBytes(action.getInputBytes())
             .setInputFiles(action.getInputFiles());
 
-    maybeWriteParamFilesLocally(spawn);
+    remoteExecutionService.maybeWriteParamFilesLocally(spawn);
 
     spawnMetrics.setParseTime(totalTime.elapsed());
 
@@ -522,17 +520,6 @@ public class RemoteSpawnRunner implements SpawnRunner {
             && !message.isEmpty();
     if (printMessage) {
       outErr.printErr("Remote server execution message: " + message + "\n");
-    }
-  }
-
-  private void maybeWriteParamFilesLocally(Spawn spawn) throws IOException {
-    if (!executionOptions.shouldMaterializeParamFiles()) {
-      return;
-    }
-    for (ActionInput actionInput : spawn.getInputFiles().toList()) {
-      if (actionInput instanceof ParamFileActionInput paramFileActionInput) {
-        paramFileActionInput.atomicallyWriteRelativeTo(execRoot);
-      }
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -95,6 +95,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
+import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.remote.CombinedCache.CachedActionResult;
@@ -2696,6 +2697,7 @@ public class RemoteExecutionServiceTest {
         "none",
         digestUtil,
         remoteOptions,
+        Options.getDefaults(ExecutionOptions.class),
         cache,
         executor,
         tempPathGenerator,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -1160,7 +1160,6 @@ public class RemoteSpawnRunnerTest {
   private void testParamFilesAreMaterializedForFlag(String flag) throws Exception {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     ExecutionOptions executionOptions = Options.parse(ExecutionOptions.class, flag).getOptions();
-    executionOptions.materializeParamFiles = true;
     RemoteExecutionService remoteExecutionService =
         new RemoteExecutionService(
             directExecutor(),
@@ -1172,6 +1171,7 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             digestUtil,
             remoteOptions,
+            executionOptions,
             cache,
             executor,
             tempPathGenerator,
@@ -1709,6 +1709,7 @@ public class RemoteSpawnRunnerTest {
                 "command-id",
                 digestUtil,
                 remoteOptions,
+                Options.getDefaults(ExecutionOptions.class),
                 cache,
                 executor,
                 tempPathGenerator,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -347,6 +347,7 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             "command-id",
             DIGEST_UTIL,
             remoteOptions,
+            Options.getDefaults(ExecutionOptions.class),
             remoteCache,
             executor,
             tempPathGenerator,


### PR DESCRIPTION
Before this change parameter files were only materialized with remote execution.

Also makes the existing test for remote execution more precise.