### PR TITLE
Fix truthiness of `Sequence` toolchain variables

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainVariables.java
@@ -617,7 +617,7 @@ public abstract class CcToolchainVariables implements CcToolchainVariablesApi {
 
     @Override
     public boolean isTruthy() {
-      return values.isEmpty();
+      return !values.isEmpty();
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariablesTest.java
@@ -115,6 +115,13 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
 
     ConfiguredTarget target = getConfiguredTarget("//x:bin");
     CcToolchainVariables variables = getLinkBuildVariables(target, Link.LinkTargetType.EXECUTABLE);
+    assertThat(
+            variables
+                .getVariable(
+                    LinkBuildVariables.LIBRARY_SEARCH_DIRECTORIES.getVariableName(),
+                    PathMapper.NOOP)
+                .isTruthy())
+        .isTrue();
     List<String> variableValue =
         getSequenceVariableValue(
             getRuleContext(),


### PR DESCRIPTION
The truthiness of sequence toolchain variables has been flipped for a long time. This became a problem in 1b7dfd8a2a93a6ff38bffc463afad518c78c9f1b, which normalized `null`/`None` values to empty sequences and thus ended up flipping the truthiness (e.g., when consumed via `expand_if_false`).