### PR TITLE
Refactor Bazel module selection

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Discovery.java
@@ -152,15 +152,14 @@ final class Discovery {
      */
     DepSpec applyOverrides(DepSpec depSpec) {
       if (root.module().getName().equals(depSpec.name())) {
-        return DepSpec.fromModuleKey(ModuleKey.ROOT);
+        return DepSpec.ROOT_MODULE;
       }
-      Version newVersion =
+      return depSpec.withVersion(
           switch (root.overrides().get(depSpec.name())) {
-            case NonRegistryOverride nro -> Version.EMPTY;
+            case NonRegistryOverride ignored -> Version.EMPTY;
             case SingleVersionOverride svo when !svo.version().isEmpty() -> svo.version();
             case null, default -> depSpec.version();
-          };
-      return new DepSpec(depSpec.name(), newVersion, depSpec.maxCompatibilityLevel());
+          });
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/InterimModule.java
@@ -18,6 +18,7 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 import static java.util.Objects.requireNonNull;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -62,15 +63,18 @@ public abstract class InterimModule extends ModuleBase {
       requireNonNull(version, "version");
     }
 
-    public static DepSpec create(String name, Version version, int maxCompatibilityLevel) {
-      return new DepSpec(name, version, maxCompatibilityLevel);
-    }
+    public static final DepSpec ROOT_MODULE = fromModuleKey(ModuleKey.ROOT);
 
+    @VisibleForTesting
     public static DepSpec fromModuleKey(ModuleKey key) {
-      return create(key.name(), key.version(), -1);
+      return new DepSpec(key.name(), key.version(), -1);
     }
 
-    public final ModuleKey toModuleKey() {
+    public DepSpec withVersion(Version version) {
+      return new DepSpec(name(), version, maxCompatibilityLevel());
+    }
+
+    public ModuleKey toModuleKey() {
       return new ModuleKey(name(), version());
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -307,8 +307,7 @@ public class ModuleFileGlobals {
     if (!(context.shouldIgnoreDevDeps() && devDependency)) {
       context.addDep(
           repoName,
-          DepSpec.create(
-              name, parsedVersion, maxCompatibilityLevel.toInt("max_compatibility_level")));
+          new DepSpec(name, parsedVersion, maxCompatibilityLevel.toInt("max_compatibility_level")));
     }
 
     if (repoName.isPresent()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleThreadContext.java
@@ -341,7 +341,7 @@ public class ModuleThreadContext extends StarlarkThreadContext {
         // The built-in module does not depend on itself.
         continue;
       }
-      deps.put(builtinModule, DepSpec.create(builtinModule, Version.EMPTY, -1));
+      deps.put(builtinModule, new DepSpec(builtinModule, Version.EMPTY, -1));
       try {
         addRepoNameUsage(builtinModule, "as a built-in dependency", ImmutableList.of());
       } catch (EvalException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
@@ -451,7 +451,7 @@ final class Selection {
               depSpec.toModuleKey(),
               repoName,
               previousRepoName,
-              key.name());
+              depSpec.name());
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Selection.java
@@ -179,11 +179,11 @@ final class Selection {
   }
 
   /**
-   * Computes the possible list of ModuleKeys a single given DepSpec can resolve to. This is
-   * normally just one ModuleKey, but when max_compatibility_level is involved, multiple choices may
+   * Computes the possible list of versions a single given DepSpec can resolve to. This is
+   * normally just one version, but when max_compatibility_level is involved, multiple choices may
    * be possible.
    */
-  private static ImmutableList<ModuleKey> computePossibleResolutionResultsForOneDepSpec(
+  private static ImmutableList<Version> computePossibleResolutionResultsForOneDepSpec(
       DepSpec depSpec,
       ImmutableMap<ModuleKey, SelectionGroup> selectionGroups,
       Map<SelectionGroup, Version> selectedVersions) {
@@ -204,7 +204,7 @@ final class Selection {
         .stream()
         // Collect into an ImmutableSortedMap so that:
         //  1. The final list is sorted by compatibility level, guaranteeing lowest version first;
-        //  2. Only one ModuleKey is attempted per compatibility level, so that in the case of a
+        //  2. Only one version is attempted per compatibility level, so that in the case of a
         //     multiple-version override, we only try the lowest allowed version in that
         //     compatibility level (note the Comparators::min call).
         .collect(
@@ -215,7 +215,6 @@ final class Selection {
                 Comparators::min))
         .values()
         .stream()
-        .map(v -> new ModuleKey(depSpec.name(), v))
         .collect(toImmutableList());
   }
 
@@ -223,12 +222,12 @@ final class Selection {
    * Computes the possible list of ModuleKeys a DepSpec can resolve to, for all distinct DepSpecs in
    * the dependency graph.
    */
-  private static ImmutableMap<DepSpec, ImmutableList<ModuleKey>> computePossibleResolutionResults(
+  private static ImmutableMap<DepSpec, ImmutableList<Version>> computePossibleResolutionResults(
       ImmutableMap<ModuleKey, InterimModule> depGraph,
       ImmutableMap<ModuleKey, SelectionGroup> selectionGroups,
       Map<SelectionGroup, Version> selectedVersions) {
     // Important that we use a LinkedHashMap here to ensure reproducibility.
-    Map<DepSpec, ImmutableList<ModuleKey>> results = new LinkedHashMap<>();
+    Map<DepSpec, ImmutableList<Version>> results = new LinkedHashMap<>();
     for (InterimModule module : depGraph.values()) {
       for (DepSpec depSpec : module.getDeps().values()) {
         results.computeIfAbsent(
@@ -242,12 +241,12 @@ final class Selection {
   }
 
   /**
-   * Given the possible list of ModuleKeys each DepSpec can resolve to, enumerate through all the
-   * possible resolution strategies. Each strategy assigns each DepSpec to a single ModuleKey out of
+   * Given the possible list of versions each DepSpec can resolve to, enumerate through all the
+   * possible resolution strategies. Each strategy assigns each DepSpec to a single version out of
    * its possible list.
    */
-  private static List<Function<DepSpec, ModuleKey>> enumerateStrategies(
-      ImmutableMap<DepSpec, ImmutableList<ModuleKey>> possibleResolutionResults) {
+  private static List<Function<DepSpec, Version>> enumerateStrategies(
+      ImmutableMap<DepSpec, ImmutableList<Version>> possibleResolutionResults) {
     Map<DepSpec, Integer> depSpecToPosition = new HashMap<>();
     int position = 0;
     for (DepSpec depSpec : possibleResolutionResults.keySet()) {
@@ -255,7 +254,7 @@ final class Selection {
     }
     return Lists.transform(
         Lists.cartesianProduct(possibleResolutionResults.values().asList()),
-        (List<ModuleKey> choices) ->
+        (List<Version> choices) ->
             (DepSpec depSpec) -> choices.get(depSpecToPosition.get(depSpec)));
     // TODO(wyv): There are some strategies that we could eliminate earlier. For example, the
     //   strategy where (foo@1.1, maxCL=3) resolves to foo@2.0 and (foo@1.2, maxCL=3) resolves to
@@ -290,10 +289,10 @@ final class Selection {
       selectedVersions.merge(selectionGroup, key.version(), Comparators::max);
     }
 
-    // Compute the possible list of ModuleKeys that each DepSpec could resolve to.
-    ImmutableMap<DepSpec, ImmutableList<ModuleKey>> possibleResolutionResults =
+    // Compute the possible list of versions that each DepSpec could resolve to.
+    ImmutableMap<DepSpec, ImmutableList<Version>> possibleResolutionResults =
         computePossibleResolutionResults(depGraph, selectionGroups, selectedVersions);
-    for (Map.Entry<DepSpec, ImmutableList<ModuleKey>> e : possibleResolutionResults.entrySet()) {
+    for (Map.Entry<DepSpec, ImmutableList<Version>> e : possibleResolutionResults.entrySet()) {
       if (e.getValue().isEmpty()) {
         throw ExternalDepsException.withMessage(
             Code.VERSION_RESOLUTION_ERROR,
@@ -316,7 +315,7 @@ final class Selection {
     // we attempted to walk the graph using the first resolution strategy.
     DepGraphWalker depGraphWalker = new DepGraphWalker(depGraph, overrides, selectionGroups);
     ExternalDepsException firstFailure = null;
-    for (Function<DepSpec, ModuleKey> resolutionStrategy :
+    for (Function<DepSpec, Version> resolutionStrategy :
         enumerateStrategies(possibleResolutionResults)) {
       try {
         ImmutableMap<ModuleKey, InterimModule> prunedDepGraph =
@@ -328,7 +327,7 @@ final class Selection {
                     depGraph,
                     module ->
                         module.withDepsTransformed(
-                            depSpec -> DepSpec.fromModuleKey(resolutionStrategy.apply(depSpec)))));
+                            depSpec -> depSpec.withVersion(resolutionStrategy.apply(depSpec)))));
         return new Result(prunedDepGraph, unprunedDepGraph);
       } catch (ExternalDepsException e) {
         if (firstFailure == null) {
@@ -364,7 +363,7 @@ final class Selection {
      * Walks the old dep graph and builds a new dep graph containing only deps reachable from the
      * root module. The returned map has a guaranteed breadth-first iteration order.
      */
-    ImmutableMap<ModuleKey, InterimModule> walk(Function<DepSpec, ModuleKey> resolutionStrategy)
+    ImmutableMap<ModuleKey, InterimModule> walk(Function<DepSpec, Version> resolutionStrategy)
         throws ExternalDepsException {
       HashMap<String, ExistingModule> moduleByName = new HashMap<>();
       ImmutableMap.Builder<ModuleKey, InterimModule> newDepGraph = ImmutableMap.builder();
@@ -379,7 +378,7 @@ final class Selection {
             oldDepGraph
                 .get(key)
                 .withDepsTransformed(
-                    depSpec -> DepSpec.fromModuleKey(resolutionStrategy.apply(depSpec)));
+                    depSpec -> depSpec.withVersion(resolutionStrategy.apply(depSpec)));
         visit(key, module, moduleKeyAndDependent.dependent(), moduleByName);
 
         for (DepSpec depSpec : module.getDeps().values()) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodTestUtil.java
@@ -47,7 +47,7 @@ public final class BzlmodTestUtil {
 
   public static DepSpec createDepSpec(String name, String version, int maxCompatibilityLevel) {
     try {
-      return DepSpec.create(name, Version.parse(version), maxCompatibilityLevel);
+      return new DepSpec(name, Version.parse(version), maxCompatibilityLevel);
     } catch (Version.ParseException e) {
       throw new IllegalArgumentException(e);
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionTest.java
@@ -120,7 +120,7 @@ public class SelectionTest {
                 .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("bbb", "1.0")
-                .addDep("ddd_from_bbb", createModuleKey("ddd", "2.0"))
+                .addDep("ddd_from_bbb", createDepSpec("ddd", "2.0", 3))
                 .addOriginalDep("ddd_from_bbb", createDepSpec("ddd", "1.0", 3))
                 .buildEntry(),
             InterimModuleBuilder.create("ccc", "2.0")
@@ -137,7 +137,7 @@ public class SelectionTest {
                 .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("bbb", "1.0")
-                .addDep("ddd_from_bbb", createModuleKey("ddd", "2.0"))
+                .addDep("ddd_from_bbb", createDepSpec("ddd", "2.0", 3))
                 .addOriginalDep("ddd_from_bbb", createDepSpec("ddd", "1.0", 3))
                 .buildEntry(),
             InterimModuleBuilder.create("ccc", "2.0")
@@ -182,7 +182,7 @@ public class SelectionTest {
                 .addOriginalDep("ddd_from_bbb", createModuleKey("ddd", "1.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("ccc", "2.0")
-                .addDep("ddd_from_ccc", createModuleKey("ddd", "2.0"))
+                .addDep("ddd_from_ccc", createDepSpec("ddd", "2.0", 4))
                 .addOriginalDep("ddd_from_ccc", createDepSpec("ddd", "2.0", 4))
                 .buildEntry(),
             InterimModuleBuilder.create("ddd", "2.0", 1).buildEntry())
@@ -200,7 +200,7 @@ public class SelectionTest {
                 .addOriginalDep("ddd_from_bbb", createModuleKey("ddd", "1.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("ccc", "2.0")
-                .addDep("ddd_from_ccc", createModuleKey("ddd", "2.0"))
+                .addDep("ddd_from_ccc", createDepSpec("ddd", "2.0", 4))
                 .addOriginalDep("ddd_from_ccc", createDepSpec("ddd", "2.0", 4))
                 .buildEntry(),
             InterimModuleBuilder.create("ddd", "1.0", 1).buildEntry(),
@@ -429,7 +429,7 @@ public class SelectionTest {
                 .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("bbb", "1.0")
-                .addDep("ddd_from_bbb", createModuleKey("ddd", "2.0"))
+                .addDep("ddd_from_bbb", createDepSpec("ddd", "2.0", 2))
                 .addOriginalDep("ddd_from_bbb", createDepSpec("ddd", "1.0", 2))
                 .buildEntry(),
             InterimModuleBuilder.create("ccc", "2.0")
@@ -446,7 +446,7 @@ public class SelectionTest {
                 .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("bbb", "1.0")
-                .addDep("ddd_from_bbb", createModuleKey("ddd", "2.0"))
+                .addDep("ddd_from_bbb", createDepSpec("ddd", "2.0", 2))
                 .addOriginalDep("ddd_from_bbb", createDepSpec("ddd", "1.0", 2))
                 .buildEntry(),
             InterimModuleBuilder.create("ccc", "2.0")
@@ -486,7 +486,7 @@ public class SelectionTest {
                 .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("bbb", "1.0")
-                .addDep("ddd_from_bbb", createModuleKey("ddd", "2.0"))
+                .addDep("ddd_from_bbb", createDepSpec("ddd", "2.0", 3))
                 .addOriginalDep("ddd_from_bbb", createDepSpec("ddd", "2.0", 3))
                 .buildEntry(),
             InterimModuleBuilder.create("ccc", "2.0")
@@ -503,7 +503,7 @@ public class SelectionTest {
                 .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
                 .buildEntry(),
             InterimModuleBuilder.create("bbb", "1.0")
-                .addDep("ddd_from_bbb", createModuleKey("ddd", "2.0"))
+                .addDep("ddd_from_bbb", createDepSpec("ddd", "2.0", 3))
                 .addOriginalDep("ddd_from_bbb", createDepSpec("ddd", "2.0", 3))
                 .buildEntry(),
             InterimModuleBuilder.create("ccc", "2.0")
@@ -591,7 +591,7 @@ public class SelectionTest {
                 .setKey(ModuleKey.ROOT)
                 .addDep("bbb", createModuleKey("bbb", "1.1"))
                 .addOriginalDep("bbb", createModuleKey("bbb", "1.0"))
-                .addDep("ccc", createModuleKey("ccc", "1.1"))
+                .addDep("ccc", createDepSpec("ccc", "1.1", 2))
                 .addOriginalDep("ccc", createDepSpec("ccc", "1.0", 2))
                 .addDep("ddd", createModuleKey("ddd", "1.0"))
                 .addDep("eee", createModuleKey("eee", "1.0"))
@@ -612,7 +612,7 @@ public class SelectionTest {
                 .setKey(ModuleKey.ROOT)
                 .addDep("bbb", createModuleKey("bbb", "1.1"))
                 .addOriginalDep("bbb", createModuleKey("bbb", "1.0"))
-                .addDep("ccc", createModuleKey("ccc", "1.1"))
+                .addDep("ccc", createDepSpec("ccc", "1.1", 2))
                 .addOriginalDep("ccc", createDepSpec("ccc", "1.0", 2))
                 .addDep("ddd", createModuleKey("ddd", "1.0"))
                 .addDep("eee", createModuleKey("eee", "1.0"))

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionTest.java
@@ -633,6 +633,61 @@ public class SelectionTest {
   }
 
   @Test
+  public void maxCompatibilityBasedSelection_withMultipleVersionOverride() throws Exception {
+    ImmutableMap<ModuleKey, InterimModule> depGraph =
+        ImmutableMap.<ModuleKey, InterimModule>builder()
+            .put(
+                InterimModuleBuilder.create("aaa", Version.EMPTY)
+                    .setKey(ModuleKey.ROOT)
+                    .addDep("bbb_from_aaa", createModuleKey("bbb", "1.0"))
+                    .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
+                    .buildEntry())
+            .put(
+                InterimModuleBuilder.create("bbb", "1.0")
+                    .addDep("ccc_from_bbb", createDepSpec("ccc", "1.5", 2))
+                    .buildEntry())
+            .put(InterimModuleBuilder.create("ccc", "1.0").buildEntry())
+            .put(InterimModuleBuilder.create("ccc", "1.5").buildEntry())
+            .put(InterimModuleBuilder.create("ccc", "2.0", 2).buildEntry())
+            .buildOrThrow();
+    ImmutableMap<String, ModuleOverride> overrides =
+        ImmutableMap.of(
+            "ccc",
+            MultipleVersionOverride.create(
+                ImmutableList.of(Version.parse("1.0"), Version.parse("2.0")), ""));
+
+    Selection.Result selectionResult = Selection.run(depGraph, overrides);
+    assertThat(selectionResult.resolvedDepGraph().entrySet())
+        .containsExactly(
+            InterimModuleBuilder.create("aaa", Version.EMPTY)
+                .setKey(ModuleKey.ROOT)
+                .addDep("bbb_from_aaa", createModuleKey("bbb", "1.0"))
+                .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
+                .buildEntry(),
+            InterimModuleBuilder.create("bbb", "1.0")
+                .addDep("ccc_from_bbb", createDepSpec("ccc", "2.0", 2))
+                .addOriginalDep("ccc_from_bbb", createDepSpec("ccc", "1.5", 2))
+                .buildEntry(),
+            InterimModuleBuilder.create("ccc", "2.0", 2).buildEntry())
+        .inOrder();
+
+    assertThat(selectionResult.unprunedDepGraph().entrySet())
+        .containsExactly(
+            InterimModuleBuilder.create("aaa", Version.EMPTY)
+                .setKey(ModuleKey.ROOT)
+                .addDep("bbb_from_aaa", createModuleKey("bbb", "1.0"))
+                .addDep("ccc_from_aaa", createModuleKey("ccc", "2.0"))
+                .buildEntry(),
+            InterimModuleBuilder.create("bbb", "1.0")
+                .addDep("ccc_from_bbb", createDepSpec("ccc", "2.0", 2))
+                .addOriginalDep("ccc_from_bbb", createDepSpec("ccc", "1.5", 2))
+                .buildEntry(),
+            InterimModuleBuilder.create("ccc", "1.0").buildEntry(),
+            InterimModuleBuilder.create("ccc", "1.5").buildEntry(),
+            InterimModuleBuilder.create("ccc", "2.0", 2).buildEntry()).inOrder();
+  }
+
+  @Test
   public void differentCompatibilityLevelIsOkIfUnreferenced() throws Exception {
     // aaa 1.0 -> bbb 1.0 -> ccc 2.0
     //       \-> ccc 1.0

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionTest.java
@@ -811,6 +811,9 @@ public class SelectionTest {
         .containsMatch(
             "aaa@_ depends on bbb@1.5 at least twice \\(with repo names (bbb2 and bbb3)|(bbb3 and"
                 + " bbb2)\\)");
+    assertThat(e)
+        .hasMessageThat()
+        .contains("if you want to depend on multiple versions of bbb simultaneously");
   }
 
   @Test


### PR DESCRIPTION
* Enforce via the type system that a resolution strategy can't change the module name.
* Use a wither instead of the constructor to avoid losing information when changing the version of a `DepSpec`.

This will be used as a base for simplifications to the selection algorithm, whose runtime is currently exponential in the number of deps with non-trivial `max_compatibility_level`.

Along the way, fix an error message and add test cases.
