### PR TITLE
Reenable test in bazel_test_test.sh

### DIFF
--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -107,20 +107,6 @@ EOF
   bazel test --nocache_test_results --test_output=all --test_tmpdir=$TEST_TMPDIR //foo:bar_test \
     >& $TEST_log || fail "Running sh_test failed"
   expect_log "TEST_TMPDIR=$TEST_TMPDIR"
-
-  # If we run `bazel test //src/test/shell/bazel:bazel_test_test` on Linux, it
-  # will be sandboxed and this "inner test" creating /foo/bar will actually
-  # succeed. If we run it on OS X (or in general without sandboxing enabled),
-  # it will fail to create /foo/bar, since obviously we don't have write
-  # permissions.
-  if bazel test --nocache_test_results --test_output=all \
-    --test_tmpdir=/foo/bar //foo:bar_test >& $TEST_log; then
-    # We are in a sandbox.
-    expect_log "TEST_TMPDIR=/foo/bar"
-  else
-    # We are not sandboxed.
-    expect_log "Could not create TEST_TMPDIR"
-  fi
 }
 
 function test_env_vars() {

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -84,8 +84,7 @@ function test_3_local_jobs() {
     --runs_per_test=10 //dir:test
 }
 
-# TODO(#2228): Re-enable when the tmpdir creation is fixed.
-function DISABLED_test_tmpdir() {
+function test_tmpdir() {
   add_rules_shell "MODULE.bazel"
   mkdir -p foo
   cat > foo/bar_test.sh <<'EOF'

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -89,7 +89,9 @@ function test_tmpdir() {
   mkdir -p foo
   cat > foo/bar_test.sh <<'EOF'
 #!/bin/sh
+set -e
 echo TEST_TMPDIR=$TEST_TMPDIR
+touch "$TEST_TMPDIR/foo"
 EOF
   chmod +x foo/bar_test.sh
   cat > foo/BUILD <<EOF


### PR DESCRIPTION
Drop wonky absolute path logic, the rest of the test already verifies that the directory set via the flag is propagated to the test. Also add a check to verify that it is writable.

Closes #2228