### PR TITLE
Print interactive debug instructions in HardlinkedSandboxedSpawn

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -354,6 +354,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
           sandboxDebugPath,
           statisticsPath,
           sandboxOptions.sandboxDebug,
+          makeInteractiveDebugArguments(commandLineBuilder, sandboxOptions),
           spawn.getMnemonic());
     } else {
       return new SymlinkedSandboxedSpawn(


### PR DESCRIPTION
When running with --experimental_use_hermetic_linux_sandbox, this allows us to see the interactive debug instructions like we'd see without it.

Note that `EnterWorkingDirectory()` in `linux-sandbox` requires that the working directory is under the sandbox_root path, so we need to include `cwd=sandboxExecRoot()` when calling `describeCommand`. This is a stricter requirement than for SymlinkedSandboxedSpawn which was changed in #26448 more for UX reasons.

Fixes #26580.