### PR TITLE
[8.4.0] Normalize C++ action config tool paths based on exec platform OS

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -1421,6 +1421,17 @@ public class RuleContext extends TargetContext
         .hasConstraintValue(OS_TO_CONSTRAINTS.get(OS.WINDOWS));
   }
 
+  /** Returns the OS of the execution platform. */
+  public OS getExecutionPlatformOs() {
+    for (var osToConstraint : OS_TO_CONSTRAINTS.entrySet()) {
+      if (getExecutionPlatform().constraints().hasConstraintValue(osToConstraint.getValue())) {
+        return osToConstraint.getKey();
+      }
+    }
+    // Fall back to assuming exec OS == host OS.
+    return OS.getCurrent();
+  }
+
   /**
    * @return the set of features applicable for the current rule.
    */

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/ConstraintConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/ConstraintConstants.java
@@ -31,37 +31,31 @@ public final class ConstraintConstants {
 
   // Standard mapping between OS and the corresponding platform constraints.
   public static final ImmutableBiMap<OS, ConstraintValueInfo> OS_TO_CONSTRAINTS =
-      ImmutableBiMap.<OS, ConstraintValueInfo>builder()
-          .put(
-              OS.LINUX,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING, Label.parseCanonicalUnchecked("@platforms//os:linux")))
-          .put(
-              OS.DARWIN,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:osx")))
-          .put(
-              OS.WINDOWS,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:windows")))
-          .put(
-              OS.FREEBSD,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:freebsd")))
-          .put(
-              OS.OPENBSD,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:openbsd")))
-          .put(
-              OS.UNKNOWN,
-              ConstraintValueInfo.create(
-                  OS_CONSTRAINT_SETTING,
-                  Label.parseCanonicalUnchecked("@platforms//os:none")))
-          .buildOrThrow();
+      ImmutableBiMap.of(
+          OS.LINUX,
+          ConstraintValueInfo.create(
+              OS_CONSTRAINT_SETTING,
+              Label.parseCanonicalUnchecked("@platforms//os:linux")),
+          OS.DARWIN,
+          ConstraintValueInfo.create(
+              OS_CONSTRAINT_SETTING,
+              Label.parseCanonicalUnchecked("@platforms//os:osx")),
+          OS.WINDOWS,
+          ConstraintValueInfo.create(
+              OS_CONSTRAINT_SETTING,
+              Label.parseCanonicalUnchecked("@platforms//os:windows")),
+          OS.FREEBSD,
+          ConstraintValueInfo.create(
+              OS_CONSTRAINT_SETTING,
+              Label.parseCanonicalUnchecked("@platforms//os:freebsd")),
+          OS.OPENBSD,
+          ConstraintValueInfo.create(
+              OS_CONSTRAINT_SETTING,
+              Label.parseCanonicalUnchecked("@platforms//os:openbsd")),
+          OS.UNKNOWN,
+          ConstraintValueInfo.create(
+              OS_CONSTRAINT_SETTING,
+              Label.parseCanonicalUnchecked("@platforms//os:none")));
 
   /**
    * Returns the OS corresponding to the given constraint collection based on the contained platform

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
@@ -991,21 +991,16 @@ public class CcToolchainFeatures implements StarlarkValue {
 
     /** Returns the path to this action's tool relative to the provided crosstool path. */
     String getToolPathString(PathFragment ccToolchainPath) {
-      switch (toolPathOrigin) {
-        case CROSSTOOL_PACKAGE:
+      return switch (toolPathOrigin) {
+        case CROSSTOOL_PACKAGE -> {
           // Legacy behavior.
           if (toolPathString == null) {
             toolPathString = ccToolchainPath.getRelative(toolPathFragment).getSafePathString();
           }
-          return toolPathString;
-
-        case FILESYSTEM_ROOT: // fallthrough.
-        case WORKSPACE_ROOT:
-          return toolPathFragment.getSafePathString();
-      }
-
-      // Unreached.
-      throw new IllegalStateException();
+          yield toolPathString;
+        }
+        case FILESYSTEM_ROOT, WORKSPACE_ROOT -> toolPathFragment.getSafePathString();
+      };
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
@@ -95,11 +95,22 @@ public interface OsPathPolicy {
     return os == OS.WINDOWS ? WindowsOsPathPolicy.INSTANCE : UnixOsPathPolicy.INSTANCE;
   }
 
-  // We *should* use a case-insensitive policy for OS.DARWIN, but we currently don't handle this.
-  OsPathPolicy HOST_POLICY = of(OS.getCurrent());
+  /** The policy for the OS of the machine running the Bazel server's JVM. */
+  OsPathPolicy HOST_POLICY = getFilePathOs(OS.getCurrent());
 
   static OsPathPolicy getFilePathOs() {
     return HOST_POLICY;
+  }
+
+  static OsPathPolicy getFilePathOs(OS os) {
+    if (os != OS.WINDOWS) {
+      // We *should* use a case-insensitive policy for OS.DARWIN, but we currently don't handle
+      // this.
+      return UnixOsPathPolicy.INSTANCE;
+    }
+    return os == OS.getCurrent()
+        ? WindowsOsPathPolicy.INSTANCE
+        : WindowsOsPathPolicy.CROSS_PLATFORM_INSTANCE;
   }
 
   /** Utilities for implementations of {@link OsPathPolicy}. */

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathFragment.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathFragment.java
@@ -69,15 +69,23 @@ public abstract sealed class PathFragment
 
   /** Creates a new normalized path fragment. */
   public static PathFragment create(String path) {
+    return createInternal(path, OS);
+  }
+
+  public static PathFragment createForOs(String path, com.google.devtools.build.lib.util.OS os) {
+    return createInternal(path, OsPathPolicy.getFilePathOs(os));
+  }
+
+  private static PathFragment createInternal(String path, OsPathPolicy osPathPolicy) {
     if (path.isEmpty()) {
       return EMPTY_FRAGMENT;
     }
-    int normalizationLevel = OS.needsToNormalize(path);
+    int normalizationLevel = osPathPolicy.needsToNormalize(path);
     String normalizedPath =
         normalizationLevel != OsPathPolicy.NORMALIZED
-            ? OS.normalize(path, normalizationLevel)
+            ? osPathPolicy.normalize(path, normalizationLevel)
             : path;
-    int driveStrLength = OS.getDriveStrLength(normalizedPath);
+    int driveStrLength = osPathPolicy.getDriveStrLength(normalizedPath);
     return makePathFragment(normalizedPath, driveStrLength);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/WindowsOsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/WindowsOsPathPolicy.java
@@ -24,7 +24,11 @@ import java.io.IOException;
 @VisibleForTesting
 class WindowsOsPathPolicy implements OsPathPolicy {
 
-  static final WindowsOsPathPolicy INSTANCE = new WindowsOsPathPolicy();
+  static final WindowsOsPathPolicy INSTANCE =
+      new WindowsOsPathPolicy(new DefaultShortPathResolver());
+
+  static final WindowsOsPathPolicy CROSS_PLATFORM_INSTANCE =
+      new WindowsOsPathPolicy(new CrossPlatformShortPathResolver());
 
   static final int NEEDS_SHORT_PATH_NORMALIZATION = NEEDS_NORMALIZE + 1;
 
@@ -52,10 +56,21 @@ class WindowsOsPathPolicy implements OsPathPolicy {
     }
   }
 
-  WindowsOsPathPolicy() {
-    this(new DefaultShortPathResolver());
+  static class CrossPlatformShortPathResolver implements ShortPathResolver {
+    @Override
+    public String resolveShortPath(String path) {
+      // Short paths can only be resolved on a Windows host.
+      // Skipping short path resolution when running on a non-Windows host can
+      // result in paths considered different that are actually the same.
+      // TODO: Consider failing when a short path is detected on a non-Windows
+      //  host. Since short path segments can arise from most operations on
+      //  PathFragment, this would however require exception handling in many
+      //  places.
+      return path;
+    }
   }
 
+  @VisibleForTesting
   WindowsOsPathPolicy(ShortPathResolver shortPathResolver) {
     this.shortPathResolver = shortPathResolver;
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -684,7 +684,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/main/java/com/google/devtools/build/lib/skyframe:bzl_load_value",
         "//src/main/java/com/google/devtools/build/lib/util",
-        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/util:os",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/net/starlark/java/eval",
         "//src/main/protobuf:crosstool_config_java_proto",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.rules.cpp;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
 import static com.google.devtools.build.lib.actions.util.ActionsTestUtil.baseArtifactNames;
 import static com.google.devtools.build.lib.rules.cpp.SolibSymlinkAction.MAX_FILENAME_LENGTH;
 import static com.google.devtools.build.lib.skyframe.BzlLoadValue.keyForBuild;
@@ -61,6 +62,7 @@ import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.WithFeatureSe
 import com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.StringValueParser;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.testutil.TestConstants;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.view.config.crosstool.CrosstoolConfig.CToolchain;
@@ -3447,7 +3449,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
     EvalException e =
-        assertThrows(EvalException.class, () -> CcModule.toolFromStarlark(toolStruct));
+        assertThrows(
+            EvalException.class, () -> CcModule.toolFromStarlark(toolStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("Expected object of type 'with_feature_set', received 'struct'");
@@ -3466,7 +3469,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
     EvalException e =
-        assertThrows(EvalException.class, () -> CcModule.toolFromStarlark(toolStruct));
+        assertThrows(
+            EvalException.class, () -> CcModule.toolFromStarlark(toolStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("at index 0 of execution_requirements, got element of type struct, want string");
@@ -3484,7 +3488,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     ConfiguredTarget t = getConfiguredTarget("//six:a");
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
-    Tool tool = CcModule.toolFromStarlark(toolStruct);
+    Tool tool = CcModule.toolFromStarlark(toolStruct, OS.getCurrent());
     assertThat(tool.getExecutionRequirements()).containsExactly("a", "b");
     assertThat(tool.getToolPathString(PathFragment.EMPTY_FRAGMENT)).isEqualTo("/a/b/c");
     assertThat(tool.getWithFeatureSetSets())
@@ -3516,7 +3520,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
     EvalException e =
-        assertThrows(EvalException.class, () -> CcModule.toolFromStarlark(toolStruct));
+        assertThrows(
+            EvalException.class, () -> CcModule.toolFromStarlark(toolStruct, OS.getCurrent()));
     assertThat(e).hasMessageThat().contains("The 'path' field of tool must be a nonempty string.");
   }
 
@@ -3530,7 +3535,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
     EvalException e =
-        assertThrows(EvalException.class, () -> CcModule.toolFromStarlark(toolStruct));
+        assertThrows(
+            EvalException.class, () -> CcModule.toolFromStarlark(toolStruct, OS.getCurrent()));
     assertThat(e).hasMessageThat().contains("Field 'path' is not of 'java.lang.String' type.");
   }
 
@@ -3544,7 +3550,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
     EvalException e =
-        assertThrows(EvalException.class, () -> CcModule.toolFromStarlark(toolStruct));
+        assertThrows(
+            EvalException.class, () -> CcModule.toolFromStarlark(toolStruct, OS.getCurrent()));
     assertThat(e).hasMessageThat().contains("for with_features, got struct, want sequence");
   }
 
@@ -3561,7 +3568,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
     EvalException e =
-        assertThrows(EvalException.class, () -> CcModule.toolFromStarlark(toolStruct));
+        assertThrows(
+            EvalException.class, () -> CcModule.toolFromStarlark(toolStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("Expected object of type 'with_feature_set', received 'struct'");
@@ -3577,7 +3585,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
     EvalException e =
-        assertThrows(EvalException.class, () -> CcModule.toolFromStarlark(toolStruct));
+        assertThrows(
+            EvalException.class, () -> CcModule.toolFromStarlark(toolStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("for execution_requirements, got string, want sequence");
@@ -3593,10 +3602,104 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
     assertThat(toolStruct).isNotNull();
     EvalException e =
-        assertThrows(EvalException.class, () -> CcModule.toolFromStarlark(toolStruct));
+        assertThrows(
+            EvalException.class, () -> CcModule.toolFromStarlark(toolStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("at index 0 of execution_requirements, got element of type struct, want string");
+  }
+
+  @Test
+  public void testCustomTool_windowsAbsolutePath() throws Exception {
+    loadCcToolchainConfigLib();
+    createCustomToolRule(
+        "seven",
+        /* path= */ Starlark.repr(
+            "C:\\Program Files\\Microsoft Visual"
+                + " Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.39.33519\\bin/HostX64/x64/cl.exe"),
+        /* withFeatures= */ "[]",
+        /* requirements= */ "[]");
+
+    ConfiguredTarget t = getConfiguredTarget("//seven:a");
+    StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
+    assertThat(toolStruct).isNotNull();
+    Tool tool = CcModule.toolFromStarlark(toolStruct, OS.WINDOWS);
+    assertThat(tool.getToolPathString(PathFragment.create("external/my_toolchain")))
+        .isEqualTo(
+            "C:/Program Files/Microsoft Visual"
+                + " Studio/2022/Community/VC/Tools/MSVC/14.39.33519/bin/HostX64/x64/cl.exe");
+  }
+
+  @Test
+  public void testCustomTool_windowsRelativePath() throws Exception {
+    loadCcToolchainConfigLib();
+    createCustomToolRule(
+        "seven",
+        /* path= */ Starlark.repr("bin\\HostX64\\x64/cl.exe"),
+        /* withFeatures= */ "[]",
+        /* requirements= */ "[]");
+
+    ConfiguredTarget t = getConfiguredTarget("//seven:a");
+    StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
+    assertThat(toolStruct).isNotNull();
+    Tool tool = CcModule.toolFromStarlark(toolStruct, OS.WINDOWS);
+    assertThat(tool.getToolPathString(PathFragment.create("external/my_toolchain")))
+        .isEqualTo("external/my_toolchain/bin/HostX64/x64/cl.exe");
+  }
+
+  @Test
+  public void testCustomTool_windowsShortPath_preservedOnNonWindowsHostOs() throws Exception {
+    assume().that(OS.getCurrent()).isNotEqualTo(OS.WINDOWS);
+
+    loadCcToolchainConfigLib();
+    createCustomToolRule(
+        "seven",
+        /* path= */ Starlark.repr(
+            "C:\\PROGRA~1\\MICROS~1\\2022\\COMMUN~1\\VC\\TOOLS\\MSVC\\14.39.33519\\BIN\\HOSTX64\\X64\\CL.EXE"),
+        /* withFeatures= */ "[]",
+        /* requirements= */ "[]");
+
+    ConfiguredTarget t = getConfiguredTarget("//seven:a");
+    StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
+    assertThat(toolStruct).isNotNull();
+    Tool tool = CcModule.toolFromStarlark(toolStruct, OS.WINDOWS);
+    assertThat(tool.getToolPathString(PathFragment.create("external/my_toolchain")))
+        .isEqualTo(
+            "C:/PROGRA~1/MICROS~1/2022/COMMUN~1/VC/TOOLS/MSVC/14.39.33519/BIN/HOSTX64/X64/CL.EXE");
+  }
+
+  @Test
+  public void testCustomTool_unixAbsolutePath() throws Exception {
+    loadCcToolchainConfigLib();
+    createCustomToolRule(
+        "seven",
+        /* path= */ Starlark.repr("/usr/bin/gcc"),
+        /* withFeatures= */ "[]",
+        /* requirements= */ "[]");
+
+    ConfiguredTarget t = getConfiguredTarget("//seven:a");
+    StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
+    assertThat(toolStruct).isNotNull();
+    Tool tool = CcModule.toolFromStarlark(toolStruct, OS.LINUX);
+    assertThat(tool.getToolPathString(PathFragment.create("external/my_toolchain")))
+        .isEqualTo("/usr/bin/gcc");
+  }
+
+  @Test
+  public void testCustomTool_unixRelativePath() throws Exception {
+    loadCcToolchainConfigLib();
+    createCustomToolRule(
+        "seven",
+        /* path= */ Starlark.repr("bin/gcc"),
+        /* withFeatures= */ "[]",
+        /* requirements= */ "[]");
+
+    ConfiguredTarget t = getConfiguredTarget("//seven:a");
+    StarlarkInfo toolStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("tool");
+    assertThat(toolStruct).isNotNull();
+    Tool tool = CcModule.toolFromStarlark(toolStruct, OS.LINUX);
+    assertThat(tool.getToolPathString(PathFragment.create("external/my_toolchain")))
+        .isEqualTo("external/my_toolchain/bin/gcc");
   }
 
   private void createCustomToolRule(
@@ -3899,7 +4002,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("Expected object of type 'tool', received 'with_feature_set'");
@@ -3921,7 +4025,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e).hasMessageThat().contains("Expected object of type 'flag_set', received 'tool'");
   }
 
@@ -3958,7 +4063,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("at index 0 of implies, got element of type struct, want string");
@@ -3980,7 +4086,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("at index 0 of implies, got element of type struct, want string");
@@ -4000,7 +4107,7 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     ConfiguredTarget t = getConfiguredTarget("//eight:a");
     StarlarkInfo actionConfigStruct = (StarlarkInfo) getMyInfoFromTarget(t).getValue("config");
     assertThat(actionConfigStruct).isNotNull();
-    ActionConfig a = CcModule.actionConfigFromStarlark(actionConfigStruct);
+    ActionConfig a = CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent());
     assertThat(a).isNotNull();
     assertThat(a.getActionName()).isEqualTo("actionname32._++-");
     assertThat(a.getImplies()).containsExactly("a", "b").inOrder();
@@ -4024,7 +4131,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains(
@@ -4048,7 +4156,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains(
@@ -4092,7 +4201,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e)
         .hasMessageThat()
         .contains("Field 'action_name' is not of 'java.lang.String' type.");
@@ -4114,7 +4224,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e).hasMessageThat().contains("Field 'enabled' is not of 'java.lang.Boolean' type.");
   }
 
@@ -4134,7 +4245,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e).hasMessageThat().contains("for tools, got struct, want sequence");
   }
 
@@ -4154,7 +4266,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e).hasMessageThat().contains("for flag_sets, got bool, want sequence");
   }
 
@@ -4174,7 +4287,8 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
     assertThat(actionConfigStruct).isNotNull();
     EvalException e =
         assertThrows(
-            EvalException.class, () -> CcModule.actionConfigFromStarlark(actionConfigStruct));
+            EvalException.class,
+            () -> CcModule.actionConfigFromStarlark(actionConfigStruct, OS.getCurrent()));
     assertThat(e).hasMessageThat().contains("for implies, got struct, want sequence");
   }
 


### PR DESCRIPTION
Work towards #19208

RELNOTES: Tool paths specified in `cc_toolchain` action configs are now normalized based on the current execution platform's OS rather than the host OS. In particular, Windows-style absolute paths are now treated as absolute paths when building on a Windows executor from a non-Windows host.

Closes #22218.

PiperOrigin-RevId: 785464222
Change-Id: I0866b0c9d87ab518c061369d836a8a08fb793630

Commit https://github.com/bazelbuild/bazel/commit/71a7c2b8d5dc0eb3ba73a3e701a20a21aa3c06c0