### PR TITLE
[8.4.0] Materialize parameter files with a remote cache if requested

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -128,9 +128,9 @@ public class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.EXECUTION},
       help =
-          "Writes intermediate parameter files to output tree even when using "
-              + "remote action execution. Useful when debugging actions. "
-              + "This is implied by --subcommands and --verbose_failures.")
+          "Writes intermediate parameter files to output tree even when using remote action "
+              + "execution or caching. Useful when debugging actions. This is implied by "
+              + "--subcommands and --verbose_failures.")
   public boolean materializeParamFiles;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -183,6 +183,7 @@ final class RemoteActionContextProvider {
               env.getCommandId().toString(),
               digestUtil,
               checkNotNull(env.getOptions().getOptions(RemoteOptions.class)),
+              checkNotNull(env.getOptions().getOptions(ExecutionOptions.class)),
               combinedCache,
               remoteExecutor,
               tempPathGenerator,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -66,6 +66,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
+import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
@@ -83,6 +84,7 @@ import com.google.devtools.build.lib.buildtool.buildevent.BuildCompleteEvent;
 import com.google.devtools.build.lib.buildtool.buildevent.BuildInterruptedEvent;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.SpawnInputExpander.InputWalker;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.local.LocalEnvProvider;
@@ -184,6 +186,7 @@ public class RemoteExecutionService {
   private final String commandId;
   private final DigestUtil digestUtil;
   private final RemoteOptions remoteOptions;
+  private final ExecutionOptions executionOptions;
   @Nullable private final CombinedCache combinedCache;
   @Nullable private final RemoteExecutionClient remoteExecutor;
   private final TempPathGenerator tempPathGenerator;
@@ -215,6 +218,7 @@ public class RemoteExecutionService {
       String commandId,
       DigestUtil digestUtil,
       RemoteOptions remoteOptions,
+      ExecutionOptions executionOptions,
       @Nullable CombinedCache combinedCache,
       @Nullable RemoteExecutionClient remoteExecutor,
       TempPathGenerator tempPathGenerator,
@@ -230,6 +234,7 @@ public class RemoteExecutionService {
     this.commandId = commandId;
     this.digestUtil = digestUtil;
     this.remoteOptions = remoteOptions;
+    this.executionOptions = executionOptions;
     this.combinedCache = combinedCache;
     this.remoteExecutor = remoteExecutor;
 
@@ -2136,6 +2141,20 @@ public class RemoteExecutionService {
 
     if (remoteExecutor != null) {
       remoteExecutor.close();
+    }
+  }
+
+  /**
+   * Whether parameter files should be written locally, even when using remote execution or caching.
+   */
+  public void maybeWriteParamFilesLocally(Spawn spawn) throws IOException {
+    if (!executionOptions.shouldMaterializeParamFiles()) {
+      return;
+    }
+    for (ActionInput actionInput : spawn.getInputFiles().toList()) {
+      if (actionInput instanceof CommandLines.ParamFileActionInput paramFileActionInput) {
+        paramFileActionInput.atomicallyWriteRelativeTo(execRoot);
+      }
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -176,6 +176,7 @@ final class RemoteSpawnCache implements SpawnCache {
                     result.getExecutionMetadata().getExecutionCompletedTimestamp(),
                     spawnMetrics.build(),
                     spawn.getMnemonic());
+            remoteExecutionService.maybeWriteParamFilesLocally(spawn);
             return SpawnCache.success(spawnResult);
           }
         } catch (CacheNotFoundException e) {
@@ -215,6 +216,7 @@ final class RemoteSpawnCache implements SpawnCache {
                 .setTotalTimeInMs((int) totalTime.elapsed().toMillis())
                 .setNetworkTimeInMs((int) action.getNetworkTime().getDuration().toMillis());
             SpawnMetrics buildMetrics = spawnMetrics.build();
+            remoteExecutionService.maybeWriteParamFilesLocally(spawn);
             return SpawnCache.success(
                 new SpawnResult.DelegateSpawnResult(previousResult) {
                   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -36,9 +36,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
-import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputDepOwnerMap;
-import com.google.devtools.build.lib.actions.CommandLines.ParamFileActionInput;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.LostInputsExecException;
@@ -203,7 +201,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
             .setInputBytes(action.getInputBytes())
             .setInputFiles(action.getInputFiles());
 
-    maybeWriteParamFilesLocally(spawn);
+    remoteExecutionService.maybeWriteParamFilesLocally(spawn);
 
     spawnMetrics.setParseTimeInMs((int) totalTime.elapsed().toMillis());
 
@@ -533,17 +531,6 @@ public class RemoteSpawnRunner implements SpawnRunner {
             && !message.isEmpty();
     if (printMessage) {
       outErr.printErr("Remote server execution message: " + message + "\n");
-    }
-  }
-
-  private void maybeWriteParamFilesLocally(Spawn spawn) throws IOException {
-    if (!executionOptions.shouldMaterializeParamFiles()) {
-      return;
-    }
-    for (ActionInput actionInput : spawn.getInputFiles().toList()) {
-      if (actionInput instanceof ParamFileActionInput paramFileActionInput) {
-        paramFileActionInput.atomicallyWriteRelativeTo(execRoot);
-      }
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -36,6 +36,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputDepOwnerMap;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -93,6 +93,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
+import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.remote.CombinedCache.CachedActionResult;
@@ -2671,6 +2672,7 @@ public class RemoteExecutionServiceTest {
         "none",
         digestUtil,
         remoteOptions,
+        Options.getDefaults(ExecutionOptions.class),
         cache,
         executor,
         tempPathGenerator,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
+import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.actions.ActionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
@@ -51,10 +52,12 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ArtifactExpander;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
+import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.InputMetadataProvider;
+import com.google.devtools.build.lib.actions.ParameterFile;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -68,6 +71,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
+import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.SpawnCache.CacheHandle;
 import com.google.devtools.build.lib.exec.SpawnInputExpander;
 import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
@@ -100,6 +104,8 @@ import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Set;
 import java.util.SortedMap;
@@ -286,6 +292,11 @@ public class RemoteSpawnCacheTest {
   }
 
   private RemoteSpawnCache remoteSpawnCacheWithOptions(RemoteOptions options) {
+    return remoteSpawnCacheWithOptions(options, Options.getDefaults(ExecutionOptions.class));
+  }
+
+  private RemoteSpawnCache remoteSpawnCacheWithOptions(
+      RemoteOptions options, ExecutionOptions executionOptions) {
     RemoteExecutionService service =
         spy(
             new RemoteExecutionService(
@@ -298,6 +309,7 @@ public class RemoteSpawnCacheTest {
                 COMMAND_ID,
                 digestUtil,
                 options,
+                executionOptions,
                 combinedCache,
                 null,
                 tempPathGenerator,
@@ -1235,5 +1247,60 @@ public class RemoteSpawnCacheTest {
 
     // assert
     assertThat(cache.getInFlightExecutionsSize()).isEqualTo(0);
+  }
+
+  @Test
+  public void testMaterializeParamFiles() throws Exception {
+    testParamFilesAreMaterializedForFlag("--materialize_param_files");
+  }
+
+  @Test
+  public void testMaterializeParamFilesIsImpliedBySubcommands() throws Exception {
+    testParamFilesAreMaterializedForFlag("--subcommands");
+  }
+
+  private void testParamFilesAreMaterializedForFlag(String flag) throws Exception {
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    ExecutionOptions executionOptions = Options.parse(ExecutionOptions.class, flag).getOptions();
+    var cache = remoteSpawnCacheWithOptions(remoteOptions, executionOptions);
+
+    ImmutableList<String> args = ImmutableList.of("--foo", "--bar");
+    CommandLines.ParamFileActionInput input =
+        new CommandLines.ParamFileActionInput(
+            PathFragment.create("out/param_file"), args, ParameterFile.ParameterFileType.UNQUOTED);
+    Spawn spawn =
+        new SimpleSpawn(
+            new FakeOwner("foo", "bar", "//dummy:label"),
+            /* arguments= */ ImmutableList.of(),
+            /* environment= */ ImmutableMap.of(),
+            /* executionInfo= */ ImmutableMap.of(),
+            /* inputs= */ NestedSetBuilder.create(Order.STABLE_ORDER, input),
+            /* outputs= */ ImmutableSet.of(),
+            ResourceSet.ZERO);
+    Path paramFile = execRoot.getRelative("out/param_file");
+
+    ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
+    when(combinedCache.downloadActionResult(
+            any(RemoteActionExecutionContext.class),
+            any(),
+            /* inlineOutErr= */ eq(false),
+            /* inlineOutputFiles= */ eq(ImmutableSet.of())))
+        .thenReturn(CachedActionResult.remote(success));
+    doReturn(null).when(cache.getRemoteExecutionService()).downloadOutputs(any(), any());
+
+    var policy =
+        createSpawnExecutionContext(
+            spawn, execRoot, new FakeActionInputFileCache(execRoot), outErr);
+    try (CacheHandle secondCacheHandle = cache.lookup(spawn, policy)) {
+      assertThat(secondCacheHandle.hasResult()).isTrue();
+      assertThat(paramFile.exists()).isTrue();
+      try (InputStream inputStream = paramFile.getInputStream()) {
+        assertThat(
+                new String(ByteStreams.toByteArray(inputStream), StandardCharsets.UTF_8)
+                    .split("\n"))
+            .asList()
+            .containsExactly("--foo", "--bar");
+      }
+    }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -1163,7 +1163,6 @@ public class RemoteSpawnRunnerTest {
   private void testParamFilesAreMaterializedForFlag(String flag) throws Exception {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     ExecutionOptions executionOptions = Options.parse(ExecutionOptions.class, flag).getOptions();
-    executionOptions.materializeParamFiles = true;
     RemoteExecutionService remoteExecutionService =
         new RemoteExecutionService(
             directExecutor(),
@@ -1175,6 +1174,7 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             digestUtil,
             remoteOptions,
+            executionOptions,
             cache,
             executor,
             tempPathGenerator,
@@ -1712,6 +1712,7 @@ public class RemoteSpawnRunnerTest {
                 "command-id",
                 digestUtil,
                 remoteOptions,
+                Options.getDefaults(ExecutionOptions.class),
                 cache,
                 executor,
                 tempPathGenerator,

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -349,6 +349,7 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             "command-id",
             DIGEST_UTIL,
             remoteOptions,
+            Options.getDefaults(ExecutionOptions.class),
             remoteCache,
             executor,
             tempPathGenerator,


### PR DESCRIPTION
Before this change parameter files were only materialized with remote execution.

Also makes the existing test for remote execution more precise.

Closes #26566.

PiperOrigin-RevId: 785431102
Change-Id: If3b8a1995bf3269a9e1a087eedaf22540b12b488

Commit https://github.com/bazelbuild/bazel/commit/7527a0423f78914da36479aac2c61acf8a8ce2b2