### PR TITLE
Update async-profiler to 4.1

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -318,7 +318,7 @@
   "moduleExtensions": {
     "//:repositories.bzl%async_profiler_repos": {
       "general": {
-        "bzlTransitiveDigest": "hNhLCETCPGnkfXo10uoqWNfGLgNqaQJcTIin05ZXqQE=",
+        "bzlTransitiveDigest": "rsNxO3/Ur5Vfnzzldl/mhwXpxrUXUa6nAKMId+SN474=",
         "usagesDigest": "fv/Ru+up/1CLlox7G1yNn9y4JOVK1qeU6uQCAkCcMaM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -328,9 +328,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "downloaded_file_path": "async-profiler.jar",
-              "sha256": "da95a5292fb203966196ecb68a39a8c26ad7276aeef642ec1de872513be1d8b3",
+              "integrity": "sha256-d2VI3O7jJpa197ArxjzAixnb/nTciR6X/j4p4H+qeMw=",
               "urls": [
-                "https://mirror.bazel.build/github.com/async-profiler/async-profiler/releases/download/nightly/async-profiler.jar"
+                "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler.jar"
               ]
             }
           },
@@ -338,10 +338,10 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file_content": "\nload(\"@bazel_skylib//rules:copy_file.bzl\", \"copy_file\")\n\ncopy_file(\n    name = \"libasyncProfiler\",\n    src = \"libasyncProfiler.so\",\n    out = \"linux-arm64/libasyncProfiler.so\",\n    visibility = [\"//visibility:public\"],\n)\n",
-              "sha256": "7c6243bb91272a2797acb8cc44acf3e406e0b658a94d90d9391ca375fc961857",
-              "strip_prefix": "async-profiler-3.0-f0ceda6-linux-arm64/lib",
+              "integrity": "sha256-0Mucl8OAZytiXAblo+1XjpkPRnTGqui1JJ9YTEyaxQ4=",
+              "strip_prefix": "async-profiler-4.1-linux-arm64/lib",
               "urls": [
-                "https://mirror.bazel.build/github.com/async-profiler/async-profiler/releases/download/nightly/async-profiler-3.0-f0ceda6-linux-arm64.tar.gz"
+                "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-arm64.tar.gz"
               ]
             }
           },
@@ -349,10 +349,10 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file_content": "\nload(\"@bazel_skylib//rules:copy_file.bzl\", \"copy_file\")\n\ncopy_file(\n    name = \"libasyncProfiler\",\n    src = \"libasyncProfiler.so\",\n    out = \"linux-x64/libasyncProfiler.so\",\n    visibility = [\"//visibility:public\"],\n)\n",
-              "sha256": "448a3dc681375860eba2264d6cae7a848bd3f07f81f547a9ce58b742a1541d25",
-              "strip_prefix": "async-profiler-3.0-f0ceda6-linux-x64/lib",
+              "integrity": "sha256-OxOjigBj9pcNmFo3ndrtkbzzfiOaHqRh0J6s9inz3eE=",
+              "strip_prefix": "async-profiler-4.1-linux-x64/lib",
               "urls": [
-                "https://mirror.bazel.build/github.com/async-profiler/async-profiler/releases/download/nightly/async-profiler-3.0-f0ceda6-linux-x64.tar.gz"
+                "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-x64.tar.gz"
               ]
             }
           },
@@ -360,10 +360,10 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file_content": "\nload(\"@bazel_skylib//rules:copy_file.bzl\", \"copy_file\")\n\ncopy_file(\n    name = \"libasyncProfiler\",\n    src = \"libasyncProfiler.dylib\",\n    out = \"macos/libasyncProfiler.so\",\n    visibility = [\"//visibility:public\"],\n)\n",
-              "sha256": "0651004c78d080f67763cddde6e1f58cd0d0c4cb0b57034beef80b450ff5adf2",
-              "strip_prefix": "async-profiler-3.0-f0ceda6-macos/lib",
+              "integrity": "sha256-xfsFjiEiguk4SiYDGgURn183UMdVsrX7bQimtngD6tA=",
+              "strip_prefix": "async-profiler-4.1-macos/lib",
               "urls": [
-                "https://mirror.bazel.build/github.com/async-profiler/async-profiler/releases/download/nightly/async-profiler-3.0-f0ceda6-macos.zip"
+                "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-macos.zip"
               ]
             }
           }

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -140,9 +140,8 @@ def _async_profiler_repos(ctx):
     http_file(
         name = "async_profiler",
         downloaded_file_path = "async-profiler.jar",
-        # At commit f0ceda6356f05b7ad0a6593670c8c113113bf0b3 (2024-12-09).
-        sha256 = "da95a5292fb203966196ecb68a39a8c26ad7276aeef642ec1de872513be1d8b3",
-        urls = ["https://mirror.bazel.build/github.com/async-profiler/async-profiler/releases/download/nightly/async-profiler.jar"],
+        integrity = "sha256-d2VI3O7jJpa197ArxjzAixnb/nTciR6X/j4p4H+qeMw=",
+        urls = ["https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler.jar"],
     )
 
     _ASYNC_PROFILER_BUILD_TEMPLATE = """
@@ -162,9 +161,9 @@ copy_file(
             ext = "so",
             tag = "linux-arm64",
         ),
-        sha256 = "7c6243bb91272a2797acb8cc44acf3e406e0b658a94d90d9391ca375fc961857",
-        strip_prefix = "async-profiler-3.0-f0ceda6-linux-arm64/lib",
-        urls = ["https://mirror.bazel.build/github.com/async-profiler/async-profiler/releases/download/nightly/async-profiler-3.0-f0ceda6-linux-arm64.tar.gz"],
+        integrity = "sha256-0Mucl8OAZytiXAblo+1XjpkPRnTGqui1JJ9YTEyaxQ4=",
+        strip_prefix = "async-profiler-4.1-linux-arm64/lib",
+        urls = ["https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-arm64.tar.gz"],
     )
 
     http_archive(
@@ -173,9 +172,9 @@ copy_file(
             ext = "so",
             tag = "linux-x64",
         ),
-        sha256 = "448a3dc681375860eba2264d6cae7a848bd3f07f81f547a9ce58b742a1541d25",
-        strip_prefix = "async-profiler-3.0-f0ceda6-linux-x64/lib",
-        urls = ["https://mirror.bazel.build/github.com/async-profiler/async-profiler/releases/download/nightly/async-profiler-3.0-f0ceda6-linux-x64.tar.gz"],
+        integrity = "sha256-OxOjigBj9pcNmFo3ndrtkbzzfiOaHqRh0J6s9inz3eE=",
+        strip_prefix = "async-profiler-4.1-linux-x64/lib",
+        urls = ["https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-x64.tar.gz"],
     )
 
     http_archive(
@@ -184,9 +183,9 @@ copy_file(
             ext = "dylib",
             tag = "macos",
         ),
-        sha256 = "0651004c78d080f67763cddde6e1f58cd0d0c4cb0b57034beef80b450ff5adf2",
-        strip_prefix = "async-profiler-3.0-f0ceda6-macos/lib",
-        urls = ["https://mirror.bazel.build/github.com/async-profiler/async-profiler/releases/download/nightly/async-profiler-3.0-f0ceda6-macos.zip"],
+        integrity = "sha256-xfsFjiEiguk4SiYDGgURn183UMdVsrX7bQimtngD6tA=",
+        strip_prefix = "async-profiler-4.1-macos/lib",
+        urls = ["https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-macos.zip"],
     )
 
 # This is an extension (instead of use_repo_rule usages) only to create a

--- a/src/tools/bzlmod/utils.bzl
+++ b/src/tools/bzlmod/utils.bzl
@@ -110,7 +110,8 @@ def parse_http_artifacts(ctx, lockfile_path, required_repos):
                     found_repos.append(repo_name)
 
                     http_artifacts.append({
-                        "sha256": attributes["sha256"],
+                        "sha256": attributes.get("sha256", None),
+                        "integrity": attributes.get("integrity", None),
                         "url": extract_url(attributes),
                     })
 


### PR DESCRIPTION
Adds support for JDK 25.

Requires fixing the distdir logic so that it accepts `integrity` and not just `sha256`.