### PR TITLE
Path map environment variable values

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -233,12 +233,12 @@ public abstract class AbstractAction extends ActionKeyComputer implements Action
   }
 
   @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException {
+  public ImmutableMap<String, String> getEffectiveEnvironment(
+      Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException {
     ActionEnvironment env = getEnvironment();
     Map<String, String> effectiveEnvironment =
         Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
-    env.resolve(effectiveEnvironment, clientEnv);
+    env.resolve(effectiveEnvironment, clientEnv, pathMapper);
     return ImmutableMap.copyOf(effectiveEnvironment);
   }
 
@@ -465,7 +465,7 @@ public abstract class AbstractAction extends ActionKeyComputer implements Action
     }
 
     for (PathFragment path : additionalPathOutputsToDelete) {
-      deleteOutput(execRoot.getRelative(path), /*root=*/ null);
+      deleteOutput(execRoot.getRelative(path), /* root= */ null);
     }
 
     for (PathFragment path : directoryOutputsToDelete) {

--- a/src/main/java/com/google/devtools/build/lib/actions/Action.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Action.java
@@ -235,6 +235,6 @@ public interface Action extends ActionExecutionMetadata {
    * mutate any of the called action data but if necessary, its implementation must synchronize any
    * accesses to mutable data.
    */
-  ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException;
+  ImmutableMap<String, String> getEffectiveEnvironment(
+      Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException;
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Interner;
+import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.util.Fingerprint;
 import java.util.Map;
@@ -120,9 +121,10 @@ public abstract class ActionEnvironment {
    *
    * <p>We pass in a map to mutate to avoid creating and merging intermediate maps.
    */
-  public final void resolve(Map<String, String> result, Map<String, String> clientEnv) {
+  public final void resolve(
+      Map<String, String> result, Map<String, String> clientEnv, PathMapper pathMapper) {
     checkNotNull(clientEnv);
-    result.putAll(getFixedEnv());
+    result.putAll(Maps.transformValues(getFixedEnv(), pathMapper::mapHeuristically));
     for (String var : getInheritedEnv()) {
       String value = clientEnv.get(var);
       if (value != null) {

--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -213,6 +213,7 @@ java_library(
     name = "action_environment",
     srcs = ["ActionEnvironment.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -479,35 +479,20 @@ public class StarlarkAction extends SpawnAction {
           || (shadowedAction.isPresent() && shadowedAction.get().discoversInputs());
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * <p>Adds the environment of the shadowed action, if any, to the execution spawn.
-     */
     @Override
-    public Spawn getSpawn(ActionExecutionContext actionExecutionContext)
-        throws CommandLineExpansionException, InterruptedException {
-      return getSpawn(
-          actionExecutionContext,
-          getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
-          /* envResolved= */ true,
-          /* reportOutputs= */ true);
-    }
-
-    @Override
-    public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-        throws CommandLineExpansionException {
+    public ImmutableMap<String, String> getEffectiveEnvironment(
+        Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException {
       ActionEnvironment env = getEnvironment();
       Map<String, String> environment = Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
 
       if (shadowedAction.isPresent()) {
         // Put all the variables of the shadowed action's environment
-        environment.putAll(shadowedAction.get().getEffectiveEnvironment(clientEnv));
+        environment.putAll(shadowedAction.get().getEffectiveEnvironment(clientEnv, pathMapper));
       }
 
       // This order guarantees that the Starlark action can overwrite any variable in its shadowed
       // action environment with a new value.
-      env.resolve(environment, clientEnv);
+      env.resolve(environment, clientEnv, pathMapper);
       return ImmutableMap.copyOf(environment);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
@@ -202,14 +202,7 @@ public final class ExtraAction extends SpawnAction {
   @Override
   public Spawn getSpawn(ActionExecutionContext actionExecutionContext)
       throws CommandLineExpansionException, InterruptedException {
-    if (!createDummyOutput) {
-      return super.getSpawn(actionExecutionContext);
-    }
-    return getSpawn(
-        actionExecutionContext,
-        actionExecutionContext.getClientEnv(),
-        /* envResolved= */ false,
-        /* reportOutputs= */ false);
+    return super.getSpawn(actionExecutionContext, /* reportOutputs= */ !createDummyOutput);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -488,6 +488,7 @@ java_library(
     name = "test_policy",
     srcs = ["TestPolicy.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/exec/TestPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestPolicy.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.exec;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.test.TestRunnerAction;
 import com.google.devtools.build.lib.util.UserUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -86,13 +87,16 @@ public class TestPolicy {
     }
 
     // Overwrite with the environment common to all actions, see --action_env.
-    testAction.getConfiguration().getActionEnvironment().resolve(env, clientEnv);
+    testAction.getConfiguration().getActionEnvironment().resolve(env, clientEnv, PathMapper.NOOP);
 
     // Overwrite with the environment common to all tests, see --test_env.
-    testAction.getConfiguration().getTestActionEnvironment().resolve(env, clientEnv);
+    testAction
+        .getConfiguration()
+        .getTestActionEnvironment()
+        .resolve(env, clientEnv, PathMapper.NOOP);
 
     // Rule-specified test env.
-    testAction.getExtraTestEnv().resolve(env, clientEnv);
+    testAction.getExtraTestEnv().resolve(env, clientEnv, PathMapper.NOOP);
 
     // Setup any test-specific env variables; note that this does not overwrite existing values for
     // TEST_RANDOM_SEED or TEST_SIZE if they're already set.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -938,28 +938,25 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
   public ImmutableMap<String, String> getIncompleteEnvironmentForTesting()
       throws ActionExecutionException {
     try {
-      return getEffectiveEnvironment(ImmutableMap.of());
+      return getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP);
     } catch (CommandLineExpansionException e) {
       String message =
           String.format(
               "failed to generate compile environment variables for rule '%s: %s",
               getOwner().getLabel(), e.getMessage());
       DetailedExitCode code = createDetailedExitCode(message, Code.COMMAND_GENERATION_FAILURE);
-      throw new ActionExecutionException(message, this, /*catastrophe=*/ false, code);
+      throw new ActionExecutionException(message, this, /* catastrophe= */ false, code);
     }
   }
 
   @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv)
-      throws CommandLineExpansionException {
-    return getEffectiveEnvironment(clientEnv, PathMapper.NOOP);
-  }
-
   public ImmutableMap<String, String> getEffectiveEnvironment(
       Map<String, String> clientEnv, PathMapper pathMapper) throws CommandLineExpansionException {
     ActionEnvironment env = getEnvironment();
     Map<String, String> environment = Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
-    env.resolve(environment, clientEnv);
+    // This is only the fixed action environment, which doesn't contain any action-specific
+    // variables and thus doesn't need to be path mapped.
+    env.resolve(environment, clientEnv, PathMapper.NOOP);
 
     if (!getExecutionInfo().containsKey(ExecutionRequirements.REQUIRES_DARWIN)) {
       // Linux: this prevents gcc/clang from writing the unpredictable (and often irrelevant) value
@@ -1034,7 +1031,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     }
     // TODO(ulfjack): Extra actions currently ignore the client environment.
     for (Map.Entry<String, String> envVariable :
-        getEffectiveEnvironment(/*clientEnv=*/ ImmutableMap.of()).entrySet()) {
+        getEffectiveEnvironment(/* clientEnv= */ ImmutableMap.of(), PathMapper.NOOP).entrySet()) {
       info.addVariable(
           EnvironmentVariable.newBuilder()
               .setName(envVariable.getKey())
@@ -1173,7 +1170,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
                 includePath);
         DetailedExitCode code =
             createDetailedExitCode(message, Code.INCLUDE_PATH_OUTSIDE_EXEC_ROOT);
-        throw new ActionExecutionException(message, this, /*catastrophe=*/ false, code);
+        throw new ActionExecutionException(message, this, /* catastrophe= */ false, code);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.AbstractAction;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
@@ -84,7 +83,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -344,7 +342,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
             .build();
     return new JavaSpawn(
         expandedCommandLines,
-        getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
+        getEffectiveEnvironment(actionExecutionContext.getClientEnv(), pathMapper),
         getExecutionInfo(),
         inputs,
         /* onlyMandatoryOutput= */ fallback ? null : outputDepsProto,
@@ -365,7 +363,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
                 configuration.getCommandLineLimits());
     return new JavaSpawn(
         expandedCommandLines,
-        getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
+        getEffectiveEnvironment(actionExecutionContext.getClientEnv(), pathMapper),
         getExecutionInfo(),
         NestedSetBuilder.<Artifact>stableOrder()
             .addTransitive(mandatoryInputs)
@@ -382,15 +380,6 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
             .build(),
         /* onlyMandatoryOutput= */ null,
         pathMapper);
-  }
-
-  @Override
-  public ImmutableMap<String, String> getEffectiveEnvironment(Map<String, String> clientEnv) {
-    ActionEnvironment env = getEnvironment();
-    LinkedHashMap<String, String> effectiveEnvironment =
-        Maps.newLinkedHashMapWithExpectedSize(env.estimatedSize());
-    env.resolve(effectiveEnvironment, clientEnv);
-    return ImmutableMap.copyOf(effectiveEnvironment);
   }
 
   private ActionExecutionException wrapIOException(IOException e, String message) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.ExecException;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.AliasProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
@@ -672,7 +673,7 @@ public class RunCommand implements BlazeCommand {
     TreeMap<String, String> runEnvironment = makeMutableRunEnvironment(env);
     HashSet<String> envVariablesToClear = new HashSet<>();
     ImmutableMap<String, String> clientEnv = env.getClientEnv();
-    actionEnvironment.resolve(runEnvironment, clientEnv);
+    actionEnvironment.resolve(runEnvironment, clientEnv, PathMapper.NOOP);
     for (var envVar : extraRunEnvironment) {
       switch (envVar) {
         case Converters.EnvVar.Set(String name, String value) -> {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandAction;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.analysis.AnalysisProtosV2;
 import com.google.devtools.build.lib.analysis.AspectValue;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -140,7 +141,9 @@ public class ActionGraphDump {
   }
 
   private void dumpSingleAction(ConfiguredTarget configuredTarget, ActionAnalysisMetadata action)
-      throws CommandLineExpansionException, InterruptedException, IOException,
+      throws CommandLineExpansionException,
+          InterruptedException,
+          IOException,
           TemplateExpansionException {
 
     // Store the content of param files.
@@ -187,7 +190,7 @@ public class ActionGraphDump {
       // TODO(twerth): This handles the fixed environment. We probably want to output the inherited
       // environment as well.
       ImmutableMap<String, String> fixedEnvironment =
-          spawnAction.getEffectiveEnvironment(ImmutableMap.of());
+          spawnAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP);
       for (Map.Entry<String, String> environmentVariable : fixedEnvironment.entrySet()) {
         actionBuilder.addEnvironmentVariables(
             AnalysisProtosV2.KeyValuePair.newBuilder()
@@ -210,7 +213,6 @@ public class ActionGraphDump {
         actionBuilder.setFileContents(contents);
       }
     }
-
 
     if (action instanceof UnresolvedSymlinkAction) {
       actionBuilder.setUnresolvedSymlinkTarget(((UnresolvedSymlinkAction) action).getTarget());
@@ -315,7 +317,9 @@ public class ActionGraphDump {
   }
 
   public void dumpConfiguredTarget(RuleConfiguredTargetValue configuredTargetValue)
-      throws CommandLineExpansionException, InterruptedException, IOException,
+      throws CommandLineExpansionException,
+          InterruptedException,
+          IOException,
           TemplateExpansionException {
     ConfiguredTarget configuredTarget = configuredTargetValue.getConfiguredTarget();
     if (!includeInActionGraph(configuredTarget.getLabel().toString())) {

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
@@ -54,7 +54,7 @@ public final class ActionEnvironmentTest {
     Map<String, String> clientEnv =
         ImmutableMap.of("INHERITED_ONLY", "inherited", "FIXED_AND_INHERITED", "inherited");
     Map<String, String> result = new HashMap<>();
-    env.resolve(result, clientEnv);
+    env.resolve(result, clientEnv, PathMapper.NOOP);
 
     assertThat(result)
         .containsExactly(

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/PathMappersTest.java
@@ -128,6 +128,7 @@ public class PathMappersTest extends BuildViewTestCase {
         "        inputs = ctx.files.srcs,",
         "        executable = ctx.executable._tool,",
         "        arguments = [args],",
+        "        env = {'MY_TOOL': ctx.executable._tool.path},",
         "        mnemonic = 'MyRuleAction',",
         format("        execution_requirements = %s,", Starlark.repr(executionRequirements)),
         "    )",
@@ -202,6 +203,8 @@ public class PathMappersTest extends BuildViewTestCase {
             "-source",
             "<pkg/source.txt:pkg/source.txt::pkg>")
         .inOrder();
+    assertThat(spawn.getEnvironment())
+        .containsExactly("MY_TOOL", format("%s/cfg/bin/tool/tool", outDir));
   }
 
   @Test
@@ -234,6 +237,8 @@ public class PathMappersTest extends BuildViewTestCase {
             "-source",
             "<pkg/source.txt:pkg/source.txt::pkg>")
         .inOrder();
+    assertThat(spawn.getEnvironment())
+        .containsExactly("MY_TOOL", format("%s/cfg/bin/tool/tool", outDir));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
@@ -257,12 +257,7 @@ public final class SpawnActionTest extends BuildViewTestCase {
             .setMetadataProvider(new FakeActionInputFileCache())
             .build();
 
-    Spawn spawn =
-        action.getSpawn(
-            actionExecutionContext,
-            ImmutableMap.of(),
-            /* envResolved= */ false,
-            /* reportOutputs= */ true);
+    Spawn spawn = action.getSpawn(actionExecutionContext);
     String paramFileName = output.getExecPathString() + "-0.params";
     // The spawn's primary arguments should reference the param file
     assertThat(spawn.getArguments())

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionTest.java
@@ -356,7 +356,8 @@ toolchain(name = "toolchain", toolchain = ":cc_toolchain", toolchain_type = '\
     scratch.file("foo/BUILD", "cc_binary(name = 'foo')");
 
     SpawnAction linkAction = (SpawnAction) Iterables.getOnlyElement(getActions("//foo", "CppLink"));
-    assertThat(linkAction.getEffectiveEnvironment(ImmutableMap.of())).containsEntry("foo", "bar");
+    assertThat(linkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP))
+        .containsEntry("foo", "bar");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionWithShadowedActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkActionWithShadowedActionTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.starlark;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.actions.util.ActionsTestUtil.NULL_ACTION_OWNER;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +29,7 @@ import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.DiscoveredModulesPruner;
 import com.google.devtools.build.lib.actions.Executor;
+import com.google.devtools.build.lib.actions.PathMapper;
 import com.google.devtools.build.lib.actions.ThreadStateReceiver;
 import com.google.devtools.build.lib.analysis.actions.StarlarkAction;
 import com.google.devtools.build.lib.analysis.util.AnalysisTestUtil;
@@ -124,7 +126,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     // them should return empty set
     Action shadowedAction =
         createShadowedAction(
-            NestedSetBuilder.emptySet(Order.STABLE_ORDER), /*discoversInputs=*/ false, null);
+            NestedSetBuilder.emptySet(Order.STABLE_ORDER), /* discoversInputs= */ false, null);
     StarlarkAction starlarkAction =
         (StarlarkAction)
             new StarlarkAction.Builder()
@@ -164,7 +166,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     Action shadowedAction =
         createShadowedAction(
             NestedSetBuilder.emptySet(Order.STABLE_ORDER),
-            /*discoversInputs=*/ true,
+            /* discoversInputs= */ true,
             discoveredInputs);
     StarlarkAction starlarkAction =
         (StarlarkAction)
@@ -236,7 +238,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     // Test using Starlark actions's inputs with shadowed action's inputs
     Action shadowedAction =
         createShadowedAction(
-            shadowedActionInputs, /*discoversInputs=*/ false, /*discoveredInputs=*/ null);
+            shadowedActionInputs, /* discoversInputs= */ false, /* discoveredInputs= */ null);
     starlarkAction =
         (StarlarkAction)
             new StarlarkAction.Builder()
@@ -307,13 +309,13 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
                 .build(NULL_ACTION_OWNER, targetConfig);
     collectingAnalysisEnvironment.registerAction(starlarkAction);
 
-    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of()))
+    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP))
         .containsExactlyEntriesIn(starlarkActionEnvironment);
 
     // Test using shadowed action's environment without Starlark actions's environment
     Action shadowedAction =
         createShadowedAction(
-            shadowedActionInputs, /*discoversInputs=*/ false, /*discoveredInputs=*/ null);
+            shadowedActionInputs, /* discoversInputs= */ false, /* discoveredInputs= */ null);
     starlarkAction =
         (StarlarkAction)
             new StarlarkAction.Builder()
@@ -324,7 +326,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
                 .build(NULL_ACTION_OWNER, targetConfig);
     collectingAnalysisEnvironment.registerAction(starlarkAction);
 
-    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of()))
+    assertThat(starlarkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP))
         .containsExactlyEntriesIn(shadowedActionEnvironment);
 
     // Test using Starlark actions's environment with shadowed action's environment
@@ -344,7 +346,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
     expectedEnvironment.putAll(starlarkActionEnvironment);
 
     ImmutableMap<String, String> actualEnvironment =
-        starlarkAction.getEffectiveEnvironment(ImmutableMap.of());
+        starlarkAction.getEffectiveEnvironment(ImmutableMap.of(), PathMapper.NOOP);
     assertThat(actualEnvironment).hasSize(5);
     // Starlark action's env overwrites any repeated variable from the shadowed action env
     assertThat(actualEnvironment).containsEntry("repeated_var", "starlark_val");
@@ -363,7 +365,7 @@ public final class StarlarkActionWithShadowedActionTest extends BuildViewTestCas
         .thenReturn(discoveredInputs);
     when(shadowedAction.inputsKnown()).thenReturn(true);
     when(shadowedAction.getOwner()).thenReturn(NULL_ACTION_OWNER);
-    when(shadowedAction.getEffectiveEnvironment(ArgumentMatchers.anyMap()))
+    when(shadowedAction.getEffectiveEnvironment(ArgumentMatchers.anyMap(), any()))
         .thenReturn(ImmutableMap.copyOf(shadowedActionEnvironment));
 
     return shadowedAction;


### PR DESCRIPTION
Apart from threading through `PathMapper` to `getEffectiveEnvironment`, this required refactoring away the `envResolved` logic in `EnhancedStarlarkAction` and `ExtraAction`. Instead, `ActionSpawn` now always calls out to `getEffectiveEnvironment` to resolve the env, while giving subclasses of `SpawnAction` a chance to override it.

RELNOTES: The values of environment variables are now subject to path mapping (if enabled for the action).

Work towards #6526