### PR TITLE
[8.4.0] Print interactive debug instructions in HardlinkedSandboxedSpawn

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.util.CommandDescriptionForm;
 import com.google.devtools.build.lib.util.CommandFailureUtils;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Symlinks;

--- a/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/HardlinkedSandboxedSpawn.java
@@ -110,6 +110,7 @@ public class HardlinkedSandboxedSpawn extends AbstractContainerizingSandboxedSpa
     }
   }
 
+  @Nullable
   @Override
   public Optional<String> getInteractiveDebugInstructions() {
     if (interactiveDebugArguments == null) {

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -369,6 +369,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
           sandboxDebugPath,
           statisticsPath,
           sandboxOptions.sandboxDebug,
+          makeInteractiveDebugArguments(commandLineBuilder, sandboxOptions),
           spawn.getMnemonic());
     } else {
       return new SymlinkedSandboxedSpawn(


### PR DESCRIPTION
When running with --experimental_use_hermetic_linux_sandbox, this allows us to see the interactive debug instructions like we'd see without it.

Note that `EnterWorkingDirectory()` in `linux-sandbox` requires that the working directory is under the sandbox_root path, so we need to include `cwd=sandboxExecRoot()` when calling `describeCommand`. This is a stricter requirement than for SymlinkedSandboxedSpawn which was changed in #26448 more for UX reasons.

Fixes #26580.

Closes #26581.

PiperOrigin-RevId: 786165593
Change-Id: Ib1a2dfccb7731691314d88d10e4c6a168977c875

Commit https://github.com/bazelbuild/bazel/commit/289e3859aedab2af7253b6053f6fd575bfd0f3af