### PR TITLE
[8.4.0] Prevent hangs during overflow conditions in grpc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -84,6 +84,8 @@ genrule(
         "//third_party/remoteapis:MODULE.bazel",
         "//third_party:BUILD",
         "//third_party:rules_jvm_external_6.0.patch",
+        "//third_party:grpc-java-12207.patch",
+        "//third_party:grpc-java-12222.patch",
         "//third_party:rules_graalvm_fix.patch",
         "//third_party:rules_graalvm_unicode.patch",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -75,6 +75,18 @@ single_version_override(
     ],
 )
 
+# Remove once the following PRs are available in a grpc-java release.
+#   https://github.com/grpc/grpc-java/pull/12207
+#   https://github.com/grpc/grpc-java/pull/12222
+single_version_override(
+    module_name = "grpc-java",
+    patch_strip = 1,
+    patches = [
+        "//third_party:grpc-java-12207.patch",
+        "//third_party:grpc-java-12222.patch",
+    ],
+)
+
 local_path_override(
     module_name = "remoteapis",
     path = "./third_party/remoteapis",

--- a/third_party/grpc-java-12207.patch
+++ b/third_party/grpc-java-12207.patch
@@ -1,0 +1,66 @@
+commit a37d3eb349e048b953633027ed011cda8b68c603
+Author: George Gensure <werkt0@gmail.com>
+Date:   Thu Jul 10 09:49:54 2025 -0400
+
+    Guarantee missing stream promise delivery
+    
+    In observed cases, whether RST_STREAM or another failure from netty or
+    the server, listeners can fail to be notified when a connection yields a
+    null stream for the selected streamId. This causes hangs in clients,
+    despite deadlines, with no obvious resolution.
+    
+    Tests which relied upon this promise succeeding must now change.
+
+diff --git a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+index a5fa0f800..276fa623c 100644
+--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
++++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+@@ -738,14 +738,19 @@ class NettyClientHandler extends AbstractNettyHandler {
+ 
+                 // Attach the client stream to the HTTP/2 stream object as user data.
+                 stream.setHttp2Stream(http2Stream);
++                promise.setSuccess();
++              } else {
++                // Otherwise, the stream has been cancelled and Netty is sending a
++                // RST_STREAM frame which causes it to purge pending writes from the
++                // flow-controller and delete the http2Stream. The stream listener has already
++                // been notified of cancellation so there is nothing to do.
++                //
++                // This process has been observed to fail in some circumstances, leaving listeners
++                // unanswered. Ensure that some exception has been delivered consistent with the
++                // implied RST_STREAM result above.
++                Status status = Status.INTERNAL.withDescription("unknown stream for connection");
++                promise.setFailure(status.asRuntimeException());
+               }
+-              // Otherwise, the stream has been cancelled and Netty is sending a
+-              // RST_STREAM frame which causes it to purge pending writes from the
+-              // flow-controller and delete the http2Stream. The stream listener has already
+-              // been notified of cancellation so there is nothing to do.
+-
+-              // Just forward on the success status to the original promise.
+-              promise.setSuccess();
+             } else {
+               Throwable cause = future.cause();
+               if (cause instanceof StreamBufferingEncoder.Http2GoAwayException) {
+diff --git a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+index f8fbeea9b..dd4fcb4ea 100644
+--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
++++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+@@ -268,7 +268,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
+     // Cancel the stream.
+     cancelStream(Status.CANCELLED);
+ 
+-    assertTrue(createFuture.isSuccess());
++    assertFalse(createFuture.isSuccess());
+     verify(streamListener).closed(eq(Status.CANCELLED), same(PROCESSED), any(Metadata.class));
+   }
+ 
+@@ -311,7 +311,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
+     ChannelFuture cancelFuture = cancelStream(Status.CANCELLED);
+     assertTrue(cancelFuture.isSuccess());
+     assertTrue(createFuture.isDone());
+-    assertTrue(createFuture.isSuccess());
++    assertFalse(createFuture.isSuccess());
+   }
+ 
+   /**

--- a/third_party/grpc-java-12222.patch
+++ b/third_party/grpc-java-12222.patch
@@ -1,0 +1,66 @@
+commit 2e96fbf1e851242f8028af2cbc16dbc96e1037ff
+Author: Eric Anderson <ejona@google.com>
+Date:   Tue Jul 15 15:00:24 2025 -0700
+
+    netty: Associate netty stream eagerly to avoid client hang
+    
+    In #12185, RPCs were randomly hanging. In #12207 this was tracked down
+    to the headers promise completing successfully, but the netty stream
+    was null. This was because the headers write hadn't completed but
+    stream.close() had been called by goingAway().
+
+diff --git a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+index 276fa623c..d6bb37904 100644
+--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
++++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+@@ -773,6 +773,19 @@ class NettyClientHandler extends AbstractNettyHandler {
+             }
+           }
+         });
++    // When the HEADERS are not buffered because of MAX_CONCURRENT_STREAMS in
++    // StreamBufferingEncoder, the stream is created immediately even if the bytes of the HEADERS
++    // are delayed because the OS may have too much buffered and isn't accepting the write. The
++    // write promise is also delayed until flush(). However, we need to associate the netty stream
++    // with the transport state so that goingAway() and forcefulClose() and able to notify the
++    // stream of failures.
++    //
++    // This leaves a hole when MAX_CONCURRENT_STREAMS is reached, as http2Stream will be null, but
++    // it is better than nothing.
++    Http2Stream http2Stream = connection().stream(streamId);
++    if (http2Stream != null) {
++      http2Stream.setProperty(streamKey, stream);
++    }
+   }
+ 
+   /**
+diff --git a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+index dd4fcb4ea..5a2605eea 100644
+--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
++++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+@@ -453,6 +453,26 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
+     assertTrue(future.isDone());
+   }
+ 
++  @Test
++  public void receivedAbruptGoAwayShouldFailRacingQueuedIoStreamid() throws Exception {
++    // Purposefully avoid flush(), since we want the write to not actually complete.
++    // EmbeddedChannel doesn't support flow control, so this is the next closest approximation.
++    ChannelFuture future = channel().write(
++        newCreateStreamCommand(grpcHeaders, streamTransportState));
++    // Read a GOAWAY that indicates our stream can't be sent
++    channelRead(goAwayFrame(0, 0 /* NO_ERROR */, Unpooled.copiedBuffer("this is a test", UTF_8)));
++
++    ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
++    verify(streamListener).closed(captor.capture(), same(REFUSED),
++        ArgumentMatchers.<Metadata>notNull());
++    assertEquals(Status.UNAVAILABLE.getCode(), captor.getValue().getCode());
++    assertEquals(
++        "Abrupt GOAWAY closed sent stream. HTTP/2 error code: NO_ERROR, "
++          + "debug data: this is a test",
++        captor.getValue().getDescription());
++    assertTrue(future.isDone());
++  }
++
+   @Test
+   public void receivedGoAway_shouldFailBufferedStreamsExceedingMaxConcurrentStreams()
+       throws Exception {


### PR DESCRIPTION
Apply two changes from upstream grpc-java which prevent hangs specifically observed during ensureInputsPresent, action cache download, and action execution. These hangs did not respect specified deadlines, and builds which experienced them required interruption.

Backported to 8.4.0
Fixes #26616

Commit https://github.com/bazelbuild/bazel/commit/7fec47694dca8a9a03e63e0d8ba79bab20cb74a6