### PR TITLE
Skip job control and cleanup for tests executed with `bazel run`

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -250,6 +250,14 @@ start=$(date +%s)
 # eventuality. So, what we do is spawn a *second* background process that
 # watches for us to be killed, and then chain-kills the test's process group.
 # Aren't processes fun?
+# Note: When running under bazel run, as determined by the availability of an
+# environment variable specific to it, don't use job control as it interferes
+# with interactive debugging. Also skip cleanup and post-processing steps such
+# as undeclared outputs zipping to avoid unexpected latency when the user
+# finishes debugging.
+if [ -n "$BUILD_EXECROOT" ]; then
+  exec "${TEST_PATH}" "$@" 2>&1
+fi
 set -m
 if [ -z "$COVERAGE_DIR" ]; then
   ("${TEST_PATH}" "$@" 2>&1) <&0 &


### PR DESCRIPTION
Job control gets in the way of interactive debugging while cleanup (including undeclared test output zipping) can result in unexpected latency when the user stops the interactive test run.

This change is not considered to be backwards incompatible as `bazel run` has always only promised a best effort at mimicking the test environment, requiring `bazel test --test_output=streamed -t-` or similar for a true reproduction of the test environment.

Fixes #13934