### PR TITLE
Expose generate_modmap attribute

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/cc_toolchain.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_toolchain.bzl
@@ -99,7 +99,7 @@ def _attributes(ctx):
         link_dynamic_library_tool = ctx.file._link_dynamic_library_tool,
         grep_includes = grep_includes,
         aggregate_ddi = _single_file(ctx, "_aggregate_ddi"),
-        generate_modmap = _single_file(ctx, "_generate_modmap"),
+        generate_modmap = ctx.attr.generate_modmap[DefaultInfo].files_to_run if ctx.attr.generate_modmap else None,
         module_map = ctx.attr.module_map,
         as_files = _files(ctx, "as_files"),
         ar_files = _files(ctx, "ar_files"),

--- a/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_info.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_info.bzl
@@ -118,6 +118,7 @@ def _create_cc_toolchain_info(
         strip_executable = strip_executable,
         ld_executable = ld_executable,
         gcov_executable = gcov_executable,
+        generate_modmap = generate_modmap,
         _as_files = as_files,
         _ar_files = ar_files,
         _strip_files = strip_files,
@@ -156,7 +157,6 @@ def _create_cc_toolchain_info(
         _cc_info = cc_info,
         _objcopy_files = objcopy_files,
         _aggregate_ddi = aggregate_ddi,
-        _generate_modmap = generate_modmap,
     )
     return cc_toolchain_info
 
@@ -201,6 +201,7 @@ CcToolchainInfo, _ = provider(
         "strip_executable": "The path to the strip binary.",
         "ld_executable": "The path to the ld binary.",
         "gcov_executable": "The path to the gcov binary.",
+        "generate_modmap": "The path to the generate_modmap wrapper.",
         # Private fields used by Starlark.
         "_as_files": "INTERNAL API, DO NOT USE!",
         "_ar_files": "INTERNAL API, DO NOT USE!",
@@ -245,7 +246,6 @@ CcToolchainInfo, _ = provider(
         "_cc_info": "INTERNAL API, DO NOT USE!",
         "_objcopy_files": "INTERNAL API, DO NOT USE!",
         "_aggregate_ddi": "INTERNAL API, DO NOT USE!",
-        "_generate_modmap": "INTERNAL API, DO NOT USE!",
     },
     init = _create_cc_toolchain_info,
 )

--- a/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/semantics.bzl
@@ -137,10 +137,9 @@ def _cpp_modules_tools():
             cfg = "exec",
             default = "@" + _get_repo() + "//tools/cpp:aggregate-ddi",
         ),
-        "_generate_modmap": attr.label(
+        "generate_modmap": attr.label(
             executable = True,
             cfg = "exec",
-            default = "@" + _get_repo() + "//tools/cpp:generate-modmap",
         ),
     }
 


### PR DESCRIPTION
This patch exports the `generate_modmap` attribute.  A wrapper can now invoke the `generate_modmap` executable.  It also removes Java’s dependency on the free-form `compiler` field.

see https://github.com/bazelbuild/bazel/pull/22553#discussion_r2202381024
