### PR TITLE
Fix split coverage logging

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -809,6 +809,7 @@ public class StandaloneTestStrategy extends TestStrategy {
         throw e;
       }
 
+      // Append all output from the coverage spawn to the test log.
       writeOutFile(coverageOutErr.getErrorPath(), coverageOutErr.getOutputPath());
       appendCoverageLog(coverageOutErr, fileOutErr);
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -785,8 +785,6 @@ public class StandaloneTestStrategy extends TestStrategy {
               .withFileOutErr(coverageOutErr)
               .withOutputsAsInputs(coverageSpawnMetadata);
 
-      writeOutFile(coverageOutErr.getErrorPath(), coverageOutErr.getOutputPath());
-      appendCoverageLog(coverageOutErr, fileOutErr);
       try {
         spawnStrategyResolver.exec(coveragePostProcessingSpawn, coverageActionExecutionContext);
       } catch (SpawnExecException e) {
@@ -810,6 +808,9 @@ public class StandaloneTestStrategy extends TestStrategy {
         closeSuppressed(e, fileOutErr);
         throw e;
       }
+
+      writeOutFile(coverageOutErr.getErrorPath(), coverageOutErr.getOutputPath());
+      appendCoverageLog(coverageOutErr, fileOutErr);
     }
 
     Verify.verify(


### PR DESCRIPTION
The output produced by the split coverage postprocessing spawn has to be appended to the test log *after* the spawn has run, otherwise it's always empty.