### PR TITLE
Strictify exception types in `remote` package to reduce wrapping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BazelOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/BazelOutputService.java
@@ -360,7 +360,7 @@ public class BazelOutputService implements OutputService {
 
   @Override
   public void finalizeAction(Action action, OutputMetadataStore outputMetadataStore)
-      throws IOException, EnvironmentalExecException, InterruptedException {
+      throws IOException, InterruptedException {
     var execRoot = execRootSupplier.get();
     var outputPath = outputPathSupplier.get();
 


### PR DESCRIPTION
This makes it easier to understand what kinds of exceptions can be thrown by a particular function and avoids wrapping in `RuntimeException` that can turn regular failures into crashes.

In particular, this resolves an issue seen on a PR in which `RemoteSpawnRunner` turned an `ExecException` raised by `RES.uploadInputsIfNotPresent` due to a lost input into a `RuntimeException`, thus resulting in a crash. It's not clear whether this behavior can also happen at HEAD or whether all callers unwrap the `RuntimeException`, so this change doesn't necessarily fix a bug.

Work towards #21378 