### PR TITLE
[8.4.0] Fix split coverage logging

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -792,8 +792,6 @@ public class StandaloneTestStrategy extends TestStrategy {
               .withFileOutErr(coverageOutErr)
               .withOutputsAsInputs(coverageSpawnMetadata);
 
-      writeOutFile(coverageOutErr.getErrorPath(), coverageOutErr.getOutputPath());
-      appendCoverageLog(coverageOutErr, fileOutErr);
       try {
         spawnStrategyResolver.exec(coveragePostProcessingSpawn, coverageActionExecutionContext);
       } catch (SpawnExecException e) {
@@ -817,6 +815,10 @@ public class StandaloneTestStrategy extends TestStrategy {
         closeSuppressed(e, fileOutErr);
         throw e;
       }
+
+      // Append all output from the coverage spawn to the test log.
+      writeOutFile(coverageOutErr.getErrorPath(), coverageOutErr.getOutputPath());
+      appendCoverageLog(coverageOutErr, fileOutErr);
     }
 
     Verify.verify(


### PR DESCRIPTION
The output produced by the split coverage postprocessing spawn has to be appended to the test log *after* the spawn has run, otherwise it's always empty.

Closes #26647.

PiperOrigin-RevId: 788016012
Change-Id: I4f5307de343ef73fd1a3770b64d0725d4b1d0a89

Commit https://github.com/bazelbuild/bazel/commit/12ce11b8dfd66db903f1c35d3f73f3e18d21f5bd