### PR TITLE
Beautify select() "no matching conditions" error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
@@ -391,33 +391,53 @@ public class ConfiguredAttributeMapper extends AbstractAttributeMapper {
       Label targetLabel,
       String configHash) {
     String error =
-        String.format(
-            "configurable attribute \"%s\" in %s doesn't match this configuration",
-            attribute, targetLabel);
+        "%s has a select() on attribute \"%s\" that doesn't match configuration %s"
+            .formatted(targetLabel, attribute, configHash);
     if (!customNoMatchError.isEmpty()) {
       error += String.format(": %s\n", customNoMatchError);
     } else {
       error +=
-          ". Would a default condition help?\n\n"
-              + "Conditions checked:\n "
-              + Joiner.on("\n ").join(conditionLabels)
-              + "\n\n"
-              + "To see a condition's definition, run: bazel query --output=build "
-              + "<condition label>.\n";
+"""
+.
+
+Conditions checked:
+ %s
+
+Explanation:
+ - A configuration is a collection of build flags.
+ - select() conditions are expectations that certain build flags have certain values.
+ - A target may build with different configurations in the same build.
+ - This instance of %s fails with configuration %s.
+
+Diagnostics:
+ - To see configuration %s's build flags, run: %s config %s
+ - To see %s's "%s" attribute, run: %s query --output=build %s
+ - To see a condition's criteria, run, for example: %s query --output=build %s
+
+Suggestions:
+  - Add "//conditions:default" to match a select() when no other conditions match.
+
+More info:
+ - https://bazel.build/docs/configurable-attributes#faq-select-choose-condition
+
+"""
+              .formatted(
+                  Joiner.on("\n ").join(conditionLabels),
+                  targetLabel,
+                  configHash,
+                  configHash,
+                  ProductName.get(),
+                  configHash,
+                  targetLabel,
+                  attribute,
+                  ProductName.get(),
+                  targetLabel,
+                  ProductName.get(),
+                  conditionLabels.getFirst());
     }
-    // See ConfiguredTargetQueryEnvironment#shortID for the substring rationale.
-    String configShortHash = configHash.substring(0, 7);
-    error +=
-        String.format(
-            "\nThis instance of %s has configuration identifier %s. "
-                + "To inspect its configuration, run: bazel config %s.\n",
-            targetLabel, configShortHash, configShortHash);
-    error +=
-        "\n"
-            + "For more help, see"
-            + " https://bazel.build/docs/configurable-attributes#faq-select-choose-condition.\n\n";
     return error;
   }
+
 
   @Override
   public <T> T get(String attributeName, Type<T> type) {

--- a/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/ConfiguredAttributeMapper.java
@@ -438,7 +438,6 @@ More info:
     return error;
   }
 
-
   @Override
   public <T> T get(String attributeName, Type<T> type) {
     try {


### PR DESCRIPTION
**This is an experiment. Requesting feedback on structural ideas, and if this is worthwhile as a broader error pattern.**

For https://github.com/bazelbuild/bazel/issues/11984.

### Scenario
Build a target with a `select()` where no conditions match:

```sh
$ cat testapp/BUILD
cc_library(
    name = "cc",
    srcs = select({
        ":doesnt_match": ["cc1.cc"],
        ":also_doesnt_match": ["cc2.cc"],
    }),
)

$ bazel build //testapp:cc
```

### Before
```
ERROR: testapp/BUILD:6:11: configurable attribute "srcs" in //testapp:cc doesn't match this configuration. Would a default condition help?

Conditions checked:
 //testapp:doesnt_match
 //testapp:also_doesnt_match

To see a condition's definition, run: bazel query --output=build <condition label>.

This instance of //testapp:cc has configuration identifier 200b39c. To inspect its configuration, run: bazel config 200b39c.

For more help, see https://bazel.build/docs/configurable-attributes#faq-select-choose-condition.
```
### After
```
ERROR: testapp/BUILD:6:11: //testapp:cc has a select() on attribute "srcs" that doesn't match configuration b411ff2.

Conditions checked:
 //testapp:doesnt_match
 //testapp:also_doesnt_match

Explanation:
 - A configuration is a collection of build flags.
 - select() conditions are expectations that certain build flags have certain values.
 - A target may build with different configurations in the same build.
 - This instance of //testapp:cc fails with configuration b411ff2.

Diagnostics:
 - To see configuration b411ff2's build flags, run: bazel config b411ff2
 - To see //testapp:cc's "srcs" attribute, run: bazel query --output=build //testapp:cc
 - To see a condition's criteria, run, for example: bazel query --output=build //testapp:config

Suggestions:
  - Add "//conditions:default" to match a select() when no other conditions match.

More info:
 - https://bazel.build/docs/configurable-attributes#faq-select-choose-condition
```

### Proposed improvements

- Standard structure we can apply to all errors:
  - **single-line grep-friendly summary**
  - **Explanation:** minimal context to help non-power users understand basic concepts
  -  **Diagnostics:** brief actionables users can take to debug
  -  **Suggestions:**  ideas on possible resolutions
  - **More info:** link to more complete context
- Doesn't assume users are bazel experts
- Leads with source file, then target name to quickly isolate error location
- Less mystery language in the summary (e.g. what's a "configurable attribute"? what's "this configuration?")
- Better-organized both conceptually and visually. If it's a standard pattern, users learn how to parse all errors more quickly
- More explicit suggestions. "Add "//conditions:default" to match a select() when no other conditions match" is clearer than "Would a default condition help?"
- All feedback is actionable without having to do more research
- Bazel can construct these errors with structured Java objects to support ANSI effects like bolded headers.
- Better feedback for agentic workflows? 

### Critiques
This is clearly more verbose at 22 lines for this example. One can argue program errors should be concise, and should link to docs for deep discussion.

I'm actually trying to follow that principle. It just so happens that a minimal complete error context takes 22 lines here, as I see it. Reducing it further saves screen space at the expense of leaving non-power users with an incomplete picture. 

IMO the most important priority is helping users feel informed and able to respond. For non-power users that's going to take some space.

Another critique is this embeds more API info, i.e. exact bazel commands to do some task. That's an extra obligation to keep the APIs up-to-date. It's especially bad if error messages provide feedback that doesn't work. 

### Other thoughts
I'd actually take this farther and consider standard error codes that *also* make log parsing, grepping, etc work well. i.e.:

```
ERROR(1234): <whatever error #1234 is>
...
More info:
 - https://bazel.build/docs/messages/1234
```

Then as general pattern we can have supporting docs focused on specific errors with as much extra context as we want. 

WDYT?
