### PR TITLE
Use the system trust store by default with the embedded JDK

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -387,9 +387,11 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
   // Add JVM arguments particular to building blaze64 and particular JVM
   // versions.
   string error;
+  auto [server_javabase, server_javabase_type] =
+      startup_options.GetServerJavabaseAndType();
   blaze_exit_code::ExitCode jvm_args_exit_code =
-      startup_options.AddJVMArguments(startup_options.GetServerJavabase(),
-                                      &result, user_options, &error);
+      startup_options.AddJVMArguments(server_javabase, &result, user_options,
+                                      &error);
   if (jvm_args_exit_code != blaze_exit_code::SUCCESS) {
     BAZEL_DIE(jvm_args_exit_code) << error;
   }
@@ -438,6 +440,28 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
   // protobuf.
   // TODO: Drop this when protobuf uses VarHandle.
   result.push_back("-Dsun.misc.unsafe.memory.access=allow");
+
+  if (server_javabase_type == StartupOptions::JavabaseType::EMBEDDED) {
+    // Use the system trust store instead of the certificates shipped with the
+    // embedded JDK since users can't easily update it and may not even be aware
+    // of its existence.
+#if defined(_WIN32)
+    result.push_back("-Djavax.net.ssl.trustStoreType=Windows-ROOT");
+#elif defined(__APPLE__)
+    // This type is available as of JDK 23 and provides root certificates in
+    // addition to user certificates.
+    // https://bugs.openjdk.org/browse/JDK-8320362
+    result.push_back("-Djavax.net.ssl.trustStoreType=KeychainStore-ROOT");
+#elif defined(__linux__)
+    if (blaze_util::Path("/etc/ssl/certs/java/cacerts").Exists()) {
+      // The default trust store location on Debian and Ubuntu.
+      result.push_back("-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts");
+    } else if (blaze_util::Path("/etc/pki/java/cacerts").Exists()) {
+      // The default trust store location on Fedora and CentOS.
+      result.push_back("-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts");
+    }
+#endif
+  }
 
 #if defined(_WIN32)
   // See and use more than 64 CPUs on Windows.

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -453,10 +453,11 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
     // https://bugs.openjdk.org/browse/JDK-8320362
     result.push_back("-Djavax.net.ssl.trustStoreType=KeychainStore-ROOT");
 #elif defined(__linux__)
-    if (blaze_util::Path("/etc/ssl/certs/java/cacerts").Exists()) {
+    if (blaze_util::IsDirectory(blaze_util::Path("/etc/ssl/certs/java/cacerts"))) {
       // The default trust store location on Debian and Ubuntu.
-      result.push_back("-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts");
-    } else if (blaze_util::Path("/etc/pki/java/cacerts").Exists()) {
+      result.push_back(
+          "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts");
+    } else if (blaze_util::IsDirectory(blaze_util::Path("/etc/pki/java/cacerts"))) {
       // The default trust store location on Fedora and CentOS.
       result.push_back("-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts");
     }


### PR DESCRIPTION
Users can't easily update the certificates in the embedded JDK and arguably shouldn't even have to be aware of the fact that Bazel relies on a bundled JVM. Since JDK 23 made it possible to rely on the system store on all major OSes, do so by default.

RELNOTES[INC]: Bazel releases that include a bundled JDK now use the system trust store for certificates by default. Set `-Djavax.net.ssl.trustStore` and `-Djavax.net.ssl.trustStoreType` via `--host_jvm_args` to override the default location.

Fixes #16223 
Fixes #10349