### PR TITLE
Properly escape arguments passed to LaunchProcess() in JavaBinaryLauncher::CreateClasspathJar

### DIFF
--- a/src/tools/launcher/BUILD
+++ b/src/tools/launcher/BUILD
@@ -33,6 +33,7 @@ win_cc_library(
         "//src/main/cpp/util:filesystem",
         "//src/tools/launcher/util",
         "//src/tools/launcher/util:data_parser",
+        "//src/main/native/windows:lib-process"
     ],
 )
 

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -70,7 +70,7 @@ ExitCode BashBinaryLauncher::Launch() {
 
   vector<wstring> args;
   args.push_back(L"-c");
-  args.push_back(BashEscapeArg(bash_command.str()));
+  args.push_back(bash_command.str());
   return this->LaunchProcess(bash_binary, args);
 }
 

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -74,5 +74,8 @@ ExitCode BashBinaryLauncher::Launch() {
   return this->LaunchProcess(bash_binary, args);
 }
 
+std::wstring BashBinaryLauncher::EscapeArg(const std::wstring &arg) const {
+  return BashEscapeArg(arg);
+}
 }  // namespace launcher
 }  // namespace bazel

--- a/src/tools/launcher/bash_launcher.h
+++ b/src/tools/launcher/bash_launcher.h
@@ -28,6 +28,8 @@ class BashBinaryLauncher : public BinaryLauncherBase {
       : BinaryLauncherBase(launch_info, launcher_path, argc, argv) {}
   ~BashBinaryLauncher() override = default;
   ExitCode Launch() override;
+ protected:
+  std::wstring EscapeArg(const std::wstring &arg) const override;
 };
 
 }  // namespace launcher

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -280,8 +280,8 @@ wstring JavaBinaryLauncher::CreateClasspathJar(const wstring& classpath) {
   wstring jar_bin = this->Rlocation(this->GetLaunchInfoByKey(JAR_BIN_PATH));
   vector<wstring> arguments;
   arguments.push_back(L"cvfm");
-  arguments.push_back(bazel::windows::WindowsEscapeArg(manifest_jar_path));
-  arguments.push_back(bazel::windows::WindowsEscapeArg(jar_manifest_file_path));
+  arguments.push_back(manifest_jar_path);
+  arguments.push_back(jar_manifest_file_path);
 
   if (this->LaunchProcess(jar_bin, arguments, /* suppressOutput */ true) != 0) {
     die(L"Couldn't create classpath jar: %s", manifest_jar_path.c_str());
@@ -416,13 +416,7 @@ ExitCode JavaBinaryLauncher::Launch() {
     arguments.push_back(arg);
   }
 
-  vector<wstring> escaped_arguments;
-  // Quote the arguments if having spaces
-  for (const auto& arg : arguments) {
-    escaped_arguments.push_back(bazel::windows::WindowsEscapeArg(arg));
-  }
-
-  ExitCode exit_code = this->LaunchProcess(java_bin, escaped_arguments);
+  ExitCode exit_code = this->LaunchProcess(java_bin, arguments);
 
   // Delete classpath jar file after execution.
   if (!classpath_jar.empty()) {

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -280,8 +280,8 @@ wstring JavaBinaryLauncher::CreateClasspathJar(const wstring& classpath) {
   wstring jar_bin = this->Rlocation(this->GetLaunchInfoByKey(JAR_BIN_PATH));
   vector<wstring> arguments;
   arguments.push_back(L"cvfm");
-  arguments.push_back(manifest_jar_path);
-  arguments.push_back(jar_manifest_file_path);
+  arguments.push_back(bazel::windows::WindowsEscapeArg(manifest_jar_path));
+  arguments.push_back(bazel::windows::WindowsEscapeArg(jar_manifest_file_path));
 
   if (this->LaunchProcess(jar_bin, arguments, /* suppressOutput */ true) != 0) {
     die(L"Couldn't create classpath jar: %s", manifest_jar_path.c_str());

--- a/src/tools/launcher/launcher.cc
+++ b/src/tools/launcher/launcher.cc
@@ -29,6 +29,7 @@
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/path_platform.h"
 #include "src/main/cpp/util/strings.h"
+#include "src/main/native/windows/process.h"
 #include "src/tools/launcher/util/data_parser.h"
 #include "src/tools/launcher/util/launcher_util.h"
 
@@ -137,6 +138,10 @@ wstring BinaryLauncherBase::GetRunfilesPath() const {
   return runfiles_path;
 }
 
+std::wstring BinaryLauncherBase::EscapeArg(const std::wstring &arg) const {
+  return windows::WindowsEscapeArg(arg);
+}
+
 void BinaryLauncherBase::ParseManifestFile(ManifestFileMap* manifest_file_map,
                                            const wstring& manifest_path) {
   ifstream manifest_file(AsAbsoluteWindowsPath(manifest_path.c_str()).c_str());
@@ -215,7 +220,7 @@ void BinaryLauncherBase::CreateCommandLine(
   wostringstream cmdline;
   cmdline << L'\"' << executable << L'\"';
   for (const auto& s : arguments) {
-    cmdline << L' ' << s;
+    cmdline << L' ' << EscapeArg(s);
   }
 
   wstring cmdline_str = cmdline.str();

--- a/src/tools/launcher/launcher.cc
+++ b/src/tools/launcher/launcher.cc
@@ -220,7 +220,7 @@ void BinaryLauncherBase::CreateCommandLine(
   wostringstream cmdline;
   cmdline << L'\"' << executable << L'\"';
   for (const auto& s : arguments) {
-    cmdline << L' ' << EscapeArg(s);
+    cmdline << L' ' << s;
   }
 
   wstring cmdline_str = cmdline.str();
@@ -252,7 +252,11 @@ bool BinaryLauncherBase::PrintLauncherCommandLine(
 ExitCode BinaryLauncherBase::LaunchProcess(const wstring& executable,
                                            const vector<wstring>& arguments,
                                            bool suppressOutput) const {
-  if (PrintLauncherCommandLine(executable, arguments)) {
+  std::vector<std::wstring> escaped_arguments(arguments.size());
+  std::transform(arguments.cbegin(), arguments.cend(), escaped_arguments.begin(), [this](const wstring& arg) {
+    return EscapeArg(arg);
+  });
+  if (PrintLauncherCommandLine(executable, escaped_arguments)) {
     return 0;
   }
   // Set RUNFILES_DIR if:
@@ -267,7 +271,7 @@ ExitCode BinaryLauncherBase::LaunchProcess(const wstring& executable,
     SetEnv(L"RUNFILES_MANIFEST_FILE", manifest_file);
   }
   CmdLine cmdline;
-  CreateCommandLine(&cmdline, executable, arguments);
+  CreateCommandLine(&cmdline, executable, escaped_arguments);
   PROCESS_INFORMATION processInfo = {0};
   STARTUPINFOW startupInfo = {0};
   startupInfo.cb = sizeof(startupInfo);

--- a/src/tools/launcher/launcher.h
+++ b/src/tools/launcher/launcher.h
@@ -91,6 +91,9 @@ class BinaryLauncherBase {
   // converts forward slashes to backslashes, then returns that.
   std::wstring GetRunfilesPath() const;
 
+ protected:
+  virtual std::wstring EscapeArg(const std::wstring& arg) const;
+
  private:
   // The path of the launcher binary.
   const std::wstring launcher_path;

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -70,13 +70,7 @@ ExitCode PythonBinaryLauncher::Launch() {
   }
 
   // Replace the first argument with python file path
-  // Escaping it, as the python file might contain a " " (eg. When the file is
-  // located under C:\Program Files\...)
-  args[0] = bazel::windows::WindowsEscapeArg(python_file);
-
-  for (int i = 1; i < args.size(); i++) {
-    args[i] = bazel::windows::WindowsEscapeArg(args[i]);
-  }
+  args[0] = python_file;
 
   return this->LaunchProcess(python_binary, args);
 }


### PR DESCRIPTION
It's the fix for #26666.