### PR TITLE
Deduplicate identical repo contents cache entries during GC

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -400,14 +400,12 @@ public class BazelRepositoryModule extends BlazeModule {
                   "could not acquire lock on repo contents cache", Code.BAD_REPO_CONTENTS_CACHE),
               e);
         }
-        if (!repoOptions.repoContentsCacheGcMaxAge.isZero()) {
-          env.addIdleTask(
-              repositoryCache
-                  .getRepoContentsCache()
-                  .createGcIdleTask(
-                      repoOptions.repoContentsCacheGcMaxAge,
-                      repoOptions.repoContentsCacheGcIdleDelay));
-        }
+        env.addIdleTask(
+            repositoryCache
+                .getRepoContentsCache()
+                .createGcIdleTask(
+                    repoOptions.repoContentsCacheGcMaxAge,
+                    repoOptions.repoContentsCacheGcIdleDelay));
       }
 
       try {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -75,7 +75,7 @@ public class RepositoryOptions extends OptionsBase {
       help =
           """
           Specifies the amount of time an entry in the repo contents cache can stay unused before \
-          it's garbage collected. If set to zero, garbage collection is disabled.
+          it's garbage collected. If set to zero, only duplicate entries will be garbage collected.
           """)
   public Duration repoContentsCacheGcMaxAge;
 


### PR DESCRIPTION
Such entries are created when multiple Bazel servers fetch the same repo at the same time and waste space.

This has been tested manually by running 20 concurrent Bazel commands with different output bases. After the specified idle delay, only a single repo remained and subsequent runs with all these output bases succeeded and shared the same entry.