### PR TITLE
[8.4.0] Support generational ZGC and generational Shenandoah

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/metrics/GarbageCollectionMetricsUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/GarbageCollectionMetricsUtils.java
@@ -25,7 +25,9 @@ public final class GarbageCollectionMetricsUtils {
         || "PS Old Gen".equals(name)
         || "Tenured Gen".equals(name)
         || "Shenandoah".equals(name)
-        || "ZHeap".equals(name);
+        || "Shenandoah Old Gen".equals(name)
+        || "ZHeap".equals(name)
+        || "ZGC Old Generation".equals(name);
   }
 
   public static boolean isFullGc(GarbageCollectionNotificationInfo info) {


### PR DESCRIPTION
Bazel currently does not start when you launch the server JVM with generational ZGC using `-XX:+UseZGC` and `-XX:+ZGenerational`. Or if you're on JDK 24+ the same problem is encountered with just `-XX:+UseZGC`.

The same problem is encountered with `-XX:+UseShenandoahGC` and `-XX:ShenandoahGCMode=generational`.

Non-generational ZGC is removed as of JDK 24. Generational Shenandoah is being promoted from experimental to production in JDK 25.

This fix is modeled after #12644

Closes #26676.

PiperOrigin-RevId: 789746919
Change-Id: Ia070fa9b39cef07cc9987544c014d589b2504dce

Commit https://github.com/bazelbuild/bazel/commit/3a1fe64444ead88b1951f4b7a1eb9b5a9ae6d8fa