### PR TITLE
[8.4.0] Properly escape arguments passed to LaunchProcess() in JavaBinaryLauncher::CreateClasspathJar

### DIFF
--- a/src/tools/launcher/BUILD
+++ b/src/tools/launcher/BUILD
@@ -30,6 +30,7 @@ win_cc_library(
     hdrs = ["launcher.h"],
     deps = [
         "//src/main/cpp/util:filesystem",
+        "//src/main/native/windows:lib-process",
         "//src/tools/launcher/util",
         "//src/tools/launcher/util:data_parser",
     ],

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -65,9 +65,12 @@ ExitCode BashBinaryLauncher::Launch() {
 
   vector<wstring> args;
   args.push_back(L"-c");
-  args.push_back(BashEscapeArg(bash_command.str()));
+  args.push_back(bash_command.str());
   return this->LaunchProcess(bash_binary, args);
 }
 
+std::wstring BashBinaryLauncher::EscapeArg(const std::wstring& arg) const {
+  return BashEscapeArg(arg);
+}
 }  // namespace launcher
 }  // namespace bazel

--- a/src/tools/launcher/bash_launcher.h
+++ b/src/tools/launcher/bash_launcher.h
@@ -28,6 +28,9 @@ class BashBinaryLauncher : public BinaryLauncherBase {
       : BinaryLauncherBase(launch_info, launcher_path, argc, argv) {}
   ~BashBinaryLauncher() override = default;
   ExitCode Launch() override;
+
+ protected:
+  std::wstring EscapeArg(const std::wstring& arg) const override;
 };
 
 }  // namespace launcher

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -416,13 +416,7 @@ ExitCode JavaBinaryLauncher::Launch() {
     arguments.push_back(arg);
   }
 
-  vector<wstring> escaped_arguments;
-  // Quote the arguments if having spaces
-  for (const auto& arg : arguments) {
-    escaped_arguments.push_back(bazel::windows::WindowsEscapeArg(arg));
-  }
-
-  ExitCode exit_code = this->LaunchProcess(java_bin, escaped_arguments);
+  ExitCode exit_code = this->LaunchProcess(java_bin, arguments);
 
   // Delete classpath jar file after execution.
   if (!classpath_jar.empty()) {

--- a/src/tools/launcher/launcher.h
+++ b/src/tools/launcher/launcher.h
@@ -91,6 +91,9 @@ class BinaryLauncherBase {
   // converts forward slashes to backslashes, then returns that.
   std::wstring GetRunfilesPath() const;
 
+ protected:
+  virtual std::wstring EscapeArg(const std::wstring& arg) const;
+
  private:
   // The path of the launcher binary.
   const std::wstring launcher_path;

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -70,13 +70,7 @@ ExitCode PythonBinaryLauncher::Launch() {
   }
 
   // Replace the first argument with python file path
-  // Escaping it, as the python file might contain a " " (eg. When the file is
-  // located under C:\Program Files\...)
-  args[0] = bazel::windows::WindowsEscapeArg(python_file);
-
-  for (int i = 1; i < args.size(); i++) {
-    args[i] = bazel::windows::WindowsEscapeArg(args[i]);
-  }
+  args[0] = python_file;
 
   return this->LaunchProcess(python_binary, args);
 }


### PR DESCRIPTION
It's the fix for #26666.

Closes #26667.

PiperOrigin-RevId: 789833713
Change-Id: I54ac9740cbd528c7f115c132671e5416f0118400

Commit https://github.com/bazelbuild/bazel/commit/b64805173bf7b3d1b8cb1893d62e9d61bcb07f8b