### PR TITLE
Add configuration short ID to analysis error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
@@ -1017,7 +1017,11 @@ final class AspectFunction implements SkyFunction {
     events.replayOn(env.getListener());
     if (events.hasErrors()) {
       analysisEnvironment.disable(associatedTarget);
-      String msg = "Analysis of target '" + associatedTarget.getLabel() + "' failed";
+      String msg =
+          "Analysis of target '%s' (config: %s) failed"
+              .formatted(
+                  associatedTarget.getLabel(),
+                  configuration != null ? configuration.getOptions().shortId() : "none");
       throw new AspectFunctionException(
           new AspectCreationException(msg, key.getLabel(), configuration));
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.ConfiguredTargetValue;
 import com.google.devtools.build.lib.analysis.DependencyKind;
+import com.google.devtools.build.lib.analysis.DependencyResolutionHelpers;
 import com.google.devtools.build.lib.analysis.ExecGroupCollection;
 import com.google.devtools.build.lib.analysis.ExecGroupCollection.InvalidExecGroupException;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
@@ -491,7 +492,10 @@ public final class ConfiguredTargetFunction implements SkyFunction {
       throw new ConfiguredValueCreationException(
           ctgValue.getTarget(),
           null,
-          "Analysis of target '" + target.getLabel() + "' failed",
+          "Analysis of target '%s' (config: %s) failed"
+              .formatted(
+                  target.getLabel(),
+                  configuration != null ? configuration.getOptions().shortId() : "none"),
           rootCauses,
           null);
     }

--- a/src/test/java/com/google/devtools/build/lib/buildtool/OutputArtifactConflictTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/OutputArtifactConflictTest.java
@@ -557,7 +557,8 @@ public class OutputArtifactConflictTest extends BuildIntegrationTestCase {
       events.assertContainsError("/bin/x/y/whatever' (belonging to //x/y:y)");
       events.assertContainsError("/bin/x/y' (belonging to //x:y)");
       events.assertContainsError("is a prefix of the other");
-      events.assertContainsError("Analysis of target '//x:fail_analysis' failed");
+      events.assertContainsError("Analysis of target '//x:fail_analysis' (config: ");
+      events.assertContainsError(") failed");
 
       assertThat(eventListener.analysisFailures).containsAtLeast("//x:y", "//x:fail_analysis");
     } else if (minimizeMemory) {


### PR DESCRIPTION
This makes it possible to debug config-dependent errors.