### PR TITLE
Set HOME in Unix test environment

### DIFF
--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -91,7 +91,9 @@ function test_tmpdir() {
 #!/bin/sh
 set -e
 echo TEST_TMPDIR=$TEST_TMPDIR
+echo HOME=$HOME
 touch "$TEST_TMPDIR/foo"
+touch "$HOME/bar
 EOF
   chmod +x foo/bar_test.sh
   cat > foo/BUILD <<EOF
@@ -105,10 +107,12 @@ EOF
   bazel test --test_output=all //foo:bar_test >& $TEST_log || \
     fail "Running sh_test failed"
   expect_log "TEST_TMPDIR=/.*"
+  expect_log "HOME=/.*
 
   bazel test --nocache_test_results --test_output=all --test_tmpdir=$TEST_TMPDIR //foo:bar_test \
     >& $TEST_log || fail "Running sh_test failed"
   expect_log "TEST_TMPDIR=$TEST_TMPDIR"
+  expect_log "HOME=$TEST_TMPDIR"
 }
 
 function test_env_vars() {

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -93,7 +93,7 @@ set -e
 echo TEST_TMPDIR=$TEST_TMPDIR
 echo HOME=$HOME
 touch "$TEST_TMPDIR/foo"
-touch "$HOME/bar
+touch "$HOME/bar"
 EOF
   chmod +x foo/bar_test.sh
   cat > foo/BUILD <<EOF
@@ -107,7 +107,7 @@ EOF
   bazel test --test_output=all //foo:bar_test >& $TEST_log || \
     fail "Running sh_test failed"
   expect_log "TEST_TMPDIR=/.*"
-  expect_log "HOME=/.*
+  expect_log "HOME=/.*"
 
   bazel test --nocache_test_results --test_output=all --test_tmpdir=$TEST_TMPDIR //foo:bar_test \
     >& $TEST_log || fail "Running sh_test failed"

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -118,6 +118,7 @@ function test_env_vars() {
 #!/bin/sh
 echo "pwd: $PWD"
 echo "src: $TEST_SRCDIR"
+echo "rd: $RUNFILES_DIR"
 echo "ws: $TEST_WORKSPACE"
 EOF
   chmod +x foo/testenv.sh
@@ -131,8 +132,9 @@ sh_test(
 EOF
 
   bazel test --test_output=all //foo &> $TEST_log || fail "Test failed"
-  expect_log "pwd: .*/foo.runfiles/_main$"
-  expect_log "src: .*/foo.runfiles$"
+  expect_log "pwd: /.*/foo.runfiles/_main$"
+  expect_log "src: /.*/foo.runfiles$"
+  expect_log "rd: /.*/foo.runfiles$"
   expect_log "ws: _main$"
 }
 

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -64,6 +64,7 @@ is_absolute "$TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR" ||
 is_absolute "$TEST_SRCDIR" || TEST_SRCDIR="$PWD/$TEST_SRCDIR"
 is_absolute "$TEST_TMPDIR" || TEST_TMPDIR="$PWD/$TEST_TMPDIR"
 is_absolute "$HOME" || HOME="$TEST_TMPDIR"
+export HOME
 is_absolute "$XML_OUTPUT_FILE" || XML_OUTPUT_FILE="$PWD/$XML_OUTPUT_FILE"
 
 # Set USER to the current user, unless passed by Bazel via --test_env.


### PR DESCRIPTION
This is mandated by the test encyclopedia, but HOME wasn't exported and isn't set by the test action.

Fixes #10652
Fixes https://github.com/bazel-contrib/rules_go/issues/4108