### PR TITLE
[8.4.0] Drop reduced classpath stats from the JavaCompileAction command line

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilderTest.java
@@ -199,8 +199,7 @@ public final class JavaCompileActionBuilderTest extends BuildViewTestCase {
     context.insertDependencies(bJdeps, Deps.Dependencies.newBuilder().addDependency(dep).build());
     assertThat(
             artifactsToStrings(
-                action.getReducedClasspath(new ActionExecutionContextBuilder().build(), context)
-                    .reducedJars))
+                action.getReducedClasspath(new ActionExecutionContextBuilder().build(), context)))
         .containsExactly(
             "bin java/com/google/test/libb-hjar.jar", "bin java/com/google/test/libc-hjar.jar");
   }


### PR DESCRIPTION
The stats include the length of the full classpath, which can invalidate the reduced spawn even if the reduced classpath doesn't change.

Closes #26692.

PiperOrigin-RevId: 790715967
Change-Id: Iee2a56bd287705db994c8749ef92c7d44f19879d

Commit https://github.com/bazelbuild/bazel/commit/453ba30db0fe03598f50b36378a946f9fe1c401b